### PR TITLE
Extract location of storage directory to one place

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -593,8 +593,7 @@ final class EmbraceImpl {
             nativeModule,
             sessionModule,
             anrModule,
-            dataContainerModule,
-            coreModule
+            dataContainerModule
         );
 
         loadCrashVerifier(crashModule, nonNullWorkerThreadModule);

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
@@ -24,7 +24,7 @@ import java.net.URI
  */
 internal class ApiResponseCache @JvmOverloads constructor(
     private val serializer: EmbraceSerializer,
-    cacheDirProvider: () -> File,
+    storageDirProvider: () -> File,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : Closeable {
 
@@ -35,7 +35,7 @@ internal class ApiResponseCache @JvmOverloads constructor(
 
     @Volatile
     private var cache: HttpResponseCache? = null
-    private val cacheDir: File by lazy { cacheDirProvider() }
+    private val storageDir: File by lazy { storageDirProvider() }
     private val lock = Object()
 
     private fun initializeIfNeeded() {
@@ -43,7 +43,7 @@ internal class ApiResponseCache @JvmOverloads constructor(
             synchronized(lock) {
                 if (cache == null) {
                     cache = try {
-                        HttpResponseCache.install(cacheDir, MAX_CACHE_SIZE_BYTES)
+                        HttpResponseCache.install(storageDir, MAX_CACHE_SIZE_BYTES)
                     } catch (exc: IOException) {
                         logger.logWarning("Failed to initialize HTTP cache.", exc)
                         null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
@@ -24,12 +24,14 @@ internal class CrashModuleImpl(
     nativeModule: NativeModule,
     sessionModule: SessionModule,
     anrModule: AnrModule,
-    dataContainerModule: DataContainerModule,
-    coreModule: CoreModule
+    dataContainerModule: DataContainerModule
 ) : CrashModule {
 
     private val crashMarker: CrashFileMarker by singleton {
-        val markerFile = lazy { File(coreModule.context.cacheDir.path, CrashFileMarker.CRASH_MARKER_FILE_NAME) }
+        val markerFile = lazy {
+            val dir = essentialServiceModule.storageDirectory.value
+            File(dir, CrashFileMarker.CRASH_MARKER_FILE_NAME)
+        }
         CrashFileMarker(markerFile)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -72,6 +72,7 @@ internal interface EssentialServiceModule {
     val cacheService: CacheService
     val deliveryCacheManager: DeliveryCacheManager
     val deliveryRetryManager: DeliveryRetryManager
+    val storageDirectory: Lazy<File>
 }
 
 internal class EssentialServiceModuleImpl(
@@ -229,7 +230,7 @@ internal class EssentialServiceModuleImpl(
     override val cache by singleton {
         ApiResponseCache(
             coreModule.jsonSerializer,
-            { File(coreModule.context.cacheDir, "emb_config_cache") }
+            { File(storageDirectory.value, "emb_config_cache") }
         )
     }
 
@@ -261,7 +262,7 @@ internal class EssentialServiceModuleImpl(
     }
 
     override val cacheService: CacheService by singleton {
-        EmbraceCacheService(coreModule.context, coreModule.jsonSerializer, coreModule.logger)
+        EmbraceCacheService(storageDirectory, coreModule.jsonSerializer, coreModule.logger)
     }
 
     override val deliveryCacheManager: DeliveryCacheManager by singleton {
@@ -303,6 +304,10 @@ internal class EssentialServiceModuleImpl(
         ApiClientImpl(
             coreModule.logger
         )
+    }
+
+    override val storageDirectory: Lazy<File> = lazy {
+        coreModule.context.cacheDir
     }
 }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.java
@@ -9,7 +9,6 @@ import android.util.Base64;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -118,7 +117,7 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
 
     private String unityCrashId;
 
-    private final Lazy<File> cacheDir;
+    private final Lazy<File> storageDir;
 
     private final ExecutorService cleanCacheExecutorService;
     private final ExecutorService ndkStartupExecutorService;
@@ -132,6 +131,7 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
 
     EmbraceNdkService(
         @NonNull Context context,
+        @NonNull Lazy<File> storageDir,
         @NonNull MetadataService metadataService,
         @NonNull ProcessStateService processStateService,
         @NonNull ConfigService configService,
@@ -148,6 +148,7 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
         @NonNull DeviceArchitecture deviceArchitecture) {
 
         this.context = context;
+        this.storageDir = storageDir;
         this.metadataService = metadataService;
         this.configService = configService;
         this.deliveryService = deliveryService;
@@ -168,7 +169,6 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
             return null;
         });
 
-        this.cacheDir = LazyKt.lazy(context::getCacheDir);
         this.cleanCacheExecutorService = cleanCacheExecutorService;
         this.ndkStartupExecutorService = ndkStartupExecutorService;
 
@@ -305,7 +305,7 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
     }
 
     protected void createCrashReportDirectory() {
-        String directory = cacheDir.getValue() + "/" + NATIVE_CRASH_FILE_FOLDER;
+        String directory = storageDir.getValue() + "/" + NATIVE_CRASH_FILE_FOLDER;
         File directoryFile = new File(directory);
 
         if (directoryFile.exists()) {
@@ -318,8 +318,8 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
     }
 
     protected void installSignals() {
-        String reportBasePath = cacheDir.getValue().getAbsolutePath() + "/" + NATIVE_CRASH_FILE_FOLDER;
-        String markerFilePath = cacheDir.getValue().getAbsolutePath() + "/" + CrashFileMarker.CRASH_MARKER_FILE_NAME;
+        String reportBasePath = storageDir.getValue().getAbsolutePath() + "/" + NATIVE_CRASH_FILE_FOLDER;
+        String markerFilePath = storageDir.getValue().getAbsolutePath() + "/" + CrashFileMarker.CRASH_MARKER_FILE_NAME;
         logger.logDeveloper("EmbraceNDKService", "Creating report path at " + reportBasePath);
 
         String nativeCrashId;
@@ -516,7 +516,7 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
 
     private File[] getNativeFiles(FilenameFilter filter) {
         File[] matchingFiles = null;
-        final File[] files = cacheDir.getValue().listFiles();
+        final File[] files = storageDir.getValue().listFiles();
 
         if (files == null) {
             return null;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepository.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepository.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.ndk
 
-import android.content.Context
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.NativeCrashData
 import java.io.File
@@ -16,9 +15,11 @@ private const val NATIVE_CRASH_MAP_FILE_SUFFIX = ".map"
  * Encapsulates the logic of managing Files to get, sort and or delete them
  */
 internal class EmbraceNdkServiceRepository(
-    private val context: Context,
+    fileProvider: Lazy<File>,
     private val logger: InternalEmbraceLogger
 ) {
+
+    private val storageDir by fileProvider
 
     fun sortNativeCrashes(byOldest: Boolean): List<File> {
         val nativeCrashFiles: Array<File>? = getNativeCrashFiles()
@@ -58,7 +59,7 @@ internal class EmbraceNdkServiceRepository(
 
     private fun getNativeFiles(filter: FilenameFilter): Array<File>? {
         var matchingFiles: Array<File>? = null
-        val files: Array<File> = context.cacheDir.listFiles() ?: return null
+        val files: Array<File> = storageDir.listFiles() ?: return null
         for (cached in files) {
             if (cached.isDirectory && cached.name == NATIVE_CRASH_FILE_FOLDER) {
                 matchingFiles = cached.listFiles(filter)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
@@ -30,6 +30,7 @@ internal class NativeModuleImpl(
     override val ndkService: NdkService by singleton {
         EmbraceNdkService(
             coreModule.context,
+            essentialServiceModule.storageDirectory,
             essentialServiceModule.metadataService,
             essentialServiceModule.processStateService,
             essentialServiceModule.configService,
@@ -73,7 +74,7 @@ internal class NativeModuleImpl(
 
     private val embraceNdkServiceRepository by singleton {
         EmbraceNdkServiceRepository(
-            coreModule.context,
+            essentialServiceModule.storageDirectory,
             coreModule.logger
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import android.content.Context
 import io.embrace.android.embracesdk.comms.api.ApiRequest
 import io.embrace.android.embracesdk.comms.api.EmbraceUrl
 import io.embrace.android.embracesdk.comms.delivery.CacheService
@@ -10,8 +9,6 @@ import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.network.http.HttpMethod
-import io.mockk.every
-import io.mockk.mockk
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -25,18 +22,15 @@ import java.nio.file.Files
 
 internal class EmbraceCacheServiceTest {
 
-    private lateinit var context: Context
     private lateinit var service: CacheService
     private lateinit var dir: File
 
     @Before
     fun setUp() {
-        context = mockk()
 
         dir = Files.createTempDirectory("tmpDirPrefix").toFile()
-        every { context.cacheDir } returns dir
         service = EmbraceCacheService(
-            context,
+            lazy { dir },
             EmbraceSerializer(),
             InternalEmbraceLogger()
         )
@@ -151,7 +145,11 @@ internal class EmbraceCacheServiceTest {
         // In order to force File.listFiles() to return null, we make the File not to be a directory
         val myDir = File("no_directory_file")
         myDir.createNewFile()
-        every { context.cacheDir } returns myDir
+        service = EmbraceCacheService(
+            lazy { myDir },
+            EmbraceSerializer(),
+            InternalEmbraceLogger()
+        )
 
         val deleted = service.deleteObjectsByRegex(".*object.*")
         assertFalse(deleted)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
@@ -18,6 +18,7 @@ import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -55,6 +56,7 @@ internal class EssentialServiceModuleImplTest {
         assertNotNull(module.activityLifecycleTracker)
         assertTrue(module.configService is EmbraceConfigService)
         assertTrue(module.gatingService is EmbraceGatingService)
+        assertEquals(module.storageDirectory.value, coreModule.context.cacheDir)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -37,6 +37,7 @@ import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
+import java.io.File
 
 internal class FakeEssentialServiceModule(
     override val processStateService: ProcessStateService = FakeProcessStateService(),
@@ -62,4 +63,6 @@ internal class FakeEssentialServiceModule(
         get() = throw UnsupportedOperationException()
 
     override val cpuInfoDelegate: CpuInfoDelegate = FakeCpuInfoDelegate()
+
+    override val storageDirectory: Lazy<File> = lazy { throw UnsupportedOperationException() }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
-import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataContainerModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -21,8 +20,7 @@ internal class CrashModuleImplTest {
             FakeNativeModule(),
             FakeSessionModule(),
             FakeAnrModule(),
-            FakeDataContainerModule(),
-            FakeCoreModule()
+            FakeDataContainerModule()
         )
         assertNotNull(module.lastRunCrashVerifier)
         assertNotNull(module.crashService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepositoryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepositoryTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.ndk
 
-import android.content.Context
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.mockk.every
@@ -20,16 +19,15 @@ internal class EmbraceNdkServiceRepositoryTest {
 
     companion object {
         private lateinit var repository: EmbraceNdkServiceRepository
-        private lateinit var context: Context
         private lateinit var logger: InternalEmbraceLogger
+        private lateinit var storageDir: File
 
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
             mockkStatic(InternalEmbraceLogger::class)
-            context = mockk(relaxUnitFun = true)
             logger = mockk(relaxed = true)
-            repository = EmbraceNdkServiceRepository(context, logger)
+            repository = EmbraceNdkServiceRepository(lazy { storageDir }, logger)
         }
 
         @AfterClass
@@ -64,8 +62,9 @@ internal class EmbraceNdkServiceRepositoryTest {
         every { file2.name } returns "ndk"
 
         val fileArray = arrayOf(file1, file2)
-        every { context.cacheDir } returns mockk()
-        every { context.cacheDir.listFiles() } returns fileArray
+        storageDir = mockk {
+            every { listFiles() } returns fileArray
+        }
 
         mockedRepository.sortNativeCrashes(true)
         verify { mockedRepository["getNativeFiles"](any() as FilenameFilter) }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -111,7 +111,7 @@ internal class EmbraceNdkServiceTest {
             objectMocks = false
         )
 
-        val file = File(context.cacheDir.toString() + "/ndk")
+        val file = File("$storageDir/ndk")
         if (file.exists()) {
             file.delete()
         }
@@ -120,6 +120,7 @@ internal class EmbraceNdkServiceTest {
     private fun initializeService() {
         embraceNdkService = TestEmbraceNdkService(
             context,
+            lazy { storageDir },
             metadataService,
             activityService,
             mockDeliveryService,
@@ -203,8 +204,9 @@ internal class EmbraceNdkServiceTest {
         initializeService()
         assertTrue(activityService.listeners.contains(embraceNdkService))
 
-        val reportBasePath = context.cacheDir.absolutePath + "/ndk"
-        val markerFilePath = context.cacheDir.absolutePath + "/" + CrashFileMarker.CRASH_MARKER_FILE_NAME
+        val reportBasePath = storageDir.absolutePath + "/ndk"
+        val markerFilePath =
+            storageDir.absolutePath + "/" + CrashFileMarker.CRASH_MARKER_FILE_NAME
         verify(exactly = 1) {
             delegate._installSignalHandlers(
                 reportBasePath,
@@ -253,8 +255,9 @@ internal class EmbraceNdkServiceTest {
         initializeService()
         assertTrue(activityService.listeners.contains(embraceNdkService))
 
-        val reportBasePath = context.cacheDir.absolutePath + "/ndk"
-        val markerFilePath = context.cacheDir.absolutePath + "/" + CrashFileMarker.CRASH_MARKER_FILE_NAME
+        val reportBasePath = storageDir.absolutePath + "/ndk"
+        val markerFilePath =
+            storageDir.absolutePath + "/" + CrashFileMarker.CRASH_MARKER_FILE_NAME
 
         verifyOrder {
             metadataService.getLightweightAppInfo()
@@ -294,8 +297,8 @@ internal class EmbraceNdkServiceTest {
     fun `test initialization with ndk disabled doesn't run _installSignalHandlers and _updateMetaData`() {
         enableNdk(false)
         initializeService()
-        val reportBasePath = context.cacheDir.absolutePath + "/ndk"
-        val markerFilePath = context.cacheDir.absolutePath + "/crash_file_marker"
+        val reportBasePath = storageDir.absolutePath + "/ndk"
+        val markerFilePath = storageDir.absolutePath + "/crash_file_marker"
 
         verify(exactly = 0) {
             delegate._installSignalHandlers(
@@ -546,8 +549,11 @@ internal class EmbraceNdkServiceTest {
         })
     }
 
+    private val storageDir by lazy { context.cacheDir }
+
     private class TestEmbraceNdkService(
         context: Context,
+        storageDir: Lazy<File>,
         metadataService: MetadataService,
         processStateService: ProcessStateService,
         deliveryService: DeliveryService,
@@ -562,6 +568,7 @@ internal class EmbraceNdkServiceTest {
         ndkStartupExecutorService: ExecutorService
     ) : EmbraceNdkService(
         context,
+        storageDir,
         metadataService,
         processStateService,
         configService,

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/BaseTest.kt
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/BaseTest.kt
@@ -38,6 +38,7 @@ public open class BaseTest {
     protected val gson: Gson = Gson()
     public val testServer: TestServer = TestServer()
     private var fileObserver: EmbraceFileObserver? = null
+    private val storageDir by lazy { mContext.cacheDir }
 
     @SuppressLint("VisibleForTests")
     @Before
@@ -51,7 +52,7 @@ public open class BaseTest {
         mContext =
             EmbraceContext(InstrumentationRegistry.getInstrumentation().context.applicationContext)
 
-        failedApiCallsFilePath = mContext.cacheDir.absolutePath + "/emb_failed_api_calls.json"
+        failedApiCallsFilePath = storageDir.absolutePath + "/emb_failed_api_calls.json"
 
         // attach our mock context to the ProcessLifecycleOwner, this will give us control over the
         // activity/application lifecycle for callbacks registered with the ProcessLifecycleOwner
@@ -75,7 +76,7 @@ public open class BaseTest {
     }
 
     private fun clearCacheFolder() {
-        mContext.cacheDir.deleteRecursively()
+        storageDir.deleteRecursively()
     }
 
     private fun getDefaultNetworkResponses(): Map<String, TestServerResponse> {
@@ -312,8 +313,7 @@ public open class BaseTest {
      * @param failedCallFileName file name that contains our failed api request
      */
     public fun readFileContent(failedApiContent: String, failedCallFileName: String) {
-        val failedApiFilePath =
-            mContext.cacheDir.path + "/emb_" + failedCallFileName
+        val failedApiFilePath = storageDir.path + "/emb_" + failedCallFileName
         val failedApiFile = File(failedApiFilePath)
         val failedApiJsonString: String =
             failedApiFile.reader().use { it.readText() }


### PR DESCRIPTION
## Goal

Extracts the location where the storage directory is set to one place in the `EssentialServiceModule`. This will make it much simpler to alter the location of the storage directory (for example, if we want to store in the filesDir rather than cacheDir).

## Testing

Updated unit test coverage.

