### PR TITLE
Remove Flutter methods from Embrace.java

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -56,7 +56,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public fun logRnAction (Ljava/lang/String;JJLjava/util/Map;ILjava/lang/String;)V
 	public fun logRnView (Ljava/lang/String;)V
-	public fun logUnhandledDartException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun logWarning (Ljava/lang/String;)V
 	public fun recordCompletedSpan (Ljava/lang/String;JJ)Z
 	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
@@ -110,6 +109,13 @@ public final class io/embrace/android/embracesdk/EmbraceSamples {
 	public static final fun triggerAnr ()V
 	public static final fun triggerLongAnr ()V
 	public static final fun verifyIntegration ()V
+}
+
+public abstract interface class io/embrace/android/embracesdk/FlutterInternalInterface : io/embrace/android/embracesdk/internal/EmbraceInternalInterface {
+	public abstract fun logHandledDartException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun logUnhandledDartException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setDartVersion (Ljava/lang/String;)V
+	public abstract fun setEmbraceFlutterSdkVersion (Ljava/lang/String;)V
 }
 
 public final class io/embrace/android/embracesdk/LogExceptionType : java/lang/Enum {

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -50,7 +50,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logException (Ljava/lang/Throwable;Lio/embrace/android/embracesdk/Severity;)V
 	public fun logException (Ljava/lang/Throwable;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
 	public fun logException (Ljava/lang/Throwable;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;)V
-	public fun logHandledDartException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun logInfo (Ljava/lang/String;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
@@ -70,8 +69,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun recordSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun removeSessionProperty (Ljava/lang/String;)Z
 	public fun setAppId (Ljava/lang/String;)Z
-	public fun setDartVersion (Ljava/lang/String;)V
-	public fun setEmbraceFlutterSdkVersion (Ljava/lang/String;)V
 	public fun setUserAsPayer ()V
 	public fun setUserEmail (Ljava/lang/String;)V
 	public fun setUserIdentifier (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
-import io.embrace.android.embracesdk.config.ConfigService;
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface;
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger;
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger;
@@ -569,6 +568,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Get internal interface for the intra-Embrace, not-publicly-supported API
+     *
      * @hide
      */
     @NonNull
@@ -579,7 +579,8 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Gets the {@link ReactNativeInternalInterface} that should be used as the sole source of
-     * communication with the Android SDK for React Native.
+     * communication with the Android SDK for React Native. Not part of the supported public API.
+     *
      * @hide
      */
     @Nullable
@@ -590,6 +591,7 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Logs a React Native Redux Action - this is not intended for public use.
+     *
      * @hide
      */
     @InternalApi
@@ -605,9 +607,9 @@ public final class Embrace implements EmbraceAndroidApi {
      * <p>
      * If the previously logged view has the same name, a duplicate view breadcrumb will not be
      * logged.
-     * @hide
      *
      * @param screen the name of the view to log
+     * @hide
      */
     @InternalApi
     public void logRnView(@NonNull String screen) {
@@ -616,7 +618,8 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Gets the {@link UnityInternalInterface} that should be used as the sole source of
-     * communication with the Android SDK for Unity.
+     * communication with the Android SDK for Unity. Not part of the supported public API.
+     *
      * @hide
      */
     @Nullable
@@ -627,61 +630,14 @@ public final class Embrace implements EmbraceAndroidApi {
 
     /**
      * Gets the {@link FlutterInternalInterface} that should be used as the sole source of
-     * communication with the Android SDK for Flutter.
+     * communication with the Android SDK for Flutter. Not part of the supported public API.
+     *
      * @hide
      */
     @Nullable
     @InternalApi
     public FlutterInternalInterface getFlutterInternalInterface() {
         return impl.getFlutterInternalInterface();
-    }
-
-    /**
-     * Sets the Embrace Flutter SDK version - this is not intended for public use.
-     * @hide
-     */
-    @InternalApi
-    public void setEmbraceFlutterSdkVersion(@Nullable String version) {
-        impl.setEmbraceFlutterSdkVersion(version);
-    }
-
-    /**
-     * Sets the Dart version - this is not intended for public use.
-     * @hide
-     */
-    @InternalApi
-    public void setDartVersion(@Nullable String version) {
-        impl.setDartVersion(version);
-    }
-
-    /**
-     * Logs a handled Dart error to the Embrace SDK - this is not intended for public use.
-     * @hide
-     */
-    @InternalApi
-    public void logHandledDartException(
-        @Nullable String stack,
-        @Nullable String name,
-        @Nullable String message,
-        @Nullable String context,
-        @Nullable String library
-    ) {
-        impl.logDartException(stack, name, message, context, library, LogExceptionType.HANDLED);
-    }
-
-    /**
-     * Logs an unhandled Dart error to the Embrace SDK - this is not intended for public use.
-     * @hide
-     */
-    @InternalApi
-    public void logUnhandledDartException(
-        @Nullable String stack,
-        @Nullable String name,
-        @Nullable String message,
-        @Nullable String context,
-        @Nullable String library
-    ) {
-        impl.logDartException(stack, name, message, context, library, LogExceptionType.UNHANDLED);
     }
 
     private boolean verifyNonNullParameters(@NonNull String functionName, @NonNull Object... params) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1542,45 +1542,6 @@ final class EmbraceImpl {
         return flutterInternalInterface;
     }
 
-    /**
-     * Logs a Dart error to the Embrace SDK - this is not intended for public use.
-     */
-    void logDartException(
-        @Nullable String stack,
-        @Nullable String name,
-        @Nullable String message,
-        @Nullable String context,
-        @Nullable String library,
-        @NonNull LogExceptionType logExceptionType
-    ) {
-        if (flutterInternalInterface != null) {
-            if (logExceptionType == LogExceptionType.HANDLED) {
-                flutterInternalInterface.logHandledDartException(stack, name, message, context, library);
-            } else if (logExceptionType == LogExceptionType.UNHANDLED) {
-                flutterInternalInterface.logUnhandledDartException(stack, name, message, context, library);
-            }
-            onActivityReported();
-        }
-    }
-
-    /**
-     * Sets the Embrace Flutter SDK version - this is not intended for public use.
-     */
-    void setEmbraceFlutterSdkVersion(@Nullable String version) {
-        if (flutterInternalInterface != null) {
-            flutterInternalInterface.setEmbraceFlutterSdkVersion(version);
-        }
-    }
-
-    /**
-     * Sets the Dart version - this is not intended for public use.
-     */
-    void setDartVersion(@Nullable String version) {
-        if (flutterInternalInterface != null) {
-            flutterInternalInterface.setDartVersion(version);
-        }
-    }
-
     private void onActivityReported() {
         if (backgroundActivityService != null) {
             backgroundActivityService.save();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterface.kt
@@ -1,27 +1,29 @@
 package io.embrace.android.embracesdk
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 
 /**
  * Provides an internal interface to Embrace that is intended for use by Flutter as its
  * sole source of communication with the Android SDK.
  */
-internal interface FlutterInternalInterface : EmbraceInternalInterface {
+@InternalApi
+public interface FlutterInternalInterface : EmbraceInternalInterface {
 
     /**
      * Sets the Embrace Flutter SDK version - this is not intended for public use.
      */
-    fun setEmbraceFlutterSdkVersion(version: String?)
+    public fun setEmbraceFlutterSdkVersion(version: String?)
 
     /**
      * Sets the Dart version - this is not intended for public use.
      */
-    fun setDartVersion(version: String?)
+    public fun setDartVersion(version: String?)
 
     /**
      * Logs a handled Dart error to the Embrace SDK - this is not intended for public use.
      */
-    fun logHandledDartException(
+    public fun logHandledDartException(
         stack: String?,
         name: String?,
         message: String?,
@@ -32,7 +34,7 @@ internal interface FlutterInternalInterface : EmbraceInternalInterface {
     /**
      * Logs an unhandled Dart error to the Embrace SDK - this is not intended for public use.
      */
-    fun logUnhandledDartException(
+    public fun logUnhandledDartException(
         stack: String?,
         name: String?,
         message: String?,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterface.kt
@@ -9,17 +9,17 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 internal interface FlutterInternalInterface : EmbraceInternalInterface {
 
     /**
-     * See [Embrace.setEmbraceFlutterSdkVersion]
+     * Sets the Embrace Flutter SDK version - this is not intended for public use.
      */
     fun setEmbraceFlutterSdkVersion(version: String?)
 
     /**
-     * See [Embrace.setDartVersion]
+     * Sets the Dart version - this is not intended for public use.
      */
     fun setDartVersion(version: String?)
 
     /**
-     * See [Embrace.logHandledDartException]
+     * Logs a handled Dart error to the Embrace SDK - this is not intended for public use.
      */
     fun logHandledDartException(
         stack: String?,
@@ -30,7 +30,7 @@ internal interface FlutterInternalInterface : EmbraceInternalInterface {
     )
 
     /**
-     * See [Embrace.logUnhandledDartException]
+     * Logs an unhandled Dart error to the Embrace SDK - this is not intended for public use.
      */
     fun logUnhandledDartException(
         stack: String?,


### PR DESCRIPTION
## Goal

Remove Flutter methods from Embrace.java

Note: I will wait for the Flutter team's go-ahead before merging this, as their implementation will need to be updated to use the internal methods instead.