### PR TITLE
Stop setting KVM group permissions on CI job

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -21,13 +21,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # EMB-11508 - See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
## Goal

CI is intermittently failing because [some machines](https://github.com/embrace-io/embrace-android-sdk/actions/runs/6862892082/job/18661536915?pr=55) don't have KVM installed.

We don't actually use KVM in the one job where it is enabled because there isn't any step that loads an emulator. Therefore it should be safe to remove this & prevent CI failing intermittently.
