### PR TITLE
EMB-14180 - Fixed link to very old docs.embrace.io URL.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAndroidApi.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAndroidApi.java
@@ -16,7 +16,7 @@ interface EmbraceAndroidApi extends EmbraceApi {
      * Starts instrumentation of the Android application using the Embrace SDK. This should be
      * called during creation of the application, as early as possible.
      * <p>
-     * See <a href="https://docs.embrace.io/docs/android-integration-guide">Embrace Docs</a> for
+     * See <a href="https://embrace.io/docs/android/">Embrace Docs</a> for
      * integration instructions. For compatibility with other networking SDKs such as Akamai,
      * the Embrace SDK must be initialized after any other SDK.
      *
@@ -28,7 +28,7 @@ interface EmbraceAndroidApi extends EmbraceApi {
      * Starts instrumentation of the Android application using the Embrace SDK. This should be
      * called during creation of the application, as early as possible.
      * <p>
-     * See <a href="https://docs.embrace.io/docs/android-integration-guide">Embrace Docs</a> for
+     * See <a href="https://embrace.io/docs/android/">Embrace Docs</a> for
      * integration instructions. For compatibility with other networking SDKs such as Akamai,
      * the Embrace SDK must be initialized after any other SDK.
      *
@@ -45,7 +45,7 @@ interface EmbraceAndroidApi extends EmbraceApi {
      * Starts instrumentation of the Android application using the Embrace SDK. This should be
      * called during creation of the application, as early as possible.
      * <p>
-     * See <a href="https://docs.embrace.io/docs/android-integration-guide">Embrace Docs</a> for
+     * See <a href="https://embrace.io/docs/android/">Embrace Docs</a> for
      * integration instructions. For compatibility with other networking SDKs such as Akamai,
      * the Embrace SDK must be initialized after any other SDK.
      *

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -307,7 +307,7 @@ final class EmbraceImpl {
      * Starts instrumentation of the Android application using the Embrace SDK. This should be
      * called during creation of the application, as early as possible.
      * <p>
-     * See <a href="https://docs.embrace.io/docs/android-integration-guide">Embrace Docs</a> for
+     * See <a href="https://embrace.io/docs/android/">Embrace Docs</a> for
      * integration instructions. For compatibility with other networking SDKs such as Akamai,
      * the Embrace SDK must be initialized after any other SDK.
      *

--- a/scripts/release.gradle
+++ b/scripts/release.gradle
@@ -40,8 +40,8 @@ publishing {
                 url = "https://github.com/embrace-io/embrace-android-sdk"
                 licenses {
                     license {
-                        name = "Embrace license"
-                        url = "https://embrace.io/docs/embrace-software-notice/"
+                        name = "Embrace License"
+                        url = "https://embrace.io/docs/terms-of-service/"
                     }
                 }
                 developers {


### PR DESCRIPTION
## Goal

Docs have been at https://embrace.io/docs/ for years.

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

