### PR TITLE
Restore public methods used by the Flutter SDK

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -77,6 +77,8 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun removeSessionProperty (Ljava/lang/String;)Z
 	public fun sampleCurrentThreadDuringAnrs ()V
 	public fun setAppId (Ljava/lang/String;)Z
+	public fun setDartVersion (Ljava/lang/String;)V
+	public fun setEmbraceFlutterSdkVersion (Ljava/lang/String;)V
 	public fun setProcessStartedByNotification ()V
 	public fun setUserAsPayer ()V
 	public fun setUserEmail (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -611,6 +611,22 @@ public final class Embrace implements EmbraceAndroidApi {
     }
 
     /**
+     * Sets the Embrace Flutter SDK version - this is not intended for public use.
+     */
+    @InternalApi
+    public void setEmbraceFlutterSdkVersion(@Nullable String version) {
+        impl.setEmbraceFlutterSdkVersion(version);
+    }
+
+    /**
+     * Sets the Dart version - this is not intended for public use.
+     */
+    @InternalApi
+    public void setDartVersion(@Nullable String version) {
+        impl.setDartVersion(version);
+    }
+
+    /**
      * Logs a handled Dart error to the Embrace SDK - this is not intended for public use.
      */
     @InternalApi

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1597,6 +1597,26 @@ final class EmbraceImpl {
     }
 
     /**
+     * Sets the Embrace Flutter SDK version - this is not intended for public use.
+     */
+    @InternalApi
+    public void setEmbraceFlutterSdkVersion(@Nullable String version) {
+        if (flutterInternalInterface != null) {
+            flutterInternalInterface.setEmbraceFlutterSdkVersion(version);
+        }
+    }
+
+    /**
+     * Sets the Dart version - this is not intended for public use.
+     */
+    @InternalApi
+    public void setDartVersion(@Nullable String version) {
+        if (flutterInternalInterface != null) {
+            flutterInternalInterface.setDartVersion(version);
+        }
+    }
+
+    /**
      * Saves captured push notification information into session payload
      *
      * @param title                    the title of the notification as a string (or null)


### PR DESCRIPTION
## Goal

The methods `setEmbraceFlutterSdkVersion` and `setDartVersion` were removed from the public API during the 6.0.0 refactor. However, these are needed by the Flutter SDK, so this PR restores them as they previously were.

## Testing

Built and ran the Flutter SDK using this branch.

