### PR TITLE
Suppress deprecation warnings in tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.testcases
 
 import android.os.Build

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
@@ -88,6 +88,7 @@ internal class EmbraceInternalInterfaceImplTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLogHandledException() {
         val exception = Throwable("handled exception")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
@@ -142,6 +142,7 @@ internal class LocalConfigTest {
         assertFalse(localConfig.ndkEnabled)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testSessionOnlyConfig() {
         var localConfig =
@@ -238,7 +239,7 @@ internal class LocalConfigTest {
 
     @Test
     fun testStartupMomentOnlyConfig() {
-        var localConfig = LocalConfig.buildConfig(
+        val localConfig = LocalConfig.buildConfig(
             "GrCPU",
             false,
             "{\"startup_moment\": {\"automatically_end\": false}}",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 
 internal class SessionRemoteConfigTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDefaults() {
         val cfg = SessionRemoteConfig(false, 100f, false, null, null)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -63,6 +63,7 @@ internal class EmbraceMetadataServiceTest {
             unmockkAll()
         }
 
+        @Suppress("DEPRECATION")
         private fun initContext() {
             packageInfo.versionName = "1.0.0"
             @Suppress("DEPRECATION")
@@ -111,6 +112,7 @@ internal class EmbraceMetadataServiceTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     private fun getMetadataService(framework: Embrace.AppFramework = Embrace.AppFramework.NATIVE) =
         EmbraceMetadataService.ofContext(
             context,
@@ -130,6 +132,7 @@ internal class EmbraceMetadataServiceTest {
             lazy { packageInfo.versionCode.toString() }
         ).apply { precomputeValues() }
 
+    @Suppress("DEPRECATION")
     private fun getReactNativeMetadataService() =
         EmbraceMetadataService.ofContext(
             context,
@@ -260,6 +263,7 @@ internal class EmbraceMetadataServiceTest {
         assertTrue(deviceInfo.contains("\"da\":\"arm64-v8a\""))
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `test device info without running async operations`() {
         every { Environment.getDataDirectory() }.returns(File("ANDROID_DATA"))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataUnityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataUnityTest.kt
@@ -62,13 +62,14 @@ internal class EmbraceMetadataUnityTest {
         }
 
         @AfterClass
+        @JvmStatic
         fun tearDown() {
             unmockkAll()
         }
 
+        @Suppress("DEPRECATION")
         private fun initContext() {
             packageInfo.versionName = "1.0.0"
-            @Suppress("DEPRECATION")
             packageInfo.versionCode = 10
 
             every { context.getSystemService(Context.WINDOW_SERVICE) }.returns(mockk<WindowManager>())
@@ -97,6 +98,7 @@ internal class EmbraceMetadataUnityTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     private fun getMetadataService() = EmbraceMetadataService.ofContext(
         context,
         buildInfo,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -60,6 +60,7 @@ internal class EmbraceApiServiceTest {
         initApiService()
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `test getConfig returns correct values in Response`() {
         fakeApiClient.queueResponse(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
@@ -31,6 +31,7 @@ internal class SessionBehaviorTest {
         maxSessionProperties = 57,
     )
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDefaults() {
         with(fakeSessionBehavior()) {
@@ -46,6 +47,7 @@ internal class SessionBehaviorTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testLocalOnly() {
         with(fakeSessionBehavior(localCfg = { local })) {
@@ -59,6 +61,7 @@ internal class SessionBehaviorTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testRemoteAndLocal() {
         with(fakeSessionBehavior(localCfg = { local }, remoteCfg = { remote })) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
@@ -15,6 +15,7 @@ internal class SessionLocalConfigTest {
         verifyDefaults(cfg)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testDeserialization() {
         val json = ResourceReader.readResourceAsText("session_config.json")
@@ -32,6 +33,7 @@ internal class SessionLocalConfigTest {
         verifyDefaults(obj)
     }
 
+    @Suppress("DEPRECATION")
     private fun verifyDefaults(cfg: SessionLocalConfig) {
         assertNull(cfg.maxSessionSeconds)
         assertNull(cfg.asyncEnd)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -34,10 +34,11 @@ internal class FakeCoreModule(
 ) : CoreModule {
 
     companion object {
+
+        @Suppress("DEPRECATION")
         fun getMockedContext(): Context {
             val packageInfo = PackageInfo()
             packageInfo.versionName = "1.0.0"
-            @Suppress("DEPRECATION")
             packageInfo.versionCode = 10
 
             val mockContext = mockk<Context>(relaxed = true)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.prefs
 
 import android.content.Context

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/FakePackageManager.kt
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/FakePackageManager.kt
@@ -1,3 +1,5 @@
+@file:Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
+
 package io.embrace.android.embracesdk
 
 import android.content.ComponentName


### PR DESCRIPTION
## Goal

Suppresses some deprecation warnings in the tests that were cluttering up the build log.

