### PR TITLE
[POC] combine envelope classes into one

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.payload.BackgroundActivity
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -11,7 +12,7 @@ internal interface DeliveryCacheManager {
     fun loadSessionBytes(sessionId: String): ByteArray?
     fun deleteSession(sessionId: String)
     fun getAllCachedSessionIds(): List<String>
-    fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage): ByteArray?
+    fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>): ByteArray?
     fun loadBackgroundActivity(backgroundActivityId: String): ByteArray?
     fun saveCrash(crash: EventMessage)
     fun loadCrash(): EventMessage?

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.comms.delivery
 
 import io.embrace.android.embracesdk.ndk.NdkService
+import io.embrace.android.embracesdk.payload.BackgroundActivity
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -15,8 +16,8 @@ internal interface DeliveryService {
     fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState)
     fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?)
     fun saveCrash(crash: EventMessage)
-    fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage)
-    fun sendBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage)
+    fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>)
+    fun sendBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>)
     fun sendBackgroundActivities()
     fun sendLog(eventMessage: EventMessage)
     fun sendNetworkCall(networkEvent: NetworkEvent)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.utils.threadLocal
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.payload.BackgroundActivity
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -133,7 +134,7 @@ internal class EmbraceDeliveryCacheManager(
         return cachedSessions.keys.toList()
     }
 
