### PR TITLE
Avoid ending session on background thread

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
@@ -54,6 +54,7 @@ internal class SessionBehavior(
     /**
      * Whether sessions are allowed to be persisted async or not.
      */
+    @Deprecated("This flag is obsolete and is no longer respected.")
     fun isAsyncEndEnabled(): Boolean =
         remote?.sessionConfig?.endAsync ?: local?.asyncEnd ?: ASYNC_END_DEFAULT
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/local/SessionLocalConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/local/SessionLocalConfig.kt
@@ -17,6 +17,7 @@ internal class SessionLocalConfig(
      * End session messages are sent asynchronously.
      */
     @SerializedName("async_end")
+    @Deprecated("This flag is obsolete and is no longer respected.")
     val asyncEnd: Boolean? = null,
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
@@ -12,6 +12,7 @@ internal data class SessionRemoteConfig(
     val isEnabled: Boolean? = null,
 
     @SerializedName("async_end")
+    @Deprecated("This flag is obsolete and is no longer respected.")
     val endAsync: Boolean? = null,
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -55,8 +55,7 @@ internal class SessionModuleImpl(
             nativeModule.nativeThreadSamplerService,
             initModule.clock,
             workerThreadModule.scheduledExecutor(ExecutorName.SESSION_CLOSER),
-            workerThreadModule.scheduledExecutor(ExecutorName.SESSION_CACHING),
-            workerThreadModule.backgroundExecutor(ExecutorName.SESSION)
+            workerThreadModule.scheduledExecutor(ExecutorName.SESSION_CACHING)
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
@@ -40,7 +40,6 @@ internal enum class ExecutorName(internal val threadName: String) {
     NATIVE_STARTUP("native-startup"),
     SESSION_CACHE_EXECUTOR("session-cache"),
     REMOTE_LOGGING("remote-logging"),
-    SESSION("session"),
     SESSION_CLOSER("session-closer"),
     SESSION_CACHING("session-caching"),
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -56,7 +56,6 @@ import org.junit.BeforeClass
 import org.junit.Test
 import java.util.Locale
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
@@ -172,8 +171,7 @@ internal class SessionHandlerTest {
             null,
             clock,
             automaticSessionStopper = mockAutomaticSessionStopper,
-            sessionPeriodicCacheExecutorService = mockSessionPeriodicCacheExecutorService,
-            Executors.newSingleThreadExecutor()
+            sessionPeriodicCacheExecutorService = mockSessionPeriodicCacheExecutorService
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
@@ -2,9 +2,7 @@ package io.embrace.android.embracesdk.worker
 
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
-import org.junit.Assert.fail
 import org.junit.Test
-import java.util.concurrent.RejectedExecutionException
 
 internal class WorkerThreadModuleImplTest {
 
@@ -13,7 +11,6 @@ internal class WorkerThreadModuleImplTest {
         val module = WorkerThreadModuleImpl()
         assertNotNull(module)
 
-        assertNotNull(module.backgroundExecutor(ExecutorName.SESSION))
         val backgroundExecutor = module.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR)
         assertNotNull(backgroundExecutor)
         assertNotNull(module.scheduledExecutor(ExecutorName.SESSION_CACHE_EXECUTOR))
@@ -23,10 +20,5 @@ internal class WorkerThreadModuleImplTest {
 
         // test shutting down module
         module.close()
-        try {
-            module.backgroundExecutor(ExecutorName.SESSION).submit {}
-            fail("Should have thrown RejectedExecutionException")
-        } catch (ignored: RejectedExecutionException) {
-        }
     }
 }


### PR DESCRIPTION
## Goal

Ending the session on a background executor is likely to cause problems. Firstly, the current implementation means that if the executor is not scheduled CPU time all the services could have their data cleared _during_ the next background activity or session.

Secondly, it's plausible that under strain the executor might not be able to run in time if a process was exiting, leaving us only with the periodic cached session.

This approach avoids respecting the `isAsyncEndEnabled()` flag. My understanding is that historically we wrote the session to disk on the main thread which is the main reason why the config was necessary. This is no longer true - `deliveryService.sendSession` submits to an executor. @fnewberg tagging you as you have the most context on the historical tradeoffs here.
