### PR TITLE
Add tests for state transition

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
@@ -1,9 +1,11 @@
 package io.embrace.android.embracesdk.session
 
+import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
+
 /**
  * Service that captures and sends information when the app is in background
  */
-internal interface BackgroundActivityService {
+internal interface BackgroundActivityService : ProcessStateListener {
 
     /**
      * Stops the current background activity session and sends the session message to the backend

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -26,7 +26,6 @@ import io.embrace.android.embracesdk.payload.BackgroundActivity.LifeEventType
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.Breadcrumbs
 import io.embrace.android.embracesdk.prefs.PreferencesService
-import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.utils.submitSafe
 import java.util.concurrent.Callable
@@ -52,7 +51,7 @@ internal class EmbraceBackgroundActivityService(
     private val clock: Clock,
     private val spansService: SpansService,
     private val executorServiceSupplier: Lazy<ExecutorService>
-) : BackgroundActivityService, ProcessStateListener, ConfigListener {
+) : BackgroundActivityService, ConfigListener {
 
     @get:Synchronized
     private val cacheExecutorService: ExecutorService by lazy { executorServiceSupplier.value }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session
-import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 
 internal class EmbraceSessionService(
@@ -20,7 +19,7 @@ internal class EmbraceSessionService(
     private val clock: Clock,
     private val spansService: SpansService,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
-) : SessionService, ProcessStateListener {
+) : SessionService {
 
     companion object {
         private const val TAG = "EmbraceSessionService"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -1,9 +1,10 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.payload.Session.SessionLifeEventType
+import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import java.io.Closeable
 
-internal interface SessionService : Closeable {
+internal interface SessionService : ProcessStateListener, Closeable {
 
     /**
      * Starts a new session.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.session.BackgroundActivityService
+
+internal class FakeBackgroundActivityService : BackgroundActivityService {
+
+    override fun sendBackgroundActivity() {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleCrash(crashId: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun save() {
+        TODO("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeProcessStateListener.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeProcessStateListener.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class FakeProcessStateListener : ProcessStateListener {
+    var coldStart: Boolean = false
+    var startupTime: Long = -1
+    var timestamp: Long = -1
+
+    val foregroundCount = AtomicInteger(0)
+    val backgroundCount = AtomicInteger(0)
+
+    override fun onBackground(timestamp: Long) {
+        this.timestamp = timestamp
+        backgroundCount.incrementAndGet()
+    }
+
+    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+        this.coldStart = coldStart
+        this.timestamp = timestamp
+        this.startupTime = startupTime
+        foregroundCount.incrementAndGet()
+    }
+}


### PR DESCRIPTION
## Goal

Adds tests for the existing session/background activity state transition behavior & formalises some of the interfaces by making them extend `ProcessStateListener`. I've separated this out from #83 to make it easier to debug test failures on that branch.

## Testing

Added unit test coverage.

