### PR TITLE
Replace Gson usage with EmbraceSerializer where possible

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -47,7 +47,7 @@ internal class EmbraceCacheService(
     }
 
     /**
-     * Writes a file to the cache. Must be serializable by GSON.
+     * Writes a file to the cache. Must be serializable JSON.
      *
      *
      * If writing the object to the cache fails, an exception is logged.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceSerializer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceSerializer.kt
@@ -32,11 +32,11 @@ internal class EmbraceSerializer {
             ?: throw JsonIOException("Failed converting object to JSON.")
     }
 
-    fun <T> fromJson(json: String, type: Type): T? {
+    fun <T> fromJson(json: String, type: Type): T {
         return gson.fromJson(json, type)
     }
 
-    fun <T> fromJson(json: String, clz: Class<T>): T? {
+    fun <T> fromJson(json: String, clz: Class<T>): T {
         return gson.fromJson(json, clz)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
@@ -45,6 +45,7 @@ internal class NativeModuleImpl(
             workerThreadModule.backgroundExecutor(ExecutorName.NATIVE_CRASH_CLEANER),
             workerThreadModule.backgroundExecutor(ExecutorName.NATIVE_STARTUP),
             essentialServiceModule.deviceArchitecture,
+            coreModule.jsonSerializer
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationChecker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationChecker.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.samples
 
 import android.app.Activity
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import java.io.File
 import java.io.FileNotFoundException
@@ -10,7 +10,7 @@ internal class AutomaticVerificationChecker {
     private val fileName = "emb_marker_file.txt"
     private val verificationResult = VerificationResult()
     private lateinit var file: File
-    private var gson = Gson()
+    private val serializer = EmbraceSerializer()
 
     /**
      * Returns true if the file was created, false if it already existed
@@ -56,7 +56,7 @@ internal class AutomaticVerificationChecker {
                 return if (fileContent.isEmpty()) {
                     true
                 } else {
-                    gson.fromJson(fileContent, VerificationResult::class.java).exceptions.isEmpty()
+                    serializer.fromJson(fileContent, VerificationResult::class.java).exceptions.isEmpty()
                 }
             }
         } catch (e: FileNotFoundException) {
@@ -67,7 +67,7 @@ internal class AutomaticVerificationChecker {
 
     fun addException(e: Throwable) {
         verificationResult.exceptions.add(e)
-        file.writeText(gson.toJson(verificationResult).toString())
+        file.writeText(serializer.toJson(verificationResult).toString())
     }
 
     fun getExceptions(): List<Throwable> {
@@ -75,7 +75,7 @@ internal class AutomaticVerificationChecker {
         return if (fileContent.isBlank()) {
             emptyList()
         } else {
-            gson.fromJson(fileContent, VerificationResult::class.java).exceptions
+            serializer.fromJson(fileContent, VerificationResult::class.java).exceptions
         }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AnrSampleTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AnrSampleTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import org.junit.Assert.assertEquals
@@ -8,6 +8,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class AnrSampleTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val threadInfo = ThreadInfo(
         13, Thread.State.RUNNABLE, "my-thread", 5,
@@ -23,14 +25,14 @@ internal class AnrSampleTest {
             .filter { !it.isWhitespace() }
 
         val obj = AnrSample(156098234092, listOf(threadInfo), 2)
-        val observed = Gson().toJson(obj)
+        val observed = serializer.toJson(obj)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testAnrTickDeserialization() {
         val json = ResourceReader.readResourceAsText("anr_tick_expected.json")
-        val obj = Gson().fromJson(json, AnrSample::class.java)
+        val obj = serializer.fromJson(json, AnrSample::class.java)
         assertEquals(2L, obj.sampleOverheadMs)
         assertEquals(156098234092, obj.timestamp)
         assertEquals(listOf(threadInfo), obj.threads)
@@ -38,7 +40,7 @@ internal class AnrSampleTest {
 
     @Test
     fun testThreadInfoEmptyObject() {
-        val threadInfo = Gson().fromJson("{}", AnrSample::class.java)
+        val threadInfo = serializer.fromJson("{}", AnrSample::class.java)
         assertNotNull(threadInfo)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AppInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AppInfoTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.AppInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -8,6 +8,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class AppInfoTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = AppInfo(
         appVersion = "1.0",
@@ -34,14 +36,14 @@ internal class AppInfoTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("app_info_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("app_info_expected.json")
-        val obj = Gson().fromJson(json, AppInfo::class.java)
+        val obj = serializer.fromJson(json, AppInfo::class.java)
         assertEquals("1.0", obj.appVersion)
         assertEquals(Embrace.AppFramework.NATIVE.value, obj.appFramework)
         assertEquals("1234", obj.buildId)
@@ -63,7 +65,7 @@ internal class AppInfoTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", AppInfo::class.java)
+        val info = serializer.fromJson("{}", AppInfo::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ConfigRoundTripTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ConfigRoundTripTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -13,10 +13,10 @@ internal class ConfigRoundTripTest {
      */
     @Test
     fun testConfigRoundTrip() {
-        val gson = Gson()
+        val serializer = EmbraceSerializer()
         val cfg = RemoteConfig()
-        val json = gson.toJson(cfg)
-        val observed = gson.fromJson(json, RemoteConfig::class.java)
+        val json = serializer.toJson(cfg)
+        val observed = serializer.fromJson(json, RemoteConfig::class.java)
         assertNotNull(observed)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DeviceInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DeviceInfoTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.DeviceInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class DeviceInfoTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = DeviceInfo(
         "samsung",
@@ -26,14 +28,14 @@ internal class DeviceInfoTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("device_info_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("device_info_expected.json")
-        val obj = Gson().fromJson(json, DeviceInfo::class.java)
+        val obj = serializer.fromJson(json, DeviceInfo::class.java)
         assertEquals("samsung", obj.manufacturer)
         assertEquals("S20", obj.model)
         assertEquals("armeabi", obj.architecture)
@@ -50,7 +52,7 @@ internal class DeviceInfoTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", DeviceInfo::class.java)
+        val info = serializer.fromJson("{}", DeviceInfo::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DiskUsageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DiskUsageTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.DiskUsage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class DiskUsageTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = DiskUsage(
         150982302,
@@ -17,21 +19,21 @@ internal class DiskUsageTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("disk_usage_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("disk_usage_expected.json")
-        val obj = Gson().fromJson(json, DiskUsage::class.java)
+        val obj = serializer.fromJson(json, DiskUsage::class.java)
         assertEquals(150982302L, obj.appDiskUsage)
         assertEquals(150923L, obj.deviceDiskFree)
     }
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", DiskUsage::class.java)
+        val info = serializer.fromJson("{}", DiskUsage::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.anr.AnrService
 import io.embrace.android.embracesdk.capture.crash.EmbraceCrashService
 import io.embrace.android.embracesdk.capture.crash.EmbraceUncaughtExceptionHandler
@@ -17,6 +16,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarker
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Crash
@@ -38,6 +38,8 @@ import org.junit.Before
 import org.junit.Test
 
 internal class EmbraceCrashServiceTest {
+
+    private val serializer = EmbraceSerializer()
 
     private lateinit var embraceCrashService: EmbraceCrashService
     private lateinit var sessionService: SessionService
@@ -202,14 +204,14 @@ internal class EmbraceCrashServiceTest {
         )
         val expectedInfo = ResourceReader.readResourceAsText("crash_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(crash)
+        val observed = serializer.toJson(crash)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("crash_expected.json")
-        val obj = Gson().fromJson(json, Crash::class.java)
+        val obj = serializer.fromJson(json, Crash::class.java)
 
         assertEquals("123", obj.crashId)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceEventTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceEventTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.payload.Event
 import org.junit.Assert.assertEquals
@@ -8,6 +8,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class EmbraceEventTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val event = Event(
         eventId = Uuid.getEmbUuid(),
@@ -40,14 +42,14 @@ internal class EmbraceEventTest {
     fun testSerialization() {
         val data = ResourceReader.readResourceAsText("event_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(eventComplete)
+        val observed = serializer.toJson(eventComplete)
         assertEquals(data, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("event_expected.json")
-        val obj = Gson().fromJson(json, Event::class.java)
+        val obj = serializer.fromJson(json, Event::class.java)
         assertEquals("eventId", obj.eventId)
         assertEquals("sessionId", obj.sessionId)
         assertEquals("messageId", obj.messageId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionErrorInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionErrorInfoTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ExceptionErrorInfo
 import io.embrace.android.embracesdk.payload.ExceptionInfo
 import org.junit.Assert.assertEquals
@@ -8,6 +8,7 @@ import org.junit.Test
 
 internal class ExceptionErrorInfoTest {
 
+    private val serializer = EmbraceSerializer()
     private val info = ExceptionInfo(
         "java.lang.IllegalStateException",
         "Whoops!",
@@ -29,14 +30,14 @@ internal class ExceptionErrorInfoTest {
         val expectedInfo = ResourceReader.readResourceAsText("exception_error_info_expected.json")
             .filter { !it.isWhitespace() }
 
-        val observed = Gson().toJson(exceptionErrorInfo)
+        val observed = serializer.toJson(exceptionErrorInfo)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testExceptionErrorInfoDeserialization() {
         val json = ResourceReader.readResourceAsText("exception_error_info_expected.json")
-        val obj = Gson().fromJson(json, ExceptionErrorInfo::class.java)
+        val obj = serializer.fromJson(json, ExceptionErrorInfo::class.java)
         assertEquals(0L, obj.timestamp)
         assertEquals("STATE", obj.state)
         val exceptionInfo = obj.exceptions?.get(0)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionInfoTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ExceptionInfo
 import io.mockk.every
 import io.mockk.mockk
@@ -11,6 +11,7 @@ import org.junit.Test
 
 internal class ExceptionInfoTest {
 
+    private val serializer = EmbraceSerializer()
     private val info = ExceptionInfo(
         "java.lang.IllegalStateException",
         "Whoops!",
@@ -24,14 +25,14 @@ internal class ExceptionInfoTest {
     fun testExceptionInfoSerialization() {
         val data = ResourceReader.readResourceAsText("exception_info_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(data, observed)
     }
 
     @Test
     fun testExceptionInfoDeserialization() {
         val json = ResourceReader.readResourceAsText("exception_info_expected.json")
-        val obj = Gson().fromJson(json, ExceptionInfo::class.java)
+        val obj = serializer.fromJson(json, ExceptionInfo::class.java)
         assertEquals("java.lang.IllegalStateException", obj.name)
         assertEquals("Whoops!", obj.message)
         assertEquals("java.base/java.lang.Thread.getStackTrace(Thread.java:1602)", obj.lines[0])
@@ -43,7 +44,7 @@ internal class ExceptionInfoTest {
 
     @Test
     fun testExceptionInfoEmptyObject() {
-        val info = Gson().fromJson("{}", ExceptionInfo::class.java)
+        val info = serializer.fromJson("{}", ExceptionInfo::class.java)
         assertNotNull(info)
         info.name
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FragmentBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FragmentBreadcrumbTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.FragmentBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -8,6 +8,7 @@ import org.junit.Test
 
 internal class FragmentBreadcrumbTest {
 
+    private val serializer = EmbraceSerializer()
     private val info = FragmentBreadcrumb(
         "test",
         1600000000,
@@ -18,14 +19,14 @@ internal class FragmentBreadcrumbTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("fragment_breadcrumb_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("fragment_breadcrumb_expected.json")
-        val obj = Gson().fromJson(json, FragmentBreadcrumb::class.java)
+        val obj = serializer.fromJson(json, FragmentBreadcrumb::class.java)
         assertEquals("test", obj.name)
         assertEquals(1600000000, obj.getStartTime())
         assertEquals(1600001000, obj.endTime)
@@ -33,7 +34,7 @@ internal class FragmentBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", FragmentBreadcrumb::class.java)
+        val info = serializer.fromJson("{}", FragmentBreadcrumb::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/JsExceptionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/JsExceptionTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.JsException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -8,6 +8,7 @@ import org.junit.Test
 
 internal class JsExceptionTest {
 
+    private val serializer = EmbraceSerializer()
     private val info = JsException(
         "java.lang.IllegalStateException",
         "Whoops!",
@@ -19,14 +20,14 @@ internal class JsExceptionTest {
     fun testSerialization() {
         val data = ResourceReader.readResourceAsText("js_exception_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(data, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("js_exception_expected.json")
-        val obj = Gson().fromJson(json, JsException::class.java)
+        val obj = serializer.fromJson(json, JsException::class.java)
         assertEquals("java.lang.IllegalStateException", obj.name)
         assertEquals("Whoops!", obj.message)
         assertEquals("JsError", obj.type)
@@ -35,7 +36,7 @@ internal class JsExceptionTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", JsException::class.java)
+        val info = serializer.fromJson("{}", JsException::class.java)
         assertNotNull(info)
         info.name
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/MemoryWarningTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/MemoryWarningTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.MemoryWarning
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -8,26 +8,27 @@ import org.junit.Test
 
 internal class MemoryWarningTest {
 
+    private val serializer = EmbraceSerializer()
     private val info = MemoryWarning(16098234098234)
 
     @Test
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("memory_warning_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("memory_warning_expected.json")
-        val obj = Gson().fromJson(json, MemoryWarning::class.java)
+        val obj = serializer.fromJson(json, MemoryWarning::class.java)
         assertEquals(16098234098234, obj.timestamp)
     }
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", MemoryWarning::class.java)
+        val info = serializer.fromJson("{}", MemoryWarning::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/OrientationTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/OrientationTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk
 
 import android.content.res.Configuration
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.Orientation
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class OrientationTest {
+
+    private val serializer = EmbraceSerializer()
     private val testOrientation = Orientation(
         "p",
         12345678L
@@ -16,14 +18,14 @@ internal class OrientationTest {
     fun testSerialization() {
         val data = ResourceReader.readResourceAsText("orientation_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(testOrientation)
+        val observed = serializer.toJson(testOrientation)
         assertEquals(data, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("orientation_expected.json")
-        val obj = Gson().fromJson(json, Orientation::class.java)
+        val obj = serializer.fromJson(json, Orientation::class.java)
         assertEquals("p", obj.orientation)
         assertEquals(12345678L, obj.timestamp)
         assertEquals(Configuration.ORIENTATION_PORTRAIT, obj.internalOrientation)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PerformanceInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PerformanceInfoTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.DiskUsage
@@ -18,6 +18,7 @@ import org.junit.Test
 
 internal class PerformanceInfoTest {
 
+    private val serializer = EmbraceSerializer()
     private val diskUsage: DiskUsage = DiskUsage(10000000, 2000000)
     private val networkRequests: NetworkRequests = mockk()
     private val memoryWarnings: List<MemoryWarning> = emptyList()
@@ -34,20 +35,20 @@ internal class PerformanceInfoTest {
         val expectedInfo = ResourceReader.readResourceAsText("perf_info_expected.json")
             .filter { !it.isWhitespace() }
 
-        val observed = Gson().toJson(buildPerformanceInfo())
+        val observed = serializer.toJson(buildPerformanceInfo())
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testPerfInfoDeserialization() {
         val json = ResourceReader.readResourceAsText("perf_info_expected.json")
-        val obj = Gson().fromJson(json, PerformanceInfo::class.java)
+        val obj = serializer.fromJson(json, PerformanceInfo::class.java)
         verifyFields(obj)
     }
 
     @Test
     fun testPerfInfoEmptyObject() {
-        val anrInterval = Gson().fromJson("{}", PerformanceInfo::class.java)
+        val anrInterval = serializer.fromJson("{}", PerformanceInfo::class.java)
         assertNotNull(anrInterval)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PushNotificationBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PushNotificationBreadcrumbTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class PushNotificationBreadcrumbTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = PushNotificationBreadcrumb(
         "title",
@@ -22,14 +24,14 @@ internal class PushNotificationBreadcrumbTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("push_notification_breadcrumb_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("push_notification_breadcrumb_expected.json")
-        val obj = Gson().fromJson(json, PushNotificationBreadcrumb::class.java)
+        val obj = serializer.fromJson(json, PushNotificationBreadcrumb::class.java)
         assertEquals("title", obj.title)
         assertEquals("body", obj.body)
         assertEquals("from", obj.from)
@@ -41,7 +43,7 @@ internal class PushNotificationBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", PushNotificationBreadcrumb::class.java)
+        val info = serializer.fromJson("{}", PushNotificationBreadcrumb::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionStacktraceSampleJsonTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionStacktraceSampleJsonTest.kt
@@ -18,10 +18,12 @@ import org.junit.Test
  */
 internal class SessionStacktraceSampleJsonTest {
 
+    private val gson = Gson()
+
     @Test
     fun testSymbolSerialization() {
         val session = fakeSession().copy(symbols = mapOf("foo" to "bar"))
-        val root = Gson().toJsonTree(session).asJsonObject
+        val root = gson.toJsonTree(session).asJsonObject
 
         // assert symbols included
         val symbols = root.getAsJsonObject("sb")
@@ -34,7 +36,7 @@ internal class SessionStacktraceSampleJsonTest {
         val session = PerformanceInfo(
             nativeThreadAnrIntervals = listOf(fixture)
         )
-        val root = Gson().toJsonTree(session).asJsonObject
+        val root = gson.toJsonTree(session).asJsonObject
 
         // assert ticks included
         val ticks = root.getAsJsonArray("nst")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.BetaFeatures
 import io.embrace.android.embracesdk.payload.ExceptionError
 import io.embrace.android.embracesdk.payload.Orientation
@@ -14,6 +14,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = Session(
         sessionId = "fake-session-id",
@@ -61,14 +63,14 @@ internal class SessionTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("session_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("session_expected.json")
-        val obj = Gson().fromJson(json, Session::class.java)
+        val obj = serializer.fromJson(json, Session::class.java)
         assertNotNull(obj)
 
         with(obj) {
@@ -109,7 +111,7 @@ internal class SessionTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", Session::class.java)
+        val info = serializer.fromJson("{}", Session::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ThreadInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ThreadInfoTest.kt
@@ -1,12 +1,13 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class ThreadInfoTest {
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testThreadInfoMaxLines() {
@@ -34,14 +35,14 @@ internal class ThreadInfoTest {
         val expectedInfo = ResourceReader.readResourceAsText("thread_info_expected.json")
             .filter { !it.isWhitespace() }
 
-        val observed = Gson().toJson(threadInfo)
+        val observed = serializer.toJson(threadInfo)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testThreadInfoDeserialization() {
         val json = ResourceReader.readResourceAsText("thread_info_expected.json")
-        val obj = Gson().fromJson(json, ThreadInfo::class.java)
+        val obj = serializer.fromJson(json, ThreadInfo::class.java)
         assertEquals(13, obj.threadId)
         assertEquals(5, obj.priority)
         assertEquals(Thread.State.RUNNABLE, obj.state)
@@ -57,7 +58,7 @@ internal class ThreadInfoTest {
 
     @Test
     fun testThreadInfoEmptyObject() {
-        val threadInfo = Gson().fromJson("{}", ThreadInfo::class.java)
+        val threadInfo = serializer.fromJson("{}", ThreadInfo::class.java)
         assertNotNull(threadInfo)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UserInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UserInfoTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.UserInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -16,19 +16,20 @@ internal class UserInfoTest {
         username = "joebloggs",
         personas = setOf("first_day"),
     )
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
         val data = ResourceReader.readResourceAsText("user_info_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(data, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("user_info_expected.json")
-        val obj = Gson().fromJson(json, UserInfo::class.java)
+        val obj = serializer.fromJson(json, UserInfo::class.java)
         assertEquals("123", obj.userId)
         assertEquals("fake@example.com", obj.email)
         assertEquals("joebloggs", obj.username)
@@ -37,7 +38,7 @@ internal class UserInfoTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", UserInfo::class.java)
+        val info = serializer.fromJson("{}", UserInfo::class.java)
         assertNotNull(info)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ViewBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ViewBreadcrumbTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ViewBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -14,19 +14,20 @@ internal class ViewBreadcrumbTest {
     ).apply {
         end = 1700000000
     }
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("view_breadcrumb_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("view_breadcrumb_expected.json")
-        val obj = Gson().fromJson(json, ViewBreadcrumb::class.java)
+        val obj = serializer.fromJson(json, ViewBreadcrumb::class.java)
         assertEquals("screen", obj.screen)
         assertEquals(1600000000L, obj.getStartTime())
         assertEquals(1700000000L, obj.end)
@@ -34,7 +35,7 @@ internal class ViewBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", ViewBreadcrumb::class.java)
+        val info = serializer.fromJson("{}", ViewBreadcrumb::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/WebViewBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/WebViewBreadcrumbTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import com.google.gson.Gson
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -12,26 +12,27 @@ internal class WebViewBreadcrumbTest {
         "url",
         1600000000
     )
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("webview_breadcrumb_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("webview_breadcrumb_expected.json")
-        val obj = Gson().fromJson(json, WebViewBreadcrumb::class.java)
+        val obj = serializer.fromJson(json, WebViewBreadcrumb::class.java)
         assertEquals("url", obj.url)
         assertEquals(1600000000, obj.getStartTime())
     }
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", WebViewBreadcrumb::class.java)
+        val info = serializer.fromJson("{}", WebViewBreadcrumb::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrIntervalTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrIntervalTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.anr
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.embrace.android.embracesdk.payload.AnrSampleList
@@ -35,6 +35,8 @@ internal class AnrIntervalTest {
         code = AnrInterval.CODE_SAMPLES_CLEARED
     )
 
+    private val serializer = EmbraceSerializer()
+
     @Test
     fun testClearAnrSamples() {
         val interval = interval.copy(code = AnrInterval.CODE_DEFAULT)
@@ -53,14 +55,14 @@ internal class AnrIntervalTest {
         val expectedInfo = ResourceReader.readResourceAsText("anr_interval_expected.json")
             .filter { !it.isWhitespace() }
 
-        val observed = Gson().toJson(interval.copy())
+        val observed = serializer.toJson(interval.copy())
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testAnrTickDeserialization() {
         val json = ResourceReader.readResourceAsText("anr_interval_expected.json")
-        val obj = Gson().fromJson(json, AnrInterval::class.java)
+        val obj = serializer.fromJson(json, AnrInterval::class.java)
         assertEquals(150980980980, obj.startTime)
         assertEquals(150980980980 + 5000, obj.endTime)
         assertEquals(150980980980 + 4000, obj.lastKnownTime)
@@ -70,7 +72,7 @@ internal class AnrIntervalTest {
 
     @Test
     fun testAnrIntervalEmptyObject() {
-        val anrInterval = Gson().fromJson("{}", AnrInterval::class.java)
+        val anrInterval = serializer.fromJson("{}", AnrInterval::class.java)
         assertNotNull(anrInterval)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrSampleJsonTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrSampleJsonTest.kt
@@ -9,6 +9,8 @@ import org.junit.Test
 
 internal class NativeThreadAnrSampleJsonTest {
 
+    private val serializer = Gson()
+
     @Test
     fun testSerialization() {
         val sample = NativeThreadAnrSample(
@@ -35,7 +37,7 @@ internal class NativeThreadAnrSampleJsonTest {
         assertEquals("/data/foo/libtest.so", stackframe.soPath)
         assertEquals(5, stackframe.result)
 
-        val tree = Gson().toJsonTree(sample).asJsonObject
+        val tree = serializer.toJsonTree(sample).asJsonObject
         assertNotNull(tree)
         assertEquals(4, tree.size())
         assertEquals(2, tree.get("r").asInt)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrStackframeJsonTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrStackframeJsonTest.kt
@@ -8,6 +8,8 @@ import org.junit.Test
 
 internal class NativeThreadAnrStackframeJsonTest {
 
+    private val serializer = Gson()
+
     @Test
     fun testSerialization() {
         val frame = NativeThreadAnrStackframe(
@@ -17,7 +19,7 @@ internal class NativeThreadAnrStackframeJsonTest {
             11
         )
 
-        val tree = Gson().toJsonTree(frame).asJsonObject
+        val tree = serializer.toJsonTree(frame).asJsonObject
         assertNotNull(tree)
         assertEquals(4, tree.size())
         assertEquals("0x5092afb9", tree.get("pc").asString)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
@@ -4,7 +4,6 @@ import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import com.android.server.os.TombstoneProtos
 import com.google.common.util.concurrent.MoreExecutors
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.local.AppExitInfoLocalConfig
@@ -13,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.mockk.every
@@ -55,8 +55,9 @@ internal class AeiNdkCrashProtobufSendTest {
         assertProtobufIsReadable(obj.asStream())
 
         // JSON serialization does not corrupt the protobuf
-        val json = Gson().toJson(obj)
-        val aei = Gson().fromJson(json, AppExitInfoData::class.java)
+        val serializer = EmbraceSerializer()
+        val json = serializer.toJson(obj)
+        val aei = serializer.fromJson(json, AppExitInfoData::class.java)
         val byteStream = aei.asStream()
         assertProtobufIsReadable(byteStream)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.comms.api
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.fakes.fakeSession
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.mockk.every
@@ -27,6 +27,7 @@ import kotlin.IllegalStateException
  */
 internal class ApiClientImplTest {
 
+    private val serializer = EmbraceSerializer()
     private lateinit var apiClient: ApiClientImpl
     private lateinit var server: MockWebServer
     private lateinit var baseUrl: String
@@ -265,7 +266,7 @@ internal class ApiClientImplTest {
     private fun createLargeSessionPayload(): String {
         val props = (1..5000).associate { "my_big_key_$it" to "my_big_val_$it" }
         val session = fakeSession().copy(properties = props)
-        return Gson().toJson(session)
+        return serializer.toJson(session)
     }
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlAdapterTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlAdapterTest.kt
@@ -1,28 +1,26 @@
 package io.embrace.android.embracesdk.comms.api
 
-import com.google.gson.GsonBuilder
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class EmbraceUrlAdapterTest {
 
+    private val serializer = EmbraceSerializer()
+
     @Test
     fun `test EmbraceUrl serialization`() {
         val embraceUrl = EmbraceUrl.create("http://fake.url")
-        val gson = GsonBuilder().registerTypeAdapter(EmbraceUrl::class.java, EmbraceUrlAdapter()).create()
-        val jsonStr = gson.toJson(embraceUrl, EmbraceUrl::class.java)
-        val serialized = gson.fromJson(jsonStr, EmbraceUrl::class.java)
-
+        val jsonStr = serializer.toJson(embraceUrl, EmbraceUrl::class.java)
+        val serialized = serializer.fromJson(jsonStr, EmbraceUrl::class.java)
         assertEquals(embraceUrl.toString(), serialized.toString())
     }
 
     @Test
     fun `test null EmbraceUrl serialization`() {
-        val gson = GsonBuilder().registerTypeAdapter(EmbraceUrl::class.java, EmbraceUrlAdapter()).create()
-        val jsonStr = gson.toJson(null, EmbraceUrl::class.java)
-        val serialized = gson.fromJson(jsonStr, EmbraceUrl::class.java)
-
+        val jsonStr = serializer.toJson(null, EmbraceUrl::class.java)
+        val serialized = serializer.fromJson(jsonStr, EmbraceUrl::class.java)
         assertNull(serialized)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/ApplicationExitInfoRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/ApplicationExitInfoRemoteConfigTest.kt
@@ -1,14 +1,16 @@
 package io.embrace.android.embracesdk.config
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.behavior.AppExitInfoBehavior.Companion.AEI_MAX_NUM_DEFAULT
 import io.embrace.android.embracesdk.config.remote.AppExitInfoConfig
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class ApplicationExitInfoRemoteConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -31,7 +33,7 @@ internal class ApplicationExitInfoRemoteConfigTest {
     @Test
     fun testDeserialization() {
         val data = ResourceReader.readResourceAsText("application_exit_info_remote_config.json")
-        val appExitInfoConfig = Gson().fromJson(data, AppExitInfoConfig::class.java)
+        val appExitInfoConfig = serializer.fromJson(data, AppExitInfoConfig::class.java)
         assertEquals(100, appExitInfoConfig.appExitInfoTracesLimit)
         assertEquals(100f, appExitInfoConfig.pctAeiCaptureEnabled)
         assertEquals(50, appExitInfoConfig.aeiMaxNum)
@@ -39,7 +41,7 @@ internal class ApplicationExitInfoRemoteConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val appExitInfoConfig = Gson().fromJson("{}", AppExitInfoConfig::class.java)
+        val appExitInfoConfig = serializer.fromJson("{}", AppExitInfoConfig::class.java)
         assertNull(appExitInfoConfig.appExitInfoTracesLimit)
         assertNull(appExitInfoConfig.pctAeiCaptureEnabled)
         assertEquals(AEI_MAX_NUM_DEFAULT, appExitInfoConfig.aeiMaxNum)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/BgActivityConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/BgActivityConfigTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.config
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class BgActivityConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -26,13 +28,13 @@ internal class BgActivityConfigTest {
     @Test
     fun testDeserialization() {
         val data = ResourceReader.readResourceAsText("bg_activity_config.json")
-        val cfg = Gson().fromJson(data, BackgroundActivityRemoteConfig::class.java)
+        val cfg = serializer.fromJson(data, BackgroundActivityRemoteConfig::class.java)
         assertEquals(0.5f, cfg.threshold)
     }
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = Gson().fromJson("{}", BackgroundActivityRemoteConfig::class.java)
+        val cfg = serializer.fromJson("{}", BackgroundActivityRemoteConfig::class.java)
         assertNull(cfg.threshold)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/LogRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/LogRemoteConfigTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.config
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class LogRemoteConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -32,7 +34,7 @@ internal class LogRemoteConfigTest {
     @Test
     fun testDeserialization() {
         val data = ResourceReader.readResourceAsText("log_config.json")
-        val cfg = Gson().fromJson(data, LogRemoteConfig::class.java)
+        val cfg = serializer.fromJson(data, LogRemoteConfig::class.java)
         assertEquals(768, cfg.logMessageMaximumAllowedLength)
         assertEquals(50, cfg.logInfoLimit)
         assertEquals(200, cfg.logWarnLimit)
@@ -41,7 +43,7 @@ internal class LogRemoteConfigTest {
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = Gson().fromJson("{}", LogRemoteConfig::class.java)
+        val cfg = serializer.fromJson("{}", LogRemoteConfig::class.java)
         verifyDefaults(cfg)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/NetworkRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/NetworkRemoteConfigTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.config
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class NetworkRemoteConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -28,7 +30,7 @@ internal class NetworkRemoteConfigTest {
     @Test
     fun testDeserialization() {
         val data = ResourceReader.readResourceAsText("network_config.json")
-        val cfg = Gson().fromJson(data, NetworkRemoteConfig::class.java)
+        val cfg = serializer.fromJson(data, NetworkRemoteConfig::class.java)
 
         assertEquals(2000, cfg.defaultCaptureLimit)
         assertEquals(mapOf("google.com" to 500), cfg.domainLimits)
@@ -36,7 +38,7 @@ internal class NetworkRemoteConfigTest {
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = Gson().fromJson("{}", NetworkRemoteConfig::class.java)
+        val cfg = serializer.fromJson("{}", NetworkRemoteConfig::class.java)
         verifyDefaults(cfg)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/UiRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/UiRemoteConfigTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.config
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.UiRemoteConfig
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class UiRemoteConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -34,7 +36,7 @@ internal class UiRemoteConfigTest {
     @Test
     fun testDeserialization() {
         val data = ResourceReader.readResourceAsText("ui_config.json")
-        val cfg = Gson().fromJson(data, UiRemoteConfig::class.java)
+        val cfg = serializer.fromJson(data, UiRemoteConfig::class.java)
         assertEquals(80, cfg.breadcrumbs)
         assertEquals(50, cfg.taps)
         assertEquals(200, cfg.views)
@@ -44,7 +46,7 @@ internal class UiRemoteConfigTest {
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = Gson().fromJson("{}", UiRemoteConfig::class.java)
+        val cfg = serializer.fromJson("{}", UiRemoteConfig::class.java)
         verifyDefaults(cfg)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AnrLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AnrLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class AnrLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,14 +20,14 @@ internal class AnrLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("anr_config.json")
-        val obj = Gson().fromJson(json, AnrLocalConfig::class.java)
+        val obj = serializer.fromJson(json, AnrLocalConfig::class.java)
         assertTrue(checkNotNull(obj.captureGoogle))
         assertTrue(checkNotNull(obj.captureUnityThread))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", AnrLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", AnrLocalConfig::class.java)
         assertNull(obj.captureGoogle)
         assertNull(obj.captureUnityThread)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AppLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AppLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class AppLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,13 +19,13 @@ internal class AppLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("app_config.json")
-        val obj = Gson().fromJson(json, AppLocalConfig::class.java)
+        val obj = serializer.fromJson(json, AppLocalConfig::class.java)
         assertFalse(checkNotNull(obj.reportDiskUsage))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", AppLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", AppLocalConfig::class.java)
         assertNull(obj.reportDiskUsage)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ApplicationExitInfoLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ApplicationExitInfoLocalConfigTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class ApplicationExitInfoLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -19,14 +21,14 @@ internal class ApplicationExitInfoLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("application_exit_info_local_config.json")
-        val obj = Gson().fromJson(json, AppExitInfoLocalConfig::class.java)
+        val obj = serializer.fromJson(json, AppExitInfoLocalConfig::class.java)
         assertEquals(10, obj.appExitInfoTracesLimit)
         assertTrue(obj.aeiCaptureEnabled ?: false)
     }
 
     @Test
     fun testEmptyObject() {
-        val appExitInfoLocalConfig = Gson().fromJson("{}", AppExitInfoLocalConfig::class.java)
+        val appExitInfoLocalConfig = serializer.fromJson("{}", AppExitInfoLocalConfig::class.java)
         assertNull(appExitInfoLocalConfig.appExitInfoTracesLimit)
         assertNull(appExitInfoLocalConfig.aeiCaptureEnabled)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AutomaticDataCaptureLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AutomaticDataCaptureLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class AutomaticDataCaptureLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,7 +19,7 @@ internal class AutomaticDataCaptureLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("auto_data_capture_config.json")
-        val obj = Gson().fromJson(json, AutomaticDataCaptureLocalConfig::class.java)
+        val obj = serializer.fromJson(json, AutomaticDataCaptureLocalConfig::class.java)
 
         assertFalse(checkNotNull(obj.anrServiceEnabled))
         assertFalse(checkNotNull(obj.memoryServiceEnabled))
@@ -27,7 +29,7 @@ internal class AutomaticDataCaptureLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", AutomaticDataCaptureLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", AutomaticDataCaptureLocalConfig::class.java)
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BackgroundActivityLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BackgroundActivityLocalConfigTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class BackgroundActivityLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,7 +20,7 @@ internal class BackgroundActivityLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("background_activity_config.json")
-        val obj = Gson().fromJson(json, BackgroundActivityLocalConfig::class.java)
+        val obj = serializer.fromJson(json, BackgroundActivityLocalConfig::class.java)
         assertTrue(checkNotNull(obj.backgroundActivityCaptureEnabled))
         assertEquals(15, obj.manualBackgroundActivityLimit)
         assertEquals(10000L, obj.minBackgroundActivityDuration)
@@ -27,7 +29,7 @@ internal class BackgroundActivityLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", BackgroundActivityLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", BackgroundActivityLocalConfig::class.java)
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BaseUrlLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BaseUrlLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class BaseUrlLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,7 +19,7 @@ internal class BaseUrlLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("base_url_config.json")
-        val obj = Gson().fromJson(json, BaseUrlLocalConfig::class.java)
+        val obj = serializer.fromJson(json, BaseUrlLocalConfig::class.java)
         assertEquals("https://config.example.com", obj.config)
         assertEquals("https://data.example.com", obj.data)
         assertEquals("https://data-dev.example.com", obj.dataDev)
@@ -26,7 +28,7 @@ internal class BaseUrlLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", BaseUrlLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", BaseUrlLocalConfig::class.java)
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/CrashHandlerLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/CrashHandlerLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class CrashHandlerLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,13 +19,13 @@ internal class CrashHandlerLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("crash_handler_config.json")
-        val obj = Gson().fromJson(json, CrashHandlerLocalConfig::class.java)
+        val obj = serializer.fromJson(json, CrashHandlerLocalConfig::class.java)
         assertFalse(checkNotNull(obj.enabled))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", CrashHandlerLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", CrashHandlerLocalConfig::class.java)
         assertNull(obj.enabled)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/DomainLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/DomainLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class DomainLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,14 +19,14 @@ internal class DomainLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("domain_config.json")
-        val obj = Gson().fromJson(json, DomainLocalConfig::class.java)
+        val obj = serializer.fromJson(json, DomainLocalConfig::class.java)
         assertEquals("example-apis.com", obj.domain)
         assertEquals(400, obj.limit)
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", DomainLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", DomainLocalConfig::class.java)
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/NetworkLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/NetworkLocalConfigTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -9,6 +9,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class NetworkLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -19,7 +21,7 @@ internal class NetworkLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("local_network_config.json")
-        val obj = Gson().fromJson(json, NetworkLocalConfig::class.java)
+        val obj = serializer.fromJson(json, NetworkLocalConfig::class.java)
 
         assertEquals(200, obj.defaultCaptureLimit)
         assertEquals(DomainLocalConfig("google.com", 80).domain, obj.domains?.single()?.domain)
@@ -31,7 +33,7 @@ internal class NetworkLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", NetworkLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", NetworkLocalConfig::class.java)
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -19,7 +21,7 @@ internal class SessionLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("session_config.json")
-        val obj = Gson().fromJson(json, SessionLocalConfig::class.java)
+        val obj = serializer.fromJson(json, SessionLocalConfig::class.java)
         assertEquals(120, obj.maxSessionSeconds)
         assertTrue(checkNotNull(obj.asyncEnd))
         assertTrue(checkNotNull(obj.sessionEnableErrorLogStrictMode))
@@ -29,7 +31,7 @@ internal class SessionLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", SessionLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", SessionLocalConfig::class.java)
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/StartupMomentLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/StartupMomentLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class StartupMomentLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,13 +19,13 @@ internal class StartupMomentLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("startup_moment_config.json")
-        val obj = Gson().fromJson(json, StartupMomentLocalConfig::class.java)
+        val obj = serializer.fromJson(json, StartupMomentLocalConfig::class.java)
         assertFalse(checkNotNull(obj.automaticallyEnd))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", StartupMomentLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", StartupMomentLocalConfig::class.java)
         assertNull(obj.automaticallyEnd)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/TapsLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/TapsLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class TapsLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,13 +19,13 @@ internal class TapsLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("taps_config.json")
-        val obj = Gson().fromJson(json, TapsLocalConfig::class.java)
+        val obj = serializer.fromJson(json, TapsLocalConfig::class.java)
         assertFalse(checkNotNull(obj.captureCoordinates))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", TapsLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", TapsLocalConfig::class.java)
         assertNull(obj.captureCoordinates)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ViewLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ViewLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class ViewLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -17,13 +19,13 @@ internal class ViewLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("view_config.json")
-        val obj = Gson().fromJson(json, ViewLocalConfig::class.java)
+        val obj = serializer.fromJson(json, ViewLocalConfig::class.java)
         assertFalse(checkNotNull(obj.enableAutomaticActivityCapture))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", ViewLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", ViewLocalConfig::class.java)
         assertNull(obj.enableAutomaticActivityCapture)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/WebViewLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/WebViewLocalConfigTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.config.local
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class WebViewLocalConfigTest {
+
+    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,14 +20,14 @@ internal class WebViewLocalConfigTest {
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("web_view_config.json")
-        val obj = Gson().fromJson(json, WebViewLocalConfig::class.java)
+        val obj = serializer.fromJson(json, WebViewLocalConfig::class.java)
         assertFalse(checkNotNull(obj.captureWebViews))
         assertFalse(checkNotNull(obj.captureQueryParams))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = Gson().fromJson("{}", WebViewLocalConfig::class.java)
+        val obj = serializer.fromJson("{}", WebViewLocalConfig::class.java)
         assertNull(obj.captureWebViews)
         assertNull(obj.captureQueryParams)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/EmbraceSerializerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/EmbraceSerializerTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal
 
-import com.google.gson.Gson
 import com.google.gson.stream.JsonReader
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.payload.Session
@@ -25,7 +24,7 @@ internal class EmbraceSerializerTest {
 
     @Test
     fun testLoadObject() {
-        val reader = JsonReader(StringReader(Gson().toJson(payload)))
+        val reader = JsonReader(StringReader(serializer.toJson(payload)))
         val result = serializer.loadObject(reader, SessionMessage::class.java)
         assertEquals("fakeSessionId", result?.session?.sessionId)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanDataTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanDataTest.kt
@@ -1,16 +1,19 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fixtures.testSpan
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class EmbraceSpanDataTest {
+
+    private val serializer = EmbraceSerializer()
+
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("span_expected.json")
-        val deserializedSpan = Gson().fromJson(json, EmbraceSpanData::class.java)
+        val deserializedSpan = serializer.fromJson(json, EmbraceSpanData::class.java)
         assertEquals(testSpan.name, deserializedSpan.name)
         assertEquals(testSpan.spanId, deserializedSpan.spanId)
         assertEquals(testSpan.parentSpanId, deserializedSpan.parentSpanId)
@@ -33,8 +36,8 @@ internal class EmbraceSpanDataTest {
     fun testSerialization() {
         // Take a span, serialize it to JSON, then deserialize it back and compare. This avoids having to deal with the exactly
         // serialized form details like whitespace that won't matter when we deserialize it back to the object form.
-        val serializedSpanJson = Gson().toJson(testSpan)
-        val deserializedSpan = Gson().fromJson(serializedSpanJson, EmbraceSpanData::class.java)
+        val serializedSpanJson = serializer.toJson(testSpan)
+        val deserializedSpan = serializer.fromJson(serializedSpanJson, EmbraceSpanData::class.java)
         assertEquals(testSpan, deserializedSpan)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -5,7 +5,6 @@ import android.content.res.Resources
 import android.os.Build
 import android.util.Base64
 import com.google.common.util.concurrent.MoreExecutors
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
@@ -19,6 +18,7 @@ import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarker
 import io.embrace.android.embracesdk.internal.utils.Uuid
@@ -67,7 +67,6 @@ internal class EmbraceNdkServiceTest {
         private lateinit var delegate: NdkServiceDelegate.NdkDelegate
         private lateinit var repository: EmbraceNdkServiceRepository
         private lateinit var resources: Resources
-        private lateinit var gson: Gson
         private val deviceArchitecture = FakeDeviceArchitecture()
 
         @BeforeClass
@@ -90,7 +89,6 @@ internal class EmbraceNdkServiceTest {
             delegate = mockk(relaxed = true)
             repository = mockk(relaxUnitFun = true)
             resources = mockk(relaxUnitFun = true)
-            gson = Gson()
 
             val appInfo = AppInfo(appFramework = Embrace.AppFramework.NATIVE.value)
             every { metadataService.getAppInfo() } returns appInfo
@@ -582,7 +580,8 @@ internal class EmbraceNdkServiceTest {
         delegate,
         cleanCacheExecutorService,
         ndkStartupExecutorService,
-        deviceArchitecture
+        deviceArchitecture,
+        EmbraceSerializer()
     ) {
         override fun createCrashReportDirectory() {
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -10,6 +10,7 @@ import org.junit.Test
 
 internal class BackgroundActivityMessageTest {
 
+    private val serializer = EmbraceSerializer()
     private val backgroundActivity = BackgroundActivity("fake-activity", 0, "")
     private val userInfo = UserInfo("fake-user-id")
     private val appInfo = AppInfo("fake-app-id")
@@ -34,14 +35,14 @@ internal class BackgroundActivityMessageTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("bg_activity_message_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("bg_activity_message_expected.json")
-        val obj = Gson().fromJson(json, BackgroundActivityMessage::class.java)
+        val obj = serializer.fromJson(json, BackgroundActivityMessage::class.java)
         assertNotNull(obj)
 
         assertEquals(backgroundActivity.startTime, obj.backgroundActivity.startTime)
@@ -55,7 +56,7 @@ internal class BackgroundActivityMessageTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", BackgroundActivityMessage::class.java)
+        val info = serializer.fromJson("{}", BackgroundActivityMessage::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class BackgroundActivityTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = BackgroundActivity(
         sessionId = "fake-session-id",
@@ -38,14 +40,14 @@ internal class BackgroundActivityTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("bg_activity_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("bg_activity_expected.json")
-        val obj = Gson().fromJson(json, BackgroundActivity::class.java)
+        val obj = serializer.fromJson(json, BackgroundActivity::class.java)
         assertNotNull(obj)
 
         with(obj) {
@@ -75,7 +77,7 @@ internal class BackgroundActivityTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", BackgroundActivity::class.java)
+        val info = serializer.fromJson("{}", BackgroundActivity::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BreadcrumbsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BreadcrumbsTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class BreadcrumbsTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = Breadcrumbs(
         viewBreadcrumbs = listOf(ViewBreadcrumb("View", 1600000000)),
@@ -49,14 +51,14 @@ internal class BreadcrumbsTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("breadcrumbs_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("breadcrumbs_expected.json")
-        val obj = Gson().fromJson(json, Breadcrumbs::class.java)
+        val obj = serializer.fromJson(json, Breadcrumbs::class.java)
         assertNotNull(obj)
         assertNotNull(obj.viewBreadcrumbs?.single())
         assertNotNull(obj.customBreadcrumbs?.single())
@@ -69,7 +71,7 @@ internal class BreadcrumbsTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", Breadcrumbs::class.java)
+        val info = serializer.fromJson("{}", Breadcrumbs::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/CustomBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/CustomBreadcrumbTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class CustomBreadcrumbTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = CustomBreadcrumb(
         "test",
@@ -17,21 +19,21 @@ internal class CustomBreadcrumbTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("custom_breadcrumb_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("custom_breadcrumb_expected.json")
-        val obj = Gson().fromJson(json, CustomBreadcrumb::class.java)
+        val obj = serializer.fromJson(json, CustomBreadcrumb::class.java)
         assertEquals("test", obj.message)
         assertEquals(1600000000, obj.getStartTime())
     }
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", CustomBreadcrumb::class.java)
+        val info = serializer.fromJson("{}", CustomBreadcrumb::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/EmbraceEventMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/EmbraceEventMessageTest.kt
@@ -1,14 +1,16 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.EmbraceEvent
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class EmbraceEventMessageTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val eventComplete = Event(
         eventId = "eventId",
@@ -43,14 +45,14 @@ internal class EmbraceEventMessageTest {
     fun testSerialization() {
         val data = ResourceReader.readResourceAsText("eventmessage_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(eventMessage)
+        val observed = serializer.toJson(eventMessage)
         assertEquals(data, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("eventmessage_expected.json")
-        val obj = Gson().fromJson(json, EventMessage::class.java)
+        val obj = serializer.fromJson(json, EventMessage::class.java)
         assertEquals("eventId", obj.event.eventId)
         assertEquals("sessionId", obj.event.sessionId)
         assertEquals("messageId", obj.event.messageId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataErrorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataErrorTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeCrashDataErrorTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info =
         NativeCrashDataError(
@@ -18,21 +20,21 @@ internal class NativeCrashDataErrorTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("native_crash_data_error_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("native_crash_data_error_expected.json")
-        val obj = Gson().fromJson(json, NativeCrashDataError::class.java)
+        val obj = serializer.fromJson(json, NativeCrashDataError::class.java)
         assertEquals(5, obj.number)
         assertEquals(2, obj.context)
     }
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", NativeCrashDataError::class.java)
+        val info = serializer.fromJson("{}", NativeCrashDataError::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeCrashDataTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = NativeCrashData(
         "report_id",
@@ -35,14 +37,14 @@ internal class NativeCrashDataTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("native_crash_data_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("native_crash_data_expected.json")
-        val obj = Gson().fromJson(json, NativeCrashData::class.java)
+        val obj = serializer.fromJson(json, NativeCrashData::class.java)
         assertEquals("report_id", obj.nativeCrashId)
         assertEquals("sid", obj.sessionId)
         assertEquals(1610000000000, obj.timestamp)
@@ -57,7 +59,7 @@ internal class NativeCrashDataTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", NativeCrashData::class.java)
+        val info = serializer.fromJson("{}", NativeCrashData::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashMetadataTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashMetadataTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeCrashMetadataTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = NativeCrashMetadata(
         AppInfo("1.0"),
@@ -19,27 +21,27 @@ internal class NativeCrashMetadataTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("native_crash_metadata_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("native_crash_metadata_expected.json")
-        val obj = Gson().fromJson(json, NativeCrashMetadata::class.java)
+        val obj = serializer.fromJson(json, NativeCrashMetadata::class.java)
         verifyInfoPopulated(obj)
     }
 
     @Test
     fun testToJsonImpl() {
         val json = info.toJson()
-        val obj = Gson().fromJson(json, NativeCrashMetadata::class.java)
+        val obj = serializer.fromJson(json, NativeCrashMetadata::class.java)
         verifyInfoPopulated(obj)
     }
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", NativeCrashMetadata::class.java)
+        val info = serializer.fromJson("{}", NativeCrashMetadata::class.java)
         assertNotNull(info)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeCrashTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = NativeCrash(
         "id",
@@ -26,14 +28,14 @@ internal class NativeCrashTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("native_crash_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("native_crash_expected.json")
-        val obj = Gson().fromJson(json, NativeCrash::class.java)
+        val obj = serializer.fromJson(json, NativeCrash::class.java)
         assertEquals("id", obj.id)
         assertEquals("crashMessage", obj.crashMessage)
         assertEquals(mapOf("key" to "value"), obj.symbols)
@@ -47,7 +49,7 @@ internal class NativeCrashTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", NativeCrash::class.java)
+        val info = serializer.fromJson("{}", NativeCrash::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeSymbolsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeSymbolsTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeSymbolsTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val armv7Symbols = mapOf(
         "libfoo-armeabi-v7a.so" to "0x1234",
@@ -44,14 +46,14 @@ internal class NativeSymbolsTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("native_symbols_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(symbols)
+        val observed = serializer.toJson(symbols)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("native_symbols_expected.json")
-        val obj = Gson().fromJson(json, NativeSymbols::class.java)
+        val obj = serializer.fromJson(json, NativeSymbols::class.java)
         assertEquals(armv7Symbols, obj.getSymbolByArchitecture("arm64-v8a"))
         assertEquals(armv7Symbols, obj.getSymbolByArchitecture("armeabi-v7a"))
         assertEquals(x86Symbols, obj.getSymbolByArchitecture("x86"))
@@ -60,7 +62,7 @@ internal class NativeSymbolsTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", NativeSymbols::class.java)
+        val info = serializer.fromJson("{}", NativeSymbols::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/RnActionBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/RnActionBreadcrumbTest.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class RnActionBreadcrumbTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = RnActionBreadcrumb(
         "my_action",
@@ -21,14 +23,14 @@ internal class RnActionBreadcrumbTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("rn_action_breadcrumb_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("rn_action_breadcrumb_expected.json")
-        val obj = Gson().fromJson(json, RnActionBreadcrumb::class.java)
+        val obj = serializer.fromJson(json, RnActionBreadcrumb::class.java)
         assertEquals("my_action", obj.name)
         assertEquals(1600000000, obj.getStartTime())
         assertEquals(1600000100, obj.endTime)
@@ -39,7 +41,7 @@ internal class RnActionBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", RnActionBreadcrumb::class.java)
+        val info = serializer.fromJson("{}", RnActionBreadcrumb::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.payload
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.fakeSession
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -11,6 +11,7 @@ import org.junit.Test
 
 internal class SessionMessageTest {
 
+    private val serializer = EmbraceSerializer()
     private val session = fakeSession()
     private val userInfo = UserInfo("fake-user-id", "fake-user-name")
     private val appInfo = AppInfo("fake-app-version")
@@ -46,14 +47,14 @@ internal class SessionMessageTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("session_message_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("session_message_expected.json")
-        val obj = Gson().fromJson(json, SessionMessage::class.java)
+        val obj = serializer.fromJson(json, SessionMessage::class.java)
         assertNotNull(obj)
         assertEquals(session, obj.session)
         assertEquals(userInfo, obj.userInfo)
@@ -66,7 +67,7 @@ internal class SessionMessageTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", SessionMessage::class.java)
+        val info = serializer.fromJson("{}", SessionMessage::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/TapBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/TapBreadcrumbTest.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.payload
 
 import android.util.Pair
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class TapBreadcrumbTest {
+
+    private val serializer = EmbraceSerializer()
 
     private val info = TapBreadcrumb(
         Pair(0f, 0f),
@@ -20,14 +22,14 @@ internal class TapBreadcrumbTest {
     fun testSerialization() {
         val expectedInfo = ResourceReader.readResourceAsText("tap_breadcrumb_expected.json")
             .filter { !it.isWhitespace() }
-        val observed = Gson().toJson(info)
+        val observed = serializer.toJson(info)
         assertEquals(expectedInfo, observed)
     }
 
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("tap_breadcrumb_expected.json")
-        val obj = Gson().fromJson(json, TapBreadcrumb::class.java)
+        val obj = serializer.fromJson(json, TapBreadcrumb::class.java)
         assertEquals("0,0", obj.location)
         assertEquals("tappedElementName", obj.tappedElementName)
         assertEquals(1600000000, obj.getStartTime())
@@ -36,7 +38,7 @@ internal class TapBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = Gson().fromJson("{}", TapBreadcrumb::class.java)
+        val info = serializer.fromJson("{}", TapBreadcrumb::class.java)
         assertNotNull(info)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionMessageSerializerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionMessageSerializerTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.session
 
-import com.google.gson.Gson
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fixtures.testSpan
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
@@ -15,6 +14,8 @@ import org.junit.Before
 import org.junit.Test
 
 internal class SessionMessageSerializerTest {
+
+    private val embraceSerializer = EmbraceSerializer()
 
     private lateinit var msg: SessionMessage
 
@@ -33,11 +34,10 @@ internal class SessionMessageSerializerTest {
 
     @Test
     fun testSessionMessageSerializer() {
-        val gson = Gson()
         val serializer = SessionMessageSerializer(EmbraceSerializer())
 
         // message should be identical to JSON.
-        val expected = gson.toJson(msg, SessionMessage::class.java)
+        val expected = embraceSerializer.toJson(msg, SessionMessage::class.java)
         val observed = serializer.serialize(msg)
         assertEquals(expected, observed)
 

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/ConfigHooks.java
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/ConfigHooks.java
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.config.local.SdkLocalConfig;
 import io.embrace.android.embracesdk.config.remote.RemoteConfig;
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig;
 import io.embrace.android.embracesdk.config.remote.WebViewVitals;
+import io.embrace.android.embracesdk.internal.EmbraceSerializer;
 
 /**
  * Provides hooks into SessionConfig that aren't accessible via Kotlin.
@@ -97,7 +98,7 @@ public class ConfigHooks {
             null
         );
 
-        String json = new Gson().toJson(sdkConfig);
+        String json = new EmbraceSerializer().toJson(sdkConfig);
         return Base64.encodeToString(
             json.getBytes(StandardCharsets.UTF_8),
             Base64.DEFAULT


### PR DESCRIPTION
## Goal

Replaces Gson usage with EmbraceSerializer where possible. This will make it easier to replace the JSON library if we ever choose to do so. Some production code was altered but this mainly applies to test code.

## Testing

Updated existing test coverage.

