### PR TITLE
Remove internal API from Embrace.java

### DIFF
--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeInternalErrorLogger.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeInternalErrorLogger.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.Embrace
 internal class ComposeInternalErrorLogger {
 
     fun logError(throwable: Throwable) {
-        Embrace.getInstance().logInternalError(
+        Embrace.getInstance().internalInterface.logInternalError(
             throwable
         )
     }

--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
@@ -191,7 +191,7 @@ public class EmbraceOkHttp3NetworkInterceptor internal constructor(
                 i++
             }
             dataCaptureErrorMessage = "There were errors in capturing the following part(s) of the network call: %s$errors"
-            embrace.logInternalError(
+            embrace.internalInterface.logInternalError(
                 RuntimeException("Failure during the building of NetworkCaptureData. $dataCaptureErrorMessage", e)
             )
         }
@@ -227,7 +227,7 @@ public class EmbraceOkHttp3NetworkInterceptor internal constructor(
                 return buffer.readByteArray()
             }
         } catch (e: IOException) {
-            embrace.logInternalError("Failed to capture okhttp request body.", e.javaClass.toString())
+            embrace.internalInterface.logInternalError("Failed to capture okhttp request body.", e.javaClass.toString())
         }
         return null
     }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -29,7 +29,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun endSession (Z)V
 	public fun endView (Ljava/lang/String;)Z
 	public fun generateW3cTraceparent ()Ljava/lang/String;
-	public fun getConfigService ()Lio/embrace/android/embracesdk/config/ConfigService;
 	public fun getCurrentSessionId ()Ljava/lang/String;
 	public fun getDeviceId ()Ljava/lang/String;
 	public fun getFlutterInternalInterface ()Lio/embrace/android/embracesdk/FlutterInternalInterface;
@@ -53,8 +52,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logException (Ljava/lang/Throwable;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;)V
 	public fun logHandledDartException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun logInfo (Ljava/lang/String;)V
