### PR TITLE
Make requests using streams

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClient.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.comms.api
 
-import java.io.ByteArrayInputStream
-
 /**
  * A simple interface to make internal HTTP requests to the Embrace API
  */
@@ -12,10 +10,10 @@ internal interface ApiClient {
     fun executeGet(request: ApiRequest): ApiResponse
 
     /**
-     * Executes [ApiRequest] as a POST with the given body defined by [payloadStream], returning the response as a [ApiResponse].
-     * The body will be gzip compressed.
+     * Executes [ApiRequest] as a POST with the supplied action that writes to an outputstream,
+     * returning the response as a [ApiResponse]. The body will be gzip compressed.
      */
-    fun executePost(request: ApiRequest, payloadStream: ByteArrayInputStream): ApiResponse
+    fun executePost(request: ApiRequest, action: SerializationAction): ApiResponse
 
     companion object {
         /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.NO_HTTP_RESPO
 import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.TOO_MANY_REQUESTS
 import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.defaultTimeoutMs
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -47,7 +46,7 @@ internal class ApiClientImpl(
 
     override fun executePost(
         request: ApiRequest,
-        payloadStream: ByteArrayInputStream
+        action: SerializationAction
     ): ApiResponse {
         logger.logDeveloper("ApiClient", request.httpMethod.toString() + " " + request.url)
         logger.logDeveloper("ApiClient", "Request details: $request")
@@ -57,9 +56,7 @@ internal class ApiClientImpl(
             setTimeouts(connection)
 
             connection.outputStream?.let { httpStream ->
-                GZIPOutputStream(httpStream).use { outputStream ->
-                    payloadStream.copyTo(outputStream)
-                }
+                GZIPOutputStream(httpStream).use(action)
             }
             connection.connect()
             val response = executeHttpRequest(connection)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/SerializationAction.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/SerializationAction.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.comms.api
+
+import java.io.OutputStream
+
+/**
+ * Typealias for a function that writes to an [OutputStream]. This is used to make it
+ * easier to pass around logic for serializing data to arbitrary streams.
+ */
+internal typealias SerializationAction = (outputStream: OutputStream) -> Unit

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.payload.SessionMessage
 
 /**
@@ -35,6 +36,14 @@ internal interface CacheService {
     fun cacheBytes(name: String, bytes: ByteArray?)
 
     /**
+     * Caches a payload to disk.
+     *
+     * @param name   the name of this cache in disk
+     * @param action action that writes bytes
+     */
+    fun cachePayload(name: String, action: SerializationAction)
+
+    /**
      * Serializes a session object to disk via a stream. This saves memory when the session is
      * large & the return value isn't used (e.g. for a crash & periodic caching)
      */
@@ -47,6 +56,15 @@ internal interface CacheService {
      * @return the byte array, if it can be read successfully
      */
     fun loadBytes(name: String): ByteArray?
+
+    /**
+     * Provides a function that writes the bytes from a cached file, if it exists, to an
+     * outputstream
+     *
+     * @param name  the name of the file to read
+     * @return a function that writes the byte array, if it can be read successfully
+     */
+    fun loadPayload(name: String): SerializationAction
 
     /**
      * Delete a file from the cache

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -16,8 +17,9 @@ internal interface DeliveryCacheManager {
     fun saveCrash(crash: EventMessage)
     fun loadCrash(): EventMessage?
     fun deleteCrash()
-    fun savePayload(bytes: ByteArray): String
+    fun savePayload(action: SerializationAction): String
     fun loadPayload(name: String): ByteArray?
+    fun loadPayloadAsAction(name: String): SerializationAction?
     fun deletePayload(name: String)
     fun savePendingApiCalls(pendingApiCalls: PendingApiCalls)
     fun loadPendingApiCalls(): PendingApiCalls

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
@@ -180,16 +181,20 @@ internal class EmbraceDeliveryCacheManager(
         cacheService.deleteFile(CRASH_FILE_NAME)
     }
 
-    override fun savePayload(bytes: ByteArray): String {
+    override fun savePayload(action: SerializationAction): String {
         val name = "payload_" + Uuid.getEmbUuid()
         executorService.submit {
-            cacheService.cacheBytes(name, bytes)
+            cacheService.cachePayload(name, action)
         }
         return name
     }
 
     override fun loadPayload(name: String): ByteArray? {
         return cacheService.loadBytes(name)
+    }
+
+    override fun loadPayloadAsAction(name: String): SerializationAction? {
+        return cacheService.loadPayload(name)
     }
 
     override fun deletePayload(name: String) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCallsSender.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCallsSender.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.comms.delivery
 
 import io.embrace.android.embracesdk.comms.api.ApiRequest
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 
 /**
  * Manages the Pending API calls and schedules them to be sent later.
@@ -10,10 +11,10 @@ internal interface PendingApiCallsSender {
     /**
      * Sets the method to be used when sending an [ApiRequest]
      */
-    fun setSendMethod(sendMethod: (request: ApiRequest, payload: ByteArray) -> Unit)
+    fun setSendMethod(sendMethod: (request: ApiRequest, action: SerializationAction) -> Unit)
 
     /**
      * Schedules an API call to be sent later.
      */
-    fun scheduleApiCall(request: ApiRequest, payload: ByteArray)
+    fun scheduleApiCall(request: ApiRequest, action: SerializationAction)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
 
@@ -86,6 +87,34 @@ internal class EmbraceCacheServiceTest {
 
         val loadedObject = service.loadObject(CUSTOM_OBJECT_1_FILE_NAME, Session::class.java)
         assertEquals(myObject, checkNotNull(loadedObject))
+    }
+
+    @Test
+    fun `test cachePayload and loadPayload`() {
+        service.cachePayload(CUSTOM_OBJECT_1_FILE_NAME) { it.write("test".toByteArray()) }
+        val children = checkNotNull(dir.listFiles())
+        val file = children.single()
+        assertEquals("emb_$CUSTOM_OBJECT_1_FILE_NAME", file.name)
+
+        val action = checkNotNull(service.loadPayload(CUSTOM_OBJECT_1_FILE_NAME))
+        val stream = ByteArrayOutputStream()
+        action(stream)
+        assertEquals("test", String(stream.toByteArray()))
+    }
+
+    @Test
+    fun `cachePayload action throws exception`() {
+        service.cachePayload(CUSTOM_OBJECT_1_FILE_NAME) { error("Whoops") }
+        val children = checkNotNull(dir.listFiles())
+        assertTrue(children.isEmpty())
+    }
+
+    @Test
+    fun `test loadPayload with non-existent file returns null`() {
+        val action = service.loadPayload("some_file.jpeg")
+        val stream = ByteArrayOutputStream()
+        action(stream)
+        assertEquals("", String(stream.toByteArray()))
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
@@ -1,9 +1,11 @@
 package io.embrace.android.embracesdk
 
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.comms.delivery.CacheService
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.SessionMessage
+import java.io.ByteArrayOutputStream
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
 
@@ -72,5 +74,17 @@ internal class TestCacheService : CacheService {
 
     override fun loadOldPendingApiCalls(name: String): List<PendingApiCall>? {
         return oldPendingApiCalls
+    }
+
+    override fun cachePayload(name: String, action: SerializationAction) {
+        val stream = ByteArrayOutputStream()
+        action(stream)
+        cache[name] = stream.toByteArray()
+    }
+
+    override fun loadPayload(name: String): SerializationAction {
+        return {
+            it.write(cache[name])
+        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
@@ -49,7 +49,9 @@ internal class ApiClientImplTest {
     fun testUnreachableHost() {
         // attempt some unreachable port
         val request = ApiRequest(url = EmbraceUrl.create("http://localhost:1565"))
-        val response = apiClient.executePost(request, "Hello world".toByteArray().inputStream())
+        val response = apiClient.executePost(request) {
+            it.write("Hello world".toByteArray())
+        }
         check(response is ApiResponse.Incomplete)
         assertTrue(response.exception is IllegalStateException)
     }
@@ -117,7 +119,9 @@ internal class ApiClientImplTest {
 
     @Test
     fun testPostConnectionThrows() {
-        val response = apiClient.executePost(createThrowingRequest(), DEFAULT_REQUEST_BODY.toByteArray().inputStream())
+        val response = apiClient.executePost(createThrowingRequest()) {
+            it.write(DEFAULT_REQUEST_BODY.toByteArray())
+        }
         check(response is ApiResponse.Incomplete)
         assertTrue(response.exception is java.lang.IllegalStateException)
     }
@@ -176,7 +180,9 @@ internal class ApiClientImplTest {
             EmbraceUrl.create(baseUrl)
         )
         server.enqueue(response200)
-        apiClient.executePost(postRequest, DEFAULT_REQUEST_BODY.toByteArray().inputStream())
+        apiClient.executePost(postRequest) {
+            it.write(DEFAULT_REQUEST_BODY.toByteArray())
+        }
 
         // assert all request headers were set
         val delivered = server.takeRequest()
@@ -215,9 +221,10 @@ internal class ApiClientImplTest {
             ApiRequest(
                 url = EmbraceUrl.create(baseUrl),
                 httpMethod = HttpMethod.POST
-            ),
-            payload.inputStream()
-        )
+            )
+        ) {
+            it.write(payload)
+        }
 
     private fun createThrowingRequest(): ApiRequest {
         val mockEmbraceUrl: EmbraceUrl = mockk(relaxed = true)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiClient.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiClient.kt
@@ -3,7 +3,9 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.comms.api.ApiClient
 import io.embrace.android.embracesdk.comms.api.ApiRequest
 import io.embrace.android.embracesdk.comms.api.ApiResponse
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.util.LinkedList
 import java.util.Queue
 
@@ -11,15 +13,18 @@ internal class FakeApiClient : ApiClient {
     val sentRequests: MutableList<Pair<ApiRequest, ByteArrayInputStream?>> = mutableListOf()
     private val queuedResponses: Queue<ApiResponse> = LinkedList()
 
-    override fun executeGet(request: ApiRequest): ApiResponse = getNext(request, null)
+    override fun executeGet(request: ApiRequest): ApiResponse = getNext(request) {}
 
-    override fun executePost(request: ApiRequest, payloadStream: ByteArrayInputStream): ApiResponse = getNext(request, payloadStream)
+    override fun executePost(request: ApiRequest, action: SerializationAction): ApiResponse = getNext(request, action)
 
     fun queueResponse(response: ApiResponse) {
         queuedResponses.add(response)
     }
 
-    private fun getNext(request: ApiRequest, bytes: ByteArrayInputStream?): ApiResponse {
+    private fun getNext(request: ApiRequest, action: SerializationAction): ApiResponse {
+        val stream = ByteArrayOutputStream()
+        action(stream)
+        val bytes = ByteArrayInputStream(stream.toByteArray())
         sentRequests.add(Pair(request, bytes))
         return checkNotNull(queuedResponses.poll()) { "No response" }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.comms.delivery.CacheService
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -46,6 +47,14 @@ internal class FakeCacheService : CacheService {
     }
 
     override fun loadOldPendingApiCalls(name: String): List<PendingApiCall>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun cachePayload(name: String, action: SerializationAction) {
+        TODO("Not yet implemented")
+    }
+
+    override fun loadPayload(name: String): SerializationAction {
         TODO("Not yet implemented")
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.comms.delivery.DeliveryCacheManager
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
@@ -49,10 +50,6 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
         TODO("Not yet implemented")
     }
 
-    override fun savePayload(bytes: ByteArray): String {
-        TODO("Not yet implemented")
-    }
-
     override fun loadPayload(name: String): ByteArray? {
         TODO("Not yet implemented")
     }
@@ -66,6 +63,14 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
     }
 
     override fun loadPendingApiCalls(): PendingApiCalls {
+        TODO("Not yet implemented")
+    }
+
+    override fun savePayload(action: SerializationAction): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun loadPayloadAsAction(name: String): SerializationAction? {
         TODO("Not yet implemented")
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePendingApiCallsSender.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePendingApiCallsSender.kt
@@ -1,21 +1,25 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.comms.api.ApiRequest
+import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCallsSender
+import java.io.ByteArrayOutputStream
 import java.util.LinkedList
 import java.util.Queue
 
 internal class FakePendingApiCallsSender : PendingApiCallsSender {
 
     val retryQueue: Queue<Pair<ApiRequest, ByteArray?>> = LinkedList()
-    private var sendMethod: ((ApiRequest, ByteArray) -> Unit)? = null
+    private var sendMethod: ((ApiRequest, SerializationAction) -> Unit)? = null
 
-    override fun scheduleApiCall(request: ApiRequest, payload: ByteArray) {
+    override fun scheduleApiCall(request: ApiRequest, action: SerializationAction) {
         check(sendMethod != null) { "Retried to schedule retry before component is ready" }
-        retryQueue.add(Pair(request, payload))
+        val stream = ByteArrayOutputStream()
+        action(stream)
+        retryQueue.add(Pair(request, stream.toByteArray()))
     }
 
-    override fun setSendMethod(sendMethod: (request: ApiRequest, payload: ByteArray) -> Unit) {
+    override fun setSendMethod(sendMethod: (request: ApiRequest, action: SerializationAction) -> Unit) {
         this.sendMethod = sendMethod
     }
 }


### PR DESCRIPTION
## Goal

Instead of serializing to a `ByteArray` this alters requests so that they write directly to the HTTP request's outputstream. This reduces the memory impact of the SDK and should have negligible impact on CPU usage (the only negative case is where a network connection is poor, the request fails & it's necessary to reserialize the payload to disk).

This is implemented by taking a lambda parameter that writes to an `OutputStream`. I have created a typealias for convenience. This PR makes the change for all requests other than sessions; subsequent requests will attempt to remove the remaining uses of in-memory buffers.

## Testing

Added to existing unit test coverage.
