### PR TITLE
Gzip encode HTTP requests via stream

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.comms.api
 
+import java.io.ByteArrayInputStream
+
 /**
  * A simple interface to make internal HTTP requests to the Embrace API
  */
@@ -10,10 +12,10 @@ internal interface ApiClient {
     fun executeGet(request: ApiRequest): ApiResponse
 
     /**
-     * Executes [ApiRequest] as a POST with the given body defined by [payloadToCompress], returning the response as a [ApiResponse].
+     * Executes [ApiRequest] as a POST with the given body defined by [payloadStream], returning the response as a [ApiResponse].
      * The body will be gzip compressed.
      */
-    fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse
+    fun executePost(request: ApiRequest, payloadStream: ByteArrayInputStream): ApiResponse
 
     companion object {
         /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.NO_HTTP_RESPO
 import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.TOO_MANY_REQUESTS
 import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.defaultTimeoutMs
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -45,25 +45,23 @@ internal class ApiClientImpl(
         }
     }
 
-    override fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse =
-        executeRawPost(request, gzip(payloadToCompress))
-
-    /**
-     * Posts a payload according to the ApiRequest parameter. The payload will not be gzip compressed.
-     */
-    private fun executeRawPost(request: ApiRequest, payload: ByteArray?): ApiResponse {
+    override fun executePost(
+        request: ApiRequest,
+        payloadStream: ByteArrayInputStream
+    ): ApiResponse {
         logger.logDeveloper("ApiClient", request.httpMethod.toString() + " " + request.url)
         logger.logDeveloper("ApiClient", "Request details: $request")
-
         var connection: EmbraceConnection? = null
         return try {
             connection = request.toConnection()
             setTimeouts(connection)
-            if (payload != null) {
-                logger.logDeveloper("ApiClient", "Payload size: " + payload.size)
-                connection.outputStream?.write(payload)
-                connection.connect()
+
+            connection.outputStream?.let { httpStream ->
+                GZIPOutputStream(httpStream).use { outputStream ->
+                    payloadStream.copyTo(outputStream)
+                }
             }
+            connection.connect()
             val response = executeHttpRequest(connection)
             response
         } catch (ex: Throwable) {
@@ -152,26 +150,6 @@ internal class ApiClientImpl(
         } catch (ex: IOException) {
             logger.logDeveloper("ApiClient", "Failed to read response body.", ex)
             throw IllegalStateException("Failed to read response body.", ex)
-        }
-    }
-
-    /**
-     * Compresses a given byte array using the GZIP compression algorithm.
-     *
-     * @param bytes the byte array to compress
-     * @return the compressed byte array
-     */
-    private fun gzip(bytes: ByteArray): ByteArray {
-        return try {
-            ByteArrayOutputStream().use { baos ->
-                GZIPOutputStream(baos).use { gzipStream ->
-                    gzipStream.write(bytes)
-                    gzipStream.finish()
-                }
-                baos.toByteArray()
-            }
-        } catch (ex: IOException) {
-            throw IllegalStateException("Failed to gzip payload.", ex)
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
+import java.io.ByteArrayInputStream
 import java.io.StringReader
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
@@ -216,7 +217,7 @@ internal class EmbraceApiService(
 
     @Suppress("UseCheckOrError")
     private fun executePost(request: ApiRequest, payload: ByteArray) {
-        val response = apiClient.executePost(request, payload)
+        val response = apiClient.executePost(request, ByteArrayInputStream(payload))
         if (response !is ApiResponse.Success) {
             throw IllegalStateException("Failed to retrieve from Embrace server.")
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
@@ -49,7 +49,7 @@ internal class ApiClientImplTest {
     fun testUnreachableHost() {
         // attempt some unreachable port
         val request = ApiRequest(url = EmbraceUrl.create("http://localhost:1565"))
-        val response = apiClient.executePost(request, "Hello world".toByteArray())
+        val response = apiClient.executePost(request, "Hello world".toByteArray().inputStream())
         check(response is ApiResponse.Incomplete)
         assertTrue(response.exception is IllegalStateException)
     }
@@ -117,7 +117,7 @@ internal class ApiClientImplTest {
 
     @Test
     fun testPostConnectionThrows() {
-        val response = apiClient.executePost(createThrowingRequest(), DEFAULT_REQUEST_BODY.toByteArray())
+        val response = apiClient.executePost(createThrowingRequest(), DEFAULT_REQUEST_BODY.toByteArray().inputStream())
         check(response is ApiResponse.Incomplete)
         assertTrue(response.exception is java.lang.IllegalStateException)
     }
@@ -176,7 +176,7 @@ internal class ApiClientImplTest {
             EmbraceUrl.create(baseUrl)
         )
         server.enqueue(response200)
-        apiClient.executePost(postRequest, DEFAULT_REQUEST_BODY.toByteArray())
+        apiClient.executePost(postRequest, DEFAULT_REQUEST_BODY.toByteArray().inputStream())
 
         // assert all request headers were set
         val delivered = server.takeRequest()
@@ -216,7 +216,7 @@ internal class ApiClientImplTest {
                 url = EmbraceUrl.create(baseUrl),
                 httpMethod = HttpMethod.POST
             ),
-            payload
+            payload.inputStream()
         )
 
     private fun createThrowingRequest(): ApiRequest {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -247,7 +247,7 @@ internal class EmbraceApiServiceTest {
         }
 
         expectedPayload?.let {
-            assertArrayEquals(it, fakeApiClient.sentRequests[0].second)
+            assertArrayEquals(it, fakeApiClient.sentRequests[0].second?.readBytes())
         } ?: assertNull(fakeApiClient.sentRequests[0].second)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiClient.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiClient.kt
@@ -3,22 +3,23 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.comms.api.ApiClient
 import io.embrace.android.embracesdk.comms.api.ApiRequest
 import io.embrace.android.embracesdk.comms.api.ApiResponse
+import java.io.ByteArrayInputStream
 import java.util.LinkedList
 import java.util.Queue
 
 internal class FakeApiClient : ApiClient {
-    val sentRequests: MutableList<Pair<ApiRequest, ByteArray?>> = mutableListOf()
+    val sentRequests: MutableList<Pair<ApiRequest, ByteArrayInputStream?>> = mutableListOf()
     private val queuedResponses: Queue<ApiResponse> = LinkedList()
 
     override fun executeGet(request: ApiRequest): ApiResponse = getNext(request, null)
 
-    override fun executePost(request: ApiRequest, payloadToCompress: ByteArray): ApiResponse = getNext(request, payloadToCompress)
+    override fun executePost(request: ApiRequest, payloadStream: ByteArrayInputStream): ApiResponse = getNext(request, payloadStream)
 
     fun queueResponse(response: ApiResponse) {
         queuedResponses.add(response)
     }
 
-    private fun getNext(request: ApiRequest, bytes: ByteArray?): ApiResponse {
+    private fun getNext(request: ApiRequest, bytes: ByteArrayInputStream?): ApiResponse {
         sentRequests.add(Pair(request, bytes))
         return checkNotNull(queuedResponses.poll()) { "No response" }
     }


### PR DESCRIPTION
## Goal

Performs GZIP encoding on the HTTP request `OutputStream` rather than copying the results to a temporary string buffer. This should reduce memory usage as we no longer need to retain the buffer that holds the gzipped contents.

I investigated the possibility of streaming JSON serialization to further reduce memory usage, but Gson doesn't support that without migrating to the manual `JsonReader/JsonWriter` implementations (which we probably don't want to do). Therefore migrating to a different JSON library (probably kotlinx) would be a prerequisite if we wanted to optimize this area of the codebase.

## Testing

Updated unit tests. Confirmed that requests still show up in dashboard.

