### PR TITLE
[EMBR-1196] Create a retry queue for each endpoint.

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
@@ -69,7 +69,7 @@ internal class LogMessageTest : BaseTest() {
                     jsonreader.isLenient = true
                     val obj = serializer.loadObject(jsonreader, DeliveryFailedApiCalls::class.java)
                     if (obj != null) {
-                        val failedCallFileName = obj.element().cachedPayload
+                        val failedCallFileName = obj.element().cachedPayloadFilename
                         assert(failedCallFileName.isNotBlank())
                         readFileContent("Test log info fail", failedCallFileName)
                     } else {

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk
 
 import com.google.gson.stream.JsonReader
-import io.embrace.android.embracesdk.comms.api.EmbraceApiService
 import io.embrace.android.embracesdk.comms.delivery.FailedApiCallsPerEndpoint
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.After
@@ -70,9 +69,9 @@ internal class LogMessageTest : BaseTest() {
                     jsonreader.isLenient = true
                     val obj = serializer.loadObject(jsonreader, FailedApiCallsPerEndpoint::class.java)
                     if (obj != null) {
-                        val failedApiCall = obj.get(EmbraceApiService.Companion.Endpoint.LOGGING)
+                        val failedApiCall = obj.pollNextFailedApiCall()
                         checkNotNull(failedApiCall)
-                        val failedCallFileName = failedApiCall.element().cachedPayloadFilename
+                        val failedCallFileName = failedApiCall.cachedPayloadFilename
                         assert(failedCallFileName.isNotBlank())
                         readFileContent("Test log info fail", failedCallFileName)
                     } else {

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
@@ -1,7 +1,8 @@
 package io.embrace.android.embracesdk
 
 import com.google.gson.stream.JsonReader
-import io.embrace.android.embracesdk.comms.delivery.DeliveryFailedApiCalls
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService
+import io.embrace.android.embracesdk.comms.delivery.FailedApiCallsPerEndpoint
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -67,9 +68,11 @@ internal class LogMessageTest : BaseTest() {
             file.bufferedReader().use { bufferedReader ->
                 JsonReader(bufferedReader).use { jsonreader ->
                     jsonreader.isLenient = true
-                    val obj = serializer.loadObject(jsonreader, DeliveryFailedApiCalls::class.java)
+                    val obj = serializer.loadObject(jsonreader, FailedApiCallsPerEndpoint::class.java)
                     if (obj != null) {
-                        val failedCallFileName = obj.element().cachedPayloadFilename
+                        val failedApiCall = obj.get(EmbraceApiService.Companion.Endpoint.LOGGING)
+                        checkNotNull(failedApiCall)
+                        val failedCallFileName = failedApiCall.element().cachedPayloadFilename
                         assert(failedCallFileName.isNotBlank())
                         readFileContent("Test log info fail", failedCallFileName)
                     } else {

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
@@ -1,7 +1,8 @@
 package io.embrace.android.embracesdk
 
 import com.google.gson.stream.JsonReader
-import io.embrace.android.embracesdk.comms.delivery.DeliveryFailedApiCalls
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService
+import io.embrace.android.embracesdk.comms.delivery.FailedApiCallsPerEndpoint
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -109,9 +110,11 @@ internal class MomentMessageTest : BaseTest() {
             file.bufferedReader().use { bufferedReader ->
                 JsonReader(bufferedReader).use { jsonreader ->
                     jsonreader.isLenient = true
-                    val obj = serializer.loadObject(jsonreader, DeliveryFailedApiCalls::class.java)
+                    val obj = serializer.loadObject(jsonreader, FailedApiCallsPerEndpoint::class.java)
                     if (obj != null) {
-                        val failedCallFileName = obj.element().cachedPayloadFilename
+                        val failedApiCall = obj.get(EmbraceApiService.Companion.Endpoint.EVENTS)
+                        checkNotNull(failedApiCall)
+                        val failedCallFileName = failedApiCall.element().cachedPayloadFilename
                         assert(failedCallFileName.isNotBlank())
                         readFileContent("\"t\":\"start\"", failedCallFileName)
                     } else {

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
@@ -111,7 +111,7 @@ internal class MomentMessageTest : BaseTest() {
                     jsonreader.isLenient = true
                     val obj = serializer.loadObject(jsonreader, DeliveryFailedApiCalls::class.java)
                     if (obj != null) {
-                        val failedCallFileName = obj.element().cachedPayload
+                        val failedCallFileName = obj.element().cachedPayloadFilename
                         assert(failedCallFileName.isNotBlank())
                         readFileContent("\"t\":\"start\"", failedCallFileName)
                     } else {

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk
 
 import com.google.gson.stream.JsonReader
-import io.embrace.android.embracesdk.comms.api.EmbraceApiService
 import io.embrace.android.embracesdk.comms.delivery.FailedApiCallsPerEndpoint
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.After
@@ -112,9 +111,9 @@ internal class MomentMessageTest : BaseTest() {
                     jsonreader.isLenient = true
                     val obj = serializer.loadObject(jsonreader, FailedApiCallsPerEndpoint::class.java)
                     if (obj != null) {
-                        val failedApiCall = obj.get(EmbraceApiService.Companion.Endpoint.EVENTS)
+                        val failedApiCall = obj.pollNextFailedApiCall()
                         checkNotNull(failedApiCall)
-                        val failedCallFileName = failedApiCall.element().cachedPayloadFilename
+                        val failedCallFileName = failedApiCall.cachedPayloadFilename
                         assert(failedCallFileName.isNotBlank())
                         readFileContent("\"t\":\"start\"", failedCallFileName)
                     } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -228,20 +228,7 @@ internal class EmbraceApiService(
             BLOBS("blobs"),
             LOGGING("logging"),
             NETWORK("network"),
-            SESSIONS("sessions");
-
-            companion object {
-                fun fromEmbraceUrl(embraceUrl: EmbraceUrl): Endpoint? {
-                    return when (embraceUrl.url.path.substringAfterLast("/")) {
-                        EVENTS.path -> EVENTS
-                        BLOBS.path -> BLOBS
-                        LOGGING.path -> LOGGING
-                        NETWORK.path -> NETWORK
-                        SESSIONS.path -> SESSIONS
-                        else -> null
-                    }
-                }
-            }
+            SESSIONS("sessions")
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -228,7 +228,8 @@ internal class EmbraceApiService(
             BLOBS("blobs"),
             LOGGING("logging"),
             NETWORK("network"),
-            SESSIONS("sessions")
+            SESSIONS("sessions"),
+            UNKNOWN("unknown")
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -228,7 +228,20 @@ internal class EmbraceApiService(
             BLOBS("blobs"),
             LOGGING("logging"),
             NETWORK("network"),
-            SESSIONS("sessions")
+            SESSIONS("sessions");
+
+            companion object {
+                fun fromEmbraceUrl(embraceUrl: EmbraceUrl): Endpoint? {
+                    return when (embraceUrl.url.path.substringAfterLast("/")) {
+                        EVENTS.path -> EVENTS
+                        BLOBS.path -> BLOBS
+                        LOGGING.path -> LOGGING
+                        NETWORK.path -> NETWORK
+                        SESSIONS.path -> SESSIONS
+                        else -> null
+                    }
+                }
+            }
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
@@ -12,7 +12,7 @@ internal class EmbraceUrl(val url: URL) {
         return EmbraceConnectionImpl(url.openConnection() as HttpURLConnection, this)
     }
 
-    fun toEndpoint(): Endpoint? {
+    fun endpoint(): Endpoint? {
         return when (url.path.substringAfterLast("/")) {
             Endpoint.EVENTS.path -> Endpoint.EVENTS
             Endpoint.BLOBS.path -> Endpoint.BLOBS

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.api
 
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
@@ -9,6 +10,17 @@ internal class EmbraceUrl(val url: URL) {
     @Throws(IOException::class)
     fun openConnection(): EmbraceConnection {
         return EmbraceConnectionImpl(url.openConnection() as HttpURLConnection, this)
+    }
+
+    fun toEndpoint(): Endpoint? {
+        return when (url.path.substringAfterLast("/")) {
+            Endpoint.EVENTS.path -> Endpoint.EVENTS
+            Endpoint.BLOBS.path -> Endpoint.BLOBS
+            Endpoint.LOGGING.path -> Endpoint.LOGGING
+            Endpoint.NETWORK.path -> Endpoint.NETWORK
+            Endpoint.SESSIONS.path -> Endpoint.SESSIONS
+            else -> null
+        }
     }
 
     override fun toString(): String {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
@@ -12,14 +12,14 @@ internal class EmbraceUrl(val url: URL) {
         return EmbraceConnectionImpl(url.openConnection() as HttpURLConnection, this)
     }
 
-    fun endpoint(): Endpoint? {
+    fun endpoint(): Endpoint {
         return when (url.path.substringAfterLast("/")) {
             Endpoint.EVENTS.path -> Endpoint.EVENTS
             Endpoint.BLOBS.path -> Endpoint.BLOBS
             Endpoint.LOGGING.path -> Endpoint.LOGGING
             Endpoint.NETWORK.path -> Endpoint.NETWORK
             Endpoint.SESSIONS.path -> Endpoint.SESSIONS
-            else -> null
+            else -> Endpoint.UNKNOWN
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -19,6 +19,6 @@ internal interface DeliveryCacheManager {
     fun savePayload(bytes: ByteArray): String
     fun loadPayload(name: String): ByteArray?
     fun deletePayload(name: String)
-    fun saveFailedApiCalls(failedApiCalls: DeliveryFailedApiCalls)
-    fun loadFailedApiCalls(): DeliveryFailedApiCalls
+    fun saveFailedApiCalls(failedApiCalls: FailedApiCallsPerEndpoint)
+    fun loadFailedApiCalls(): FailedApiCallsPerEndpoint
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
@@ -1,8 +1,78 @@
 package io.embrace.android.embracesdk.comms.delivery
 
 import io.embrace.android.embracesdk.comms.api.ApiRequest
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
+/**
+ * A queue containing failed API calls.
+ */
 internal class DeliveryFailedApiCalls : ConcurrentLinkedQueue<DeliveryFailedApiCall>()
 
-internal data class DeliveryFailedApiCall(val apiRequest: ApiRequest, val cachedPayload: String)
+/**
+ * A failed API call.
+ */
+internal data class DeliveryFailedApiCall(
+    val apiRequest: ApiRequest,
+    val cachedPayload: String,
+    val queueTime: Long? = null
+)
+
+/**
+ * A map containing a list of failed API calls per endpoint.
+ */
+internal class FailedApiCallsPerEndpoint : ConcurrentHashMap<Endpoint, DeliveryFailedApiCalls>() {
+
+    /**
+     * Adds a failed API call in the corresponding endpoint's list.
+     */
+    fun add(endpoint: Endpoint, failedApiCall: DeliveryFailedApiCall) {
+        if (this.containsKey(endpoint)) {
+            this[endpoint]?.add(failedApiCall)
+        } else {
+            val failedApiCalls = DeliveryFailedApiCalls()
+            failedApiCalls.add(failedApiCall)
+            this[endpoint] = failedApiCalls
+        }
+    }
+
+    /**
+     * Returns the number of failed API calls in the corresponding endpoint's list.
+     */
+    fun failedApiCallsCount(endpoint: Endpoint) = this[endpoint]?.size ?: 0
+
+    /**
+     * Returns true if there are any failed API calls in any endpoint's list.
+     */
+    fun hasAnyFailedApiCalls(): Boolean {
+        return this.values.any { it.isNotEmpty() }
+    }
+
+    /**
+     * Returns true if there are no failed API calls in any endpoint's list.
+     */
+    fun hasNoFailedApiCalls(): Boolean {
+        return !hasAnyFailedApiCalls()
+    }
+
+    /**
+     * Returns the next failed API call to be sent and removes it from the corresponding
+     * endpoint's list.
+     */
+    fun pollNextFailedApiCall(): DeliveryFailedApiCall? {
+        this[Endpoint.SESSIONS]?.let { sessions ->
+            if (sessions.isNotEmpty()) {
+                return sessions.poll()
+            }
+        }
+
+        val entryToPollFrom = this
+            .entries
+            .filter { it.value.isNotEmpty() }
+            .minByOrNull { it.value.peek()?.queueTime ?: Long.MAX_VALUE }
+            ?.key
+
+        return this[entryToPollFrom]?.poll()
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.comms.delivery
 
 import com.google.gson.annotations.SerializedName
 import io.embrace.android.embracesdk.comms.api.ApiRequest
-import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
@@ -19,77 +17,3 @@ internal data class DeliveryFailedApiCall(
     @SerializedName("cachedPayload") val cachedPayloadFilename: String,
     @SerializedName("queueTime") val queueTime: Long? = null
 )
-
-/**
- * A map containing a list of failed API calls per endpoint.
- */
-internal class FailedApiCallsPerEndpoint {
-
-    private val failedApiCallsMap = ConcurrentHashMap<Endpoint, DeliveryFailedApiCalls>()
-
-    /**
-     * Adds a failed API call in the corresponding endpoint's list.
-     */
-    fun add(endpoint: Endpoint, failedApiCall: DeliveryFailedApiCall) {
-        val failedApiCallsForEndpoint = failedApiCallsMap.getOrPut(endpoint) { DeliveryFailedApiCalls() }
-        failedApiCallsForEndpoint.add(failedApiCall)
-    }
-
-    /**
-     * Returns the list of failed API calls for the corresponding endpoint.
-     */
-    fun get(endpoint: Endpoint): DeliveryFailedApiCalls? {
-        return failedApiCallsMap[endpoint]
-    }
-
-    /**
-     * Clears all lists of failed API calls.
-     */
-    fun clear() {
-        failedApiCallsMap.clear()
-    }
-
-    /**
-     * Returns the total number of failed API calls in all endpoints' lists.
-     */
-    fun failedApiCallsCount() = failedApiCallsMap.values.sumOf { it.size }
-
-    /**
-     * Returns the number of failed API calls in the corresponding endpoint's list.
-     */
-    fun failedApiCallsCount(endpoint: Endpoint) = failedApiCallsMap[endpoint]?.size ?: 0
-
-    /**
-     * Returns true if there are any failed API calls in any endpoint's list.
-     */
-    fun hasAnyFailedApiCalls(): Boolean {
-        return failedApiCallsMap.values.any { it.isNotEmpty() }
-    }
-
-    /**
-     * Returns true if there are no failed API calls in any endpoint's list.
-     */
-    fun hasNoFailedApiCalls(): Boolean {
-        return !hasAnyFailedApiCalls()
-    }
-
-    /**
-     * Returns the next failed API call to be sent and removes it from the corresponding
-     * endpoint's list.
-     */
-    fun pollNextFailedApiCall(): DeliveryFailedApiCall? {
-        failedApiCallsMap[Endpoint.SESSIONS]?.let { sessions ->
-            if (sessions.isNotEmpty()) {
-                return sessions.poll()
-            }
-        }
-
-        val entryToPollFrom = failedApiCallsMap
-            .entries
-            .filter { it.value.isNotEmpty() }
-            .minByOrNull { it.value.peek()?.queueTime ?: Long.MAX_VALUE }
-            ?.key
-
-        return failedApiCallsMap[entryToPollFrom]?.poll()
-    }
-}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
@@ -39,6 +39,11 @@ internal class FailedApiCallsPerEndpoint : ConcurrentHashMap<Endpoint, DeliveryF
     }
 
     /**
+     * Returns the total number of failed API calls in all endpoints' lists.
+     */
+    fun failedApiCallsCount() = this.values.sumOf { it.size }
+
+    /**
      * Returns the number of failed API calls in the corresponding endpoint's list.
      */
     fun failedApiCallsCount(endpoint: Endpoint) = this[endpoint]?.size ?: 0

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryFailedApiCalls.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import com.google.gson.annotations.SerializedName
 import io.embrace.android.embracesdk.comms.api.ApiRequest
 import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
 import java.util.concurrent.ConcurrentHashMap
@@ -14,9 +15,9 @@ internal class DeliveryFailedApiCalls : ConcurrentLinkedQueue<DeliveryFailedApiC
  * A failed API call.
  */
 internal data class DeliveryFailedApiCall(
-    val apiRequest: ApiRequest,
-    val cachedPayload: String,
-    val queueTime: Long? = null
+    @SerializedName("apiRequest") val apiRequest: ApiRequest,
+    @SerializedName("cachedPayload") val cachedPayloadFilename: String,
+    @SerializedName("queueTime") val queueTime: Long? = null
 )
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.comms.delivery
 
-import io.embrace.android.embracesdk.comms.api.EmbraceApiService
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
@@ -225,10 +224,10 @@ internal class EmbraceDeliveryCacheManager(
         if (cachedApiCalls != null) {
             cachedApiCallsPerEndpoint = FailedApiCallsPerEndpoint()
             cachedApiCalls.forEach { cachedApiCall ->
-                val endpoint = EmbraceApiService.Companion.Endpoint.valueOf(
-                    cachedApiCall.apiRequest.url.url.path.substringAfterLast("/")
-                )
-                cachedApiCallsPerEndpoint.add(endpoint, cachedApiCall)
+                val endpoint = cachedApiCall.apiRequest.url.toEndpoint()
+                endpoint?.let {
+                    cachedApiCallsPerEndpoint.add(it, cachedApiCall)
+                }
             }
         }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -238,10 +238,7 @@ internal class EmbraceDeliveryCacheManager(
         if (loadFailedApiCalls.isSuccess) {
             cachedApiCallsPerEndpoint = FailedApiCallsPerEndpoint()
             loadFailedApiCalls.getOrNull()?.forEach { cachedApiCall ->
-                val endpoint = cachedApiCall.apiRequest.url.endpoint()
-                endpoint?.let {
-                    cachedApiCallsPerEndpoint.add(it, cachedApiCall)
-                }
+                cachedApiCallsPerEndpoint.add(cachedApiCall)
             }
         }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -207,14 +207,10 @@ internal class EmbraceDeliveryCacheManager(
     override fun loadFailedApiCalls(): FailedApiCallsPerEndpoint {
         logger.logDeveloper(TAG, "Loading failed api calls")
         val cached = executorService.submit<FailedApiCallsPerEndpoint> {
-            val loadFailedApiCalls = runCatching {
+            val loadApiCallsResult = runCatching {
                 cacheService.loadObject(FAILED_API_CALLS_FILE_NAME, FailedApiCallsPerEndpoint::class.java)
             }
-            if (loadFailedApiCalls.isSuccess) {
-                loadFailedApiCalls.getOrNull()
-            } else {
-                loadFailedApiCallsOldVersion()
-            }
+            loadApiCallsResult.getOrNull() ?: loadFailedApiCallsOldVersion()
         }.get()
         return if (cached != null) {
             cached

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -238,7 +238,7 @@ internal class EmbraceDeliveryCacheManager(
         if (loadFailedApiCalls.isSuccess) {
             cachedApiCallsPerEndpoint = FailedApiCallsPerEndpoint()
             loadFailedApiCalls.getOrNull()?.forEach { cachedApiCall ->
-                val endpoint = cachedApiCall.apiRequest.url.toEndpoint()
+                val endpoint = cachedApiCall.apiRequest.url.endpoint()
                 endpoint?.let {
                     cachedApiCallsPerEndpoint.add(it, cachedApiCall)
                 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
@@ -48,7 +48,7 @@ internal class EmbraceDeliveryRetryManager(
     override fun scheduleForRetry(request: ApiRequest, payload: ByteArray) {
         logger.logDeveloper(TAG, "Scheduling api call for retry")
 
-        val endpoint = request.url.toEndpoint()
+        val endpoint = request.url.endpoint()
         endpoint?.let { e ->
             if (isBelowRetryLimit(e)) {
                 val cachedPayloadName = cacheManager.savePayload(payload)
@@ -143,7 +143,7 @@ internal class EmbraceDeliveryRetryManager(
                                                 cacheManager.saveFailedApiCalls(retryMap)
                                             } else {
                                                 // if the retry failed, add the call back to the queue.
-                                                val endpoint = failedApiCall.apiRequest.url.toEndpoint()
+                                                val endpoint = failedApiCall.apiRequest.url.endpoint()
                                                 endpoint?.let { e ->
                                                     retryMap.add(e, failedApiCall)
                                                 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
@@ -133,7 +133,8 @@ internal class EmbraceDeliveryRetryManager(
                                 try {
                                     logger.logDeveloper(TAG, "Retrying failed API calls")
 
-                                    while (retryMap.hasAnyFailedApiCalls()) {
+                                    val retries = retryMap.failedApiCallsCount()
+                                    repeat(retries) {
                                         val failedApiCall = retryMap.pollNextFailedApiCall()
                                         if (failedApiCall != null) {
                                             val callSucceeded = retryFailedApiCall(failedApiCall)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
@@ -48,7 +48,7 @@ internal class EmbraceDeliveryRetryManager(
     override fun scheduleForRetry(request: ApiRequest, payload: ByteArray) {
         logger.logDeveloper(TAG, "Scheduling api call for retry")
 
-        val endpoint = Endpoint.fromEmbraceUrl(request.url)
+        val endpoint = request.url.toEndpoint()
         endpoint?.let { e ->
             if (isBelowRetryLimit(e)) {
                 val cachedPayloadName = cacheManager.savePayload(payload)
@@ -142,7 +142,7 @@ internal class EmbraceDeliveryRetryManager(
                                                 cacheManager.saveFailedApiCalls(retryMap)
                                             } else {
                                                 // if the retry failed, add the call back to the queue.
-                                                val endpoint = Endpoint.fromEmbraceUrl(failedApiCall.apiRequest.url)
+                                                val endpoint = failedApiCall.apiRequest.url.toEndpoint()
                                                 endpoint?.let { e ->
                                                     retryMap.add(e, failedApiCall)
                                                 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManager.kt
@@ -185,12 +185,12 @@ internal class EmbraceDeliveryRetryManager(
      * Executes the network call for a DeliveryFailedApiCall.
      */
     private fun retryFailedApiCall(call: DeliveryFailedApiCall): Boolean {
-        val payload = cacheManager.loadPayload(call.cachedPayload)
+        val payload = cacheManager.loadPayload(call.cachedPayloadFilename)
         if (payload != null) {
             try {
                 logger.logDeveloper(TAG, "Retrying failed API call")
                 retryMethod(call.apiRequest, payload)
-                cacheManager.deletePayload(call.cachedPayload)
+                cacheManager.deletePayload(call.cachedPayloadFilename)
             } catch (ex: Exception) {
                 logger.logDeveloper(
                     TAG,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
@@ -73,6 +73,8 @@ internal class FailedApiCallsPerEndpoint {
             .minByOrNull { it.value.peek()?.queueTime ?: Long.MAX_VALUE }
             ?.key
 
-        return failedApiCallsMap[entryToPollFrom]?.poll()
+        return entryToPollFrom?.let {
+            failedApiCallsMap[it]?.poll()
+        }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
@@ -20,44 +20,6 @@ internal class FailedApiCallsPerEndpoint {
     }
 
     /**
-     * Returns the list of failed API calls for the corresponding endpoint.
-     */
-    fun get(endpoint: Endpoint): DeliveryFailedApiCalls? {
-        return failedApiCallsMap[endpoint]
-    }
-
-    /**
-     * Clears all lists of failed API calls.
-     */
-    fun clear() {
-        failedApiCallsMap.clear()
-    }
-
-    /**
-     * Returns the total number of failed API calls in all endpoints' lists.
-     */
-    fun failedApiCallsCount() = failedApiCallsMap.values.sumOf { it.size }
-
-    /**
-     * Returns the number of failed API calls in the corresponding endpoint's list.
-     */
-    fun failedApiCallsCount(endpoint: Endpoint) = failedApiCallsMap[endpoint]?.size ?: 0
-
-    /**
-     * Returns true if there are any failed API calls in any endpoint's list.
-     */
-    fun hasAnyFailedApiCalls(): Boolean {
-        return failedApiCallsMap.values.any { it.isNotEmpty() }
-    }
-
-    /**
-     * Returns true if there are no failed API calls in any endpoint's list.
-     */
-    fun hasNoFailedApiCalls(): Boolean {
-        return !hasAnyFailedApiCalls()
-    }
-
-    /**
      * Returns the next failed API call to be sent and removes it from the corresponding
      * endpoint's list.
      */
@@ -76,6 +38,55 @@ internal class FailedApiCallsPerEndpoint {
 
         return entryToPollFrom?.let {
             failedApiCallsMap[it]?.poll()
+        }
+    }
+
+    /**
+     * Returns true if the number of retries for the endpoint is below the limit.
+     */
+    fun isBelowRetryLimit(endpoint: Endpoint): Boolean {
+        return failedApiCallsCount(endpoint) < endpoint.getMaxFailedApiCalls()
+    }
+
+    /**
+     * Clears all lists of failed API calls.
+     */
+    fun clear() {
+        failedApiCallsMap.clear()
+    }
+
+    /**
+     * Returns true if there are any failed API calls in any endpoint's list.
+     */
+    fun hasAnyFailedApiCalls(): Boolean {
+        return failedApiCallsMap.values.any { it.isNotEmpty() }
+    }
+
+    /**
+     * Returns true if there are no failed API calls in any endpoint's list.
+     */
+    fun hasNoFailedApiCalls(): Boolean {
+        return !hasAnyFailedApiCalls()
+    }
+
+    /**
+     * Returns the total number of failed API calls in all endpoints' lists.
+     */
+    fun failedApiCallsCount() = failedApiCallsMap.values.sumOf { it.size }
+
+    /**
+     * Returns the number of failed API calls in the corresponding endpoint's list.
+     */
+    private fun failedApiCallsCount(endpoint: Endpoint) = failedApiCallsMap[endpoint]?.size ?: 0
+
+    private fun Endpoint.getMaxFailedApiCalls(): Int {
+        return when (this) {
+            Endpoint.EVENTS -> 100
+            Endpoint.BLOBS -> 50
+            Endpoint.LOGGING -> 100
+            Endpoint.NETWORK -> 50
+            Endpoint.SESSIONS -> 100
+            Endpoint.UNKNOWN -> 50
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A map containing a list of failed API calls per endpoint.
+ * Public methods on this class aren't meant to be accessed by multiple threads.
  */
 internal class FailedApiCallsPerEndpoint {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
@@ -13,7 +13,8 @@ internal class FailedApiCallsPerEndpoint {
     /**
      * Adds a failed API call in the corresponding endpoint's list.
      */
-    fun add(endpoint: Endpoint, failedApiCall: DeliveryFailedApiCall) {
+    fun add(failedApiCall: DeliveryFailedApiCall) {
+        val endpoint = failedApiCall.apiRequest.url.endpoint()
         val failedApiCallsForEndpoint = failedApiCallsMap.getOrPut(endpoint) { DeliveryFailedApiCalls() }
         failedApiCallsForEndpoint.add(failedApiCall)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
@@ -1,0 +1,78 @@
+package io.embrace.android.embracesdk.comms.delivery
+
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A map containing a list of failed API calls per endpoint.
+ */
+internal class FailedApiCallsPerEndpoint {
+
+    private val failedApiCallsMap = ConcurrentHashMap<Endpoint, DeliveryFailedApiCalls>()
+
+    /**
+     * Adds a failed API call in the corresponding endpoint's list.
+     */
+    fun add(endpoint: Endpoint, failedApiCall: DeliveryFailedApiCall) {
+        val failedApiCallsForEndpoint = failedApiCallsMap.getOrPut(endpoint) { DeliveryFailedApiCalls() }
+        failedApiCallsForEndpoint.add(failedApiCall)
+    }
+
+    /**
+     * Returns the list of failed API calls for the corresponding endpoint.
+     */
+    fun get(endpoint: Endpoint): DeliveryFailedApiCalls? {
+        return failedApiCallsMap[endpoint]
+    }
+
+    /**
+     * Clears all lists of failed API calls.
+     */
+    fun clear() {
+        failedApiCallsMap.clear()
+    }
+
+    /**
+     * Returns the total number of failed API calls in all endpoints' lists.
+     */
+    fun failedApiCallsCount() = failedApiCallsMap.values.sumOf { it.size }
+
+    /**
+     * Returns the number of failed API calls in the corresponding endpoint's list.
+     */
+    fun failedApiCallsCount(endpoint: Endpoint) = failedApiCallsMap[endpoint]?.size ?: 0
+
+    /**
+     * Returns true if there are any failed API calls in any endpoint's list.
+     */
+    fun hasAnyFailedApiCalls(): Boolean {
+        return failedApiCallsMap.values.any { it.isNotEmpty() }
+    }
+
+    /**
+     * Returns true if there are no failed API calls in any endpoint's list.
+     */
+    fun hasNoFailedApiCalls(): Boolean {
+        return !hasAnyFailedApiCalls()
+    }
+
+    /**
+     * Returns the next failed API call to be sent and removes it from the corresponding
+     * endpoint's list.
+     */
+    fun pollNextFailedApiCall(): DeliveryFailedApiCall? {
+        failedApiCallsMap[Endpoint.SESSIONS]?.let { sessions ->
+            if (sessions.isNotEmpty()) {
+                return sessions.poll()
+            }
+        }
+
+        val entryToPollFrom = failedApiCallsMap
+            .entries
+            .filter { it.value.isNotEmpty() }
+            .minByOrNull { it.value.peek()?.queueTime ?: Long.MAX_VALUE }
+            ?.key
+
+        return failedApiCallsMap[entryToPollFrom]?.poll()
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpoint.kt
@@ -45,7 +45,8 @@ internal class FailedApiCallsPerEndpoint {
      * Returns true if the number of retries for the endpoint is below the limit.
      */
     fun isBelowRetryLimit(endpoint: Endpoint): Boolean {
-        return failedApiCallsCount(endpoint) < endpoint.getMaxFailedApiCalls()
+        val failedApiCallsCount = failedApiCallsMap[endpoint]?.size ?: 0
+        return failedApiCallsCount < endpoint.getMaxFailedApiCalls()
     }
 
     /**
@@ -68,16 +69,6 @@ internal class FailedApiCallsPerEndpoint {
     fun hasNoFailedApiCalls(): Boolean {
         return !hasAnyFailedApiCalls()
     }
-
-    /**
-     * Returns the total number of failed API calls in all endpoints' lists.
-     */
-    fun failedApiCallsCount() = failedApiCallsMap.values.sumOf { it.size }
-
-    /**
-     * Returns the number of failed API calls in the corresponding endpoint's list.
-     */
-    private fun failedApiCallsCount(endpoint: Endpoint) = failedApiCallsMap[endpoint]?.size ?: 0
 
     private fun Endpoint.getMaxFailedApiCalls(): Int {
         return when (this) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -278,7 +278,8 @@ internal class EssentialServiceModuleImpl(
         EmbraceDeliveryRetryManager(
             networkConnectivityService,
             apiRetryExecutor,
-            deliveryCacheManager
+            deliveryCacheManager,
+            initModule.clock
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk
 
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.comms.api.ApiRequest
-import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
 import io.embrace.android.embracesdk.comms.api.EmbraceUrl
 import io.embrace.android.embracesdk.comms.delivery.CacheService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryFailedApiCall
@@ -307,19 +306,10 @@ internal class EmbraceDeliveryCacheManagerTest {
         deliveryCacheManager.saveFailedApiCalls(failedCalls)
         val cachedCalls = deliveryCacheManager.loadFailedApiCalls()
 
-        assertEquals(3, cachedCalls.failedApiCallsCount())
-        assertEquals(
-            listOf("request_1"),
-            cachedCalls.get(Endpoint.SESSIONS)?.map { failedCall -> failedCall.apiRequest.eventId }
-        )
-        assertEquals(
-            listOf("request_2"),
-            cachedCalls.get(Endpoint.EVENTS)?.map { failedCall -> failedCall.apiRequest.eventId }
-        )
-        assertEquals(
-            listOf("request_3"),
-            cachedCalls.get(Endpoint.LOGGING)?.map { failedCall -> failedCall.apiRequest.eventId }
-        )
+        assertEquals(failedApiCall1, cachedCalls.pollNextFailedApiCall())
+        assertEquals(failedApiCall2, cachedCalls.pollNextFailedApiCall())
+        assertEquals(failedApiCall3, cachedCalls.pollNextFailedApiCall())
+        assertNull(cachedCalls.pollNextFailedApiCall())
     }
 
     /**
@@ -360,17 +350,9 @@ internal class EmbraceDeliveryCacheManagerTest {
         )
 
         val cachedCalls = deliveryCacheManager.loadFailedApiCalls()
-        assertEquals(2, cachedCalls.failedApiCallsCount())
-        assertEquals(1, cachedCalls.failedApiCallsCount(Endpoint.SESSIONS))
-        assertEquals(1, cachedCalls.failedApiCallsCount(Endpoint.EVENTS))
-        assertEquals(
-            listOf("request_1"),
-            cachedCalls.get(Endpoint.SESSIONS)?.map { failedCall -> failedCall.apiRequest.eventId }
-        )
-        assertEquals(
-            listOf("request_2"),
-            cachedCalls.get(Endpoint.EVENTS)?.map { failedCall -> failedCall.apiRequest.eventId }
-        )
+        assertEquals(failedApiCall1, cachedCalls.pollNextFailedApiCall())
+        assertEquals(failedApiCall2, cachedCalls.pollNextFailedApiCall())
+        assertEquals(null, cachedCalls.pollNextFailedApiCall())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -270,7 +270,7 @@ internal class EmbraceDeliveryCacheManagerTest {
     fun `save and load failed api calls`() {
         val failedCalls = FailedApiCallsPerEndpoint()
         val request1 = ApiRequest(
-            url = EmbraceUrl.create("http://test.url"),
+            url = EmbraceUrl.create("http://test.url/sessions"),
             httpMethod = HttpMethod.POST,
             appId = "test_app_id_1",
             deviceId = "test_device_id",
@@ -278,10 +278,10 @@ internal class EmbraceDeliveryCacheManagerTest {
             contentEncoding = "gzip"
         )
         val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_1.json", fakeClock.now())
-        failedCalls.add(Endpoint.SESSIONS, failedApiCall1)
+        failedCalls.add(failedApiCall1)
 
         val request2 = ApiRequest(
-            url = EmbraceUrl.create("http://test.url"),
+            url = EmbraceUrl.create("http://test.url/events"),
             httpMethod = HttpMethod.POST,
             appId = "test_app_id",
             deviceId = "test_device_id",
@@ -290,10 +290,10 @@ internal class EmbraceDeliveryCacheManagerTest {
         )
         fakeClock.tickSecond()
         val failedApiCall2 = DeliveryFailedApiCall(request2, "payload_2.json", fakeClock.now())
-        failedCalls.add(Endpoint.EVENTS, failedApiCall2)
+        failedCalls.add(failedApiCall2)
 
         val request3 = ApiRequest(
-            url = EmbraceUrl.create("http://test.url"),
+            url = EmbraceUrl.create("http://test.url/logging"),
             httpMethod = HttpMethod.POST,
             appId = "test_app_id",
             deviceId = "test_device_id",
@@ -302,7 +302,7 @@ internal class EmbraceDeliveryCacheManagerTest {
         )
         fakeClock.tickSecond()
         val failedApiCall3 = DeliveryFailedApiCall(request3, "payload_3.json", fakeClock.now())
-        failedCalls.add(Endpoint.LOGGING, failedApiCall3)
+        failedCalls.add(failedApiCall3)
 
         deliveryCacheManager.saveFailedApiCalls(failedCalls)
         val cachedCalls = deliveryCacheManager.loadFailedApiCalls()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -306,25 +306,25 @@ internal class EmbraceDeliveryCacheManagerTest {
         deliveryCacheManager.saveFailedApiCalls(failedCalls)
         val cachedCalls = deliveryCacheManager.loadFailedApiCalls()
 
-        assertEquals(3, cachedCalls.size)
+        assertEquals(3, cachedCalls.failedApiCallsCount())
         assertEquals(
             listOf("request_1"),
-            cachedCalls[Endpoint.SESSIONS]?.map { failedCall -> failedCall.apiRequest.eventId }
+            cachedCalls.get(Endpoint.SESSIONS)?.map { failedCall -> failedCall.apiRequest.eventId }
         )
         assertEquals(
             listOf("request_2"),
-            cachedCalls[Endpoint.EVENTS]?.map { failedCall -> failedCall.apiRequest.eventId }
+            cachedCalls.get(Endpoint.EVENTS)?.map { failedCall -> failedCall.apiRequest.eventId }
         )
         assertEquals(
             listOf("request_3"),
-            cachedCalls[Endpoint.LOGGING]?.map { failedCall -> failedCall.apiRequest.eventId }
+            cachedCalls.get(Endpoint.LOGGING)?.map { failedCall -> failedCall.apiRequest.eventId }
         )
     }
 
     @Test
     fun `load empty set of delivery calls if non cached`() {
         val failedCalls = deliveryCacheManager.loadFailedApiCalls()
-        assertTrue(failedCalls.isEmpty())
+        assertTrue(failedCalls.hasNoFailedApiCalls())
     }
 
     private fun assertSessionsMatch(session1: SessionMessage, session2: SessionMessage) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -371,7 +371,6 @@ internal class EmbraceDeliveryCacheManagerTest {
             listOf("request_2"),
             cachedCalls.get(Endpoint.EVENTS)?.map { failedCall -> failedCall.apiRequest.eventId }
         )
-
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
@@ -1,10 +1,28 @@
 package io.embrace.android.embracesdk.comms.api
 
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 internal class EmbraceUrlTest {
+
+    @Test
+    fun `test toEndpoint`() {
+        val embraceUrlSessions = EmbraceUrl.create("https://embrace.io/sessions")
+        val embraceUrlEvents = EmbraceUrl.create("https://embrace.io/events")
+        val embraceUrlBlobs = EmbraceUrl.create("https://embrace.io/blobs")
+        val embraceUrlLogging = EmbraceUrl.create("https://embrace.io/logging")
+        val embraceUrlNetwork = EmbraceUrl.create("https://embrace.io/network")
+        val embraceUrlOther = EmbraceUrl.create("https://embrace.io/other")
+
+        assertEquals(Endpoint.SESSIONS, embraceUrlSessions.toEndpoint())
+        assertEquals(Endpoint.EVENTS, embraceUrlEvents.toEndpoint())
+        assertEquals(Endpoint.BLOBS, embraceUrlBlobs.toEndpoint())
+        assertEquals(Endpoint.LOGGING, embraceUrlLogging.toEndpoint())
+        assertEquals(Endpoint.NETWORK, embraceUrlNetwork.toEndpoint())
+        assertEquals(null, embraceUrlOther.toEndpoint())
+    }
     @Test
     fun `test equality`() {
         val embraceUrl1 = EmbraceUrl.create("https://embrace.io")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
@@ -21,7 +21,7 @@ internal class EmbraceUrlTest {
         assertEquals(Endpoint.BLOBS, embraceUrlBlobs.endpoint())
         assertEquals(Endpoint.LOGGING, embraceUrlLogging.endpoint())
         assertEquals(Endpoint.NETWORK, embraceUrlNetwork.endpoint())
-        assertEquals(null, embraceUrlOther.endpoint())
+        assertEquals(Endpoint.UNKNOWN, embraceUrlOther.endpoint())
     }
     @Test
     fun `test equality`() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 internal class EmbraceUrlTest {
 
     @Test
-    fun `test toEndpoint`() {
+    fun `test endpoint()`() {
         val embraceUrlSessions = EmbraceUrl.create("https://embrace.io/sessions")
         val embraceUrlEvents = EmbraceUrl.create("https://embrace.io/events")
         val embraceUrlBlobs = EmbraceUrl.create("https://embrace.io/blobs")
@@ -16,12 +16,12 @@ internal class EmbraceUrlTest {
         val embraceUrlNetwork = EmbraceUrl.create("https://embrace.io/network")
         val embraceUrlOther = EmbraceUrl.create("https://embrace.io/other")
 
-        assertEquals(Endpoint.SESSIONS, embraceUrlSessions.toEndpoint())
-        assertEquals(Endpoint.EVENTS, embraceUrlEvents.toEndpoint())
-        assertEquals(Endpoint.BLOBS, embraceUrlBlobs.toEndpoint())
-        assertEquals(Endpoint.LOGGING, embraceUrlLogging.toEndpoint())
-        assertEquals(Endpoint.NETWORK, embraceUrlNetwork.toEndpoint())
-        assertEquals(null, embraceUrlOther.toEndpoint())
+        assertEquals(Endpoint.SESSIONS, embraceUrlSessions.endpoint())
+        assertEquals(Endpoint.EVENTS, embraceUrlEvents.endpoint())
+        assertEquals(Endpoint.BLOBS, embraceUrlBlobs.endpoint())
+        assertEquals(Endpoint.LOGGING, embraceUrlLogging.endpoint())
+        assertEquals(Endpoint.NETWORK, embraceUrlNetwork.endpoint())
+        assertEquals(null, embraceUrlOther.endpoint())
     }
     @Test
     fun `test equality`() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
@@ -347,7 +347,10 @@ internal class EmbraceDeliveryRetryManagerTest {
         failedApiCalls.clear()
 
         if (loadFailedRequest) {
-            failedApiCalls.add(Endpoint.SESSIONS, DeliveryFailedApiCall(mockk(), "cached_payload_1"))
+            val mockApiRequest = mockk<ApiRequest>(relaxed = true) {
+                every { url.toEndpoint() } returns Endpoint.SESSIONS
+            }
+            failedApiCalls.add(Endpoint.SESSIONS, DeliveryFailedApiCall(mockApiRequest, "cached_payload_1"))
         }
 
         if (runRetryJobAfterScheduling) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
@@ -350,7 +350,7 @@ internal class EmbraceDeliveryRetryManagerTest {
             val mockApiRequest = mockk<ApiRequest>(relaxed = true) {
                 every { url.endpoint() } returns Endpoint.SESSIONS
             }
-            failedApiCalls.add(Endpoint.SESSIONS, DeliveryFailedApiCall(mockApiRequest, "cached_payload_1"))
+            failedApiCalls.add(DeliveryFailedApiCall(mockApiRequest, "cached_payload_1"))
         }
 
         if (runRetryJobAfterScheduling) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
@@ -249,19 +249,19 @@ internal class EmbraceDeliveryRetryManagerTest {
         assertTrue(failedApiCalls.hasNoFailedApiCalls())
 
         val mockApiRequestSessions = mockk<ApiRequest>(relaxed = true) {
-            every { url.url.path } returns "https://mytesturl.com/sessions"
+            every { url.toEndpoint() } returns Endpoint.SESSIONS
         }
         val mockApiRequestEvents = mockk<ApiRequest>(relaxed = true) {
-            every { url.url.path } returns "https://mytesturl.com/events"
+            every { url.toEndpoint() } returns Endpoint.EVENTS
         }
         val mockApiRequestLogging = mockk<ApiRequest>(relaxed = true) {
-            every { url.url.path } returns "https://mytesturl.com/logging"
+            every { url.toEndpoint() } returns Endpoint.LOGGING
         }
         val mockApiRequestBlobs = mockk<ApiRequest>(relaxed = true) {
-            every { url.url.path } returns "https://mytesturl.com/blobs"
+            every { url.toEndpoint() } returns Endpoint.BLOBS
         }
         val mockApiRequestNetwork = mockk<ApiRequest>(relaxed = true) {
-            every { url.url.path } returns "https://mytesturl.com/network"
+            every { url.toEndpoint() } returns Endpoint.NETWORK
         }
 
         repeat(201) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
@@ -249,19 +249,19 @@ internal class EmbraceDeliveryRetryManagerTest {
         assertTrue(failedApiCalls.hasNoFailedApiCalls())
 
         val mockApiRequestSessions = mockk<ApiRequest>(relaxed = true) {
-            every { url.toEndpoint() } returns Endpoint.SESSIONS
+            every { url.endpoint() } returns Endpoint.SESSIONS
         }
         val mockApiRequestEvents = mockk<ApiRequest>(relaxed = true) {
-            every { url.toEndpoint() } returns Endpoint.EVENTS
+            every { url.endpoint() } returns Endpoint.EVENTS
         }
         val mockApiRequestLogging = mockk<ApiRequest>(relaxed = true) {
-            every { url.toEndpoint() } returns Endpoint.LOGGING
+            every { url.endpoint() } returns Endpoint.LOGGING
         }
         val mockApiRequestBlobs = mockk<ApiRequest>(relaxed = true) {
-            every { url.toEndpoint() } returns Endpoint.BLOBS
+            every { url.endpoint() } returns Endpoint.BLOBS
         }
         val mockApiRequestNetwork = mockk<ApiRequest>(relaxed = true) {
-            every { url.toEndpoint() } returns Endpoint.NETWORK
+            every { url.endpoint() } returns Endpoint.NETWORK
         }
 
         repeat(201) {
@@ -348,7 +348,7 @@ internal class EmbraceDeliveryRetryManagerTest {
 
         if (loadFailedRequest) {
             val mockApiRequest = mockk<ApiRequest>(relaxed = true) {
-                every { url.toEndpoint() } returns Endpoint.SESSIONS
+                every { url.endpoint() } returns Endpoint.SESSIONS
             }
             failedApiCalls.add(Endpoint.SESSIONS, DeliveryFailedApiCall(mockApiRequest, "cached_payload_1"))
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryRetryManagerTest.kt
@@ -308,16 +308,16 @@ internal class EmbraceDeliveryRetryManagerTest {
         }
 
         // verify logs were added to the queue, and that most recently added requests are dropped
-        assertEquals(100, failedApiCalls[Endpoint.LOGGING]?.size)
-        assertEquals("il:message_id_0", failedApiCalls[Endpoint.LOGGING]?.first()?.apiRequest?.logId)
-        assertEquals("il:message_id_99", failedApiCalls[Endpoint.LOGGING]?.last()?.apiRequest?.logId)
+        assertEquals(100, failedApiCalls.get(Endpoint.LOGGING)?.size)
+        assertEquals("il:message_id_0", failedApiCalls.get(Endpoint.LOGGING)?.first()?.apiRequest?.logId)
+        assertEquals("il:message_id_99", failedApiCalls.get(Endpoint.LOGGING)?.last()?.apiRequest?.logId)
 
         // now add some sessions for retry
         val sessionRequest = mapper.sessionRequest().copy(logId = "is:session_id_0")
         deliveryRetryManager.scheduleForRetry(sessionRequest, ByteArray(0))
-        assertEquals(1, failedApiCalls[Endpoint.SESSIONS]?.size)
-        assertEquals("is:session_id_0", failedApiCalls[Endpoint.SESSIONS]?.first()?.apiRequest?.logId)
-        val request = failedApiCalls[Endpoint.SESSIONS]?.last()?.apiRequest
+        assertEquals(1, failedApiCalls.get(Endpoint.SESSIONS)?.size)
+        assertEquals("is:session_id_0", failedApiCalls.get(Endpoint.SESSIONS)?.first()?.apiRequest?.logId)
+        val request = failedApiCalls.get(Endpoint.SESSIONS)?.last()?.apiRequest
         assertTrue(request?.url.toString().endsWith("/sessions"))
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpointTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpointTest.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.comms.api.ApiRequest
 import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
 import io.embrace.android.embracesdk.comms.api.EmbraceUrl
 import io.embrace.android.embracesdk.network.http.HttpMethod
-import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -31,7 +30,7 @@ internal class FailedApiCallsPerEndpointTest {
             contentEncoding = "gzip"
         )
         val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
-        failedApiCalls.add(Endpoint.SESSIONS, failedApiCall1)
+        failedApiCalls.add(failedApiCall1)
 
         val request2 = ApiRequest(
             url = EmbraceUrl.create("http://test.url/events"),
@@ -42,7 +41,7 @@ internal class FailedApiCallsPerEndpointTest {
             contentEncoding = "gzip"
         )
         val failedApiCall2 = DeliveryFailedApiCall(request2, "payload_filename")
-        failedApiCalls.add(Endpoint.EVENTS, failedApiCall2)
+        failedApiCalls.add(failedApiCall2)
 
         assertEquals(2, failedApiCalls.failedApiCallsCount())
         assertEquals(1, failedApiCalls.failedApiCallsCount(Endpoint.SESSIONS))
@@ -59,15 +58,31 @@ internal class FailedApiCallsPerEndpointTest {
 
     @Test
     fun `test hasAnyFailedApiCalls`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/sessions"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
         assertFalse(failedApiCalls.hasAnyFailedApiCalls())
-        failedApiCalls.add(Endpoint.EVENTS, DeliveryFailedApiCall(mockk(), "payload_filename"))
+        failedApiCalls.add(DeliveryFailedApiCall(request1, "payload_filename"))
         assertTrue(failedApiCalls.hasAnyFailedApiCalls())
     }
 
     @Test
     fun `test hasNoFailedApiCalls`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/sessions"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
         assertTrue(failedApiCalls.hasNoFailedApiCalls())
-        failedApiCalls.add(Endpoint.EVENTS, DeliveryFailedApiCall(mockk(), "payload_filename"))
+        failedApiCalls.add(DeliveryFailedApiCall(request1, "payload_filename"))
         assertFalse(failedApiCalls.hasNoFailedApiCalls())
     }
 
@@ -87,7 +102,7 @@ internal class FailedApiCallsPerEndpointTest {
             contentEncoding = "gzip"
         )
         val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
-        failedApiCalls.add(Endpoint.EVENTS, failedApiCall1)
+        failedApiCalls.add(failedApiCall1)
 
         assertEquals(failedApiCall1, failedApiCalls.get(Endpoint.EVENTS)?.first())
         failedApiCalls.clear()
@@ -105,7 +120,7 @@ internal class FailedApiCallsPerEndpointTest {
             contentEncoding = "gzip"
         )
         val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
-        failedApiCalls.add(Endpoint.EVENTS, failedApiCall1)
+        failedApiCalls.add(failedApiCall1)
 
         val request2 = ApiRequest(
             url = EmbraceUrl.create("http://test.url/sessions"),
@@ -116,7 +131,7 @@ internal class FailedApiCallsPerEndpointTest {
             contentEncoding = "gzip"
         )
         val failedApiCall2 = DeliveryFailedApiCall(request2, "payload_filename")
-        failedApiCalls.add(Endpoint.SESSIONS, failedApiCall2)
+        failedApiCalls.add(failedApiCall2)
 
         assertEquals(failedApiCall2, failedApiCalls.pollNextFailedApiCall())
         assertEquals(failedApiCall1, failedApiCalls.pollNextFailedApiCall())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpointTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpointTest.kt
@@ -1,0 +1,130 @@
+package io.embrace.android.embracesdk.comms.delivery
+
+import io.embrace.android.embracesdk.comms.api.ApiRequest
+import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
+import io.embrace.android.embracesdk.comms.api.EmbraceUrl
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class FailedApiCallsPerEndpointTest {
+
+    private lateinit var failedApiCalls: FailedApiCallsPerEndpoint
+
+    @Before
+    fun setUp() {
+        failedApiCalls = FailedApiCallsPerEndpoint()
+    }
+
+    @Test
+    fun `test adding failed api calls associated to endpoints`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/sessions"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        failedApiCalls.add(Endpoint.SESSIONS, failedApiCall1)
+
+        val request2 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/events"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_2",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall2 = DeliveryFailedApiCall(request2, "payload_filename")
+        failedApiCalls.add(Endpoint.EVENTS, failedApiCall2)
+
+        assertEquals(2, failedApiCalls.failedApiCallsCount())
+        assertEquals(1, failedApiCalls.failedApiCallsCount(Endpoint.SESSIONS))
+        assertEquals(1, failedApiCalls.failedApiCallsCount(Endpoint.EVENTS))
+        assertEquals(
+            listOf("request_1"),
+            failedApiCalls.get(Endpoint.SESSIONS)?.map { failedCall -> failedCall.apiRequest.eventId }
+        )
+        assertEquals(
+            listOf("request_2"),
+            failedApiCalls.get(Endpoint.EVENTS)?.map { failedCall -> failedCall.apiRequest.eventId }
+        )
+    }
+
+    @Test
+    fun `test hasAnyFailedApiCalls`() {
+        assertFalse(failedApiCalls.hasAnyFailedApiCalls())
+        failedApiCalls.add(Endpoint.EVENTS, DeliveryFailedApiCall(mockk(), "payload_filename"))
+        assertTrue(failedApiCalls.hasAnyFailedApiCalls())
+    }
+
+    @Test
+    fun `test hasNoFailedApiCalls`() {
+        assertTrue(failedApiCalls.hasNoFailedApiCalls())
+        failedApiCalls.add(Endpoint.EVENTS, DeliveryFailedApiCall(mockk(), "payload_filename"))
+        assertFalse(failedApiCalls.hasNoFailedApiCalls())
+    }
+
+    @Test
+    fun `test get returns null if no failed api calls exist`() {
+        assertEquals(null, failedApiCalls.get(Endpoint.EVENTS))
+    }
+
+    @Test
+    fun `test get returns failed api calls if exist`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/events"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        failedApiCalls.add(Endpoint.EVENTS, failedApiCall1)
+
+        assertEquals(failedApiCall1, failedApiCalls.get(Endpoint.EVENTS)?.first())
+        failedApiCalls.clear()
+        assertEquals(null, failedApiCalls.get(Endpoint.EVENTS))
+    }
+
+    @Test
+    fun `test pollNextFailedApiCall always return session if exists`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/events"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        failedApiCalls.add(Endpoint.EVENTS, failedApiCall1)
+
+        val request2 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/sessions"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_2",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall2 = DeliveryFailedApiCall(request2, "payload_filename")
+        failedApiCalls.add(Endpoint.SESSIONS, failedApiCall2)
+
+        assertEquals(failedApiCall2, failedApiCalls.pollNextFailedApiCall())
+        assertEquals(failedApiCall1, failedApiCalls.pollNextFailedApiCall())
+        assertEquals(null, failedApiCalls.pollNextFailedApiCall())
+    }
+
+    @Test
+    fun `test pollNextFailedApiCall returns null if no failed api calls exist`() {
+        assertEquals(null, failedApiCalls.pollNextFailedApiCall())
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpointTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/FailedApiCallsPerEndpointTest.kt
@@ -43,17 +43,9 @@ internal class FailedApiCallsPerEndpointTest {
         val failedApiCall2 = DeliveryFailedApiCall(request2, "payload_filename")
         failedApiCalls.add(failedApiCall2)
 
-        assertEquals(2, failedApiCalls.failedApiCallsCount())
-        assertEquals(1, failedApiCalls.failedApiCallsCount(Endpoint.SESSIONS))
-        assertEquals(1, failedApiCalls.failedApiCallsCount(Endpoint.EVENTS))
-        assertEquals(
-            listOf("request_1"),
-            failedApiCalls.get(Endpoint.SESSIONS)?.map { failedCall -> failedCall.apiRequest.eventId }
-        )
-        assertEquals(
-            listOf("request_2"),
-            failedApiCalls.get(Endpoint.EVENTS)?.map { failedCall -> failedCall.apiRequest.eventId }
-        )
+        assertEquals(failedApiCall1, failedApiCalls.pollNextFailedApiCall())
+        assertEquals(failedApiCall2, failedApiCalls.pollNextFailedApiCall())
+        assertEquals(null, failedApiCalls.pollNextFailedApiCall())
     }
 
     @Test
@@ -84,29 +76,6 @@ internal class FailedApiCallsPerEndpointTest {
         assertTrue(failedApiCalls.hasNoFailedApiCalls())
         failedApiCalls.add(DeliveryFailedApiCall(request1, "payload_filename"))
         assertFalse(failedApiCalls.hasNoFailedApiCalls())
-    }
-
-    @Test
-    fun `test get returns null if no failed api calls exist`() {
-        assertEquals(null, failedApiCalls.get(Endpoint.EVENTS))
-    }
-
-    @Test
-    fun `test get returns failed api calls if exist`() {
-        val request1 = ApiRequest(
-            url = EmbraceUrl.create("http://test.url/events"),
-            httpMethod = HttpMethod.POST,
-            appId = "test_app_id_1",
-            deviceId = "test_device_id",
-            eventId = "request_1",
-            contentEncoding = "gzip"
-        )
-        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
-        failedApiCalls.add(failedApiCall1)
-
-        assertEquals(failedApiCall1, failedApiCalls.get(Endpoint.EVENTS)?.first())
-        failedApiCalls.clear()
-        assertEquals(null, failedApiCalls.get(Endpoint.EVENTS))
     }
 
     @Test
@@ -142,4 +111,155 @@ internal class FailedApiCallsPerEndpointTest {
     fun `test pollNextFailedApiCall returns null if no failed api calls exist`() {
         assertEquals(null, failedApiCalls.pollNextFailedApiCall())
     }
+
+    @Test
+    fun `test isBellowRetryLimit for sessions`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/sessions"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        repeat(SESSIONS_LIMIT - 1) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertTrue(failedApiCalls.isBelowRetryLimit(Endpoint.SESSIONS))
+
+        repeat(2) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertFalse(failedApiCalls.isBelowRetryLimit(Endpoint.SESSIONS))
+    }
+
+    @Test
+    fun `test isBellowRetryLimit for events`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/events"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        repeat(EVENTS_LIMIT - 1) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertTrue(failedApiCalls.isBelowRetryLimit(Endpoint.EVENTS))
+
+        repeat(2) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertFalse(failedApiCalls.isBelowRetryLimit(Endpoint.EVENTS))
+    }
+
+    @Test
+    fun `test isBellowRetryLimit for blobs`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/blobs"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        repeat(BLOBS_LIMIT - 1) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertTrue(failedApiCalls.isBelowRetryLimit(Endpoint.BLOBS))
+
+        repeat(2) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertFalse(failedApiCalls.isBelowRetryLimit(Endpoint.BLOBS))
+    }
+
+    @Test
+    fun `test isBellowRetryLimit for logging`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/logging"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        repeat(LOGGING_LIMIT - 1) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertTrue(failedApiCalls.isBelowRetryLimit(Endpoint.LOGGING))
+
+        repeat(2) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertFalse(failedApiCalls.isBelowRetryLimit(Endpoint.LOGGING))
+    }
+
+    @Test
+    fun `test isBellowRetryLimit for network`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/network"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        repeat(NETWORK_LIMIT - 1) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertTrue(failedApiCalls.isBelowRetryLimit(Endpoint.NETWORK))
+
+        repeat(2) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertFalse(failedApiCalls.isBelowRetryLimit(Endpoint.NETWORK))
+    }
+
+    @Test
+    fun `test isBellowRetryLimit for unknown`() {
+        val request1 = ApiRequest(
+            url = EmbraceUrl.create("http://test.url/any"),
+            httpMethod = HttpMethod.POST,
+            appId = "test_app_id_1",
+            deviceId = "test_device_id",
+            eventId = "request_1",
+            contentEncoding = "gzip"
+        )
+        val failedApiCall1 = DeliveryFailedApiCall(request1, "payload_filename")
+        repeat(UNKNOWN_LIMIT - 1) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertTrue(failedApiCalls.isBelowRetryLimit(Endpoint.UNKNOWN))
+
+        repeat(2) {
+            failedApiCalls.add(failedApiCall1)
+        }
+
+        assertFalse(failedApiCalls.isBelowRetryLimit(Endpoint.UNKNOWN))
+    }
 }
+
+private const val EVENTS_LIMIT = 100
+private const val BLOBS_LIMIT = 50
+private const val LOGGING_LIMIT = 100
+private const val NETWORK_LIMIT = 50
+private const val SESSIONS_LIMIT = 100
+private const val UNKNOWN_LIMIT = 50

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryCacheManager
-import io.embrace.android.embracesdk.comms.delivery.DeliveryFailedApiCalls
+import io.embrace.android.embracesdk.comms.delivery.FailedApiCallsPerEndpoint
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -63,11 +63,11 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
         TODO("Not yet implemented")
     }
 
-    override fun saveFailedApiCalls(failedApiCalls: DeliveryFailedApiCalls) {
+    override fun saveFailedApiCalls(failedApiCalls: FailedApiCallsPerEndpoint) {
         TODO("Not yet implemented")
     }
 
-    override fun loadFailedApiCalls(): DeliveryFailedApiCalls {
+    override fun loadFailedApiCalls(): FailedApiCallsPerEndpoint {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Goal

- Created a retry queue for each endpoint. 
- Now it loads and saves from cache the new map that holds the retry queues for each endpoint. 
- When loads return null, we still need to verify if it's returning null because of an exception caused by an old file version. (we can discuss doing this differently)
- Now, the limits are established for each endpoint.

## Testing

Added new unit tests and updated others. 

