### PR TITLE
Enforce call order for session/background activity state transition

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -762,6 +762,7 @@ final class EmbraceImpl {
                 serviceRegistry.close();
                 internalEmbraceLogger.logDeveloper("Embrace", "Services closed");
                 workerThreadModule.close();
+                processStateService.close();
             } catch (Exception ex) {
                 internalEmbraceLogger.logError("Error while shutting down Embrace SDK", ex);
             }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
@@ -177,9 +177,9 @@ internal class EmbraceProcessStateServiceTest {
         // verify on foreground follows specific call order
         stateService.onForeground()
         val foregroundExpected = listOf(
+            "DecoratedBackgroundActivityService",
             "DecoratedSessionService",
-            "DecoratedListener",
-            "DecoratedBackgroundActivityService"
+            "DecoratedListener"
         )
         assertEquals(foregroundExpected, invocations)
 
@@ -188,8 +188,8 @@ internal class EmbraceProcessStateServiceTest {
         stateService.onBackground()
         val backgroundExpected = listOf(
             "DecoratedSessionService",
-            "DecoratedListener",
             "DecoratedBackgroundActivityService",
+            "DecoratedListener"
         )
         assertEquals(backgroundExpected, invocations)
     }


### PR DESCRIPTION
## Goal

Enforces a specific call order for the session/background activity state transition. Previously we prioritised the session service but were not prioritising the background activity service.

The existing behavior almost certainly led to subtle bugs. As an example, the background activity service sets a session ID on the `MetadataService`. If this was called in the wrong order then events/logs could have the wrong session ID towards the end of a session.

## Testing

Added unit test coverage.

