### PR TITLE
Remove session start message

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -114,12 +114,9 @@ internal fun <T> returnIfConditionMet(desiredValueSupplier: () -> T, waitTimeMs:
     throw TimeoutException("Timeout period elapsed before condition met")
 }
 
-internal fun verifySessionHappened(startMessage: SessionMessage, endMessage: SessionMessage) {
-    verifySessionMessage(startMessage)
-    assertEquals("st", startMessage.session.messageType)
-    verifySessionMessage(endMessage)
-    assertEquals("en", endMessage.session.messageType)
-    assertEquals(startMessage.session.sessionId, endMessage.session.sessionId)
+internal fun verifySessionHappened(message: SessionMessage) {
+    verifySessionMessage(message)
+    assertEquals("en", message.session.messageType)
 }
 
 internal fun verifySessionMessage(sessionMessage: SessionMessage) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/CrashSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/CrashSessionTest.kt
@@ -40,9 +40,8 @@ internal class CrashSessionTest {
         }
 
         // verify first session
-        val startMessage = testRule.harness.getSentSessionMessages().single()
-        val endMessage = checkNotNull(testRule.harness.getLastSavedSessionMessage())
-        verifySessionHappened(startMessage, endMessage)
-        assertNotNull(endMessage.session.crashReportId)
+        val message = checkNotNull(testRule.harness.getLastSavedSessionMessage())
+        verifySessionHappened(message)
+        assertNotNull(message.session.crashReportId)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -37,10 +37,9 @@ internal class ManualSessionTest {
             harness.recordSession {
                 embrace.endSession()
             }
-            val messages = harness.getSentSessionMessages()
-            assertEquals(2, messages.size)
-            verifySessionHappened(messages[0], messages[1])
-            assertEquals(1, messages[1].session.number)
+            val message = harness.getSentSessionMessages().single()
+            verifySessionHappened(message)
+            assertEquals(1, message.session.number)
         }
     }
 
@@ -55,10 +54,10 @@ internal class ManualSessionTest {
                 embrace.endSession()
             }
             val messages = harness.getSentSessionMessages()
-            assertEquals(4, messages.size)
-            verifySessionHappened(messages[0], messages[1])
-            verifySessionHappened(messages[2], messages[3])
-            assertNotEquals(messages[1].session.sessionId, messages[3].session.sessionId)
+            assertEquals(2, messages.size)
+            verifySessionHappened(messages[0])
+            verifySessionHappened(messages[1])
+            assertNotEquals(messages[0].session.sessionId, messages[1].session.sessionId)
         }
     }
 
@@ -72,11 +71,9 @@ internal class ManualSessionTest {
                 harness.fakeClock.tick(1000) // not enough to trigger new session
                 embrace.endSession()
             }
-            val messages = harness.getSentSessionMessages()
-
-            assertEquals(2, messages.size)
-            verifySessionHappened(messages[0], messages[1])
-            assertEquals(1, messages[1].session.number)
+            val message = harness.getSentSessionMessages().single()
+            verifySessionHappened(message)
+            assertEquals(1, message.session.number)
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
@@ -46,9 +46,6 @@ internal class PeriodicSessionCacheTest {
                 harness.workerThreadModule.scheduledExecutor(SESSION_CACHING) as BlockingScheduledExecutorService
 
             harness.recordSession {
-                val startMessage = harness.getSentSessionMessages().single()
-                verifySessionMessage(startMessage)
-
                 executor.runCurrentlyBlocked()
                 embrace.addBreadcrumb("Test")
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
@@ -44,16 +44,16 @@ internal class StatefulSessionTest {
 
             // verify first session
             val messages = testRule.harness.getSentSessionMessages()
-            val first = messages[1]
-            verifySessionHappened(messages[0], first)
+            val first = messages[0]
+            verifySessionHappened(first)
             assertEquals(SessionLifeEventType.STATE, first.session.startType)
             assertEquals(SessionLifeEventType.STATE, first.session.endType)
             val crumb = checkNotNull(first.breadcrumbs?.customBreadcrumbs?.single())
             assertEquals("Hello, World!", crumb.message)
 
             // verify second session
-            val second = messages[3]
-            verifySessionHappened(messages[2], second)
+            val second = messages[1]
+            verifySessionHappened(second)
             assertNotEquals(first.session.sessionId, second.session.sessionId)
             assertEquals(true, second.breadcrumbs?.customBreadcrumbs?.isEmpty())
         }
@@ -70,7 +70,7 @@ internal class StatefulSessionTest {
             // TODO: future the logic seems wrong here - nested calls should probably be ignored
             //  and should not drop a session. However, it's an unlikely scenario (if we trust)
             //  Google's process lifecycle implementation.
-            assertEquals(3, messages.size)
+            assertEquals(1, messages.size)
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/TimedSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/TimedSessionTest.kt
@@ -54,13 +54,13 @@ internal class TimedSessionTest {
                 }
             }
             val messages = harness.getSentSessionMessages()
-            assertEquals(10, messages.size)
-            verifySessionHappened(messages[0], messages[1])
-            verifySessionHappened(messages[2], messages[3])
-            verifySessionHappened(messages[4], messages[5])
-            verifySessionHappened(messages[6], messages[7])
-            verifySessionHappened(messages[8], messages[9])
-            assertNotEquals(messages[1].session.sessionId, messages[3].session.sessionId)
+            assertEquals(5, messages.size)
+            verifySessionHappened(messages[0])
+            verifySessionHappened(messages[1])
+            verifySessionHappened(messages[2])
+            verifySessionHappened(messages[3])
+            verifySessionHappened(messages[4])
+            assertNotEquals(messages[0].session.sessionId, messages[1].session.sessionId)
         }
     }
 
