### PR TITLE
Disable GH Actions for benchmarking that references a private repo's actions

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -138,16 +138,16 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
           
-  measure-sdk-size:
-    uses: embrace-io/android-size-measure/.github/workflows/analyze-sdk-size.yml@main
-    needs: release
-    with:
-      sdk_version: ${{ github.event.inputs.current_version }}
-      token: ${{ secrets.CD_GITHUB_TOKEN }}
-      
-  measure-startup-time:
-    uses: embrace-io/android-sdk-benchmark/.github/workflows/macrobenchmark.yml@main
-    needs: release
-    with:
-      sdk_version: ${{ github.event.inputs.current_version }}
-      token: ${{ secrets.CD_GITHUB_TOKEN }}
+#  measure-sdk-size:
+#    uses: embrace-io/android-size-measure/.github/workflows/analyze-sdk-size.yml@main
+#    needs: release
+#    with:
+#      sdk_version: ${{ github.event.inputs.current_version }}
+#      token: ${{ secrets.CD_GITHUB_TOKEN }}
+#
+#  measure-startup-time:
+#    uses: embrace-io/android-sdk-benchmark/.github/workflows/macrobenchmark.yml@main
+#    needs: release
+#    with:
+#      sdk_version: ${{ github.event.inputs.current_version }}
+#      token: ${{ secrets.CD_GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

Disabling these GH actions that are in a private repo because you can't call them from a public repo's action