### PR TITLE
Remove public internal things from public docs generated by Dokka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.detekt}")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:${Versions.dokka}")
+        classpath("org.jetbrains.dokka:android-documentation-plugin:${Versions.dokka}")
     }
 }
 

--- a/embrace-android-sdk/build.gradle
+++ b/embrace-android-sdk/build.gradle
@@ -105,7 +105,8 @@ dependencies {
     testImplementation("com.google.protobuf:protobuf-java:3.24.0")
     testImplementation("com.google.protobuf:protobuf-java-util:3.24.0")
 
-    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
+    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:${Versions.dokka}")
+    dokkaHtmlPlugin("org.jetbrains.dokka:android-documentation-plugin:${Versions.dokka}")
 }
 
 dokkaHtml {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -567,6 +567,10 @@ public final class Embrace implements EmbraceAndroidApi {
         return impl.getLastRunEndState();
     }
 
+    /**
+     * Get internal interface for the intra-Embrace, not-publicly-supported API
+     * @hide
+     */
     @NonNull
     @InternalApi
     public EmbraceInternalInterface getInternalInterface() {
@@ -575,6 +579,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Logs an internal error to the Embrace SDK - this is not intended for public use.
+     * @hide
      */
     @InternalApi
     public void logInternalError(@Nullable String message, @Nullable String details) {
@@ -583,12 +588,16 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Logs an internal error to the Embrace SDK - this is not intended for public use.
+     * @hide
      */
     @InternalApi
     public void logInternalError(@NonNull Throwable error) {
         impl.logInternalError(error);
     }
 
+    /**
+     * @hide
+     */
     @Nullable
     @InternalApi
     public ConfigService getConfigService() {
@@ -598,6 +607,7 @@ public final class Embrace implements EmbraceAndroidApi {
     /**
      * Gets the {@link ReactNativeInternalInterface} that should be used as the sole source of
      * communication with the Android SDK for React Native.
+     * @hide
      */
     @Nullable
     @InternalApi
@@ -607,6 +617,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Logs a React Native Redux Action - this is not intended for public use.
+     * @hide
      */
     @InternalApi
     public void logRnAction(@NonNull String name, long startTime, long endTime,
@@ -621,6 +632,7 @@ public final class Embrace implements EmbraceAndroidApi {
      * <p>
      * If the previously logged view has the same name, a duplicate view breadcrumb will not be
      * logged.
+     * @hide
      *
      * @param screen the name of the view to log
      */
@@ -632,6 +644,7 @@ public final class Embrace implements EmbraceAndroidApi {
     /**
      * Gets the {@link UnityInternalInterface} that should be used as the sole source of
      * communication with the Android SDK for Unity.
+     * @hide
      */
     @Nullable
     @InternalApi
@@ -647,6 +660,7 @@ public final class Embrace implements EmbraceAndroidApi {
     /**
      * Gets the {@link FlutterInternalInterface} that should be used as the sole source of
      * communication with the Android SDK for Flutter.
+     * @hide
      */
     @Nullable
     @InternalApi
@@ -656,6 +670,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Sets the Embrace Flutter SDK version - this is not intended for public use.
+     * @hide
      */
     @InternalApi
     public void setEmbraceFlutterSdkVersion(@Nullable String version) {
@@ -664,6 +679,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Sets the Dart version - this is not intended for public use.
+     * @hide
      */
     @InternalApi
     public void setDartVersion(@Nullable String version) {
@@ -672,6 +688,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Logs a handled Dart error to the Embrace SDK - this is not intended for public use.
+     * @hide
      */
     @InternalApi
     public void logHandledDartException(
@@ -686,6 +703,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Logs an unhandled Dart error to the Embrace SDK - this is not intended for public use.
+     * @hide
      */
     @InternalApi
     public void logUnhandledDartException(
@@ -698,6 +716,9 @@ public final class Embrace implements EmbraceAndroidApi {
         impl.logDartException(stack, name, message, context, library, LogExceptionType.UNHANDLED);
     }
 
+    /**
+     * @hide
+     */
     @InternalApi
     public void sampleCurrentThreadDuringAnrs() {
         impl.sampleCurrentThreadDuringAnrs();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceSamples.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceSamples.kt
@@ -7,6 +7,8 @@ import io.embrace.android.embracesdk.samples.EmbraceCrashSamples
  * Helps to verify and test embrace SDK integration.
  * it allows users to execute code that automatically verifies the integration by calling the verifyIntegration method.
  * It also provides example code to generate ANR and JVM/NDK crashes
+ *
+ * @suppress
  */
 @InternalApi
 public object EmbraceSamples {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LogExceptionType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LogExceptionType.kt
@@ -6,6 +6,8 @@ import io.embrace.android.embracesdk.annotation.InternalApi
  * Enum representing the type of exception that occurred.
  * NONE is for a native android log, whether have or not an exception.
  * HANDLED or UNHANDLED are ONLY for Unity and Flutter handled and unhandled exceptions.
+ *
+ * @suppress
  */
 @InternalApi
 public enum class LogExceptionType(internal val value: String) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
@@ -6,6 +6,9 @@ import io.embrace.android.embracesdk.annotation.InternalApi;
 import io.embrace.android.embracesdk.payload.TapBreadcrumb.TapBreadcrumbType;
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger;
 
+/**
+ * @hide
+ */
 @InternalApi
 public final class ViewSwazzledHooks {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
@@ -8,6 +8,9 @@ import androidx.annotation.NonNull;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
 
+/**
+ * @hide
+ */
 @InternalApi
 public final class WebViewChromeClientSwazzledHooks {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewClientSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewClientSwazzledHooks.java
@@ -2,6 +2,9 @@ package io.embrace.android.embracesdk;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
 
+/**
+ * @hide
+ */
 @InternalApi
 public final class WebViewClientSwazzledHooks {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SpansBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SpansBehavior.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.config.behavior
 
-import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.config.remote.SpansRemoteConfig
 
-@InternalApi
 internal class SpansBehavior(
     thresholdCheck: BehaviorThresholdCheck,
     remoteSupplier: () -> SpansRemoteConfig?

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SpansRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SpansRemoteConfig.kt
@@ -1,12 +1,10 @@
 package io.embrace.android.embracesdk.config.remote
 
 import com.google.gson.annotations.SerializedName
-import io.embrace.android.embracesdk.annotation.InternalApi
 
 /**
  * Configuration values for the spans feature
  */
-@InternalApi
 internal data class SpansRemoteConfig(
     @SerializedName("pct_enabled")
     val pctEnabled: Float? = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.payload
 
 import com.google.gson.annotations.SerializedName
-import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.session.EmbraceSessionService
 import io.embrace.android.embracesdk.session.MESSAGE_TYPE_START
 
 /**
  * Represents a particular user's session within the app.
  */
-@InternalApi
 internal data class Session @JvmOverloads internal constructor(
 
     /**


### PR DESCRIPTION
## Goal

Add the Android Dokka plugin so we can use `@hide` to suppress Java things, which `@suppress` won't work for as it's a KDoc thing.
