### PR TITLE
Stream pending api calls to disk

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -203,9 +203,8 @@ internal class EmbraceDeliveryCacheManager(
      */
     override fun savePendingApiCalls(pendingApiCalls: PendingApiCalls) {
         logger.logDeveloper(TAG, "Saving pending api calls")
-        val bytes = serializer.toJson(pendingApiCalls).toByteArray()
         executorService.submit {
-            cacheService.cacheBytes(PENDING_API_CALLS_FILE_NAME, bytes)
+            cacheService.cacheObject(PENDING_API_CALLS_FILE_NAME, pendingApiCalls, PendingApiCalls::class.java)
         }
     }
 


### PR DESCRIPTION
## Goal

Streams pending API calls to disk on a background thread. This avoids serialization on the main thread that could happen often if a network request failed, and also reduces the memory pressure where the number of requests is high.

## Testing

Manually tested & relied on existing test coverage.

