### PR TITLE
Extract creation of background activity message

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.ndk.NativeModule
+import io.embrace.android.embracesdk.session.BackgroundActivityCollator
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.EmbraceBackgroundActivityService
 import io.embrace.android.embracesdk.session.EmbraceSessionService
@@ -18,6 +19,7 @@ internal interface SessionModule {
     val sessionService: SessionService
     val backgroundActivityService: BackgroundActivityService?
     val sessionMessageCollator: SessionMessageCollator
+    val backgroundActivityCollator: BackgroundActivityCollator
     val sessionPropertiesService: SessionPropertiesService
 }
 
@@ -99,24 +101,32 @@ internal class SessionModuleImpl(
     override val backgroundActivityService: BackgroundActivityService? by singleton {
         if (essentialServiceModule.configService.isBackgroundActivityCaptureEnabled()) {
             EmbraceBackgroundActivityService(
-                dataContainerModule.performanceInfoService,
                 essentialServiceModule.metadataService,
-                dataCaptureServiceModule.breadcrumbService,
                 essentialServiceModule.processStateService,
-                dataContainerModule.eventService,
-                customerLogModule.remoteLogger,
-                essentialServiceModule.userService,
-                sdkObservabilityModule.exceptionService,
                 deliveryModule.deliveryService,
                 essentialServiceModule.configService,
                 nativeModule.ndkService,
-                androidServicesModule.preferencesService,
                 initModule.clock,
-                initModule.spansService,
+                backgroundActivityCollator,
                 lazy { workerThreadModule.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR) }
             )
         } else {
             null
         }
+    }
+
+    override val backgroundActivityCollator: BackgroundActivityCollator by singleton {
+        BackgroundActivityCollator(
+            essentialServiceModule.userService,
+            androidServicesModule.preferencesService,
+            dataContainerModule.eventService,
+            customerLogModule.remoteLogger,
+            sdkObservabilityModule.exceptionService,
+            dataCaptureServiceModule.breadcrumbService,
+            essentialServiceModule.metadataService,
+            dataContainerModule.performanceInfoService,
+            initModule.spansService,
+            initModule.clock
+        )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivity.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivity.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.payload
 
 import com.google.gson.annotations.SerializedName
-import io.embrace.android.embracesdk.prefs.PreferencesService
 
 /**
  * Represents a particular user's session within the app.
@@ -114,64 +113,5 @@ internal data class BackgroundActivity(
 
         @SerializedName("be")
         BKGND_SIZE
-    }
-
-    companion object {
-
-        @JvmStatic
-        fun createStartMessage(
-            embUuid: String,
-            startTime: Long,
-            coldStart: Boolean,
-            startType: LifeEventType,
-            applicationState: String,
-            userInfo: UserInfo?,
-            preferencesService: PreferencesService
-        ) = BackgroundActivity(
-            sessionId = embUuid,
-            startTime = startTime,
-            appState = applicationState,
-            isColdStart = coldStart,
-            startType = startType,
-            user = userInfo,
-            number = preferencesService.incrementAndGetBackgroundActivityNumber()
-        )
-
-        @JvmStatic
-        @Suppress("LongParameterList")
-        fun createStopMessage(
-            original: BackgroundActivity,
-            applicationState: String,
-            messageType: String,
-            endTime: Long?,
-            eventIdsForSession: List<String>,
-            infoLogIds: List<String>,
-            warningLogIds: List<String>,
-            errorLogIds: List<String>,
-            infoLogsAttemptedToSend: Int,
-            warnLogsAttemptedToSend: Int,
-            errorLogsAttemptedToSend: Int,
-            currentExceptionError: ExceptionError?,
-            lastHeartbeatTime: Long,
-            endType: LifeEventType?,
-            unhandledExceptionsSent: Int,
-            crashId: String?
-        ) = original.copy(
-            appState = applicationState,
-            messageType = messageType,
-            endTime = endTime,
-            eventIds = eventIdsForSession,
-            infoLogIds = infoLogIds,
-            warningLogIds = warningLogIds,
-            errorLogIds = errorLogIds,
-            infoLogsAttemptedToSend = infoLogsAttemptedToSend,
-            warnLogsAttemptedToSend = warnLogsAttemptedToSend,
-            errorLogsAttemptedToSend = errorLogsAttemptedToSend,
-            exceptionError = currentExceptionError,
-            lastHeartbeatTime = lastHeartbeatTime,
-            endType = endType,
-            unhandledExceptions = unhandledExceptionsSent,
-            crashReportId = crashId
-        )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityCollator.kt
@@ -1,0 +1,124 @@
+package io.embrace.android.embracesdk.session
+
+import io.embrace.android.embracesdk.capture.PerformanceInfoService
+import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
+import io.embrace.android.embracesdk.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.capture.user.UserService
+import io.embrace.android.embracesdk.event.EmbraceRemoteLogger
+import io.embrace.android.embracesdk.event.EventService
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.internal.utils.Uuid
+import io.embrace.android.embracesdk.logging.EmbraceInternalErrorService
+import io.embrace.android.embracesdk.payload.BackgroundActivity
+import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
+import io.embrace.android.embracesdk.payload.Breadcrumbs
+import io.embrace.android.embracesdk.prefs.PreferencesService
+
+internal class BackgroundActivityCollator(
+    private val userService: UserService,
+    private val preferencesService: PreferencesService,
+    private val eventService: EventService,
+    private val remoteLogger: EmbraceRemoteLogger,
+    private val exceptionService: EmbraceInternalErrorService,
+    private val breadcrumbService: BreadcrumbService,
+    private val metadataService: MetadataService,
+    private val performanceInfoService: PerformanceInfoService,
+    private val spansService: SpansService,
+    private val clock: Clock
+) {
+
+    fun createStartMessage(
+        startTime: Long,
+        coldStart: Boolean,
+        startType: BackgroundActivity.LifeEventType
+    ): BackgroundActivity {
+        return BackgroundActivity(
+            sessionId = Uuid.getEmbUuid(),
+            startTime = startTime,
+            appState = EmbraceBackgroundActivityService.APPLICATION_STATE_BACKGROUND,
+            isColdStart = coldStart,
+            startType = startType,
+            user = userService.loadUserInfoFromDisk(),
+            number = preferencesService
+                .incrementAndGetBackgroundActivityNumber()
+        )
+    }
+
+    fun createStopMessage(
+        activity: BackgroundActivity,
+        endTime: Long,
+        endType: BackgroundActivity.LifeEventType?,
+        crashId: String?
+    ): BackgroundActivity {
+        val startTime = activity.startTime ?: 0
+        return activity.copy(
+            appState = EmbraceBackgroundActivityService.APPLICATION_STATE_BACKGROUND,
+            messageType = EmbraceBackgroundActivityService.MESSAGE_TYPE_END,
+            endTime = endTime,
+            eventIds = eventService.findEventIdsForSession(startTime, endTime),
+            infoLogIds = remoteLogger.findInfoLogIds(startTime, endTime),
+            warningLogIds = remoteLogger.findWarningLogIds(startTime, endTime),
+            errorLogIds = remoteLogger.findErrorLogIds(startTime, endTime),
+            infoLogsAttemptedToSend = remoteLogger.getInfoLogsAttemptedToSend(),
+            warnLogsAttemptedToSend = remoteLogger.getWarnLogsAttemptedToSend(),
+            errorLogsAttemptedToSend = remoteLogger.getErrorLogsAttemptedToSend(),
+            exceptionError = exceptionService.currentExceptionError,
+            lastHeartbeatTime = endTime,
+            endType = endType,
+            unhandledExceptions = remoteLogger.getUnhandledExceptionsSent(),
+            crashReportId = crashId
+        )
+    }
+
+    /**
+     * Create the background session message with the current state of the background activity.
+     *
+     * @param backgroundActivity      the current state of a background activity
+     * @param isBackgroundActivityEnd true if the message is being built for the termination of the background activity
+     * @return a background activity message for backend
+     */
+    fun buildBgActivityMessage(
+        backgroundActivity: BackgroundActivity?,
+        isBackgroundActivityEnd: Boolean
+    ): BackgroundActivityMessage? {
+        if (backgroundActivity != null) {
+            val startTime = backgroundActivity.startTime ?: 0L
+            val endTime = backgroundActivity.endTime ?: clock.now()
+            val isCrash = backgroundActivity.crashReportId != null
+            val breadcrumbs: Breadcrumbs
+            val spans: List<EmbraceSpanData>?
+            if (isBackgroundActivityEnd) {
+                breadcrumbs = breadcrumbService.flushBreadcrumbs()
+                spans = spansService.flushSpans(
+                    if (isCrash) {
+                        EmbraceAttributes.AppTerminationCause.CRASH
+                    } else {
+                        null
+                    }
+                )
+            } else {
+                breadcrumbs = breadcrumbService.getBreadcrumbs(startTime, endTime)
+                spans = spansService.completedSpans()
+            }
+
+            return BackgroundActivityMessage(
+                backgroundActivity = backgroundActivity,
+                userInfo = backgroundActivity.user,
+                appInfo = metadataService.getAppInfo(),
+                deviceInfo = metadataService.getDeviceInfo(),
+                performanceInfo = performanceInfoService.getSessionPerformanceInfo(
+                    startTime,
+                    endTime,
+                    java.lang.Boolean.TRUE == backgroundActivity.isColdStart,
+                    null
+                ),
+                breadcrumbs = breadcrumbs,
+                spans = spans
+            )
+        }
+        return null
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -2,30 +2,16 @@ package io.embrace.android.embracesdk.session
 
 import android.os.Handler
 import android.os.Looper
-import io.embrace.android.embracesdk.capture.PerformanceInfoService
-import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
-import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.config.ConfigListener
 import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.event.EmbraceRemoteLogger
-import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.internal.spans.SpansService
-import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
-import io.embrace.android.embracesdk.logging.EmbraceInternalErrorService
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BackgroundActivity
-import io.embrace.android.embracesdk.payload.BackgroundActivity.Companion.createStartMessage
-import io.embrace.android.embracesdk.payload.BackgroundActivity.Companion.createStopMessage
 import io.embrace.android.embracesdk.payload.BackgroundActivity.LifeEventType
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
-import io.embrace.android.embracesdk.payload.Breadcrumbs
-import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.utils.submitSafe
 import java.util.concurrent.Callable
@@ -33,23 +19,16 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicInteger
 
 internal class EmbraceBackgroundActivityService(
-    private val performanceInfoService: PerformanceInfoService,
     private val metadataService: MetadataService,
-    private val breadcrumbService: BreadcrumbService,
     processStateService: ProcessStateService,
-    private val eventService: EventService,
-    private val remoteLogger: EmbraceRemoteLogger,
-    private val userService: UserService,
-    private val exceptionService: EmbraceInternalErrorService,
     private val deliveryService: DeliveryService,
     private val configService: ConfigService,
     private val ndkService: NdkService,
-    private val preferencesService: PreferencesService,
     /**
      * Embrace service dependencies of the background activity session service.
      */
     private val clock: Clock,
-    private val spansService: SpansService,
+    private val backgroundActivityCollator: BackgroundActivityCollator,
     private val executorServiceSupplier: Lazy<ExecutorService>
 ) : BackgroundActivityService, ConfigListener {
 
@@ -61,7 +40,6 @@ internal class EmbraceBackgroundActivityService(
     /**
      * The active background activity session.
      */
-
     @Volatile
     var backgroundActivity: BackgroundActivity? = null
     private val manualBkgSessionsSent = AtomicInteger(0)
@@ -179,14 +157,10 @@ internal class EmbraceBackgroundActivityService(
         coldStart: Boolean,
         startType: LifeEventType
     ) {
-        val activity = createStartMessage(
-            getEmbUuid(),
+        val activity = backgroundActivityCollator.createStartMessage(
             startTime,
             coldStart,
-            startType,
-            APPLICATION_STATE_BACKGROUND,
-            userService.loadUserInfoFromDisk(),
-            preferencesService
+            startType
         )
         backgroundActivity = activity
         metadataService.setActiveSessionId(activity.sessionId)
@@ -214,27 +188,14 @@ internal class EmbraceBackgroundActivityService(
             InternalStaticEmbraceLogger.logError("No background activity to report")
             return null
         }
-        val startTime = activity.startTime ?: 0
-        val sendBackgroundActivity = createStopMessage(
+        val sendBackgroundActivity = backgroundActivityCollator.createStopMessage(
             activity,
-            APPLICATION_STATE_BACKGROUND,
-            MESSAGE_TYPE_END,
-            endTime,
-            eventService.findEventIdsForSession(startTime, endTime),
-            remoteLogger.findInfoLogIds(startTime, endTime),
-            remoteLogger.findWarningLogIds(startTime, endTime),
-            remoteLogger.findErrorLogIds(startTime, endTime),
-            remoteLogger.getInfoLogsAttemptedToSend(),
-            remoteLogger.getWarnLogsAttemptedToSend(),
-            remoteLogger.getErrorLogsAttemptedToSend(),
-            exceptionService.currentExceptionError,
             endTime,
             endType,
-            remoteLogger.getUnhandledExceptionsSent(),
             crashId
         )
         backgroundActivity = null
-        return buildBackgroundActivityMessage(sendBackgroundActivity, true)
+        return backgroundActivityCollator.buildBgActivityMessage(sendBackgroundActivity, true)
     }
 
     /**
@@ -265,55 +226,6 @@ internal class EmbraceBackgroundActivityService(
     }
 
     /**
-     * Create the background session message with the current state of the background activity.
-     *
-     * @param backgroundActivity      the current state of a background activity
-     * @param isBackgroundActivityEnd true if the message is being built for the termination of the background activity
-     * @return a background activity message for backend
-     */
-    private fun buildBackgroundActivityMessage(
-        backgroundActivity: BackgroundActivity?,
-        isBackgroundActivityEnd: Boolean
-    ): BackgroundActivityMessage? {
-        if (backgroundActivity != null) {
-            val startTime = backgroundActivity.startTime ?: 0L
-            val endTime = backgroundActivity.endTime ?: clock.now()
-            val isCrash = backgroundActivity.crashReportId != null
-            val breadcrumbs: Breadcrumbs
-            val spans: List<EmbraceSpanData>?
-            if (isBackgroundActivityEnd) {
-                breadcrumbs = breadcrumbService.flushBreadcrumbs()
-                spans = spansService.flushSpans(
-                    if (isCrash) {
-                        EmbraceAttributes.AppTerminationCause.CRASH
-                    } else {
-                        null
-                    }
-                )
-            } else {
-                breadcrumbs = breadcrumbService.getBreadcrumbs(startTime, endTime)
-                spans = spansService.completedSpans()
-            }
-
-            return BackgroundActivityMessage(
-                backgroundActivity = backgroundActivity,
-                userInfo = backgroundActivity.user,
-                appInfo = metadataService.getAppInfo(),
-                deviceInfo = metadataService.getDeviceInfo(),
-                performanceInfo = performanceInfoService.getSessionPerformanceInfo(
-                    startTime,
-                    endTime,
-                    java.lang.Boolean.TRUE == backgroundActivity.isColdStart,
-                    null
-                ),
-                breadcrumbs = breadcrumbs,
-                spans = spans
-            )
-        }
-        return null
-    }
-
-    /**
      * Cache the activity, with performance information generated up to the current point.
      */
     private fun cacheBackgroundActivity() {
@@ -321,27 +233,14 @@ internal class EmbraceBackgroundActivityService(
             val activity = backgroundActivity
             if (activity != null) {
                 lastSaved = clock.now()
-                val startTime = activity.startTime ?: 0L
                 val endTime = activity.endTime ?: clock.now()
-                val cachedActivity = createStopMessage(
+                val cachedActivity = backgroundActivityCollator.createStopMessage(
                     activity,
-                    APPLICATION_STATE_BACKGROUND,
-                    MESSAGE_TYPE_END,
+                    endTime,
                     null,
-                    eventService.findEventIdsForSession(startTime, endTime),
-                    remoteLogger.findInfoLogIds(startTime, endTime),
-                    remoteLogger.findWarningLogIds(startTime, endTime),
-                    remoteLogger.findErrorLogIds(startTime, endTime),
-                    remoteLogger.getInfoLogsAttemptedToSend(),
-                    remoteLogger.getWarnLogsAttemptedToSend(),
-                    remoteLogger.getErrorLogsAttemptedToSend(),
-                    exceptionService.currentExceptionError,
-                    clock.now(),
-                    null,
-                    remoteLogger.getUnhandledExceptionsSent(),
                     null
                 )
-                val message = buildBackgroundActivityMessage(cachedActivity, false)
+                val message = backgroundActivityCollator.buildBgActivityMessage(cachedActivity, false)
                 if (message == null) {
                     InternalStaticEmbraceLogger.logDebug("Failed to cache background activity message.")
                     return
@@ -357,12 +256,12 @@ internal class EmbraceBackgroundActivityService(
         /**
          * Signals to the API that this is a background session.
          */
-        private const val APPLICATION_STATE_BACKGROUND = "background"
+        internal const val APPLICATION_STATE_BACKGROUND = "background"
 
         /**
          * Signals to the API the end of a session.
          */
-        private const val MESSAGE_TYPE_END = "en"
+        internal const val MESSAGE_TYPE_END = "en"
 
         /**
          * Minimum time between writes of the background activity to disk

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes.injection
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.FakeSessionService
 import io.embrace.android.embracesdk.injection.SessionModule
+import io.embrace.android.embracesdk.session.BackgroundActivityCollator
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.SessionHandler
 import io.embrace.android.embracesdk.session.SessionMessageCollator
@@ -18,5 +19,8 @@ internal class FakeSessionModule(
         get() = TODO("Not yet implemented")
 
     override val sessionMessageCollator: SessionMessageCollator
+        get() = TODO("Not yet implemented")
+
+    override val backgroundActivityCollator: BackgroundActivityCollator
         get() = TODO("Not yet implemented")
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/BackgroundActivityCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/BackgroundActivityCollatorTest.kt
@@ -1,0 +1,82 @@
+package io.embrace.android.embracesdk.session
+
+import io.embrace.android.embracesdk.FakeBreadcrumbService
+import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
+import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.payload.BackgroundActivity
+import io.embrace.android.embracesdk.payload.BackgroundActivity.LifeEventType
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+internal class BackgroundActivityCollatorTest {
+
+    private lateinit var collator: BackgroundActivityCollator
+
+    @Before
+    fun setUp() {
+        collator = BackgroundActivityCollator(
+            userService = FakeUserService(),
+            preferencesService = FakePreferenceService(),
+            eventService = mockk(relaxed = true),
+            remoteLogger = mockk(relaxed = true),
+            exceptionService = mockk(relaxed = true),
+            breadcrumbService = FakeBreadcrumbService(),
+            metadataService = FakeAndroidMetadataService(),
+            performanceInfoService = FakePerformanceInfoService(),
+            spansService = SpansService.Companion.featureDisabledSpansService,
+            clock = FakeClock()
+        )
+    }
+
+    @Test
+    fun createStartMessage() {
+        val msg = collator.createStartMessage(5, false, LifeEventType.BKGND_STATE)
+        msg.verifyStartFieldsPopulated()
+    }
+
+    @Test
+    fun createStartAndStopMessages() {
+        // create start message
+        val startMsg = collator.createStartMessage(5, false, LifeEventType.BKGND_STATE)
+        startMsg.verifyStartFieldsPopulated()
+
+        // create stop message
+        val msg = collator.createStopMessage(startMsg, 10, LifeEventType.BKGND_STATE, "crashId")
+        msg.verifyStartFieldsPopulated()
+
+        with(msg) {
+            assertEquals(LifeEventType.BKGND_STATE, endType)
+            assertEquals(10L, endTime)
+            assertEquals("crashId", crashReportId)
+        }
+
+        // create envelope
+        with(checkNotNull(collator.buildBgActivityMessage(msg, true))) {
+            assertSame(msg, backgroundActivity)
+            assertNotNull(userInfo)
+            assertNotNull(appInfo)
+            assertNotNull(deviceInfo)
+            assertNotNull(performanceInfo)
+            assertNotNull(breadcrumbs)
+        }
+    }
+
+    private fun BackgroundActivity.verifyStartFieldsPopulated() {
+        assertNotNull(sessionId)
+        assertEquals(5L, startTime)
+        assertEquals(EmbraceBackgroundActivityService.APPLICATION_STATE_BACKGROUND, appState)
+        assertFalse(checkNotNull(isColdStart))
+        assertEquals(LifeEventType.BKGND_STATE, startType)
+        assertNotNull(user)
+        assertNotNull(number)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -321,21 +321,26 @@ internal class EmbraceBackgroundActivityServiceTest {
     }
 
     private fun createService(): EmbraceBackgroundActivityService {
-        return EmbraceBackgroundActivityService(
-            performanceInfoService,
-            metadataService,
-            mockBreadcrumbService,
-            activityService,
+        val collator = BackgroundActivityCollator(
+            userService,
+            preferencesService,
             eventService,
             remoteLogger,
-            userService,
             exceptionService,
+            mockBreadcrumbService,
+            metadataService,
+            performanceInfoService,
+            spansService,
+            clock,
+        )
+        return EmbraceBackgroundActivityService(
+            metadataService,
+            activityService,
             deliveryService,
             configService,
             ndkService,
-            preferencesService,
             clock,
-            spansService,
+            collator,
             lazy { blockableExecutorService }
         )
     }


### PR DESCRIPTION
## Goal

Extracts the code that creates background activity objects in the start/stop state out of the service. This will make it easier to refactor in future (and possibly align with the `SessionMessage` as there's a lot of duplication).

## Testing

Relied on existing test coverage.

