### PR TITLE
Fix flaky behavior in CrashSessionTest

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -21,7 +21,6 @@ internal class FakeSessionService : SessionService {
     }
 
     override fun handleCrash(crashId: String) {
-        TODO("Not yet implemented")
     }
 
     override fun endSessionManually(clearUserInfo: Boolean) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAnrService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAnrService.kt
@@ -20,7 +20,6 @@ internal class FakeAnrService : AnrService {
     override fun getAnrProcessErrors(startTime: Long): List<AnrProcessErrorStateInfo> = anrProcessErrors
 
     override fun forceAnrTrackingStopOnCrash() {
-        TODO("Not yet implemented")
     }
 
     override fun finishInitialization(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -9,7 +9,6 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
     }
 
     override fun handleCrash(crashId: String) {
-        TODO("Not yet implemented")
     }
 
     override fun save() {


### PR DESCRIPTION
## Goal

I noticed that `CrashSessionTest` [can flake](https://github.com/embrace-io/embrace-android-sdk/actions/runs/7129063657?pr=159) - I think this is due to a timing issue that causes `AnrService#handleCrash()` to sometimes get invoked. `FakeAnrService` currently throws a `NotImplementedError`. Therefore I've updated all the fake services to do nothing in the case of this function being invoked.