-    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage): ByteArray? {
+    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>): ByteArray? {
         val baId = backgroundActivityMessage.backgroundActivity.sessionId
         val baBytes = serializer.bytesFromPayload(
             backgroundActivityMessage,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.comms.api.ApiService
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
+import io.embrace.android.embracesdk.payload.BackgroundActivity
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -107,7 +108,7 @@ internal class EmbraceDeliveryService(
      *
      * @param backgroundActivityMessage    The background activity message to cache
      */
-    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage) {
+    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>) {
         backgroundActivities.add(backgroundActivityMessage.backgroundActivity.sessionId)
         cacheManager.saveBackgroundActivity(backgroundActivityMessage)
     }
@@ -117,7 +118,7 @@ internal class EmbraceDeliveryService(
      *
      * @param backgroundActivityMessage    The background activity message to send
      */
-    override fun sendBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage) {
+    override fun sendBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>) {
         logger.logDeveloper(TAG, "Sending background activity message")
 
         sendSessionsExecutorService.submit {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessage.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessage.kt
@@ -8,13 +8,15 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
  * The session message, containing the session itself, as well as performance information about the
  * device which occurred during the session.
  */
-internal data class BackgroundActivityMessage @JvmOverloads internal constructor(
+internal data class BackgroundActivityMessage<T> @JvmOverloads internal constructor(
+
+    // TODO: this is identical to SessionMessage. We can combine the two classes.
 
     /**
      * The session information.
      */
     @SerializedName("s")
-    val backgroundActivity: BackgroundActivity,
+    val backgroundActivity: T,
 
     /**
      * The user information.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -208,7 +208,7 @@ internal class EmbraceBackgroundActivityService(
         endTime: Long,
         endType: LifeEventType,
         crashId: String?
-    ): BackgroundActivityMessage? {
+    ): BackgroundActivityMessage<BackgroundActivity>? {
         val activity = backgroundActivity
         if (activity == null) {
             InternalStaticEmbraceLogger.logError("No background activity to report")
@@ -274,7 +274,7 @@ internal class EmbraceBackgroundActivityService(
     private fun buildBackgroundActivityMessage(
         backgroundActivity: BackgroundActivity?,
         isBackgroundActivityEnd: Boolean
-    ): BackgroundActivityMessage? {
+    ): BackgroundActivityMessage<BackgroundActivity>? {
         if (backgroundActivity != null) {
             val startTime = backgroundActivity.startTime ?: 0L
             val endTime = backgroundActivity.endTime ?: clock.now()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.payload.PerformanceInfo
 import io.embrace.android.embracesdk.payload.UserInfo
 import io.opentelemetry.api.trace.StatusCode
 
-internal fun fakeBackgroundActivity(): BackgroundActivityMessage {
+internal fun fakeBackgroundActivity(): BackgroundActivityMessage<BackgroundActivity> {
     val backgroundActivity = BackgroundActivity("fake-activity", 0, "")
     val userInfo = UserInfo("fake-user-id")
     val appInfo = AppInfo("fake-app-id")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.comms.delivery.SessionMessageState
 import io.embrace.android.embracesdk.ndk.NdkService
+import io.embrace.android.embracesdk.payload.BackgroundActivity
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -19,9 +20,9 @@ internal class FakeDeliveryService : DeliveryService {
     var lastSentEvent: EventMessage? = null
     val lastSentLogs: MutableList<EventMessage> = mutableListOf()
     var sendBackgroundActivitiesInvokedCount: Int = 0
-    var lastSentBackgroundActivity: BackgroundActivityMessage? = null
+    var lastSentBackgroundActivity: BackgroundActivityMessage<BackgroundActivity>? = null
     var saveBackgroundActivityInvokedCount: Int = 0
-    var lastSavedBackgroundActivity: BackgroundActivityMessage? = null
+    var lastSavedBackgroundActivity: BackgroundActivityMessage<BackgroundActivity>? = null
     var lastEventSentAsync: EventMessage? = null
     var eventSentAsyncInvokedCount: Int = 0
     var lastSavedCrash: EventMessage? = null
@@ -55,12 +56,12 @@ internal class FakeDeliveryService : DeliveryService {
         lastEventSentAsync = eventMessage
     }
 
-    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage) {
+    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>) {
         saveBackgroundActivityInvokedCount++
         lastSavedBackgroundActivity = backgroundActivityMessage
     }
 
-    override fun sendBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage) {
+    override fun sendBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>) {
         lastSentBackgroundActivity = backgroundActivityMessage
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryCacheManager
 import io.embrace.android.embracesdk.comms.delivery.DeliveryFailedApiCalls
+import io.embrace.android.embracesdk.payload.BackgroundActivity
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -31,7 +32,7 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
         TODO("Not yet implemented")
     }
 
-    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage): ByteArray? {
+    override fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage<BackgroundActivity>): ByteArray? {
         TODO("Not yet implemented")
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.payload
 
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
@@ -41,7 +42,8 @@ internal class BackgroundActivityMessageTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("bg_activity_message_expected.json")
-        val obj = Gson().fromJson(json, BackgroundActivityMessage::class.java)
+        val collectionType = object : TypeToken<BackgroundActivityMessage<BackgroundActivity>>() {}.type
+        val obj: BackgroundActivityMessage<BackgroundActivity> = Gson().fromJson(json, collectionType)
         assertNotNull(obj)
 
         assertEquals(backgroundActivity.startTime, obj.backgroundActivity.startTime)


### PR DESCRIPTION
## Goal

@bidetofevil could use your opinion on whether it's wise to consolidate some of the payload classes that duplicated fields, and the approach we should take if so. This PR alters the `BackgroundActivityMessage` to make it capable of sending both a `BackgroundActivity` and a `Session`. The only difference between these two classes is whether a background activity or session is serialized under the 's' key, so therefore I've used generics to specify that type.

That ties us to these types always having the same schema. I'm reasonably sure this will always be true (we can check before committing to this approach). Another disadvantage is that it slightly complicates Gson (de)serialization.

A second option I considered is having some form of inheritance hierarchy, either via an interface or an abstract class. This would be highly beneficial for related classes such as `BlobMessage` + `EventMessage`, which share most but not all of the same fields. One downside with this approach is that it negates the possibility of using data classes (we currently use copy & equals functions, but could implement our own).

IMO it makes sense to combine some of these types into combined types, because it will stop future divergence in the payload fields. It should also mean we can share more code (particularly between the session/background activity services, which is the main driver for why I looked at this in the first place).

