### PR TITLE
Call SDK Size & Startup time benchmarks after releasing

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -137,3 +137,17 @@ jobs:
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
+          
+  measure-sdk-size:
+    uses: embrace-io/android-size-measure/.github/workflows/analyze-sdk-size.yml@main
+    needs: release
+    with:
+      sdk_version: ${{ github.event.inputs.current_version }}
+      token: ${{ secrets.CD_GITHUB_TOKEN }}
+      
+  measure-startup-time:
+    uses: embrace-io/android-sdk-benchmark/blob/main/.github/workflows/macrobenchmark.yml@main
+    needs: release
+    with:
+      sdk_version: ${{ github.event.inputs.current_version }}
+      token: ${{ secrets.CD_GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

After every release, we'll call some workflows to measure startup time and library size.

