### PR TITLE
Fix locally failing test

### DIFF
--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/BaseTest.kt
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/BaseTest.kt
@@ -163,6 +163,11 @@ public open class BaseTest {
         Embrace.getInstance().setUserIdentifier("some id")
         Embrace.getInstance().setUsername("John Doe")
 
+        // ensure that the 'first_day' persona is always set so that
+        // the session message is always deterministic no matter
+        // what device it ran on
+        Embrace.getInstance().addUserPersona("first_day")
+
         validateInitializationRequests()
     }
 


### PR DESCRIPTION
## Goal

The `SessionMessageTest` fails locally if Embrace has not been installed on the device in the same day, because we assume the `first_day` persona has always been set when validating the payload. This alters the setup of the test so that persona will always test & therefore the test will consistently pass.

