### PR TITLE
Bump gradle version to 7.6.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip


### PR DESCRIPTION
## Goal

Bumps the gradle version from 7.4 to 7.6.3.

## Testing

Ran the build, and also did a dry-run of publishing to the snapshot repo. I didn't encounter any obvious build errors

