### PR TITLE
Consolidate send + save functions for sessions

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.SessionSnapshotType
 
 internal interface DeliveryService {
-    fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?)
     fun saveCrash(crash: EventMessage)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -61,18 +61,18 @@ internal class EmbraceDeliveryCacheManager(
         snapshotType: SessionSnapshotType
     ): ByteArray? {
         return when (snapshotType) {
-            SessionSnapshotType.NORMAL_END -> {
-                val sessionBytes: ByteArray = sessionMessageSerializer.serialize(sessionMessage).toByteArray()
+            SessionSnapshotType.PERIODIC_CACHE -> {
                 saveSessionImpl(sessionMessage, false) { filename ->
-                    cacheService.cacheBytes(filename, sessionBytes)
-                }
-                sessionBytes
-            }
-            else -> {
-                saveSessionImpl(sessionMessage, snapshotType == SessionSnapshotType.JVM_CRASH) { filename ->
                     cacheService.writeSession(filename, sessionMessage)
                 }
                 null
+            }
+            else -> {
+                val sessionBytes: ByteArray = sessionMessageSerializer.serialize(sessionMessage).toByteArray()
+                saveSessionImpl(sessionMessage, snapshotType == SessionSnapshotType.JVM_CRASH) { filename ->
+                    cacheService.cacheBytes(filename, sessionBytes)
+                }
+                sessionBytes
             }
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -194,7 +194,7 @@ internal class SessionHandler(
                 crashId,
             )
             activeSession = null
-            fullEndSessionMessage?.let { deliveryService.saveSession(it, SessionSnapshotType.JVM_CRASH) }
+            fullEndSessionMessage?.let { deliveryService.sendSession(it, SessionSnapshotType.JVM_CRASH) }
         }
     }
 
@@ -229,7 +229,7 @@ internal class SessionHandler(
                 SessionLifeEventType.STATE,
                 clock.now()
             )
-            msg?.let { deliveryService.saveSession(it, SessionSnapshotType.PERIODIC_CACHE) }
+            msg?.let { deliveryService.sendSession(it, SessionSnapshotType.PERIODIC_CACHE) }
             return msg
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -124,17 +124,15 @@ internal class EmbraceDeliveryCacheManagerTest {
         val sessionMessage = createSessionMessage("test_cache")
 
         deliveryCacheManager.saveSession(sessionMessage, JVM_CRASH)
+        val expectedByteArray = serializer.toJson(sessionMessage).toByteArray()
 
-        verify {
-            cacheService.writeSession(
+        verify(exactly = 1) {
+            cacheService.cacheBytes(
                 "$prefix.$clockInit.test_cache.json",
-                sessionMessage
+                expectedByteArray
             )
         }
-
         assertSessionsMatch(sessionMessage, checkNotNull(deliveryCacheManager.loadSession("test_cache")))
-
-        val expectedByteArray = serializer.toJson(sessionMessage).toByteArray()
         assertArrayEquals(expectedByteArray, checkNotNull(deliveryCacheManager.loadSessionBytes("test_cache")))
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -31,13 +31,12 @@ internal class FakeDeliveryService : DeliveryService {
     val lastSentSessions: MutableList<Pair<SessionMessage, SessionSnapshotType>> = mutableListOf()
     var blobMessages: MutableList<BlobMessage> = mutableListOf()
 
-    override fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
+    override fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
+        if (snapshotType != SessionSnapshotType.PERIODIC_CACHE) {
+            lastSentSessions.add(sessionMessage to snapshotType)
+        }
         lastSavedSession = sessionMessage
         lastSnapshotType = snapshotType
-    }
-
-    override fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
-        lastSentSessions.add(Pair(sessionMessage, snapshotType))
     }
 
     override fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -75,7 +75,7 @@ internal class EmbraceDeliveryServiceTest {
             mockDeliveryCacheManager.saveSession(mockSessionMessage, NORMAL_END)
         } returns "cached_session".toByteArray()
 
-        deliveryService.saveSession(mockSessionMessage, NORMAL_END)
+        deliveryService.sendSession(mockSessionMessage, NORMAL_END)
 
         verify(exactly = 1) { mockDeliveryCacheManager.saveSession(mockSessionMessage, NORMAL_END) }
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
@@ -86,7 +86,7 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val mockSessionMessage: SessionMessage = mockk()
 
-        deliveryService.saveSession(mockSessionMessage, PERIODIC_CACHE)
+        deliveryService.sendSession(mockSessionMessage, PERIODIC_CACHE)
 
         verify(exactly = 1) { mockDeliveryCacheManager.saveSession(mockSessionMessage, PERIODIC_CACHE) }
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
@@ -97,7 +97,7 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val mockSessionMessage: SessionMessage = mockk()
 
-        deliveryService.saveSession(mockSessionMessage, JVM_CRASH)
+        deliveryService.sendSession(mockSessionMessage, JVM_CRASH)
 
         verify(exactly = 1) { mockDeliveryCacheManager.saveSession(mockSessionMessage, JVM_CRASH) }
         assertEquals(1, gatingService.sessionMessagesFiltered.size)


### PR DESCRIPTION
## Goal

Combines the send/save functions for delivering sessions. This achieves a few goals:

1. Simplifies the internal API of `DeliveryService`
2. Ensures that a HTTP request is made for a session on a crash, which follows the same behavior as crashes. Data analysis has showed there is a surprisingly high success rate for deliverability, so we should enable it for sessions
3. Simplified the threading model somewhat - I/O is performed on a background thread, but other activities such as serialization happen on the calling thread. In practice this was always a background thread so shouldn't present an issue

## Testing

Updated existing test coverage.
