### PR TITLE
Fix AAR metadata to point to new minCompileSdk requirement

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/InternalEmbracePlugin.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/InternalEmbracePlugin.kt
@@ -120,7 +120,7 @@ class InternalEmbracePlugin : Plugin<Project> {
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
                 aarMetadata {
-                    minCompileSdk = 16
+                    minCompileSdk = Versions.minSdk
                 }
             }
 


### PR DESCRIPTION
## Goal

Fix the metadata in the AAR about the minimum compile SDK version that is required
