### PR TITLE
Improve systrace shim to only use async sections

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Systrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Systrace.kt
@@ -1,26 +1,42 @@
 package io.embrace.android.embracesdk.internal
 
+import android.os.Build
+import android.os.Build.VERSION_CODES
 import android.os.Trace
+import androidx.annotation.ChecksSdkIntAtLeast
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanName
+import kotlin.random.Random
 
 /**
- * Shim to add custom events to system traces if running in the applicable API versions. Basic alternative to using androidx.tracing.
+ * Shim to add custom events to system traces for API 29+. Basic alternative to using androidx.tracing that is safe to interleave.
  */
 internal class Systrace private constructor() {
+    data class Instance(val name: String, val id: Int)
+
     companion object {
 
         /**
-         * Start a trace section. The name of the section will be [sectionName] prefixed by "emb-"
+         * Start a system trace section and return an instance identifier that is required to close it.
+         * The name of the section in the logged trace will be [name] prefixed by "emb-".
+         * If the application is running on version earlier than [VERSION_CODES.Q], no trace section will be started.
          */
-        fun start(sectionName: String) {
-            Trace.beginSection(sectionName.toEmbraceSpanName())
+        fun start(name: String): Instance? {
+            return if (enabled()) {
+                val instance = Instance(name.toEmbraceSpanName().take(127), Random.nextInt())
+                Trace.beginAsyncSection(instance.name, instance.id)
+                instance
+            } else {
+                null
+            }
         }
 
         /**
-         * Close the last trace section that was started
+         * Close trace section identified by [instance]
          */
-        fun end() {
-            Trace.endSection()
+        fun end(instance: Instance) {
+            if (enabled()) {
+                Trace.endAsyncSection(instance.name, instance.id)
+            }
         }
 
         /**
@@ -32,16 +48,20 @@ internal class Systrace private constructor() {
         @Suppress("RethrowCaughtException")
         inline fun <T> trace(sectionName: String, code: () -> T): T {
             val returnValue: T
+            var instance: Instance? = null
             try {
-                start(sectionName)
+                instance = start(sectionName)
                 returnValue = code()
             } catch (t: Throwable) {
                 throw t
             } finally {
-                end()
+                instance?.let { end(it) }
             }
 
             return returnValue
         }
+
+        @ChecksSdkIntAtLeast(api = VERSION_CODES.Q)
+        private fun enabled(): Boolean = Build.VERSION.SDK_INT >= VERSION_CODES.Q
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/SystraceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/SystraceTest.kt
@@ -1,0 +1,60 @@
+package io.embrace.android.embracesdk.internal
+
+import android.os.Build.VERSION_CODES
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@Config(sdk = [VERSION_CODES.TIRAMISU])
+@RunWith(AndroidJUnit4::class)
+internal class SystraceTest {
+
+    @Test
+    fun `check name is as expected`() {
+        var instance: Systrace.Instance? = null
+        try {
+            instance = checkNotNull(Systrace.start("test 屈福特"))
+            assertEquals("emb-test 屈福特", instance.name)
+        } finally {
+            instance?.let { Systrace.end(it) }
+        }
+    }
+
+    @Test
+    fun `check long name is truncated and does not throw`() {
+        var instance: Systrace.Instance? = null
+        try {
+            instance = checkNotNull(Systrace.start(longName))
+            assertEquals(127, instance.name.length)
+            assertTrue(instance.name.startsWith("emb-a"))
+        } finally {
+            instance?.let { Systrace.end(it) }
+        }
+    }
+
+    @Config(sdk = [VERSION_CODES.Q])
+    @Test
+    fun `check supported API version does not throw`() {
+        recordAndVerifyTrace()
+    }
+
+    @Config(sdk = [VERSION_CODES.R])
+    @Test
+    fun `check unsupported API version does not throw`() {
+        recordAndVerifyTrace()
+    }
+
+    private fun recordAndVerifyTrace() {
+        val returnValue = Systrace.trace("test") {
+            1 + 1
+        }
+        assertEquals(2, returnValue)
+    }
+
+    companion object {
+        private val longName = "a".repeat(100) + " " + "b".repeat(100)
+    }
+}


### PR DESCRIPTION
## Goal

Improve this so it doesn't ever throw exceptions and make it generally usable in our spans code without worrying about call order (but restricted to api 29+).

## Testing

Add unit test to verify the specific behaviours of the shim