### PR TITLE
Prevent duplicate heartbeats

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/ThreadMonitoringState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/ThreadMonitoringState.kt
@@ -46,7 +46,6 @@ internal class ThreadMonitoringState(
      */
     fun resetState() {
         anrInProgress = false
-        started.set(false)
         lastTargetThreadResponseMs = clock.now()
         lastMonitorThreadResponseMs = clock.now()
         lastSampleAttemptMs = 0

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceTimingTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceTimingTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -50,6 +51,20 @@ internal class EmbraceAnrServiceTimingTest {
             targetThreadHandler.onIdleThread()
             anrExecutorService.runCurrentlyBlocked()
             assertFalse(state.anrInProgress)
+        }
+    }
+
+    @Test
+    fun `only one recurring heartbeat task is created after foregrounding`() {
+        with(rule) {
+            anrService.finishInitialization(fakeConfigService)
+            anrExecutorService.runCurrentlyBlocked()
+            anrExecutorService.runCurrentlyBlocked()
+            assertEquals(1, anrExecutorService.scheduledTasksCount())
+            anrService.onForeground(true, clock.now(), clock.now() + 1)
+            anrExecutorService.runCurrentlyBlocked()
+            anrExecutorService.runCurrentlyBlocked()
+            assertEquals(1, anrExecutorService.scheduledTasksCount())
         }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
@@ -169,8 +169,20 @@ internal class LivenessCheckSchedulerTest {
         anrExecutorService.runCurrentlyBlocked()
         assertEquals(fakeClock.now(), state.lastMonitorThreadResponseMs)
         cfg = cfg.copy(sampleIntervalMs = 10)
+        assertEquals(1, anrExecutorService.scheduledTasksCount())
         anrExecutorService.moveForwardAndRunBlocked(100)
         anrExecutorService.runCurrentlyBlocked()
+        anrExecutorService.moveForwardAndRunBlocked(10)
         assertEquals(fakeClock.now(), state.lastMonitorThreadResponseMs)
+        assertEquals(1, anrExecutorService.scheduledTasksCount())
+    }
+
+    @Test
+    fun `starting monitoring thread twice does not result in multiple recurring tasks`() {
+        repeat(2) {
+            scheduler.startMonitoringThread()
+            anrExecutorService.runCurrentlyBlocked()
+            assertEquals(1, anrExecutorService.scheduledTasksCount())
+        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
@@ -88,6 +88,8 @@ internal class BlockingScheduledExecutorService(
         runCurrentlyBlocked()
     }
 
+    fun scheduledTasksCount(): Int = scheduledTasks.size
+
     override fun execute(command: Runnable?) {
         requireNotNull(command)
         delegateExecutorService.execute(command)
@@ -271,6 +273,14 @@ internal class BlockingScheduledExecutorService(
         }
 
         override fun isPeriodic(): Boolean = periodMs != 0L
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            val cancelled = super.cancel(mayInterruptIfRunning)
+            if (cancelled) {
+                scheduledTasks.remove(this)
+            }
+            return cancelled
+        }
     }
 
     private class BlockedScheduledFutureTaskComparator : Comparator<BlockedFutureScheduledTask<*>> {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorServiceTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorServiceTests.kt
@@ -131,9 +131,11 @@ internal class BlockingScheduledExecutorServiceTests {
             unit = TimeUnit.SECONDS
         )
         assertFalse(taskStatus.isDone)
+        assertEquals(1, executorService.scheduledTasksCount())
         executorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(10L))
         assertEquals(1, tasksExecuted)
         assertTrue(taskStatus.isDone)
+        assertEquals(0, executorService.scheduledTasksCount())
     }
 
     @Test
@@ -144,11 +146,13 @@ internal class BlockingScheduledExecutorServiceTests {
             unit = TimeUnit.SECONDS
         )
         assertFalse(taskStatus.isDone)
+        assertEquals(1, executorService.scheduledTasksCount())
         executorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(10L))
         assertEquals(1, tasksExecuted)
         assertTrue(taskStatus.isDone)
         // welp, callable result not returned
         assertEquals(0, taskStatus.get())
+        assertEquals(0, executorService.scheduledTasksCount())
     }
 
     @Test
@@ -160,11 +164,13 @@ internal class BlockingScheduledExecutorServiceTests {
         )
         assertFalse(taskStatus.isDone)
         assertFalse(taskStatus.isCancelled)
+        assertEquals(1, executorService.scheduledTasksCount())
         taskStatus.cancel(true)
         executorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(10L))
         assertEquals(0, tasksExecuted)
         assertTrue(taskStatus.isDone)
         assertTrue(taskStatus.isCancelled)
+        assertEquals(0, executorService.scheduledTasksCount())
     }
 
     @Test
@@ -188,11 +194,13 @@ internal class BlockingScheduledExecutorServiceTests {
         executorService.moveForwardAndRunBlocked(1L)
         assertEquals(3, tasksExecuted)
         assertFalse(taskStatus.isDone)
+        assertEquals(1, executorService.scheduledTasksCount())
         taskStatus.cancel(true)
         assertTrue(taskStatus.isDone)
         assertTrue(taskStatus.isCancelled)
         executorService.moveForwardAndRunBlocked(10L)
         assertEquals(3, tasksExecuted)
+        assertEquals(0, executorService.scheduledTasksCount())
     }
 
     @Test
@@ -233,11 +241,13 @@ internal class BlockingScheduledExecutorServiceTests {
         executorService.moveForwardAndRunBlocked(1L)
         assertEquals(3, tasksExecuted)
         assertFalse(taskStatus.isDone)
+        assertEquals(1, executorService.scheduledTasksCount())
         taskStatus.cancel(true)
         assertTrue(taskStatus.isDone)
         assertTrue(taskStatus.isCancelled)
         executorService.moveForwardAndRunBlocked(10L)
         assertEquals(3, tasksExecuted)
+        assertEquals(0, executorService.scheduledTasksCount())
     }
 
     @Test


### PR DESCRIPTION
## Goal

The callback in EmbraceAnrService that is called when the app foregrounds resets the state of the ANR tracking object. This is because we can't do this when the app backgrounds, in case the method to retrieve ANR data happens after the onBackground callback is called, as it is called on another thread. However, the reset is too aggressive, as it needlessly resets the ANR tracking state to false as well as resetting the stats, which is what we really need. As this is called right before we check the state to create the heartbeat recurring task, this will always be called, regardless of what the state of the service prior to the reset was.

When we background the app, we set this to false, so doing this is just a no-op. But upon app start, this set to true, which means there should already be a heartbeat job that's scheduled. This means the foregrounding will create an another one, rendering the first one "lost" as the reference to it gets overridden, so this task will always keep running.

This PR fixes this issue by not not reseting the state of the service, but just the stats. In additional, the logic to stop and reschedule the heartbeat has been consolidated and streamlined so we schedule another job to do the reschedule, thus ensuring the recurring task won't be running when it gets canceled and replaced.

## Testing

Add component test to verify the case being fixed, as well as additional changes in the supporting infra to ensuring that double job creations won't happen.
