### PR TITLE
Enforce static analysis against business logic in data classes

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -64,3 +64,11 @@ style:
     active: true
   UnusedImports:
     active: true
+
+  # Avoid business logic in payload/config classes
+  DataClassShouldBeImmutable:
+    active: true
+    includes: [ '**/io/embrace/android/embracesdk/payload/**' ]
+  DataClassContainsFunctions:
+    active: true
+    includes: [ '**/io/embrace/android/embracesdk/payload/**' ]

--- a/embrace-android-sdk/config/detekt/baseline.xml
+++ b/embrace-android-sdk/config/detekt/baseline.xml
@@ -1,6 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues/>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
+    <ID>DataClassContainsFunctions:ExceptionError.kt$ExceptionError$fun addException(ex: Throwable?, appState: String?, clock: Clock)</ID>
+    <ID>DataClassContainsFunctions:ExceptionError.kt$ExceptionError$private fun getExceptionInfo(ex: Throwable?): List&lt;ExceptionInfo&gt;</ID>
+    <ID>DataClassShouldBeImmutable:ExceptionError.kt$ExceptionError$@SerializedName("c") var occurrences = 0</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BetaFeatures.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/BetaFeatures.kt
@@ -12,5 +12,5 @@ import com.google.gson.annotations.SerializedName
 internal data class BetaFeatures(
 
     @SerializedName("ts")
-    internal var thermalStates: List<ThermalState>? = null
+    internal val thermalStates: List<ThermalState>? = null
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/RnActionBreadcrumb.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/RnActionBreadcrumb.kt
@@ -34,7 +34,7 @@ internal data class RnActionBreadcrumb(
     /**
      * The timestamp at which the action ended.
      */
-    @SerializedName("pz") var bytesSent: Int,
+    @SerializedName("pz") val bytesSent: Int,
 
     /**
      * The output message SUCCESS | FAIL | INCOMPLETE

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/UserInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/UserInfo.kt
@@ -9,16 +9,16 @@ import io.embrace.android.embracesdk.prefs.PreferencesService
 internal data class UserInfo(
 
     @SerializedName("id")
-    var userId: String? = null,
+    val userId: String? = null,
 
     @SerializedName("em")
-    var email: String? = null,
+    val email: String? = null,
 
     @SerializedName("un")
-    var username: String? = null,
+    val username: String? = null,
 
     @SerializedName("per")
-    var personas: Set<String>? = null
+    val personas: Set<String>? = null
 ) {
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UserInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UserInfoTest.kt
@@ -66,22 +66,6 @@ internal class UserInfoTest {
     }
 
     /**
-     * Construct UserInfo object with nulls then set values
-     */
-    @Test
-    fun testNullsInCtor() {
-        val info = UserInfo(null, null, null, null)
-        info.userId = "5"
-        info.username = "root"
-        info.email = "faker22@example.com"
-        info.personas = setOf("payer")
-        assertEquals("5", info.userId)
-        assertEquals("faker22@example.com", info.email)
-        assertEquals("root", info.username)
-        assertEquals(setOf("payer"), info.personas)
-    }
-
-    /**
      * Construct UserInfo from an empty PreferenceService
      */
     @Test


### PR DESCRIPTION
## Goal

This is somewhat opinionated but the changeset adds [Detekt rules](https://github.com/embrace-io/embrace-android-sdk/pull/new/data-class-business-logic) that flag any data class containing business logic. This is defined as any mutable variables or the presence of functions that are not on an allowlist. I would like the config/payload classes to be as dumb as possible to make creating fakes etc easy.

I have enabled this for the `io.embrace.android.embracesdk.payload` package only at this point & have suppressed the existing warnings (this prevents the problem getting worse). I haven't enabled it for the config classes as those are mostly not data classes.
