### PR TITLE
Log internal errors when session writing fails

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -273,8 +273,8 @@ internal class EmbraceDeliveryService(
                     } else {
                         logger.logError("Session $id not found")
                     }
-                } catch (ex: Exception) {
-                    logger.logError("Could not send cached session $id")
+                } catch (ex: Throwable) {
+                    logger.logError("Could not send cached session", ex, true)
                 }
             }
         }


### PR DESCRIPTION
## Goal

Alters logging to ensure an internal error is sent when writing or reading a session fails. This should get us more insight when using the Grafana internal errors dashboard.
