### PR TITLE
Rename function to sendMoment

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -18,6 +18,6 @@ internal interface DeliveryService {
     fun sendNetworkCall(networkEvent: NetworkEvent)
     fun sendCrash(crash: EventMessage)
     fun sendAEIBlob(blobMessage: BlobMessage)
-    fun sendEventAsync(eventMessage: EventMessage)
+    fun sendMoment(eventMessage: EventMessage)
     fun sendEventAndWait(eventMessage: EventMessage)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -229,7 +229,7 @@ internal class EmbraceDeliveryService(
         }
     }
 
-    override fun sendEventAsync(eventMessage: EventMessage) {
+    override fun sendMoment(eventMessage: EventMessage) {
         sendSessionsExecutorService.submit {
             apiService.sendEvent(eventMessage)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
@@ -64,7 +64,7 @@ internal class EventHandler(
 
         if (shouldSendMoment(eventName)) {
             val eventMessage = buildStartEventMessage(event)
-            deliveryService.sendEventAsync(eventMessage)
+            deliveryService.sendMoment(eventMessage)
         } else {
             logger.logDebug("$eventName start moment not sent based on gating config.")
         }
@@ -101,7 +101,7 @@ internal class EventHandler(
         val endEventMessage = buildEndEventMessage(endEvent, startTime, endTime)
 
         if (shouldSendMoment(event.name)) {
-            deliveryService.sendEventAsync(endEventMessage)
+            deliveryService.sendMoment(endEventMessage)
         } else {
             logger.logDebug("${event.name} end moment not sent based on gating config.")
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -43,7 +43,7 @@ internal class FakeDeliveryService : DeliveryService {
         lastSentCachedSession = currentSession
     }
 
-    override fun sendEventAsync(eventMessage: EventMessage) {
+    override fun sendMoment(eventMessage: EventMessage) {
         eventSentAsyncInvokedCount++
         lastEventSentAsync = eventMessage
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -271,7 +271,7 @@ internal class EmbraceDeliveryServiceTest {
     fun testSendEventAsync() {
         initializeDeliveryService()
         val obj = EventMessage(Event(eventId = "abc", type = EmbraceEvent.Type.END))
-        deliveryService.sendEventAsync(obj)
+        deliveryService.sendMoment(obj)
         verify(exactly = 1) { apiService.sendEvent(obj) }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
@@ -258,7 +258,7 @@ internal class EventHandlerTest {
         )
 
         verify { mockLateTimer.cancel(false) }
-        verify { mockDeliveryService.sendEventAsync(any()) }
+        verify { mockDeliveryService.sendMoment(any()) }
         assertEquals(builtEndEventMessage, result)
     }
     @Test
@@ -316,7 +316,7 @@ internal class EventHandlerTest {
         )
 
         verify { mockLateTimer.cancel(false) }
-        verify { mockDeliveryService.sendEventAsync(any()) }
+        verify { mockDeliveryService.sendMoment(any()) }
         assertEquals(builtEndEventMessage, result)
     }
 
@@ -370,7 +370,7 @@ internal class EventHandlerTest {
         }
         assertNotNull(eventDescription)
         assertEquals(builtEvent, eventDescription.event)
-        verify { mockDeliveryService.sendEventAsync(builtEventMessage) }
+        verify { mockDeliveryService.sendMoment(builtEventMessage) }
         blockingScheduledExecutorService.runCurrentlyBlocked()
         assertTrue(hasCallableBeenInvoked)
     }
@@ -436,7 +436,7 @@ internal class EventHandlerTest {
             mockTimeoutCallback
         )
 
-        verify { mockDeliveryService.sendEventAsync(any()) }
+        verify { mockDeliveryService.sendMoment(any()) }
     }
 
     @Test
@@ -500,7 +500,7 @@ internal class EventHandlerTest {
             mockTimeoutCallback
         )
 
-        verify { mockDeliveryService.sendEventAsync(any()) }
+        verify { mockDeliveryService.sendMoment(any()) }
     }
 
     @Test
@@ -579,7 +579,7 @@ internal class EventHandlerTest {
             mockSessionProperties
         )
 
-        verify { mockDeliveryService.sendEventAsync(any()) }
+        verify { mockDeliveryService.sendMoment(any()) }
     }
 
     @Test
@@ -660,7 +660,7 @@ internal class EventHandlerTest {
             mockSessionProperties
         )
 
-        verify { mockDeliveryService.sendEventAsync(any()) }
+        verify { mockDeliveryService.sendMoment(any()) }
     }
 
     private fun createGatingConfig(components: Set<String>) = RemoteConfig(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -406,7 +406,7 @@ internal class EmbraceNdkServiceTest {
                 any() as NativeCrashData
             )
         }
-        verify(exactly = 0) { mockDeliveryService.sendEventAsync(any() as EventMessage) }
+        verify(exactly = 0) { mockDeliveryService.sendMoment(any() as EventMessage) }
     }
 
     @Test
@@ -516,7 +516,7 @@ internal class EmbraceNdkServiceTest {
         verify(exactly = 0) { delegate._getCrashReport(any()) }
         verify(exactly = 0) { repository.errorFileForCrash(any()) }
         verify(exactly = 0) { repository.mapFileForCrash(any()) }
-        verify(exactly = 0) { mockDeliveryService.sendEventAsync(any() as EventMessage) }
+        verify(exactly = 0) { mockDeliveryService.sendMoment(any() as EventMessage) }
         verify(exactly = 0) {
             repository.deleteFiles(
                 any() as File,
@@ -525,7 +525,7 @@ internal class EmbraceNdkServiceTest {
                 any() as NativeCrashData
             )
         }
-        verify(exactly = 0) { mockDeliveryService.sendEventAsync(any() as EventMessage) }
+        verify(exactly = 0) { mockDeliveryService.sendMoment(any() as EventMessage) }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Renames a function on `DeliveryService` to indicate better that it sends moments, not any events.

