### PR TITLE
[EMBR-1230] Make rawPost private in ApiClient

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
@@ -65,12 +65,13 @@ internal class ApiClient @JvmOverloads constructor(
     /**
      * Posts a payload according to the ApiRequest parameter. The payload will be gzip compressed.
      */
-    fun post(request: ApiRequest, payload: ByteArray): String = rawPost(request, gzip(payload))
+    fun executePost(request: ApiRequest, payloadToCompress: ByteArray): String =
+        rawPost(request, gzip(payloadToCompress))
 
     /**
      * Posts a payload according to the ApiRequest parameter. The payload will not be gzip compressed.
      */
-    fun rawPost(request: ApiRequest, payload: ByteArray?): String {
+    private fun rawPost(request: ApiRequest, payload: ByteArray?): String {
         logger.logDeveloper("ApiClient", request.httpMethod.toString() + " " + request.url)
         logger.logDeveloper("ApiClient", "Request details: $request")
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
@@ -66,12 +66,12 @@ internal class ApiClient @JvmOverloads constructor(
      * Posts a payload according to the ApiRequest parameter. The payload will be gzip compressed.
      */
     fun executePost(request: ApiRequest, payloadToCompress: ByteArray): String =
-        rawPost(request, gzip(payloadToCompress))
+        executeRawPost(request, gzip(payloadToCompress))
 
     /**
      * Posts a payload according to the ApiRequest parameter. The payload will not be gzip compressed.
      */
-    private fun rawPost(request: ApiRequest, payload: ByteArray?): String {
+    private fun executeRawPost(request: ApiRequest, payload: ByteArray?): String {
         logger.logDeveloper("ApiClient", request.httpMethod.toString() + " " + request.url)
         logger.logDeveloper("ApiClient", "Request details: $request")
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
@@ -211,7 +211,7 @@ internal class EmbraceDeliveryRetryManager(
     }
 }
 
-private const val TAG = "DeliveryRetryManager"
+private const val TAG = "EmbraceDeliveryRetryManager"
 private const val RETRY_PERIOD = 120L // In seconds
 private const val MAX_EXPONENTIAL_RETRY_PERIOD = 3600 // In seconds
 private const val MAX_FAILED_CALLS = 200 // Max number of failed calls that will be cached for retry

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientTest.kt
@@ -48,27 +48,13 @@ internal class ApiClientTest {
     fun testUnreachableHost() {
         // attempt some unreachable port
         val request = ApiRequest(url = EmbraceUrl.getUrl("http://localhost:1565"))
-        apiClient.post(request, "Hello world".toByteArray())
-    }
-
-    @Test
-    fun test200ResponseUncompressed() {
-        server.enqueue(MockResponse().setBody(DEFAULT_RESPONSE_BODY))
-        val result = apiClient.rawPost(request, DEFAULT_REQUEST_BODY.toByteArray())
-
-        // assert on result parsed by ApiClient
-        Assert.assertEquals(DEFAULT_RESPONSE_BODY, result)
-
-        // assert on request received by mock server
-        val delivered = server.takeRequest()
-        assertRequestContents(delivered)
-        Assert.assertEquals(DEFAULT_REQUEST_BODY, delivered.body.readUtf8())
+        apiClient.executePost(request, "Hello world".toByteArray())
     }
 
     @Test
     fun test200ResponseCompressed() {
         server.enqueue(MockResponse().setBody(DEFAULT_RESPONSE_BODY))
-        val result = apiClient.post(request, DEFAULT_REQUEST_BODY.toByteArray())
+        val result = apiClient.executePost(request, DEFAULT_REQUEST_BODY.toByteArray())
 
         // assert on result parsed by ApiClient
         Assert.assertEquals(DEFAULT_RESPONSE_BODY, result)
@@ -82,19 +68,19 @@ internal class ApiClientTest {
     @Test(expected = RuntimeException::class)
     fun test400Response() {
         server.enqueue(MockResponse().setBody(DEFAULT_RESPONSE_BODY).setResponseCode(400))
-        apiClient.rawPost(request, DEFAULT_REQUEST_BODY.toByteArray())
+        apiClient.executePost(request, DEFAULT_REQUEST_BODY.toByteArray())
     }
 
     @Test(expected = RuntimeException::class)
     fun test500Response() {
         server.enqueue(MockResponse().setBody(DEFAULT_RESPONSE_BODY).setResponseCode(500))
-        apiClient.rawPost(request, DEFAULT_REQUEST_BODY.toByteArray())
+        apiClient.executePost(request, DEFAULT_REQUEST_BODY.toByteArray())
     }
 
     @Test(expected = RuntimeException::class)
     fun testClientSideConnectionTimeout() {
         apiClient.timeoutMs = 1000
-        apiClient.rawPost(request, DEFAULT_REQUEST_BODY.toByteArray())
+        apiClient.executePost(request, DEFAULT_REQUEST_BODY.toByteArray())
     }
 
     /**
@@ -106,7 +92,7 @@ internal class ApiClientTest {
         server.enqueue(MockResponse().setBody(DEFAULT_RESPONSE_BODY))
 
         val payload = createLargeSessionPayload()
-        val result = apiClient.post(request, payload.toByteArray())
+        val result = apiClient.executePost(request, payload.toByteArray())
 
         // assert on result parsed by ApiClient
         Assert.assertEquals(DEFAULT_RESPONSE_BODY, result)
@@ -130,7 +116,7 @@ internal class ApiClientTest {
         }, 25, TimeUnit.MILLISECONDS)
 
         // fire off the api request
-        apiClient.rawPost(request, DEFAULT_REQUEST_BODY.toByteArray())
+        apiClient.executePost(request, DEFAULT_REQUEST_BODY.toByteArray())
     }
 
     @Test
@@ -148,7 +134,7 @@ internal class ApiClientTest {
             EmbraceUrl.getUrl(baseUrl)
         )
         server.enqueue(MockResponse().setBody(DEFAULT_RESPONSE_BODY))
-        apiClient.rawPost(request, DEFAULT_REQUEST_BODY.toByteArray())
+        apiClient.executePost(request, DEFAULT_REQUEST_BODY.toByteArray())
 
         // assert all request headers were set
         val delivered = server.takeRequest()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -59,7 +59,7 @@ internal class EmbraceApiServiceTest {
     @Before
     fun setUp() {
         mockApiClient = mockk {
-            every { post(any(), any()) } returns ""
+            every { executePost(any(), any()) } returns ""
         }
         cachedConfig = CachedConfig(
             config = null,


### PR DESCRIPTION
## Goal

- The method postOnExecutor in EmbraceApiService was always being called with a true value for the compress parameter, so postRaw() method was never being called. 
- I removed the if and make rawPost private in ApiClient. 

## Testing

Updated unit tests. 


