### PR TITLE
Allow session retries to continue

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequest.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequest.kt
@@ -62,4 +62,10 @@ internal data class ApiRequest(
             throw IllegalStateException(ex.localizedMessage ?: "", ex)
         }
     }
+
+    /**
+     * Returns true if the request is a session request. This heuristic should not be widely used
+     * - it is only used to prioritise session requests over other requests.
+     */
+    fun isSessionRequest(): Boolean = url.toString().endsWith("sessions")
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
@@ -43,7 +43,7 @@ internal class EmbraceDeliveryRetryManager(
      */
     override fun scheduleForRetry(request: ApiRequest, payload: ByteArray) {
         logger.logDeveloper(TAG, "Scheduling api call for retry")
-        if (pendingRetriesCount() < MAX_FAILED_CALLS) {
+        if (pendingRetriesCount() < MAX_FAILED_CALLS || request.isSessionRequest()) {
             val scheduleJob = retryQueue.isEmpty()
             val cachedPayloadName = cacheManager.savePayload(payload)
             val failedApiCall = DeliveryFailedApiCall(request, cachedPayloadName)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestTest.kt
@@ -4,7 +4,10 @@ import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.network.http.HttpMethod
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class ApiRequestTest {
@@ -28,7 +31,7 @@ internal class ApiRequestTest {
 
     @Test
     fun testFullHeaders() {
-        Assert.assertEquals(
+        assertEquals(
             mapOf(
                 "Accept" to "application/json",
                 "User-Agent" to "Embrace/a/1",
@@ -48,7 +51,7 @@ internal class ApiRequestTest {
     @Test
     fun testMinimalHeaders() {
         val minimal = ApiRequest(url = EmbraceUrl.create("https://google.com"))
-        Assert.assertEquals(
+        assertEquals(
             mapOf(
                 "Accept" to "application/json",
                 "User-Agent" to "Embrace/a/${BuildConfig.VERSION_NAME}",
@@ -63,14 +66,14 @@ internal class ApiRequestTest {
         val expectedInfo = ResourceReader.readResourceAsText("api_request.json")
             .filter { !it.isWhitespace() }
         val observed = serializer.toJson(request)
-        Assert.assertEquals(expectedInfo, observed)
+        assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("api_request.json")
         val obj = serializer.fromJson(json, ApiRequest::class.java)
-        Assert.assertEquals(
+        assertEquals(
             mapOf(
                 "Accept" to "application/json",
                 "User-Agent" to "Embrace/a/1",
@@ -90,6 +93,14 @@ internal class ApiRequestTest {
     @Test
     fun testEmptyObject() {
         val info = serializer.fromJson("{}", ApiRequest::class.java)
-        Assert.assertNotNull(info)
+        assertNotNull(info)
+    }
+
+    @Test
+    fun testSessionRequest() {
+        assertFalse(request.isSessionRequest())
+
+        val copy = request.copy(url = EmbraceUrl.create("https://example.com/sessions"))
+        assertTrue(copy.isSessionRequest())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
@@ -1,8 +1,13 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.EmbraceEvent
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.comms.api.ApiRequest
+import io.embrace.android.embracesdk.comms.api.ApiRequestMapper
+import io.embrace.android.embracesdk.comms.api.EmbraceApiUrlBuilder
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.payload.Event
+import io.embrace.android.embracesdk.payload.EventMessage
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -241,12 +246,53 @@ internal class EmbraceDeliveryRetryManagerTest {
 
         assertEquals(0, deliveryRetryManager.pendingRetriesCount())
 
-        val mockApiRequest = mockk<ApiRequest>()
+        val mockApiRequest = mockk<ApiRequest>(relaxed = true)
         repeat(201) {
             deliveryRetryManager.scheduleForRetry(mockApiRequest, "{ dummy_payload }".toByteArray())
             blockingScheduledExecutorService.runCurrentlyBlocked()
         }
         assertEquals(200, deliveryRetryManager.pendingRetriesCount())
+    }
+
+    @Test
+    fun `queue prioritises keeping sessions when saturated`() {
+        initDeliveryRetryManager(status = NetworkStatus.WIFI, loadFailedRequest = false)
+
+        // populate queue with logs up to max of 200 items
+        val mapper = ApiRequestMapper(
+            EmbraceApiUrlBuilder(
+                "https://data.emb-api.com",
+                "https://config.emb-api.com",
+                "appId",
+                lazy { "deviceId" },
+                lazy { "appVersionName" }
+            ),
+            lazy { "deviceId" }, "appId"
+        )
+        repeat(250) { k ->
+            val request = mapper.logRequest(
+                EventMessage(
+                    Event(
+                        type = EmbraceEvent.Type.INFO_LOG,
+                        eventId = "eventId",
+                        messageId = "message_id_$k"
+                    )
+                )
+            )
+            deliveryRetryManager.scheduleForRetry(request, ByteArray(0))
+        }
+
+        // verify logs were added to the queue, and that most recently added requests are dropped
+        assertEquals(200, failedApiCalls.size)
+        assertEquals("il:message_id_0", failedApiCalls.first().apiRequest.logId)
+        assertEquals("il:message_id_199", failedApiCalls.last().apiRequest.logId)
+
+        // now add some sessions for retry
+        deliveryRetryManager.scheduleForRetry(mapper.sessionRequest(), ByteArray(0))
+        assertEquals(201, failedApiCalls.size)
+        assertEquals("il:message_id_0", failedApiCalls.first().apiRequest.logId)
+        val request = failedApiCalls.last().apiRequest
+        assertTrue(request.url.toString().endsWith("/sessions"))
     }
 
     private fun clearApiPipeline() {


### PR DESCRIPTION
## Goal

Allows session retries to continue past the limit of 200 requests. There are a couple of ways this could be done - I chose the fairly naive approach of just allowing session requests to go past the arbitrary limit. This approach is fairly simple to implement & it's unlikely that this will add more than a few extra retries to the queue.

## Testing

Added unit test coverage.
