### PR TITLE
Combine save/send operations for crashes in DeliveryService

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
@@ -131,17 +131,15 @@ internal class EmbraceCrashService(
             val crashEvent = gatingService.gateEventMessage(versionedEvent)
             logDeveloper("EmbraceCrashService", "Attempting to send event...")
 
-            // Save the crash to file
-            deliveryService.saveCrash(crashEvent)
-            // End, cache and send the session
-            sessionService.handleCrash(crash.crashId)
-            backgroundActivityService?.handleCrash(crash.crashId)
-
             // Send the crash. This is not guaranteed to succeed since the process is terminating
             // and the request is made on a background executor, but data analysis shows that
             // a surprising % of crashes make it through based on the receive time. Therefore we
             // attempt to send the crash and if it fails, we will send it again on the next launch.
             deliveryService.sendCrash(crashEvent)
+
+            // End, cache and send the session
+            sessionService.handleCrash(crash.crashId)
+            backgroundActivityService?.handleCrash(crash.crashId)
 
             // Indicate that a crash happened so we can know that in the next launch
             crashMarker.mark()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.session.SessionSnapshotType
 internal interface DeliveryService {
     fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun sendCachedSessions(isNdkEnabled: Boolean, ndkService: NdkService, currentSession: String?)
-    fun saveCrash(crash: EventMessage)
     fun saveBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage)
     fun sendBackgroundActivity(backgroundActivityMessage: BackgroundActivityMessage)
     fun sendBackgroundActivities()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -136,6 +136,7 @@ internal class EmbraceDeliveryService(
     }
 
     override fun sendCrash(crash: EventMessage) {
+        cacheManager.saveCrash(crash)
         apiService.sendCrash(crash)
     }
 
@@ -154,13 +155,6 @@ internal class EmbraceDeliveryService(
         } else {
             sendCachedSessionsWithoutNdk(currentSession)
         }
-    }
-
-    /**
-     * Persist crash to disk so it can be sent on the next SDK start.
-     */
-    override fun saveCrash(crash: EventMessage) {
-        cacheManager.saveCrash(crash)
     }
 
     private fun sendCachedCrash() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -43,10 +43,6 @@ internal class FakeDeliveryService : DeliveryService {
         lastSentCachedSession = currentSession
     }
 
-    override fun saveCrash(crash: EventMessage) {
-        lastSavedCrash = crash
-    }
-
     override fun sendEventAsync(eventMessage: EventMessage) {
         eventSentAsyncInvokedCount++
         lastEventSentAsync = eventMessage
@@ -78,6 +74,7 @@ internal class FakeDeliveryService : DeliveryService {
     }
 
     override fun sendCrash(crash: EventMessage) {
+        lastSavedCrash = crash
         lastSentCrash = crash
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -279,8 +279,9 @@ internal class EmbraceDeliveryServiceTest {
     fun testSaveCrash() {
         initializeDeliveryService()
         val obj = EventMessage(Event(eventId = "abc", type = EmbraceEvent.Type.CRASH))
-        deliveryService.saveCrash(obj)
+        deliveryService.sendCrash(obj)
         verify(exactly = 1) { mockDeliveryCacheManager.saveCrash(obj) }
+        verify(exactly = 1) { apiService.sendCrash(obj) }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Combines the save/send operation for crashes in the `DeliveryService` as they are both only called from one place.

## Testing

Updated existing test coverage.
