### PR TITLE
refactor: stream final payload to disk

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -136,8 +136,9 @@ internal class EmbraceDeliveryCacheManager(
         // Do not add background activities to disk if we are over the limit
         if (cachedSessions.size < MAX_SESSIONS_CACHED || cachedSessions.containsKey(baId)) {
             saveBytes(baId) { filename ->
-                val baBytes = serializer.toJson(backgroundActivityMessage).toByteArray()
-                cacheService.cacheBytes(filename, baBytes)
+                cacheService.cachePayload(filename) {
+                    serializer.toJson(backgroundActivityMessage, BackgroundActivityMessage::class.java, it)
+                }
             }
             return loadBackgroundActivity(baId)
         }


### PR DESCRIPTION
## Goal

Streams the background activity to disk when saving it - this is the last place in the SDK that was holding a byte array.

## Testing

Relied on existing test coverage + manual testing.

