### PR TITLE
Avoid dropping session when endSession called

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -6,12 +6,10 @@ import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.getSentSessionMessages
-import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifySessionHappened
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -40,13 +38,9 @@ internal class ManualSessionTest {
                 embrace.endSession()
             }
             val messages = harness.getSentSessionMessages()
-
-            // FIXME (future): ending a session manually drops the session end event of a
-            //  stateful session.
-            assertEquals(3, messages.size)
-            val second = messages[2]
-            verifySessionHappened(messages[1], second)
-            assertEquals(2, second.session.number)
+            assertEquals(2, messages.size)
+            verifySessionHappened(messages[0], messages[1])
+            assertEquals(1, messages[1].session.number)
         }
     }
 
@@ -80,12 +74,9 @@ internal class ManualSessionTest {
             }
             val messages = harness.getSentSessionMessages()
 
-            // FIXME (future): ending a session manually drops the session end event of a
-            //  stateful session.
-            assertEquals(3, messages.size)
-            val second = messages[2]
-            verifySessionHappened(messages[1], second)
-            assertEquals(2, second.session.number)
+            assertEquals(2, messages.size)
+            verifySessionHappened(messages[0], messages[1])
+            assertEquals(1, messages[1].session.number)
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -86,7 +86,7 @@ internal class EmbraceSessionService(
         }
 
         // Ends active session.
-        sessionHandler.onSessionEnded(endType, clock.now(), clearUserInfo)
+        sessionHandler.onSessionEnded(endType, clock.now(), clearUserInfo) ?: return
 
         // Starts a new session.
         if (!processStateService.isInBackground) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -142,9 +142,13 @@ internal class SessionHandler(
     /**
      * It performs all corresponding operations in order to end a session.
      */
-    fun onSessionEnded(endType: SessionLifeEventType, endTime: Long, clearUserInfo: Boolean) {
+    fun onSessionEnded(
+        endType: SessionLifeEventType,
+        endTime: Long,
+        clearUserInfo: Boolean
+    ): SessionMessage? {
         synchronized(lock) {
-            val session = activeSession ?: return
+            val session = activeSession ?: return null
             logger.logDebug("SessionHandler: running onSessionEnded. endType=$endType, endTime=$endTime")
             val fullEndSessionMessage = createSessionSnapshot(
                 SessionSnapshotType.NORMAL_END,
@@ -153,7 +157,7 @@ internal class SessionHandler(
                 spansService.flushSpans(),
                 endType,
                 endTime
-            ) ?: return
+            ) ?: return null
 
             // Clean every collection of those services which have collections in memory.
             memoryCleanerService.cleanServicesCollections(exceptionService)
@@ -172,6 +176,7 @@ internal class SessionHandler(
             // clear active session
             activeSession = null
             logger.logDebug("SessionHandler: cleared active session")
+            return fullEndSessionMessage
         }
     }
 


### PR DESCRIPTION
## Goal

Avoids dropping a session when `endSession` is called and manual session is not enabled. The previous logic did not check whether a session had ended before starting a new one, which resulted in the previous session message getting dropped. This changeset returns the session message if one was ended, or returns null if not.

## Testing

Covered by updating existing integration tests.
