### PR TITLE
Add lock for creating session ordinal

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -62,6 +62,8 @@ internal class SessionHandler(
     private val sessionPeriodicCacheExecutorService: ScheduledExecutorService
 ) : Closeable {
 
+    private val sharedPrefLock = Any()
+
     @VisibleForTesting
     var scheduledFuture: ScheduledFuture<*>? = null
 
@@ -506,12 +508,15 @@ internal class SessionHandler(
     }
 
     /**
-     * @return session number incremented by 1
+     * Increments the session ordinal number and saves it to shared preferences. This is used
+     * in our telemetry to track session loss %.
      */
     private fun incrementAndGetSessionNumber(): Int {
-        val sessionNumber = preferencesService.sessionNumber + 1
-        preferencesService.sessionNumber = sessionNumber
-        return sessionNumber
+        synchronized(sharedPrefLock) {
+            val sessionNumber = preferencesService.sessionNumber + 1
+            preferencesService.sessionNumber = sessionNumber
+            return sessionNumber
+        }
     }
 
     /**


### PR DESCRIPTION
## Goal

Adds synchronisation so that there is no possibility of a race condition when creating the session ordinal. Admittedly this function is only called in one place when a session is started, but there isn't currently any synchronisation for the session starting so a double-call could lead to misleading dropped session %.

This lock might be something we can remove when looking at how the session boundary control works more generally.
