### PR TITLE
Enhance information available for debugging NDK stack unwinds

### DIFF
--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsArm.cpp
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsArm.cpp
@@ -43,6 +43,10 @@ uint64_t RegsArm::sp() {
   return regs_[ARM_REG_SP];
 }
 
+uint64_t RegsArm::lr() {
+  return regs_[ARM_REG_LR];
+}
+
 void RegsArm::set_pc(uint64_t pc) {
   regs_[ARM_REG_PC] = pc;
 }

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsArm64.cpp
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsArm64.cpp
@@ -47,6 +47,10 @@ uint64_t RegsArm64::sp() {
   return regs_[ARM64_REG_SP];
 }
 
+uint64_t RegsArm64::lr() {
+  return regs_[ARM64_REG_LR];
+}
+
 static uint64_t strip_pac(uint64_t pc, uint64_t mask) {
   // If the target is aarch64 then the return address may have been
   // signed using the Armv8.3-A Pointer Authentication extension. The

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsX86.cpp
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsX86.cpp
@@ -42,6 +42,10 @@ uint64_t RegsX86::sp() {
   return regs_[X86_REG_SP];
 }
 
+uint64_t RegsX86::lr() {
+  return 0;
+}
+
 void RegsX86::set_pc(uint64_t pc) {
   regs_[X86_REG_PC] = static_cast<uint32_t>(pc);
 }

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsX86_64.cpp
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/RegsX86_64.cpp
@@ -43,6 +43,10 @@ uint64_t RegsX86_64::sp() {
   return regs_[X86_64_REG_SP];
 }
 
+uint64_t RegsX86_64::lr() {
+  return 0;
+}
+
 void RegsX86_64::set_pc(uint64_t pc) {
   regs_[X86_64_REG_PC] = pc;
 }

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/Regs.h
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/Regs.h
@@ -58,6 +58,7 @@ class Regs {
   virtual void* RawData() = 0;
   virtual uint64_t pc() = 0;
   virtual uint64_t sp() = 0;
+  virtual uint64_t lr() = 0; // embrace added
 
   virtual void set_pc(uint64_t pc) = 0;
   virtual void set_sp(uint64_t sp) = 0;

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsArm.h
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsArm.h
@@ -43,6 +43,7 @@ class RegsArm : public RegsImpl<uint32_t> {
 
   uint64_t pc() override;
   uint64_t sp() override;
+  uint64_t lr() override;
 
   void set_pc(uint64_t pc) override;
   void set_sp(uint64_t sp) override;

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsArm64.h
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsArm64.h
@@ -44,6 +44,7 @@ class RegsArm64 : public RegsImpl<uint64_t> {
 
   uint64_t pc() override;
   uint64_t sp() override;
+  uint64_t lr() override;
 
   void set_pc(uint64_t pc) override;
   void set_sp(uint64_t sp) override;

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsX86.h
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsX86.h
@@ -46,6 +46,7 @@ class RegsX86 : public RegsImpl<uint32_t> {
 
   uint64_t pc() override;
   uint64_t sp() override;
+  uint64_t lr() override;
 
   void set_pc(uint64_t pc) override;
   void set_sp(uint64_t sp) override;

--- a/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsX86_64.h
+++ b/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/RegsX86_64.h
@@ -46,6 +46,7 @@ class RegsX86_64 : public RegsImpl<uint64_t> {
 
   uint64_t pc() override;
   uint64_t sp() override;
+  uint64_t lr() override;
 
   void set_pc(uint64_t pc) override;
   void set_sp(uint64_t sp) override;

--- a/embrace-android-sdk/src/main/cpp/file_writer.c
+++ b/embrace-android-sdk/src/main/cpp/file_writer.c
@@ -41,6 +41,7 @@ static const char *kFunctionNameKey = "function_name";
 static const char *kRelPcKey = "rel_pc";
 static const char *kPcKey = "pc";
 static const char *kSpKey = "sp";
+static const char *kLrKey = "lr";
 static const char *kStartKey = "start";
 static const char *kEndKey = "end";
 static const char *kOffsetKey = "offset";
@@ -148,6 +149,7 @@ void emb_log_frame_dbg_info(int i, emb_sframe *frame) {
     EMB_LOGDEV("rel_pc: 0x%lx", (unsigned long) frame->rel_pc);
     EMB_LOGDEV("pc: 0x%lx", (unsigned long) frame->pc);
     EMB_LOGDEV("sp: 0x%lx", (unsigned long) frame->sp);
+    EMB_LOGDEV("lr: 0x%lx", (unsigned long) frame->lr);
     EMB_LOGDEV("start: 0x%lx", (unsigned long) frame->start);
     EMB_LOGDEV("end: 0x%lx", (unsigned long) frame->end);
     EMB_LOGDEV("offset: 0x%lx", (unsigned long) frame->offset);
@@ -245,6 +247,7 @@ char *emb_crash_to_json(emb_crash *crash) {
         json_object_set_number(frame_object, kRelPcKey, (unsigned long) frame.rel_pc);
         json_object_set_number(frame_object, kPcKey, (unsigned long) frame.pc);
         json_object_set_number(frame_object, kSpKey, (unsigned long) frame.sp);
+        json_object_set_number(frame_object, kLrKey, (unsigned long) frame.lr);
         json_object_set_number(frame_object, kStartKey, (unsigned long) frame.start);
         json_object_set_number(frame_object, kEndKey, (unsigned long) frame.end);
         json_object_set_number(frame_object, kOffsetKey, (unsigned long) frame.offset);

--- a/embrace-android-sdk/src/main/cpp/stack_frames.h
+++ b/embrace-android-sdk/src/main/cpp/stack_frames.h
@@ -82,6 +82,7 @@ typedef struct {
     uint64_t rel_pc;
     uint64_t pc;
     uint64_t sp;
+    uint64_t lr; // only populated for the first frame.
     uint64_t function_offset;
     char function_name[EMB_FRAME_STR_SIZE];
 

--- a/embrace-android-sdk/src/main/cpp/unwinders/unwinder_stack.cpp
+++ b/embrace-android-sdk/src/main/cpp/unwinders/unwinder_stack.cpp
@@ -30,8 +30,16 @@ emb_process_stack(emb_env *env, siginfo_t *info, void *user_context) {
 
     if (unwindSuccessful) {
         int i = 0;
+
+
         for (const auto &frame: android_unwinder_data.frames) {
             emb_sframe *data = &stacktrace[i++];
+
+            // populate the link register for the first value only
+            if (i == 0 && android_unwinder_data.saved_initial_regs.has_value()) {
+                data->lr = android_unwinder_data.saved_initial_regs->get()->lr();
+            }
+
             data->frame_addr = frame.pc;
             const auto map_info = frame.map_info;
             emb_strncpy(data->build_id, map_info->GetPrintableBuildID().c_str(), EMB_FRAME_STR_SIZE);


### PR DESCRIPTION
## Goal

Captures more information at crash-time in the `emb_crash` struct. This allows us to read the information on the next launch & debug when things go wrong with stack unwinding.

I went with the approach of looking at the [Regs header](https://github.com/embrace-io/embrace-android-sdk/blob/1c8e4abf7d8a7e605250c6aace01d7c13a10d4fe/embrace-android-sdk/src/main/cpp/3rdparty/libunwindstack-ndk/include/unwindstack/Regs.h#L35) and capturing any value that looks interesting. These aren't added to the payload that is sent to the backend.

@fnewberg I have two questions:

1. Should we put these values in the payload that is sent to the backend, to make it easier to debug when stack unwinding goes wrong?
2. Do you see value in also capturing the initial register values? We have the capability of doing this with libunwindstack but I figured PC/SP should probably be enough

## Testing

Ran the example app with the changes and read the device logs. Full log is below, as well as a snippet of what the captured information looks like.

```
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  Logging out debug info for stackframe 0
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  filename: /data/app/~~093Cr25uK1t59z27vs9-pQ==/io.embrace.ndktestapp-P4XZ0DII0V6tniPtFsbnLg==/lib/arm64/libnative-lib-crash-test.so
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  method: Java_io_embrace_ndktestapp_NativeDelegate_abort
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  frame_addr: 0x734fbdb3f4
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  offset_addr: 0x734fbdb3a0
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  module_addr: 0x734fbc0000
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  line_num: 0x1b3f4
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  build_id: 5a8ed710faa5cdff68d6c69be957da3c0d5e2529
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  full_name: /data/app/~~093Cr25uK1t59z27vs9-pQ==/io.embrace.ndktestapp-P4XZ0DII0V6tniPtFsbnLg==/lib/arm64/libnative-lib-crash-test.so
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  function_name: Java_io_embrace_ndktestapp_NativeDelegate_abort
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  rel_pc: 0x1b3f4
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  pc: 0x734fbdb3f4
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  sp: 0x7feb008580
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  start: 0x734fbc0000
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  end: 0x734fbfa000
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  offset: 0x0
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  function_offset: 0x54
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  flags: 0x5
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  flags: 0
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  Logging out debug info for stackframe 1
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  filename: /apex/com.android.art/lib64/libart.so
2023-10-20 14:55:42.712 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  method: 
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  frame_addr: 0x73d82d7644
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  offset_addr: 0x0
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  module_addr: 0x73d8000000
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  line_num: 0x2d7644
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  build_id: 2b417e2566f5eb686666666b6ee952ea
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  full_name: /apex/com.android.art/lib64/libart.so
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  function_name: art_quick_generic_jni_trampoline
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  rel_pc: 0x2d7644
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  pc: 0x73d82d7644
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  sp: 0x7feb0085b0
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  start: 0x73d8200000
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  end: 0x73d87fe000
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  offset: 0x200000
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  function_offset: 0x94
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  flags: 0x5
2023-10-20 14:55:42.714 14017-14049 emb_ndk_dev             io.embrace.ndktestapp                E  flags: 0
```

[ndk_crash.log](https://github.com/embrace-io/embrace-android-sdk/files/13054994/ndk_crash.log)

