### PR TITLE
Get rid of unnecessary @VisibleForTest annotations

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAutomaticVerification.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAutomaticVerification.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logger
 import io.embrace.android.embracesdk.samples.AutomaticVerificationChecker
 import io.embrace.android.embracesdk.samples.VerificationActions
@@ -40,16 +39,12 @@ internal class EmbraceAutomaticVerification(
 
     private var foregroundEventTriggered = false
 
-    @VisibleForTesting
     internal lateinit var activityLifecycleTracker: ActivityTracker
 
-    @VisibleForTesting
     internal lateinit var processStateService: ProcessStateService
 
-    @VisibleForTesting
     var automaticVerificationChecker = AutomaticVerificationChecker()
 
-    @VisibleForTesting
     var verificationActions = VerificationActions(Embrace.getInstance(), automaticVerificationChecker)
 
     /**
@@ -72,7 +67,6 @@ internal class EmbraceAutomaticVerification(
         instance.runVerifyIntegration()
     }
 
-    @VisibleForTesting
     fun setActivityListener() {
         if (!::activityLifecycleTracker.isInitialized) {
             activityLifecycleTracker = checkNotNull(Embrace.getImpl().activityLifecycleTracker)
@@ -101,7 +95,6 @@ internal class EmbraceAutomaticVerification(
         }
     }
 
-    @VisibleForTesting
     fun startVerification() {
         val activity = activityLifecycleTracker.foregroundActivity
         if (activity != null) {
@@ -144,7 +137,6 @@ internal class EmbraceAutomaticVerification(
         }
     }
 
-    @VisibleForTesting
     fun runEndSession() {
         Embrace.getInstance().endSession()
         logger.logInfo("$TAG End session manually")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrStacktraceSampler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrStacktraceSampler.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.anr
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.anr.detection.ThreadMonitoringState
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -24,7 +23,6 @@ internal class AnrStacktraceSampler(
     private val anrExecutorService: ExecutorService
 ) : BlockedThreadListener, MemoryCleanerListener {
 
-    @VisibleForTesting
     internal val anrIntervals = CopyOnWriteArrayList<AnrInterval>()
     private val samples = mutableListOf<AnrSample>()
     private var lastUnblockedMs: Long = 0
@@ -90,7 +88,7 @@ internal class AnrStacktraceSampler(
      * intervals with samples has been reached & the SDK needs to discard samples. We attempt
      * to pick the least valuable interval in this case.
      */
-    @VisibleForTesting
+
     internal fun findLeastValuableIntervalWithSamples() =
         findIntervalsWithSamples().minByOrNull(AnrInterval::duration)
 
@@ -101,7 +99,6 @@ internal class AnrStacktraceSampler(
         }
     }
 
