### PR TITLE
Remove unnecessary serialization functions

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
@@ -63,14 +63,12 @@ internal class LogMessageTest : BaseTest() {
             assertTrue(file.exists() && !file.isDirectory)
             readFile(file, "/v1/log/logging")
             val serializer = EmbraceSerializer()
-            file.bufferedReader().use { bufferedReader ->
-                val obj = serializer.fromJson(bufferedReader, PendingApiCalls::class.java)
-                val pendingApiCall = obj.pollNextPendingApiCall()
-                checkNotNull(pendingApiCall)
-                val pendingApiCallFileName = pendingApiCall.cachedPayloadFilename
-                assert(pendingApiCallFileName.isNotBlank())
-                readFileContent("Test log info fail", pendingApiCallFileName)
-            }
+            val obj = serializer.fromJson(file.inputStream(), PendingApiCalls::class.java)
+            val pendingApiCall = obj.pollNextPendingApiCall()
+            checkNotNull(pendingApiCall)
+            val pendingApiCallFileName = pendingApiCall.cachedPayloadFilename
+            assert(pendingApiCallFileName.isNotBlank())
+            readFileContent("Test log info fail", pendingApiCallFileName)
         } catch (e: IOException) {
             fail("IOException error: ${e.message}")
         }

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
@@ -105,14 +105,11 @@ internal class MomentMessageTest : BaseTest() {
             assertTrue(file.exists() && !file.isDirectory)
             readFile(file, EmbraceEndpoint.EVENTS.url)
             val serializer = EmbraceSerializer()
-            file.bufferedReader().use { bufferedReader ->
-                val obj = serializer.fromJson(bufferedReader, PendingApiCalls::class.java)
-                val pendingApiCall = obj.pollNextPendingApiCall()
-                checkNotNull(pendingApiCall)
-                val pendingApiCallFileName = pendingApiCall.cachedPayloadFilename
-                assert(pendingApiCallFileName.isNotBlank())
-                readFileContent("\"t\":\"start\"", pendingApiCallFileName)
-            }
+            val obj = serializer.fromJson(file.inputStream(), PendingApiCalls::class.java)
+            val pendingApiCall = checkNotNull(obj.pollNextPendingApiCall())
+            val pendingApiCallFileName = pendingApiCall.cachedPayloadFilename
+            assert(pendingApiCallFileName.isNotBlank())
+            readFileContent("\"t\":\"start\"", pendingApiCallFileName)
         } catch (e: IOException) {
             fail("IOException error: ${e.message}")
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import java.io.Closeable
 import java.io.File
 import java.io.IOException
-import java.io.InputStreamReader
 import java.net.CacheResponse
 import java.net.URI
 
@@ -59,9 +58,7 @@ internal class ApiResponseCache @JvmOverloads constructor(
     fun retrieveCachedConfig(url: String, request: ApiRequest): CachedConfig {
         val cachedResponse = retrieveCacheResponse(url, request)
         val obj = cachedResponse?.runCatching {
-            InputStreamReader(body).buffered().use {
-                serializer.fromJson(it, RemoteConfig::class.java)
-            }
+            serializer.fromJson(body, RemoteConfig::class.java)
         }?.getOrNull()
         val eTag = cachedResponse?.let { retrieveETag(cachedResponse) }
         return CachedConfig(obj, eTag)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -67,9 +67,7 @@ internal class EmbraceCacheService(
         logger.logDeveloper(TAG, "Attempting to cache object: $name")
         val file = File(storageDir, EMBRACE_PREFIX + name)
         try {
-            file.bufferedWriter().use {
-                serializer.toJson(objectToCache, clazz, it)
-            }
+            serializer.toJson(objectToCache, clazz, file.outputStream())
         } catch (ex: Exception) {
             logger.logDebug("Failed to store cache object " + file.path, ex)
         }
@@ -78,14 +76,7 @@ internal class EmbraceCacheService(
     override fun <T> loadObject(name: String, clazz: Class<T>): T? {
         val file = File(storageDir, EMBRACE_PREFIX + name)
         try {
-            file.bufferedReader().use { bufferedReader ->
-                val obj = serializer.fromJson(bufferedReader, clazz)
-                if (obj != null) {
-                    return obj
-                } else {
-                    logger.logDeveloper("EmbraceCacheService", "Object $name not found")
-                }
-            }
+            return serializer.fromJson(file.inputStream(), clazz)
         } catch (ex: FileNotFoundException) {
             logger.logDebug("Cache file cannot be found " + file.path)
         } catch (ex: Exception) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceSerializer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceSerializer.kt
@@ -1,66 +1,47 @@
 package io.embrace.android.embracesdk.internal
 
 import com.google.gson.GsonBuilder
-import com.google.gson.JsonIOException
 import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import io.embrace.android.embracesdk.comms.api.EmbraceUrl
 import io.embrace.android.embracesdk.comms.api.EmbraceUrlAdapter
 import io.embrace.android.embracesdk.internal.utils.threadLocal
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
-import java.io.BufferedWriter
-import java.io.Reader
-import java.lang.reflect.Type
-import java.nio.charset.Charset
+import java.io.InputStream
+import java.io.OutputStream
 
 /**
  * A wrapper around Gson to allow for thread-safe serialization.
  */
 internal class EmbraceSerializer {
 
-    private val gson by threadLocal {
+    private val impl by threadLocal {
         GsonBuilder()
             .registerTypeAdapter(EmbraceUrl::class.java, EmbraceUrlAdapter())
             .create()
     }
 
     fun <T> toJson(src: T): String {
-        return gson.toJson(src) ?: throw JsonIOException("Failed converting object to JSON.")
+        return impl.toJson(src)
     }
 
-    fun <T> toJson(src: T, type: Type): String {
-        return gson.toJson(src, type)
-            ?: throw JsonIOException("Failed converting object to JSON.")
-    }
-
-    fun <T> toJson(any: T, clazz: Class<T>, writer: BufferedWriter): Boolean {
-        return try {
-            gson.toJson(any, clazz, JsonWriter(writer))
-            true
-        } catch (e: Exception) {
-            InternalStaticEmbraceLogger.logDebug("cannot write to bufferedWriter", e)
-            false
+    fun <T> toJson(any: T, clazz: Class<T>, outputStream: OutputStream) {
+        outputStream.writer().buffered().use {
+            impl.toJson(any, clazz, JsonWriter(it))
         }
     }
 
-    fun <T> fromJson(json: String, type: Type): T {
-        return gson.fromJson(json, type)
-    }
-
     fun <T> fromJson(json: String, clz: Class<T>): T {
-        return gson.fromJson(json, clz)
+        return impl.fromJson(json, clz)
     }
 
-    fun <T> fromJson(reader: Reader, clz: Class<T>): T {
-        return gson.fromJson(reader, clz)
+    fun <T> fromJson(inputStream: InputStream, clz: Class<T>): T {
+        inputStream.bufferedReader().use {
+            return impl.fromJson(JsonReader(it), clz)
+        }
     }
 
-    fun <T> fromJson(json: String): T {
-        return gson.fromJson(json, object : TypeToken<T>() {}.type)
-    }
-
-    fun <T> bytesFromPayload(payload: T, clazz: Class<T>): ByteArray? {
-        val json = toJson(payload, clazz)
-        return json.toByteArray(Charset.forName("UTF-8"))
+    fun <T> fromJsonWithTypeToken(json: String): T {
+        return impl.fromJson(json, object : TypeToken<T>() {}.type)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.java
@@ -366,7 +366,7 @@ class EmbraceNdkService implements NdkService, ProcessStateListener {
             String errorsRaw = delegate._getErrors(absolutePath);
             if (errorsRaw != null) {
                 try {
-                    return serializer.<ArrayList<NativeCrashDataError>>fromJson(errorsRaw);
+                    return serializer.<ArrayList<NativeCrashDataError>>fromJsonWithTypeToken(errorsRaw);
                 } catch (Exception e) {
                     logger.logError("Failed to parse native crash error file {crashId=" + nativeCrash.getNativeCrashId() +
                         ", errorFilePath=" + absolutePath + "}");

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Crash.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Crash.kt
@@ -81,7 +81,7 @@ internal data class Crash(
             var jsExceptions: List<String>? = null
             if (jsException != null) {
                 try {
-                    val jsonException = serializer.toJson(jsException, jsException.javaClass).toByteArray()
+                    val jsonException = serializer.toJson(jsException).toByteArray()
                     val encodedString = Base64.encodeToString(jsonException, Base64.NO_WRAP)
                     jsExceptions = listOf(encodedString)
                 } catch (ex: Exception) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -150,7 +150,7 @@ internal class EmbracePreferencesService(
         key: String
     ): Map<String, String>? {
         val mapString = getString(key, null) ?: return null
-        return serializer.fromJson<HashMap<String, String>>(mapString)
+        return serializer.fromJsonWithTypeToken<HashMap<String, String>>(mapString)
     }
 
     override var appVersion: String?

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionMessageSerializer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionMessageSerializer.kt
@@ -2,13 +2,7 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.comms.api.ApiClient
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
-import io.embrace.android.embracesdk.payload.AppInfo
-import io.embrace.android.embracesdk.payload.Breadcrumbs
-import io.embrace.android.embracesdk.payload.DeviceInfo
-import io.embrace.android.embracesdk.payload.PerformanceInfo
-import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.payload.UserInfo
 import java.io.BufferedWriter
 import java.io.StringWriter
 import java.io.Writer
@@ -42,26 +36,26 @@ internal class SessionMessageSerializer(
     private fun BufferedWriter.serializeImpl(msg: SessionMessage) {
         append("{")
 
-        val session = jsonValue(msg, "s", Session::class.java, SessionMessage::session)
+        val session = jsonValue(msg, "s", SessionMessage::session)
         addJsonProperty("\"s\":", session)
 
-        val userInfo = jsonValue(msg, "u", UserInfo::class.java, SessionMessage::userInfo)
+        val userInfo = jsonValue(msg, "u", SessionMessage::userInfo)
         addJsonProperty("\"u\":", userInfo)
 
-        val appInfo = jsonValue(msg, "a", AppInfo::class.java, SessionMessage::appInfo)
+        val appInfo = jsonValue(msg, "a", SessionMessage::appInfo)
         addJsonProperty("\"a\":", appInfo)
 
-        val deviceInfo = jsonValue(msg, "d", DeviceInfo::class.java, SessionMessage::deviceInfo)
+        val deviceInfo = jsonValue(msg, "d", SessionMessage::deviceInfo)
         addJsonProperty("\"d\":", deviceInfo)
 
         val performanceInfo =
-            jsonValue(msg, "p", PerformanceInfo::class.java, SessionMessage::performanceInfo)
+            jsonValue(msg, "p", SessionMessage::performanceInfo)
         addJsonProperty("\"p\":", performanceInfo)
 
-        val breadcrumbs = jsonValue(msg, "br", Breadcrumbs::class.java, SessionMessage::breadcrumbs)
+        val breadcrumbs = jsonValue(msg, "br", SessionMessage::breadcrumbs)
         addJsonProperty("\"br\":", breadcrumbs)
 
-        val spans = jsonValue(msg, "spans", List::class.java, SessionMessage::spans)
+        val spans = jsonValue(msg, "spans", SessionMessage::spans)
         addJsonProperty("\"spans\":", spans)
 
         append("\"v\":")
@@ -80,7 +74,6 @@ internal class SessionMessageSerializer(
     private fun <T> jsonValue(
         msg: SessionMessage,
         key: String,
-        clz: Class<T>,
         fieldProvider: (sessionMessage: SessionMessage) -> T?
     ): String {
         return runCatching {
@@ -90,7 +83,7 @@ internal class SessionMessageSerializer(
             val isCacheValid = newValue == oldValue
             return when {
                 cache != null && isCacheValid -> cache
-                else -> return serializer.toJson(newValue, clz).apply {
+                else -> return serializer.toJson(newValue).apply {
                     jsonCache[key] = this
                 }
             }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -78,8 +78,7 @@ internal class EmbraceDeliveryCacheManagerTest {
     @Test
     fun `cache current session successfully`() {
         val sessionMessage = createSessionMessage("test_cache")
-        val expectedBytes =
-            EmbraceSerializer().bytesFromPayload(sessionMessage, SessionMessage::class.java)
+        val expectedBytes = EmbraceSerializer().toJson(sessionMessage).toByteArray()
 
         val serialized = deliveryCacheManager.saveSession(sessionMessage)
 
@@ -94,8 +93,7 @@ internal class EmbraceDeliveryCacheManagerTest {
 
         assertSessionsMatch(sessionMessage, checkNotNull(deliveryCacheManager.loadSession("test_cache")))
 
-        val expectedByteArray =
-            serializer.bytesFromPayload(sessionMessage, SessionMessage::class.java)
+        val expectedByteArray = serializer.toJson(sessionMessage).toByteArray()
         assertArrayEquals(expectedByteArray, checkNotNull(deliveryCacheManager.loadSessionBytes("test_cache")))
     }
 
@@ -114,8 +112,7 @@ internal class EmbraceDeliveryCacheManagerTest {
 
         assertSessionsMatch(sessionMessage, checkNotNull(deliveryCacheManager.loadSession("test_cache")))
 
-        val expectedByteArray =
-            serializer.bytesFromPayload(sessionMessage, SessionMessage::class.java)
+        val expectedByteArray = serializer.toJson(sessionMessage).toByteArray()
         assertArrayEquals(expectedByteArray, checkNotNull(deliveryCacheManager.loadSessionBytes("test_cache")))
     }
 
@@ -134,8 +131,7 @@ internal class EmbraceDeliveryCacheManagerTest {
 
         assertSessionsMatch(sessionMessage, checkNotNull(deliveryCacheManager.loadSession("test_cache")))
 
-        val expectedByteArray =
-            serializer.bytesFromPayload(sessionMessage, SessionMessage::class.java)
+        val expectedByteArray = serializer.toJson(sessionMessage).toByteArray()
         assertArrayEquals(expectedByteArray, checkNotNull(deliveryCacheManager.loadSessionBytes("test_cache")))
     }
 
@@ -165,12 +161,7 @@ internal class EmbraceDeliveryCacheManagerTest {
         every { cacheService.cacheBytes(any(), any()) } throws Exception()
 
         val sessionMessage = createSessionMessage("test_cache_fails")
-        val expectedBytes = checkNotNull(
-            EmbraceSerializer().bytesFromPayload(
-                sessionMessage,
-                SessionMessage::class.java
-            )
-        )
+        val expectedBytes = EmbraceSerializer().toJson(sessionMessage).toByteArray()
 
         val serialized = checkNotNull(deliveryCacheManager.saveSession(sessionMessage))
 
@@ -453,8 +444,8 @@ internal class EmbraceDeliveryCacheManagerTest {
     private fun assertSessionsMatch(session1: SessionMessage, session2: SessionMessage) {
         // SessionMessage does not implement equals, so we have to serialize to compare
         assertEquals(
-            String(checkNotNull(serializer.bytesFromPayload(session1, SessionMessage::class.java))),
-            String(checkNotNull(serializer.bytesFromPayload(session2, SessionMessage::class.java)))
+            serializer.toJson(session1),
+            serializer.toJson(session2)
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
@@ -13,7 +13,7 @@ internal class TestCacheService : CacheService {
     private val cache: MutableMap<String, ByteArray> = ConcurrentHashMap()
 
     override fun <T> cacheObject(name: String, objectToCache: T, clazz: Class<T>) {
-        cache[name] = serializer.toJson(objectToCache, checkNotNull(clazz.genericSuperclass)).toByteArray()
+        cache[name] = serializer.toJson(objectToCache).toByteArray()
     }
 
     override fun <T> loadObject(name: String, clazz: Class<T>): T? {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -148,7 +148,7 @@ internal class EmbraceApiServiceTest {
         verifyOnlyRequest(
             expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/logging",
             expectedLogId = "el:message-id",
-            expectedPayload = serializer.bytesFromPayload(event, EventMessage::class.java)
+            expectedPayload = serializer.toJson(event).toByteArray()
         )
     }
 
@@ -159,7 +159,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendAEIBlob(blob)
         verifyOnlyRequest(
             expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/blobs",
-            expectedPayload = serializer.bytesFromPayload(blob, BlobMessage::class.java)
+            expectedPayload = serializer.toJson(blob).toByteArray()
         )
     }
 
@@ -172,7 +172,7 @@ internal class EmbraceApiServiceTest {
         verifyOnlyRequest(
             expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/network",
             expectedLogId = "n:network-event-id",
-            expectedPayload = serializer.bytesFromPayload(networkEvent, NetworkEvent::class.java)
+            expectedPayload = serializer.toJson(networkEvent).toByteArray()
         )
     }
 
@@ -189,7 +189,7 @@ internal class EmbraceApiServiceTest {
         verifyOnlyRequest(
             expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/events",
             expectedEventId = "e:event-id",
-            expectedPayload = serializer.bytesFromPayload(event, EventMessage::class.java)
+            expectedPayload = serializer.toJson(event).toByteArray()
         )
     }
 
@@ -206,7 +206,7 @@ internal class EmbraceApiServiceTest {
         verifyOnlyRequest(
             expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/events",
             expectedEventId = "c:event-1,event-2",
-            expectedPayload = serializer.bytesFromPayload(crash, EventMessage::class.java)
+            expectedPayload = serializer.toJson(crash).toByteArray()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlAdapterTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlAdapterTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.comms.api
 
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class EmbraceUrlAdapterTest {
@@ -12,15 +11,8 @@ internal class EmbraceUrlAdapterTest {
     @Test
     fun `test EmbraceUrl serialization`() {
         val embraceUrl = EmbraceUrl.create("http://fake.url")
-        val jsonStr = serializer.toJson(embraceUrl, EmbraceUrl::class.java)
-        val serialized = serializer.fromJson(jsonStr, EmbraceUrl::class.java)
+        val jsonStr: String = serializer.toJson(embraceUrl)
+        val serialized: EmbraceUrl = serializer.fromJson(jsonStr, EmbraceUrl::class.java)
         assertEquals(embraceUrl.toString(), serialized.toString())
-    }
-
-    @Test
-    fun `test null EmbraceUrl serialization`() {
-        val jsonStr = serializer.toJson(null, EmbraceUrl::class.java)
-        val serialized = serializer.fromJson(jsonStr, EmbraceUrl::class.java)
-        assertNull(serialized)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/EmbraceSerializerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/EmbraceSerializerTest.kt
@@ -5,10 +5,7 @@ import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.StringReader
 
 internal class EmbraceSerializerTest {
     private val serializer = EmbraceSerializer()
@@ -17,20 +14,13 @@ internal class EmbraceSerializerTest {
 
     @Test
     fun testWriteToFile() {
-        val result = serializer.toJson(payload, SessionMessage::class.java, mockk(relaxed = true))
-        assertTrue(result)
+        serializer.toJson(payload, SessionMessage::class.java, mockk(relaxed = true))
     }
 
     @Test
     fun testLoadObject() {
-        val reader = StringReader(serializer.toJson(payload))
-        val result = serializer.fromJson(reader, SessionMessage::class.java)
+        val stream = serializer.toJson(payload).byteInputStream()
+        val result = serializer.fromJson(stream, SessionMessage::class.java)
         assertEquals("fakeSessionId", result.session.sessionId)
-    }
-
-    @Test
-    fun testBytesFromPayload() {
-        val result = serializer.bytesFromPayload(payload, SessionMessage::class.java)
-        assertNotNull(result)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionMessageSerializerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionMessageSerializerTest.kt
@@ -39,7 +39,7 @@ internal class SessionMessageSerializerTest {
         val serializer = SessionMessageSerializer(EmbraceSerializer())
 
         // message should be identical to JSON.
-        val expected = embraceSerializer.toJson(msg, SessionMessage::class.java)
+        val expected = embraceSerializer.toJson(msg)
         val observed = serializer.serialize(msg)
         assertEquals(expected, observed)
 


### PR DESCRIPTION
## Goal

Removes some unnecessary function overloads on `EmbraceSerializer`. This also renames a couple of signatures & takes an `InputStream` & `OutputStream` rather than `Reader/Writer`.

## Testing

Relied on existing test coverage.

