### PR TITLE
Move session enum and session properties

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -69,6 +69,7 @@ internal class SessionModuleImpl(
             essentialServiceModule.memoryCleanerService,
             deliveryModule.deliveryService,
             sessionMessageCollator,
+            sessionProperties,
             initModule.clock,
             workerThreadModule.scheduledExecutor(ExecutorName.SESSION_CLOSER),
             workerThreadModule.scheduledExecutor(ExecutorName.SESSION_CACHING)
@@ -86,13 +87,12 @@ internal class SessionModuleImpl(
         EmbraceSessionService(
             essentialServiceModule.processStateService,
             nativeModule.ndkService,
-            sessionProperties,
-            coreModule.logger,
             sessionHandler,
             deliveryModule.deliveryService,
             essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled(),
             initModule.clock,
-            initModule.spansService
+            initModule.spansService,
+            coreModule.logger
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -5,22 +5,21 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
-import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 
 internal class EmbraceSessionService(
     private val processStateService: ProcessStateService,
     ndkService: NdkService,
-    private val sessionProperties: EmbraceSessionProperties,
-    private val logger: InternalEmbraceLogger,
     private val sessionHandler: SessionHandler,
     deliveryService: DeliveryService,
     isNdkEnabled: Boolean,
     private val clock: Clock,
-    private val spansService: SpansService
+    private val spansService: SpansService,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : SessionService, ProcessStateListener {
 
     companion object {
@@ -92,7 +91,6 @@ internal class EmbraceSessionService(
             coldStart,
             startType,
             startTime,
-            sessionProperties,
             automaticSessionCloserCallback,
             this::onPeriodicCacheActiveSession
         )
@@ -113,7 +111,6 @@ internal class EmbraceSessionService(
             sessionHandler.onCrash(
                 it,
                 crashId,
-                sessionProperties,
                 sdkStartupDuration,
                 spansService.flushSpans(EmbraceAttributes.AppTerminationCause.CRASH)
             )
@@ -129,7 +126,6 @@ internal class EmbraceSessionService(
             val session = activeSession ?: return
             sessionHandler.onPeriodicCacheActiveSession(
                 session,
-                sessionProperties,
                 sdkStartupDuration,
                 spansService.completedSpans()
             )
@@ -190,7 +186,6 @@ internal class EmbraceSessionService(
         sessionHandler.onSessionEnded(
             endType,
             session,
-            sessionProperties,
             sdkStartupDuration,
             endTime,
             spansService.flushSpans()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -42,48 +42,11 @@ internal class SessionHandler(
     private val memoryCleanerService: MemoryCleanerService,
     private val deliveryService: DeliveryService,
     private val sessionMessageCollator: SessionMessageCollator,
+    private val sessionProperties: EmbraceSessionProperties,
     private val clock: Clock,
     private val automaticSessionStopper: ScheduledExecutorService,
     private val sessionPeriodicCacheExecutorService: ScheduledExecutorService
 ) : Closeable {
-
-    /**
-     * Defines the states in which a session can end.
-     */
-    private enum class SessionSnapshotType(
-
-        /**
-         * Whether the session ended cleanly (i.e. not because of a crash).
-         */
-        val endedCleanly: Boolean,
-
-        /**
-         * Whether the session process experienced a force quit/unexpected termination.
-         */
-        val forceQuit: Boolean,
-
-        /**
-         * Whether periodic caching of the session should stop or not.
-         */
-        val shouldStopCaching: Boolean
-    ) {
-
-        /**
-         * The end session happened in the normal way (i.e. process state changes or manual/timed end).
-         */
-        NORMAL_END(true, false, true),
-
-        /**
-         * The end session is being constructed so that it can be periodically cached. This avoids
-         * the scenario of data loss in the event of NDK crashes.
-         */
-        PERIODIC_CACHE(false, true, false),
-
-        /**
-         * The end session is being constructed because of a JVM crash.
-         */
-        JVM_CRASH(false, false, true);
-    }
 
     var scheduledFuture: ScheduledFuture<*>? = null
 
@@ -99,7 +62,6 @@ internal class SessionHandler(
         coldStart: Boolean,
         startType: SessionLifeEventType,
         startTime: Long,
-        sessionProperties: EmbraceSessionProperties,
         automaticSessionCloserCallback: Runnable,
         cacheCallback: Runnable
     ): SessionMessage? {
@@ -148,7 +110,6 @@ internal class SessionHandler(
     fun onSessionEnded(
         endType: SessionLifeEventType,
         originSession: Session,
-        sessionProperties: EmbraceSessionProperties,
         sdkStartupDuration: Long,
         endTime: Long,
         completedSpans: List<EmbraceSpanData>? = null
@@ -182,7 +143,6 @@ internal class SessionHandler(
     fun onCrash(
         originSession: Session,
         crashId: String,
-        sessionProperties: EmbraceSessionProperties,
         sdkStartupDuration: Long,
         completedSpans: List<EmbraceSpanData>? = null
     ) {
@@ -210,7 +170,6 @@ internal class SessionHandler(
      */
     fun onPeriodicCacheActiveSession(
         activeSession: Session?,
-        sessionProperties: EmbraceSessionProperties,
         sdkStartupDuration: Long,
         completedSpans: List<EmbraceSpanData>? = null
     ): SessionMessage? {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionSnapshotType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionSnapshotType.kt
@@ -1,0 +1,39 @@
+package io.embrace.android.embracesdk.session
+
+/**
+ * Defines the states in which a session can end.
+ */
+internal enum class SessionSnapshotType(
+
+    /**
+     * Whether the session ended cleanly (i.e. not because of a crash).
+     */
+    val endedCleanly: Boolean,
+
+    /**
+     * Whether the session process experienced a force quit/unexpected termination.
+     */
+    val forceQuit: Boolean,
+
+    /**
+     * Whether periodic caching of the session should stop or not.
+     */
+    val shouldStopCaching: Boolean
+) {
+
+    /**
+     * The end session happened in the normal way (i.e. process state changes or manual/timed end).
+     */
+    NORMAL_END(true, false, true),
+
+    /**
+     * The end session is being constructed so that it can be periodically cached. This avoids
+     * the scenario of data loss in the event of NDK crashes.
+     */
+    PERIODIC_CACHE(false, true, false),
+
+    /**
+     * The end session is being constructed because of a JVM crash.
+     */
+    JVM_CRASH(false, false, true);
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.SessionLifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -44,7 +43,6 @@ internal class EmbraceSessionServiceTest {
         private val mockSession: Session = mockk(relaxed = true)
         private val mockSessionMessage: SessionMessage = mockk(relaxed = true)
         private val mockSessionHandler: SessionHandler = mockk(relaxed = true)
-        private val mockSessionProperties: EmbraceSessionProperties = mockk(relaxed = true)
         private val clock = FakeClock()
 
         @BeforeClass
@@ -89,7 +87,6 @@ internal class EmbraceSessionServiceTest {
                 /* automatically detecting a cold start */ true,
                 SessionLifeEventType.STATE,
                 any(),
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -106,7 +103,6 @@ internal class EmbraceSessionServiceTest {
                 coldStart,
                 type,
                 any(),
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -122,7 +118,6 @@ internal class EmbraceSessionServiceTest {
                 coldStart,
                 type,
                 startTime,
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -140,7 +135,6 @@ internal class EmbraceSessionServiceTest {
                 coldStart,
                 type,
                 any(),
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -155,7 +149,6 @@ internal class EmbraceSessionServiceTest {
                 coldStart,
                 type,
                 startTime,
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -173,7 +166,6 @@ internal class EmbraceSessionServiceTest {
                 true,
                 SessionLifeEventType.STATE,
                 any(),
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -182,7 +174,7 @@ internal class EmbraceSessionServiceTest {
 
         service.handleCrash(crashId)
 
-        verify { mockSessionHandler.onCrash(mockSession, crashId, mockSessionProperties, 0) }
+        verify { mockSessionHandler.onCrash(mockSession, crashId, 0) }
     }
 
     @Test
@@ -200,7 +192,6 @@ internal class EmbraceSessionServiceTest {
                 coldStart,
                 SessionLifeEventType.STATE,
                 456,
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -221,7 +212,6 @@ internal class EmbraceSessionServiceTest {
                 coldStart,
                 SessionLifeEventType.STATE,
                 456,
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -243,7 +233,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler.onSessionEnded(
                 SessionLifeEventType.STATE,
                 mockSession,
-                mockSessionProperties,
                 sdkStartupDuration,
                 456
             )
@@ -265,7 +254,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler.onSessionEnded(
                 SessionLifeEventType.MANUAL,
                 mockSession,
-                mockSessionProperties,
                 0,
                 any()
             )
@@ -282,14 +270,13 @@ internal class EmbraceSessionServiceTest {
         service.triggerStatelessSessionEnd(endType)
 
         // verify session is ended
-        verify { mockSessionHandler.onSessionEnded(endType, mockSession, mockSessionProperties, 0, any()) }
+        verify { mockSessionHandler.onSessionEnded(endType, mockSession, 0, any()) }
         // verify that a MANUAL session is started
         verify {
             mockSessionHandler.onSessionStarted(
                 false,
                 endType,
                 any(),
-                mockSessionProperties,
                 any(),
                 any()
             )
@@ -322,7 +309,6 @@ internal class EmbraceSessionServiceTest {
         verify {
             mockSessionHandler.onPeriodicCacheActiveSession(
                 any(),
-                mockSessionProperties,
                 0
             )
         }
@@ -347,7 +333,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler.onSessionEnded(
                 endType = any(),
                 originSession = any(),
-                sessionProperties = any(),
                 sdkStartupDuration = any(),
                 endTime = any(),
                 completedSpans = match {
@@ -373,7 +358,6 @@ internal class EmbraceSessionServiceTest {
                 mockSessionHandler.onSessionEnded(
                     endType = any(),
                     originSession = any(),
-                    sessionProperties = any(),
                     sdkStartupDuration = any(),
                     endTime = any(),
                     completedSpans = match {
@@ -399,7 +383,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler.onCrash(
                 originSession = any(),
                 crashId = any(),
-                sessionProperties = any(),
                 sdkStartupDuration = any(),
                 completedSpans = match {
                     it.size == 2
@@ -429,8 +412,6 @@ internal class EmbraceSessionServiceTest {
         service = EmbraceSessionService(
             activityService,
             mockNdkService,
-            mockSessionProperties,
-            mockk(relaxed = true),
             mockSessionHandler,
             deliveryService,
             ndkEnabled,
@@ -445,7 +426,6 @@ internal class EmbraceSessionServiceTest {
                 true,
                 SessionLifeEventType.STATE,
                 any(),
-                mockSessionProperties,
                 any(),
                 any()
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -177,6 +177,7 @@ internal class SessionHandlerTest {
             mockMemoryCleanerService,
             deliveryService,
             sessionMessageCollator,
+            mockSessionProperties,
             clock,
             automaticSessionStopper = mockAutomaticSessionStopper,
             sessionPeriodicCacheExecutorService = mockSessionPeriodicCacheExecutorService
@@ -204,7 +205,6 @@ internal class SessionHandlerTest {
             true,
             sessionStartType,
             now,
-            mockSessionProperties,
             mockAutomaticSessionStopperRunnable,
             mockPeriodicCachingRunnable
         )
@@ -262,7 +262,6 @@ internal class SessionHandlerTest {
             true,
             /* any event type */ Session.SessionLifeEventType.STATE,
             now,
-            mockSessionProperties,
             mockAutomaticSessionStopperRunnable,
             mockPeriodicCachingRunnable
         )
@@ -289,7 +288,6 @@ internal class SessionHandlerTest {
             true,
             sessionStartType,
             now,
-            mockSessionProperties,
             mockAutomaticSessionStopperRunnable,
             mockPeriodicCachingRunnable
         )
@@ -310,7 +308,6 @@ internal class SessionHandlerTest {
             true,
             sessionStartType,
             now,
-            mockSessionProperties,
             mockAutomaticSessionStopperRunnable,
             mockPeriodicCachingRunnable
         )
@@ -336,7 +333,6 @@ internal class SessionHandlerTest {
             true,
             sessionStartType,
             now,
-            mockSessionProperties,
             mockAutomaticSessionStopperRunnable,
             mockPeriodicCachingRunnable
         )
@@ -360,7 +356,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             /* any type */ Session.SessionLifeEventType.STATE,
             mockActiveSession,
-            mockSessionProperties,
             /* any duration */ 2,
             1000
         )
@@ -381,7 +376,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             Session.SessionLifeEventType.MANUAL,
             mockActiveSession,
-            mockSessionProperties,
             /* any duration */ 2,
             1000
         )
@@ -399,7 +393,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             Session.SessionLifeEventType.TIMED,
             mockActiveSession,
-            mockSessionProperties,
             /* any duration */ 2,
             1000
         )
@@ -422,7 +415,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             Session.SessionLifeEventType.MANUAL,
             mockActiveSession,
-            mockSessionProperties,
             /* any duration */ 2,
             1000
         )
@@ -445,7 +437,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             /* any type */ Session.SessionLifeEventType.STATE,
             mockActiveSession,
-            mockSessionProperties,
             /* any duration */ 2,
             1000
         )
@@ -471,7 +462,6 @@ internal class SessionHandlerTest {
         sessionHandler.onCrash(
             mockActiveSession,
             crashId,
-            mockSessionProperties,
             /* any duration */sdkStartupDuration
         )
 
@@ -515,7 +505,6 @@ internal class SessionHandlerTest {
     fun `onPeriodicCacheActiveSession caches session successfully`() {
         val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
             mockActiveSession,
-            mockSessionProperties,
             /* any duration */2
         )
 
@@ -542,7 +531,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             endType = Session.SessionLifeEventType.STATE,
             originSession = mockActiveSession,
-            sessionProperties = mockSessionProperties,
             sdkStartupDuration = 1L,
             endTime = 10L,
             listOf(testSpan)
@@ -556,7 +544,6 @@ internal class SessionHandlerTest {
         sessionHandler.onCrash(
             mockActiveSession,
             "fakeCrashId",
-            mockSessionProperties,
             10L,
             listOf(testSpan)
         )
@@ -568,7 +555,6 @@ internal class SessionHandlerTest {
     fun `periodically cached sessions included currently completed spans`() {
         val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
             mockActiveSession,
-            mockSessionProperties,
             10L,
             listOf(testSpan)
         )


### PR DESCRIPTION
## Goal

Moves an enum out of the `SessionHandler` class & also avoids unnecessary passing of the `sessionProperties` as a function parameter.

## Testing

Updated existing test coverage.