@@ -75,9 +75,8 @@ internal class TimedSessionTest {
             harness.recordSession {
                 executor.moveForwardAndRunBlocked(90000)
             }
-            val messages = harness.getSentSessionMessages()
-            assertEquals(2, messages.size)
-            verifySessionHappened(messages[0], messages[1])
+            val message = harness.getSentSessionMessages().single()
+            verifySessionHappened(message)
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -268,7 +268,7 @@ internal class NetworkRequestApiTest {
                 embrace.recordNetworkRequest(request)
             }
 
-            val session = testRule.harness.fakeDeliveryModule.deliveryService.lastSentSessions[1].first
+            val session = testRule.harness.fakeDeliveryModule.deliveryService.lastSentSessions[0].first
             val requests = checkNotNull(session.performanceInfo?.networkRequests?.networkSessionV2?.requests)
             assertEquals(
                 "Unexpected number of requests in sent session: ${requests.size}",
@@ -317,7 +317,7 @@ internal class NetworkRequestApiTest {
     }
 
     private fun validateAndReturnExpectedNetworkCall(): NetworkCallV2 {
-        val session = testRule.harness.fakeDeliveryModule.deliveryService.lastSentSessions[1].first
+        val session = testRule.harness.fakeDeliveryModule.deliveryService.lastSentSessions[0].first
 
         // Look for a specific error where the fetch from the cache returns a stale value
         session.session.exceptionError?.exceptionErrors?.forEach { errorInfo ->

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -95,12 +95,10 @@ internal class TracingApiTest {
                 )
             }
             val sessionEndTime = harness.fakeClock.now()
-            assertEquals(2, harness.fakeDeliveryModule.deliveryService.lastSentSessions.size)
-            val startSession = harness.fakeDeliveryModule.deliveryService.lastSentSessions[0]
-            assertEquals(SessionMessageState.START, startSession.second)
-            val endSession = harness.fakeDeliveryModule.deliveryService.lastSentSessions[1]
-            assertEquals(SessionMessageState.END, endSession.second)
-            with(endSession.first) {
+            assertEquals(1, harness.fakeDeliveryModule.deliveryService.lastSentSessions.size)
+            val sessionMessage = harness.fakeDeliveryModule.deliveryService.lastSentSessions[0]
+            assertEquals(SessionMessageState.END, sessionMessage.second)
+            with(sessionMessage.first) {
                 checkNotNull(spans)
                 assertEquals(6, spans.size)
                 val spansMap = spans.associateBy { it.name }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
 
-internal enum class SessionMessageState { START, END, END_WITH_CRASH }
+internal enum class SessionMessageState { END, END_WITH_CRASH }
 
 internal interface DeliveryService {
     fun saveSessionPeriodicCache(sessionMessage: SessionMessage)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
@@ -143,14 +143,6 @@ internal class SessionBehavior(
         getFullSessionEvents().contains(SessionGatingKeys.FULL_SESSION_ERROR_LOGS)
 
     /**
-     * Checks whether the session start message should be sent to the API or not.
-     */
-    fun isStartMessageEnabled(): Boolean {
-        return thresholdCheck.isBehaviorEnabled(remote?.sessionConfig?.pctStartMessageEnabled)
-            ?: true
-    }
-
-    /**
      * Checks whether a feature should be gated.
      * If [getSessionComponents] is null, this will return false.
      * If [getSessionComponents] is empty, this will return true.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
@@ -11,12 +11,6 @@ internal data class SessionRemoteConfig(
     @SerializedName("enable")
     val isEnabled: Boolean? = null,
 
-    /**
-     * Whether the start message should be enabled or not
-     */
-    @SerializedName("pct_start_message_enabled")
-    val pctStartMessageEnabled: Float? = null,
-
     @SerializedName("async_end")
     @Deprecated("This flag is obsolete and is no longer respected.")
     val endAsync: Boolean? = null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
@@ -147,7 +147,7 @@ internal data class Session @JvmOverloads internal constructor(
         internal const val APPLICATION_STATE_FOREGROUND = "foreground"
 
         @JvmStatic
-        fun buildStartSession(
+        fun buildInitialSession(
             id: String,
             coldStart: Boolean,
             startType: SessionLifeEventType,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -104,7 +104,7 @@ internal class SessionHandler(
                 return null
             }
 
-            val session = Session.buildStartSession(
+            val session = Session.buildInitialSession(
                 Uuid.getEmbUuid(),
                 coldStart,
                 startType,
@@ -119,13 +119,10 @@ internal class SessionHandler(
             // Record the connection type at the start of the session.
             networkConnectivityService.networkStatusOnSessionStarted(session.startTime)
 
-            val sessionMessage = sessionMessageCollator.buildStartSessionMessage(session)
+            val sessionMessage = sessionMessageCollator.buildInitialSessionMessage(session)
 
             metadataService.setActiveSessionId(session.sessionId, true)
 
-            if (configService.sessionBehavior.isStartMessageEnabled()) {
-                deliveryService.sendSession(sessionMessage, SessionMessageState.START)
-            }
             logger.logDebug("Start session sent to delivery service.")
 
             handleAutomaticSessionStopper(automaticSessionCloserCallback)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionMessageCollator.kt
@@ -147,7 +147,7 @@ internal class SessionMessageCollator(
         )
     }
 
-    internal fun buildStartSessionMessage(session: Session) = SessionMessage(
+    internal fun buildInitialSessionMessage(session: Session) = SessionMessage(
         session = session,
         appInfo = captureDataSafely(metadataService::getAppInfo),
         deviceInfo = captureDataSafely(metadataService::getDeviceInfo)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
@@ -478,7 +478,6 @@ internal class EmbraceGatingServiceTest {
         RemoteConfig(
             sessionConfig = SessionRemoteConfig(
                 true,
-                100f,
                 false,
                 components,
                 fullSessionEvents

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -11,9 +10,8 @@ internal class SessionRemoteConfigTest {
     @Suppress("DEPRECATION")
     @Test
     fun testDefaults() {
-        val cfg = SessionRemoteConfig(false, 100f, false, null, null)
+        val cfg = SessionRemoteConfig(false, false, null, null)
         assertFalse(checkNotNull(cfg.isEnabled))
-        assertEquals(100f, checkNotNull(cfg.pctStartMessageEnabled))
         assertFalse(checkNotNull(cfg.endAsync))
         assertNull(cfg.sessionComponents)
         assertNull(cfg.fullSessionEvents)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -174,29 +174,6 @@ internal class EmbraceDeliveryServiceTest {
     }
 
     @Test
-    fun `send session start`() {
-        initializeDeliveryService()
-
-        every {
-            mockDeliveryCacheManager.saveSession(any())
-        } returns "cached_session".toByteArray()
-
-        val mockFuture: Future<Unit> = mockk()
-        every { apiService.sendSession(any(), any()) } returns mockFuture
-
-        deliveryService.sendSession(mockk(), SessionMessageState.START)
-
-        verify(exactly = 1) {
-            apiService.sendSession(
-                any(),
-                null
-            )
-        }
-        verify { mockFuture wasNot Called }
-        assertEquals(1, gatingService.sessionMessagesFiltered.size)
-    }
-
-    @Test
     fun `send session end`() {
         initializeDeliveryService()
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
@@ -24,7 +24,6 @@ internal class SessionBehaviorTest {
         sessionConfig = SessionRemoteConfig(
             isEnabled = true,
             endAsync = false,
-            pctStartMessageEnabled = 0f,
             sessionComponents = setOf("test"),
             fullSessionEvents = setOf("test2")
         ),
@@ -42,7 +41,6 @@ internal class SessionBehaviorTest {
             assertNull(getSessionComponents())
             assertFalse(isGatingFeatureEnabled())
             assertFalse(isSessionControlEnabled())
-            assertTrue(isStartMessageEnabled())
             assertEquals(10, getMaxSessionProperties())
         }
     }
@@ -57,7 +55,6 @@ internal class SessionBehaviorTest {
             assertEquals(setOf("breadcrumbs"), getSessionComponents())
             assertEquals(setOf("crash"), getFullSessionEvents())
             assertTrue(isGatingFeatureEnabled())
-            assertTrue(isStartMessageEnabled())
         }
     }
 
@@ -71,7 +68,6 @@ internal class SessionBehaviorTest {
             assertEquals(setOf("test"), getSessionComponents())
             assertEquals(setOf("test2"), getFullSessionEvents())
             assertEquals(57, getMaxSessionProperties())
-            assertFalse(isStartMessageEnabled())
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.payload.Session
 
-internal fun fakeSession(): Session = Session.buildStartSession(
+internal fun fakeSession(): Session = Session.buildInitialSession(
     "fakeSessionId",
     true,
     Session.SessionLifeEventType.STATE,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -418,7 +418,6 @@ internal class SessionHandlerTest {
         // verify automatic session stopper was called
         verify { sessionHandler.scheduledFuture?.cancel(false) }
         verify { mockMemoryCleanerService wasNot Called }
-        assertEquals(SessionMessageState.START, deliveryService.lastSentSessions.single().second)
         assertEquals(0, gatingService.sessionMessagesFiltered.size)
     }
 
@@ -440,7 +439,6 @@ internal class SessionHandlerTest {
         // about to crash we can save some time on not doing these //
         verify { mockMemoryCleanerService wasNot Called }
         verify(exactly = 0) { mockSessionProperties.clearTemporary() }
-        assertEquals(SessionMessageState.START, deliveryService.lastSentSessions.single().second)
 
         val session = checkNotNull(deliveryService.lastSavedSession).session
 
@@ -480,7 +478,6 @@ internal class SessionHandlerTest {
         // when periodic caching, the following calls should not be made
         verify { mockMemoryCleanerService wasNot Called }
         verify(exactly = 0) { mockSessionProperties.clearTemporary() }
-        assertEquals(SessionMessageState.START, deliveryService.lastSentSessions.single().second)
         assertEquals(0, gatingService.sessionMessagesFiltered.size)
     }
 
@@ -609,29 +606,7 @@ internal class SessionHandlerTest {
     }
 
     @Test
-    fun `start + end session message requests are sent`() {
-        startFakeSession()
-        clock.tick(10000)
-        sessionHandler.onSessionEnded(
-            endType = Session.SessionLifeEventType.STATE,
-            endTime = clock.now(),
-            false
-        )
-        val sessions = deliveryService.lastSentSessions
-        assertEquals(2, sessions.size)
-        assertEquals(1, sessions.count { it.second == SessionMessageState.START })
-        assertEquals(1, sessions.count { it.second == SessionMessageState.END })
-    }
-
-    @Test
-    fun `start message is not sent when disabled`() {
-        // disable sending of session start messages
-        remoteConfig = RemoteConfig(
-            sessionConfig = SessionRemoteConfig(
-                pctStartMessageEnabled = 0f
-            )
-        )
-        configService.sessionBehavior.isStartMessageEnabled()
+    fun `session message is sent`() {
         startFakeSession()
         clock.tick(10000)
         sessionHandler.onSessionEnded(

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/BaseTest.kt
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/BaseTest.kt
@@ -201,10 +201,6 @@ public open class BaseTest {
                             )
                         }
                     }
-                    EmbraceEndpoint.SESSIONS.url -> {
-                        assertEquals("POST", request.method)
-                        validateMessageAgainstGoldenFile(request, "session-start.json")
-                    }
                     EmbraceEndpoint.CONFIG.url -> {
                         assertEquals("GET", request.method)
                     }
@@ -334,7 +330,7 @@ public open class BaseTest {
     }
 }
 
-public const val TOTAL_REQUESTS_AT_INIT: Int = 4
+public const val TOTAL_REQUESTS_AT_INIT: Int = 3
 public const val BITMAP_HEIGHT: Int = 100
 public const val BITMAP_WIDTH: Int = 100
 

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/ConfigHooks.java
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/ConfigHooks.java
@@ -45,7 +45,6 @@ public class ConfigHooks {
 
     static SessionRemoteConfig getSessionConfig() {
         return new SessionRemoteConfig(true,
-            100f,
             false,
             null,
             null);


### PR DESCRIPTION
## Goal

Removes the session start message. This concept is no longer required & the message is dropped by the backend, so we should avoid sending it to save device bandwidth.

## Testing

Updated existing test coverage
