### PR TITLE
Extract session ordinal logic to preference service

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -226,9 +226,11 @@ internal class EmbracePreferencesService(
         get() = prefs.getBooleanPreference(LAST_USER_MESSAGE_FAILED_KEY, false)
         set(value) = prefs.setBooleanPreference(LAST_USER_MESSAGE_FAILED_KEY, value)
 
-    override var sessionNumber: Int
-        get() = prefs.getIntegerPreference(LAST_SESSION_NUMBER_KEY) ?: 0
-        set(value) = prefs.setIntegerPreference(LAST_SESSION_NUMBER_KEY, value)
+    override fun getIncrementAndGetSessionNumber(): Int {
+        val sessionNumber = (prefs.getIntegerPreference(LAST_SESSION_NUMBER_KEY) ?: 0) + 1
+        prefs.setIntegerPreference(LAST_SESSION_NUMBER_KEY, sessionNumber)
+        return sessionNumber
+    }
 
     override var javaScriptBundleURL: String?
         get() = prefs.getStringPreference(JAVA_SCRIPT_BUNDLE_URL_KEY)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
@@ -84,9 +84,11 @@ internal interface PreferencesService {
     var userMessageNeedsRetry: Boolean
 
     /**
-     * Last session number. Increments by one.
+     * Increments and returns the session number ordinal. This is an integer that increments
+     * at the start of every session. This allows us to check the % of sessions that didn't get
+     * delivered to the backend.
      */
-    var sessionNumber: Int
+    fun getIncrementAndGetSessionNumber(): Int
 
     /**
      * Last javaScript bundle string url.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -71,7 +71,7 @@ internal class SessionHandler(
             coldStart,
             startType,
             startTime,
-            incrementAndGetSessionNumber(),
+            preferencesService.getIncrementAndGetSessionNumber(),
             userService.loadUserInfoFromDisk(),
             sessionProperties.get()
         )
@@ -352,15 +352,6 @@ internal class SessionHandler(
         logger.logDeveloper("SessionHandler", "End session message=$fullEndSessionMessage")
 
         return fullEndSessionMessage
-    }
-
-    /**
-     * @return session number incremented by 1
-     */
-    private fun incrementAndGetSessionNumber(): Int {
-        val sessionNumber = preferencesService.sessionNumber + 1
-        preferencesService.sessionNumber = sessionNumber
-        return sessionNumber
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -19,7 +19,6 @@ internal class FakePreferenceService(
     @Deprecated("") override var customPersonas: Set<String>? = null,
     override var lastConfigFetchDate: Long? = null,
     override var userMessageNeedsRetry: Boolean = false,
-    override var sessionNumber: Int = 0,
     override var reactNativeVersionNumber: String? = null,
     override var unityVersionNumber: String? = null,
     override var unityBuildIdNumber: String? = null,
@@ -34,7 +33,8 @@ internal class FakePreferenceService(
     override var jailbroken: Boolean? = null,
     override var applicationExitInfoHistory: Set<String>? = null,
     override var cpuName: String? = null,
-    override var egl: String? = null
+    override var egl: String? = null,
+    val sessionNumber: () -> Int = { 0 }
 ) : PreferencesService {
 
     var networkCaptureRuleOver = false
@@ -46,6 +46,8 @@ internal class FakePreferenceService(
 
     override fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int) {
     }
+
+    override fun getIncrementAndGetSessionNumber(): Int = sessionNumber()
 
     override fun isUsersFirstDay(): Boolean = firstDay
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
@@ -188,13 +188,10 @@ internal class EmbracePreferencesServiceTest {
 
     @Test
     fun `test session number is saved`() {
-        assertEquals(0, service.sessionNumber)
-
-        service.sessionNumber = 1234
-        assertEquals(1234, service.sessionNumber)
-
-        service.sessionNumber = -1
-        assertEquals(0, service.sessionNumber)
+        assertEquals(1, service.getIncrementAndGetSessionNumber())
+        assertEquals(2, service.getIncrementAndGetSessionNumber())
+        assertEquals(3, service.getIncrementAndGetSessionNumber())
+        assertEquals(4, service.getIncrementAndGetSessionNumber())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Extracts the business logic for incrementing the session number to the preference service. This means `SessionHandler` no longer needs knowledge about how the ordinal is calculated.

As far as the session number calculation goes, I think the implementation should be thread-safe. Starting a session is always synchronised with a lock, and that's the only place the function is called. Flushing the change to shared preferences is done using `apply()` which is async, but internally within the OS implementation the change is kept in an in-memory hashmap. The only two scenarios where the ordinal won't be incremented is if I/O fails before the process can terminate (e.g. due to a race), or if storage is wiped by a user (in which case a new device ID/ordinal is created).

## Testing

Updated unit test coverage.
