### PR TITLE
Remove RN methods from Embrace.java

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -54,8 +54,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
 	public fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public fun logRnAction (Ljava/lang/String;JJLjava/util/Map;ILjava/lang/String;)V
-	public fun logRnView (Ljava/lang/String;)V
 	public fun logWarning (Ljava/lang/String;)V
 	public fun recordCompletedSpan (Ljava/lang/String;JJ)Z
 	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;)Z

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -132,6 +132,17 @@ public final class io/embrace/android/embracesdk/LogType : java/lang/Enum {
 	public static fun values ()[Lio/embrace/android/embracesdk/LogType;
 }
 
+public abstract interface class io/embrace/android/embracesdk/ReactNativeInternalInterface : io/embrace/android/embracesdk/internal/EmbraceInternalInterface {
+	public abstract fun logHandledJsException (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public abstract fun logRnAction (Ljava/lang/String;JJLjava/util/Map;ILjava/lang/String;)V
+	public abstract fun logRnView (Ljava/lang/String;)V
+	public abstract fun logUnhandledJsException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setJavaScriptBundleUrl (Landroid/content/Context;Ljava/lang/String;)V
+	public abstract fun setJavaScriptPatchNumber (Ljava/lang/String;)V
+	public abstract fun setReactNativeSdkVersion (Ljava/lang/String;)V
+	public abstract fun setReactNativeVersionNumber (Ljava/lang/String;)V
+}
+
 public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 	public static final field ERROR Lio/embrace/android/embracesdk/Severity;
 	public static final field INFO Lio/embrace/android/embracesdk/Severity;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -591,33 +591,8 @@ public final class Embrace implements EmbraceAndroidApi {
     }
 
     /**
-     * Logs a React Native Redux Action - this is not intended for public use.
      *
      * @hide
-     */
-    @InternalApi
-    public void logRnAction(@NonNull String name, long startTime, long endTime,
-                            @NonNull Map<String, Object> properties, int bytesSent, @NonNull String output) {
-        if (verifyNonNullParameters("logRnAction", name, properties, output)) {
-            impl.logRnAction(name, startTime, endTime, properties, bytesSent, output);
-        }
-    }
-
-    /**
-     * Logs the fact that a particular view was entered.
-     * <p>
-     * If the previously logged view has the same name, a duplicate view breadcrumb will not be
-     * logged.
-     *
-     * @param screen the name of the view to log
-     * @hide
-     */
-    @InternalApi
-    public void logRnView(@NonNull String screen) {
-        impl.logRnView(screen);
-    }
-
-    /**
      * Gets the {@link UnityInternalInterface} that should be used as the sole source of
      * communication with the Android SDK for Unity. Not part of the supported public API.
      *

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1294,21 +1294,6 @@ final class EmbraceImpl {
     }
 
     /**
-     * Logs the fact that a particular view was entered.
-     * <p>
-     * If the previously logged view has the same name, a duplicate view breadcrumb will not be
-     * logged.
-     *
-     * @param screen the name of the view to log
-     */
-    void logView(String screen) {
-        if (checkSdkStartedAndLogPublicApiUsage("log_view")) {
-            breadcrumbService.logView(screen, sdkClock.now());
-            onActivityReported();
-        }
-    }
-
-    /**
      * Saves captured push notification information into session payload
      *
      * @param title                    the title of the notification as a string (or null)
@@ -1501,7 +1486,10 @@ final class EmbraceImpl {
             return;
         }
 
-        logView(screen);
+        if (checkSdkStartedAndLogPublicApiUsage("log RN view")) {
+            breadcrumbService.logView(screen, sdkClock.now());
+            onActivityReported();
+        }
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
@@ -42,4 +42,26 @@ internal interface ReactNativeInternalInterface : EmbraceInternalInterface {
      * See [Embrace.setJavaScriptBundleURL]
      */
     fun setJavaScriptBundleUrl(context: Context, url: String)
+
+    /**
+     * Logs a React Native Redux Action - this is not intended for public use.
+     */
+    fun logRnAction(
+        name: String,
+        startTime: Long,
+        endTime: Long,
+        properties: Map<String?, Any?>,
+        bytesSent: Int,
+        output: String
+    )
+
+    /**
+     * Logs the fact that a particular view was entered.
+     *
+     * If the previously logged view has the same name, a duplicate view breadcrumb will not be
+     * logged.
+     *
+     * @param screen the name of the view to log
+     */
+    fun logRnView(screen: String)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
@@ -1,52 +1,42 @@
 package io.embrace.android.embracesdk
 
 import android.content.Context
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 
 /**
- * Provides an internal interface to Embrace that is intended for use by React Native as its
+ * Provides an internal interface to Embrace that is intended for use by the React Native SDK as its
  * sole source of communication with the Android SDK.
  */
-internal interface ReactNativeInternalInterface : EmbraceInternalInterface {
+@InternalApi
+public interface ReactNativeInternalInterface : EmbraceInternalInterface {
 
-    /**
-     * See [Embrace.logUnhandledJsException]
-     */
-    fun logUnhandledJsException(
+    public fun logUnhandledJsException(
         name: String,
         message: String,
         type: String?,
         stacktrace: String?
     )
 
-    fun logHandledJsException(
+    public fun logHandledJsException(
         name: String,
         message: String,
         properties: Map<String, Any>,
         stacktrace: String?
     )
 
-    /**
-     * See [Embrace.setJavaScriptPatchNumber]
-     */
-    fun setJavaScriptPatchNumber(number: String?)
+    public fun setJavaScriptPatchNumber(number: String?)
 
-    fun setReactNativeSdkVersion(version: String?)
+    public fun setReactNativeSdkVersion(version: String?)
 
-    /**
-     * See [Embrace.setReactNativeVersionNumber]
-     */
-    fun setReactNativeVersionNumber(version: String?)
+    public fun setReactNativeVersionNumber(version: String?)
 
-    /**
-     * See [Embrace.setJavaScriptBundleURL]
-     */
-    fun setJavaScriptBundleUrl(context: Context, url: String)
+    public fun setJavaScriptBundleUrl(context: Context, url: String)
 
     /**
      * Logs a React Native Redux Action - this is not intended for public use.
      */
-    fun logRnAction(
+    public fun logRnAction(
         name: String,
         startTime: Long,
         endTime: Long,
@@ -63,5 +53,5 @@ internal interface ReactNativeInternalInterface : EmbraceInternalInterface {
      *
      * @param screen the name of the view to log
      */
-    fun logRnView(screen: String)
+    public fun logRnView(screen: String)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
@@ -109,4 +109,19 @@ internal class ReactNativeInternalInterfaceImpl(
             logger.logSDKNotInitialized("set JavaScript bundle URL")
         }
     }
+
+    override fun logRnAction(
+        name: String,
+        startTime: Long,
+        endTime: Long,
+        properties: Map<String?, Any?>,
+        bytesSent: Int,
+        output: String
+    ) {
+        embrace.logRnAction(name, startTime, endTime, properties, bytesSent, output)
+    }
+
+    override fun logRnView(screen: String) {
+        embrace.logRnView(screen)
+    }
 }


### PR DESCRIPTION
## Goal

Move React Native methods from Embrace.java to the internal RN interface.

Note: I will wait for the React Native team's go-ahead before merging this, as their implementation will need to be updated to use the internal methods instead.