### PR TITLE
Avoid access exceeds rights error message

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -4,17 +4,40 @@ package io.embrace.gradle
  * Defines dependency versions that are used in the project.
  */
 object Versions {
+    @JvmField
     val compileSdk = 33
+
+    @JvmField
     val minSdk = 21
+
+    @JvmField
     val junit = "4.13.2"
+
+    @JvmField
     val kotlin = "1.7.21"
+
     // kotin library exposed to the customer
+    @JvmField
     val kotlinExposed = "1.4.32"
+
+    @JvmField
     val dokka = "1.7.10"
+
+    @JvmField
     val detekt = "1.22.0"
+
+    @JvmField
     val binaryCompatValidator = "0.12.1"
+
+    @JvmField
     val agp = "7.3.0"
+
+    @JvmField
     val lint = "30.1.0"
+
+    @JvmField
     val ndk = "21.4.7075529"
+
+    @JvmField
     val openTelemetry = "1.29.0"
 }


### PR DESCRIPTION
## Goal

Avoids a warning message in the gradle build script that access exceeds its rights when accessing version fields from Groovy. Making the properties JVM fields is enough to stop the warning.
