### PR TITLE
Fix warning about Java/Kotlin compiler version mismatch

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -26,3 +26,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.12.1")
 }
+
+// ensure the Kotlin + Java compilers both use the same language level.
+project.tasks.withType(JavaCompile::class.java) {
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}


### PR DESCRIPTION
## Goal

Fixes a compiler warning about our build's Java/Kotlin versions mismatching. Note that this isn't a problem with the code we were shipping to our customers, rather it's just an annoying message that shows up each build.

