### PR TITLE
Add ordinal number to track background activity requests

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -110,6 +110,7 @@ internal class SessionModuleImpl(
                 deliveryModule.deliveryService,
                 essentialServiceModule.configService,
                 nativeModule.ndkService,
+                androidServicesModule.preferencesService,
                 initModule.clock,
                 initModule.spansService,
                 lazy { workerThreadModule.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR) }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivity.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivity.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.payload
 
 import com.google.gson.annotations.SerializedName
+import io.embrace.android.embracesdk.prefs.PreferencesService
 
 /**
  * Represents a particular user's session within the app.
@@ -32,7 +33,7 @@ internal data class BackgroundActivity(
     val endTime: Long? = null,
 
     /**
-     * The ordinal of the session, starting from 1.
+     * The ordinal of the background activity, starting from 1.
      */
     @SerializedName("sn")
     val number: Int? = null,
@@ -124,14 +125,16 @@ internal data class BackgroundActivity(
             coldStart: Boolean,
             startType: LifeEventType,
             applicationState: String,
-            userInfo: UserInfo?
+            userInfo: UserInfo?,
+            preferencesService: PreferencesService
         ) = BackgroundActivity(
             sessionId = embUuid,
             startTime = startTime,
             appState = applicationState,
             isColdStart = coldStart,
             startType = startType,
-            user = userInfo
+            user = userInfo,
+            number = preferencesService.incrementAndGetBackgroundActivityNumber()
         )
 
         @JvmStatic

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -226,10 +226,18 @@ internal class EmbracePreferencesService(
         get() = prefs.getBooleanPreference(LAST_USER_MESSAGE_FAILED_KEY, false)
         set(value) = prefs.setBooleanPreference(LAST_USER_MESSAGE_FAILED_KEY, value)
 
-    override fun getIncrementAndGetSessionNumber(): Int {
-        val sessionNumber = (prefs.getIntegerPreference(LAST_SESSION_NUMBER_KEY) ?: 0) + 1
-        prefs.setIntegerPreference(LAST_SESSION_NUMBER_KEY, sessionNumber)
-        return sessionNumber
+    override fun incrementAndGetSessionNumber(): Int {
+        return incrementAndGetOrdinal(LAST_SESSION_NUMBER_KEY)
+    }
+
+    override fun incrementAndGetBackgroundActivityNumber(): Int {
+        return incrementAndGetOrdinal(LAST_BACKGROUND_ACTIVITY_NUMBER_KEY)
+    }
+
+    private fun incrementAndGetOrdinal(key: String): Int {
+        val ordinal = (prefs.getIntegerPreference(key) ?: 0) + 1
+        prefs.setIntegerPreference(key, ordinal)
+        return ordinal
     }
 
     override var javaScriptBundleURL: String?
@@ -339,6 +347,7 @@ internal class EmbracePreferencesService(
         private const val CUSTOM_PERSONAS_KEY = "io.embrace.custompersonas"
         private const val LAST_USER_MESSAGE_FAILED_KEY = "io.embrace.userupdatefailed"
         private const val LAST_SESSION_NUMBER_KEY = "io.embrace.sessionnumber"
+        private const val LAST_BACKGROUND_ACTIVITY_NUMBER_KEY = "io.embrace.bgactivitynumber"
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"
         private const val JAVA_SCRIPT_PATCH_NUMBER_KEY = "io.embrace.javascript.patch"
         private const val REACT_NATIVE_VERSION_KEY = "io.embrace.reactnative.version"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
@@ -88,7 +88,14 @@ internal interface PreferencesService {
      * at the start of every session. This allows us to check the % of sessions that didn't get
      * delivered to the backend.
      */
-    fun getIncrementAndGetSessionNumber(): Int
+    fun incrementAndGetSessionNumber(): Int
+
+    /**
+     * Increments and returns the background activity number ordinal. This is an integer that
+     * increments at the start of every background activity. This allows us to check the % of
+     * requests that didn't get delivered to the backend.
+     */
+    fun incrementAndGetBackgroundActivityNumber(): Int
 
     /**
      * Last javaScript bundle string url.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -25,6 +25,7 @@ import io.embrace.android.embracesdk.payload.BackgroundActivity.Companion.create
 import io.embrace.android.embracesdk.payload.BackgroundActivity.LifeEventType
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.Breadcrumbs
+import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.utils.submitSafe
@@ -44,6 +45,7 @@ internal class EmbraceBackgroundActivityService(
     private val deliveryService: DeliveryService,
     private val configService: ConfigService,
     private val ndkService: NdkService,
+    private val preferencesService: PreferencesService,
     /**
      * Embrace service dependencies of the background activity session service.
      */
@@ -184,7 +186,8 @@ internal class EmbraceBackgroundActivityService(
             coldStart,
             startType,
             APPLICATION_STATE_BACKGROUND,
-            userService.loadUserInfoFromDisk()
+            userService.loadUserInfoFromDisk(),
+            preferencesService
         )
         backgroundActivity = activity
         metadataService.setActiveSessionId(activity.sessionId)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -77,7 +77,7 @@ internal class SessionHandler(
                 coldStart,
                 startType,
                 startTime,
-                preferencesService.getIncrementAndGetSessionNumber(),
+                preferencesService.incrementAndGetSessionNumber(),
                 userService.loadUserInfoFromDisk(),
                 sessionProperties.get()
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -34,7 +34,8 @@ internal class FakePreferenceService(
     override var applicationExitInfoHistory: Set<String>? = null,
     override var cpuName: String? = null,
     override var egl: String? = null,
-    val sessionNumber: () -> Int = { 0 }
+    val sessionNumber: () -> Int = { 0 },
+    val bgActivityNumber: () -> Int = { 5 }
 ) : PreferencesService {
 
     var networkCaptureRuleOver = false
@@ -47,7 +48,9 @@ internal class FakePreferenceService(
     override fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int) {
     }
 
-    override fun getIncrementAndGetSessionNumber(): Int = sessionNumber()
+    override fun incrementAndGetSessionNumber(): Int = sessionNumber()
+
+    override fun incrementAndGetBackgroundActivityNumber(): Int = bgActivityNumber()
 
     override fun isUsersFirstDay(): Boolean = firstDay
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
@@ -188,10 +188,24 @@ internal class EmbracePreferencesServiceTest {
 
     @Test
     fun `test session number is saved`() {
-        assertEquals(1, service.getIncrementAndGetSessionNumber())
-        assertEquals(2, service.getIncrementAndGetSessionNumber())
-        assertEquals(3, service.getIncrementAndGetSessionNumber())
-        assertEquals(4, service.getIncrementAndGetSessionNumber())
+        assertEquals(1, service.incrementAndGetSessionNumber())
+        assertEquals(2, service.incrementAndGetSessionNumber())
+        assertEquals(3, service.incrementAndGetSessionNumber())
+        assertEquals(4, service.incrementAndGetSessionNumber())
+
+        // bg activity uses independent key
+        assertEquals(1, service.incrementAndGetBackgroundActivityNumber())
+    }
+
+    @Test
+    fun `test bg activity number is saved`() {
+        assertEquals(1, service.incrementAndGetBackgroundActivityNumber())
+        assertEquals(2, service.incrementAndGetBackgroundActivityNumber())
+        assertEquals(3, service.incrementAndGetBackgroundActivityNumber())
+        assertEquals(4, service.incrementAndGetBackgroundActivityNumber())
+
+        // session uses independent key
+        assertEquals(1, service.incrementAndGetSessionNumber())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -249,7 +249,7 @@ internal class SessionHandlerTest {
             assertEquals(metadataService.getDeviceInfo(), deviceInfo)
             assertEquals(metadataService.getAppInfo(), appInfo)
         }
-        verify(exactly = 1) { preferencesService.getIncrementAndGetSessionNumber() }
+        verify(exactly = 1) { preferencesService.incrementAndGetSessionNumber() }
     }
 
     @Test
@@ -292,7 +292,7 @@ internal class SessionHandlerTest {
             mockPeriodicCachingRunnable
         )
 
-        verify(exactly = 1) { preferencesService.getIncrementAndGetSessionNumber() }
+        verify(exactly = 1) { preferencesService.incrementAndGetSessionNumber() }
         assertNotNull(sessionMessage)
         assertNotNull(sessionMessage!!.session)
         // no need to verify anything else because it's already verified in another test case


### PR DESCRIPTION
## Goal

Each session has an incrementing integer included in its payload that helps us diagnose what % of sessions don't make it to the backend. Background activities don't have this in their payload so it's impossible to check the loss rate. This was noted in #81 

I've added this using the same key that is used for sessions (`s.sn`). Capturing this data will allow us to run similar analysis as we have done for sessions.

## Testing

Added unit test coverage.
