### PR TITLE
Convert ApiResponse into a seal class.

### DIFF
--- a/embrace-android-sdk/config/detekt/baseline.xml
+++ b/embrace-android-sdk/config/detekt/baseline.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>UseCheckOrError:EmbraceApiService.kt$EmbraceApiService$throw IllegalStateException("Failed to retrieve from Embrace server.")</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-sdk/config/detekt/baseline.xml
+++ b/embrace-android-sdk/config/detekt/baseline.xml
@@ -1,6 +1,7 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues/>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
+    <ID>UseCheckOrError:EmbraceApiService.kt$EmbraceApiService$throw IllegalStateException("Failed to retrieve from Embrace server.")</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
@@ -7,13 +7,13 @@ internal interface ApiClient {
     /**
      * Executes [ApiRequest] as a GET, returning the response as a [ApiResponse]
      */
-    fun executeGet(request: ApiRequest): ApiResponse<String>
+    fun executeGet(request: ApiRequest): ApiResponse
 
     /**
      * Executes [ApiRequest] as a POST with the given body defined by [payloadToCompress], returning the response as a [ApiResponse].
      * The body will be gzip compressed.
      */
-    fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse<String>
+    fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse
 
     companion object {
         /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
@@ -23,6 +23,8 @@ internal interface ApiClient {
 
         const val NO_HTTP_RESPONSE = -1
 
+        const val TOO_MANY_REQUESTS = 429
+
         const val defaultTimeoutMs = 60 * 1000
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
@@ -31,7 +31,8 @@ internal class ApiClientImpl(
             connection = request.toConnection()
             setTimeouts(connection)
             connection.connect()
-            executeHttpRequest(connection)
+            val response = executeHttpRequest(connection)
+            response
         } catch (ex: Throwable) {
             ApiResponse.Error(IllegalStateException(ex.localizedMessage ?: "", ex))
         } finally {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
@@ -34,7 +34,7 @@ internal class ApiClientImpl(
             val response = executeHttpRequest(connection)
             response
         } catch (ex: Throwable) {
-            ApiResponse.Error(IllegalStateException(ex.localizedMessage ?: "", ex))
+            ApiResponse.Incomplete(IllegalStateException(ex.localizedMessage ?: "", ex))
         } finally {
             runCatching {
                 connection?.inputStream?.close()
@@ -64,7 +64,7 @@ internal class ApiClientImpl(
             val response = executeHttpRequest(connection)
             response
         } catch (ex: Throwable) {
-            ApiResponse.Error(IllegalStateException(ex.localizedMessage ?: "", ex))
+            ApiResponse.Incomplete(IllegalStateException(ex.localizedMessage ?: "", ex))
         } finally {
             runCatching {
                 connection?.inputStream?.close()
@@ -96,7 +96,7 @@ internal class ApiClientImpl(
                 ApiResponse.Failure(errorMessage, responseCode, responseHeaders)
             }
         } catch (exc: Throwable) {
-            ApiResponse.Error(IllegalStateException("Error occurred during HTTP request execution", exc))
+            ApiResponse.Incomplete(IllegalStateException("Error occurred during HTTP request execution", exc))
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
@@ -24,7 +24,7 @@ internal class ApiClientImpl(
     private val logger: InternalEmbraceLogger
 ) : ApiClient {
 
-    override fun executeGet(request: ApiRequest): ApiResponse<String> {
+    override fun executeGet(request: ApiRequest): ApiResponse {
         var connection: EmbraceConnection? = null
 
         return try {
@@ -42,13 +42,13 @@ internal class ApiClientImpl(
         }
     }
 
-    override fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse<String> =
+    override fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse =
         executeRawPost(request, gzip(payloadToCompress))
 
     /**
      * Posts a payload according to the ApiRequest parameter. The payload will not be gzip compressed.
      */
-    private fun executeRawPost(request: ApiRequest, payload: ByteArray?): ApiResponse<String> {
+    private fun executeRawPost(request: ApiRequest, payload: ByteArray?): ApiResponse {
         logger.logDeveloper("ApiClient", request.httpMethod.toString() + " " + request.url)
         logger.logDeveloper("ApiClient", "Request details: $request")
 
@@ -81,7 +81,7 @@ internal class ApiClientImpl(
      * Executes a HTTP call using the specified connection, returning the response from the
      * server as a string.
      */
-    private fun executeHttpRequest(connection: EmbraceConnection): ApiResponse<String> {
+    private fun executeHttpRequest(connection: EmbraceConnection): ApiResponse {
         return try {
             val responseCode = readHttpResponseCode(connection)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
@@ -17,5 +17,5 @@ internal sealed class ApiResponse<out T> {
     /**
      * Represents an exception thrown while making the API call.
      */
-    data class Error(val exception: Throwable) : ApiResponse<Nothing>()
+    data class Incomplete(val exception: Throwable) : ApiResponse<Nothing>()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
@@ -1,7 +1,21 @@
 package io.embrace.android.embracesdk.comms.api
 
-internal data class ApiResponse<T>(
-    val statusCode: Int?,
-    val headers: Map<String, String>,
-    val body: T?
-)
+/**
+ * ApiResponse is a sealed class that represents the result of an API call.
+ */
+internal sealed class ApiResponse<out T> {
+    /**
+     * Represents a successful API call (status code 200-299)
+     */
+    data class Success<T>(val body: T?, val headers: Map<String, String>?) : ApiResponse<T>()
+
+    /**
+     * Represents a failed API call. (status code 400-499 or 500-599)
+     */
+    data class Failure(val errorMessage: String?, val code: Int, val headers: Map<String, String>?) : ApiResponse<Nothing>()
+
+    /**
+     * Represents an exception thrown while making the API call.
+     */
+    data class Error(val exception: Throwable) : ApiResponse<Nothing>()
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
@@ -5,14 +5,29 @@ package io.embrace.android.embracesdk.comms.api
  */
 internal sealed class ApiResponse {
     /**
-     * Represents a successful API call (status code 200-299)
+     * Represents an API call that returned a 200 OK status code.
      */
     data class Success(val body: String?, val headers: Map<String, String>?) : ApiResponse()
 
     /**
+     * Represents an API call that returned a 304 Not Modified status code.
+     */
+    object NotModified : ApiResponse()
+
+    /**
+     * Represents an API call that returned a 413 Payload Too Large status code.
+     */
+    object PayloadTooLarge : ApiResponse()
+
+    /**
+     * Represents an API call that returned a 429 Too Many Requests status code.
+     */
+    data class TooManyRequests(val retryAfter: Long?) : ApiResponse()
+
+    /**
      * Represents a failed API call. (status code 400-499 or 500-599)
      */
-    data class Failure(val errorMessage: String?, val code: Int, val headers: Map<String, String>?) : ApiResponse()
+    data class Failure(val code: Int, val headers: Map<String, String>?) : ApiResponse()
 
     /**
      * Represents an exception thrown while making the API call.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
@@ -25,7 +25,7 @@ internal sealed class ApiResponse {
     data class TooManyRequests(val retryAfter: Long?) : ApiResponse()
 
     /**
-     * Represents a failed API call. (status code 400-499 or 500-599)
+     * Represents a failed API call. (status code 400-499 or 500-599 except 413 and 429)
      */
     data class Failure(val code: Int, val headers: Map<String, String>?) : ApiResponse()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponse.kt
@@ -3,19 +3,19 @@ package io.embrace.android.embracesdk.comms.api
 /**
  * ApiResponse is a sealed class that represents the result of an API call.
  */
-internal sealed class ApiResponse<out T> {
+internal sealed class ApiResponse {
     /**
      * Represents a successful API call (status code 200-299)
      */
-    data class Success<T>(val body: T?, val headers: Map<String, String>?) : ApiResponse<T>()
+    data class Success(val body: String?, val headers: Map<String, String>?) : ApiResponse()
 
     /**
      * Represents a failed API call. (status code 400-499 or 500-599)
      */
-    data class Failure(val errorMessage: String?, val code: Int, val headers: Map<String, String>?) : ApiResponse<Nothing>()
+    data class Failure(val errorMessage: String?, val code: Int, val headers: Map<String, String>?) : ApiResponse()
 
     /**
      * Represents an exception thrown while making the API call.
      */
-    data class Incomplete(val exception: Throwable) : ApiResponse<Nothing>()
+    data class Incomplete(val exception: Throwable) : ApiResponse()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -61,7 +61,7 @@ internal class EmbraceApiService(
         }
 
         return when (val response = apiClient.executeGet(request)) {
-            is ApiResponse.Success<String> -> {
+            is ApiResponse.Success -> {
                 logger.logInfo("Fetched new config successfully.")
                 val jsonReader = JsonReader(StringReader(response.body))
                 serializer.loadObject(jsonReader, RemoteConfig::class.java)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -83,7 +83,7 @@ internal class EmbraceApiService(
                     }
                 }
             }
-            is ApiResponse.Error -> {
+            is ApiResponse.Incomplete -> {
                 logger.logWarning("Failed to fetch config.", response.exception)
                 throw response.exception
             }
@@ -224,7 +224,7 @@ internal class EmbraceApiService(
                 logger.logWarning("Post failed with code: ${response.code}")
                 throw IllegalStateException("Failed to retrieve from Embrace server.")
             }
-            is ApiResponse.Error -> {
+            is ApiResponse.Incomplete -> {
                 // Temporarily, we just throw an exception. In the future, we will handle this.
                 logger.logError("Post failed with exception: ${response.exception.message}")
                 throw IllegalStateException("Failed to retrieve from Embrace server.")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -73,7 +73,7 @@ internal class EmbraceApiService(
             is ApiResponse.TooManyRequests -> {
                 // TODO: We should retry after the retryAfter time or 3 seconds and apply exponential backoff.
                 logger.logWarning("Too many requests. ")
-                throw IllegalStateException("Too many requests.")
+                null
             }
             is ApiResponse.Failure -> {
                 logger.logInfo("Failed to fetch config (no response).")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -214,6 +214,7 @@ internal class EmbraceApiService(
         }
     }
 
+    @Suppress("UseCheckOrError")
     private fun executePost(request: ApiRequest, payload: ByteArray) {
         when (val response = apiClient.executePost(request, payload)) {
             is ApiResponse.Success -> {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
@@ -67,7 +67,7 @@ internal class ApiClientImplTest {
     fun testPost200ResponseCompressed() {
         server.enqueue(response200)
         val response = runPostRequest()
-        check(response is ApiResponse.Success<String>)
+        check(response is ApiResponse.Success)
         assertEquals(DEFAULT_RESPONSE_BODY, response.body)
 
         val delivered = server.takeRequest()
@@ -199,7 +199,7 @@ internal class ApiClientImplTest {
         )
     }
 
-    private fun runGetRequest(): ApiResponse<String> =
+    private fun runGetRequest(): ApiResponse =
         apiClient.executeGet(
             ApiRequest(
                 url = EmbraceUrl.create(baseUrl),
@@ -209,7 +209,7 @@ internal class ApiClientImplTest {
 
     private fun runPostRequest(
         payload: ByteArray = DEFAULT_REQUEST_BODY.toByteArray()
-    ): ApiResponse<String> =
+    ): ApiResponse =
         apiClient.executePost(
             ApiRequest(
                 url = EmbraceUrl.create(baseUrl),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
@@ -49,7 +49,7 @@ internal class ApiClientImplTest {
         // attempt some unreachable port
         val request = ApiRequest(url = EmbraceUrl.create("http://localhost:1565"))
         val response = apiClient.executePost(request, "Hello world".toByteArray())
-        check(response is ApiResponse.Error)
+        check(response is ApiResponse.Incomplete)
         assertTrue(response.exception is IllegalStateException)
     }
 
@@ -110,14 +110,14 @@ internal class ApiClientImplTest {
     @Test
     fun testGetConnectionThrows() {
         val response = apiClient.executeGet(createThrowingRequest())
-        check(response is ApiResponse.Error)
+        check(response is ApiResponse.Incomplete)
         assertTrue(response.exception is java.lang.IllegalStateException)
     }
 
     @Test
     fun testPostConnectionThrows() {
         val response = apiClient.executePost(createThrowingRequest(), DEFAULT_REQUEST_BODY.toByteArray())
-        check(response is ApiResponse.Error)
+        check(response is ApiResponse.Incomplete)
         assertTrue(response.exception is java.lang.IllegalStateException)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
@@ -156,8 +156,8 @@ internal class ApiClientImplTest {
 
         // fire off the api request
         val response = runPostRequest()
-        check(response is ApiResponse.Failure)
-        assertEquals(-1, response.code)
+        check(response is ApiResponse.Incomplete)
+        assertTrue(response.exception is IllegalStateException)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -64,8 +64,7 @@ internal class EmbraceApiServiceTest {
     @Test
     fun `test getConfig returns correct values in Response`() {
         fakeApiClient.queueResponse(
-            ApiResponse(
-                statusCode = 200,
+            ApiResponse.Success(
                 headers = emptyMap(),
                 body = defaultConfigResponseBody
             )
@@ -82,8 +81,8 @@ internal class EmbraceApiServiceTest {
 
     @Test(expected = SocketException::class)
     fun `getConfig rethrows an exception thrown by apiClient`() {
-        val killerResponse: ApiResponse<String> = mockk(relaxed = true)
-        every { killerResponse.statusCode } answers { throw SocketException() }
+        val killerResponse: ApiResponse.Failure = mockk(relaxed = true)
+        every { killerResponse.code } answers { throw SocketException() }
         fakeApiClient.queueResponse(killerResponse)
         apiService.getConfig()
     }
@@ -91,10 +90,10 @@ internal class EmbraceApiServiceTest {
     @Test
     fun `cached remote config returned when 304 received`() {
         fakeApiClient.queueResponse(
-            ApiResponse(
-                statusCode = 304,
-                headers = emptyMap(),
-                body = null,
+            ApiResponse.Failure(
+                errorMessage = "Not modified",
+                code = 304,
+                headers = emptyMap()
             )
         )
         assertEquals(cachedConfig.remoteConfig, apiService.getConfig())
@@ -103,10 +102,10 @@ internal class EmbraceApiServiceTest {
     @Test
     fun `getConfig did not complete returns a null config`() {
         fakeApiClient.queueResponse(
-            ApiResponse(
-                statusCode = NO_HTTP_RESPONSE,
-                headers = emptyMap(),
-                body = null
+            ApiResponse.Failure(
+                errorMessage = "No response code",
+                code = NO_HTTP_RESPONSE,
+                headers = emptyMap()
             )
         )
         assertNull(apiService.getConfig())
@@ -115,10 +114,10 @@ internal class EmbraceApiServiceTest {
     @Test
     fun `getConfig results in unexpected response code returns a null config`() {
         fakeApiClient.queueResponse(
-            ApiResponse(
-                statusCode = 400,
-                headers = emptyMap(),
-                body = null
+            ApiResponse.Failure(
+                errorMessage = "Bad Request",
+                code = 400,
+                headers = emptyMap()
             )
         )
         assertNull(apiService.getConfig())
@@ -129,10 +128,10 @@ internal class EmbraceApiServiceTest {
         val cfg = RemoteConfig()
         cachedConfig = CachedConfig(cfg, "my_etag")
         fakeApiClient.queueResponse(
-            ApiResponse(
-                statusCode = 304,
-                headers = emptyMap(),
-                body = null
+            ApiResponse.Failure(
+                errorMessage = "Not modified",
+                code = 304,
+                headers = emptyMap()
             )
         )
         val remoteConfig = apiService.getConfig()
@@ -291,8 +290,7 @@ internal class EmbraceApiServiceTest {
         private const val fakeDeviceId = "ajflkadsflkadslkfjds"
         private const val fakeAppVersionName = "6.1.0"
         private val defaultConfigResponseBody = ResourceReader.readResourceAsText("remote_config_response.json")
-        private val successfulPostResponse = ApiResponse(
-            statusCode = 200,
+        private val successfulPostResponse = ApiResponse.Success(
             headers = emptyMap(),
             body = ""
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiClient.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiClient.kt
@@ -8,17 +8,17 @@ import java.util.Queue
 
 internal class FakeApiClient : ApiClient {
     val sentRequests: MutableList<Pair<ApiRequest, ByteArray?>> = mutableListOf()
-    private val queuedResponses: Queue<ApiResponse<String>> = LinkedList()
+    private val queuedResponses: Queue<ApiResponse> = LinkedList()
 
-    override fun executeGet(request: ApiRequest): ApiResponse<String> = getNext(request, null)
+    override fun executeGet(request: ApiRequest): ApiResponse = getNext(request, null)
 
-    override fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse<String> = getNext(request, payloadToCompress)
+    override fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse = getNext(request, payloadToCompress)
 
-    fun queueResponse(response: ApiResponse<String>) {
+    fun queueResponse(response: ApiResponse) {
         queuedResponses.add(response)
     }
 
-    private fun getNext(request: ApiRequest, bytes: ByteArray?): ApiResponse<String> {
+    private fun getNext(request: ApiRequest, bytes: ByteArray?): ApiResponse {
         sentRequests.add(Pair(request, bytes))
         return checkNotNull(queuedResponses.poll()) { "No response" }
     }


### PR DESCRIPTION
## Goal

- Convert ApiResponse into a seal class.
- This way ApiClient will always return an ApiResponse of type Success, Failure or Error. 

## Testing

Updated unit tests. 

