### PR TITLE
Harden session message creation

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.session
+
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+/**
+ * Captures a block of data safely, logging any exceptions that occur as an internal error.
+ * This is intended for use when building the session/background activity payloads. If an
+ * exception is thrown during capture, then we still want to send the request.
+ */
+internal inline fun <R> captureDataSafely(result: () -> R): R? {
+    return try {
+        result()
+    } catch (exc: Throwable) {
+        InternalStaticEmbraceLogger.logger.logError(
+            "Exception thrown capturing session data",
+            exc
+        )
+        null
+    }
+}


### PR DESCRIPTION
## Goal

Catches any exceptions that are thrown from individual services when building the session message. Exceptions could result in the loss of a start/end message so if they happen we should catch it, set the field to null, and log an internal error so we can fix the error in future releases.

## Testing

Relied on existing test coverage.

