### PR TITLE
Simplify json assertions in tests

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AnrSampleTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AnrSampleTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import org.junit.Assert.assertEquals
@@ -8,8 +7,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class AnrSampleTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val threadInfo = ThreadInfo(
         13, Thread.State.RUNNABLE, "my-thread", 5,
@@ -21,18 +18,13 @@ internal class AnrSampleTest {
 
     @Test
     fun testAnrTickSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("anr_tick_expected.json")
-            .filter { !it.isWhitespace() }
-
         val obj = AnrSample(156098234092, listOf(threadInfo), 2)
-        val observed = serializer.toJson(obj)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("anr_tick_expected.json", obj)
     }
 
     @Test
     fun testAnrTickDeserialization() {
-        val json = ResourceReader.readResourceAsText("anr_tick_expected.json")
-        val obj = serializer.fromJson(json, AnrSample::class.java)
+        val obj = deserializeJsonFromResource<AnrSample>("anr_tick_expected.json")
         assertEquals(2L, obj.sampleOverheadMs)
         assertEquals(156098234092, obj.timestamp)
         assertEquals(listOf(threadInfo), obj.threads)
@@ -40,7 +32,7 @@ internal class AnrSampleTest {
 
     @Test
     fun testThreadInfoEmptyObject() {
-        val threadInfo = serializer.fromJson("{}", AnrSample::class.java)
-        assertNotNull(threadInfo)
+        val obj = deserializeEmptyJsonString<AnrSample>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AppInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AppInfoTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.AppInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -8,8 +7,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class AppInfoTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = AppInfo(
         appVersion = "1.0",
@@ -34,16 +31,12 @@ internal class AppInfoTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("app_info_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("app_info_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("app_info_expected.json")
-        val obj = serializer.fromJson(json, AppInfo::class.java)
+        val obj: AppInfo = deserializeJsonFromResource("app_info_expected.json")
         assertEquals("1.0", obj.appVersion)
         assertEquals(Embrace.AppFramework.NATIVE.value, obj.appFramework)
         assertEquals("1234", obj.buildId)
@@ -65,7 +58,7 @@ internal class AppInfoTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", AppInfo::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<AppInfo>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DeviceInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DeviceInfoTest.kt
@@ -1,14 +1,11 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.DeviceInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class DeviceInfoTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = DeviceInfo(
         "samsung",
@@ -26,16 +23,12 @@ internal class DeviceInfoTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("device_info_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("device_info_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("device_info_expected.json")
-        val obj = serializer.fromJson(json, DeviceInfo::class.java)
+        val obj = deserializeJsonFromResource<DeviceInfo>("device_info_expected.json")
         assertEquals("samsung", obj.manufacturer)
         assertEquals("S20", obj.model)
         assertEquals("armeabi", obj.architecture)
@@ -52,7 +45,7 @@ internal class DeviceInfoTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", DeviceInfo::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<DeviceInfo>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DiskUsageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/DiskUsageTest.kt
@@ -1,14 +1,11 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.DiskUsage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class DiskUsageTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = DiskUsage(
         150982302,
@@ -17,23 +14,19 @@ internal class DiskUsageTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("disk_usage_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("disk_usage_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("disk_usage_expected.json")
-        val obj = serializer.fromJson(json, DiskUsage::class.java)
+        val obj = deserializeJsonFromResource<DiskUsage>("disk_usage_expected.json")
         assertEquals(150982302L, obj.appDiskUsage)
         assertEquals(150923L, obj.deviceDiskFree)
     }
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", DiskUsage::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<DiskUsage>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -27,13 +27,15 @@ internal class EmbraceCacheServiceTest {
     private lateinit var service: CacheService
     private lateinit var dir: File
 
+    private val serializer = EmbraceSerializer()
+
     @Before
     fun setUp() {
 
         dir = Files.createTempDirectory("tmpDirPrefix").toFile()
         service = EmbraceCacheService(
             lazy { dir },
-            EmbraceSerializer(),
+            serializer,
             InternalEmbraceLogger()
         )
 
@@ -149,7 +151,7 @@ internal class EmbraceCacheServiceTest {
         myDir.createNewFile()
         service = EmbraceCacheService(
             lazy { myDir },
-            EmbraceSerializer(),
+            serializer,
             InternalEmbraceLogger()
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarker
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Crash
@@ -38,8 +37,6 @@ import org.junit.Before
 import org.junit.Test
 
 internal class EmbraceCrashServiceTest {
-
-    private val serializer = EmbraceSerializer()
 
     private lateinit var embraceCrashService: EmbraceCrashService
     private lateinit var sessionService: SessionService
@@ -202,29 +199,21 @@ internal class EmbraceCrashServiceTest {
                 )
             )
         )
-        val expectedInfo = ResourceReader.readResourceAsText("crash_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(crash)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("crash_expected.json", crash)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("crash_expected.json")
-        val obj = serializer.fromJson(json, Crash::class.java)
-
+        val obj = deserializeJsonFromResource<Crash>("crash_expected.json")
         assertEquals("123", obj.crashId)
-
-        assertEquals("java.lang.RuntimeException", obj?.exceptions?.at(0)?.name)
-        assertEquals("ExceptionMessage", obj?.exceptions?.at(0)?.message)
-        assertEquals("stacktrace.line", obj?.exceptions?.at(0)?.lines?.at(0))
-
-        assertEquals("js_exception", obj?.jsExceptions?.at(0))
-
-        assertEquals(123L, obj?.threads?.at(0)?.threadId)
-        assertEquals(Thread.State.RUNNABLE, obj?.threads?.at(0)?.state)
-        assertEquals("ReferenceHandler", obj?.threads?.at(0)?.name)
-        assertEquals(1, obj?.threads?.at(0)?.priority)
-        assertEquals("stacktrace.line.thread", obj?.threads?.at(0)?.lines?.at(0))
+        assertEquals("java.lang.RuntimeException", obj.exceptions?.at(0)?.name)
+        assertEquals("ExceptionMessage", obj.exceptions?.at(0)?.message)
+        assertEquals("stacktrace.line", obj.exceptions?.at(0)?.lines?.at(0))
+        assertEquals("js_exception", obj.jsExceptions?.at(0))
+        assertEquals(123L, obj.threads?.at(0)?.threadId)
+        assertEquals(Thread.State.RUNNABLE, obj.threads?.at(0)?.state)
+        assertEquals("ReferenceHandler", obj.threads?.at(0)?.name)
+        assertEquals(1, obj.threads?.at(0)?.priority)
+        assertEquals("stacktrace.line.thread", obj.threads?.at(0)?.lines?.at(0))
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -71,14 +71,14 @@ internal class EmbraceDeliveryCacheManagerTest {
             executor,
             logger,
             fakeClock,
-            EmbraceSerializer()
+            serializer
         )
     }
 
     @Test
     fun `cache current session successfully`() {
         val sessionMessage = createSessionMessage("test_cache")
-        val expectedBytes = EmbraceSerializer().toJson(sessionMessage).toByteArray()
+        val expectedBytes = serializer.toJson(sessionMessage).toByteArray()
 
         val serialized = deliveryCacheManager.saveSession(sessionMessage)
 
@@ -161,7 +161,7 @@ internal class EmbraceDeliveryCacheManagerTest {
         every { cacheService.cacheBytes(any(), any()) } throws Exception()
 
         val sessionMessage = createSessionMessage("test_cache_fails")
-        val expectedBytes = EmbraceSerializer().toJson(sessionMessage).toByteArray()
+        val expectedBytes = serializer.toJson(sessionMessage).toByteArray()
 
         val serialized = checkNotNull(deliveryCacheManager.saveSession(sessionMessage))
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceEventTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceEventTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.payload.Event
 import org.junit.Assert.assertEquals
@@ -8,8 +7,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class EmbraceEventTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val event = Event(
         eventId = Uuid.getEmbUuid(),
@@ -40,16 +37,12 @@ internal class EmbraceEventTest {
 
     @Test
     fun testSerialization() {
-        val data = ResourceReader.readResourceAsText("event_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(eventComplete)
-        assertEquals(data, observed)
+        assertJsonMatchesGoldenFile("event_expected.json", eventComplete)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("event_expected.json")
-        val obj = serializer.fromJson(json, Event::class.java)
+        val obj = deserializeJsonFromResource<Event>("event_expected.json")
         assertEquals("eventId", obj.eventId)
         assertEquals("sessionId", obj.sessionId)
         assertEquals("messageId", obj.messageId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionErrorInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionErrorInfoTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ExceptionErrorInfo
 import io.embrace.android.embracesdk.payload.ExceptionInfo
 import org.junit.Assert.assertEquals
@@ -8,7 +7,6 @@ import org.junit.Test
 
 internal class ExceptionErrorInfoTest {
 
-    private val serializer = EmbraceSerializer()
     private val info = ExceptionInfo(
         "java.lang.IllegalStateException",
         "Whoops!",
@@ -26,18 +24,12 @@ internal class ExceptionErrorInfoTest {
                 info,
             )
         )
-
-        val expectedInfo = ResourceReader.readResourceAsText("exception_error_info_expected.json")
-            .filter { !it.isWhitespace() }
-
-        val observed = serializer.toJson(exceptionErrorInfo)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("exception_error_info_expected.json", exceptionErrorInfo)
     }
 
     @Test
     fun testExceptionErrorInfoDeserialization() {
-        val json = ResourceReader.readResourceAsText("exception_error_info_expected.json")
-        val obj = serializer.fromJson(json, ExceptionErrorInfo::class.java)
+        val obj = deserializeJsonFromResource<ExceptionErrorInfo>("exception_error_info_expected.json")
         assertEquals(0L, obj.timestamp)
         assertEquals("STATE", obj.state)
         val exceptionInfo = obj.exceptions?.get(0)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionInfoTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ExceptionInfo
 import io.mockk.every
 import io.mockk.mockk
@@ -11,7 +10,6 @@ import org.junit.Test
 
 internal class ExceptionInfoTest {
 
-    private val serializer = EmbraceSerializer()
     private val info = ExceptionInfo(
         "java.lang.IllegalStateException",
         "Whoops!",
@@ -23,16 +21,12 @@ internal class ExceptionInfoTest {
 
     @Test
     fun testExceptionInfoSerialization() {
-        val data = ResourceReader.readResourceAsText("exception_info_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(data, observed)
+        assertJsonMatchesGoldenFile("exception_info_expected.json", info)
     }
 
     @Test
     fun testExceptionInfoDeserialization() {
-        val json = ResourceReader.readResourceAsText("exception_info_expected.json")
-        val obj = serializer.fromJson(json, ExceptionInfo::class.java)
+        val obj = deserializeJsonFromResource<ExceptionInfo>("exception_info_expected.json")
         assertEquals("java.lang.IllegalStateException", obj.name)
         assertEquals("Whoops!", obj.message)
         assertEquals("java.base/java.lang.Thread.getStackTrace(Thread.java:1602)", obj.lines[0])
@@ -44,9 +38,8 @@ internal class ExceptionInfoTest {
 
     @Test
     fun testExceptionInfoEmptyObject() {
-        val info = serializer.fromJson("{}", ExceptionInfo::class.java)
-        assertNotNull(info)
-        info.name
+        val obj = deserializeEmptyJsonString<ExceptionInfo>()
+        assertNotNull(obj)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FragmentBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FragmentBreadcrumbTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.FragmentBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -8,7 +7,6 @@ import org.junit.Test
 
 internal class FragmentBreadcrumbTest {
 
-    private val serializer = EmbraceSerializer()
     private val info = FragmentBreadcrumb(
         "test",
         1600000000,
@@ -17,16 +15,12 @@ internal class FragmentBreadcrumbTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("fragment_breadcrumb_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("fragment_breadcrumb_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("fragment_breadcrumb_expected.json")
-        val obj = serializer.fromJson(json, FragmentBreadcrumb::class.java)
+        val obj = deserializeJsonFromResource<FragmentBreadcrumb>("fragment_breadcrumb_expected.json")
         assertEquals("test", obj.name)
         assertEquals(1600000000, obj.getStartTime())
         assertEquals(1600001000, obj.endTime)
@@ -34,7 +28,7 @@ internal class FragmentBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", FragmentBreadcrumb::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<FragmentBreadcrumb>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/JsExceptionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/JsExceptionTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.JsException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -8,7 +7,6 @@ import org.junit.Test
 
 internal class JsExceptionTest {
 
-    private val serializer = EmbraceSerializer()
     private val info = JsException(
         "java.lang.IllegalStateException",
         "Whoops!",
@@ -18,16 +16,12 @@ internal class JsExceptionTest {
 
     @Test
     fun testSerialization() {
-        val data = ResourceReader.readResourceAsText("js_exception_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(data, observed)
+        assertJsonMatchesGoldenFile("js_exception_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("js_exception_expected.json")
-        val obj = serializer.fromJson(json, JsException::class.java)
+        val obj = deserializeJsonFromResource<JsException>("js_exception_expected.json")
         assertEquals("java.lang.IllegalStateException", obj.name)
         assertEquals("Whoops!", obj.message)
         assertEquals("JsError", obj.type)
@@ -36,8 +30,7 @@ internal class JsExceptionTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", JsException::class.java)
-        assertNotNull(info)
-        info.name
+        val obj = deserializeEmptyJsonString<JsException>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/JsonComparison.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/JsonComparison.kt
@@ -1,0 +1,35 @@
+package io.embrace.android.embracesdk
+
+import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import org.junit.Assert.assertEquals
+
+private val serializer = EmbraceSerializer()
+
+/**
+ * Asserts that the JSON representation of the object matches the contents of a golden file
+ * stored in the resources directory.
+ *
+ * This is implemented by converting both the supplied object & resource file into a Map
+ * representation. The two maps are then compared.
+ */
+internal inline fun <reified T> assertJsonMatchesGoldenFile(resourceName: String, obj: T) {
+    val json = ResourceReader.readResourceAsText(resourceName)
+    val expected = serializer.fromJson(json, Map::class.java)
+    val observed = serializer.fromJson(serializer.toJson(obj), Map::class.java)
+    assertEquals(expected, observed)
+}
+
+/**
+ * Deserializes a JSON file stored in the resources directory.
+ */
+internal inline fun <reified T> deserializeJsonFromResource(resourceName: String): T {
+    val json = ResourceReader.readResourceAsText(resourceName)
+    return serializer.fromJson(json, T::class.java)
+}
+
+/**
+ * Deserializes an empty JSON object into the supplied type.
+ */
+internal inline fun <reified T> deserializeEmptyJsonString(): T {
+    return serializer.fromJson("{}", T::class.java)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
@@ -11,9 +11,11 @@ import org.junit.Test
 
 internal class LocalConfigTest {
 
+    private val serializer = EmbraceSerializer()
+
     @Test
     fun testEmptyConfig() {
-        val localConfig = LocalConfig.buildConfig("GrCPU", false, null, EmbraceSerializer())
+        val localConfig = LocalConfig.buildConfig("GrCPU", false, null, serializer)
         assertNotNull(localConfig)
     }
 
@@ -24,7 +26,7 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"app\": {\"report_disk_usage\": false}}",
-                EmbraceSerializer()
+                serializer
             )
         assertFalse(checkNotNull(localConfig.sdkConfig.app?.reportDiskUsage))
     }
@@ -33,7 +35,7 @@ internal class LocalConfigTest {
     fun testBetaFunctionalityOnlyConfig() {
         // disabled explicitly
         var localConfig =
-            LocalConfig.buildConfig("GrCPU", false, "{\"beta_features_enabled\": false}", EmbraceSerializer())
+            LocalConfig.buildConfig("GrCPU", false, "{\"beta_features_enabled\": false}", serializer)
         assertFalse(checkNotNull(localConfig.sdkConfig.betaFeaturesEnabled))
 
         // enabled explicitly
@@ -41,12 +43,12 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"beta_features_enabled\": true}",
-            EmbraceSerializer()
+            serializer
         )
         assertTrue(checkNotNull(localConfig.sdkConfig.betaFeaturesEnabled))
 
         // enabled by default
-        localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", EmbraceSerializer())
+        localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", serializer)
         assertNull(localConfig.sdkConfig.betaFeaturesEnabled)
     }
 
@@ -54,7 +56,7 @@ internal class LocalConfigTest {
     fun testSigHandlerDetectionOnlyConfig() {
         // disabled explicitly
         var localConfig =
-            LocalConfig.buildConfig("GrCPU", false, "{\"sig_handler_detection\": false}", EmbraceSerializer())
+            LocalConfig.buildConfig("GrCPU", false, "{\"sig_handler_detection\": false}", serializer)
         assertFalse(checkNotNull(localConfig.sdkConfig.sigHandlerDetection))
 
         // enabled explicitly
@@ -62,12 +64,12 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"sig_handler_detection\": true}",
-            EmbraceSerializer()
+            serializer
         )
         assertTrue(checkNotNull(localConfig.sdkConfig.sigHandlerDetection))
 
         // enabled by default
-        localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", EmbraceSerializer())
+        localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", serializer)
         assertNull(localConfig.sdkConfig.sigHandlerDetection)
     }
 
@@ -77,7 +79,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"base_urls\": {\"config\": \"custom_config\"}}",
-            EmbraceSerializer()
+            serializer
         )
         assertEquals(localConfig.sdkConfig.baseUrls?.config, "custom_config")
         localConfig =
@@ -85,14 +87,14 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"base_urls\": {\"data\": \"custom_data\"}}",
-                EmbraceSerializer()
+                serializer
             )
         assertEquals(localConfig.sdkConfig.baseUrls?.data, "custom_data")
         localConfig = LocalConfig.buildConfig(
             "GrCPU",
             false,
             "{\"base_urls\": {\"data_dev\": \"custom_data_dev\"}}",
-            EmbraceSerializer()
+            serializer
         )
         assertEquals(
             localConfig.sdkConfig.baseUrls?.dataDev,
@@ -102,14 +104,14 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"base_urls\": {\"images\": \"custom_images\"}}",
-            EmbraceSerializer()
+            serializer
         )
         assertEquals(localConfig.sdkConfig.baseUrls?.images, "custom_images")
     }
 
     @Test
     fun testViewConfigOnlyConfig() {
-        var localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", EmbraceSerializer())
+        var localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", serializer)
         assertNull(
             localConfig.sdkConfig.viewConfig?.enableAutomaticActivityCapture,
         )
@@ -117,7 +119,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"view_config\":{\"enable_automatic_activity_capture\":false}}",
-            EmbraceSerializer()
+            serializer
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.viewConfig?.enableAutomaticActivityCapture))
     }
@@ -129,7 +131,7 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"crash_handler\": {\"enabled\": false}}",
-                EmbraceSerializer()
+                serializer
             )
         assertFalse(checkNotNull(localConfig.sdkConfig.crashHandler?.enabled))
         localConfig =
@@ -137,7 +139,7 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"crash_handler\": {\"ndk_enabled\": false}}",
-                EmbraceSerializer()
+                serializer
             )
         assertFalse(localConfig.ndkEnabled)
     }
@@ -150,7 +152,7 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"session\": {\"max_session_seconds\": 60}}",
-                EmbraceSerializer()
+                serializer
             )
         assertEquals(
             localConfig.sdkConfig.sessionConfig?.maxSessionSeconds,
@@ -163,7 +165,7 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"session\": {\"max_session_seconds\": 59}}",
-                EmbraceSerializer()
+                serializer
             )
         assertEquals(
             59,
@@ -175,7 +177,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"session\": {\"max_session_seconds\": null}}",
-            EmbraceSerializer()
+            serializer
         )
         assertNull(
             localConfig.sdkConfig.sessionConfig?.maxSessionSeconds,
@@ -183,7 +185,7 @@ internal class LocalConfigTest {
 
         // ignore max_session_seconds when it is too small
         localConfig =
-            LocalConfig.buildConfig("GrCPU", false, "{\"session\": {\"async_end\": true}}", EmbraceSerializer())
+            LocalConfig.buildConfig("GrCPU", false, "{\"session\": {\"async_end\": true}}", serializer)
         assertTrue(checkNotNull(localConfig.sdkConfig.sessionConfig?.asyncEnd))
 
         // error_log_strict_mode is true
@@ -191,7 +193,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"session\": {\"error_log_strict_mode\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.sessionConfig?.sessionEnableErrorLogStrictMode)
@@ -202,7 +204,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"session\": {\"components\": [\"breadcrumbs_taps\"]}}",
-            EmbraceSerializer()
+            serializer
         )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.sessionConfig?.sessionComponents)
@@ -215,7 +217,7 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"session\": {\"send_full_for\": []}}",
-                EmbraceSerializer()
+                serializer
             )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.sessionConfig?.fullSessionEvents).isEmpty()
@@ -226,7 +228,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"session\": {\"send_full_for\": [\"crashes\"]}}",
-            EmbraceSerializer()
+            serializer
         )
         val sessionConfig = localConfig.sdkConfig.sessionConfig
         assertFalse(
@@ -243,7 +245,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"startup_moment\": {\"automatically_end\": false}}",
-            EmbraceSerializer()
+            serializer
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.startupMoment?.automaticallyEnd))
     }
@@ -255,7 +257,7 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"taps\": {\"capture_coordinates\": false}}",
-                EmbraceSerializer()
+                serializer
             )
         assertFalse(checkNotNull(localConfig.sdkConfig.taps?.captureCoordinates))
     }
@@ -266,7 +268,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"networking\": {\"capture_request_content_length\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.networking?.captureRequestContentLength)
@@ -276,14 +278,14 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"networking\": {\"enable_native_monitoring\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         assertTrue(checkNotNull(localConfig.sdkConfig.networking?.enableNativeMonitoring))
         localConfig = LocalConfig.buildConfig(
             "GrCPU",
             false,
             "{\"networking\": {\"trace_id_header\": \"custom-value\"}}",
-            EmbraceSerializer()
+            serializer
         )
         assertEquals(
             checkNotNull(localConfig.sdkConfig.networking?.traceIdHeader),
@@ -293,7 +295,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"networking\": {\"disabled_url_patterns\": [\"a.b.c\", \"https://example.com\", \"https://example2.com/foo/123/bar\"]}}",
-            EmbraceSerializer()
+            serializer
         )
         assertEquals(
             3,
@@ -307,14 +309,14 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"webview\": {\"enable\": false}}",
-            EmbraceSerializer()
+            serializer
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.webViewConfig?.captureWebViews))
         localConfig = LocalConfig.buildConfig(
             "GrCPU",
             false,
             "{\"webview\": {\"capture_query_params\": false}}",
-            EmbraceSerializer()
+            serializer
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.webViewConfig?.captureQueryParams))
     }
@@ -325,7 +327,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {}}",
-            EmbraceSerializer()
+            serializer
         )
         var backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertNull(
@@ -344,7 +346,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
 
@@ -355,7 +357,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true, \"manual_background_activity_limit\": 50}}",
-            EmbraceSerializer()
+            serializer
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertTrue(
@@ -369,7 +371,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true, \"min_background_activity_duration\": 300}}",
-            EmbraceSerializer()
+            serializer
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertTrue(
@@ -383,7 +385,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true, \"max_cached_activities\": 50}}",
-            EmbraceSerializer()
+            serializer
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertTrue(
@@ -397,7 +399,7 @@ internal class LocalConfigTest {
 
     @Test
     fun testComposeConfig() {
-        var localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", EmbraceSerializer())
+        var localConfig = LocalConfig.buildConfig("GrCPU", false, "{}", serializer)
         assertNull(
             localConfig.sdkConfig.composeConfig?.captureComposeOnClick,
         )
@@ -405,7 +407,7 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"compose\":{\"capture_compose_onclick\":false}}",
-            EmbraceSerializer()
+            serializer
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.composeConfig?.captureComposeOnClick))
     }
@@ -415,7 +417,7 @@ internal class LocalConfigTest {
         var localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"memory_info\": false}}",
-            EmbraceSerializer()
+            serializer
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertFalse(
@@ -424,7 +426,7 @@ internal class LocalConfigTest {
         localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"memory_info\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertTrue(
@@ -437,7 +439,7 @@ internal class LocalConfigTest {
         var localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"power_save_mode_info\": false}}",
-            EmbraceSerializer()
+            serializer
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertFalse(
@@ -446,7 +448,7 @@ internal class LocalConfigTest {
         localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"power_save_mode_info\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertTrue(
@@ -459,7 +461,7 @@ internal class LocalConfigTest {
         var localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"network_connectivity_info\": false}}",
-            EmbraceSerializer()
+            serializer
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
 
@@ -469,7 +471,7 @@ internal class LocalConfigTest {
         localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"network_connectivity_info\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
 
@@ -483,7 +485,7 @@ internal class LocalConfigTest {
         var localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"anr_info\": false}}",
-            EmbraceSerializer()
+            serializer
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertFalse(
@@ -492,7 +494,7 @@ internal class LocalConfigTest {
         localConfig = LocalConfig.buildConfig(
             "GrCPU", false,
             "{\"automatic_data_capture\": { \"anr_info\": true}}",
-            EmbraceSerializer()
+            serializer
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertTrue(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/MemoryWarningTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/MemoryWarningTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.MemoryWarning
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -8,27 +7,22 @@ import org.junit.Test
 
 internal class MemoryWarningTest {
 
-    private val serializer = EmbraceSerializer()
     private val info = MemoryWarning(16098234098234)
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("memory_warning_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("memory_warning_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("memory_warning_expected.json")
-        val obj = serializer.fromJson(json, MemoryWarning::class.java)
+        val obj = deserializeJsonFromResource<MemoryWarning>("memory_warning_expected.json")
         assertEquals(16098234098234, obj.timestamp)
     }
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", MemoryWarning::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<MemoryWarning>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/OrientationTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/OrientationTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk
 
 import android.content.res.Configuration
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.Orientation
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class OrientationTest {
 
-    private val serializer = EmbraceSerializer()
     private val testOrientation = Orientation(
         "p",
         12345678L
@@ -16,16 +14,12 @@ internal class OrientationTest {
 
     @Test
     fun testSerialization() {
-        val data = ResourceReader.readResourceAsText("orientation_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(testOrientation)
-        assertEquals(data, observed)
+        assertJsonMatchesGoldenFile("orientation_expected.json", testOrientation)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("orientation_expected.json")
-        val obj = serializer.fromJson(json, Orientation::class.java)
+        val obj = deserializeJsonFromResource<Orientation>("orientation_expected.json")
         assertEquals("p", obj.orientation)
         assertEquals(12345678L, obj.timestamp)
         assertEquals(Configuration.ORIENTATION_PORTRAIT, obj.internalOrientation)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PerformanceInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PerformanceInfoTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.DiskUsage
@@ -18,7 +17,6 @@ import org.junit.Test
 
 internal class PerformanceInfoTest {
 
-    private val serializer = EmbraceSerializer()
     private val diskUsage: DiskUsage = DiskUsage(10000000, 2000000)
     private val networkRequests: NetworkRequests = mockk()
     private val memoryWarnings: List<MemoryWarning> = emptyList()
@@ -32,24 +30,19 @@ internal class PerformanceInfoTest {
 
     @Test
     fun testPerfInfoSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("perf_info_expected.json")
-            .filter { !it.isWhitespace() }
-
-        val observed = serializer.toJson(buildPerformanceInfo())
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("perf_info_expected.json", buildPerformanceInfo())
     }
 
     @Test
     fun testPerfInfoDeserialization() {
-        val json = ResourceReader.readResourceAsText("perf_info_expected.json")
-        val obj = serializer.fromJson(json, PerformanceInfo::class.java)
+        val obj = deserializeJsonFromResource<PerformanceInfo>("perf_info_expected.json")
         verifyFields(obj)
     }
 
     @Test
     fun testPerfInfoEmptyObject() {
-        val anrInterval = serializer.fromJson("{}", PerformanceInfo::class.java)
-        assertNotNull(anrInterval)
+        val obj = deserializeEmptyJsonString<PerformanceInfo>()
+        assertNotNull(obj)
     }
 
     private fun verifyFields(performanceInfo: PerformanceInfo) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PushNotificationBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PushNotificationBreadcrumbTest.kt
@@ -1,14 +1,11 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class PushNotificationBreadcrumbTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = PushNotificationBreadcrumb(
         "title",
@@ -22,16 +19,12 @@ internal class PushNotificationBreadcrumbTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("push_notification_breadcrumb_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("push_notification_breadcrumb_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("push_notification_breadcrumb_expected.json")
-        val obj = serializer.fromJson(json, PushNotificationBreadcrumb::class.java)
+        val obj = deserializeJsonFromResource<PushNotificationBreadcrumb>("push_notification_breadcrumb_expected.json")
         assertEquals("title", obj.title)
         assertEquals("body", obj.body)
         assertEquals("from", obj.from)
@@ -43,7 +36,7 @@ internal class PushNotificationBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", PushNotificationBreadcrumb::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<PushNotificationBreadcrumb>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionStacktraceSampleJsonTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionStacktraceSampleJsonTest.kt
@@ -2,13 +2,11 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeSession
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe
 import io.embrace.android.embracesdk.payload.PerformanceInfo
 import io.embrace.android.embracesdk.payload.ThreadState
-import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
@@ -16,15 +14,10 @@ import org.junit.Test
  */
 internal class SessionStacktraceSampleJsonTest {
 
-    private val serializer = EmbraceSerializer()
-
     @Test
     fun testSymbolSerialization() {
         val session = fakeSession().copy(symbols = mapOf("foo" to "bar"))
-        val json = serializer.toJson(session)
-        val expected = ResourceReader.readResourceAsText("session_stacktrace_symbols.json")
-            .filter { !it.isWhitespace() }
-        assertEquals(expected, json)
+        assertJsonMatchesGoldenFile("session_stacktrace_symbols.json", session)
     }
 
     @Test
@@ -33,10 +26,7 @@ internal class SessionStacktraceSampleJsonTest {
         val session = PerformanceInfo(
             nativeThreadAnrIntervals = listOf(fixture)
         )
-        val json = serializer.toJson(session)
-        val expected = ResourceReader.readResourceAsText("session_native_stacktrace.json")
-            .filter { !it.isWhitespace() }
-        assertEquals(expected, json)
+        assertJsonMatchesGoldenFile("session_native_stacktrace.json", session)
     }
 
     private fun generateNativeSampleTick(): NativeThreadAnrInterval {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.BetaFeatures
 import io.embrace.android.embracesdk.payload.ExceptionError
 import io.embrace.android.embracesdk.payload.Orientation
@@ -14,8 +13,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = Session(
         sessionId = "fake-session-id",
@@ -61,16 +58,12 @@ internal class SessionTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("session_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("session_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("session_expected.json")
-        val obj = serializer.fromJson(json, Session::class.java)
+        val obj = deserializeJsonFromResource<Session>("session_expected.json")
         assertNotNull(obj)
 
         with(obj) {
@@ -111,7 +104,7 @@ internal class SessionTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", Session::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<Session>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ThreadInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ThreadInfoTest.kt
@@ -1,13 +1,11 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class ThreadInfoTest {
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testThreadInfoMaxLines() {
@@ -31,18 +29,12 @@ internal class ThreadInfoTest {
                 "io.embrace.android.embracesdk.ThreadInfoTest.testThreadInfoSerialization(ThreadInfoTest.kt:18)"
             )
         )
-
-        val expectedInfo = ResourceReader.readResourceAsText("thread_info_expected.json")
-            .filter { !it.isWhitespace() }
-
-        val observed = serializer.toJson(threadInfo)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("thread_info_expected.json", threadInfo)
     }
 
     @Test
     fun testThreadInfoDeserialization() {
-        val json = ResourceReader.readResourceAsText("thread_info_expected.json")
-        val obj = serializer.fromJson(json, ThreadInfo::class.java)
+        val obj = deserializeJsonFromResource<ThreadInfo>("thread_info_expected.json")
         assertEquals(13, obj.threadId)
         assertEquals(5, obj.priority)
         assertEquals(Thread.State.RUNNABLE, obj.state)
@@ -58,7 +50,7 @@ internal class ThreadInfoTest {
 
     @Test
     fun testThreadInfoEmptyObject() {
-        val threadInfo = serializer.fromJson("{}", ThreadInfo::class.java)
-        assertNotNull(threadInfo)
+        val obj = deserializeEmptyJsonString<ThreadInfo>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UserInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UserInfoTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.UserInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -16,20 +15,15 @@ internal class UserInfoTest {
         username = "joebloggs",
         personas = setOf("first_day"),
     )
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
-        val data = ResourceReader.readResourceAsText("user_info_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(data, observed)
+        assertJsonMatchesGoldenFile("user_info_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("user_info_expected.json")
-        val obj = serializer.fromJson(json, UserInfo::class.java)
+        val obj = deserializeJsonFromResource<UserInfo>("user_info_expected.json")
         assertEquals("123", obj.userId)
         assertEquals("fake@example.com", obj.email)
         assertEquals("joebloggs", obj.username)
@@ -38,8 +32,8 @@ internal class UserInfoTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", UserInfo::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<UserInfo>()
+        assertNotNull(obj)
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ViewBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ViewBreadcrumbTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.ViewBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -14,20 +13,15 @@ internal class ViewBreadcrumbTest {
     ).apply {
         end = 1700000000
     }
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("view_breadcrumb_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("view_breadcrumb_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("view_breadcrumb_expected.json")
-        val obj = serializer.fromJson(json, ViewBreadcrumb::class.java)
+        val obj = deserializeJsonFromResource<ViewBreadcrumb>("view_breadcrumb_expected.json")
         assertEquals("screen", obj.screen)
         assertEquals(1600000000L, obj.getStartTime())
         assertEquals(1700000000L, obj.end)
@@ -35,7 +29,7 @@ internal class ViewBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", ViewBreadcrumb::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<ViewBreadcrumb>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/WebViewBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/WebViewBreadcrumbTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -12,27 +11,22 @@ internal class WebViewBreadcrumbTest {
         "url",
         1600000000
     )
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("webview_breadcrumb_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("webview_breadcrumb_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("webview_breadcrumb_expected.json")
-        val obj = serializer.fromJson(json, WebViewBreadcrumb::class.java)
+        val obj = deserializeJsonFromResource<WebViewBreadcrumb>("webview_breadcrumb_expected.json")
         assertEquals("url", obj.url)
         assertEquals(1600000000, obj.getStartTime())
     }
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", WebViewBreadcrumb::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<WebViewBreadcrumb>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrIntervalTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrIntervalTest.kt
@@ -1,7 +1,8 @@
 package io.embrace.android.embracesdk.anr
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.embrace.android.embracesdk.payload.AnrSampleList
@@ -35,8 +36,6 @@ internal class AnrIntervalTest {
         code = AnrInterval.CODE_SAMPLES_CLEARED
     )
 
-    private val serializer = EmbraceSerializer()
-
     @Test
     fun testClearAnrSamples() {
         val interval = interval.copy(code = AnrInterval.CODE_DEFAULT)
@@ -52,17 +51,12 @@ internal class AnrIntervalTest {
 
     @Test
     fun testAnrTickSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("anr_interval_expected.json")
-            .filter { !it.isWhitespace() }
-
-        val observed = serializer.toJson(interval.copy())
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("anr_interval_expected.json", interval.copy())
     }
 
     @Test
     fun testAnrTickDeserialization() {
-        val json = ResourceReader.readResourceAsText("anr_interval_expected.json")
-        val obj = serializer.fromJson(json, AnrInterval::class.java)
+        val obj = deserializeJsonFromResource<AnrInterval>("anr_interval_expected.json")
         assertEquals(150980980980, obj.startTime)
         assertEquals(150980980980 + 5000, obj.endTime)
         assertEquals(150980980980 + 4000, obj.lastKnownTime)
@@ -72,7 +66,7 @@ internal class AnrIntervalTest {
 
     @Test
     fun testAnrIntervalEmptyObject() {
-        val anrInterval = serializer.fromJson("{}", AnrInterval::class.java)
+        val anrInterval = deserializeEmptyJsonString<AnrInterval>()
         assertNotNull(anrInterval)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrSampleJsonTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrSampleJsonTest.kt
@@ -1,15 +1,11 @@
 package io.embrace.android.embracesdk.anr.ndk
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe
-import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class NativeThreadAnrSampleJsonTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
@@ -26,10 +22,6 @@ internal class NativeThreadAnrSampleJsonTest {
                 )
             )
         )
-
-        val expected = ResourceReader.readResourceAsText("native_thread_anr_sample.json")
-            .filter { !it.isWhitespace() }
-        val json = serializer.toJson(sample)
-        assertEquals(expected, json)
+        assertJsonMatchesGoldenFile("native_thread_anr_sample.json", sample)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrStackframeJsonTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadAnrStackframeJsonTest.kt
@@ -1,14 +1,10 @@
 package io.embrace.android.embracesdk.anr.ndk
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
 import io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe
-import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class NativeThreadAnrStackframeJsonTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testSerialization() {
@@ -18,11 +14,6 @@ internal class NativeThreadAnrStackframeJsonTest {
             "/data/foo/libtest.so",
             11
         )
-
-        val expected = ResourceReader.readResourceAsText("native_thread_anr_stackframe.json")
-            .filter { !it.isWhitespace() }
-
-        val json = serializer.toJson(frame)
-        assertEquals(expected, json)
+        assertJsonMatchesGoldenFile("native_thread_anr_stackframe.json", frame)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.capture.crumbs
 
 import android.app.Activity
-import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.config.local.TapsLocalConfig
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.fakes.fakeSession
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -36,7 +35,6 @@ internal class EmbraceBreadcrumbServiceTest {
     private lateinit var memoryCleanerService: EmbraceMemoryCleanerService
     private lateinit var activity: Activity
     private val logger = InternalEmbraceLogger()
-    private val serializer = EmbraceSerializer()
     private val clock = FakeClock()
 
     @Before
@@ -79,8 +77,7 @@ internal class EmbraceBreadcrumbServiceTest {
                 0, clock.now()
             )
         )
-        val jsonMessage = serializer.toJson(message)
-        assertEquals(jsonMessage, expected)
+        assertJsonMatchesGoldenFile(expected, message)
     }
 
     /*
@@ -98,9 +95,7 @@ internal class EmbraceBreadcrumbServiceTest {
         service.logView("viewB", clock.now())
         clock.tickSecond()
         service.onViewClose(activity)
-        val expected = ResourceReader.readResourceAsText("breadcrumb_view.json")
-            .filter { !it.isWhitespace() }
-        assertJsonMessage(service, expected)
+        assertJsonMessage(service, "breadcrumb_view.json")
     }
 
     /*
@@ -115,9 +110,7 @@ internal class EmbraceBreadcrumbServiceTest {
         service.logWebView("https://example.com/path2", clock.now())
         val webViews = service.webViewBreadcrumbs
         assertEquals("two webviews captured", 2, webViews.size)
-        val expected = ResourceReader.readResourceAsText("breadcrumb_webview.json")
-            .filter { !it.isWhitespace() }
-        assertJsonMessage(service, expected)
+        assertJsonMessage(service, "breadcrumb_webview.json")
     }
 
     /*
@@ -129,9 +122,7 @@ internal class EmbraceBreadcrumbServiceTest {
         service.logCustom("breadcrumb", clock.now())
         val breadcrumbs = service.customBreadcrumbs
         assertEquals("one breadcrumb captured", 1, breadcrumbs.size)
-        val expected = ResourceReader.readResourceAsText("breadcrumb_custom.json")
-            .filter { !it.isWhitespace() }
-        assertJsonMessage(service, expected)
+        assertJsonMessage(service, "breadcrumb_custom.json")
     }
 
     /*
@@ -446,10 +437,7 @@ internal class EmbraceBreadcrumbServiceTest {
                 0, clock.now()
             )
         )
-        val jsonMessage = serializer.toJson(message)
-        val expected = ResourceReader.readResourceAsText("breadcrumb_fragment.json")
-            .filter { !it.isWhitespace() }
-        assertEquals(expected, jsonMessage)
+        assertJsonMatchesGoldenFile("breadcrumb_fragment.json", message)
     }
 
     @Test
@@ -470,19 +458,13 @@ internal class EmbraceBreadcrumbServiceTest {
             session = fakeSession(),
             breadcrumbs = service.flushBreadcrumbs()
         )
-        val jsonMessage = serializer.toJson(message)
-        val expected = ResourceReader.readResourceAsText("breadcrumb_view_custom.json")
-            .filter { !it.isWhitespace() }
-        assertEquals(expected, jsonMessage)
+        assertJsonMatchesGoldenFile("breadcrumb_view_custom.json", message)
 
         val secondMessage = SessionMessage(
             session = fakeSession(),
             breadcrumbs = service.flushBreadcrumbs()
         )
-        val secondJsonMessage = serializer.toJson(secondMessage)
-        val expectedEmpty = ResourceReader.readResourceAsText("breadcrumb_empty.json")
-            .filter { !it.isWhitespace() }
-        assertEquals(expectedEmpty, secondJsonMessage)
+        assertJsonMatchesGoldenFile("breadcrumb_empty.json", secondMessage)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestTest.kt
@@ -1,8 +1,9 @@
 package io.embrace.android.embracesdk.comms.api
 
 import io.embrace.android.embracesdk.BuildConfig
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,8 +12,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class ApiRequestTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val request = ApiRequest(
         "application/json",
@@ -63,16 +62,12 @@ internal class ApiRequestTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("api_request.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(request)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("api_request.json", request)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("api_request.json")
-        val obj = serializer.fromJson(json, ApiRequest::class.java)
+        val obj = deserializeJsonFromResource<ApiRequest>("api_request.json")
         assertEquals(
             mapOf(
                 "Accept" to "application/json",
@@ -86,14 +81,14 @@ internal class ApiRequestTest {
                 "X-EM-LID" to "test_lid",
                 "If-None-Match" to "d800f828fec4409dcabc7f5252e7ce71"
             ),
-            obj?.getHeaders()
+            obj.getHeaders()
         )
     }
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", ApiRequest::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<ApiRequest>()
+        assertNotNull(obj)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -31,6 +31,9 @@ import org.junit.Test
 import java.util.concurrent.ScheduledExecutorService
 
 internal class EmbraceApiServiceTest {
+
+    private val serializer = EmbraceSerializer()
+
     private lateinit var apiUrlBuilder: ApiUrlBuilder
     private lateinit var fakeApiClient: FakeApiClient
     private lateinit var fakeCacheManager: DeliveryCacheManager
@@ -284,6 +287,5 @@ internal class EmbraceApiServiceTest {
             headers = emptyMap(),
             body = ""
         )
-        private val serializer = EmbraceSerializer()
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/ApplicationExitInfoRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/ApplicationExitInfoRemoteConfigTest.kt
@@ -1,16 +1,14 @@
 package io.embrace.android.embracesdk.config
 
-import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.behavior.AppExitInfoBehavior.Companion.AEI_MAX_NUM_DEFAULT
 import io.embrace.android.embracesdk.config.remote.AppExitInfoConfig
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class ApplicationExitInfoRemoteConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -32,8 +30,7 @@ internal class ApplicationExitInfoRemoteConfigTest {
 
     @Test
     fun testDeserialization() {
-        val data = ResourceReader.readResourceAsText("application_exit_info_remote_config.json")
-        val appExitInfoConfig = serializer.fromJson(data, AppExitInfoConfig::class.java)
+        val appExitInfoConfig = deserializeJsonFromResource<AppExitInfoConfig>("application_exit_info_remote_config.json")
         assertEquals(100, appExitInfoConfig.appExitInfoTracesLimit)
         assertEquals(100f, appExitInfoConfig.pctAeiCaptureEnabled)
         assertEquals(50, appExitInfoConfig.aeiMaxNum)
@@ -41,7 +38,7 @@ internal class ApplicationExitInfoRemoteConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val appExitInfoConfig = serializer.fromJson("{}", AppExitInfoConfig::class.java)
+        val appExitInfoConfig = deserializeEmptyJsonString<AppExitInfoConfig>()
         assertNull(appExitInfoConfig.appExitInfoTracesLimit)
         assertNull(appExitInfoConfig.pctAeiCaptureEnabled)
         assertEquals(AEI_MAX_NUM_DEFAULT, appExitInfoConfig.aeiMaxNum)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/BgActivityConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/BgActivityConfigTest.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.config
 
-import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.BackgroundActivityRemoteConfig
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class BgActivityConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -27,14 +25,13 @@ internal class BgActivityConfigTest {
 
     @Test
     fun testDeserialization() {
-        val data = ResourceReader.readResourceAsText("bg_activity_config.json")
-        val cfg = serializer.fromJson(data, BackgroundActivityRemoteConfig::class.java)
+        val cfg = deserializeJsonFromResource<BackgroundActivityRemoteConfig>("bg_activity_config.json")
         assertEquals(0.5f, cfg.threshold)
     }
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = serializer.fromJson("{}", BackgroundActivityRemoteConfig::class.java)
+        val cfg = deserializeEmptyJsonString<BackgroundActivityRemoteConfig>()
         assertNull(cfg.threshold)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/LogRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/LogRemoteConfigTest.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.config
 
-import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class LogRemoteConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -33,8 +31,7 @@ internal class LogRemoteConfigTest {
 
     @Test
     fun testDeserialization() {
-        val data = ResourceReader.readResourceAsText("log_config.json")
-        val cfg = serializer.fromJson(data, LogRemoteConfig::class.java)
+        val cfg = deserializeJsonFromResource<LogRemoteConfig>("log_config.json")
         assertEquals(768, cfg.logMessageMaximumAllowedLength)
         assertEquals(50, cfg.logInfoLimit)
         assertEquals(200, cfg.logWarnLimit)
@@ -43,7 +40,7 @@ internal class LogRemoteConfigTest {
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = serializer.fromJson("{}", LogRemoteConfig::class.java)
+        val cfg = deserializeEmptyJsonString<LogRemoteConfig>()
         verifyDefaults(cfg)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/NetworkRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/NetworkRemoteConfigTest.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.config
 
-import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class NetworkRemoteConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -29,16 +27,14 @@ internal class NetworkRemoteConfigTest {
 
     @Test
     fun testDeserialization() {
-        val data = ResourceReader.readResourceAsText("network_config.json")
-        val cfg = serializer.fromJson(data, NetworkRemoteConfig::class.java)
-
+        val cfg = deserializeJsonFromResource<NetworkRemoteConfig>("network_config.json")
         assertEquals(2000, cfg.defaultCaptureLimit)
         assertEquals(mapOf("google.com" to 500), cfg.domainLimits)
     }
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = serializer.fromJson("{}", NetworkRemoteConfig::class.java)
+        val cfg = deserializeEmptyJsonString<NetworkRemoteConfig>()
         verifyDefaults(cfg)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/UiRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/UiRemoteConfigTest.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.config
 
-import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.remote.UiRemoteConfig
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class UiRemoteConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -35,8 +33,7 @@ internal class UiRemoteConfigTest {
 
     @Test
     fun testDeserialization() {
-        val data = ResourceReader.readResourceAsText("ui_config.json")
-        val cfg = serializer.fromJson(data, UiRemoteConfig::class.java)
+        val cfg = deserializeJsonFromResource<UiRemoteConfig>("ui_config.json")
         assertEquals(80, cfg.breadcrumbs)
         assertEquals(50, cfg.taps)
         assertEquals(200, cfg.views)
@@ -46,7 +43,7 @@ internal class UiRemoteConfigTest {
 
     @Test
     fun testDeserializationEmptyObj() {
-        val cfg = serializer.fromJson("{}", UiRemoteConfig::class.java)
+        val cfg = deserializeEmptyJsonString<UiRemoteConfig>()
         verifyDefaults(cfg)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AnrLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AnrLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class AnrLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -19,15 +17,14 @@ internal class AnrLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("anr_config.json")
-        val obj = serializer.fromJson(json, AnrLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<AnrLocalConfig>("anr_config.json")
         assertTrue(checkNotNull(obj.captureGoogle))
         assertTrue(checkNotNull(obj.captureUnityThread))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", AnrLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<AnrLocalConfig>()
         assertNull(obj.captureGoogle)
         assertNull(obj.captureUnityThread)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AppLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AppLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class AppLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,14 +16,13 @@ internal class AppLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("app_config.json")
-        val obj = serializer.fromJson(json, AppLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<AppLocalConfig>("app_config.json")
         assertFalse(checkNotNull(obj.reportDiskUsage))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", AppLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<AppLocalConfig>()
         assertNull(obj.reportDiskUsage)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ApplicationExitInfoLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ApplicationExitInfoLocalConfigTest.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class ApplicationExitInfoLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -20,15 +18,14 @@ internal class ApplicationExitInfoLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("application_exit_info_local_config.json")
-        val obj = serializer.fromJson(json, AppExitInfoLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<AppExitInfoLocalConfig>("application_exit_info_local_config.json")
         assertEquals(10, obj.appExitInfoTracesLimit)
         assertTrue(obj.aeiCaptureEnabled ?: false)
     }
 
     @Test
     fun testEmptyObject() {
-        val appExitInfoLocalConfig = serializer.fromJson("{}", AppExitInfoLocalConfig::class.java)
+        val appExitInfoLocalConfig = deserializeEmptyJsonString<AppExitInfoLocalConfig>()
         assertNull(appExitInfoLocalConfig.appExitInfoTracesLimit)
         assertNull(appExitInfoLocalConfig.aeiCaptureEnabled)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AutomaticDataCaptureLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/AutomaticDataCaptureLocalConfigTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class AutomaticDataCaptureLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,9 +17,7 @@ internal class AutomaticDataCaptureLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("auto_data_capture_config.json")
-        val obj = serializer.fromJson(json, AutomaticDataCaptureLocalConfig::class.java)
-
+        val obj = deserializeJsonFromResource<AutomaticDataCaptureLocalConfig>("auto_data_capture_config.json")
         assertFalse(checkNotNull(obj.anrServiceEnabled))
         assertFalse(checkNotNull(obj.memoryServiceEnabled))
         assertFalse(checkNotNull(obj.networkConnectivityServiceEnabled))
@@ -29,8 +26,8 @@ internal class AutomaticDataCaptureLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", AutomaticDataCaptureLocalConfig::class.java)
-        verifyDefaults(obj)
+        val obj = deserializeEmptyJsonString<AutomaticDataCaptureLocalConfig>()
+        assertNotNull(obj)
     }
 
     private fun verifyDefaults(cfg: AutomaticDataCaptureLocalConfig) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BackgroundActivityLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BackgroundActivityLocalConfigTest.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class BackgroundActivityLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -19,8 +17,7 @@ internal class BackgroundActivityLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("background_activity_config.json")
-        val obj = serializer.fromJson(json, BackgroundActivityLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<BackgroundActivityLocalConfig>("background_activity_config.json")
         assertTrue(checkNotNull(obj.backgroundActivityCaptureEnabled))
         assertEquals(15, obj.manualBackgroundActivityLimit)
         assertEquals(10000L, obj.minBackgroundActivityDuration)
@@ -29,7 +26,7 @@ internal class BackgroundActivityLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", BackgroundActivityLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<BackgroundActivityLocalConfig>()
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BaseUrlLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/BaseUrlLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class BaseUrlLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,8 +16,7 @@ internal class BaseUrlLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("base_url_config.json")
-        val obj = serializer.fromJson(json, BaseUrlLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<BaseUrlLocalConfig>("base_url_config.json")
         assertEquals("https://config.example.com", obj.config)
         assertEquals("https://data.example.com", obj.data)
         assertEquals("https://data-dev.example.com", obj.dataDev)
@@ -28,7 +25,7 @@ internal class BaseUrlLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", BaseUrlLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<BaseUrlLocalConfig>()
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/CrashHandlerLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/CrashHandlerLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class CrashHandlerLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,14 +16,13 @@ internal class CrashHandlerLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("crash_handler_config.json")
-        val obj = serializer.fromJson(json, CrashHandlerLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<CrashHandlerLocalConfig>("crash_handler_config.json")
         assertFalse(checkNotNull(obj.enabled))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", CrashHandlerLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<CrashHandlerLocalConfig>()
         assertNull(obj.enabled)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/DomainLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/DomainLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class DomainLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,15 +16,14 @@ internal class DomainLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("domain_config.json")
-        val obj = serializer.fromJson(json, DomainLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<DomainLocalConfig>("domain_config.json")
         assertEquals("example-apis.com", obj.domain)
         assertEquals(400, obj.limit)
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", DomainLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<DomainLocalConfig>()
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/NetworkLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/NetworkLocalConfigTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -9,8 +9,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class NetworkLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -20,9 +18,7 @@ internal class NetworkLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("local_network_config.json")
-        val obj = serializer.fromJson(json, NetworkLocalConfig::class.java)
-
+        val obj = deserializeJsonFromResource<NetworkLocalConfig>("local_network_config.json")
         assertEquals(200, obj.defaultCaptureLimit)
         assertEquals(DomainLocalConfig("google.com", 80).domain, obj.domains?.single()?.domain)
         assertEquals("x-my-header-id", obj.traceIdHeader)
@@ -33,7 +29,7 @@ internal class NetworkLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", NetworkLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<NetworkLocalConfig>()
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -20,8 +18,7 @@ internal class SessionLocalConfigTest {
     @Suppress("DEPRECATION")
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("session_config.json")
-        val obj = serializer.fromJson(json, SessionLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<SessionLocalConfig>("session_config.json")
         assertEquals(120, obj.maxSessionSeconds)
         assertTrue(checkNotNull(obj.asyncEnd))
         assertTrue(checkNotNull(obj.sessionEnableErrorLogStrictMode))
@@ -31,7 +28,7 @@ internal class SessionLocalConfigTest {
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", SessionLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<SessionLocalConfig>()
         verifyDefaults(obj)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/StartupMomentLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/StartupMomentLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class StartupMomentLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,14 +16,13 @@ internal class StartupMomentLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("startup_moment_config.json")
-        val obj = serializer.fromJson(json, StartupMomentLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<StartupMomentLocalConfig>("startup_moment_config.json")
         assertFalse(checkNotNull(obj.automaticallyEnd))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", StartupMomentLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<StartupMomentLocalConfig>()
         assertNull(obj.automaticallyEnd)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/TapsLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/TapsLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class TapsLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,14 +16,13 @@ internal class TapsLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("taps_config.json")
-        val obj = serializer.fromJson(json, TapsLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<TapsLocalConfig>("taps_config.json")
         assertFalse(checkNotNull(obj.captureCoordinates))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", TapsLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<TapsLocalConfig>()
         assertNull(obj.captureCoordinates)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ViewLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/ViewLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class ViewLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -18,14 +16,13 @@ internal class ViewLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("view_config.json")
-        val obj = serializer.fromJson(json, ViewLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<ViewLocalConfig>("view_config.json")
         assertFalse(checkNotNull(obj.enableAutomaticActivityCapture))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", ViewLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<ViewLocalConfig>()
         assertNull(obj.enableAutomaticActivityCapture)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/WebViewLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/WebViewLocalConfigTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.config.local
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class WebViewLocalConfigTest {
-
-    private val serializer = EmbraceSerializer()
 
     @Test
     fun testDefaults() {
@@ -19,15 +17,14 @@ internal class WebViewLocalConfigTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("web_view_config.json")
-        val obj = serializer.fromJson(json, WebViewLocalConfig::class.java)
+        val obj = deserializeJsonFromResource<WebViewLocalConfig>("web_view_config.json")
         assertFalse(checkNotNull(obj.captureWebViews))
         assertFalse(checkNotNull(obj.captureQueryParams))
     }
 
     @Test
     fun testEmptyObject() {
-        val obj = serializer.fromJson("{}", WebViewLocalConfig::class.java)
+        val obj = deserializeEmptyJsonString<WebViewLocalConfig>()
         assertNull(obj.captureWebViews)
         assertNull(obj.captureQueryParams)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanDataTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanDataTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import io.embrace.android.embracesdk.fixtures.testSpan
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
@@ -12,8 +12,7 @@ internal class EmbraceSpanDataTest {
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("span_expected.json")
-        val deserializedSpan = serializer.fromJson(json, EmbraceSpanData::class.java)
+        val deserializedSpan = deserializeJsonFromResource<EmbraceSpanData>("span_expected.json")
         assertEquals(testSpan.name, deserializedSpan.name)
         assertEquals(testSpan.spanId, deserializedSpan.spanId)
         assertEquals(testSpan.parentSpanId, deserializedSpan.parentSpanId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
@@ -1,7 +1,8 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -10,7 +11,6 @@ import org.junit.Test
 
 internal class BackgroundActivityMessageTest {
 
-    private val serializer = EmbraceSerializer()
     private val backgroundActivity = BackgroundActivity("fake-activity", 0, "")
     private val userInfo = UserInfo("fake-user-id")
     private val appInfo = AppInfo("fake-app-id")
@@ -33,16 +33,12 @@ internal class BackgroundActivityMessageTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("bg_activity_message_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("bg_activity_message_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("bg_activity_message_expected.json")
-        val obj = serializer.fromJson(json, BackgroundActivityMessage::class.java)
+        val obj = deserializeJsonFromResource<BackgroundActivityMessage>("bg_activity_message_expected.json")
         assertNotNull(obj)
 
         assertEquals(backgroundActivity.startTime, obj.backgroundActivity.startTime)
@@ -56,7 +52,7 @@ internal class BackgroundActivityMessageTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", BackgroundActivityMessage::class.java)
-        assertNotNull(info)
+        val cfg = deserializeEmptyJsonString<BackgroundActivityMessage>()
+        assertNotNull(cfg)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
@@ -1,15 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class BackgroundActivityTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = BackgroundActivity(
         sessionId = "fake-session-id",
@@ -38,16 +37,12 @@ internal class BackgroundActivityTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("bg_activity_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("bg_activity_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("bg_activity_expected.json")
-        val obj = serializer.fromJson(json, BackgroundActivity::class.java)
+        val obj = deserializeJsonFromResource<BackgroundActivity>("bg_activity_expected.json")
         assertNotNull(obj)
 
         with(obj) {
@@ -77,7 +72,7 @@ internal class BackgroundActivityTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", BackgroundActivity::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<BackgroundActivity>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BreadcrumbsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BreadcrumbsTest.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
-import org.junit.Assert.assertEquals
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class BreadcrumbsTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = Breadcrumbs(
         viewBreadcrumbs = listOf(ViewBreadcrumb("View", 1600000000)),
@@ -49,16 +47,12 @@ internal class BreadcrumbsTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("breadcrumbs_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("breadcrumbs_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("breadcrumbs_expected.json")
-        val obj = serializer.fromJson(json, Breadcrumbs::class.java)
+        val obj = deserializeJsonFromResource<Breadcrumbs>("breadcrumbs_expected.json")
         assertNotNull(obj)
         assertNotNull(obj.viewBreadcrumbs?.single())
         assertNotNull(obj.customBreadcrumbs?.single())
@@ -71,7 +65,7 @@ internal class BreadcrumbsTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", Breadcrumbs::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<Breadcrumbs>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/CustomBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/CustomBreadcrumbTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class CustomBreadcrumbTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = CustomBreadcrumb(
         "test",
@@ -17,23 +16,19 @@ internal class CustomBreadcrumbTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("custom_breadcrumb_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("custom_breadcrumb_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("custom_breadcrumb_expected.json")
-        val obj = serializer.fromJson(json, CustomBreadcrumb::class.java)
+        val obj = deserializeJsonFromResource<CustomBreadcrumb>("custom_breadcrumb_expected.json")
         assertEquals("test", obj.message)
         assertEquals(1600000000, obj.getStartTime())
     }
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", CustomBreadcrumb::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<CustomBreadcrumb>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/EmbraceEventMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/EmbraceEventMessageTest.kt
@@ -2,15 +2,13 @@ package io.embrace.android.embracesdk.payload
 
 import io.embrace.android.embracesdk.EmbraceEvent
 import io.embrace.android.embracesdk.LogExceptionType
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class EmbraceEventMessageTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val eventComplete = Event(
         eventId = "eventId",
@@ -43,16 +41,12 @@ internal class EmbraceEventMessageTest {
 
     @Test
     fun testSerialization() {
-        val data = ResourceReader.readResourceAsText("eventmessage_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(eventMessage)
-        assertEquals(data, observed)
+        assertJsonMatchesGoldenFile("eventmessage_expected.json", eventMessage)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("eventmessage_expected.json")
-        val obj = serializer.fromJson(json, EventMessage::class.java)
+        val obj = deserializeJsonFromResource<EventMessage>("eventmessage_expected.json")
         assertEquals("eventId", obj.event.eventId)
         assertEquals("sessionId", obj.event.sessionId)
         assertEquals("messageId", obj.event.messageId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataErrorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataErrorTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeCrashDataErrorTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info =
         NativeCrashDataError(
@@ -18,23 +17,19 @@ internal class NativeCrashDataErrorTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("native_crash_data_error_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("native_crash_data_error_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("native_crash_data_error_expected.json")
-        val obj = serializer.fromJson(json, NativeCrashDataError::class.java)
+        val obj = deserializeJsonFromResource<NativeCrashDataError>("native_crash_data_error_expected.json")
         assertEquals(5, obj.number)
         assertEquals(2, obj.context)
     }
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", NativeCrashDataError::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<NativeCrashDataError>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeCrashDataTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = NativeCrashData(
         "report_id",
@@ -35,16 +34,12 @@ internal class NativeCrashDataTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("native_crash_data_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("native_crash_data_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("native_crash_data_expected.json")
-        val obj = serializer.fromJson(json, NativeCrashData::class.java)
+        val obj = deserializeJsonFromResource<NativeCrashData>("native_crash_data_expected.json")
         assertEquals("report_id", obj.nativeCrashId)
         assertEquals("sid", obj.sessionId)
         assertEquals(1610000000000, obj.timestamp)
@@ -59,7 +54,7 @@ internal class NativeCrashDataTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", NativeCrashData::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<NativeCrashData>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashMetadataTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashMetadataTest.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -19,16 +21,12 @@ internal class NativeCrashMetadataTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("native_crash_metadata_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("native_crash_metadata_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("native_crash_metadata_expected.json")
-        val obj = serializer.fromJson(json, NativeCrashMetadata::class.java)
+        val obj = deserializeJsonFromResource<NativeCrashMetadata>("native_crash_metadata_expected.json")
         verifyInfoPopulated(obj)
     }
 
@@ -41,8 +39,8 @@ internal class NativeCrashMetadataTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", NativeCrashMetadata::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<NativeCrashMetadata>()
+        assertNotNull(obj)
     }
 
     private fun verifyInfoPopulated(obj: NativeCrashMetadata) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeCrashTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = NativeCrash(
         "id",
@@ -26,16 +25,12 @@ internal class NativeCrashTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("native_crash_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("native_crash_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("native_crash_expected.json")
-        val obj = serializer.fromJson(json, NativeCrash::class.java)
+        val obj = deserializeJsonFromResource<NativeCrash>("native_crash_expected.json")
         assertEquals("id", obj.id)
         assertEquals("crashMessage", obj.crashMessage)
         assertEquals(mapOf("key" to "value"), obj.symbols)
@@ -49,7 +44,7 @@ internal class NativeCrashTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", NativeCrash::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<NativeCrash>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeSymbolsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeSymbolsTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class NativeSymbolsTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val armv7Symbols = mapOf(
         "libfoo-armeabi-v7a.so" to "0x1234",
@@ -44,16 +43,12 @@ internal class NativeSymbolsTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("native_symbols_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(symbols)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("native_symbols_expected.json", symbols)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("native_symbols_expected.json")
-        val obj = serializer.fromJson(json, NativeSymbols::class.java)
+        val obj = deserializeJsonFromResource<NativeSymbols>("native_symbols_expected.json")
         assertEquals(armv7Symbols, obj.getSymbolByArchitecture("arm64-v8a"))
         assertEquals(armv7Symbols, obj.getSymbolByArchitecture("armeabi-v7a"))
         assertEquals(x86Symbols, obj.getSymbolByArchitecture("x86"))
@@ -62,7 +57,7 @@ internal class NativeSymbolsTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", NativeSymbols::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<NativeSymbols>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/RnActionBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/RnActionBreadcrumbTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class RnActionBreadcrumbTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = RnActionBreadcrumb(
         "my_action",
@@ -21,16 +20,12 @@ internal class RnActionBreadcrumbTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("rn_action_breadcrumb_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("rn_action_breadcrumb_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("rn_action_breadcrumb_expected.json")
-        val obj = serializer.fromJson(json, RnActionBreadcrumb::class.java)
+        val obj = deserializeJsonFromResource<RnActionBreadcrumb>("rn_action_breadcrumb_expected.json")
         assertEquals("my_action", obj.name)
         assertEquals(1600000000, obj.getStartTime())
         assertEquals(1600000100, obj.endTime)
@@ -41,7 +36,7 @@ internal class RnActionBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", RnActionBreadcrumb::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<RnActionBreadcrumb>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
@@ -1,8 +1,9 @@
 package io.embrace.android.embracesdk.payload
 
-import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import io.embrace.android.embracesdk.fakes.fakeSession
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -11,7 +12,6 @@ import org.junit.Test
 
 internal class SessionMessageTest {
 
-    private val serializer = EmbraceSerializer()
     private val session = fakeSession()
     private val userInfo = UserInfo("fake-user-id", "fake-user-name")
     private val appInfo = AppInfo("fake-app-version")
@@ -45,16 +45,12 @@ internal class SessionMessageTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("session_message_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("session_message_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("session_message_expected.json")
-        val obj = serializer.fromJson(json, SessionMessage::class.java)
+        val obj = deserializeJsonFromResource<SessionMessage>("session_message_expected.json")
         assertNotNull(obj)
         assertEquals(session, obj.session)
         assertEquals(userInfo, obj.userInfo)
@@ -67,7 +63,7 @@ internal class SessionMessageTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", SessionMessage::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<SessionMessage>()
+        assertNotNull(obj)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/TapBreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/TapBreadcrumbTest.kt
@@ -1,15 +1,14 @@
 package io.embrace.android.embracesdk.payload
 
 import android.util.Pair
-import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.EmbraceSerializer
+import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
+import io.embrace.android.embracesdk.deserializeEmptyJsonString
+import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class TapBreadcrumbTest {
-
-    private val serializer = EmbraceSerializer()
 
     private val info = TapBreadcrumb(
         Pair(0f, 0f),
@@ -20,16 +19,12 @@ internal class TapBreadcrumbTest {
 
     @Test
     fun testSerialization() {
-        val expectedInfo = ResourceReader.readResourceAsText("tap_breadcrumb_expected.json")
-            .filter { !it.isWhitespace() }
-        val observed = serializer.toJson(info)
-        assertEquals(expectedInfo, observed)
+        assertJsonMatchesGoldenFile("tap_breadcrumb_expected.json", info)
     }
 
     @Test
     fun testDeserialization() {
-        val json = ResourceReader.readResourceAsText("tap_breadcrumb_expected.json")
-        val obj = serializer.fromJson(json, TapBreadcrumb::class.java)
+        val obj = deserializeJsonFromResource<TapBreadcrumb>("tap_breadcrumb_expected.json")
         assertEquals("0,0", obj.location)
         assertEquals("tappedElementName", obj.tappedElementName)
         assertEquals(1600000000, obj.getStartTime())
@@ -38,7 +33,7 @@ internal class TapBreadcrumbTest {
 
     @Test
     fun testEmptyObject() {
-        val info = serializer.fromJson("{}", TapBreadcrumb::class.java)
-        assertNotNull(info)
+        val obj = deserializeEmptyJsonString<TapBreadcrumb>()
+        assertNotNull(obj)
     }
 }


### PR DESCRIPTION
## Goal

Simplifies the JSON assertions made in tests by adding some utility functions to the test code that perform common operations. This includes serializing an object to JSON & comparing it against a golden file, de/serializing JSON objects, and loading a value from an empty json object.