### PR TITLE
Update session span start time per new clock

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
@@ -187,7 +187,7 @@ internal class SpansServiceImpl(
         synchronized(completedSpans) {
             if (appTerminationCause == null) {
                 currentSessionSpan.get().endSpan()
-                currentSessionSpan.set(startSessionSpan(TimeUnit.MILLISECONDS.toNanos(clock.now())))
+                currentSessionSpan.set(startSessionSpan(clock.now()))
             } else {
                 currentSessionSpan.get()?.let {
                     it.setAttribute(appTerminationCause.keyName(), appTerminationCause.name)


### PR DESCRIPTION
## Goal

This services uses an OpenTelemetry-compatible clock now, so `now()` returns in nano seconds. Make sure interpret it as such. 

## Testing

Existing tests pass

