### PR TITLE
Update generate_baseline_profile.yml to inherit secrets

### DIFF
--- a/.github/workflows/generate_baseline_profile.yml
+++ b/.github/workflows/generate_baseline_profile.yml
@@ -3,9 +3,7 @@ name: Generate Baseline Profile
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      token:
-        required: true
+    secrets: inherit
 
 jobs:
   test:


### PR DESCRIPTION
## Goal

In order to update the baseline profile file before publishing each snapshot, the secrets of the workflow should be inherited.