### PR TITLE
[EMBR-1489] Prioritize most recent api calls when limit is reached.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSender.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSender.kt
@@ -39,21 +39,18 @@ internal class EmbracePendingApiCallsSender(
     override fun scheduleApiCall(request: ApiRequest, payload: ByteArray) {
         logger.logDeveloper(TAG, "Scheduling api call for retry")
 
-        val endpoint = request.url.endpoint()
-        if (pendingApiCalls.isBelowRetryLimit(endpoint)) {
-            val cachedPayloadName = cacheManager.savePayload(payload)
-            val pendingApiCall = PendingApiCall(request, cachedPayloadName, clock.now())
+        val cachedPayloadName = cacheManager.savePayload(payload)
+        val pendingApiCall = PendingApiCall(request, cachedPayloadName, clock.now())
 
-            val scheduleJob = pendingApiCalls.hasAnyPendingApiCall().not()
+        val scheduleJob = pendingApiCalls.hasAnyPendingApiCall().not()
 
-            pendingApiCalls.add(pendingApiCall)
-            cacheManager.savePendingApiCalls(pendingApiCalls)
+        pendingApiCalls.add(pendingApiCall)
+        cacheManager.savePendingApiCalls(pendingApiCalls)
 
-            // By default there are no scheduled retry jobs pending.
-            // If the retry map was initially empty, try to schedule a retry.
-            if (scheduleJob) {
-                scheduleApiCallsDelivery(RETRY_PERIOD)
-            }
+        // By default there are no scheduled retry jobs pending.
+        // If the retry map was initially empty, try to schedule a retry.
+        if (scheduleJob) {
+            scheduleApiCallsDelivery(RETRY_PERIOD)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCalls.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCalls.kt
@@ -4,15 +4,15 @@ import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpo
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * A map containing a list of pending API calls per endpoint.
+ * A map containing a queue of pending API calls for each endpoint.
  */
 internal class PendingApiCalls {
 
     private val pendingApiCallsMap = ConcurrentHashMap<Endpoint, PendingApiCallsQueue>()
 
     /**
-     * Adds a pending API call in the corresponding endpoint's list.
-     * If the endpoint's list has reached its limit, the oldest pending API call is removed and
+     * Adds a pending API call in the corresponding endpoint's queue.
+     * If the endpoint's queue has reached its limit, the oldest pending API call is removed and
      * the new one is added.
      */
     fun add(pendingApiCall: PendingApiCall) {
@@ -29,7 +29,7 @@ internal class PendingApiCalls {
 
     /**
      * Returns the next pending API call to be sent and removes it from the corresponding
-     * endpoint's list.
+     * endpoint's queue.
      */
     fun pollNextPendingApiCall(): PendingApiCall? {
         pendingApiCallsMap[Endpoint.SESSIONS]?.let { sessionsQueue ->
@@ -54,14 +54,14 @@ internal class PendingApiCalls {
     }
 
     /**
-     * Returns true if the endpoint's list has reached its limit.
+     * Returns true if the endpoint's queue has reached its limit.
      */
     private fun PendingApiCallsQueue.hasReachedLimit(endpoint: Endpoint): Boolean {
         return this.size >= endpoint.getMaxPendingApiCalls()
     }
 
     /**
-     * Returns true if there is al least one pending API call in any endpoint's list.
+     * Returns true if there is al least one pending API call in any endpoint's queue.
      */
     fun hasAnyPendingApiCall(): Boolean {
         return pendingApiCallsMap.values.any { it.isNotEmpty() }


### PR DESCRIPTION
## Goal

- When adding a new pending api call on a full queue (reached the limit) we were not doing the insertion. 
- That means that we were prioritizing old API calls over new ones. 
- This PR adds the new value when the queue is full and removes the oldest one. 
- That means that we are now prioritizing the most recent API calls. 

## Testing

Updated tests accordingly. 


