### PR TITLE
Capture build id for NDK stackframes

### DIFF
--- a/embrace-android-sdk/src/main/cpp/file_writer.c
+++ b/embrace-android-sdk/src/main/cpp/file_writer.c
@@ -35,6 +35,7 @@ static const char *kFrameAddrKey = "fa";
 static const char *kOffsetAddrKey = "oa";
 static const char *kModuleAddrKey = "ma";
 static const char *kLineNumKey = "ln";
+static const char *kBuildIdKey = "build_id";
 static const char *kCrashKey = "crash";
 static const char *kVersionKey = "v";
 
@@ -203,7 +204,7 @@ char *emb_crash_to_json(emb_crash *crash) {
         json_object_set_number(frame_object, kOffsetAddrKey, frame.offset_addr);
         json_object_set_number(frame_object, kModuleAddrKey, frame.module_addr);
         json_object_set_number(frame_object, kLineNumKey, frame.line_num);
-
+        json_object_set_string(frame_object, kBuildIdKey, frame.build_id);
         json_array_append_value(frames_object, frame_value);
     }
     EMB_LOGDEV("Finished serializing stackframes.");

--- a/embrace-android-sdk/src/main/cpp/stack_frames.h
+++ b/embrace-android-sdk/src/main/cpp/stack_frames.h
@@ -62,6 +62,10 @@
 #define EMB_SESSION_ID_SIZE 256
 #endif
 
+#ifndef EMB_BUILD_ID_SIZE
+#define EMB_BUILD_ID_SIZE 512
+#endif
+
 #ifndef EMB_PATH_SIZE
 #define EMB_PATH_SIZE 512
 #endif
@@ -69,6 +73,7 @@
 typedef struct {
     char filename[256];
     char method[256];
+    char build_id[EMB_BUILD_ID_SIZE];
 
     uintptr_t frame_addr;
     uintptr_t offset_addr;

--- a/embrace-android-sdk/src/main/cpp/unwinders/unwinder_stack.cpp
+++ b/embrace-android-sdk/src/main/cpp/unwinders/unwinder_stack.cpp
@@ -28,7 +28,10 @@ emb_process_stack(emb_env *env, siginfo_t *info, void *user_context) {
     if (unwindSuccessful) {
         int i = 0;
         for (const auto &frame: android_unwinder_data.frames) {
-            stacktrace[i++].frame_addr = frame.pc;
+            emb_sframe *data = &stacktrace[i++];
+            data->frame_addr = frame.pc;
+            const auto map_info = frame.map_info;
+            emb_strncpy(data->build_id, map_info->GetPrintableBuildID().c_str(), EMB_BUILD_ID_SIZE);
         }
     } else {
         return 0;


### PR DESCRIPTION
## Goal

Captures the build id (`.note.gnu.build.id`) when unwinding the stack during crashes. This functionality is enabled in newer versions of libunwindstack & will simplify the logic required to symbolicate on our backend. This is serialized under the key `fr[0].build_id` of the base 64 encoded crash message.

## Testing

Intercepted JSON to confirm that the `build_id` field is set in the payload, and verified native crashes are displayed in the dashboard.

[with_build_id.json](https://github.com/embrace-io/embrace-android-sdk/files/13054776/with_build_id.json)

