### PR TITLE
Add integration test for session crash

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -46,6 +46,13 @@ internal fun IntegrationTestRule.Harness.getSentSessionMessages(): List<SessionM
 }
 
 /**
+ * Returns the last [SessionMessage] that was saved by the SDK.
+ */
+internal fun IntegrationTestRule.Harness.getLastSavedSessionMessage(): SessionMessage? {
+    return fakeDeliveryModule.deliveryService.lastSavedSession
+}
+
+/**
  * Returns the last [SessionMessage] that was sent by the SDK.
  */
 internal fun IntegrationTestRule.Harness.getLastSentSessionMessage(): SessionMessage? {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/CrashSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/CrashSessionTest.kt
@@ -1,0 +1,48 @@
+package io.embrace.android.embracesdk.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.getLastSavedSessionMessage
+import io.embrace.android.embracesdk.getSentSessionMessages
+import io.embrace.android.embracesdk.recordSession
+import io.embrace.android.embracesdk.verifySessionHappened
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+
+/**
+ * Asserts that a stateful session can be recorded.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class CrashSessionTest {
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule()
+
+    @Before
+    fun setUp() {
+        assertTrue(testRule.harness.getSentSessionMessages().isEmpty())
+    }
+
+    @Test
+    fun `session messages are recorded`() {
+        testRule.harness.recordSession {
+            val handler = checkNotNull(Thread.getDefaultUncaughtExceptionHandler())
+            handler.uncaughtException(Thread.currentThread(), RuntimeException("Boom!"))
+        }
+
+        // verify first session
+        val startMessage = testRule.harness.getSentSessionMessages().single()
+        val endMessage = checkNotNull(testRule.harness.getLastSavedSessionMessage())
+        verifySessionHappened(startMessage, endMessage)
+        assertNotNull(endMessage.session.crashReportId)
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -192,6 +192,7 @@ internal class SessionHandler(
                 clock.now(),
                 crashId,
             )
+            activeSession = null
             fullEndSessionMessage?.let(deliveryService::saveSessionOnCrash)
         }
     }


### PR DESCRIPTION
## Goal

Adds an integration test that confirms on a crash, the session is written to disk. I've made a small tweak to make the `activeSession` null, as if the lifecycle callback ends the session, technically we could end up with duplicate session messages racing with each other. This seems reasonably unlikely in practice.

