### PR TITLE
Avoid setting process summary state for background activities

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -371,16 +371,19 @@ internal class EmbraceMetadataService private constructor(
     override val activeSessionId: String?
         get() = sessionId
 
-    override fun setActiveSessionId(sessionId: String?) {
+    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
         logDeveloper("EmbraceMetadataService", "Active session Id: $sessionId")
         this.sessionId = sessionId
-        setSessionIdToProcessStateSummary(this.sessionId)
+
+        if (isSession) {
+            setSessionIdToProcessStateSummary(this.sessionId)
+        }
     }
 
     override fun removeActiveSessionId(sessionId: String?) {
         if (this.sessionId != null && this.sessionId == sessionId) {
             logDeveloper("EmbraceMetadataService", "Nulling active session Id")
-            setActiveSessionId(null)
+            setActiveSessionId(null, false)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
@@ -110,11 +110,12 @@ internal interface MetadataService {
     val activeSessionId: String?
 
     /**
-     * Sets the currently active session ID;
+     * Sets the currently active session ID.
      *
      * @param sessionId the session ID that is currently active
+     * @param isSession true if it's a session, false if it's a background activity
      */
-    fun setActiveSessionId(sessionId: String?)
+    fun setActiveSessionId(sessionId: String?, isSession: Boolean)
 
     /**
      * If the currently active session ID is @param sessionId, set it to null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -163,7 +163,7 @@ internal class EmbraceBackgroundActivityService(
             startType
         )
         backgroundActivity = activity
-        metadataService.setActiveSessionId(activity.sessionId)
+        metadataService.setActiveSessionId(activity.sessionId, false)
         if (configService.autoDataCaptureBehavior.isNdkEnabled()) {
             ndkService.updateSessionId(activity.sessionId)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -104,7 +104,7 @@ internal class SessionHandler(
 
             val sessionMessage = sessionMessageCollator.buildStartSessionMessage(session)
 
-            metadataService.setActiveSessionId(session.sessionId)
+            metadataService.setActiveSessionId(session.sessionId, true)
 
             if (configService.sessionBehavior.isStartMessageEnabled()) {
                 deliveryService.sendSession(sessionMessage, SessionMessageState.START)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -312,7 +312,7 @@ internal class EmbraceMetadataServiceTest {
         activityService.isInBackground = false
         assertEquals("active", metadataService.getAppState())
 
-        metadataService.setActiveSessionId("123")
+        metadataService.setActiveSessionId("123", true)
         assertEquals("123", metadataService.activeSessionId)
 
         assertEquals("appId", metadataService.getAppId())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceRemoteLoggerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceRemoteLoggerTest.kt
@@ -105,7 +105,7 @@ internal class EmbraceRemoteLoggerTest {
         }
         every { configService.dataCaptureEventBehavior.isLogMessageEnabled(any()) } returns true
         every { configService.dataCaptureEventBehavior.isMessageTypeEnabled(any()) } returns true
-        metadataService.setActiveSessionId("session-123")
+        metadataService.setActiveSessionId("session-123", true)
         metadataService.setAppForeground()
         metadataService.setAppId("appId")
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAndroidMetadataService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAndroidMetadataService.kt
@@ -97,7 +97,7 @@ internal class FakeAndroidMetadataService(sessionId: String? = null) : MetadataS
     override val activeSessionId: String?
         get() = appSessionId
 
-    override fun setActiveSessionId(sessionId: String?) {
+    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
         appSessionId = sessionId
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -55,7 +55,7 @@ internal class EmbraceNetworkCaptureServiceTest {
     @Before
     fun setUp() {
         clearAllMocks()
-        metadataService.setActiveSessionId("session-123")
+        metadataService.setActiveSessionId("session-123", true)
         every { configService.networkBehavior } returns fakeNetworkBehavior { cfg }
         every { configService.sdkEndpointBehavior } returns fakeSdkEndpointBehavior { BaseUrlLocalConfig() }
     }


### PR DESCRIPTION
## Goal

Avoid setting the process summary state for background activities. Currently we only use the AEI to link ANRs to a given session. Overwriting this with an ID for a background activity could plausibly reduce our match rate of ANRs -> Session.