-    @VisibleForTesting
     internal fun reachedAnrStacktraceCaptureLimit(): Boolean {
         val limit = configService.anrBehavior.getMaxAnrIntervalsPerSession()
         val count = findIntervalsWithSamples().size

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
@@ -49,7 +49,6 @@ internal class EmbraceAnrService(
     private val sigquitDetectionService: SigquitDetectionService
     private val targetThreadHeartbeatScheduler: LivenessCheckScheduler
 
-    @VisibleForTesting
     val listeners = CopyOnWriteArrayList<BlockedThreadListener>()
 
     init {
@@ -151,7 +150,6 @@ internal class EmbraceAnrService(
         }
     }
 
-    @VisibleForTesting
     internal fun processAnrTick(timestamp: Long) {
         // Check if ANR capture is enabled
         if (!configService.anrBehavior.isAnrCaptureEnabled()) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ThreadInfoCollector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ThreadInfoCollector.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.anr
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import java.util.regex.Pattern
@@ -43,7 +42,7 @@ internal class ThreadInfoCollector(
      *
      * @return filtered threads
      */
-    @VisibleForTesting
+
     internal fun getAllowedThreads(configService: ConfigService): Set<ThreadInfo> {
         val allowed: MutableSet<ThreadInfo> = HashSet()
         val anrBehavior = configService.anrBehavior

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/AnrProcessErrorSampler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/AnrProcessErrorSampler.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.anr.detection
 
 import android.app.ActivityManager
 import android.os.Process
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.anr.BlockedThreadListener
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -35,14 +34,12 @@ internal class AnrProcessErrorSampler(
 
     private var intervalMs: Long = configService.anrBehavior.getAnrProcessErrorsIntervalMs()
 
-    @VisibleForTesting
     var scheduledFuture: ScheduledFuture<*>? = null
 
-    @VisibleForTesting
     var anrProcessErrors: NavigableMap<Long, AnrProcessErrorStateInfo> = ConcurrentSkipListMap()
 
     // timestamp when the thread has been unblocked
-    @VisibleForTesting
+
     var threadUnblockedMs: Long? = null
 
     override fun onThreadBlocked(thread: Thread, timestamp: Long) {
@@ -95,7 +92,7 @@ internal class AnrProcessErrorSampler(
      *
      * @param threadBlockedTimestamp timestamp of when the thread has been blocked
      */
-    @VisibleForTesting
+
     internal fun onSearchForProcessErrors(threadBlockedTimestamp: Long) {
         val shouldStopScheduler = !isSchedulerAllowedToRun()
         if (shouldStopScheduler) {
@@ -139,7 +136,7 @@ internal class AnrProcessErrorSampler(
      * Basically, once the thread has been unblocked, we still have [schedulerExtraTimeAllowance]
      * ms for the scheduler to keep running.
      */
-    @VisibleForTesting
+
     internal fun isSchedulerAllowedToRun(): Boolean {
         return when (val ms = threadUnblockedMs) {
             null -> true

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetector.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.anr.detection
 
 import android.os.Debug
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.anr.BlockedThreadListener
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -105,7 +104,7 @@ internal class BlockedThreadDetector constructor(
      * To avoid useless samples grouped within a few ms of each other, this function will return
      * false & thus avoid sampling if less than half of the interval MS has passed.
      */
-    @VisibleForTesting
+
     internal fun shouldAttemptAnrSample(timestamp: Long): Boolean {
         val lastMonitorThreadResponseMs = state.lastMonitorThreadResponseMs
         val delta = timestamp - lastMonitorThreadResponseMs // time since last check
@@ -118,7 +117,7 @@ internal class BlockedThreadDetector constructor(
      *
      * This defaults to the main thread not having processed a message within 1s.
      */
-    @VisibleForTesting
+
     internal fun isAnrDurationThresholdExceeded(timestamp: Long): Boolean {
         enforceThread(anrMonitorThread)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.anr.detection
 
 import android.os.Message
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.anr.detection.TargetThreadHandler.Companion.HEARTBEAT_REQUEST
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -107,7 +106,7 @@ internal class LivenessCheckScheduler internal constructor(
      * Called at regular intervals on the monitor thread. This function posts a message to the
      * main thread that is used to check whether it is live or not.
      */
-    @VisibleForTesting
+
     internal fun onMonitorThreadHeartbeat() {
         enforceThread(anrMonitorThread)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
@@ -4,7 +4,6 @@ import android.os.Handler
 import android.os.Looper
 import android.os.Message
 import android.os.MessageQueue
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
@@ -49,7 +48,6 @@ internal class TargetThreadHandler(
         }
     }
 
-    @VisibleForTesting
     internal fun onIdleThread(): Boolean {
         onMainThreadUnblocked()
         return true

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.anr.ndk
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.behavior.AnrBehavior
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
@@ -40,22 +39,16 @@ internal class EmbraceNativeThreadSamplerService @JvmOverloads constructor(
         fun finishSampling(): List<NativeThreadAnrSample>?
     }
 
-    @VisibleForTesting
     internal var ignored = true
 
-    @VisibleForTesting
     internal var sampling = false
 
-    @VisibleForTesting
     internal var count = -1
 
-    @VisibleForTesting
     internal var factor = -1
 
-    @VisibleForTesting
     internal var intervals: MutableList<NativeThreadAnrInterval> = mutableListOf()
 
-    @VisibleForTesting
     internal val currentInterval: NativeThreadAnrInterval?
         get() = intervals.lastOrNull()
 
@@ -239,7 +232,7 @@ internal class EmbraceNativeThreadSamplerService @JvmOverloads constructor(
      * Determines whether or not we should sample the target thread based on the thread stacktrace
      * and the ANR config.
      */
-    @VisibleForTesting
+
     internal fun containsAllowedStackframes(
         anrBehavior: AnrBehavior,
         stacktrace: Array<StackTraceElement>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadSamplerInstaller.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadSamplerInstaller.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.anr.ndk
 
 import android.os.Handler
 import android.os.Looper
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.anr.AnrService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -24,7 +23,6 @@ internal class NativeThreadSamplerInstaller(
     private val isMonitoring = AtomicBoolean(false)
     private var targetHandler: Handler? = null
 
-    @VisibleForTesting
     internal var currentThread: Thread? = null
 
     private fun prepareTargetHandler() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDetectionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDetectionService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.anr.sigquit
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -56,7 +55,6 @@ internal class SigquitDetectionService(
         }
     }
 
-    @VisibleForTesting
     fun setupGoogleAnrHandler() {
         logger.logDeveloper("EmbraceAnrService", "Setting up Google ANR Handler")
         // TODO: split up the ANR tracking and NDK crash reporter libs

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/EmbraceApplicationExitInfoService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/EmbraceApplicationExitInfoService.kt
@@ -4,7 +4,6 @@ import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import android.os.Build.VERSION_CODES
 import androidx.annotation.RequiresApi
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
@@ -42,7 +41,6 @@ internal class EmbraceApplicationExitInfoService constructor(
         private const val SDK_AEI_SEND_LIMIT = 32
     }
 
-    @VisibleForTesting
     @Volatile
     var backgroundExecution: Future<*>? = null
 
@@ -146,7 +144,6 @@ internal class EmbraceApplicationExitInfoService constructor(
         return unsentAeiObjects
     }
 
-    @VisibleForTesting
     fun buildSessionAppExitInfoData(
         appExitInfo: ApplicationExitInfo,
         trace: String?,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.capture.crumbs
 import android.app.Activity
 import android.text.TextUtils
 import android.util.Pair
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.internal.CacheableValue
@@ -60,7 +59,6 @@ internal class EmbraceBreadcrumbService(
     private val viewBreadcrumbs = LinkedBlockingDeque<ViewBreadcrumb?>()
     private val tapBreadcrumbs = LinkedBlockingDeque<TapBreadcrumb?>()
 
-    @VisibleForTesting
     val customBreadcrumbs = LinkedBlockingDeque<CustomBreadcrumb?>()
     private val rnActionBreadcrumbs = LinkedBlockingDeque<RnActionBreadcrumb?>()
     val webViewBreadcrumbs = LinkedBlockingDeque<WebViewBreadcrumb?>()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.capture.crumbs
 
 import android.app.Activity
 import android.os.Bundle
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb.NotificationType
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
@@ -15,7 +14,6 @@ internal class PushNotificationCaptureService(
     private val logger: InternalEmbraceLogger
 ) : ActivityLifecycleListener {
 
-    @VisibleForTesting
     companion object Utils {
 
         enum class PRIORITY(val priority: Int) {
@@ -39,7 +37,7 @@ internal class PushNotificationCaptureService(
          * this, or adding com.google.firebase:firebase-messaging as a dependency on the sdk and
          * add some more complex code.
          */
-        @VisibleForTesting
+
         fun getMessagePriority(priority: String?) =
             when (priority) {
                 "high" -> PRIORITY.PRIORITY_HIGH.priority
@@ -47,7 +45,6 @@ internal class PushNotificationCaptureService(
                 else -> PRIORITY.PRIORITY_UNKNOWN.priority
             }
 
-        @VisibleForTesting
         fun extractDeveloperDefinedPayload(bundle: Bundle): Map<String, String> {
             val keySet = bundle.keySet() ?: return emptyMap()
             return keySet.filter {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -9,7 +9,6 @@ import android.os.Build
 import android.os.Environment
 import android.os.StatFs
 import android.view.WindowManager
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.capture.cpu.CpuInfoDelegate
@@ -227,7 +226,6 @@ internal class EmbraceMetadataService private constructor(
         )
     }
 
-    @VisibleForTesting
     fun asyncRetrieveDiskUsage(isAndroid26OrAbove: Boolean) {
         metadataRetrieveExecutorService.submit(
             Callable<Any?> {
@@ -251,7 +249,6 @@ internal class EmbraceMetadataService private constructor(
         )
     }
 
-    @VisibleForTesting
     fun getReactNativeBundleId(): String? = reactNativeBundleId.value
 
     override fun getDeviceId(): String = deviceId.value

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/strictmode/EmbraceStrictModeService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/strictmode/EmbraceStrictModeService.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import android.os.StrictMode
 import android.os.strictmode.Violation
 import androidx.annotation.RequiresApi
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.payload.ExceptionInfo
@@ -25,7 +24,6 @@ internal class EmbraceStrictModeService(
         addStrictModeListener(executorService, StrictMode.OnThreadViolationListener(::addViolation))
     }
 
-    @VisibleForTesting
     internal fun addViolation(violation: Violation) {
         if (violations.size < configService.anrBehavior.getStrictModeViolationLimit()) {
             val exceptionInfo = ExceptionInfo.ofThrowable(violation)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/thermalstate/EmbraceThermalStatusService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/thermalstate/EmbraceThermalStatusService.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.capture.thermalstate
 import android.os.Build
 import android.os.PowerManager
 import androidx.annotation.RequiresApi
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.ThermalState
@@ -33,7 +32,6 @@ internal class EmbraceThermalStatusService(
         }
     }
 
-    @VisibleForTesting
     fun handleThermalStateChange(status: Int?) {
         if (status == null) {
             logger.logDeveloper("ThermalStatusService", "Null thermal status, no-oping.")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.capture.user
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.UserInfo
 import io.embrace.android.embracesdk.payload.UserInfo.Companion.ofStored
@@ -14,7 +13,7 @@ internal class EmbraceUserService(
 ) : ProcessStateListener, UserService {
 
     @Volatile
-    @VisibleForTesting
+
     internal var info: UserInfo = ofStored(preferencesService)
 
     override fun loadUserInfoFromDisk(): UserInfo? {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.comms.delivery
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
@@ -43,7 +42,6 @@ internal class EmbraceDeliveryCacheManager(
          */
         private const val FAILED_API_CALLS_FILE_NAME = "failed_api_calls.json"
 
-        @VisibleForTesting
         const val MAX_SESSIONS_CACHED = 64
 
         private const val TAG = "DeliveryCacheManager"
@@ -267,7 +265,6 @@ internal class EmbraceDeliveryCacheManager(
         }
     }
 
-    @VisibleForTesting
     data class CachedSession(
         val filename: String,
         val sessionId: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.comms.delivery
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityListener
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.comms.api.ApiRequest
@@ -87,7 +86,7 @@ internal class EmbraceDeliveryRetryManager(
     /**
      * Returns true if there is an active pending retry task
      */
-    @VisibleForTesting
+
     fun isRetryTaskActive(): Boolean =
         lastRetryTask?.let { task ->
             !task.isCancelled && !task.isDone
@@ -96,7 +95,7 @@ internal class EmbraceDeliveryRetryManager(
     /**
      * Returns the number of failed API calls that will be retried
      */
-    @VisibleForTesting
+
     fun pendingRetriesCount() = retryQueue.size
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.config
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.comms.api.ApiService
 import io.embrace.android.embracesdk.config.behavior.AnrBehavior
@@ -53,11 +52,9 @@ internal class EmbraceConfigService @JvmOverloads constructor(
     private val listeners: MutableSet<ConfigListener> = CopyOnWriteArraySet()
     private val lock = Any()
 
-    @VisibleForTesting
     @Volatile
     private var configProp = RemoteConfig()
 
-    @VisibleForTesting
     @Volatile
     var lastUpdated: Long = 0
 
@@ -192,7 +189,7 @@ internal class EmbraceConfigService @JvmOverloads constructor(
     /**
      * Load Config from cache if present.
      */
-    @VisibleForTesting
+
     fun loadConfigFromCache() {
         logger.logDeveloper("EmbraceConfigService", "Attempting to load config from cache")
         val cachedConfig = apiService.getCachedConfig()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.java
@@ -264,7 +264,7 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
         }
     }
 
-    @VisibleForTesting
+    
     void checkSignalHandlersOverwritten() {
         if (configService.getAutoDataCaptureBehavior().isSigHandlerDetectionEnabled()) {
             String culprit = delegate._checkForOverwrittenHandlers();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/AnrInterval.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/AnrInterval.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.payload
 
 import androidx.annotation.CheckResult
-import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
 
 /**
@@ -20,28 +19,24 @@ internal data class AnrInterval @JvmOverloads constructor(
      * The last time the thread was alive.
      */
     @SerializedName("lk")
-    @get:VisibleForTesting
     val lastKnownTime: Long? = null,
 
     /**
      * The time the application started responding.
      */
     @SerializedName("en")
-    @get:VisibleForTesting
     val endTime: Long? = null,
 
     /**
      * The component of the application which stopped responding.
      */
     @SerializedName("v")
-    @get:VisibleForTesting
     val type: Type = Type.UI,
 
     /**
      * The captured stacktraces of the anr interval.
      */
     @SerializedName("se")
-    @get:VisibleForTesting
     val anrSampleList: AnrSampleList? = null,
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/AppInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/AppInfo.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.payload
 
-import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
 import io.embrace.android.embracesdk.internal.utils.MessageUtils
 
@@ -107,7 +106,6 @@ internal data class AppInfo(
      * The version number of the platform (e.g. Unity 2021)
      */
     @SerializedName("unv")
-    @get:VisibleForTesting
     val hostedPlatformVersion: String? = null,
 
     /**
@@ -120,7 +118,6 @@ internal data class AppInfo(
      * The version number of the hosted SDK (e.g. Embrace Unity 1.7.0)
      */
     @SerializedName("usv")
-    @get:VisibleForTesting
     val hostedSdkVersion: String? = null,
 ) {
     fun toJson(): String {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ExceptionError.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ExceptionError.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.payload
 
-import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
 import io.embrace.android.embracesdk.internal.clock.Clock
 
@@ -9,11 +8,11 @@ import io.embrace.android.embracesdk.internal.clock.Clock
  */
 internal data class ExceptionError(@Transient private val logStrictMode: Boolean) {
     @SerializedName("c")
-    @VisibleForTesting
+
     var occurrences = 0
 
     @SerializedName("rep")
-    @VisibleForTesting
+
     val exceptionErrors = mutableListOf<ExceptionErrorInfo>()
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Stacktraces.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Stacktraces.kt
@@ -22,19 +22,19 @@ internal class Stacktraces @JvmOverloads constructor(
 ) {
 
     @SerializedName("tt")
-    @VisibleForTesting
+
     val jvmStacktrace: List<String>?
 
     @SerializedName("jsk")
-    @VisibleForTesting
+
     val javascriptStacktrace: String?
 
     @SerializedName("u")
-    @VisibleForTesting
+
     val unityStacktrace: String?
 
     @SerializedName("f")
-    @VisibleForTesting
+
     val flutterStacktrace: String?
 
     init {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ThreadInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ThreadInfo.kt
@@ -1,12 +1,11 @@
 package io.embrace.android.embracesdk.payload
 
-import androidx.annotation.VisibleForTesting
 import com.google.gson.annotations.SerializedName
 
 /**
  * Represents thread information at a given point in time.
  */
-internal data class ThreadInfo @VisibleForTesting internal constructor(
+internal data class ThreadInfo internal constructor(
 
     /**
      * The thread ID

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamples.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamples.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.samples
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
@@ -13,13 +12,12 @@ internal object EmbraceCrashSamples {
 
     private val logger = InternalEmbraceLogger()
 
-    @VisibleForTesting
     val ndkCrashSamplesNdkDelegate = EmbraceCrashSamplesNdkDelegateImpl()
 
     /**
      * Verifies if Embrace is initialized
      */
-    @VisibleForTesting
+
     fun isSdkStarted() {
         if (!Embrace.getInstance().isStarted) {
             val e = EmbraceSampleCodeException(
@@ -35,7 +33,7 @@ internal object EmbraceCrashSamples {
     /**
      * verifies if ANR detection is enabled
      */
-    @VisibleForTesting
+
     fun checkAnrDetectionEnabled() {
         if (Embrace.getInstance().configService?.anrBehavior?.isAnrCaptureEnabled() == false) {
             val e = EmbraceSampleCodeException(
@@ -88,7 +86,7 @@ internal object EmbraceCrashSamples {
     /**
      * verifies if NDK detection is enabled
      */
-    @VisibleForTesting
+
     fun checkNdkDetectionEnabled() {
         // First verifies is Embrace SDK is initialized
         isSdkStarted()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/VerificationActions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/VerificationActions.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.samples
 
 import android.os.Handler
 import android.os.Looper
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.EmbraceAutomaticVerification
@@ -133,7 +132,6 @@ internal class VerificationActions(
         )
     }
 
-    @VisibleForTesting
     private fun executeMoment() {
         val momentName = "Verify Integration Moment"
         val momentIdentifier = "Verify Integration identifier"
@@ -143,7 +141,6 @@ internal class VerificationActions(
         }, MOMENT_DURATION_MILLIS)
     }
 
-    @VisibleForTesting
     fun executeNetworkHttpGETRequest() {
         val connection = URL(networkingGetUrl).openConnection() as HttpURLConnection
         connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
@@ -172,7 +169,6 @@ internal class VerificationActions(
         }
     }
 
-    @VisibleForTesting
     private fun executeNetworkHttpPOSTRequest() {
         val connection = URL(networkingPostUrl).openConnection() as HttpURLConnection
         connection.doOutput = true
@@ -185,7 +181,6 @@ internal class VerificationActions(
         }
     }
 
-    @VisibleForTesting
     private fun executeNetworkHttpWrongRequest() {
         val connection = URL(networkingWrongUrl).openConnection() as HttpURLConnection
         val result = connection.responseCode
@@ -199,7 +194,6 @@ internal class VerificationActions(
         InternalStaticEmbraceLogger.logger.logInfo("${EmbraceAutomaticVerification.TAG} ANR Finished")
     }
 
-    @VisibleForTesting
     private fun throwAnException() {
         handler.postDelayed({
             throw VerifyIntegrationException("Forced Exception to verify integration")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.session
 
 import android.os.Handler
 import android.os.Looper
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
 import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
@@ -61,12 +60,11 @@ internal class EmbraceBackgroundActivityService(
     /**
      * The active background activity session.
      */
-    @VisibleForTesting
+
     @Volatile
     var backgroundActivity: BackgroundActivity? = null
     private val manualBkgSessionsSent = AtomicInteger(0)
 
-    @VisibleForTesting
     var lastSendAttempt: Long
     private var isEnabled = true
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.session
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.logging.EmbraceInternalErrorService
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
@@ -12,7 +11,7 @@ internal class EmbraceMemoryCleanerService : MemoryCleanerService {
     /**
      * List of listeners that subscribe to clean services collections.
      */
-    @VisibleForTesting
+
     val listeners = CopyOnWriteArrayList<MemoryCleanerListener>()
 
     override fun cleanServicesCollections(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.session
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
@@ -57,7 +56,7 @@ internal class EmbraceSessionService(
      * The currently active session.
      */
     @Volatile
-    @VisibleForTesting
+
     internal var activeSession: Session? = null
 
     init {
@@ -133,7 +132,7 @@ internal class EmbraceSessionService(
     /**
      * Caches the session, with performance information generated up to the current point.
      */
-    @VisibleForTesting
+
     fun onPeriodicCacheActiveSession() {
         try {
             synchronized(lock) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.session
 
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
@@ -48,7 +47,6 @@ internal class SessionHandler(
     private val sessionPeriodicCacheExecutorService: ScheduledExecutorService
 ) : Closeable {
 
-    @VisibleForTesting
     var scheduledFuture: ScheduledFuture<*>? = null
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.session.lifecycle
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.capture.orientation.OrientationService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -29,7 +28,7 @@ internal class ActivityLifecycleTracker(
     /**
      * List of listeners that subscribe to activity events.
      */
-    @VisibleForTesting
+
     val listeners = CopyOnWriteArrayList<ActivityLifecycleListener>()
 
     /**
@@ -43,7 +42,7 @@ internal class ActivityLifecycleTracker(
      *
      * @param activity the activity involved in the state change.
      */
-    @VisibleForTesting
+
     @Synchronized
     fun updateStateWithActivity(activity: Activity?) {
         logger.logDeveloper(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.session.lifecycle
 
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -23,7 +22,7 @@ internal class EmbraceProcessStateService(
     /**
      * List of listeners that subscribe to process lifecycle events.
      */
-    @VisibleForTesting
+
     val listeners = CopyOnWriteArrayList<ProcessStateListener>()
 
     /**


### PR DESCRIPTION
## Goal

Get rid of unnecessary annotations to expose internal member variables to tests. It's good that we don't need any of them because we really shouldn't expose internal state for tests if we don't have to, which for the most part we really shouldn't have to.