### PR TITLE
Extract logic for constructing ApiRequest from ApiService

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
@@ -1,0 +1,104 @@
+package io.embrace.android.embracesdk.comms.api
+
+import io.embrace.android.embracesdk.BuildConfig
+import io.embrace.android.embracesdk.EmbraceEvent
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.payload.BlobMessage
+import io.embrace.android.embracesdk.payload.EventMessage
+import io.embrace.android.embracesdk.payload.NetworkEvent
+
+internal class ApiRequestMapper(
+    private val urlBuilder: ApiUrlBuilder,
+    private val lazyDeviceId: Lazy<String>,
+    private val appId: String
+) {
+
+    private val apiUrlBuilders = Endpoint.values().associateWith {
+        urlBuilder.getEmbraceUrlWithSuffix(it.path)
+    }
+
+    private fun Endpoint.asEmbraceUrl(): EmbraceUrl {
+        val urlString: String = checkNotNull(apiUrlBuilders[this])
+        return EmbraceUrl.create(urlString)
+    }
+
+    private fun requestBuilder(url: EmbraceUrl): ApiRequest {
+        return ApiRequest(
+            url = url,
+            httpMethod = HttpMethod.POST,
+            appId = appId,
+            deviceId = lazyDeviceId.value,
+            contentEncoding = "gzip"
+        )
+    }
+
+    fun configRequest(url: String) = ApiRequest(
+        contentType = "application/json",
+        userAgent = "Embrace/a/" + BuildConfig.VERSION_NAME,
+        accept = "application/json",
+        url = EmbraceUrl.create(url),
+        httpMethod = HttpMethod.GET,
+    )
+
+    fun logRequest(
+        eventMessage: EventMessage
+    ): ApiRequest {
+        checkNotNull(eventMessage.event) { "event must be set" }
+        val event = eventMessage.event
+        val type = checkNotNull(event.type) { "event type must be set" }
+        checkNotNull(event.eventId) { "event ID must be set" }
+        val url = Endpoint.LOGGING.asEmbraceUrl()
+        val abbreviation = type.abbreviation
+        val logIdentifier = abbreviation + ":" + event.messageId
+        return requestBuilder(url).copy(logId = logIdentifier)
+    }
+
+    fun sessionRequest(): ApiRequest {
+        val url = Endpoint.SESSIONS.asEmbraceUrl()
+        return requestBuilder(url)
+    }
+
+    fun eventMessageRequest(eventMessage: EventMessage): ApiRequest {
+        checkNotNull(eventMessage.event) { "event must be set" }
+        val event = eventMessage.event
+        checkNotNull(event.type) { "event type must be set" }
+        checkNotNull(event.eventId) { "event ID must be set" }
+        val url = Endpoint.EVENTS.asEmbraceUrl()
+        val abbreviation = event.type.abbreviation
+        val eventIdentifier: String = if (event.type == EmbraceEvent.Type.CRASH) {
+            createCrashActiveEventsHeader(abbreviation, event.activeEventIds)
+        } else {
+            abbreviation + ":" + event.eventId
+        }
+        return requestBuilder(url).copy(eventId = eventIdentifier)
+    }
+
+    fun networkEventRequest(networkEvent: NetworkEvent): ApiRequest {
+        val url = Endpoint.NETWORK.asEmbraceUrl()
+        val abbreviation = EmbraceEvent.Type.NETWORK_LOG.abbreviation
+        val networkIdentifier = "$abbreviation:${networkEvent.eventId}"
+        return requestBuilder(url).copy(logId = networkIdentifier)
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun aeiBlobRequest(blobMessage: BlobMessage): ApiRequest {
+        val url = Endpoint.BLOBS.asEmbraceUrl()
+        return requestBuilder(url)
+    }
+
+    /**
+     * Crashes are sent with a header containing the list of active stories.
+     *
+     * @param abbreviation the abbreviation for the event type
+     * @param eventIds     the list of story IDs
+     * @return the header
+     */
+    private fun createCrashActiveEventsHeader(
+        abbreviation: String,
+        eventIds: List<String>?
+    ): String {
+        val stories = eventIds?.joinToString(",") ?: ""
+        return "$abbreviation:$stories"
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.Future
 internal interface ApiService {
     fun getConfig(): RemoteConfig?
     fun getCachedConfig(): CachedConfig
-    fun sendLogs(eventMessage: EventMessage)
+    fun sendLog(eventMessage: EventMessage)
     fun sendNetworkCall(networkEvent: NetworkEvent)
     fun sendEvent(eventMessage: EventMessage)
     fun sendEventAndWait(eventMessage: EventMessage)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.comms.api
 
 import com.google.gson.stream.JsonReader
 import io.embrace.android.embracesdk.BuildConfig
-import io.embrace.android.embracesdk.EmbraceEvent
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityListener
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryCacheManager
@@ -29,14 +28,14 @@ internal class EmbraceApiService(
     private val scheduledExecutorService: ScheduledExecutorService,
     private val cacheManager: DeliveryCacheManager,
     private val deliveryRetryManager: DeliveryRetryManager,
-    private val lazyDeviceId: Lazy<String>,
-    private val appId: String,
+    lazyDeviceId: Lazy<String>,
+    appId: String,
     urlBuilder: ApiUrlBuilder,
     networkConnectivityService: NetworkConnectivityService
 ) : ApiService, NetworkConnectivityListener {
 
+    private val mapper = ApiRequestMapper(urlBuilder, lazyDeviceId, appId)
     private val configUrl = urlBuilder.getConfigUrl()
-    private val apiUrlBuilders = Endpoint.values().associateWith { urlBuilder.getEmbraceUrlWithSuffix(it.path) }
     private var lastNetworkStatus: NetworkStatus = NetworkStatus.UNKNOWN
 
     init {
@@ -61,6 +60,7 @@ internal class EmbraceApiService(
             request = request.copy(eTag = cachedResponse.eTag)
         }
         val response = apiClient.executeGet(request)
+
         return when (response.statusCode) {
             HttpURLConnection.HTTP_OK -> {
                 logger.logInfo("Fetched new config successfully.")
@@ -108,14 +108,8 @@ internal class EmbraceApiService(
      * @param eventMessage the event message containing the log entry
      * @return a future containing the response body from the server
      */
-    override fun sendLogs(eventMessage: EventMessage) {
-        apiUrlBuilders[Endpoint.LOGGING]?.let { url ->
-            val event = eventMessage.event
-            val abbreviation = event.type.abbreviation
-            val logIdentifier = abbreviation + ":" + event.messageId
-            val request: ApiRequest = buildRequest(EmbraceUrl.create(url)).copy(logId = logIdentifier)
-            postEvent(eventMessage, request)
-        }
+    override fun sendLog(eventMessage: EventMessage) {
+        post(eventMessage, mapper::logRequest)
     }
 
     /**
@@ -125,19 +119,7 @@ internal class EmbraceApiService(
      * @return a future containing the response body from the server
      */
     override fun sendAEIBlob(blobMessage: BlobMessage) {
-        apiUrlBuilders[Endpoint.BLOBS]?.let { url ->
-            val embraceUrl = EmbraceUrl.create(url)
-            // TODO: remove seemingly unnecessary parameters once this is better tested
-            val request: ApiRequest = buildRequest(embraceUrl).copy(
-                deviceId = lazyDeviceId.value,
-                appId = appId,
-                url = embraceUrl,
-                httpMethod = HttpMethod.POST,
-                contentEncoding = "gzip"
-            )
-
-            postAEIBlob(blobMessage, request)
-        }
+        post(blobMessage, mapper::aeiBlobRequest)
     }
 
     /**
@@ -146,12 +128,7 @@ internal class EmbraceApiService(
      * @param networkEvent the event containing the network call information
      */
     override fun sendNetworkCall(networkEvent: NetworkEvent) {
-        apiUrlBuilders[Endpoint.NETWORK]?.let { url ->
-            val abbreviation = EmbraceEvent.Type.NETWORK_LOG.abbreviation
-            val networkIdentifier = "$abbreviation:${networkEvent.eventId}"
-            val request: ApiRequest = buildRequest(EmbraceUrl.create(url)).copy(logId = networkIdentifier)
-            postNetworkEvent(networkEvent, request)
-        }
+        post(networkEvent, mapper::networkEventRequest)
     }
 
     /**
@@ -160,9 +137,7 @@ internal class EmbraceApiService(
      * @param eventMessage the event message containing the event
      */
     override fun sendEvent(eventMessage: EventMessage) {
-        createRequest(eventMessage)?.let { request ->
-            postEvent(eventMessage, request)
-        }
+        post(eventMessage, mapper::eventMessageRequest)
     }
 
     /**
@@ -171,9 +146,7 @@ internal class EmbraceApiService(
      * @param eventMessage the event message containing the event
      */
     override fun sendEventAndWait(eventMessage: EventMessage) {
-        createRequest(eventMessage)?.let { request ->
-            postEvent(eventMessage, request)?.get()
-        }
+        post(eventMessage, mapper::eventMessageRequest)?.get()
     }
 
     /**
@@ -182,94 +155,34 @@ internal class EmbraceApiService(
      * @param crash the event message containing the crash
      */
     override fun sendCrash(crash: EventMessage) {
-        createRequest(crash)?.let { request ->
-            try {
-                postEvent(crash, request) { cacheManager.deleteCrash() }?.get(
-                    CRASH_TIMEOUT,
-                    TimeUnit.SECONDS
-                )
-            } catch (e: Exception) {
-                logger.logError("The crash report request has timed out.")
-            }
-        }
-    }
-
-    override fun sendSession(sessionPayload: ByteArray, onFinish: (() -> Unit)?): Future<*>? {
-        apiUrlBuilders[Endpoint.SESSIONS]?.let { url ->
-            val embraceUrl = EmbraceUrl.create(url)
-            // TODO: remove seemingly unnecessary parameters once this is better tested
-            val request: ApiRequest = buildRequest(embraceUrl).copy(
-                deviceId = lazyDeviceId.value,
-                appId = appId,
-                url = embraceUrl,
-                httpMethod = HttpMethod.POST,
-                contentEncoding = "gzip"
+        try {
+            post(crash, mapper::eventMessageRequest) { cacheManager.deleteCrash() }?.get(
+                CRASH_TIMEOUT,
+                TimeUnit.SECONDS
             )
-            return postOnExecutor(sessionPayload, request, onFinish)
+        } catch (e: Exception) {
+            logger.logError("The crash report request has timed out.")
         }
-
-        return null
     }
 
-    private fun createRequest(eventMessage: EventMessage): ApiRequest? {
-        apiUrlBuilders[Endpoint.EVENTS]?.let { url ->
-            val event = eventMessage.event
-            val abbreviation = event.type.abbreviation
-            val eventIdentifier: String = if (event.type == EmbraceEvent.Type.CRASH) {
-                createCrashActiveEventsHeader(abbreviation, event.activeEventIds)
-            } else {
-                abbreviation + ":" + event.eventId
-            }
-            return buildRequest(EmbraceUrl.create(url)).copy(eventId = eventIdentifier)
-        }
-
-        return null
+    override fun sendSession(sessionPayload: ByteArray, onFinish: (() -> Unit)?): Future<*> {
+        val request: ApiRequest = mapper.sessionRequest()
+        return postOnExecutor(sessionPayload, request, onFinish)
     }
 
-    private fun postEvent(eventMessage: EventMessage, request: ApiRequest): Future<*>? {
-        return postEvent(eventMessage, request, null)
-    }
-
-    private fun postEvent(
-        eventMessage: EventMessage,
-        request: ApiRequest,
-        onComplete: (() -> Unit)?
+    private inline fun <reified T> post(
+        payload: T,
+        mapper: (T) -> ApiRequest,
+        noinline onComplete: (() -> Unit)? = null
     ): Future<*>? {
-        val bytes = serializer.bytesFromPayload(eventMessage, EventMessage::class.java)
+        val bytes = serializer.bytesFromPayload(payload, T::class.java)
+        val request: ApiRequest = mapper(payload)
 
         bytes?.let {
             logger.logDeveloper(TAG, "Post event")
             return postOnExecutor(it, request, onComplete)
         }
-        logger.logError("Failed to serialize event")
-        return null
-    }
-
-    private fun postNetworkEvent(
-        event: NetworkEvent,
-        request: ApiRequest
-    ): Future<*>? {
-        val bytes = serializer.bytesFromPayload(event, NetworkEvent::class.java)
-
-        bytes?.let {
-            logger.logDeveloper(TAG, "Post Network Event")
-            return postOnExecutor(it, request, null)
-        }
-        logger.logError("Failed to serialize event")
-        return null
-    }
-
-    private fun postAEIBlob(
-        blob: BlobMessage,
-        request: ApiRequest
-    ): Future<*>? {
-        val bytes = serializer.bytesFromPayload(blob, BlobMessage::class.java)
-
-        bytes?.let {
-            logger.logDeveloper(TAG, "Post AEI Blob message")
-            return postOnExecutor(it, request, null)
-        }
-        logger.logError("Failed to serialize event")
+        logger.logError("Failed to post event")
         return null
     }
 
@@ -294,32 +207,6 @@ internal class EmbraceApiService(
                 onComplete?.invoke()
             }
         }
-    }
-
-    private fun buildRequest(url: EmbraceUrl): ApiRequest {
-        return ApiRequest(
-            url = url,
-            httpMethod = HttpMethod.POST,
-            appId = appId,
-            deviceId = lazyDeviceId.value,
-            contentEncoding = "gzip"
-        )
-    }
-
-    /**
-     * Crashes are sent with a header containing the list of active stories.
-     *
-     * @param abbreviation the abbreviation for the event type
-     * @param eventIds     the list of story IDs
-     * @return the header
-     */
-    private fun createCrashActiveEventsHeader(
-        abbreviation: String,
-        eventIds: List<String>?
-    ): String {
-        logger.logDeveloper(TAG, "createCrashActiveEventsHeader")
-        val stories = eventIds?.joinToString(",") ?: ""
-        return "$abbreviation:$stories"
     }
 
     private fun executePost(request: ApiRequest, payload: ByteArray) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -159,7 +159,7 @@ internal class EmbraceDeliveryService(
     }
 
     override fun sendLogs(eventMessage: EventMessage) {
-        apiService.sendLogs(eventMessage)
+        apiService.sendLog(eventMessage)
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
@@ -1,0 +1,127 @@
+package io.embrace.android.embracesdk.comms.api
+
+import io.embrace.android.embracesdk.EmbraceEvent
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.payload.AppInfo
+import io.embrace.android.embracesdk.payload.BlobMessage
+import io.embrace.android.embracesdk.payload.Event
+import io.embrace.android.embracesdk.payload.EventMessage
+import io.embrace.android.embracesdk.payload.NetworkCapturedCall
+import io.embrace.android.embracesdk.payload.NetworkEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class ApiRequestMapperTest {
+
+    companion object {
+        private const val BASE_URL = "http://example.com/api"
+        private const val CONFIG_URL = "http://example.com/config"
+    }
+
+    private val deviceId = lazy { "deviceId" }
+    private val mapper = ApiRequestMapper(
+        urlBuilder = EmbraceApiUrlBuilder(
+            BASE_URL,
+            CONFIG_URL,
+            "appId",
+            deviceId,
+            lazy { "appVersionName" }
+        ),
+        lazyDeviceId = deviceId,
+        appId = "appId"
+    )
+
+    @Test
+    fun testConfigRequest() {
+        with(mapper.configRequest(CONFIG_URL)) {
+            assertEquals(CONFIG_URL, url.toString())
+            assertEquals("application/json", contentType)
+            assertEquals("application/json", accept)
+            assertTrue(userAgent.startsWith("Embrace/a/"))
+            assertEquals(HttpMethod.GET, httpMethod)
+        }
+    }
+
+    @Test
+    fun testLogRequest() {
+        val request = mapper.logRequest(
+            EventMessage(
+                Event(
+                    type = EmbraceEvent.Type.INFO_LOG,
+                    eventId = "eventId",
+                    messageId = "messageId"
+                )
+            )
+        )
+        request.assertCoreFieldsPopulated("/v1/log/logging")
+        assertEquals("il:messageId", request.logId)
+    }
+
+    @Test
+    fun testSessionRequest() {
+        val request = mapper.sessionRequest()
+        request.assertCoreFieldsPopulated("/v1/log/sessions")
+    }
+
+    @Test
+    fun testEventMessageRequest() {
+        val request = mapper.eventMessageRequest(
+            EventMessage(
+                Event(
+                    type = EmbraceEvent.Type.INFO_LOG,
+                    eventId = "eventId"
+                )
+            )
+        )
+        request.assertCoreFieldsPopulated("/v1/log/events")
+        assertEquals("il:eventId", request.eventId)
+    }
+
+    @Test
+    fun testCrashRequest() {
+        val request = mapper.eventMessageRequest(
+            EventMessage(
+                Event(
+                    type = EmbraceEvent.Type.CRASH,
+                    eventId = "eventId",
+                    activeEventIdsList = listOf("activeEventId1", "activeEventId2")
+                )
+            )
+        )
+        request.assertCoreFieldsPopulated("/v1/log/events")
+        assertEquals("c:activeEventId1,activeEventId2", request.eventId)
+    }
+
+    @Test
+    fun testNetworkEventRequest() {
+        val request = mapper.networkEventRequest(
+            NetworkEvent(
+                "eventId",
+                AppInfo(),
+                deviceId.value,
+                "eventId",
+                NetworkCapturedCall(),
+                "timestamp",
+                null,
+                null
+            )
+        )
+        request.assertCoreFieldsPopulated("/v1/log/network")
+        assertEquals("n:eventId", request.logId)
+    }
+
+    @Test
+    fun testAeiBlobRequest() {
+        val request = mapper.aeiBlobRequest(BlobMessage())
+        request.assertCoreFieldsPopulated("/v1/log/blobs")
+    }
+
+    private fun ApiRequest.assertCoreFieldsPopulated(endpoint: String) {
+        assertEquals("$BASE_URL$endpoint", url.toString())
+        assertEquals(HttpMethod.POST, httpMethod)
+        assertEquals("appId", appId)
+        assertEquals("deviceId", deviceId)
+        assertEquals("gzip", contentEncoding)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -154,7 +154,7 @@ internal class EmbraceApiServiceTest {
                 type = EmbraceEvent.Type.ERROR_LOG
             )
         )
-        apiService.sendLogs(event)
+        apiService.sendLog(event)
         verifyOnlyRequest(
             expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/logging",
             expectedLogId = "el:message-id",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
@@ -18,7 +18,7 @@ internal class FakeApiService : ApiService {
         TODO("Not yet implemented")
     }
 
-    override fun sendLogs(eventMessage: EventMessage) {
+    override fun sendLog(eventMessage: EventMessage) {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
## Goal

Extracts the logic for constructing `ApiRequest` objects into a separate file. This makes it easier to unit test the business logic for mapping events/sessions to `ApiRequest`.

This is necessary for future work that will give failed request types different priorities on the retry queue. This is mostly just a case of lifting functions into a separate source file, although I did remove/alter some redundant code in a couple of functions.

## Testing

Added unit test coverage.
