### PR TITLE
Write session to disk synchronously during crash

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal interface DeliveryCacheManager {
     fun saveSession(sessionMessage: SessionMessage): ByteArray?
+    fun saveSessionOnCrash(sessionMessage: SessionMessage)
     fun loadSession(sessionId: String): SessionMessage?
     fun loadSessionBytes(sessionId: String): ByteArray?
     fun deleteSession(sessionId: String)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 internal enum class SessionMessageState { START, END, END_WITH_CRASH }
 
 internal interface DeliveryService {
+    fun saveSessionOnCrash(sessionMessage: SessionMessage)
     fun saveSession(sessionMessage: SessionMessage)
     fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState)
     fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -36,6 +36,10 @@ internal class EmbraceDeliveryService(
         cacheManager.saveSession(sessionMessage)
     }
 
+    override fun saveSessionOnCrash(sessionMessage: SessionMessage) {
+        cacheManager.saveSessionOnCrash(sessionMessage)
+    }
+
     /**
      * Caches and sends over the network a session message
      *

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -464,6 +464,9 @@ internal class SessionHandler(
             return
         }
 
+        // let's not overwrite the crash info with the periodic caching
+        stopPeriodicSessionCaching()
+
         val fullEndSessionMessage = buildEndSessionMessage(
             originSession,
             endedCleanly = false,
@@ -483,8 +486,7 @@ internal class SessionHandler(
             "SessionHandler",
             "Sanitized End session message=$sanitizedSessionMessage"
         )
-
-        deliveryService.sendSession(sanitizedSessionMessage, SessionMessageState.END_WITH_CRASH)
+        deliveryService.saveSessionOnCrash(sanitizedSessionMessage)
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -34,6 +34,10 @@ internal class FakeDeliveryService : DeliveryService {
         lastSavedSession = sessionMessage
     }
 
+    override fun saveSessionOnCrash(sessionMessage: SessionMessage) {
+        lastSavedSession = sessionMessage
+    }
+
     override fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState) {
         lastSentSessions.add(Pair(sessionMessage, state))
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -11,6 +11,10 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
         TODO("Not yet implemented")
     }
 
+    override fun saveSessionOnCrash(sessionMessage: SessionMessage) {
+        TODO("Not yet implemented")
+    }
+
     override fun loadSession(sessionId: String): SessionMessage? {
         TODO("Not yet implemented")
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -498,10 +498,10 @@ internal class SessionHandlerTest {
         verify { mockAutomaticSessionStopper wasNot Called }
         verify { mockMemoryCleanerService wasNot Called }
         verify(exactly = 0) { mockSessionProperties.clearTemporary() }
-        assertNull(deliveryService.lastSavedSession)
+        assertTrue(deliveryService.lastSentSessions.isEmpty())
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
 
-        val session = checkNotNull(deliveryService.lastSentSessions.single().first.session)
+        val session = checkNotNull(deliveryService.lastSavedSession).session
 
         with(session) {
             assertFalse(checkNotNull(isEndedCleanly))
@@ -592,7 +592,7 @@ internal class SessionHandlerTest {
             listOf(testSpan)
         )
 
-        assertSpanInSessionMessage(deliveryService.lastSentSessions.single().first)
+        assertSpanInSessionMessage(deliveryService.lastSavedSession)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Alters session persistence in the event of a crash. Previously we were calling `DeliveryService#sendSession()` which writes the session to disk then attempts a network request in a background thread. No blocking occurs before process termination so there isn't a guarantee this information will be persisted; additionally, the periodic caching could theoretically overwrite the file.

This changeset makes two changes: firstly, we suspend periodic caching of the session. Secondly, we write the session to disk synchronously to ensure it was persisted properly.

## Testing

Updated existing test coverage & manually tested

