### PR TITLE
Fix proguard rules

### DIFF
--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -11,3 +11,6 @@
 ## Proguard configuration for Arrow
 -keep class java9.** { *; }
 -dontwarn java9.**
+
+## OTel
+-keep class io.opentelemetry.api.trace.StatusCode { *; }


### PR DESCRIPTION
## Goal

Fixes a bug where the `StatusCode` enum from the OTel library was getting stripped out. Moshi fails more loudly than Gson so this was failing with an exception whenever the app went into the background.

## Testing

Manually verified in the android-test-suite app.
