### PR TITLE
Simplify CountingInputstreamWithCallback and remove unnecessary constructs

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/CountingInputStreamWithCallback.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/CountingInputStreamWithCallback.java
@@ -8,7 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.embrace.android.embracesdk.utils.Consumer;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
 
 /**
  * Counts the bytes read from an input stream and invokes a callback once the stream has reached
@@ -20,9 +21,9 @@ final class CountingInputStreamWithCallback extends FilterInputStream {
      */
     private volatile long streamMark = -1;
     /**
-     * The callback to be invoked with num of bytes after reaching the end of the stream.
+     * The callback to be invoked with raw bytes after reaching the end of the stream.
      */
-    private final Consumer<Long, byte[]> callback;
+    private final Function1<byte[], Unit> callback;
 
     /**
      * true if the callback has been invoked, false otherwise.
@@ -38,7 +39,6 @@ final class CountingInputStreamWithCallback extends FilterInputStream {
 
     ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-
     /**
      * Wraps another input stream, counting the number of bytes read.
      *
@@ -46,7 +46,7 @@ final class CountingInputStreamWithCallback extends FilterInputStream {
      */
     CountingInputStreamWithCallback(InputStream in,
                                     boolean shouldCaptureBody,
-                                    @NonNull Consumer<Long, byte[]> callback) {
+                                    @NonNull Function1<byte[], Unit> callback) {
         super(in);
         this.callback = callback;
         this.shouldCaptureBody = shouldCaptureBody;
@@ -124,6 +124,6 @@ final class CountingInputStreamWithCallback extends FilterInputStream {
 
     private void notifyCallback() {
         callbackCompleted = true;
-        callback.accept(count.longValue(), os.toByteArray());
+        callback.invoke(os.toByteArray());
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
@@ -659,11 +659,12 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
         return new CountingInputStreamWithCallback(
             inputStream,
             hasNetworkCaptureRules(),
-            (bytesCount, responseBody) -> {
+            (responseBody) -> {
                 if (startTime != null && endTime != null) {
                     cacheNetworkCallData(responseBody);
-                    internalLogNetworkCall(startTime, endTime,true);
+                    internalLogNetworkCall(startTime, endTime, true);
                 }
+                return null;
             });
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/Consumer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/Consumer.kt
@@ -1,9 +1,0 @@
-package io.embrace.android.embracesdk.utils
-
-/**
- * Backwards compatible implementation of a Java Consumer.
- */
-internal fun interface Consumer<S, T> {
-
-    fun accept(s: S, t: T)
-}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/Function.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/Function.kt
@@ -1,9 +1,0 @@
-package io.embrace.android.embracesdk.utils
-
-/**
- * Backwards compatible implementation of a Java Function.
- */
-internal fun interface Function<T, R> {
-
-    fun apply(t: T): R
-}


### PR DESCRIPTION
## Goal

Simplified implementation of the wrapped stream to not return the bytes in the callback. This could probably be furthered simplified to not count bytes, but there's some logic there involving stream marking and reseting that I don't fully grok yet, so I'd rather not touch it.

I've also removed a couple of backwards compatible constructs that aren no longer necessary.

## Testing

Existing tests pass.