### PR TITLE
Add integration test for manually ending session

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -64,7 +64,7 @@ internal fun IntegrationTestRule.Harness.getLastSentSessionMessage(): SessionMes
  */
 internal fun IntegrationTestRule.Harness.recordSession(
     simulateAppStartup: Boolean = false,
-    action: () -> Unit
+    action: () -> Unit = {}
 ): SessionMessage {
     // get the activity service & simulate the lifecycle event that triggers a new session.
     val activityService = checkNotNull(Embrace.getImpl().activityService)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk
 
 import android.app.Activity
-import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.logging.EmbraceInternalErrorService
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -10,7 +9,6 @@ import org.robolectric.Robolectric
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import org.junit.Assert
 import org.junit.Assert.assertNotNull
 
 /*** Extension functions that are syntactic sugar for retrieving information from the SDK. ***/
@@ -66,7 +64,7 @@ internal fun IntegrationTestRule.Harness.getLastSentSessionMessage(): SessionMes
  */
 internal fun IntegrationTestRule.Harness.recordSession(
     simulateAppStartup: Boolean = false,
-    action: () -> Unit = {}
+    action: () -> Unit
 ): SessionMessage {
     // get the activity service & simulate the lifecycle event that triggers a new session.
     val activityService = checkNotNull(Embrace.getImpl().activityService)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -1,0 +1,49 @@
+package io.embrace.android.embracesdk.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.getSentSessionMessages
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.recordSession
+import io.embrace.android.embracesdk.verifySessionHappened
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Asserts that a stateful session can be recorded.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class ManualSessionTest {
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule()
+
+    @Before
+    fun setUp() {
+        assertTrue(testRule.harness.getSentSessionMessages().isEmpty())
+    }
+
+    @Test
+    fun `manual session ends stateful session`() {
+        with(testRule) {
+            harness.recordSession {
+                embrace.endSession()
+            }
+            val messages = harness.getSentSessionMessages()
+
+            // FIXME (future): ending a session manually drops the session end event of a
+            //  stateful session.
+            assertEquals(3, messages.size)
+            val second = messages[2]
+            verifySessionHappened(messages[1], second)
+            assertEquals(2, second.session.number)
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.getSentSessionMessages
+import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.Session.SessionLifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifySessionHappened
@@ -44,6 +46,8 @@ internal class StatefulSessionTest {
             val messages = testRule.harness.getSentSessionMessages()
             val first = messages[1]
             verifySessionHappened(messages[0], first)
+            assertEquals(SessionLifeEventType.STATE, first.session.startType)
+            assertEquals(SessionLifeEventType.STATE, first.session.endType)
             val crumb = checkNotNull(first.breadcrumbs?.customBreadcrumbs?.single())
             assertEquals("Hello, World!", crumb.message)
 


### PR DESCRIPTION
## Goal

Adds an integration test that manually ends a session. This verifies the current behavior (which seems to be buggy & a potential cause of dropped sessions). 

