### PR TITLE
Harden creation of background activity message

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessage.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessage.kt
@@ -26,25 +26,25 @@ internal data class BackgroundActivityMessage @JvmOverloads internal constructor
      * The app information.
      */
     @SerializedName("a")
-    val appInfo: AppInfo,
+    val appInfo: AppInfo?,
 
     /**
      * The device information.
      */
     @SerializedName("d")
-    val deviceInfo: DeviceInfo,
+    val deviceInfo: DeviceInfo?,
 
     /**
      * The device's performance info, such as power, cpu, network.
      */
     @SerializedName("p")
-    val performanceInfo: PerformanceInfo,
+    val performanceInfo: PerformanceInfo?,
 
     /**
      * Breadcrumbs which occurred as part of this session.
      */
     @SerializedName("br")
-    val breadcrumbs: Breadcrumbs,
+    val breadcrumbs: Breadcrumbs?,
 
     @SerializedName("spans")
     val spans: List<EmbraceSpanData>?,


### PR DESCRIPTION
## Goal

Catches any exceptions that might be thrown when creating the background activity message & logs them as internal errors. This should improve the reliability of delivery & let us know about any exceptions that we are missing.

## Testing

Relied on existing test coverage.

