### PR TITLE
Remove Unity methods from Embrace.java

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -625,11 +625,6 @@ public final class Embrace implements EmbraceAndroidApi {
         return impl.getUnityInternalInterface();
     }
 
-    @InternalApi
-    void installUnityThreadSampler() {
-        impl.installUnityThreadSampler();
-    }
-
     /**
      * Gets the {@link FlutterInternalInterface} that should be used as the sole source of
      * communication with the Android SDK for Flutter.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterface.kt
@@ -51,4 +51,6 @@ internal interface UnityInternalInterface : EmbraceInternalInterface {
         statusCode: Int,
         traceId: String?
     )
+
+    fun installUnityThreadSampler()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterfaceImpl.kt
@@ -158,4 +158,8 @@ internal class UnityInternalInterfaceImpl(
             )
         )
     }
+
+    override fun installUnityThreadSampler() {
+        embrace.installUnityThreadSampler()
+    }
 }


### PR DESCRIPTION
## Goal

Move Unity methods from Embrace.java to the internal Unity interface.

Note: I will wait for the Unity team's go-ahead before merging this, as their implementation will need to be updated to use the internal methods instead.