### PR TITLE
Add remote config for disabling the session start message

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
@@ -143,6 +143,14 @@ internal class SessionBehavior(
         getFullSessionEvents().contains(SessionGatingKeys.FULL_SESSION_ERROR_LOGS)
 
     /**
+     * Checks whether the session start message should be sent to the API or not.
+     */
+    fun isStartMessageEnabled(): Boolean {
+        return thresholdCheck.isBehaviorEnabled(remote?.sessionConfig?.pctStartMessageEnabled)
+            ?: true
+    }
+
+    /**
      * Checks whether a feature should be gated.
      * If [getSessionComponents] is null, this will return false.
      * If [getSessionComponents] is empty, this will return true.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
@@ -11,6 +11,12 @@ internal data class SessionRemoteConfig(
     @SerializedName("enable")
     val isEnabled: Boolean? = null,
 
+    /**
+     * Whether the start message should be enabled or not
+     */
+    @SerializedName("pct_start_message_enabled")
+    val pctStartMessageEnabled: Float? = null,
+
     @SerializedName("async_end")
     @Deprecated("This flag is obsolete and is no longer respected.")
     val endAsync: Boolean? = null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -106,7 +106,9 @@ internal class SessionHandler(
 
             metadataService.setActiveSessionId(session.sessionId)
 
-            deliveryService.sendSession(sessionMessage, SessionMessageState.START)
+            if (configService.sessionBehavior.isStartMessageEnabled()) {
+                deliveryService.sendSession(sessionMessage, SessionMessageState.START)
+            }
             logger.logDebug("Start session successfully sent.")
 
             handleAutomaticSessionStopper(automaticSessionCloserCallback)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
@@ -478,6 +478,7 @@ internal class EmbraceGatingServiceTest {
         RemoteConfig(
             sessionConfig = SessionRemoteConfig(
                 true,
+                100f,
                 false,
                 components,
                 fullSessionEvents

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -9,8 +10,9 @@ internal class SessionRemoteConfigTest {
 
     @Test
     fun testDefaults() {
-        val cfg = SessionRemoteConfig(false, false, null, null)
+        val cfg = SessionRemoteConfig(false, 100f, false, null, null)
         assertFalse(checkNotNull(cfg.isEnabled))
+        assertEquals(100f, checkNotNull(cfg.pctStartMessageEnabled))
         assertFalse(checkNotNull(cfg.endAsync))
         assertNull(cfg.sessionComponents)
         assertNull(cfg.fullSessionEvents)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
@@ -24,10 +24,11 @@ internal class SessionBehaviorTest {
         sessionConfig = SessionRemoteConfig(
             isEnabled = true,
             endAsync = false,
+            pctStartMessageEnabled = 0f,
             sessionComponents = setOf("test"),
             fullSessionEvents = setOf("test2")
         ),
-        maxSessionProperties = 57
+        maxSessionProperties = 57,
     )
 
     @Test
@@ -40,6 +41,7 @@ internal class SessionBehaviorTest {
             assertNull(getSessionComponents())
             assertFalse(isGatingFeatureEnabled())
             assertFalse(isSessionControlEnabled())
+            assertTrue(isStartMessageEnabled())
             assertEquals(10, getMaxSessionProperties())
         }
     }
@@ -53,6 +55,7 @@ internal class SessionBehaviorTest {
             assertEquals(setOf("breadcrumbs"), getSessionComponents())
             assertEquals(setOf("crash"), getFullSessionEvents())
             assertTrue(isGatingFeatureEnabled())
+            assertTrue(isStartMessageEnabled())
         }
     }
 
@@ -65,6 +68,7 @@ internal class SessionBehaviorTest {
             assertEquals(setOf("test"), getSessionComponents())
             assertEquals(setOf("test2"), getFullSessionEvents())
             assertEquals(57, getMaxSessionProperties())
+            assertFalse(isStartMessageEnabled())
         }
     }
 

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/ConfigHooks.java
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/ConfigHooks.java
@@ -46,6 +46,7 @@ public class ConfigHooks {
 
     static SessionRemoteConfig getSessionConfig() {
         return new SessionRemoteConfig(true,
+            100f,
             false,
             null,
             null);


### PR DESCRIPTION
## Goal

Adds a remote config field that prevents the session start message from being sent. We don't really use the start message & it adds bandwidth when making requests + complexity to cache failed requests on disks. Therefore we will add a remote config that disables sending it so that we can experiment with disabling it by default.

## Testing

Added unit test coverage. Confirmed in an example app that sessions still show on the dashboard.

