### PR TITLE
Remove process listening from user service

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
@@ -4,13 +4,12 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.UserInfo
 import io.embrace.android.embracesdk.payload.UserInfo.Companion.ofStored
 import io.embrace.android.embracesdk.prefs.PreferencesService
-import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import java.util.regex.Pattern
 
 internal class EmbraceUserService(
     private val preferencesService: PreferencesService,
     private val logger: InternalEmbraceLogger
-) : ProcessStateListener, UserService {
+) : UserService {
 
     @Volatile
 


### PR DESCRIPTION
## Goal

Removes an unnecessary listener - the user service does not implement the onForeground/onBackground callbacks so doesn't need to implement this interface.