-	public fun logInternalError (Ljava/lang/String;Ljava/lang/String;)V
-	public fun logInternalError (Ljava/lang/Throwable;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
 	public fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
@@ -72,7 +69,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun recordSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun removeSessionProperty (Ljava/lang/String;)Z
-	public fun sampleCurrentThreadDuringAnrs ()V
 	public fun setAppId (Ljava/lang/String;)Z
 	public fun setDartVersion (Ljava/lang/String;)V
 	public fun setEmbraceFlutterSdkVersion (Ljava/lang/String;)V
@@ -173,12 +169,16 @@ public abstract interface annotation class io/embrace/android/embracesdk/annotat
 
 public abstract interface class io/embrace/android/embracesdk/internal/EmbraceInternalInterface {
 	public abstract fun getSdkCurrentTime ()J
+	public abstract fun isAnrCaptureEnabled ()Z
 	public abstract fun isInternalNetworkCaptureDisabled ()Z
+	public abstract fun isNdkEnabled ()Z
 	public abstract fun isNetworkSpanForwardingEnabled ()Z
 	public abstract fun logComposeTap (Landroid/util/Pair;Ljava/lang/String;)V
 	public abstract fun logError (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Z)V
 	public abstract fun logHandledException (Ljava/lang/Throwable;Lio/embrace/android/embracesdk/LogType;Ljava/util/Map;[Ljava/lang/StackTraceElement;)V
 	public abstract fun logInfo (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun logInternalError (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun logInternalError (Ljava/lang/Throwable;)V
 	public abstract fun logWarning (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
 	public abstract fun recordAndDeduplicateNetworkRequest (Ljava/lang/String;Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 	public abstract fun recordCompletedNetworkRequest (Ljava/lang/String;Ljava/lang/String;JJJJILjava/lang/String;Lio/embrace/android/embracesdk/internal/network/http/NetworkCaptureData;)V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -578,33 +578,6 @@ public final class Embrace implements EmbraceAndroidApi {
     }
 
     /**
-     * Logs an internal error to the Embrace SDK - this is not intended for public use.
-     * @hide
-     */
-    @InternalApi
-    public void logInternalError(@Nullable String message, @Nullable String details) {
-        impl.logInternalError(message, details);
-    }
-
-    /**
-     * Logs an internal error to the Embrace SDK - this is not intended for public use.
-     * @hide
-     */
-    @InternalApi
-    public void logInternalError(@NonNull Throwable error) {
-        impl.logInternalError(error);
-    }
-
-    /**
-     * @hide
-     */
-    @Nullable
-    @InternalApi
-    public ConfigService getConfigService() {
-        return impl.getConfigService();
-    }
-
-    /**
      * Gets the {@link ReactNativeInternalInterface} that should be used as the sole source of
      * communication with the Android SDK for React Native.
      * @hide
@@ -714,14 +687,6 @@ public final class Embrace implements EmbraceAndroidApi {
         @Nullable String library
     ) {
         impl.logDartException(stack, name, message, context, library, LogExceptionType.UNHANDLED);
-    }
-
-    /**
-     * @hide
-     */
-    @InternalApi
-    public void sampleCurrentThreadDuringAnrs() {
-        impl.sampleCurrentThreadDuringAnrs();
     }
 
     private boolean verifyNonNullParameters(@NonNull String functionName, @NonNull Object... params) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1300,23 +1300,6 @@ final class EmbraceImpl {
         return false;
     }
 
-    void sampleCurrentThreadDuringAnrs() {
-        try {
-            AnrService service = anrService;
-            if (service != null && nativeThreadSamplerInstaller != null) {
-                nativeThreadSamplerInstaller.monitorCurrentThread(
-                    nativeThreadSampler,
-                    configService,
-                    service
-                );
-            } else {
-                internalEmbraceLogger.logWarning("nativeThreadSamplerInstaller not started, cannot sample current thread");
-            }
-        } catch (Exception exc) {
-            internalEmbraceLogger.logError("Failed to sample current thread during ANRs", exc);
-        }
-    }
-
     /**
      * Logs the fact that a particular view was entered.
      * <p>
@@ -1594,6 +1577,23 @@ final class EmbraceImpl {
     private void onActivityReported() {
         if (backgroundActivityService != null) {
             backgroundActivityService.save();
+        }
+    }
+
+    private void sampleCurrentThreadDuringAnrs() {
+        try {
+            AnrService service = anrService;
+            if (service != null && nativeThreadSamplerInstaller != null) {
+                nativeThreadSamplerInstaller.monitorCurrentThread(
+                    nativeThreadSampler,
+                    configService,
+                    service
+                );
+            } else {
+                internalEmbraceLogger.logWarning("nativeThreadSamplerInstaller not started, cannot sample current thread");
+            }
+        } catch (Exception exc) {
+            internalEmbraceLogger.logError("Failed to sample current thread during ANRs", exc);
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import android.util.Pair
+import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
@@ -11,7 +12,8 @@ import io.embrace.android.embracesdk.payload.TapBreadcrumb
 
 internal class EmbraceInternalInterfaceImpl(
     private val embraceImpl: EmbraceImpl,
-    private val initModule: InitModule
+    private val initModule: InitModule,
+    private val configService: ConfigService
 ) : EmbraceInternalInterface {
 
     override fun logInfo(message: String, properties: Map<String, Any>?) {
@@ -173,11 +175,21 @@ internal class EmbraceInternalInterfaceImpl(
         embraceImpl.setProcessStartedByNotification()
     }
 
-    override fun isNetworkSpanForwardingEnabled(): Boolean {
-        return embraceImpl.configService?.networkSpanForwardingBehavior?.isNetworkSpanForwardingEnabled() ?: false
-    }
+    override fun isNetworkSpanForwardingEnabled(): Boolean = configService.networkSpanForwardingBehavior.isNetworkSpanForwardingEnabled()
 
     override fun getSdkCurrentTime(): Long = initModule.clock.now()
 
     override fun isInternalNetworkCaptureDisabled(): Boolean = ApkToolsConfig.IS_NETWORK_CAPTURE_DISABLED
+
+    override fun isAnrCaptureEnabled(): Boolean = configService.anrBehavior.isAnrCaptureEnabled()
+
+    override fun isNdkEnabled(): Boolean = configService.autoDataCaptureBehavior.isNdkEnabled()
+
+    override fun logInternalError(message: String?, details: String?) {
+        embraceImpl.logInternalError(message, details)
+    }
+
+    override fun logInternalError(error: Throwable) {
+        embraceImpl.logInternalError(error)
+    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/InternalInterfaceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/InternalInterfaceModule.kt
@@ -25,7 +25,7 @@ internal class InternalInterfaceModuleImpl(
 ) : InternalInterfaceModule {
 
     override val embraceInternalInterface: EmbraceInternalInterface by singleton {
-        EmbraceInternalInterfaceImpl(embrace, initModule)
+        EmbraceInternalInterfaceImpl(embrace, initModule, essentialServiceModule.configService)
     }
 
     override val reactNativeInternalInterface: ReactNativeInternalInterface by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
@@ -137,22 +137,37 @@ public interface EmbraceInternalInterface {
      * Whether network capture has been disabled through an internal, not-publicly supported means
      */
     public fun isInternalNetworkCaptureDisabled(): Boolean
+
+    public fun isAnrCaptureEnabled(): Boolean
+
+    public fun isNdkEnabled(): Boolean
+
+    /**
+     * Logs an internal error to the Embrace SDK - this is not intended for public use.
+     */
+    public fun logInternalError(message: String?, details: String?)
+
+    /**
+     * Logs an internal error to the Embrace SDK - this is not intended for public use.
+     */
+    public fun logInternalError(error: Throwable)
 }
 
 internal val defaultImpl = object : EmbraceInternalInterface {
 
-    override fun logInfo(message: String, properties: Map<String, Any>?) { }
+    override fun logInfo(message: String, properties: Map<String, Any>?) {}
 
-    override fun logWarning(message: String, properties: Map<String, Any>?, stacktrace: String?) { }
+    override fun logWarning(message: String, properties: Map<String, Any>?, stacktrace: String?) {}
 
-    override fun logError(message: String, properties: Map<String, Any>?, stacktrace: String?, isException: Boolean) { }
+    override fun logError(message: String, properties: Map<String, Any>?, stacktrace: String?, isException: Boolean) {}
 
     override fun logHandledException(
         throwable: Throwable,
         type: LogType,
         properties: Map<String, Any>?,
         customStackTrace: Array<StackTraceElement>?
-    ) { }
+    ) {
+    }
 
     override fun recordCompletedNetworkRequest(
         url: String,
@@ -164,7 +179,8 @@ internal val defaultImpl = object : EmbraceInternalInterface {
         statusCode: Int,
         traceId: String?,
         networkCaptureData: NetworkCaptureData?
-    ) { }
+    ) {
+    }
 
     override fun recordIncompleteNetworkRequest(
         url: String,
@@ -174,7 +190,8 @@ internal val defaultImpl = object : EmbraceInternalInterface {
         error: Throwable?,
         traceId: String?,
         networkCaptureData: NetworkCaptureData?
-    ) { }
+    ) {
+    }
 
     override fun recordIncompleteNetworkRequest(
         url: String,
@@ -185,19 +202,28 @@ internal val defaultImpl = object : EmbraceInternalInterface {
         errorMessage: String?,
         traceId: String?,
         networkCaptureData: NetworkCaptureData?
-    ) { }
+    ) {
+    }
 
-    override fun recordAndDeduplicateNetworkRequest(callId: String, embraceNetworkRequest: EmbraceNetworkRequest) { }
+    override fun recordAndDeduplicateNetworkRequest(callId: String, embraceNetworkRequest: EmbraceNetworkRequest) {}
 
-    override fun logComposeTap(point: Pair<Float, Float>, elementName: String) { }
+    override fun logComposeTap(point: Pair<Float, Float>, elementName: String) {}
 
     override fun shouldCaptureNetworkBody(url: String, method: String): Boolean = false
 
-    override fun setProcessStartedByNotification() { }
+    override fun setProcessStartedByNotification() {}
 
     override fun isNetworkSpanForwardingEnabled(): Boolean = false
 
     override fun getSdkCurrentTime(): Long = System.currentTimeMillis()
 
     override fun isInternalNetworkCaptureDisabled(): Boolean = false
+
+    override fun isAnrCaptureEnabled(): Boolean = false
+
+    override fun isNdkEnabled(): Boolean = false
+
+    override fun logInternalError(message: String?, details: String?) {}
+
+    override fun logInternalError(error: Throwable) {}
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamples.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamples.kt
@@ -12,7 +12,7 @@ internal object EmbraceCrashSamples {
 
     private val logger = InternalEmbraceLogger()
 
-    val ndkCrashSamplesNdkDelegate = EmbraceCrashSamplesNdkDelegateImpl()
+    private val ndkCrashSamplesNdkDelegate = EmbraceCrashSamplesNdkDelegateImpl()
 
     /**
      * Verifies if Embrace is initialized
@@ -35,7 +35,7 @@ internal object EmbraceCrashSamples {
      */
 
     fun checkAnrDetectionEnabled() {
-        if (Embrace.getInstance().configService?.anrBehavior?.isAnrCaptureEnabled() == false) {
+        if (!Embrace.getInstance().internalInterface.isAnrCaptureEnabled()) {
             val e = EmbraceSampleCodeException(
                 "ANR capture disabled - you need to enable it to test Embrace's ANR functionality:\n" +
                     " - add [\"anr\":{\"pct_enabled\": 100 }]" +
@@ -91,7 +91,7 @@ internal object EmbraceCrashSamples {
         // First verifies is Embrace SDK is initialized
         isSdkStarted()
 
-        if (Embrace.getInstance().configService?.autoDataCaptureBehavior?.isNdkEnabled() != true) {
+        if (!Embrace.getInstance().internalInterface.isNdkEnabled()) {
             val e = EmbraceSampleCodeException(
                 "NDK crash capture is disabled - you need to enable it to test Embrace's NDK functionality" +
                     " - To enable it, add [\"ndk_enabled\": true] inside the configuration file"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
@@ -2,7 +2,15 @@ package io.embrace.android.embracesdk
 
 import android.net.Uri
 import android.webkit.URLUtil
+import io.embrace.android.embracesdk.config.local.LocalConfig
+import io.embrace.android.embracesdk.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
+import io.embrace.android.embracesdk.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
+import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.fakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
@@ -20,28 +28,31 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.net.SocketException
 
 internal class EmbraceInternalInterfaceImplTest {
 
-    private lateinit var impl: EmbraceInternalInterfaceImpl
-    private lateinit var embrace: EmbraceImpl
+    private lateinit var internalImpl: EmbraceInternalInterfaceImpl
+    private lateinit var embraceImpl: EmbraceImpl
     private lateinit var fakeClock: FakeClock
     private lateinit var initModule: InitModule
+    private lateinit var fakeConfigService: FakeConfigService
 
     @Before
     fun setUp() {
-        embrace = mockk(relaxed = true)
+        embraceImpl = mockk(relaxed = true)
         fakeClock = FakeClock(currentTime = beforeObjectInitTime)
         initModule = FakeInitModule(clock = fakeClock)
-        impl = EmbraceInternalInterfaceImpl(embrace, initModule)
+        fakeConfigService = FakeConfigService()
+        internalImpl = EmbraceInternalInterfaceImpl(embraceImpl, initModule, fakeConfigService)
         ApkToolsConfig.IS_NETWORK_CAPTURE_DISABLED = false
     }
 
     @Test
     fun testLogInfo() {
-        impl.logInfo("", emptyMap())
+        internalImpl.logInfo("", emptyMap())
         verify(exactly = 1) {
-            embrace.logMessage(
+            embraceImpl.logMessage(
                 EmbraceEvent.Type.INFO_LOG,
                 "",
                 emptyMap(),
@@ -56,9 +67,9 @@ internal class EmbraceInternalInterfaceImplTest {
 
     @Test
     fun testLogWarning() {
-        impl.logWarning("", emptyMap(), null)
+        internalImpl.logWarning("", emptyMap(), null)
         verify(exactly = 1) {
-            embrace.logMessage(
+            embraceImpl.logMessage(
                 EmbraceEvent.Type.WARNING_LOG,
                 "",
                 emptyMap(),
@@ -73,9 +84,9 @@ internal class EmbraceInternalInterfaceImplTest {
 
     @Test
     fun testLogError() {
-        impl.logError("", emptyMap(), null, false)
+        internalImpl.logError("", emptyMap(), null, false)
         verify(exactly = 1) {
-            embrace.logMessage(
+            embraceImpl.logMessage(
                 EmbraceEvent.Type.ERROR_LOG,
                 "",
                 emptyMap(),
@@ -92,9 +103,9 @@ internal class EmbraceInternalInterfaceImplTest {
     @Test
     fun testLogHandledException() {
         val exception = Throwable("handled exception")
-        impl.logHandledException(exception, LogType.ERROR, emptyMap(), null)
+        internalImpl.logHandledException(exception, LogType.ERROR, emptyMap(), null)
         verify(exactly = 1) {
-            embrace.logMessage(
+            embraceImpl.logMessage(
                 EmbraceEvent.Type.ERROR_LOG,
                 "handled exception",
                 emptyMap(),
@@ -113,7 +124,7 @@ internal class EmbraceInternalInterfaceImplTest {
         mockkStatic(URLUtil::class)
         every { Uri.parse("https://google.com") } returns mockk(relaxed = true)
         every { URLUtil.isHttpsUrl("https://google.com") } returns true
-        impl.recordCompletedNetworkRequest(
+        internalImpl.recordCompletedNetworkRequest(
             "https://google.com",
             "get",
             15092342340,
@@ -126,7 +137,7 @@ internal class EmbraceInternalInterfaceImplTest {
         )
         val captor = slot<EmbraceNetworkRequest>()
         verify(exactly = 1) {
-            embrace.recordNetworkRequest(capture(captor))
+            embraceImpl.recordNetworkRequest(capture(captor))
         }
 
         val request = captor.captured
@@ -149,7 +160,7 @@ internal class EmbraceInternalInterfaceImplTest {
         every { URLUtil.isHttpsUrl("https://google.com") } returns true
 
         val exc = RuntimeException("Whoops")
-        impl.recordIncompleteNetworkRequest(
+        internalImpl.recordIncompleteNetworkRequest(
             "https://google.com",
             "get",
             15092342340L,
@@ -160,7 +171,7 @@ internal class EmbraceInternalInterfaceImplTest {
         )
         val captor = slot<EmbraceNetworkRequest>()
         verify(exactly = 1) {
-            embrace.recordNetworkRequest(capture(captor))
+            embraceImpl.recordNetworkRequest(capture(captor))
         }
 
         val request = captor.captured
@@ -181,10 +192,14 @@ internal class EmbraceInternalInterfaceImplTest {
         val networkRequest: EmbraceNetworkRequest = mockk()
         every { networkRequest.url } answers { url }
 
-        impl.recordAndDeduplicateNetworkRequest(callId, networkRequest)
+        defaultImpl.recordAndDeduplicateNetworkRequest(callId, networkRequest)
+        verify(exactly = 0) {
+            embraceImpl.recordAndDeduplicateNetworkRequest(any(), any())
+        }
 
+        internalImpl.recordAndDeduplicateNetworkRequest(callId, networkRequest)
         verify(exactly = 1) {
-            embrace.recordAndDeduplicateNetworkRequest(callId, capture(captor))
+            embraceImpl.recordAndDeduplicateNetworkRequest(callId, capture(captor))
         }
 
         assertEquals(url, captor.captured.url)
@@ -192,10 +207,10 @@ internal class EmbraceInternalInterfaceImplTest {
 
     @Test
     fun `check usage of SDK time`() {
-        assertEquals(beforeObjectInitTime, impl.getSdkCurrentTime())
-        assertTrue(impl.getSdkCurrentTime() < System.currentTimeMillis())
+        assertEquals(beforeObjectInitTime, internalImpl.getSdkCurrentTime())
+        assertTrue(internalImpl.getSdkCurrentTime() < System.currentTimeMillis())
         fakeClock.tick(10L)
-        assertEquals(fakeClock.now(), impl.getSdkCurrentTime())
+        assertEquals(fakeClock.now(), internalImpl.getSdkCurrentTime())
     }
 
     @Test
@@ -206,13 +221,65 @@ internal class EmbraceInternalInterfaceImplTest {
 
     @Test
     fun `test isInternalNetworkCaptureDisabled`() {
-        assertFalse(impl.isInternalNetworkCaptureDisabled())
+        assertFalse(internalImpl.isInternalNetworkCaptureDisabled())
         ApkToolsConfig.IS_NETWORK_CAPTURE_DISABLED = true
-        assertTrue(impl.isInternalNetworkCaptureDisabled())
+        assertTrue(internalImpl.isInternalNetworkCaptureDisabled())
         assertFalse(defaultImpl.isInternalNetworkCaptureDisabled())
     }
 
+    @Test
+    fun `check isNetworkSpanForwardingEnabled`() {
+        assertFalse(internalImpl.isNetworkSpanForwardingEnabled())
+        fakeConfigService.networkSpanForwardingBehavior =
+            fakeNetworkSpanForwardingBehavior(remoteConfig = { NetworkSpanForwardingRemoteConfig(pctEnabled = 100.0f) })
+        assertTrue(internalImpl.isNetworkSpanForwardingEnabled())
+    }
+
+    @Test
+    fun `check isAnrCaptureEnabled`() {
+        assertTrue(internalImpl.isAnrCaptureEnabled())
+        fakeConfigService.anrBehavior = fakeAnrBehavior(remoteCfg = { AnrRemoteConfig(pctEnabled = 0) })
+        assertFalse(internalImpl.isAnrCaptureEnabled())
+        fakeConfigService.anrBehavior = fakeAnrBehavior(remoteCfg = { AnrRemoteConfig(pctEnabled = 100) })
+        assertTrue(internalImpl.isAnrCaptureEnabled())
+        assertFalse(defaultImpl.isAnrCaptureEnabled())
+    }
+
+    @Test
+    fun `check isNdkEnabled`() {
+        assertFalse(internalImpl.isNdkEnabled())
+        fakeConfigService.autoDataCaptureBehavior =
+            fakeAutoDataCaptureBehavior(localCfg = { LocalConfig("abcde", true, SdkLocalConfig()) })
+        assertTrue(internalImpl.isNdkEnabled())
+        assertFalse(defaultImpl.isNdkEnabled())
+    }
+
+    @Test
+    fun `check logInternalError with exception`() {
+        val expectedException = SocketException()
+        defaultImpl.logInternalError(expectedException)
+        verify(exactly = 0) {
+            embraceImpl.logInternalError(any())
+        }
+        internalImpl.logInternalError(expectedException)
+        verify(exactly = 1) {
+            embraceImpl.logInternalError(expectedException)
+        }
+    }
+
+    @Test
+    fun `check logInternalError with error type and message`() {
+        defaultImpl.logInternalError("err", "message")
+        verify(exactly = 0) {
+            embraceImpl.logInternalError(any(), any())
+        }
+        internalImpl.logInternalError("err", "message")
+        verify(exactly = 1) {
+            embraceImpl.logInternalError("err", "message")
+        }
+    }
+
     companion object {
-        val beforeObjectInitTime = System.currentTimeMillis() - 1
+        private val beforeObjectInitTime = System.currentTimeMillis() - 1
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamplesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamplesTest.kt
@@ -2,12 +2,10 @@ package io.embrace.android.embracesdk.samples
 
 import io.embrace.android.embracesdk.Embrace
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.junit.AfterClass
 import org.junit.Assert.assertThrows
-import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 
@@ -30,11 +28,6 @@ internal class EmbraceCrashSamplesTest {
         }
     }
 
-    @Before
-    fun setup() {
-        every { Embrace.getInstance().configService } returns mockk(relaxed = true)
-    }
-
     @Test
     fun `test isSdkStarted with isStarted false throws EmbraceNotInitializedException`() {
         every { Embrace.getInstance().isStarted } returns false
@@ -43,7 +36,7 @@ internal class EmbraceCrashSamplesTest {
 
     @Test
     fun `test checkAnrDetectionEnabled throws EmbraceAnrDisabledException if isAnrCaptureEnabled is false`() {
-        every { Embrace.getInstance().configService?.anrBehavior?.isAnrCaptureEnabled() } returns false
+        every { Embrace.getInstance().internalInterface.isAnrCaptureEnabled() } returns false
         assertThrows(EmbraceSampleCodeException::class.java) { crashSampleTest.checkAnrDetectionEnabled() }
     }
 
@@ -56,6 +49,7 @@ internal class EmbraceCrashSamplesTest {
     @Test
     fun `test checkNdkDetectionEnabled with isNdkEnabled false throws EmbraceNdkDisabledException`() {
         every { Embrace.getInstance().isStarted } returns true
+        every { Embrace.getInstance().internalInterface.isNdkEnabled() } returns false
         assertThrows(EmbraceSampleCodeException::class.java) { crashSampleTest.checkNdkDetectionEnabled() }
     }
 


### PR DESCRIPTION
## Goal

Move internal methods from Embrace.java to the internal interface and implementation. It's better to have them in the internal interface than mark them as internal and hide them from the documentation.

## Testing

Added new unit tests but not integration test yet
