### PR TITLE
Refactor pending api call queue

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
@@ -87,4 +87,9 @@ internal interface CacheService {
      * @return list of file names
      */
     fun listFilenamesByPrefix(prefix: String): List<String>?
+
+    /**
+     * Loads pending API calls from their old location on disk.
+     */
+    fun loadOldPendingApiCalls(name: String): List<PendingApiCall>?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -160,6 +160,20 @@ internal class EmbraceCacheService(
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    override fun loadOldPendingApiCalls(name: String): List<PendingApiCall>? {
+        val file = File(storageDir, EMBRACE_PREFIX + name)
+        try {
+            val results = serializer.fromJson(file.inputStream(), ArrayList::class.java)
+            return results as List<PendingApiCall>? ?: return emptyList()
+        } catch (ex: FileNotFoundException) {
+            logger.logDebug("Cache file cannot be found " + file.path)
+        } catch (ex: Exception) {
+            logger.logDebug("Failed to read cache object " + file.path, ex)
+        }
+        return null
+    }
+
     companion object {
         private const val EMBRACE_PREFIX = "emb_"
         private const val TAG = "EmbraceCacheService"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -244,7 +244,7 @@ internal class EmbraceDeliveryCacheManager(
         logger.logDeveloper(TAG, "Loading old version of pending api calls")
         var cachedApiCallsPerEndpoint: PendingApiCalls? = null
         val loadPendingApiCallsQueue = runCatching {
-            cacheService.loadObject(PENDING_API_CALLS_FILE_NAME, PendingApiCallsQueue::class.java)
+            cacheService.loadOldPendingApiCalls(PENDING_API_CALLS_FILE_NAME)
         }
 
         if (loadPendingApiCallsQueue.isSuccess) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCall.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCall.kt
@@ -2,12 +2,6 @@ package io.embrace.android.embracesdk.comms.delivery
 
 import com.google.gson.annotations.SerializedName
 import io.embrace.android.embracesdk.comms.api.ApiRequest
-import java.util.concurrent.ConcurrentLinkedQueue
-
-/**
- * A queue containing pending API calls.
- */
-internal class PendingApiCallsQueue : ConcurrentLinkedQueue<PendingApiCall>()
 
 /**
  * A pending API call.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCalls.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCalls.kt
@@ -1,14 +1,17 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import com.google.gson.annotations.SerializedName
 import io.embrace.android.embracesdk.comms.api.EmbraceApiService.Companion.Endpoint
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A map containing a queue of pending API calls for each endpoint.
  */
-internal class PendingApiCalls {
-
-    private val pendingApiCallsMap = ConcurrentHashMap<Endpoint, PendingApiCallsQueue>()
+internal class PendingApiCalls(
+    @SerializedName("pendingApiCallsMap")
+    internal val pendingApiCallsMap: MutableMap<Endpoint, MutableList<PendingApiCall>> = ConcurrentHashMap<
+        Endpoint, MutableList<PendingApiCall>>()
+) {
 
     /**
      * Adds a pending API call in the corresponding endpoint's queue.
@@ -17,11 +20,11 @@ internal class PendingApiCalls {
      */
     fun add(pendingApiCall: PendingApiCall) {
         val endpoint = pendingApiCall.apiRequest.url.endpoint()
-        val pendingApiCallsForEndpoint = pendingApiCallsMap.getOrPut(endpoint) { PendingApiCallsQueue() }
+        val pendingApiCallsForEndpoint = pendingApiCallsMap.getOrPut(endpoint, ::mutableListOf)
 
         synchronized(pendingApiCallsForEndpoint) {
             if (pendingApiCallsForEndpoint.hasReachedLimit(endpoint)) {
-                pendingApiCallsForEndpoint.remove()
+                pendingApiCallsForEndpoint.removeFirstOrNull()
             }
             pendingApiCallsForEndpoint.add(pendingApiCall)
         }
@@ -35,7 +38,7 @@ internal class PendingApiCalls {
         pendingApiCallsMap[Endpoint.SESSIONS]?.let { sessionsQueue ->
             synchronized(sessionsQueue) {
                 if (sessionsQueue.isNotEmpty()) {
-                    return sessionsQueue.poll()
+                    return sessionsQueue.removeFirstOrNull()
                 }
             }
         }
@@ -43,12 +46,12 @@ internal class PendingApiCalls {
         val queueWithMinTime = pendingApiCallsMap
             .entries
             .filter { it.value.isNotEmpty() }
-            .minByOrNull { it.value.peek()?.queueTime ?: Long.MAX_VALUE }
+            .minByOrNull { it.value.firstOrNull()?.queueTime ?: Long.MAX_VALUE }
             ?.value
 
         return queueWithMinTime?.let { queue ->
             synchronized(queue) {
-                queue.poll()
+                queue.removeFirstOrNull()
             }
         }
     }
@@ -56,7 +59,7 @@ internal class PendingApiCalls {
     /**
      * Returns true if the endpoint's queue has reached its limit.
      */
-    private fun PendingApiCallsQueue.hasReachedLimit(endpoint: Endpoint): Boolean {
+    private fun MutableList<PendingApiCall>.hasReachedLimit(endpoint: Endpoint): Boolean {
         return this.size >= endpoint.getMaxPendingApiCalls()
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.comms.delivery.CacheService
+import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.SessionMessage
 import java.util.concurrent.ConcurrentHashMap
@@ -65,5 +66,11 @@ internal class TestCacheService : CacheService {
 
     override fun writeSession(name: String, sessionMessage: SessionMessage) {
         cacheBytes(name, serializer.toJson(sessionMessage).toByteArray())
+    }
+
+    var oldPendingApiCalls: List<PendingApiCall>? = null
+
+    override fun loadOldPendingApiCalls(name: String): List<PendingApiCall>? {
+        return oldPendingApiCalls
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.comms.delivery.CacheService
+import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
 import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal class FakeCacheService : CacheService {
@@ -41,6 +42,10 @@ internal class FakeCacheService : CacheService {
     }
 
     override fun writeSession(name: String, sessionMessage: SessionMessage) {
+        TODO("Not yet implemented")
+    }
+
+    override fun loadOldPendingApiCalls(name: String): List<PendingApiCall>? {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Goal

Refactors the pending API call queue implementation. Moshi does not handle serializing queues out of the box, so the easiest solution is to use a List instead.

## Testing

Relied on existing test coverage.
