### PR TITLE
Reduce memory usage by serializing session via stream

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.payload.SessionMessage
+
 /**
  * Handles the caching of objects.
  */
@@ -31,6 +33,12 @@ internal interface CacheService {
      * @param bytes  the bytes to write
      */
     fun cacheBytes(name: String, bytes: ByteArray?)
+
+    /**
+     * Serializes a session object to disk via a stream. This saves memory when the session is
+     * large & the return value isn't used (e.g. for a crash & periodic caching)
+     */
+    fun writeSession(name: String, sessionMessage: SessionMessage)
 
     /**
      * Reads the bytes from a cached file, if it exists.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -5,7 +5,8 @@ import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal interface DeliveryCacheManager {
-    fun saveSession(sessionMessage: SessionMessage): ByteArray?
+    fun saveSession(sessionMessage: SessionMessage): ByteArray
+    fun saveSessionPeriodicCache(sessionMessage: SessionMessage)
     fun saveSessionOnCrash(sessionMessage: SessionMessage)
     fun loadSession(sessionId: String): SessionMessage?
     fun loadSessionBytes(sessionId: String): ByteArray?

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 internal enum class SessionMessageState { START, END, END_WITH_CRASH }
 
 internal interface DeliveryService {
+    fun saveSessionPeriodicCache(sessionMessage: SessionMessage)
     fun saveSessionOnCrash(sessionMessage: SessionMessage)
     fun saveSession(sessionMessage: SessionMessage)
     fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -233,7 +233,7 @@ internal class SessionHandler(
                 SessionLifeEventType.STATE,
                 clock.now()
             )
-            msg?.let(deliveryService::saveSession)
+            msg?.let(deliveryService::saveSessionPeriodicCache)
             return msg
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -6,9 +6,11 @@ import io.embrace.android.embracesdk.comms.delivery.CacheService
 import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
+import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.payload.SessionMessage
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -211,6 +213,14 @@ internal class EmbraceCacheServiceTest {
         assertEquals(apiRequest.logId, cachedApiRequest?.logId)
         assertEquals(apiRequest.url.toString(), cachedApiRequest?.url.toString())
         assertEquals(apiRequest.httpMethod, cachedApiRequest?.httpMethod)
+    }
+
+    @Test
+    fun `test write session`() {
+        val original = SessionMessage(fakeSession())
+        service.writeSession("test", original)
+        val loadObject = service.loadObject("test", SessionMessage::class.java)
+        assertEquals(original, loadObject)
     }
 }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -100,6 +100,46 @@ internal class EmbraceDeliveryCacheManagerTest {
     }
 
     @Test
+    fun `cache periodic session successful`() {
+        val sessionMessage = createSessionMessage("test_cache")
+
+        deliveryCacheManager.saveSessionPeriodicCache(sessionMessage)
+
+        verify {
+            cacheService.writeSession(
+                "$prefix.$clockInit.test_cache.json",
+                sessionMessage
+            )
+        }
+
+        assertSessionsMatch(sessionMessage, checkNotNull(deliveryCacheManager.loadSession("test_cache")))
+
+        val expectedByteArray =
+            serializer.bytesFromPayload(sessionMessage, SessionMessage::class.java)
+        assertArrayEquals(expectedByteArray, checkNotNull(deliveryCacheManager.loadSessionBytes("test_cache")))
+    }
+
+    @Test
+    fun `cache session on crash successful`() {
+        val sessionMessage = createSessionMessage("test_cache")
+
+        deliveryCacheManager.saveSessionOnCrash(sessionMessage)
+
+        verify {
+            cacheService.writeSession(
+                "$prefix.$clockInit.test_cache.json",
+                sessionMessage
+            )
+        }
+
+        assertSessionsMatch(sessionMessage, checkNotNull(deliveryCacheManager.loadSession("test_cache")))
+
+        val expectedByteArray =
+            serializer.bytesFromPayload(sessionMessage, SessionMessage::class.java)
+        assertArrayEquals(expectedByteArray, checkNotNull(deliveryCacheManager.loadSessionBytes("test_cache")))
+    }
+
+    @Test
     fun `session not found in cache`() {
         assertNull(deliveryCacheManager.loadSession("not_found_session"))
         assertNull(deliveryCacheManager.loadSessionBytes("not_found_session"))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -38,6 +38,10 @@ internal class FakeDeliveryService : DeliveryService {
         lastSavedSession = sessionMessage
     }
 
+    override fun saveSessionPeriodicCache(sessionMessage: SessionMessage) {
+        lastSavedSession = sessionMessage
+    }
+
     override fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState) {
         lastSentSessions.add(Pair(sessionMessage, state))
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import io.embrace.android.embracesdk.comms.api.EmbraceUrl
 import io.embrace.android.embracesdk.comms.api.EmbraceUrlAdapter
 import io.embrace.android.embracesdk.comms.delivery.CacheService
+import io.embrace.android.embracesdk.payload.SessionMessage
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
 
@@ -64,5 +65,9 @@ internal class TestCacheService : CacheService {
 
     override fun listFilenamesByPrefix(prefix: String): MutableList<String> {
         return (cache.keys.filter { it.startsWith(prefix) }).toMutableList()
+    }
+
+    override fun writeSession(name: String, sessionMessage: SessionMessage) {
+        cacheBytes(name, gson.toJson(sessionMessage).toByteArray())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -79,6 +79,28 @@ internal class EmbraceDeliveryServiceTest {
     }
 
     @Test
+    fun `cache periodic session successful`() {
+        initializeDeliveryService()
+        val mockSessionMessage: SessionMessage = mockk()
+
+        deliveryService.saveSessionPeriodicCache(mockSessionMessage)
+
+        verify(exactly = 1) { mockDeliveryCacheManager.saveSessionPeriodicCache(mockSessionMessage) }
+        assertEquals(1, gatingService.sessionMessagesFiltered.size)
+    }
+
+    @Test
+    fun `cache session on crash successful`() {
+        initializeDeliveryService()
+        val mockSessionMessage: SessionMessage = mockk()
+
+        deliveryService.saveSessionOnCrash(mockSessionMessage)
+
+        verify(exactly = 1) { mockDeliveryCacheManager.saveSessionOnCrash(mockSessionMessage) }
+        assertEquals(1, gatingService.sessionMessagesFiltered.size)
+    }
+
+    @Test
     fun `if no previous cached session then send previous cached sessions should not send anything`() {
         initializeDeliveryService()
         every { mockDeliveryCacheManager.getAllCachedSessionIds() } returns emptyList()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.comms.delivery.CacheService
+import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal class FakeCacheService : CacheService {
     override fun <T> cacheObject(name: String, objectToCache: T, clazz: Class<T>) {
@@ -36,6 +37,10 @@ internal class FakeCacheService : CacheService {
     }
 
     override fun listFilenamesByPrefix(prefix: String): List<String>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun writeSession(name: String, sessionMessage: SessionMessage) {
         TODO("Not yet implemented")
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -7,11 +7,15 @@ import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal class FakeDeliveryCacheManager : DeliveryCacheManager {
-    override fun saveSession(sessionMessage: SessionMessage): ByteArray? {
+    override fun saveSession(sessionMessage: SessionMessage): ByteArray {
         TODO("Not yet implemented")
     }
 
     override fun saveSessionOnCrash(sessionMessage: SessionMessage) {
+        TODO("Not yet implemented")
+    }
+
+    override fun saveSessionPeriodicCache(sessionMessage: SessionMessage) {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
## Goal

Reduces memory usage by serializing a session via a `Writer` under certain circumstances. Specifically if the process has crashed or the session is being periodically cached, the bytes from the session payload are not required because no network request is made. Rather than retaining these in memory, we should stream the results directly to disk to reduce memory pressure.

## Testing

Added unit test coverage & manually verified that sessions are still written to disk for each method
