### PR TITLE
Remove unnecessary internal debugging traces

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Systrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Systrace.kt
@@ -1,12 +1,11 @@
 package io.embrace.android.embracesdk.internal
 
 import android.os.Trace
-import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanName
 
 /**
  * Shim to add custom events to system traces if running in the applicable API versions. Basic alternative to using androidx.tracing.
  */
-@InternalApi
 internal class Systrace private constructor() {
     companion object {
 
@@ -14,7 +13,7 @@ internal class Systrace private constructor() {
          * Start a trace section. The name of the section will be [sectionName] prefixed by "emb-"
          */
         fun start(sectionName: String) {
-            Trace.beginSection("emb-$sectionName")
+            Trace.beginSection(sectionName.toEmbraceSpanName())
         }
 
         /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.BuildConfig
-import io.embrace.android.embracesdk.annotation.InternalApi
-import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -23,7 +21,6 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Implementation of the core logic for [SpansService]
  */
-@InternalApi
 internal class SpansServiceImpl(
     sdkInitStartTimeNanos: Long,
     sdkInitEndTimeNanos: Long,
@@ -31,30 +28,23 @@ internal class SpansServiceImpl(
 ) : SpansService {
     private val sdkTracerProvider: SdkTracerProvider
         by lazy {
-            Systrace.start("spans-service-init")
-            Systrace.trace("init-sdk-tracer-provider") {
-                SdkTracerProvider
-                    .builder()
-                    .addSpanProcessor(EmbraceSpanProcessor(EmbraceSpanExporter(this)))
-                    .setClock(clock)
-                    .build()
-            }
+            SdkTracerProvider
+                .builder()
+                .addSpanProcessor(EmbraceSpanProcessor(EmbraceSpanExporter(this)))
+                .setClock(clock)
+                .build()
         }
 
     private val openTelemetry: OpenTelemetry
         by lazy {
-            Systrace.trace("init-otel-sdk") {
-                OpenTelemetrySdk.builder()
-                    .setTracerProvider(sdkTracerProvider)
-                    .build()
-            }
+            OpenTelemetrySdk.builder()
+                .setTracerProvider(sdkTracerProvider)
+                .build()
         }
 
     private val tracer: Tracer
         by lazy {
-            Systrace.trace("init-tracer") {
-                openTelemetry.getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME)
-            }
+            openTelemetry.getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME)
         }
 
     /**
@@ -78,14 +68,11 @@ internal class SpansServiceImpl(
     private var appAttributesRecorded = false
 
     init {
-        Systrace.trace("log-sdk-init") {
-            recordCompletedSpan(
-                name = "sdk-init",
-                startTimeNanos = sdkInitStartTimeNanos,
-                endTimeNanos = sdkInitEndTimeNanos
-            )
-        }
-        Systrace.end()
+        recordCompletedSpan(
+            name = "sdk-init",
+            startTimeNanos = sdkInitStartTimeNanos,
+            endTimeNanos = sdkInitEndTimeNanos
+        )
     }
 
     override fun createSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean): EmbraceSpan? {
@@ -107,12 +94,7 @@ internal class SpansServiceImpl(
         code: () -> T
     ): T {
         return if (EmbraceSpanImpl.inputsValid(name) && validateAndUpdateContext(parent, internal)) {
-            Systrace.start("log-span-$name")
-            try {
-                createRootSpanBuilder(name = name, type = type, internal = internal).updateParent(parent).record(code)
-            } finally {
-                Systrace.end()
-            }
+            createRootSpanBuilder(name = name, type = type, internal = internal).updateParent(parent).record(code)
         } else {
             code()
         }
@@ -134,26 +116,24 @@ internal class SpansServiceImpl(
         }
 
         return if (EmbraceSpanImpl.inputsValid(name, events, attributes) && validateAndUpdateContext(parent, internal)) {
-            Systrace.trace("log-completed-span-$name") {
-                val span = createRootSpanBuilder(name = name, type = type, internal = internal)
-                    .updateParent(parent)
-                    .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
-                    .startSpan()
-                    .setAllAttributes(Attributes.builder().fromMap(attributes).build())
+            val span = createRootSpanBuilder(name = name, type = type, internal = internal)
+                .updateParent(parent)
+                .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
+                .startSpan()
+                .setAllAttributes(Attributes.builder().fromMap(attributes).build())
 
-                events.forEach { event ->
-                    if (EmbraceSpanEvent.inputsValid(event.name, event.attributes)) {
-                        span.addEvent(
-                            event.name,
-                            Attributes.builder().fromMap(event.attributes).build(),
-                            event.timestampNanos,
-                            TimeUnit.NANOSECONDS
-                        )
-                    }
+            events.forEach { event ->
+                if (EmbraceSpanEvent.inputsValid(event.name, event.attributes)) {
+                    span.addEvent(
+                        event.name,
+                        Attributes.builder().fromMap(event.attributes).build(),
+                        event.timestampNanos,
+                        TimeUnit.NANOSECONDS
+                    )
                 }
-
-                span.endSpan(errorCode, endTimeNanos)
             }
+
+            span.endSpan(errorCode, endTimeNanos)
             true
         } else {
             false


### PR DESCRIPTION
## Goal

Remove unnecessary custom systrace events in spans workflow, leaving the SDK init one that customers and ourselves may potentially be interested in.

