### PR TITLE
Move SDK init span recording to SessionHandler

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
@@ -34,20 +34,15 @@ internal class EmbraceSpansService(
     private var sdkInitStartTime: Long? = null
 
     @Volatile
-    private var sdkInitEndTime: Long? = null
-
-    @Volatile
     private var currentDelegate: SpansService = SpansService.featureDisabledSpansService
 
-    override fun initializeService(sdkInitStartTimeNanos: Long, sdkInitEndTimeNanos: Long) {
+    override fun initializeService(sdkInitStartTimeNanos: Long) {
         if (!initialized.get()) {
             sdkInitStartTime = sdkInitStartTimeNanos
-            sdkInitEndTime = sdkInitEndTimeNanos
             synchronized(initialized) {
                 if (!initialized.get()) {
                     currentDelegate = SpansServiceImpl(
                         sdkInitStartTimeNanos = sdkInitStartTimeNanos,
-                        sdkInitEndTimeNanos = sdkInitEndTimeNanos,
                         clock = clock,
                         telemetryService = telemetryService
                     )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/Initializable.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/Initializable.kt
@@ -8,7 +8,7 @@ internal interface Initializable {
     /**
      * Initialize the service so the SDK can start logging spans. Spans will not be logged by this service until this call completes.
      */
-    fun initializeService(sdkInitStartTimeNanos: Long, sdkInitEndTimeNanos: Long)
+    fun initializeService(sdkInitStartTimeNanos: Long)
 
     /**
      * Returns true if this service is initialized already

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicReference
  */
 internal class SpansServiceImpl(
     sdkInitStartTimeNanos: Long,
-    sdkInitEndTimeNanos: Long,
     private val clock: Clock,
     private val telemetryService: TelemetryService
 ) : SpansService {
@@ -66,14 +65,6 @@ internal class SpansServiceImpl(
      * should be cached along with the other data in the payload.
      */
     private val completedSpans: MutableList<EmbraceSpanData> = mutableListOf()
-
-    init {
-        recordCompletedSpan(
-            name = "sdk-init",
-            startTimeNanos = sdkInitStartTimeNanos,
-            endTimeNanos = sdkInitEndTimeNanos
-        )
-    }
 
     override fun createSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean): EmbraceSpan? {
         return if (EmbraceSpanImpl.inputsValid(name) && validateAndUpdateContext(parent, internal)) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -422,8 +422,7 @@ internal class EmbraceEventServiceTest {
     @Test
     fun `startup logged as span if startup moment automatic end is enabled`() {
         spansService.initializeService(
-            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1),
-            sdkInitEndTimeNanos = TimeUnit.MILLISECONDS.toNanos(3)
+            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
         )
         configService.updateListeners()
         spansService.flushSpans()
@@ -444,8 +443,7 @@ internal class EmbraceEventServiceTest {
     fun `startup logged as span if when startup moment manually ends`() {
         startupMomentLocalConfig = StartupMomentLocalConfig(automaticallyEnd = false)
         spansService.initializeService(
-            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1),
-            sdkInitEndTimeNanos = TimeUnit.MILLISECONDS.toNanos(3)
+            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
         )
         configService.updateListeners()
         spansService.flushSpans()
@@ -472,8 +470,7 @@ internal class EmbraceEventServiceTest {
     @Test
     fun `startup not logged as span if startup moment is ended via a timeout`() {
         spansService.initializeService(
-            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1),
-            sdkInitEndTimeNanos = TimeUnit.MILLISECONDS.toNanos(3)
+            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
         )
         configService.updateListeners()
         spansService.flushSpans()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansServiceTest.kt
@@ -46,16 +46,8 @@ internal class EmbraceSpansServiceTest {
         var lambdaRan = false
         spansService.recordSpan("test-span") { lambdaRan = true }
         assertTrue(lambdaRan)
-        assertEquals(3, spansService.completedSpans()?.size)
-        assertEquals(4, spansService.flushSpans()?.size)
-    }
-
-    @Test
-    fun `second sdk startup span will not be recorded if you try to initialize the service twice`() {
-        initializeService()
-        assertEquals(1, spansService.completedSpans()?.size)
-        spansService.initializeService(10, 20)
-        assertEquals(1, spansService.completedSpans()?.size)
+        assertEquals(2, spansService.completedSpans()?.size)
+        assertEquals(3, spansService.flushSpans()?.size)
     }
 
     @Test
@@ -190,10 +182,10 @@ internal class EmbraceSpansServiceTest {
         assertTrue(spansService.recordCompletedSpan("test-span", 10, 20))
         assertTrue(spansService.recordCompletedSpan("test-span", 15, 25))
         initializeService()
-        assertEquals(3, spansService.completedSpans()?.size)
+        assertEquals(2, spansService.completedSpans()?.size)
     }
 
     private fun initializeService() {
-        spansService.initializeService(1, 5)
+        spansService.initializeService(1)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -21,10 +21,9 @@ internal class EmbraceTracerTest {
     @Before
     fun setup() {
         spansService = SpansServiceImpl(
-            100L,
-            200L,
-            FakeOpenTelemetryClock(embraceClock = clock),
-            FakeTelemetryService()
+            sdkInitStartTimeNanos = 100L,
+            clock = FakeOpenTelemetryClock(embraceClock = clock),
+            telemetryService = FakeTelemetryService()
         )
         embraceTracer = EmbraceTracer(spansService)
         spansService.flushSpans()


### PR DESCRIPTION
## Goal

Move the SDK init trace logging to SessionHandler because it is more reasonable to do it there. Technically doing it in `EmbraceImpl` is probably the most correct, but it's an OK spot here too and allows us to more explicitly test the relationship between `SessionHandler` and `EmbraceSpansService`

## Testing

Modified tests of `SpansServiceImpl` and reimplemented tests in the new `SessionHandler` test class.

