### PR TITLE
Prioritise session message delivery

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -131,8 +131,8 @@ internal class EssentialServiceModuleImpl(
     private val backgroundExecutorService =
         workerThreadModule.backgroundExecutor(ExecutorName.BACKGROUND_REGISTRATION)
 
-    private val apiRetryExecutor =
-        workerThreadModule.scheduledExecutor(ExecutorName.API_RETRY)
+    private val networkRequestExecutor =
+        workerThreadModule.backgroundExecutor(ExecutorName.NETWORK_REQUEST)
 
     private val deliveryCacheExecutorService =
         workerThreadModule.backgroundExecutor(ExecutorName.DELIVERY_CACHE)
@@ -277,7 +277,7 @@ internal class EssentialServiceModuleImpl(
     override val pendingApiCallsSender: PendingApiCallsSender by singleton {
         EmbracePendingApiCallsSender(
             networkConnectivityService,
-            apiRetryExecutor,
+            workerThreadModule.scheduledExecutor(ExecutorName.BACKGROUND_REGISTRATION),
             deliveryCacheManager,
             initModule.clock
         )
@@ -289,7 +289,7 @@ internal class EssentialServiceModuleImpl(
             serializer = coreModule.jsonSerializer,
             cachedConfigProvider = { url: String, request: ApiRequest -> cache.retrieveCachedConfig(url, request) },
             logger = coreModule.logger,
-            scheduledExecutorService = apiRetryExecutor,
+            executorService = networkRequestExecutor,
             cacheManager = deliveryCacheManager,
             pendingApiCallsSender = pendingApiCallsSender,
             lazyDeviceId = lazyDeviceId,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/NetworkRequestRunnable.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/NetworkRequestRunnable.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.embracesdk.worker
+
+import io.embrace.android.embracesdk.comms.api.ApiRequest
+import java.util.concurrent.PriorityBlockingQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+private val counter = AtomicInteger(0)
+
+/**
+ * Marks a [Runnable] as a session request. This is used to prioritise session requests.
+ */
+internal class NetworkRequestRunnable(
+    val request: ApiRequest,
+    val base: Runnable,
+) : Runnable by base {
+
+    /**
+     * The ordinal of this request. This is used to prioritise requests FIFO.
+     */
+    val ordinal = counter.incrementAndGet()
+}
+
+/**
+ * Creates a [PriorityBlockingQueue] for the network request executor. The queue prioritises
+ * sending sessions first rather than other network requests. This should improve
+ * their deliverability when the queue is saturated.
+ */
+internal fun createNetworkRequestQueue(): PriorityBlockingQueue<NetworkRequestRunnable> {
+    return PriorityBlockingQueue(
+        100,
+        compareBy<NetworkRequestRunnable> { runnable ->
+            when {
+                runnable.request.isSessionRequest() -> -1
+                else -> 1
+            }
+        }.thenBy { runnable ->
+            runnable.ordinal.toInt()
+        }
+    )
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
@@ -35,7 +35,7 @@ internal enum class ExecutorName(internal val threadName: String) {
     CACHED_SESSIONS("cached-sessions"),
     SEND_SESSIONS("send-sessions"),
     DELIVERY_CACHE("delivery-cache"),
-    API_RETRY("api-retry"),
+    NETWORK_REQUEST("network-request"),
     NATIVE_CRASH_CLEANER("native-crash-cleaner"),
     NATIVE_STARTUP("native-startup"),
     SESSION_CACHE_EXECUTOR("session-cache"),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
@@ -3,34 +3,65 @@ package io.embrace.android.embracesdk.worker
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 // This lint error seems spurious as it only flags methods annotated with @JvmStatic even though the accessor is generated regardless
 // for lazily initialized members
 internal class WorkerThreadModuleImpl : WorkerThreadModule {
 
-    private val executors: MutableMap<ExecutorName, ScheduledExecutorService> = ConcurrentHashMap()
-
-    private fun fetchExecutor(executorName: ExecutorName): ScheduledExecutorService {
-        return executors.getOrPut(executorName) {
-            Executors.newSingleThreadScheduledExecutor(createThreadFactory(executorName.threadName))
-        }
-    }
-
-    private fun createThreadFactory(name: String): ThreadFactory = ThreadFactory { runnable: Runnable ->
-        Executors.defaultThreadFactory().newThread(runnable).apply {
-            this.name = "emb-$name"
-        }
-    }
+    private val executors: MutableMap<ExecutorName, ExecutorService> = ConcurrentHashMap()
 
     override fun backgroundExecutor(executorName: ExecutorName): ExecutorService =
         fetchExecutor(executorName)
 
-    override fun scheduledExecutor(executorName: ExecutorName): ScheduledExecutorService =
-        fetchExecutor(executorName)
+    override fun scheduledExecutor(executorName: ExecutorName): ScheduledExecutorService {
+        if (executorName == ExecutorName.NETWORK_REQUEST) {
+            error("Network request executor is not a scheduled executor")
+        }
+        return fetchExecutor(executorName) as ScheduledExecutorService
+    }
 
     override fun close() {
-        executors.values.forEach(ScheduledExecutorService::shutdown)
+        executors.values.forEach(ExecutorService::shutdown)
+    }
+
+    private fun fetchExecutor(executorName: ExecutorName): ExecutorService {
+        return executors.getOrPut(executorName) {
+            val threadFactory = createThreadFactory(executorName.threadName)
+            when (executorName) {
+                ExecutorName.NETWORK_REQUEST -> ThreadPoolExecutor(
+                    1,
+                    1,
+                    60L,
+                    TimeUnit.SECONDS,
+                    createNetworkRequestQueue(),
+                    threadFactory
+                )
+                else -> Executors.newSingleThreadScheduledExecutor(threadFactory)
+            }
+        }
+    }
+
+    private fun createThreadFactory(name: String): ThreadFactory =
+        ThreadFactory { runnable: Runnable ->
+            Executors.defaultThreadFactory().newThread(runnable).apply {
+                this.name = "emb-$name"
+            }
+        }
+
+    private fun createNetworkRequestQueue(): PriorityBlockingQueue<Runnable> {
+        return PriorityBlockingQueue(
+            100,
+            compareBy { runnable: Runnable ->
+                when (runnable) {
+                    is NetworkRequestRunnable -> -1
+                    else -> 0
+                }
+            }
+        )
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -18,8 +18,10 @@ import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
+import io.embrace.android.embracesdk.worker.NetworkRequestRunnable
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -226,6 +228,25 @@ internal class EmbraceApiServiceTest {
         assertTrue(finished)
     }
 
+    @Test
+    fun `validate all API endpoint URLs`() {
+        EmbraceApiService.Companion.Endpoint.values().forEach {
+            assertEquals(
+                "https://a-$fakeAppId.data.emb-api.com/v1/log/${it.path}",
+                apiUrlBuilder.getEmbraceUrlWithSuffix(it.path)
+            )
+        }
+    }
+
+    @Test
+    fun `network request runnable is used`() {
+        testScheduledExecutor = mockk(relaxed = true)
+        initApiService()
+        val payload = "{}".toByteArray(Charsets.UTF_8)
+        apiService.sendSession(payload) {}
+        verify(exactly = 1) { testScheduledExecutor.submit(any<NetworkRequestRunnable>()) }
+    }
+
     private fun verifyOnlyRequest(
         expectedUrl: String,
         expectedMethod: HttpMethod = HttpMethod.POST,
@@ -254,13 +275,6 @@ internal class EmbraceApiServiceTest {
         } ?: assertNull(fakeApiClient.sentRequests[0].second)
     }
 
-    @Test
-    fun `validate all API endpoint URLs`() {
-        EmbraceApiService.Companion.Endpoint.values().forEach {
-            assertEquals("https://a-$fakeAppId.data.emb-api.com/v1/log/${it.path}", apiUrlBuilder.getEmbraceUrlWithSuffix(it.path))
-        }
-    }
-
     private fun initApiService() {
         networkConnectivityService.networkStatus = NetworkStatus.WIFI
         apiService = EmbraceApiService(
@@ -268,7 +282,7 @@ internal class EmbraceApiServiceTest {
             serializer = serializer,
             cachedConfigProvider = { _, _ -> cachedConfig },
             logger = InternalEmbraceLogger(),
-            scheduledExecutorService = testScheduledExecutor,
+            executorService = testScheduledExecutor,
             cacheManager = fakeCacheManager,
             lazyDeviceId = lazy { fakeDeviceId },
             appId = fakeAppId,
@@ -282,7 +296,8 @@ internal class EmbraceApiServiceTest {
         private const val fakeAppId = "A1B2C"
         private const val fakeDeviceId = "ajflkadsflkadslkfjds"
         private const val fakeAppVersionName = "6.1.0"
-        private val defaultConfigResponseBody = ResourceReader.readResourceAsText("remote_config_response.json")
+        private val defaultConfigResponseBody =
+            ResourceReader.readResourceAsText("remote_config_response.json")
         private val successfulPostResponse = ApiResponse.Success(
             headers = emptyMap(),
             body = ""

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/NetworkRequestRunnableKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/NetworkRequestRunnableKtTest.kt
@@ -1,0 +1,77 @@
+package io.embrace.android.embracesdk.worker
+
+import io.embrace.android.embracesdk.EmbraceEvent
+import io.embrace.android.embracesdk.comms.api.ApiRequestMapper
+import io.embrace.android.embracesdk.comms.api.EmbraceApiUrlBuilder
+import io.embrace.android.embracesdk.payload.Event
+import io.embrace.android.embracesdk.payload.EventMessage
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class NetworkRequestRunnableKtTest {
+
+    private val builder = EmbraceApiUrlBuilder(
+        coreBaseUrl = "https://data.emb-api.com",
+        configBaseUrl = "https://config.emb-api.com",
+        appId = "appId",
+        lazyDeviceId = lazy { "deviceId" },
+        lazyAppVersionName = lazy { "appVersionName" }
+    )
+    private val mapper = ApiRequestMapper(
+        builder,
+        lazy { "deviceId" },
+        "appVersionName",
+    )
+
+    @Test
+    fun `queue prioritises important requests`() {
+        val queue = createNetworkRequestQueue()
+        val log1 = NetworkRequestRunnable(
+            mapper.logRequest(
+                EventMessage(
+                    Event(
+                        eventId = "1",
+                        type = EmbraceEvent.Type.INFO_LOG
+                    )
+                )
+            )
+        ) {}
+        val crash1 = NetworkRequestRunnable(
+            mapper.logRequest(
+                EventMessage(
+                    Event(
+                        eventId = "2",
+                        type = EmbraceEvent.Type.CRASH
+                    )
+                )
+            )
+        ) {}
+        val log2 = NetworkRequestRunnable(
+            mapper.logRequest(
+                EventMessage(
+                    Event(
+                        eventId = "3",
+                        type = EmbraceEvent.Type.INFO_LOG
+                    )
+                )
+            )
+        ) { }
+        val session1 = NetworkRequestRunnable(mapper.sessionRequest()) { }
+        val session2 = NetworkRequestRunnable(mapper.sessionRequest()) { }
+        val session3 = NetworkRequestRunnable(mapper.sessionRequest()) { }
+
+        val jobs = listOf(log1, crash1, session3, session1, log2, session2)
+        jobs.forEach(queue::add)
+
+        // sessions are always first. otherwise order is indeterminate.
+        val expected = listOf(session1, session2, session3, log1, crash1, log2).map { it.ordinal }
+
+        val list = mutableListOf<NetworkRequestRunnable>()
+        while (queue.isNotEmpty()) {
+            list.add(checkNotNull(queue.poll()))
+        }
+
+        val observed = list.map { it.ordinal }
+        assertEquals(expected, observed)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
@@ -2,7 +2,9 @@ package io.embrace.android.embracesdk.worker
 
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.ThreadPoolExecutor
 
 internal class WorkerThreadModuleImplTest {
 
@@ -13,12 +15,26 @@ internal class WorkerThreadModuleImplTest {
 
         val backgroundExecutor = module.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR)
         assertNotNull(backgroundExecutor)
-        assertNotNull(module.scheduledExecutor(ExecutorName.SESSION_CACHE_EXECUTOR))
+        val scheduledExecutor = module.scheduledExecutor(ExecutorName.SESSION_CACHE_EXECUTOR)
+        assertNotNull(scheduledExecutor)
 
         // test caching
         assertSame(backgroundExecutor, module.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR))
+        assertSame(backgroundExecutor, scheduledExecutor)
 
         // test shutting down module
         module.close()
+    }
+
+    @Test
+    fun `network request executor uses custom queue`() {
+        val module = WorkerThreadModuleImpl()
+        assertTrue(module.backgroundExecutor(ExecutorName.NETWORK_REQUEST) is ThreadPoolExecutor)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `network request scheduled executor fails`() {
+        val module = WorkerThreadModuleImpl()
+        assertTrue(module.scheduledExecutor(ExecutorName.NETWORK_REQUEST) is ThreadPoolExecutor)
     }
 }


### PR DESCRIPTION
## Goal

Prioritises the execution of HTTP requests that are session messages. While we recently refactored the pending API call logic to prioritise session messages, we did not do so with the `ApiService`.

It's plausible that this could affect the deliverability of sessions, although the session should still get saved on disk. In a future changeset I'll look at adding similar logic to calls to the `CacheService` as this area is more likely to cause data loss if a `Runnable` does not execute.

### Changeset

This alters the SDK by:

- Submitting HTTP requests in a `NetworkRequestRunnable` wrapper class that contains a reference to the `ApiRequest` & an auto-incrementing ordinal
- Creating an executor for sending HTTP requests that uses a `PriorityBlockingQueue`
- Prioritising items on the queue that are a session HTTP request, then by request order (FIFO)
- Used a distinct executor for retrying HTTP requests

## Testing

Added test coverage.

