### PR TITLE
Use the over-the-wire response size when logging URLConnection network calls

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
@@ -75,7 +75,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             endTime = REQUEST_TIME,
             httpMethod = HttpMethod.POST.name,
             httpStatus = HTTP_OK,
-            responseBodySize = responseBodySize,
+            responseBodySize = gzippedResponseBodySize,
             requestSize = requestBodySize,
             networkDataCaptured = true,
             responseBody = responseBodyText
@@ -227,7 +227,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             endTime = REQUEST_TIME,
             httpMethod = HttpMethod.POST.name,
             httpStatus = 500,
-            responseBodySize = responseBodySize,
+            responseBodySize = gzippedResponseBodySize,
             requestSize = requestBodySize,
             networkDataCaptured = true,
             responseBody = responseBodyText
@@ -246,7 +246,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             endTime = REQUEST_TIME,
             httpMethod = HttpMethod.POST.name,
             httpStatus = HTTP_OK,
-            responseBodySize = responseBodySize,
+            responseBodySize = gzippedResponseBodySize,
             requestSize = requestBodySize,
             networkDataCaptured = true,
             responseBody = responseBodyText


### PR DESCRIPTION
## Goal

When we are wrapping the input bytestream so that we can log the response body when that feature is turned on, don't use the byte count from the wrapped, ungzipped byte stream for the size of the response. When this feature is off and we don't wrap the input stream, we just use the bytes over the wire (as defined by the content-length header). Reading the uncompressed bytes would be wrong anyway since it's not what's gone through the wire, so if we don't get a content-header, tough beans.

## Testing

Changed the existing test that was asserting the value of the compressed bytes. 

