### PR TITLE
Consolidate save session function overloads

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -3,11 +3,10 @@ package io.embrace.android.embracesdk.comms.delivery
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.SessionSnapshotType
 
 internal interface DeliveryCacheManager {
-    fun saveSession(sessionMessage: SessionMessage): ByteArray
-    fun saveSessionPeriodicCache(sessionMessage: SessionMessage)
-    fun saveSessionOnCrash(sessionMessage: SessionMessage)
+    fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType): ByteArray?
     fun loadSession(sessionId: String): SessionMessage?
     fun loadSessionBytes(sessionId: String): ByteArray?
     fun deleteSession(sessionId: String)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -6,13 +6,12 @@ import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.SessionSnapshotType
 
 internal enum class SessionMessageState { END, END_WITH_CRASH }
 
 internal interface DeliveryService {
-    fun saveSessionPeriodicCache(sessionMessage: SessionMessage)
-    fun saveSessionOnCrash(sessionMessage: SessionMessage)
-    fun saveSession(sessionMessage: SessionMessage)
+    fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState)
     fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?)
     fun saveCrash(crash: EventMessage)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -195,7 +195,7 @@ internal class SessionHandler(
                 crashId,
             )
             activeSession = null
-            fullEndSessionMessage?.let(deliveryService::saveSessionOnCrash)
+            fullEndSessionMessage?.let { deliveryService.saveSession(it, SessionSnapshotType.JVM_CRASH) }
         }
     }
 
@@ -230,7 +230,7 @@ internal class SessionHandler(
                 SessionLifeEventType.STATE,
                 clock.now()
             )
-            msg?.let(deliveryService::saveSessionPeriodicCache)
+            msg?.let { deliveryService.saveSession(it, SessionSnapshotType.PERIODIC_CACHE) }
             return msg
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.SessionSnapshotType
 
 /**
  * A [DeliveryService] that records the last parameters used to invoke each method, and for the ones that need it, count the number of
@@ -27,19 +28,13 @@ internal class FakeDeliveryService : DeliveryService {
     var lastSavedCrash: EventMessage? = null
     var lastSentCachedSession: String? = null
     var lastSavedSession: SessionMessage? = null
+    var lastSnapshotType: SessionSnapshotType? = null
     val lastSentSessions: MutableList<Pair<SessionMessage, SessionMessageState>> = mutableListOf()
     var blobMessages: MutableList<BlobMessage> = mutableListOf()
 
-    override fun saveSession(sessionMessage: SessionMessage) {
+    override fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
         lastSavedSession = sessionMessage
-    }
-
-    override fun saveSessionOnCrash(sessionMessage: SessionMessage) {
-        lastSavedSession = sessionMessage
-    }
-
-    override fun saveSessionPeriodicCache(sessionMessage: SessionMessage) {
-        lastSavedSession = sessionMessage
+        lastSnapshotType = snapshotType
     }
 
     override fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -10,6 +10,9 @@ import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.SessionSnapshotType.JVM_CRASH
+import io.embrace.android.embracesdk.session.SessionSnapshotType.NORMAL_END
+import io.embrace.android.embracesdk.session.SessionSnapshotType.PERIODIC_CACHE
 import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -69,12 +72,12 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val mockSessionMessage: SessionMessage = mockk()
         every {
-            mockDeliveryCacheManager.saveSession(mockSessionMessage)
+            mockDeliveryCacheManager.saveSession(mockSessionMessage, NORMAL_END)
         } returns "cached_session".toByteArray()
 
-        deliveryService.saveSession(mockSessionMessage)
+        deliveryService.saveSession(mockSessionMessage, NORMAL_END)
 
-        verify(exactly = 1) { mockDeliveryCacheManager.saveSession(mockSessionMessage) }
+        verify(exactly = 1) { mockDeliveryCacheManager.saveSession(mockSessionMessage, NORMAL_END) }
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
@@ -83,9 +86,9 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val mockSessionMessage: SessionMessage = mockk()
 
-        deliveryService.saveSessionPeriodicCache(mockSessionMessage)
+        deliveryService.saveSession(mockSessionMessage, PERIODIC_CACHE)
 
-        verify(exactly = 1) { mockDeliveryCacheManager.saveSessionPeriodicCache(mockSessionMessage) }
+        verify(exactly = 1) { mockDeliveryCacheManager.saveSession(mockSessionMessage, PERIODIC_CACHE) }
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
@@ -94,9 +97,9 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val mockSessionMessage: SessionMessage = mockk()
 
-        deliveryService.saveSessionOnCrash(mockSessionMessage)
+        deliveryService.saveSession(mockSessionMessage, JVM_CRASH)
 
-        verify(exactly = 1) { mockDeliveryCacheManager.saveSessionOnCrash(mockSessionMessage) }
+        verify(exactly = 1) { mockDeliveryCacheManager.saveSession(mockSessionMessage, JVM_CRASH) }
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
@@ -178,7 +181,7 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
 
         every {
-            mockDeliveryCacheManager.saveSession(any())
+            mockDeliveryCacheManager.saveSession(any(), NORMAL_END)
         } returns "cached_session".toByteArray()
 
         val mockFuture: Future<Unit> = mockk()
@@ -203,7 +206,7 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
 
         every {
-            mockDeliveryCacheManager.saveSession(any())
+            mockDeliveryCacheManager.saveSession(any(), JVM_CRASH)
         } returns "cached_session".toByteArray()
 
         val mockFuture: Future<Unit> = mockk()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -5,17 +5,11 @@ import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.SessionSnapshotType
 
 internal class FakeDeliveryCacheManager : DeliveryCacheManager {
-    override fun saveSession(sessionMessage: SessionMessage): ByteArray {
-        TODO("Not yet implemented")
-    }
 
-    override fun saveSessionOnCrash(sessionMessage: SessionMessage) {
-        TODO("Not yet implemented")
-    }
-
-    override fun saveSessionPeriodicCache(sessionMessage: SessionMessage) {
+    override fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType): ByteArray {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
## Goal

Consolidates 3 separate functions for saving a session on the `DeliveryService` into one location instead, that behaves differently according to an existing enum.

## Testing

Updated existing test coverage.

