### PR TITLE
Fix incorrect usage of @Synchronized in SessionHandler

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -200,21 +200,22 @@ internal class EmbraceSessionService(
      *
      * @param endType the origin of the event that ends the session.
      */
-    @Synchronized
     private fun endSession(endType: Session.SessionLifeEventType, endTime: Long) {
-        logger.logDebug("Will try to end session.")
-        sessionHandler.onSessionEnded(
-            endType,
-            activeSession,
-            sessionProperties,
-            sdkStartupDuration,
-            endTime,
-            spansService.flushSpans()
-        )
+        synchronized(lock) {
+            logger.logDebug("Will try to end session.")
+            sessionHandler.onSessionEnded(
+                endType,
+                activeSession,
+                sessionProperties,
+                sdkStartupDuration,
+                endTime,
+                spansService.flushSpans()
+            )
 
-        // clear active session
-        activeSession = null
-        logger.logDeveloper(TAG, "Active session cleared")
+            // clear active session
+            activeSession = null
+            logger.logDeveloper(TAG, "Active session cleared")
+        }
     }
 
     override fun close() {


### PR DESCRIPTION
## Goal

Ending the session uses `@Synchronized` but every other function synchronises on the `lock` property. This changeset updates it to use the same lock.

Further changes to the synchronisation will be made in future PRs.