### PR TITLE
Log how many times a signal handler was invoked

### DIFF
--- a/embrace-android-sdk/src/main/cpp/file_writer.c
+++ b/embrace-android-sdk/src/main/cpp/file_writer.c
@@ -258,6 +258,8 @@ char *emb_crash_to_json(emb_crash *crash) {
         json_array_append_value(frames_object, frame_value);
         emb_log_frame_dbg_info(i, &frame);
     }
+    EMB_LOGDEV("Signal handler was invoked %d times", crash->unhandled_count);
+
     EMB_LOGDEV("Finished serializing stackframes.");
 
     json_object_set_value(crash_object, kFramesKey, frames_value);


### PR DESCRIPTION
## Goal

Logs a message of how many times the signal handler was invoked when processing a native crash. This will help us rule out the theory that a signal handler being invoked multiple times causes problems in stacktrace quality. This information was actually already being recorded but wasn't being used.
