### PR TITLE
Use remote limit as ceiling for network call limits and apply consistently

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
@@ -71,7 +71,7 @@ internal class NetworkBehaviorTest {
             assertFalse(isRequestContentLengthCaptureEnabled())
             assertTrue(isNativeNetworkingMonitoringEnabled())
             assertEquals(1000, getNetworkCaptureLimit())
-            assertEquals(emptyMap<String, Int>(), getNetworkCallLimitsPerDomain())
+            assertEquals(emptyMap<String, Int>(), getNetworkCallLimitsPerDomainSuffix())
             assertTrue(isUrlEnabled("google.com"))
             assertFalse(isCaptureBodyEncryptionEnabled())
             assertNull(getCapturePublicKey())
@@ -85,7 +85,7 @@ internal class NetworkBehaviorTest {
             assertEquals("x-custom-trace", getTraceIdHeader())
             assertTrue(isRequestContentLengthCaptureEnabled())
             assertFalse(isNativeNetworkingMonitoringEnabled())
-            assertEquals(mapOf("google.com" to 100), getNetworkCallLimitsPerDomain())
+            assertEquals(mapOf("google.com" to 100), getNetworkCallLimitsPerDomainSuffix())
             assertEquals(720, getNetworkCaptureLimit())
             assertFalse(isUrlEnabled("google.com"))
             assertTrue(isCaptureBodyEncryptionEnabled())
@@ -97,7 +97,7 @@ internal class NetworkBehaviorTest {
     fun testRemoteOnly() {
         with(fakeNetworkBehavior(localCfg = { null }, remoteCfg = { remote })) {
             assertEquals(409, getNetworkCaptureLimit())
-            assertEquals(mapOf("google.com" to 50), getNetworkCallLimitsPerDomain())
+            assertEquals(mapOf("google.com" to 50), getNetworkCallLimitsPerDomainSuffix())
             assertTrue(isUrlEnabled("google.com"))
             assertFalse(isUrlEnabled("example.com"))
             assertEquals(
@@ -116,7 +116,7 @@ internal class NetworkBehaviorTest {
     fun testRemoteAndLocal() {
         with(fakeNetworkBehavior(localCfg = { local }, remoteCfg = { remote })) {
             assertEquals(409, getNetworkCaptureLimit())
-            assertEquals(mapOf("google.com" to 50), getNetworkCallLimitsPerDomain())
+            assertEquals(mapOf("google.com" to 50), getNetworkCallLimitsPerDomainSuffix())
             assertTrue(isUrlEnabled("google.com"))
             assertFalse(isUrlEnabled("example.com"))
             assertEquals(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
@@ -41,7 +41,7 @@ internal class NetworkBehaviorTest {
                 )
             ),
             disabledUrlPatterns = listOf("google.com"),
-            defaultCaptureLimit = 220,
+            defaultCaptureLimit = 720,
         ),
         capturePublicKey = "test"
     )
@@ -86,10 +86,29 @@ internal class NetworkBehaviorTest {
             assertTrue(isRequestContentLengthCaptureEnabled())
             assertFalse(isNativeNetworkingMonitoringEnabled())
             assertEquals(mapOf("google.com" to 100), getNetworkCallLimitsPerDomain())
-            assertEquals(220, getNetworkCaptureLimit())
+            assertEquals(720, getNetworkCaptureLimit())
             assertFalse(isUrlEnabled("google.com"))
             assertTrue(isCaptureBodyEncryptionEnabled())
             assertEquals("test", getCapturePublicKey())
+        }
+    }
+
+    @Test
+    fun testRemoteOnly() {
+        with(fakeNetworkBehavior(localCfg = { null }, remoteCfg = { remote })) {
+            assertEquals(409, getNetworkCaptureLimit())
+            assertEquals(mapOf("google.com" to 50), getNetworkCallLimitsPerDomain())
+            assertTrue(isUrlEnabled("google.com"))
+            assertFalse(isUrlEnabled("example.com"))
+            assertEquals(
+                NetworkCaptureRuleRemoteConfig(
+                    "test",
+                    5000,
+                    "GET",
+                    "google.com",
+                ),
+                getNetworkCaptureRules().single()
+            )
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
@@ -2,79 +2,45 @@ package io.embrace.android.embracesdk.network.logging
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.local.DomainLocalConfig
-import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.NetworkLocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
+import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.NetworkSessionV2.DomainCount
-import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.utils.at
-import io.mockk.clearAllMocks
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.unmockkAll
 import io.mockk.verify
-import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
 import java.util.UUID
 
 internal class EmbraceNetworkLoggingServiceTest {
-    private lateinit var service: EmbraceNetworkLoggingService
-
-    companion object {
-        private lateinit var configService: ConfigService
-        private lateinit var localConfig: LocalConfig
-        private lateinit var memoryCleanerService: MemoryCleanerService
-        private lateinit var metadataService: FakeAndroidMetadataService
-        private lateinit var logger: InternalEmbraceLogger
-        private lateinit var networkCaptureService: EmbraceNetworkCaptureService
-        private lateinit var cfg: SdkLocalConfig
-
-        @BeforeClass
-        @JvmStatic
-        fun beforeClass() {
-            configService = mockk(relaxed = true) {
-                every { networkBehavior } returns fakeNetworkBehavior(
-                    localCfg = { cfg }
-                )
-            }
-            localConfig = mockk(relaxed = true)
-            memoryCleanerService = mockk(relaxed = true)
-            logger = InternalEmbraceLogger()
-            metadataService = FakeAndroidMetadataService()
-            networkCaptureService = mockk(relaxed = true)
-        }
-
-        @AfterClass
-        @JvmStatic
-        fun tearDown() {
-            unmockkAll()
-        }
-    }
+    private lateinit var networkLoggingService: EmbraceNetworkLoggingService
+    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var configService: ConfigService
+    private lateinit var sdkLocalConfig: SdkLocalConfig
+    private lateinit var remoteConfig: RemoteConfig
+    private lateinit var mockNetworkCaptureService: EmbraceNetworkCaptureService
 
     @Before
     fun setUp() {
-        cfg = SdkLocalConfig(networking = NetworkLocalConfig())
-
-        clearAllMocks(
-            answers = false,
-            objectMocks = false,
-            constructorMocks = false,
-            staticMocks = false
+        mockNetworkCaptureService = mockk(relaxed = true)
+        logger = InternalEmbraceLogger()
+        configService = FakeConfigService(
+            networkBehavior = fakeNetworkBehavior(
+                localCfg = { sdkLocalConfig },
+                remoteCfg = { remoteConfig }
+            )
         )
 
-        service =
-            EmbraceNetworkLoggingService(
-                configService,
-                logger,
-                networkCaptureService
-            )
+        sdkLocalConfig = SdkLocalConfig()
+        remoteConfig = RemoteConfig()
+        createNetworkLoggingService()
     }
 
     @Test
@@ -84,7 +50,7 @@ internal class EmbraceNetworkLoggingServiceTest {
         logNetworkCall("www.example3.com", 300, 400)
         logNetworkCall("www.example4.com", 400, 500)
 
-        val result = service.getNetworkCallsForSession()
+        val result = networkLoggingService.getNetworkCallsForSession()
         assertEquals(4, result.requests.size)
 
         val sortedRequests = result.requests.sortedBy { it.startTime }
@@ -95,55 +61,273 @@ internal class EmbraceNetworkLoggingServiceTest {
     }
 
     @Test
-    fun `test getNetworkCallsForSession over limit`() {
-        every { configService.networkBehavior.getNetworkCaptureLimit() }.returns(
-            2
-        )
-
-        logNetworkCall("www.overLimit1.com")
-        logNetworkCall("www.overLimit1.com")
-        logNetworkCall("www.overLimit1.com")
-        logNetworkCall("www.overLimit1.com")
+    fun `test implicit default network call limits`() {
+        repeat(1005) {
+            logNetworkCall("www.overLimit1.com")
+        }
         logNetworkCall("www.overLimit2.com")
-        logNetworkCall("www.overLimit2.com")
-        logNetworkCall("www.overLimit3.com")
 
-        val result = service.getNetworkCallsForSession()
+        val result = networkLoggingService.getNetworkCallsForSession()
 
-        // overLimit1 has 4 calls. The limit is 2.
-        val expectedOverLimit = DomainCount(4, 2)
-        assertEquals(1, result.requestCounts.size)
-
-        assertEquals(expectedOverLimit, result.requestCounts["overLimit1.com"])
+        assertEquals(1001, result.requests.size)
+        assertEquals(DomainCount(1005, 1000), result.requestCounts["overLimit1.com"])
         assertNull(result.requestCounts["overLimit2.com"])
-        assertNull(result.requestCounts["overLimit3.com"])
     }
 
     @Test
-    fun `test getNetworkCallsForSession merged limits`() {
-        cfg = SdkLocalConfig(
+    fun `test domain specific local limits`() {
+        sdkLocalConfig = SdkLocalConfig(
             networking = NetworkLocalConfig(
                 domains = listOf(DomainLocalConfig("overLimit1.com", 2))
             )
         )
 
-        logNetworkCall("www.overLimit1.com")
-        logNetworkCall("www.overLimit1.com")
-        logNetworkCall("www.overLimit1.com")
-        logNetworkCall("www.overLimit1.com")
+        createNetworkLoggingService()
+
+        repeat(3) {
+            logNetworkCall("www.overLimit1.com")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(2, result.requests.size)
+        assertEquals(DomainCount(3, 2), result.requestCounts["overLimit1.com"])
+    }
+
+    @Test
+    fun `test default local limits`() {
+        sdkLocalConfig = SdkLocalConfig(
+            networking = NetworkLocalConfig(
+                defaultCaptureLimit = 2
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(4) {
+            logNetworkCall("www.overLimit1.com")
+        }
+
         logNetworkCall("www.overLimit2.com")
-        logNetworkCall("www.overLimit2.com")
-        logNetworkCall("www.overLimit3.com")
 
-        val result = service.getNetworkCallsForSession()
-
-        // overLimit1 has 4 calls. The local limit is 2.
-        val expectedOverLimit = DomainCount(4, 2)
-        assertEquals(1, result.requestCounts.size)
-
-        assertEquals(expectedOverLimit, result.requestCounts["overLimit1.com"])
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(3, result.requests.size)
+        assertEquals(DomainCount(4, 2), result.requestCounts["overLimit1.com"])
         assertNull(result.requestCounts["overLimit2.com"])
+    }
+
+    @Test
+    fun `test local limits with default and domain specific limits`() {
+        sdkLocalConfig = SdkLocalConfig(
+            networking = NetworkLocalConfig(
+                defaultCaptureLimit = 2,
+                domains = listOf(DomainLocalConfig("overLimit1.com", 3))
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(4) {
+            logNetworkCall("www.overLimit1.com")
+        }
+
+        repeat(3) {
+            logNetworkCall("www.overLimit2.com")
+        }
+
+        repeat(2) {
+            logNetworkCall("www.overLimit3.com")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(7, result.requests.size)
+        assertEquals(DomainCount(4, 3), result.requestCounts["overLimit1.com"])
+        assertEquals(DomainCount(3, 2), result.requestCounts["overLimit2.com"])
         assertNull(result.requestCounts["overLimit3.com"])
+    }
+
+    @Test
+    fun `test explicit remote limits as a ceiling for local limit`() {
+        sdkLocalConfig = SdkLocalConfig(
+            networking = NetworkLocalConfig(
+                domains = listOf(DomainLocalConfig("limited.org", 30)),
+                defaultCaptureLimit = 20
+            )
+        )
+
+        remoteConfig = RemoteConfig(
+            networkConfig = NetworkRemoteConfig(
+                domainLimits = mapOf("limited.org" to 10),
+                defaultCaptureLimit = 5
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(30) {
+            logNetworkCall("www.limited.org")
+            logNetworkCall("www.verylimited.com")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(15, result.requests.size)
+        assertEquals(DomainCount(30, 10), result.requestCounts["limited.org"])
+        assertEquals(DomainCount(30, 5), result.requestCounts["verylimited.com"])
+    }
+
+    @Test
+    fun `test explicit remote default limit as a ceiling for local limit`() {
+        sdkLocalConfig = SdkLocalConfig(
+            networking = NetworkLocalConfig(
+                domains = listOf(DomainLocalConfig("limited.org", 30)),
+                defaultCaptureLimit = 20
+            )
+        )
+
+        remoteConfig = RemoteConfig(
+            networkConfig = NetworkRemoteConfig(
+                defaultCaptureLimit = 5
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(30) {
+            logNetworkCall("www.limited.org")
+            logNetworkCall("www.verylimited.com")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(10, result.requests.size)
+        assertEquals(DomainCount(30, 5), result.requestCounts["limited.org"])
+        assertEquals(DomainCount(30, 5), result.requestCounts["verylimited.com"])
+    }
+
+    @Test
+    fun `test remote domain limit as a ceiling for local limit`() {
+        sdkLocalConfig = SdkLocalConfig(
+            networking = NetworkLocalConfig(
+                domains = listOf(DomainLocalConfig("limited.org", 25)),
+                defaultCaptureLimit = 15
+            )
+        )
+
+        remoteConfig = RemoteConfig(
+            networkConfig = NetworkRemoteConfig(
+                domainLimits = mapOf("limited.org" to 10)
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(30) {
+            logNetworkCall("www.limited.org")
+            logNetworkCall("www.defaultlimit.com")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(25, result.requests.size)
+        assertEquals(DomainCount(30, 10), result.requestCounts["limited.org"])
+        assertEquals(DomainCount(30, 15), result.requestCounts["defaultlimit.com"])
+    }
+
+    @Test
+    fun `test implicit remote limit as a ceiling for local limit`() {
+        sdkLocalConfig = SdkLocalConfig(
+            networking = NetworkLocalConfig(
+                domains = listOf(DomainLocalConfig("limited.org", 2000)),
+                defaultCaptureLimit = 1500
+            )
+        )
+
+        remoteConfig = RemoteConfig()
+
+        repeat(2001) {
+            logNetworkCall("www.limited.org")
+            logNetworkCall("www.verylimited.com")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(2000, result.requests.size)
+        assertEquals(DomainCount(2001, 1000), result.requestCounts["limited.org"])
+        assertEquals(DomainCount(2001, 1000), result.requestCounts["verylimited.com"])
+    }
+
+    @Test
+    fun `limit applies to all domains with a given suffix`() {
+        remoteConfig = RemoteConfig(
+            networkConfig = NetworkRemoteConfig(
+                domainLimits = mapOf("limited.org" to 15),
+                defaultCaptureLimit = 10
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(8) {
+            logNetworkCall("www.limited.org")
+            logNetworkCall("admin.limited.org")
+            logNetworkCall("verylimited.org")
+            logNetworkCall("woopwoop.com")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(23, result.requests.size)
+        assertEquals(1, result.requestCounts.size)
+        assertEquals(DomainCount(24, 15), result.requestCounts["limited.org"])
+    }
+
+    @Test
+    fun `fetching session doesn't reset limit`() {
+        remoteConfig = RemoteConfig(
+            networkConfig = NetworkRemoteConfig(
+                defaultCaptureLimit = 5
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(6) {
+            logNetworkCall("www.limited.org")
+        }
+
+        networkLoggingService.getNetworkCallsForSession()
+
+        repeat(6) {
+            logNetworkCall("www.limited.org")
+        }
+
+        val result = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(5, result.requests.size)
+        assertEquals(DomainCount(12, 5), result.requestCounts["limited.org"])
+    }
+
+    @Test
+    fun `clearing service resets the limit`() {
+        remoteConfig = RemoteConfig(
+            networkConfig = NetworkRemoteConfig(
+                defaultCaptureLimit = 5
+            )
+        )
+
+        createNetworkLoggingService()
+
+        repeat(10) {
+            logNetworkCall("www.limited.org")
+        }
+
+        val firstSession = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(5, firstSession.requests.size)
+        assertEquals(DomainCount(10, 5), firstSession.requestCounts["limited.org"])
+
+        networkLoggingService.cleanCollections()
+
+        repeat(6) {
+            logNetworkCall("www.limited.org")
+        }
+
+        val secondSession = networkLoggingService.getNetworkCallsForSession()
+        assertEquals(5, secondSession.requests.size)
+        assertEquals(DomainCount(6, 5), secondSession.requestCounts["limited.org"])
     }
 
     @Test
@@ -153,7 +337,7 @@ internal class EmbraceNetworkLoggingServiceTest {
         val startTime = 10000L
         val endTime = 20000L
 
-        service.logNetworkError(
+        networkLoggingService.logNetworkError(
             randomId(),
             url,
             httpMethod,
@@ -166,14 +350,14 @@ internal class EmbraceNetworkLoggingServiceTest {
             null
         )
 
-        val result = service.getNetworkCallsForSession()
+        val result = networkLoggingService.getNetworkCallsForSession()
 
         assertEquals(url, result.requests.at(0)?.url)
     }
 
     @Test
     fun `test logNetworkCall sends the network body if necessary`() {
-        service.logNetworkCall(
+        networkLoggingService.logNetworkCall(
             randomId(),
             "www.example.com",
             "GET",
@@ -188,7 +372,7 @@ internal class EmbraceNetworkLoggingServiceTest {
         )
 
         verify(exactly = 1) {
-            networkCaptureService.logNetworkCapturedData(
+            mockNetworkCaptureService.logNetworkCapturedData(
                 any(),
                 any(),
                 any(),
@@ -201,7 +385,7 @@ internal class EmbraceNetworkLoggingServiceTest {
 
     @Test
     fun `test logNetworkCall doesn't send the network body if null`() {
-        service.logNetworkCall(
+        networkLoggingService.logNetworkCall(
             randomId(),
             "www.example.com",
             "GET",
@@ -216,7 +400,7 @@ internal class EmbraceNetworkLoggingServiceTest {
         )
 
         verify(exactly = 0) {
-            networkCaptureService.logNetworkCapturedData(
+            mockNetworkCaptureService.logNetworkCapturedData(
                 any(),
                 any(),
                 any(),
@@ -234,9 +418,9 @@ internal class EmbraceNetworkLoggingServiceTest {
         logNetworkCall("www.example.com")
         logNetworkCall("www.example.com")
 
-        service.cleanCollections()
+        networkLoggingService.cleanCollections()
 
-        val result = service.getNetworkCallsForSession()
+        val result = networkLoggingService.getNetworkCallsForSession()
 
         assertEquals(0, result.requests.size)
         assertEquals(0, result.requestCounts.size)
@@ -254,7 +438,7 @@ internal class EmbraceNetworkLoggingServiceTest {
             logNetworkError(url = "https://embrace.io", startTime = startTime)
         }
 
-        assertEquals(4, service.getNetworkCallsForSession().requests.size)
+        assertEquals(4, networkLoggingService.getNetworkCallsForSession().requests.size)
     }
 
     @Test
@@ -268,7 +452,7 @@ internal class EmbraceNetworkLoggingServiceTest {
         logNetworkError(url = "https://embrace.io", startTime = 50, callId = callId)
         logNetworkCall(url = expectedUrl, startTime = expectedStartTime, endTime = expectedEndTime, callId = callId)
 
-        val result = service.getNetworkCallsForSession()
+        val result = networkLoggingService.getNetworkCallsForSession()
         assertEquals(1, result.requests.size)
         with(result.requests[0]) {
             assertEquals(1, result.requests.size)
@@ -278,8 +462,17 @@ internal class EmbraceNetworkLoggingServiceTest {
         }
     }
 
+    private fun createNetworkLoggingService() {
+        networkLoggingService =
+            EmbraceNetworkLoggingService(
+                configService,
+                logger,
+                mockNetworkCaptureService
+            )
+    }
+
     private fun logNetworkCall(url: String, startTime: Long = 100, endTime: Long = 200, callId: String = randomId()) {
-        service.logNetworkCall(
+        networkLoggingService.logNetworkCall(
             callId,
             url,
             "GET",
@@ -295,7 +488,7 @@ internal class EmbraceNetworkLoggingServiceTest {
     }
 
     private fun logNetworkError(url: String, startTime: Long = 100, callId: String = randomId()) {
-        service.logNetworkError(
+        networkLoggingService.logNetworkError(
             callId,
             url,
             "GET",


### PR DESCRIPTION
## Goal

There were two problems that were addressed in this PR: 

1. The initial issue was that if a remote config is not defined for network behaviour, the local settings on network call limits will be used as is, which means customers can set the limit to whatever they want, which sort of defeats the purpose of having a limit to prevent runaway payload size.
2. The second that I found while working on this is that we are clearing the limits prematurely, every time we cache a session. This means the window in which the limit will be applied before resetting was impossibly short.

This PR addresses both issues by using the default limits in the remote config (or defaults implied by the absence of a config) to act as the ceiling to whatever is set locally. This make the local setting a way of further limit what is set on the remote, and won't allow the overriding of it. I also removed the erroneous limit clearing, which ironically is probably the source of the original customer issue anyway, just obscured by what I found with the local limits

## Testing

Added more test cases to verify the fixed behaviour as well as corner cases not covered previously

## Release Notes

**WHAT**:<br>
Properly enforce network call per session limit and use the remote limit as a ceiling for any local limits set.
**WHY**:<br>
Limiting the number of session calls recorded prevents session payloads from growing to an unhealthy size.

