### PR TITLE
Move session implementation to session handler

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1337,26 +1337,9 @@ final class EmbraceImpl {
      * <p>
      * Cleans all the user info on the device.
      */
-    public synchronized void endSession(boolean clearUserInfo) {
+    public void endSession(boolean clearUserInfo) {
         if (isStarted()) {
-            SessionBehavior sessionBehavior = configService.getSessionBehavior();
-            if (sessionBehavior.getMaxSessionSecondsAllowed() != null) {
-                internalEmbraceLogger.logWarning("Can't close the session, automatic session close enabled.");
-                return;
-            }
-
-            if (sessionBehavior.isAsyncEndEnabled()) {
-                internalEmbraceLogger.logWarning("Can't close the session, session ending in background thread enabled.");
-                return;
-            }
-
-            if (clearUserInfo) {
-                userService.clearAllUserInfo();
-                // Update user info in NDK service
-                ndkService.onUserInfoUpdate();
-            }
-
-            sessionService.triggerStatelessSessionEnd(Session.SessionLifeEventType.MANUAL);
+            sessionService.endSessionManually(clearUserInfo);
         } else {
             internalEmbraceLogger.logSDKNotInitialized("end session");
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -91,6 +91,7 @@ internal class SessionModuleImpl(
             sessionHandler,
             deliveryModule.deliveryService,
             essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled(),
+            essentialServiceModule.configService,
             initModule.clock,
             coreModule.logger
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -125,7 +125,7 @@ internal class SessionHandler(
     /**
      * It performs all corresponding operations in order to end a session.
      */
-    fun onSessionEnded(endType: SessionLifeEventType, endTime: Long) {
+    fun onSessionEnded(endType: SessionLifeEventType, endTime: Long, clearUserInfo: Boolean) {
         synchronized(lock) {
             val session = activeSession ?: return
 
@@ -146,6 +146,12 @@ internal class SessionHandler(
             sessionProperties.clearTemporary()
             logger.logDebug("Session properties successfully temporary cleared.")
             deliveryService.sendSession(fullEndSessionMessage, SessionMessageState.END)
+
+            if (endType == SessionLifeEventType.MANUAL && clearUserInfo) {
+                userService.clearAllUserInfo()
+                // Update user info in NDK service
+                ndkService.onUserInfoUpdate()
+            }
 
             // clear active session
             activeSession = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -14,13 +14,15 @@ internal interface SessionService : ProcessStateListener, Closeable {
      */
     fun startSession(coldStart: Boolean, startType: SessionLifeEventType, startTime: Long)
 
+    fun endSessionManually(clearUserInfo: Boolean)
+
     /**
      * This is responsible for the current session to be cached, ended and sent to the server and
      * immediately starting a new session after that.
      *
      * @param endType the origin of the event that ends the session.
      */
-    fun triggerStatelessSessionEnd(endType: SessionLifeEventType)
+    fun triggerStatelessSessionEnd(endType: SessionLifeEventType, clearUserInfo: Boolean = false)
 
     /**
      * Handles an uncaught exception, ending the session and saving the session to disk.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -13,11 +13,18 @@ internal class FakeSessionService : SessionService {
         TODO("Not yet implemented")
     }
 
-    override fun triggerStatelessSessionEnd(endType: Session.SessionLifeEventType) {
+    override fun triggerStatelessSessionEnd(
+        endType: Session.SessionLifeEventType,
+        clearUserInfo: Boolean
+    ) {
         TODO("Not yet implemented")
     }
 
     override fun handleCrash(crashId: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun endSessionManually(clearUserInfo: Boolean) {
         TODO("Not yet implemented")
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeUserService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeUserService.kt
@@ -6,11 +6,12 @@ import io.embrace.android.embracesdk.payload.UserInfo
 internal class FakeUserService : UserService {
 
     var obj: UserInfo = UserInfo()
+    var clearedCount = 0
 
     override fun getUserInfo(): UserInfo = obj
 
     override fun clearAllUserInfo() {
-        TODO("Not yet implemented")
+        clearedCount += 1
     }
 
     override fun loadUserInfoFromDisk(): UserInfo? {


### PR DESCRIPTION
## Goal

I spotted a bit of session handling logic in `EmbraceImpl` so moved it to the `SessionHandler` class, which will aid any future refactoring to make the logic easier to understand.

## Testing

Added unit test coverage.
