### PR TITLE
Reduce duplication in session ending logic

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -17,7 +17,7 @@ internal class EmbraceSessionService(
     private val sessionProperties: EmbraceSessionProperties,
     private val logger: InternalEmbraceLogger,
     private val sessionHandler: SessionHandler,
-    private val deliveryService: DeliveryService,
+    deliveryService: DeliveryService,
     isNdkEnabled: Boolean,
     private val clock: Clock,
     private val spansService: SpansService
@@ -41,11 +41,6 @@ internal class EmbraceSessionService(
          */
         const val SESSION_CACHING_INTERVAL = 2
     }
-
-    /**
-     * Synchronization lock.
-     */
-    private val lock = Any()
 
     /**
      * SDK startup time. Only set for cold start sessions.
@@ -86,10 +81,8 @@ internal class EmbraceSessionService(
     override fun startSession(coldStart: Boolean, startType: Session.SessionLifeEventType, startTime: Long) {
         val automaticSessionCloserCallback = Runnable {
             try {
-                synchronized(lock) {
-                    logger.logInfo("Automatic session closing triggered.")
-                    triggerStatelessSessionEnd(Session.SessionLifeEventType.TIMED)
-                }
+                logger.logInfo("Automatic session closing triggered.")
+                triggerStatelessSessionEnd(Session.SessionLifeEventType.TIMED)
             } catch (ex: Exception) {
                 logger.logError("Error while trying to close the session automatically", ex)
             }
@@ -117,15 +110,13 @@ internal class EmbraceSessionService(
         logger.logDeveloper(TAG, "Attempt to handle crash id: $crashId")
 
         activeSession?.also {
-            synchronized(lock) {
-                sessionHandler.onCrash(
-                    it,
-                    crashId,
-                    sessionProperties,
-                    sdkStartupDuration,
-                    spansService.flushSpans(EmbraceAttributes.AppTerminationCause.CRASH)
-                )
-            }
+            sessionHandler.onCrash(
+                it,
+                crashId,
+                sessionProperties,
+                sdkStartupDuration,
+                spansService.flushSpans(EmbraceAttributes.AppTerminationCause.CRASH)
+            )
         } ?: logger.logDeveloper(TAG, "Active session is NULL")
     }
 
@@ -135,17 +126,12 @@ internal class EmbraceSessionService(
 
     fun onPeriodicCacheActiveSession() {
         try {
-            synchronized(lock) {
-                val activeSessionInfo = sessionHandler.getActiveSessionEndMessage(
-                    activeSession,
-                    sessionProperties,
-                    sdkStartupDuration,
-                    spansService.completedSpans()
-                )
-                activeSessionInfo?.let {
-                    deliveryService.saveSession(it)
-                }
-            }
+            sessionHandler.onPeriodicCacheActiveSession(
+                activeSession,
+                sessionProperties,
+                sdkStartupDuration,
+                spansService.completedSpans()
+            )
         } catch (ex: Exception) {
             logger.logDebug("Error while caching active session", ex)
         }
@@ -158,9 +144,7 @@ internal class EmbraceSessionService(
 
     private fun startStateSession(coldStart: Boolean, endTime: Long) {
         logger.logDeveloper(TAG, "Start state session. Is cold start: $coldStart")
-        synchronized(lock) {
-            startSession(coldStart, Session.SessionLifeEventType.STATE, endTime)
-        }
+        startSession(coldStart, Session.SessionLifeEventType.STATE, endTime)
     }
 
     override fun onBackground(timestamp: Long) {
@@ -200,21 +184,19 @@ internal class EmbraceSessionService(
      * @param endType the origin of the event that ends the session.
      */
     private fun endSession(endType: Session.SessionLifeEventType, endTime: Long) {
-        synchronized(lock) {
-            logger.logDebug("Will try to end session.")
-            sessionHandler.onSessionEnded(
-                endType,
-                activeSession,
-                sessionProperties,
-                sdkStartupDuration,
-                endTime,
-                spansService.flushSpans()
-            )
+        logger.logDebug("Will try to end session.")
+        sessionHandler.onSessionEnded(
+            endType,
+            activeSession,
+            sessionProperties,
+            sdkStartupDuration,
+            endTime,
+            spansService.flushSpans()
+        )
 
-            // clear active session
-            activeSession = null
-            logger.logDeveloper(TAG, "Active session cleared")
-        }
+        // clear active session
+        activeSession = null
+        logger.logDeveloper(TAG, "Active session cleared")
     }
 
     override fun close() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -126,8 +126,9 @@ internal class EmbraceSessionService(
 
     fun onPeriodicCacheActiveSession() {
         try {
+            val session = activeSession ?: return
             sessionHandler.onPeriodicCacheActiveSession(
-                activeSession,
+                session,
                 sessionProperties,
                 sdkStartupDuration,
                 spansService.completedSpans()
@@ -185,9 +186,10 @@ internal class EmbraceSessionService(
      */
     private fun endSession(endType: Session.SessionLifeEventType, endTime: Long) {
         logger.logDebug("Will try to end session.")
+        val session = activeSession ?: return
         sessionHandler.onSessionEnded(
             endType,
-            activeSession,
+            session,
             sessionProperties,
             sdkStartupDuration,
             endTime,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -199,21 +199,22 @@ internal class EmbraceSessionService(
      *
      * @param endType the origin of the event that ends the session.
      */
-    @Synchronized
     private fun endSession(endType: Session.SessionLifeEventType, endTime: Long) {
-        logger.logDebug("Will try to end session.")
-        sessionHandler.onSessionEnded(
-            endType,
-            activeSession,
-            sessionProperties,
-            sdkStartupDuration,
-            endTime,
-            spansService.flushSpans()
-        )
+        synchronized(lock) {
+            logger.logDebug("Will try to end session.")
+            sessionHandler.onSessionEnded(
+                endType,
+                activeSession,
+                sessionProperties,
+                sdkStartupDuration,
+                endTime,
+                spansService.flushSpans()
+            )
 
-        // clear active session
-        activeSession = null
-        logger.logDeveloper(TAG, "Active session cleared")
+            // clear active session
+            activeSession = null
+            logger.logDeveloper(TAG, "Active session cleared")
+        }
     }
 
     override fun close() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -47,6 +47,32 @@ internal class SessionHandler(
     private val sessionPeriodicCacheExecutorService: ScheduledExecutorService
 ) : Closeable {
 
+    /**
+     * Defines the states in which a session can end.
+     */
+    private enum class SessionEndType(
+        val endedCleanly: Boolean,
+        val forceQuit: Boolean,
+        val shouldStopCaching: Boolean
+    ) {
+
+        /**
+         * The end session happened in the normal way (i.e. process state changes or manual/timed end).
+         */
+        NORMAL_END(true, false, true),
+
+        /**
+         * The end session is being constructed so that it can be periodically cached. This avoids
+         * the scenario of data loss in the event of NDK crashes.
+         */
+        CACHED_END(false, true, false),
+
+        /**
+         * The end session is being constructed because of a JVM crash.
+         */
+        JVM_CRASH_END(false, false, true);
+    }
+
     var scheduledFuture: ScheduledFuture<*>? = null
 
     /**
@@ -109,14 +135,26 @@ internal class SessionHandler(
         completedSpans: List<EmbraceSpanData>? = null
     ) {
         logger.logDebug("Will try to run end session full.")
-        runEndSessionFull(
-            endType,
+        if (originSession == null) {
+            return
+        }
+        val fullEndSessionMessage = runEndSessionImpl(
+            SessionEndType.NORMAL_END,
             originSession,
             sessionProperties,
             sdkStartupDuration,
-            endTime,
-            completedSpans
-        )
+            completedSpans,
+            endType,
+            endTime
+        ) ?: return
+
+        // Clean every collection of those services which have collections in memory.
+        memoryCleanerService.cleanServicesCollections(exceptionService)
+        metadataService.removeActiveSessionId(originSession.sessionId)
+        logger.logDebug("Services collections successfully cleaned.")
+        sessionProperties.clearTemporary()
+        logger.logDebug("Session properties successfully temporary cleared.")
+        deliveryService.sendSession(fullEndSessionMessage, SessionMessageState.END)
     }
 
     /**
@@ -131,13 +169,17 @@ internal class SessionHandler(
         completedSpans: List<EmbraceSpanData>? = null
     ) {
         logger.logDebug("Will try to run end session for crash.")
-        runEndSessionForCrash(
+        val fullEndSessionMessage = runEndSessionImpl(
+            SessionEndType.JVM_CRASH_END,
             originSession,
-            crashId,
             sessionProperties,
             sdkStartupDuration,
-            completedSpans
+            completedSpans,
+            SessionLifeEventType.STATE,
+            clock.now(),
+            crashId,
         )
+        fullEndSessionMessage?.let(deliveryService::saveSessionOnCrash)
     }
 
     /**
@@ -154,11 +196,14 @@ internal class SessionHandler(
     ): SessionMessage? {
         return activeSession?.let {
             logger.logDebug("Will try to run end session for caching.")
-            runEndSessionForCaching(
+            runEndSessionImpl(
+                SessionEndType.CACHED_END,
                 activeSession,
                 sessionProperties,
                 sdkStartupDuration,
-                completedSpans
+                completedSpans,
+                SessionLifeEventType.STATE,
+                clock.now()
             )
         } ?: kotlin.run {
             logger.logDebug("Will no perform active session caching because there is no active session available.")
@@ -208,6 +253,7 @@ internal class SessionHandler(
                 logger.logDebug("Session is STATE, it is always allowed to end.")
                 true
             }
+
             SessionLifeEventType.MANUAL, SessionLifeEventType.TIMED -> {
                 logger.logDebug("Session is either MANUAL or TIMED.")
                 if (!configService.sessionBehavior.isSessionControlEnabled()) {
@@ -231,126 +277,44 @@ internal class SessionHandler(
     }
 
     /**
-     * It builds an end active session message, it sanitizes it, it performs all types of memory cleaning,
-     * it updates cache and it sends it to our servers.
-     * It also stops periodic caching and automatic session stopper.
+     * 'Ends' the active session. Note that this logic is also used for caching the session
+     * periodically so the session won't always end. The behavior is controlled by the
+     * [SessionEndType] passed to this function.
      */
-    private fun runEndSessionFull(
-        endType: SessionLifeEventType,
-        originSession: Session?,
-        sessionProperties: EmbraceSessionProperties,
-        sdkStartupDuration: Long,
-        endTime: Long,
-        completedSpans: List<EmbraceSpanData>?
-    ) {
-        if (!isAllowedToEnd(endType, originSession)) {
-            logger.logDebug("Session not allowed to end.")
-            return
-        }
-
-        stopPeriodicSessionCaching()
-
-        if (!configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.SESSION)) {
-            logger.logWarning("Session messages disabled. Ignoring all Sessions.")
-            return
-        }
-
-        val fullEndSessionMessage = sessionMessageCollator.buildEndSessionMessage(
-            /* we are previously checking in allowSessionToEnd that originSession != null */
-            originSession!!,
-            endedCleanly = true,
-            forceQuit = false,
-            null,
-            endType,
-            sessionProperties,
-            sdkStartupDuration,
-            endTime,
-            completedSpans
-        )
-
-        logger.logDeveloper("SessionHandler", "End session message=$fullEndSessionMessage")
-
-        // Clean every collection of those services which have collections in memory.
-        memoryCleanerService.cleanServicesCollections(exceptionService)
-        metadataService.removeActiveSessionId(originSession.sessionId)
-        logger.logDebug("Services collections successfully cleaned.")
-
-        sessionProperties.clearTemporary()
-        logger.logDebug("Session properties successfully temporary cleared.")
-        deliveryService.sendSession(fullEndSessionMessage, SessionMessageState.END)
-    }
-
-    /**
-     * It builds an end active session message, it sanitizes it, it updates cache and it sends it to our servers synchronously.
-     *
-     * This is because when a crash happens, we do not have the ability to start a background
-     * thread because the JVM will soon kill the process. So we force the request to be performed
-     * in main thread.
-     *
-     * Note that this may cause ANRs. In the future we should come up with a better approach.
-     *
-     * Also note that we do not perform any memory cleaning because since the app is about to crash,
-     * we do not to waste time on those things.
-     */
-    private fun runEndSessionForCrash(
-        originSession: Session,
-        crashId: String,
-        sessionProperties: EmbraceSessionProperties,
-        sdkStartupDuration: Long,
-        completedSpans: List<EmbraceSpanData>?
-    ) {
-        if (!isAllowedToEnd(SessionLifeEventType.STATE, originSession)) {
-            logger.logDebug("Session not allowed to end.")
-            return
-        }
-
-        // let's not overwrite the crash info with the periodic caching
-        stopPeriodicSessionCaching()
-
-        val fullEndSessionMessage = sessionMessageCollator.buildEndSessionMessage(
-            originSession,
-            endedCleanly = false,
-            forceQuit = false,
-            crashId,
-            SessionLifeEventType.STATE,
-            sessionProperties,
-            sdkStartupDuration,
-            clock.now(),
-            completedSpans
-        )
-        logger.logDeveloper("SessionHandler", "End session message=$fullEndSessionMessage")
-        deliveryService.saveSessionOnCrash(fullEndSessionMessage)
-    }
-
-    /**
-     * It builds an end active session message and it updates cache.
-     *
-     * Note that it does not send the session to our servers.
-     */
-    private fun runEndSessionForCaching(
+    private fun runEndSessionImpl(
+        endType: SessionEndType,
         activeSession: Session,
         sessionProperties: EmbraceSessionProperties,
         sdkStartupDuration: Long,
-        completedSpans: List<EmbraceSpanData>?
+        completedSpans: List<EmbraceSpanData>?,
+        lifeEventType: SessionLifeEventType,
+        endTime: Long,
+        crashId: String? = null,
     ): SessionMessage? {
-        if (!isAllowedToEnd(SessionLifeEventType.STATE, activeSession)) {
+        if (endType.shouldStopCaching) {
+            stopPeriodicSessionCaching()
+        }
+        if (!configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.SESSION)) {
+            logger.logWarning("Session messages disabled. Ignoring all Sessions.")
+            return null
+        }
+        if (!isAllowedToEnd(lifeEventType, activeSession)) {
             logger.logDebug("Session not allowed to end.")
             return null
         }
 
         val fullEndSessionMessage = sessionMessageCollator.buildEndSessionMessage(
             activeSession,
-            endedCleanly = false,
-            forceQuit = true,
-            null,
-            SessionLifeEventType.STATE,
+            endedCleanly = endType.endedCleanly,
+            forceQuit = endType.forceQuit,
+            crashId,
+            lifeEventType,
             sessionProperties,
             sdkStartupDuration,
-            clock.now(),
+            endTime,
             completedSpans
         )
         logger.logDeveloper("SessionHandler", "End session message=$fullEndSessionMessage")
-
         return fullEndSessionMessage
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -316,17 +316,16 @@ internal class EmbraceSessionServiceTest {
     fun `verify periodic caching`() {
         initializeSessionService()
 
+        service.startSession(true, SessionLifeEventType.STATE, clock.now())
         service.onPeriodicCacheActiveSession()
 
         verify {
-            mockSessionHandler.getActiveSessionEndMessage(
-                /* either null active session or valid active session, same test */ null,
+            mockSessionHandler.onPeriodicCacheActiveSession(
+                any(),
                 mockSessionProperties,
                 0
             )
         }
-
-        assertNotNull(deliveryService.lastSavedSession)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -87,7 +87,7 @@ internal class EmbraceSessionServiceTest {
         verify {
             mockSessionHandler.onSessionStarted(
                 /* automatically detecting a cold start */ true,
-                Session.SessionLifeEventType.STATE,
+                SessionLifeEventType.STATE,
                 any(),
                 mockSessionProperties,
                 any(),
@@ -100,7 +100,7 @@ internal class EmbraceSessionServiceTest {
     fun `start session successfully`() {
         initializeSessionService()
         val coldStart = /* same for false */ true
-        val type = /* could be any type */ Session.SessionLifeEventType.STATE
+        val type = /* could be any type */ SessionLifeEventType.STATE
         every {
             mockSessionHandler.onSessionStarted(
                 coldStart,
@@ -134,7 +134,7 @@ internal class EmbraceSessionServiceTest {
     fun `start session if not allowed then session handler will return a null session`() {
         initializeSessionService()
         val coldStart = /* same for false */ true
-        val type = /* could be any type */ Session.SessionLifeEventType.STATE
+        val type = /* could be any type */ SessionLifeEventType.STATE
         every {
             mockSessionHandler.onSessionStarted(
                 coldStart,
@@ -171,14 +171,14 @@ internal class EmbraceSessionServiceTest {
         every {
             mockSessionHandler.onSessionStarted(
                 true,
-                Session.SessionLifeEventType.STATE,
+                SessionLifeEventType.STATE,
                 any(),
                 mockSessionProperties,
                 any(),
                 any()
             )
         } returns mockSessionMessage
-        service.startSession(true, Session.SessionLifeEventType.STATE, clock.now())
+        service.startSession(true, SessionLifeEventType.STATE, clock.now())
 
         service.handleCrash(crashId)
 
@@ -198,7 +198,7 @@ internal class EmbraceSessionServiceTest {
         verify {
             mockSessionHandler.onSessionStarted(
                 coldStart,
-                Session.SessionLifeEventType.STATE,
+                SessionLifeEventType.STATE,
                 456,
                 mockSessionProperties,
                 any(),
@@ -219,7 +219,7 @@ internal class EmbraceSessionServiceTest {
         verify {
             mockSessionHandler.onSessionStarted(
                 coldStart,
-                Session.SessionLifeEventType.STATE,
+                SessionLifeEventType.STATE,
                 456,
                 mockSessionProperties,
                 any(),
@@ -241,7 +241,7 @@ internal class EmbraceSessionServiceTest {
         // verify session is ended
         verify {
             mockSessionHandler.onSessionEnded(
-                Session.SessionLifeEventType.STATE,
+                SessionLifeEventType.STATE,
                 mockSession,
                 mockSessionProperties,
                 sdkStartupDuration,
@@ -258,12 +258,12 @@ internal class EmbraceSessionServiceTest {
         // let's start session first so we have an active session
         startDefaultSession()
 
-        service.triggerStatelessSessionEnd(Session.SessionLifeEventType.MANUAL)
+        service.triggerStatelessSessionEnd(SessionLifeEventType.MANUAL)
 
         // verify session is ended
         verify {
             mockSessionHandler.onSessionEnded(
-                Session.SessionLifeEventType.MANUAL,
+                SessionLifeEventType.MANUAL,
                 mockSession,
                 mockSessionProperties,
                 0,
@@ -277,7 +277,7 @@ internal class EmbraceSessionServiceTest {
         initializeSessionService(isActivityInBackground = false)
         // let's start session first so we have an active session
         startDefaultSession()
-        val endType = Session.SessionLifeEventType.MANUAL
+        val endType = SessionLifeEventType.MANUAL
 
         service.triggerStatelessSessionEnd(endType)
 
@@ -299,7 +299,7 @@ internal class EmbraceSessionServiceTest {
     @Test
     fun `trigger stateless end session for a STATE session end type should not do anything`() {
         initializeSessionService()
-        service.triggerStatelessSessionEnd(Session.SessionLifeEventType.STATE)
+        service.triggerStatelessSessionEnd(SessionLifeEventType.STATE)
 
         verify { mockSessionHandler wasNot Called }
     }
@@ -443,13 +443,13 @@ internal class EmbraceSessionServiceTest {
         every {
             mockSessionHandler.onSessionStarted(
                 true,
-                Session.SessionLifeEventType.STATE,
+                SessionLifeEventType.STATE,
                 any(),
                 mockSessionProperties,
                 any(),
                 any()
             )
         } returns mockSessionMessage
-        service.startSession(true, Session.SessionLifeEventType.STATE, clock.now())
+        service.startSession(true, SessionLifeEventType.STATE, clock.now())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -532,7 +532,7 @@ internal class SessionHandlerTest {
 
     @Test
     fun `onPeriodicCacheActiveSession caches session successfully`() {
-        val sessionMessage = sessionHandler.getActiveSessionEndMessage(
+        val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
             mockActiveSession,
             mockSessionProperties,
             /* any duration */2
@@ -551,7 +551,7 @@ internal class SessionHandlerTest {
 
     @Test
     fun `onPeriodicCacheActiveSession does not cache if there is no active session`() {
-        val sessionMessage = sessionHandler.getActiveSessionEndMessage(
+        val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
             null,
             mockSessionProperties,
             /* any duration */2
@@ -598,7 +598,7 @@ internal class SessionHandlerTest {
 
     @Test
     fun `periodically cached sessions included currently completed spans`() {
-        val sessionMessage = sessionHandler.getActiveSessionEndMessage(
+        val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
             mockActiveSession,
             mockSessionProperties,
             10L,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -377,25 +377,6 @@ internal class SessionHandlerTest {
     }
 
     @Test
-    fun `onSession not allowed to end because no active session available`() {
-        sessionHandler.onSessionEnded(
-            /* any type */ Session.SessionLifeEventType.STATE,
-            null,
-            mockSessionProperties,
-            /* any duration */ 2,
-            1000
-        )
-
-        verify { mockSessionPeriodicCacheExecutorService wasNot Called }
-        verify { mockAutomaticSessionStopper wasNot Called }
-        verify { mockMemoryCleanerService wasNot Called }
-        verify { mockSessionProperties wasNot Called }
-
-        assertTrue(deliveryService.lastSentSessions.isEmpty())
-        assertEquals(0, gatingService.sessionMessagesFiltered.size)
-    }
-
-    @Test
     fun `onSession not allowed to end because session control is disabled for MANUAL event type`() {
         sessionHandler.onSessionEnded(
             Session.SessionLifeEventType.MANUAL,
@@ -547,19 +528,6 @@ internal class SessionHandlerTest {
         verify(exactly = 0) { mockSessionProperties.clearTemporary() }
         assertTrue(deliveryService.lastSentSessions.isEmpty())
         assertEquals(0, gatingService.sessionMessagesFiltered.size)
-    }
-
-    @Test
-    fun `onPeriodicCacheActiveSession does not cache if there is no active session`() {
-        val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
-            null,
-            mockSessionProperties,
-            /* any duration */2
-        )
-
-        assertNull(sessionMessage)
-
-        assertTrue(deliveryService.lastSentSessions.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Goal

The existing implementation of `SessionHandler` duplicates business logic on how sessions should be ended. This changeset reduces that duplication & creates an explicit enum type that models the different way a session can end.

@bidetofevil would appreciate an in-depth review on this one, as it feels like there is a lot of complexity here.

## Testing

Relied on existing unit test coverage in `SessionHandlerTest`.

