### PR TITLE
Move sdk startup duration to session handler

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -656,7 +656,7 @@ final class EmbraceImpl {
         });
 
         long startupDuration = endTime - startTime;
-        ((EmbraceSessionService) nonNullSessionService).setSdkStartupDuration(startupDuration);
+        sessionModule.getSessionHandler().setSdkStartupDuration(startupDuration);
         internalEmbraceLogger.logDeveloper("Embrace", "Startup duration: " + startupDuration + " millis");
 
         // Sets up the registered services. This method is called after the SDK has been started and

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -41,15 +41,9 @@ internal class EmbraceSessionService(
     }
 
     /**
-     * SDK startup time. Only set for cold start sessions.
-     */
-    private var sdkStartupDuration: Long = 0
-
-    /**
      * The currently active session.
      */
     @Volatile
-
     internal var activeSession: Session? = null
 
     init {
@@ -64,16 +58,6 @@ internal class EmbraceSessionService(
 
         // Send any sessions that were cached and not yet sent.
         deliveryService.sendCachedSessions(isNdkEnabled, ndkService, activeSession?.sessionId)
-    }
-
-    /**
-     * record the time taken to initialize the SDK
-     *
-     * @param sdkStartupDuration the time taken to initialize the SDK in milliseconds
-     */
-    fun setSdkStartupDuration(sdkStartupDuration: Long) {
-        logger.logDeveloper(TAG, "Setting startup duration: $sdkStartupDuration")
-        this.sdkStartupDuration = sdkStartupDuration
     }
 
     override fun startSession(coldStart: Boolean, startType: Session.SessionLifeEventType, startTime: Long) {
@@ -110,7 +94,6 @@ internal class EmbraceSessionService(
             sessionHandler.onCrash(
                 it,
                 crashId,
-                sdkStartupDuration,
                 spansService.flushSpans(EmbraceAttributes.AppTerminationCause.CRASH)
             )
         } ?: logger.logDeveloper(TAG, "Active session is NULL")
@@ -125,7 +108,6 @@ internal class EmbraceSessionService(
             val session = activeSession ?: return
             sessionHandler.onPeriodicCacheActiveSession(
                 session,
-                sdkStartupDuration,
                 spansService.completedSpans()
             )
         } catch (ex: Exception) {
@@ -185,7 +167,6 @@ internal class EmbraceSessionService(
         sessionHandler.onSessionEnded(
             endType,
             session,
-            sdkStartupDuration,
             endTime,
             spansService.flushSpans()
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -56,6 +56,11 @@ internal class SessionHandler(
     private val lock = Any()
 
     /**
+     * SDK startup time. Only set for cold start sessions.
+     */
+    var sdkStartupDuration: Long = 0
+
+    /**
      * It performs all corresponding operations in order to start a session.
      */
     fun onSessionStarted(
@@ -110,7 +115,6 @@ internal class SessionHandler(
     fun onSessionEnded(
         endType: SessionLifeEventType,
         originSession: Session,
-        sdkStartupDuration: Long,
         endTime: Long,
         completedSpans: List<EmbraceSpanData>? = null
     ) {
@@ -120,7 +124,6 @@ internal class SessionHandler(
                 SessionSnapshotType.NORMAL_END,
                 originSession,
                 sessionProperties,
-                sdkStartupDuration,
                 completedSpans,
                 endType,
                 endTime
@@ -143,7 +146,6 @@ internal class SessionHandler(
     fun onCrash(
         originSession: Session,
         crashId: String,
-        sdkStartupDuration: Long,
         completedSpans: List<EmbraceSpanData>? = null
     ) {
         synchronized(lock) {
@@ -152,7 +154,6 @@ internal class SessionHandler(
                 SessionSnapshotType.JVM_CRASH,
                 originSession,
                 sessionProperties,
-                sdkStartupDuration,
                 completedSpans,
                 SessionLifeEventType.STATE,
                 clock.now(),
@@ -170,7 +171,6 @@ internal class SessionHandler(
      */
     fun onPeriodicCacheActiveSession(
         activeSession: Session?,
-        sdkStartupDuration: Long,
         completedSpans: List<EmbraceSpanData>? = null
     ): SessionMessage? {
         synchronized(lock) {
@@ -180,7 +180,6 @@ internal class SessionHandler(
                     SessionSnapshotType.PERIODIC_CACHE,
                     activeSession,
                     sessionProperties,
-                    sdkStartupDuration,
                     completedSpans,
                     SessionLifeEventType.STATE,
                     clock.now()
@@ -259,7 +258,6 @@ internal class SessionHandler(
         endType: SessionSnapshotType,
         activeSession: Session,
         sessionProperties: EmbraceSessionProperties,
-        sdkStartupDuration: Long,
         completedSpans: List<EmbraceSpanData>?,
         lifeEventType: SessionLifeEventType,
         endTime: Long,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -174,7 +174,7 @@ internal class EmbraceSessionServiceTest {
 
         service.handleCrash(crashId)
 
-        verify { mockSessionHandler.onCrash(mockSession, crashId, 0) }
+        verify { mockSessionHandler.onCrash(mockSession, crashId) }
     }
 
     @Test
@@ -219,10 +219,8 @@ internal class EmbraceSessionServiceTest {
     }
 
     @Test
-    fun `on background ends a state session for a previously existing session, with an sdkStarupDuration = 5`() {
+    fun `on background ends a state session for a previously existing session`() {
         initializeSessionService()
-        val sdkStartupDuration = 5L
-        service.setSdkStartupDuration(sdkStartupDuration)
         // let's start session first so we have an active session
         startDefaultSession()
 
@@ -233,7 +231,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler.onSessionEnded(
                 SessionLifeEventType.STATE,
                 mockSession,
-                sdkStartupDuration,
                 456
             )
         }
@@ -306,12 +303,7 @@ internal class EmbraceSessionServiceTest {
         service.startSession(true, SessionLifeEventType.STATE, clock.now())
         service.onPeriodicCacheActiveSession()
 
-        verify {
-            mockSessionHandler.onPeriodicCacheActiveSession(
-                any(),
-                0
-            )
-        }
+        verify { mockSessionHandler.onPeriodicCacheActiveSession(any()) }
     }
 
     @Test
@@ -333,7 +325,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler.onSessionEnded(
                 endType = any(),
                 originSession = any(),
-                sdkStartupDuration = any(),
                 endTime = any(),
                 completedSpans = match {
                     it.size == 2
@@ -358,7 +349,6 @@ internal class EmbraceSessionServiceTest {
                 mockSessionHandler.onSessionEnded(
                     endType = any(),
                     originSession = any(),
-                    sdkStartupDuration = any(),
                     endTime = any(),
                     completedSpans = match {
                         it.size == 2
@@ -383,7 +373,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler.onCrash(
                 originSession = any(),
                 crashId = any(),
-                sdkStartupDuration = any(),
                 completedSpans = match {
                     it.size == 2
                 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -356,7 +356,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             /* any type */ Session.SessionLifeEventType.STATE,
             mockActiveSession,
-            /* any duration */ 2,
             1000
         )
 
@@ -376,7 +375,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             Session.SessionLifeEventType.MANUAL,
             mockActiveSession,
-            /* any duration */ 2,
             1000
         )
 
@@ -393,7 +391,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             Session.SessionLifeEventType.TIMED,
             mockActiveSession,
-            /* any duration */ 2,
             1000
         )
 
@@ -415,7 +412,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             Session.SessionLifeEventType.MANUAL,
             mockActiveSession,
-            /* any duration */ 2,
             1000
         )
 
@@ -437,7 +433,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             /* any type */ Session.SessionLifeEventType.STATE,
             mockActiveSession,
-            /* any duration */ 2,
             1000
         )
 
@@ -461,8 +456,7 @@ internal class SessionHandlerTest {
 
         sessionHandler.onCrash(
             mockActiveSession,
-            crashId,
-            /* any duration */sdkStartupDuration
+            crashId
         )
 
         // when crashing, the following calls should not be made, this is because since we're
@@ -504,8 +498,7 @@ internal class SessionHandlerTest {
     @Test
     fun `onPeriodicCacheActiveSession caches session successfully`() {
         val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
-            mockActiveSession,
-            /* any duration */2
+            mockActiveSession
         )
 
         assertNotNull(sessionMessage)
@@ -531,7 +524,6 @@ internal class SessionHandlerTest {
         sessionHandler.onSessionEnded(
             endType = Session.SessionLifeEventType.STATE,
             originSession = mockActiveSession,
-            sdkStartupDuration = 1L,
             endTime = 10L,
             listOf(testSpan)
         )
@@ -544,7 +536,6 @@ internal class SessionHandlerTest {
         sessionHandler.onCrash(
             mockActiveSession,
             "fakeCrashId",
-            10L,
             listOf(testSpan)
         )
 
@@ -555,7 +546,6 @@ internal class SessionHandlerTest {
     fun `periodically cached sessions included currently completed spans`() {
         val sessionMessage = sessionHandler.onPeriodicCacheActiveSession(
             mockActiveSession,
-            10L,
             listOf(testSpan)
         )
 


### PR DESCRIPTION
## Goal

Moves the SDK startup duration to the `SessionHandler` class, as `SessionService` always just passed it down.

## Testing

Relied on existing test coverage
