### PR TITLE
Only log startup moment span if it's not triggered by a lateness timer

### DIFF
--- a/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
+++ b/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
@@ -105,6 +105,59 @@
     "un": "John Doe",
     "per": ["first_day"]
   },
-  "spans": "__EMBRACE_TEST_IGNORE__",
+  "spans": [
+    {
+      "attributes": {
+        "emb.sequence_id": "2",
+        "emb.private": "true",
+        "emb.key": "true",
+        "emb.type": "PERFORMANCE"
+      },
+      "end_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
+      "events": [
+        {
+          "attributes": {},
+          "name": "start-time",
+          "time_unix_nano": "__EMBRACE_TEST_IGNORE__"
+        }
+      ],
+      "name": "emb-sdk-init",
+      "parent_span_id": "0000000000000000",
+      "span_id": "__EMBRACE_TEST_IGNORE__",
+      "start_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
+      "status": "OK",
+      "trace_id": "__EMBRACE_TEST_IGNORE__"
+    },
+    {
+      "attributes": {
+        "emb.sequence_id": "3",
+        "emb.key": "true",
+        "emb.type": "PERFORMANCE"
+      },
+      "end_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
+      "events": [],
+      "name": "emb-startup-moment",
+      "parent_span_id": "0000000000000000",
+      "span_id": "__EMBRACE_TEST_IGNORE__",
+      "start_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
+      "status": "OK",
+      "trace_id": "__EMBRACE_TEST_IGNORE__"
+    },
+    {
+      "attributes": {
+        "emb.sequence_id": "1",
+        "emb.private": "true",
+        "emb.type": "SESSION"
+      },
+      "end_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
+      "events": [],
+      "name": "emb-session-span",
+      "parent_span_id": "0000000000000000",
+      "span_id": "__EMBRACE_TEST_IGNORE__",
+      "start_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
+      "status": "OK",
+      "trace_id": "__EMBRACE_TEST_IGNORE__"
+    }
+  ],
   "v": 13
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -234,7 +234,9 @@ internal class EmbraceEventService(
                 sessionProperties
             )
             if (isStartupEvent(name)) {
-                logStartupSpan()
+                if (!late) {
+                    logStartupSpan()
+                }
                 logDeveloper("EmbraceEventService", "Ending Startup Ending")
                 startupEventInfo = eventHandler.buildStartupEventInfo(
                     originEventDescription.event,


### PR DESCRIPTION
## Goal

Only log a span for the startup moment if it's not "late"

## Testing

Restored functional tests and add unit test

