### PR TITLE
Upgrade the build time Kotlin runtime to 1.7.21 so we can use a newer version of detekt and enforce trailing commas

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -7,11 +7,11 @@ object Versions {
     val compileSdk = 33
     val minSdk = 21
     val junit = "4.13.2"
-    val kotlin = "1.5.20"
+    val kotlin = "1.7.21"
     // kotin library exposed to the customer
     val kotlinExposed = "1.4.32"
     val dokka = "1.7.10"
-    val detekt = "1.21.0"
+    val detekt = "1.22.0"
     val binaryCompatValidator = "0.12.1"
     val agp = "7.3.0"
     val lint = "30.1.0"

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -40,6 +40,10 @@ formatting:
     maxLineLength: 140
   MaximumLineLength:
     maxLineLength: 140
+  useTrailingCommaOnCallSite:
+    active: true
+  useTrailingCommaOnDeclarationSite:
+    active: true
 potential-bugs:
   ElseCaseInsteadOfExhaustiveWhen:
     active: true

--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeClickedTargetIterator.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeClickedTargetIterator.kt
@@ -12,7 +12,12 @@ internal class ComposeClickedTargetIterator : EmbraceClickedTargetIterator {
     private val composeInternalErrorLogger = ComposeInternalErrorLogger()
     private val nodeLocator = EmbraceNodeIterator()
 
-    override fun findTarget(decorView: View, x: Float, y: Float, onSingleTapUpBackgroundWorker: ScheduledExecutorService) {
+    override fun findTarget(
+        decorView: View,
+        x: Float,
+        y: Float,
+        onSingleTapUpBackgroundWorker: ScheduledExecutorService
+    ) {
         try {
             val queue: Queue<View> = LinkedList()
             queue.add(decorView)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
@@ -16,7 +16,9 @@ internal class EmbraceCpuInfoDelegate(
                 logger.logError("Could not get the CPU name. Exception: $exception", exception)
                 null
             }
-        } else null
+        } else {
+            null
+        }
     }
 
     override fun getElg(): String? {
@@ -27,7 +29,9 @@ internal class EmbraceCpuInfoDelegate(
                 logger.logError("Could not get the EGL name. Exception: $exception", exception)
                 null
             }
-        } else null
+        } else {
+            null
+        }
     }
 
     private external fun getNativeCpuName(): String

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbsSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbsSanitizer.kt
@@ -21,7 +21,6 @@ internal class BreadcrumbsSanitizer(
             "sanitize: " + (breadcrumbs != null).toString()
         )
         return breadcrumbs?.let {
-
             val customBreadcrumbs = if (shouldAddCustomBreadcrumbs()) {
                 InternalStaticEmbraceLogger.logger.logDeveloper(
                     "BreadcrumbsSanitizer",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -220,7 +220,8 @@ internal class EmbraceBreadcrumbService(
             val limit = configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
             tryAddBreadcrumb(
                 rnActionBreadcrumbs,
-                RnActionBreadcrumb(name, startTime, endTime, properties, bytesSent, output), limit
+                RnActionBreadcrumb(name, startTime, endTime, properties, bytesSent, output),
+                limit
             )
         } catch (ex: Exception) {
             logger.logDebug("Failed to log RN Action breadcrumb with name $name", ex)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -233,7 +233,9 @@ internal class EmbraceMetadataService private constructor(
                 val free = MetadataUtils.getInternalStorageFreeCapacity(statFs.value)
                 if (isAndroid26OrAbove && configService.autoDataCaptureBehavior.isDiskUsageReportingEnabled()) {
                     val deviceDiskAppUsage = MetadataUtils.getDeviceDiskAppUsage(
-                        storageStatsManager, packageManager, packageName
+                        storageStatsManager,
+                        packageManager,
+                        packageName
                     )
                     if (deviceDiskAppUsage != null) {
                         logDeveloper("EmbraceMetadataService", "Disk usage is present")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiUrlBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiUrlBuilder.kt
@@ -26,7 +26,8 @@ internal class EmbraceApiUrlBuilder(
 
     override fun getEmbraceUrlWithSuffix(suffix: String): String {
         InternalStaticEmbraceLogger.logDeveloper(
-            "ApiUrlBuilder", "getEmbraceUrlWithSuffix - suffix: $suffix"
+            "ApiUrlBuilder",
+            "getEmbraceUrlWithSuffix - suffix: $suffix"
         )
         return "$coreBaseUrl/v$API_VERSION/log/$suffix"
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
@@ -78,7 +78,8 @@ internal class SdkModeBehavior(
      * @return true if the sdk is enabled, false otherwise
      */
     fun isSdkDisabled(): Boolean {
-        @Suppress("DEPRECATION") val result = thresholdCheck.getNormalizedDeviceId()
+        @Suppress("DEPRECATION")
+        val result = thresholdCheck.getNormalizedDeviceId()
         // Check if this is lower than the threshold, to determine whether
         // we should enable/disable the SDK.
         val lowerBound = max(0, getOffset())

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -180,7 +180,8 @@ internal class EmbraceEventService(
         } catch (ex: Exception) {
             logger.logError(
                 "Cannot start event with name: $name, identifier: $identifier due to an exception",
-                ex, false
+                ex,
+                false
             )
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
@@ -47,7 +47,8 @@ internal class EmbraceGatingService(
                 configService.sessionBehavior.shouldSendFullForErrorLog()
             ) {
                 logDeveloper(
-                    "EmbraceGatingService", "Error logs detected - Sending full session payload"
+                    "EmbraceGatingService",
+                    "Error logs detected - Sending full session payload"
                 )
                 return sessionMessage
             }
@@ -55,7 +56,8 @@ internal class EmbraceGatingService(
             // check if the session has a crash report id. If so, send the full session payload.
             if (sessionMessage.session.crashReportId != null) {
                 logDeveloper(
-                    "EmbraceGatingService", "Crash detected - Sending full session payload"
+                    "EmbraceGatingService",
+                    "Crash detected - Sending full session payload"
                 )
                 return sessionMessage
             }
@@ -74,7 +76,8 @@ internal class EmbraceGatingService(
 
             if (configService.sessionBehavior.shouldSendFullMessage(eventMessage)) {
                 logDeveloper(
-                    "EmbraceGatingService", "Crash or error detected - Sending full session payload"
+                    "EmbraceGatingService",
+                    "Crash or error detected - Sending full session payload"
                 )
                 return eventMessage
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -120,7 +120,8 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
 
     override val pushNotificationService: PushNotificationCaptureService by singleton {
         PushNotificationCaptureService(
-            breadcrumbService, coreModule.logger
+            breadcrumbService,
+            coreModule.logger
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SystemServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SystemServiceModule.kt
@@ -40,7 +40,9 @@ internal class SystemServiceModuleImpl @JvmOverloads constructor(
     override val storageManager: StorageStatsManager? =
         if (versionChecker.isAtLeast(Build.VERSION_CODES.O)) {
             getSystemServiceSafe(Context.STORAGE_STATS_SERVICE)
-        } else null
+        } else {
+            null
+        }
 
     override val windowManager: WindowManager? by singleton {
         getSystemServiceSafe(Context.WINDOW_SERVICE)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/BuildInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/BuildInfo.kt
@@ -57,7 +57,9 @@ internal class BuildInfo internal constructor(
                 // Flavor value is optional, so we should not hard fail if doesn't exists.
                 if (buildProperty == BUILD_INFO_BUILD_FLAVOR && resourceId == 0) {
                     null
-                } else resources.getString(resourceId)
+                } else {
+                    resources.getString(resourceId)
+                }
             } catch (ex: NullPointerException) {
                 throw IllegalArgumentException(
                     "No resource found for $buildProperty property. Failed to create build info.",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -113,7 +113,11 @@ internal class EmbraceSpanImpl(
         internal const val MAX_ATTRIBUTE_KEY_LENGTH = 50
         internal const val MAX_ATTRIBUTE_VALUE_LENGTH = 200
 
-        internal fun inputsValid(name: String, events: List<EmbraceSpanEvent>? = null, attributes: Map<String, String>? = null) =
+        internal fun inputsValid(
+            name: String,
+            events: List<EmbraceSpanEvent>? = null,
+            attributes: Map<String, String>? = null
+        ) =
             name.isNotBlank() &&
                 name.length <= MAX_NAME_LENGTH &&
                 (events == null || events.size <= MAX_EVENT_COUNT) &&

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
@@ -61,7 +61,13 @@ internal class EmbraceSpansService(private val clock: Clock) : Initializable, Sp
     override fun createSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean): EmbraceSpan? =
         currentDelegate.createSpan(name = name, parent = parent, type = type, internal = internal)
 
-    override fun <T> recordSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean, code: () -> T): T =
+    override fun <T> recordSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        type: EmbraceAttributes.Type,
+        internal: Boolean,
+        code: () -> T
+    ): T =
         currentDelegate.recordSpan(name = name, parent = parent, type = type, internal = internal, code = code)
 
     override fun recordCompletedSpan(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/FeatureDisabledSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/FeatureDisabledSpansService.kt
@@ -14,7 +14,13 @@ import io.opentelemetry.sdk.trace.data.SpanData
 internal class FeatureDisabledSpansService : SpansService {
     override fun createSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean): EmbraceSpan? = null
 
-    override fun <T> recordSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean, code: () -> T) = code()
+    override fun <T> recordSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        type: EmbraceAttributes.Type,
+        internal: Boolean,
+        code: () -> T
+    ) = code()
 
     override fun recordCompletedSpan(
         name: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
@@ -71,7 +71,9 @@ internal class EmbraceInternalErrorService(
                 val addResult = capturedThrowable.add(throwable)
                 addResult && ignoreThrowableCause(throwable.cause, capturedThrowable)
             }
-        } else false
+        } else {
+            false
+        }
     }
 
     @Synchronized

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -396,7 +396,8 @@ internal class EmbraceNdkService(
         } else {
             logger.logError(
                 String.format(
-                    Locale.getDefault(), "Failed to find symbols in resources {resourceId=%d}.",
+                    Locale.getDefault(),
+                    "Failed to find symbols in resources {resourceId=%d}.",
                     resourceId
                 )
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureService.kt
@@ -76,7 +76,6 @@ internal class EmbraceNetworkCaptureService(
         networkCaptureData: NetworkCaptureData?,
         errorMessage: String?
     ) {
-
         val duration = max(endTime - startTime, 0)
 
         getNetworkCaptureRules(url, httpMethod).forEach { rule ->
@@ -124,7 +123,6 @@ internal class EmbraceNetworkCaptureService(
     }
 
     private fun getNetworkPayload(capturedNetworkCall: NetworkCapturedCall): NetworkCapturedCall {
-
         return if (configService.networkBehavior.isCaptureBodyEncryptionEnabled()) {
             val encryptedPayload = encryptNetworkCall(capturedNetworkCall)
             NetworkCapturedCall(encryptedPayload = encryptedPayload)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ExceptionError.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ExceptionError.kt
@@ -8,11 +8,9 @@ import io.embrace.android.embracesdk.internal.clock.Clock
  */
 internal data class ExceptionError(@Transient private val logStrictMode: Boolean) {
     @SerializedName("c")
-
     var occurrences = 0
 
     @SerializedName("rep")
-
     val exceptionErrors = mutableListOf<ExceptionErrorInfo>()
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Stacktraces.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Stacktraces.kt
@@ -22,19 +22,15 @@ internal class Stacktraces @JvmOverloads constructor(
 ) {
 
     @SerializedName("tt")
-
     val jvmStacktrace: List<String>?
 
     @SerializedName("jsk")
-
     val javascriptStacktrace: String?
 
     @SerializedName("u")
-
     val unityStacktrace: String?
 
     @SerializedName("f")
-
     val flutterStacktrace: String?
 
     init {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
@@ -46,7 +46,8 @@ internal class ActivityLifecycleTracker(
     @Synchronized
     fun updateStateWithActivity(activity: Activity?) {
         logger.logDeveloper(
-            "EmbraceActivityService", "Current activity: " + getActivityName(activity)
+            "EmbraceActivityService",
+            "Current activity: " + getActivityName(activity)
         )
         currentActivity = WeakReference(activity)
     }
@@ -59,7 +60,8 @@ internal class ActivityLifecycleTracker(
             val foregroundActivity = currentActivity.get()
             if (foregroundActivity == null || foregroundActivity.isFinishing) {
                 logger.logDeveloper(
-                    "EmbraceActivityService", "Foreground activity not present"
+                    "EmbraceActivityService",
+                    "Foreground activity not present"
                 )
                 return null
             }
@@ -89,7 +91,8 @@ internal class ActivityLifecycleTracker(
 
     override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
         logger.logDeveloper(
-            "ActivityLifecycleTracker", "Activity created: " + getActivityName(activity)
+            "ActivityLifecycleTracker",
+            "Activity created: " + getActivityName(activity)
         )
         updateStateWithActivity(activity)
         updateOrientationWithActivity(activity)
@@ -104,7 +107,8 @@ internal class ActivityLifecycleTracker(
 
     override fun onActivityStarted(activity: Activity) {
         logger.logDeveloper(
-            "ActivityLifecycleTracker", "Activity started: " + getActivityName(activity)
+            "ActivityLifecycleTracker",
+            "Activity started: " + getActivityName(activity)
         )
         updateStateWithActivity(activity)
         stream(listeners) { listener: ActivityLifecycleListener ->
@@ -118,13 +122,15 @@ internal class ActivityLifecycleTracker(
 
     override fun onActivityResumed(activity: Activity) {
         logger.logDeveloper(
-            "ActivityLifecycleTracker", "Activity resumed: " + getActivityName(activity)
+            "ActivityLifecycleTracker",
+            "Activity resumed: " + getActivityName(activity)
         )
         if (!activity.javaClass.isAnnotationPresent(StartupActivity::class.java)) {
             // If the activity coming to foreground doesn't have the StartupActivity annotation
             // the the SDK will finalize any pending startup moment.
             logger.logDeveloper(
-                "ActivityLifecycleTracker", "Activity resumed: " + getActivityName(activity)
+                "ActivityLifecycleTracker",
+                "Activity resumed: " + getActivityName(activity)
             )
             stream(listeners) { listener: ActivityLifecycleListener ->
                 try {
@@ -135,7 +141,8 @@ internal class ActivityLifecycleTracker(
             }
         } else {
             logger.logDeveloper(
-                "ActivityLifecycleTracker", getActivityName(activity) + " is @StartupActivity"
+                "ActivityLifecycleTracker",
+                getActivityName(activity) + " is @StartupActivity"
             )
         }
     }
@@ -143,7 +150,8 @@ internal class ActivityLifecycleTracker(
     override fun onActivityPaused(activity: Activity) {}
     override fun onActivityStopped(activity: Activity) {
         logger.logDeveloper(
-            "ActivityLifecycleTracker", "Activity stopped: " + getActivityName(activity)
+            "ActivityLifecycleTracker",
+            "Activity stopped: " + getActivityName(activity)
         )
         stream(listeners) { listener: ActivityLifecycleListener ->
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -18,6 +18,7 @@ internal interface TracingApi {
      */
     @BetaApi
     fun isTracingAvailable(): Boolean
+
     /**
      * Create an [EmbraceSpan] with the given name that will be the root span of a new trace. Returns null if the [EmbraceSpan] cannot
      * be created given the current conditions of the SDK or an invalid name.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AnrSampleTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AnrSampleTest.kt
@@ -9,7 +9,10 @@ import org.junit.Test
 internal class AnrSampleTest {
 
     private val threadInfo = ThreadInfo(
-        13, Thread.State.RUNNABLE, "my-thread", 5,
+        13,
+        Thread.State.RUNNABLE,
+        "my-thread",
+        5,
         listOf(
             "java.base/java.lang.Thread.getStackTrace(Thread.java:1602)",
             "io.embrace.android.embracesdk.ThreadInfoTest.testThreadInfoSerialization(ThreadInfoTest.kt:18)"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -31,7 +31,6 @@ internal class EmbraceCacheServiceTest {
 
     @Before
     fun setUp() {
-
         dir = Files.createTempDirectory("tmpDirPrefix").toFile()
         service = EmbraceCacheService(
             lazy { dir },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceSessionPropertiesTest.kt
@@ -188,7 +188,8 @@ internal class EmbraceSessionPropertiesTest {
             sessionProperties.add("prop0", otherValue, true)
         )
         assertEquals(
-            "property was updated", otherValue,
+            "property was updated",
+            otherValue,
             sessionProperties.get()["prop0"]
         )
         assertTrue(sessionProperties.remove("prop0"))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
@@ -51,7 +51,6 @@ internal class EmbraceWebViewServiceTest {
 
     @Test
     fun `test messages complete group by url and timestamp`() {
-
         embraceWebViewService.collectWebData("webView1", expectedCompleteData)
 
         assertEquals(1, embraceWebViewService.getCapturedData().size)
@@ -60,7 +59,6 @@ internal class EmbraceWebViewServiceTest {
 
     @Test
     fun `test two complete groups by url and timestamp`() {
-
         embraceWebViewService.collectWebData("webView1", expectedCompleteData)
         embraceWebViewService.collectWebData("webView1", expectedCompleteData2)
 
@@ -71,7 +69,6 @@ internal class EmbraceWebViewServiceTest {
 
     @Test
     fun `test two complete groups whit same url and timestamp keep correct CLS and LCP`() {
-
         embraceWebViewService.collectWebData("webView1", expectedCompleteData)
         embraceWebViewService.collectWebData("webView1", expectedCompleteRepeatedData)
 
@@ -97,7 +94,6 @@ internal class EmbraceWebViewServiceTest {
 
     @Test
     fun `test 3 groups 2 diff timestamps `() {
-
         embraceWebViewService.collectWebData("webView1", expectedCompleteData)
         embraceWebViewService.collectWebData("webView1", expectedCompleteData2)
         embraceWebViewService.collectWebData("webView1", expectedCompleteRepeatedData)
@@ -109,7 +105,6 @@ internal class EmbraceWebViewServiceTest {
 
     @Test
     fun `test repeated elements in one message`() {
-
         embraceWebViewService.collectWebData("webView1", repeatedElementsSameMessage)
 
         assertEquals(1, embraceWebViewService.getCapturedData().size)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionErrorInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ExceptionErrorInfoTest.kt
@@ -19,7 +19,8 @@ internal class ExceptionErrorInfoTest {
     @Test
     fun testExceptionErrorInfoSerialization() {
         val exceptionErrorInfo = ExceptionErrorInfo(
-            0, "STATE",
+            0,
+            "STATE",
             listOf(
                 info,
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
@@ -415,7 +415,8 @@ internal class LocalConfigTest {
     @Test
     fun testServiceEnablementMemoryServiceConfig() {
         var localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"memory_info\": false}}",
             serializer
         )
@@ -424,7 +425,8 @@ internal class LocalConfigTest {
             checkNotNull(cfg.memoryServiceEnabled)
         )
         localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"memory_info\": true}}",
             serializer
         )
@@ -437,7 +439,8 @@ internal class LocalConfigTest {
     @Test
     fun testServiceEnablementPowerSaveModeServiceConfig() {
         var localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"power_save_mode_info\": false}}",
             serializer
         )
@@ -446,7 +449,8 @@ internal class LocalConfigTest {
             checkNotNull(cfg.powerSaveModeServiceEnabled)
         )
         localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"power_save_mode_info\": true}}",
             serializer
         )
@@ -459,7 +463,8 @@ internal class LocalConfigTest {
     @Test
     fun testServiceEnablementNetworkConnectivityServiceConfig() {
         var localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"network_connectivity_info\": false}}",
             serializer
         )
@@ -469,7 +474,8 @@ internal class LocalConfigTest {
             checkNotNull(cfg.networkConnectivityServiceEnabled)
         )
         localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"network_connectivity_info\": true}}",
             serializer
         )
@@ -483,7 +489,8 @@ internal class LocalConfigTest {
     @Test
     fun testServiceEnablementAnrServiceConfig() {
         var localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"anr_info\": false}}",
             serializer
         )
@@ -492,7 +499,8 @@ internal class LocalConfigTest {
             checkNotNull(cfg.anrServiceEnabled)
         )
         localConfig = LocalConfigParser.buildConfig(
-            "GrCPU", false,
+            "GrCPU",
+            false,
             "{\"automatic_data_capture\": { \"anr_info\": true}}",
             serializer
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ThreadInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ThreadInfoTest.kt
@@ -23,7 +23,10 @@ internal class ThreadInfoTest {
     @Test
     fun testThreadInfoSerialization() {
         val threadInfo = ThreadInfo(
-            13, Thread.State.RUNNABLE, "my-thread", 5,
+            13,
+            Thread.State.RUNNABLE,
+            "my-thread",
+            5,
             listOf(
                 "java.base/java.lang.Thread.getStackTrace(Thread.java:1602)",
                 "io.embrace.android.embracesdk.ThreadInfoTest.testThreadInfoSerialization(ThreadInfoTest.kt:18)"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrIntervalTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrIntervalTest.kt
@@ -20,7 +20,10 @@ import org.junit.Test
 internal class AnrIntervalTest {
 
     private val threadInfo = ThreadInfo(
-        13, Thread.State.RUNNABLE, "my-thread", 5,
+        13,
+        Thread.State.RUNNABLE,
+        "my-thread",
+        5,
         listOf(
             "java.base/java.lang.Thread.getStackTrace(Thread.java:1602)",
             "io.embrace.android.embracesdk.ThreadInfoTest.testThreadInfoSerialization(ThreadInfoTest.kt:18)"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -74,7 +74,8 @@ internal class EmbraceBreadcrumbServiceTest {
         val message = SessionMessage(
             session = fakeSession(),
             breadcrumbs = service.getBreadcrumbs(
-                0, clock.now()
+                0,
+                clock.now()
             )
         )
         assertJsonMatchesGoldenFile(expected, message)
@@ -412,6 +413,7 @@ internal class EmbraceBreadcrumbServiceTest {
         assertEquals(0, breadcrumbsAfterClean.customBreadcrumbs?.size)
         assertEquals(0, breadcrumbsAfterClean.fragmentBreadcrumbs?.size)
     }
+
     @Test
     fun testGetBreadcrumbs() {
         val service = initializeBreadcrumbService()
@@ -434,7 +436,8 @@ internal class EmbraceBreadcrumbServiceTest {
         val message = SessionMessage(
             session = fakeSession(),
             breadcrumbs = service.getBreadcrumbs(
-                0, clock.now()
+                0,
+                clock.now()
             )
         )
         assertJsonMatchesGoldenFile("breadcrumb_fragment.json", message)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureServiceTest.kt
@@ -181,7 +181,11 @@ internal class PushNotificationCaptureServiceTest {
 
         // if only reserved words it should return empty map
         every { mockBundle.keySet() } returns setOf(
-            "google.key", "gcm.key", "from", "message_type", "collapse_key"
+            "google.key",
+            "gcm.key",
+            "from",
+            "message_type",
+            "collapse_key"
         )
         assertTrue(
             PushNotificationCaptureService.extractDeveloperDefinedPayload(mockBundle).isEmpty()
@@ -192,7 +196,12 @@ internal class PushNotificationCaptureServiceTest {
 
         // if reserved words plus user defined keys it should return user defined keys only
         every { mockBundle.keySet() } returns setOf(
-            "google.key", "gcm.key", "from", "message_type", "collapse_key", "user_defined_key1",
+            "google.key",
+            "gcm.key",
+            "from",
+            "message_type",
+            "collapse_key",
+            "user_defined_key1",
             "user_defined_key2"
         )
         every { mockBundle.getString("user_defined_key1") } returns "value1"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
@@ -23,6 +23,7 @@ internal class EmbraceUrlTest {
         assertEquals(Endpoint.NETWORK, embraceUrlNetwork.endpoint())
         assertEquals(Endpoint.UNKNOWN, embraceUrlOther.endpoint())
     }
+
     @Test
     fun `test equality`() {
         val embraceUrl1 = EmbraceUrl.create("https://embrace.io")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -87,7 +87,9 @@ internal class EmbracePendingApiCallsSenderTest {
     fun `retryTask is not active and doesn't run if there are no failed API requests`() {
         connectedNetworkStatuses.forEach { status ->
             initPendingApiCallsSender(
-                status = status, loadFailedRequest = false, runRetryJobAfterScheduling = true
+                status = status,
+                loadFailedRequest = false,
+                runRetryJobAfterScheduling = true
             )
             retryTaskNotActive(status)
             blockingScheduledExecutorService.runCurrentlyBlocked()
@@ -161,7 +163,8 @@ internal class EmbracePendingApiCallsSenderTest {
     @Test
     fun `retryTask is not active and doesn't run after init if network not reachable`() {
         initPendingApiCallsSender(
-            status = NetworkStatus.NOT_REACHABLE, runRetryJobAfterScheduling = true
+            status = NetworkStatus.NOT_REACHABLE,
+            runRetryJobAfterScheduling = true
         )
         blockingScheduledExecutorService.runCurrentlyBlocked()
         retryTaskNotActive(NetworkStatus.NOT_REACHABLE)
@@ -190,7 +193,8 @@ internal class EmbracePendingApiCallsSenderTest {
     fun `retryTask is active and runs after connection changes from not reachable to connected after retry job runs`() {
         connectedNetworkStatuses.forEach { status ->
             initPendingApiCallsSender(
-                status = NetworkStatus.NOT_REACHABLE, runRetryJobAfterScheduling = true
+                status = NetworkStatus.NOT_REACHABLE,
+                runRetryJobAfterScheduling = true
             )
             blockingScheduledExecutorService.runCurrentlyBlocked()
             pendingApiCallsSender.onNetworkConnectivityStatusChanged(status)
@@ -206,7 +210,8 @@ internal class EmbracePendingApiCallsSenderTest {
     fun `retryTask isn't active and doesn't run if there are no failed request after getting a connection before retry job is scheduled`() {
         connectedNetworkStatuses.forEach { status ->
             initPendingApiCallsSender(
-                status = NetworkStatus.NOT_REACHABLE, loadFailedRequest = false
+                status = NetworkStatus.NOT_REACHABLE,
+                loadFailedRequest = false
             )
             pendingApiCallsSender.onNetworkConnectivityStatusChanged(status)
             retryTaskNotActive(status)
@@ -254,7 +259,8 @@ internal class EmbracePendingApiCallsSenderTest {
                 lazy { "deviceId" },
                 lazy { "appVersionName" }
             ),
-            lazy { "deviceId" }, "appId"
+            lazy { "deviceId" },
+            "appId"
         )
         repeat(105) { k ->
             val request = mapper.logRequest(
@@ -323,7 +329,8 @@ internal class EmbracePendingApiCallsSenderTest {
 
     private fun retryTaskNotActive(status: NetworkStatus) {
         assertFalse(
-            "Failed for network status = $status", pendingApiCallsSender.isDeliveryTaskActive()
+            "Failed for network status = $status",
+            pendingApiCallsSender.isDeliveryTaskActive()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCallsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCallsTest.kt
@@ -99,7 +99,6 @@ internal class PendingApiCallsTest {
 
     @Test
     fun `Test that when the queue is full, the oldest api call is removed and the new one is added`() {
-
         Endpoint.values().forEach {
             pendingApiCalls = PendingApiCalls()
             val queueLimit = it.getMaxPendingApiCalls()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehaviorTest.kt
@@ -11,7 +11,8 @@ import org.junit.Test
 internal class SdkModeBehaviorTest {
 
     private val local = LocalConfig(
-        "", false,
+        "",
+        false,
         SdkLocalConfig(
             betaFeaturesEnabled = true
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
@@ -261,6 +261,7 @@ internal class EventHandlerTest {
         verify { mockDeliveryService.sendMoment(any()) }
         assertEquals(builtEndEventMessage, result)
     }
+
     @Test
     fun `verify onEventEnded builds event and sends the event`() {
         val eventProperties = mapOf<String, Any>()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
@@ -55,7 +55,8 @@ internal class AnrModuleImplTest {
     private fun createConfigServiceWithAnrDisabled() = FakeConfigService(
         autoDataCaptureBehavior = fakeAutoDataCaptureBehavior(localCfg = {
             LocalConfig(
-                "", false,
+                "",
+                false,
                 SdkLocalConfig(
                     automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(
                         anrServiceEnabled = false

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -141,6 +141,7 @@ internal class EmbraceNetworkCaptureServiceTest {
         val result = getService().getNetworkCaptureRules("https://embrace.io/changelog", "GET")
         assertTrue(result.isEmpty())
     }
+
     @Test
     fun `test capture rule duration`() {
         // capture calls that exceeds 5000ms
@@ -150,14 +151,22 @@ internal class EmbraceNetworkCaptureServiceTest {
         val service = getService()
         // duration = 2000ms shouldn't be captured
         service.logNetworkCapturedData(
-            "https://embrace.io/changelog", "GET", 200, 0, 2000,
+            "https://embrace.io/changelog",
+            "GET",
+            200,
+            0,
+            2000,
             mockk(relaxed = true)
         )
         verify(exactly = 0) { mockRemoteLogger.logNetwork(any()) }
 
         // duration = 6000ms should be captured
         service.logNetworkCapturedData(
-            "https://embrace.io/changelog", "GET", 200, 0, 6000,
+            "https://embrace.io/changelog",
+            "GET",
+            200,
+            0,
+            6000,
             mockk(relaxed = true)
         )
         verify(exactly = 1) { mockRemoteLogger.logNetwork(any()) }
@@ -170,19 +179,31 @@ internal class EmbraceNetworkCaptureServiceTest {
 
         val service = getService()
         service.logNetworkCapturedData(
-            "https://embrace.io/changelog", "GET", 200, 0, 2000,
+            "https://embrace.io/changelog",
+            "GET",
+            200,
+            0,
+            2000,
             mockk(relaxed = true)
         )
         verify(exactly = 1) { mockRemoteLogger.logNetwork(any()) }
 
         service.logNetworkCapturedData(
-            "https://embrace.io/changelog", "GET", 404, 0, 2000,
+            "https://embrace.io/changelog",
+            "GET",
+            404,
+            0,
+            2000,
             mockk(relaxed = true)
         )
         verify(exactly = 2) { mockRemoteLogger.logNetwork(any()) }
 
         service.logNetworkCapturedData(
-            "https://embrace.io/changelog", "GET", 500, 0, 2000,
+            "https://embrace.io/changelog",
+            "GET",
+            500,
+            0,
+            2000,
             mockk(relaxed = true)
         )
         verify(exactly = 2) { mockRemoteLogger.logNetwork(any()) }

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/TestServer.kt
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/TestServer.kt
@@ -69,7 +69,6 @@ public class TestServer {
  */
 public data class TestServerResponse(val statusCode: Int, val body: String = "") {
     public fun toMockWebServerResponse(): MockResponse {
-
         return MockResponse().setResponseCode(statusCode).also {
             if (body.isNotEmpty()) it.setBody(body)
         }

--- a/test-server/src/main/kotlin/io/embrace/android/embracesdk/utils/JsonValidator.kt
+++ b/test-server/src/main/kotlin/io/embrace/android/embracesdk/utils/JsonValidator.kt
@@ -51,7 +51,8 @@ internal object JsonValidator {
             }
             jsonElement1.isJsonPrimitive && jsonElement2.isJsonPrimitive -> {
                 return areJsonPrimitiveEquals(
-                    jsonElement1.asJsonPrimitive, jsonElement2.asJsonPrimitive
+                    jsonElement1.asJsonPrimitive,
+                    jsonElement2.asJsonPrimitive
                 )
             }
             jsonElement1.isJsonNull && jsonElement2.isJsonNull -> {
@@ -80,7 +81,8 @@ internal object JsonValidator {
                 try {
                     if (!areJsonElementsEquals(entry.value, jsonObject2.get(entry.key))) {
                         Log.e(
-                            JsonValidator.javaClass.simpleName, "Match failed for key: ${entry.key}"
+                            JsonValidator.javaClass.simpleName,
+                            "Match failed for key: ${entry.key}"
                         )
                         return false
                     }
@@ -111,7 +113,8 @@ internal object JsonValidator {
         jsonArray1.forEachIndexed { index, entry ->
             if (!areJsonElementsEquals(entry, jsonArray2.get(index))) {
                 Log.e(
-                    JsonValidator.javaClass.simpleName, "Different array value at position: $index."
+                    JsonValidator.javaClass.simpleName,
+                    "Different array value at position: $index."
                 )
                 return false
             }


### PR DESCRIPTION
## Goal

Update Kotlin runtime and enjoy the benefits

## Testing

Existing automated tests pass and manually tested with an app using our minimum supported versions

