### PR TITLE
Alter how periodic session caching works

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -544,7 +544,7 @@ internal class SessionHandler(
         }
 
         try {
-            this.automaticSessionStopper.scheduleAtFixedRate(
+            this.automaticSessionStopper.scheduleWithFixedDelay(
                 automaticSessionStopperCallback,
                 maxSessionSeconds.toLong(),
                 maxSessionSeconds.toLong(),
@@ -592,7 +592,7 @@ internal class SessionHandler(
      */
     private fun startPeriodicCaching(cacheCallback: Runnable) {
         try {
-            scheduledFuture = this.sessionPeriodicCacheExecutorService.scheduleAtFixedRate(
+            scheduledFuture = this.sessionPeriodicCacheExecutorService.scheduleWithFixedDelay(
                 cacheCallback,
                 0,
                 SESSION_CACHING_INTERVAL.toLong(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -211,7 +211,7 @@ internal class SessionHandlerTest {
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
         // verify automatic session stopper has been scheduled
         verify {
-            mockAutomaticSessionStopper.scheduleAtFixedRate(
+            mockAutomaticSessionStopper.scheduleWithFixedDelay(
                 mockAutomaticSessionStopperRunnable,
                 maxSessionSeconds.toLong(),
                 maxSessionSeconds.toLong(),
@@ -220,7 +220,7 @@ internal class SessionHandlerTest {
         }
         // verify periodic caching worker has been scheduled
         verify {
-            mockSessionPeriodicCacheExecutorService.scheduleAtFixedRate(
+            mockSessionPeriodicCacheExecutorService.scheduleWithFixedDelay(
                 mockPeriodicCachingRunnable,
                 0,
                 SESSION_CACHING_INTERVAL.toLong(),


### PR DESCRIPTION
## Goal

Embrace periodicially caches sessions on disk to handle the case that a crash might lead to data loss. While this is something we ultimately want to move away from, for now I've refactored the existing implementation so that it handles backpressure more gracefully.

Previously we were using a `ScheduledExecutorService` that executes a runnable at a fixed interval. This works fine for most purposes, but if the device is under severe strain then the executor service is unlikely to keep up, and will have a large queue of jobs to churn through (ironically causing more strain). Historically we had the same problem with ANR data capture.

I've therefore refactored the logic so that after each cache a new job is scheduled for the given interval.

## Testing

Relied on existing test coverage & manually verified that cached sessions make it through to the dash. I also checked that the interval is more or less the same:

```
2023-11-09 14:20:51.419  4868-4868  [Embrace] Periodic cache of session
2023-11-09 14:20:53.420  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:20:55.435  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:20:57.438  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:20:59.443  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:21:01.448  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:21:03.450  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:21:05.454  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:21:07.463  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:21:09.466  4868-4950  [Embrace] Periodic cache of session
2023-11-09 14:21:11.470  4868-4950  [Embrace] Periodic cache of session
```
