### PR TITLE
Make the buckets for the ResponsivenessMonitor constant

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ResponsivenessSnapshot.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ResponsivenessSnapshot.kt
@@ -17,7 +17,7 @@ internal data class ResponsivenessSnapshot(
     val lastPing: Long,
 
     @SerializedName("gaps")
-    val gaps: Map<Long, Long>,
+    val gaps: Map<String, Long>,
 
     @SerializedName("outliers")
     val outliers: List<ResponsivenessOutlier>,


### PR DESCRIPTION
## Goal

There's no use case to call for the buckets to be dynamic, so we're making them static so the backend can know what to expect. 

Also, I added a bucket to track 500ms to 1000ms gaps, which makes the 2000ms bucket start at 1000ms, which means it will be the minimize length of an ANR sample.

## Testing

Modified existing tests and added one to ensure the enum for the buckets are in the expected sorted order by duration.

