### PR TITLE
Remove redundant SessionMessageState enum

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -4,11 +4,11 @@ import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
-import io.embrace.android.embracesdk.comms.delivery.SessionMessageState
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.returnIfConditionMet
+import io.embrace.android.embracesdk.session.SessionSnapshotType
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
@@ -97,7 +97,7 @@ internal class TracingApiTest {
             val sessionEndTime = harness.fakeClock.now()
             assertEquals(1, harness.fakeDeliveryModule.deliveryService.lastSentSessions.size)
             val sessionMessage = harness.fakeDeliveryModule.deliveryService.lastSentSessions[0]
-            assertEquals(SessionMessageState.END, sessionMessage.second)
+            assertEquals(SessionSnapshotType.NORMAL_END, sessionMessage.second)
             with(sessionMessage.first) {
                 checkNotNull(spans)
                 assertEquals(6, spans.size)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -8,11 +8,9 @@ import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.SessionSnapshotType
 
-internal enum class SessionMessageState { END, END_WITH_CRASH }
-
 internal interface DeliveryService {
     fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
-    fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState)
+    fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?)
     fun saveCrash(crash: EventMessage)
     fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
-import io.embrace.android.embracesdk.comms.delivery.SessionMessageState
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -162,7 +161,7 @@ internal class SessionHandler(
             logger.logDebug("Services collections successfully cleaned.")
             sessionProperties.clearTemporary()
             logger.logDebug("Session properties successfully temporary cleared.")
-            deliveryService.sendSession(fullEndSessionMessage, SessionMessageState.END)
+            deliveryService.sendSession(fullEndSessionMessage, SessionSnapshotType.NORMAL_END)
 
             if (endType == SessionLifeEventType.MANUAL && clearUserInfo) {
                 userService.clearAllUserInfo()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
-import io.embrace.android.embracesdk.comms.delivery.SessionMessageState
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -29,7 +28,7 @@ internal class FakeDeliveryService : DeliveryService {
     var lastSentCachedSession: String? = null
     var lastSavedSession: SessionMessage? = null
     var lastSnapshotType: SessionSnapshotType? = null
-    val lastSentSessions: MutableList<Pair<SessionMessage, SessionMessageState>> = mutableListOf()
+    val lastSentSessions: MutableList<Pair<SessionMessage, SessionSnapshotType>> = mutableListOf()
     var blobMessages: MutableList<BlobMessage> = mutableListOf()
 
     override fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
@@ -37,8 +36,8 @@ internal class FakeDeliveryService : DeliveryService {
         lastSnapshotType = snapshotType
     }
 
-    override fun sendSession(sessionMessage: SessionMessage, state: SessionMessageState) {
-        lastSentSessions.add(Pair(sessionMessage, state))
+    override fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
+        lastSentSessions.add(Pair(sessionMessage, snapshotType))
     }
 
     override fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -187,7 +187,7 @@ internal class EmbraceDeliveryServiceTest {
         val mockFuture: Future<Unit> = mockk()
         every { apiService.sendSession(any(), any()) } returns mockFuture
 
-        deliveryService.sendSession(mockk(), SessionMessageState.END)
+        deliveryService.sendSession(mockk(), NORMAL_END)
 
         verify(exactly = 1) {
             apiService.sendSession(
@@ -212,7 +212,7 @@ internal class EmbraceDeliveryServiceTest {
         val mockFuture: Future<Unit> = mockk()
         every { apiService.sendSession(any(), any()) } returns mockFuture
 
-        deliveryService.sendSession(mockk(), SessionMessageState.END_WITH_CRASH)
+        deliveryService.sendSession(mockk(), JVM_CRASH)
 
         verify(exactly = 1) {
             apiService.sendSession(
@@ -226,6 +226,29 @@ internal class EmbraceDeliveryServiceTest {
             mockFuture.get(1L, TimeUnit.SECONDS)
         }
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
+    }
+
+    @Test
+    fun `send session invalid`() {
+        initializeDeliveryService()
+
+        every {
+            mockDeliveryCacheManager.saveSession(any(), NORMAL_END)
+        } returns "cached_session".toByteArray()
+
+        val mockFuture: Future<Unit> = mockk()
+        every { apiService.sendSession(any(), any()) } returns mockFuture
+
+        deliveryService.sendSession(mockk(), PERIODIC_CACHE)
+
+        verify(exactly = 0) {
+            apiService.sendSession(
+                any(),
+                withArg {
+                    assertNotNull(it)
+                }
+            )
+        }
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivitySer
 import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
 import io.embrace.android.embracesdk.capture.webview.WebViewService
-import io.embrace.android.embracesdk.comms.delivery.SessionMessageState
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.config.local.SessionLocalConfig
@@ -616,7 +615,7 @@ internal class SessionHandlerTest {
         )
         val sessions = deliveryService.lastSentSessions
         assertEquals(1, sessions.size)
-        assertEquals(1, sessions.count { it.second == SessionMessageState.END })
+        assertEquals(1, sessions.count { it.second == SessionSnapshotType.NORMAL_END })
     }
 
     private fun startFakeSession() {


### PR DESCRIPTION
## Goal

Removes the redundant `SessionMessageState` enum. This was not used in the session payload and was conflating two separate concepts: the start/end message, and the circumstances in which the payload was written to disk. The `SessionSnapshotType` enum has superseded this.

## Testing

Relied on existing test coverage.
