### PR TITLE
Avoid using mocks in delivery service test

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.payload.UserInfo
 import io.opentelemetry.api.trace.StatusCode
 
 internal fun fakeBackgroundActivity(): BackgroundActivityMessage {
-    val backgroundActivity = BackgroundActivity("fake-activity", 0, "")
+    val backgroundActivity = BackgroundActivity("fake-activity", 0, "", number = 1, messageType = "en", isColdStart = false)
     val userInfo = UserInfo("fake-user-id")
     val appInfo = AppInfo("fake-app-id")
     val deviceInfo = DeviceInfo("fake-manufacturer")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.NativeCrashData
 
 internal class FakeNdkService : NdkService {
+    var checkForNativeCrashCount: Int = 0
     val propUpdates = mutableListOf<Map<String, String>>()
 
     override fun updateSessionId(newSessionId: String) {
@@ -27,7 +28,8 @@ internal class FakeNdkService : NdkService {
     }
 
     override fun checkForNativeCrash(): NativeCrashData? {
-        TODO("Not yet implemented")
+        checkForNativeCrashCount++
+        return null
     }
 
     override fun getSymbolsForCurrentArch(): Map<String, String>? {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -2,67 +2,61 @@ package io.embrace.android.embracesdk.comms.delivery
 
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.EmbraceEvent
-import io.embrace.android.embracesdk.comms.api.ApiService
+import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.fakeBackgroundActivity
+import io.embrace.android.embracesdk.fakes.FakeApiService
+import io.embrace.android.embracesdk.fakes.FakeDeliveryCacheManager
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.fakeSessionMessage
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.session.SessionSnapshotType.JVM_CRASH
 import io.embrace.android.embracesdk.session.SessionSnapshotType.NORMAL_END
 import io.embrace.android.embracesdk.session.SessionSnapshotType.PERIODIC_CACHE
-import io.mockk.Called
-import io.mockk.clearAllMocks
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.BeforeClass
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.ExecutorService
 
 internal class EmbraceDeliveryServiceTest {
 
-    private lateinit var deliveryService: EmbraceDeliveryService
-    private val executor = MoreExecutors.newDirectExecutorService()
     private val session = fakeSession()
     private val sessionMessage = fakeSessionMessage()
+    private val anotherMessage =
+        fakeSessionMessage().copy(session = session.copy(sessionId = "session2"))
 
-    companion object {
-        private lateinit var mockDeliveryCacheManager: EmbraceDeliveryCacheManager
-        private lateinit var apiService: ApiService
-        private lateinit var gatingService: FakeGatingService
-        private lateinit var logger: InternalEmbraceLogger
+    private lateinit var executor: ExecutorService
+    private lateinit var deliveryCacheManager: FakeDeliveryCacheManager
+    private lateinit var apiService: FakeApiService
+    private lateinit var ndkService: FakeNdkService
+    private lateinit var gatingService: FakeGatingService
+    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var deliveryService: EmbraceDeliveryService
 
-        @BeforeClass
-        @JvmStatic
-        fun beforeClass() {
-            mockDeliveryCacheManager = mockk(relaxed = true)
-            every { mockDeliveryCacheManager.loadCrash() } returns null
-            every { mockDeliveryCacheManager.getAllCachedSessionIds() } returns emptyList()
-            apiService = mockk(relaxed = true)
-            gatingService = FakeGatingService()
-            logger = InternalEmbraceLogger()
-        }
+    @Before
+    fun setUp() {
+        executor = MoreExecutors.newDirectExecutorService()
+        deliveryCacheManager = FakeDeliveryCacheManager()
+        apiService = FakeApiService()
+        ndkService = FakeNdkService()
+        gatingService = FakeGatingService()
+        logger = InternalEmbraceLogger()
     }
 
     @After
     fun after() {
-        clearAllMocks()
         executor.shutdown()
         gatingService.sessionMessagesFiltered.clear()
     }
 
     private fun initializeDeliveryService() {
         deliveryService = EmbraceDeliveryService(
-            mockDeliveryCacheManager,
+            deliveryCacheManager,
             apiService,
             gatingService,
             executor,
@@ -77,7 +71,8 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         deliveryService.sendSession(sessionMessage, NORMAL_END)
 
-        verify(exactly = 1) { mockDeliveryCacheManager.saveSession(sessionMessage, NORMAL_END) }
+        val observed = deliveryCacheManager.saveSessionRequests.single()
+        assertEquals(Pair(sessionMessage, NORMAL_END), observed)
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
@@ -86,12 +81,8 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         deliveryService.sendSession(sessionMessage, PERIODIC_CACHE)
 
-        verify(exactly = 1) {
-            mockDeliveryCacheManager.saveSession(
-                sessionMessage,
-                PERIODIC_CACHE
-            )
-        }
+        val observed = deliveryCacheManager.saveSessionRequests.last()
+        assertEquals(Pair(sessionMessage, PERIODIC_CACHE), observed)
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
@@ -100,151 +91,58 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         deliveryService.sendSession(sessionMessage, JVM_CRASH)
 
-        verify(exactly = 1) { mockDeliveryCacheManager.saveSession(sessionMessage, JVM_CRASH) }
+        val observed = deliveryCacheManager.saveSessionRequests.last()
+        assertEquals(Pair(sessionMessage, JVM_CRASH), observed)
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     @Test
     fun `if no previous cached session then send previous cached sessions should not send anything`() {
         initializeDeliveryService()
-        every { mockDeliveryCacheManager.getAllCachedSessionIds() } returns emptyList()
-        every { mockDeliveryCacheManager.loadCrash() } returns null
 
-        deliveryService.sendCachedSessions(false, mockk(), null)
-        executor.awaitTermination(1, TimeUnit.SECONDS)
-
-        verify { apiService wasNot Called }
-        verify(exactly = 0) { mockDeliveryCacheManager.deleteSession(any()) }
+        deliveryService.sendCachedSessions(false, ndkService, null)
+        assertTrue(apiService.sessionRequests.isEmpty())
     }
 
     @Test
     fun `send previously cached sessions successfully`() {
         initializeDeliveryService()
-        every { mockDeliveryCacheManager.getAllCachedSessionIds() } returns listOf(
-            "session1",
-            "session2"
-        )
-        every { mockDeliveryCacheManager.loadSessionAsAction("session1") } returns { it.write("cached_session_1".toByteArray()) }
-        every { mockDeliveryCacheManager.loadSessionAsAction("session2") } returns { it.write("cached_session_2".toByteArray()) }
-        every { mockDeliveryCacheManager.loadCrash() } returns null
+        deliveryCacheManager.addCachedSessions(sessionMessage, anotherMessage)
 
-        deliveryService.sendCachedSessions(false, mockk(), null)
-        executor.awaitTermination(1, TimeUnit.SECONDS)
-
-        verify { mockDeliveryCacheManager.loadSessionAsAction("session1") }
-        verify { mockDeliveryCacheManager.loadSessionAsAction("session2") }
-        verify(exactly = 2) { apiService.sendSession(any(), any()) }
+        deliveryService.sendCachedSessions(false, ndkService, null)
+        assertEquals(listOf(sessionMessage, anotherMessage), apiService.sessionRequests)
     }
 
     @Test
     fun `ignore current session when sending previously cached sessions`() {
         initializeDeliveryService()
-        every { mockDeliveryCacheManager.getAllCachedSessionIds() } returns listOf(
-            "session1",
-            "session2"
-        )
-        every { mockDeliveryCacheManager.loadSessionAsAction("session1") } returns { it.write("cached_session_1".toByteArray()) }
-        every { mockDeliveryCacheManager.loadSessionAsAction("session2") } returns { it.write("cached_session_2".toByteArray()) }
-        every { mockDeliveryCacheManager.loadCrash() } returns null
-
-        deliveryService.sendCachedSessions(false, mockk(), "session2")
-        executor.awaitTermination(1, TimeUnit.SECONDS)
-
-        verify { mockDeliveryCacheManager.loadSessionAsAction("session1") }
-        verify(exactly = 0) { mockDeliveryCacheManager.loadSessionAsAction("session2") }
-        verify { apiService.sendSession(any(), any()) }
-        verify(exactly = 0) {
-            apiService.sendSession(
-                { it.write("cached_session_2".toByteArray()) },
-                any()
-            )
-        }
+        deliveryCacheManager.addCachedSessions(sessionMessage, anotherMessage)
+        deliveryService.sendCachedSessions(false, ndkService, anotherMessage.session.sessionId)
+        assertEquals(listOf(sessionMessage), apiService.sessionRequests)
     }
 
     @Test
     fun `if an exception is thrown while sending cached session then sendCachedSession should not crash`() {
         initializeDeliveryService()
-        every { mockDeliveryCacheManager.getAllCachedSessionIds() } returns listOf("session1")
-        every { mockDeliveryCacheManager.loadSessionAsAction("session1") } returns { it.write("cached_session".toByteArray()) }
-        every { apiService.sendSession(any(), any()) } throws Exception()
-        every { mockDeliveryCacheManager.loadCrash() } returns null
-
-        deliveryService.sendCachedSessions(false, mockk(), null)
-        executor.awaitTermination(1, TimeUnit.SECONDS)
-
-        verify { mockDeliveryCacheManager.loadSessionAsAction("session1") }
-        verify { apiService.sendSession(any(), any()) }
-    }
-
-    @Test
-    fun `send session end`() {
-        initializeDeliveryService()
-
-        val mockFuture: Future<Unit> = mockk()
-        every { apiService.sendSession(any(), any()) } returns mockFuture
-
-        deliveryService.sendSession(sessionMessage, NORMAL_END)
-
-        verify(exactly = 1) {
-            apiService.sendSession(
-                any(),
-                withArg {
-                    assertNotNull(it)
-                }
-            )
-        }
-        verify { mockFuture wasNot Called }
-        assertEquals(1, gatingService.sessionMessagesFiltered.size)
+        deliveryCacheManager.addCachedSessions(sessionMessage)
+        apiService.throwExceptionSendSession = true
+        deliveryService.sendCachedSessions(false, ndkService, null)
+        assertTrue(apiService.sessionRequests.isEmpty())
     }
 
     @Test
     fun `send session end with crash`() {
         initializeDeliveryService()
-
-        val mockFuture: Future<Unit> = mockk()
-        every { apiService.sendSession(any(), any()) } returns mockFuture
-
         deliveryService.sendSession(sessionMessage, JVM_CRASH)
-
-        verify(exactly = 1) {
-            apiService.sendSession(
-                any(),
-                withArg {
-                    assertNotNull(it)
-                }
-            )
-        }
-        verify(exactly = 1) {
-            mockFuture.get(1L, TimeUnit.SECONDS)
-        }
+        assertEquals(sessionMessage, apiService.sessionRequests.last())
         assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     @Test
-    fun `send session invalid`() {
-        initializeDeliveryService()
-
-        val mockFuture: Future<Unit> = mockk()
-        every { apiService.sendSession(any(), any()) } returns mockFuture
-
-        deliveryService.sendSession(sessionMessage, PERIODIC_CACHE)
-
-        verify(exactly = 0) {
-            apiService.sendSession(
-                any(),
-                withArg {
-                    assertNotNull(it)
-                }
-            )
-        }
-    }
-
-    @Test
     fun `check for native crash info if ndk feature is enabled`() {
-        val mockNdkService: NdkService = mockk()
         initializeDeliveryService()
-        deliveryService.sendCachedSessions(true, mockNdkService, "")
-        verify(exactly = 1) { mockNdkService.checkForNativeCrash() }
+        deliveryService.sendCachedSessions(true, ndkService, "")
+        assertEquals(1, ndkService.checkForNativeCrashCount)
     }
 
     @Test
@@ -252,7 +150,7 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val obj = fakeBackgroundActivity()
         deliveryService.saveBackgroundActivity(obj)
-        verify(exactly = 1) { mockDeliveryCacheManager.saveBackgroundActivity(obj) }
+        assertEquals(obj, deliveryCacheManager.saveBgActivityRequests.last())
     }
 
     @Test
@@ -260,7 +158,7 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val obj = EventMessage(Event(eventId = "abc", type = EmbraceEvent.Type.END))
         deliveryService.sendMoment(obj)
-        verify(exactly = 1) { apiService.sendEvent(obj) }
+        assertEquals(obj, apiService.eventRequests.single())
     }
 
     @Test
@@ -268,8 +166,8 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val obj = EventMessage(Event(eventId = "abc", type = EmbraceEvent.Type.CRASH))
         deliveryService.sendCrash(obj, true)
-        verify(exactly = 1) { mockDeliveryCacheManager.saveCrash(obj) }
-        verify(exactly = 1) { apiService.sendCrash(obj) }
+        assertEquals(obj, deliveryCacheManager.saveCrashRequests.single())
+        assertEquals(obj, apiService.crashRequests.single())
     }
 
     @Test
@@ -279,8 +177,8 @@ internal class EmbraceDeliveryServiceTest {
         deliveryService.sendBackgroundActivity(obj)
 
         // cache the object first in case process terminates
-        verify(exactly = 1) { mockDeliveryCacheManager.saveBackgroundActivity(obj) }
-        verify(exactly = 1) { apiService.sendSession(any(), any()) }
+        assertEquals(obj, deliveryCacheManager.saveBgActivityRequests.last())
+        assertEquals(1, apiService.sessionRequests.size)
     }
 
     @Test
@@ -288,9 +186,7 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         val obj = fakeBackgroundActivity()
         deliveryService.saveBackgroundActivity(obj)
-
-        every { mockDeliveryCacheManager.loadBackgroundActivity(any()) } returns {}
         deliveryService.sendBackgroundActivities()
-        verify(exactly = 1) { apiService.sendSession(any(), any()) }
+        assertEquals(1, apiService.sessionRequests.size)
     }
 }


### PR DESCRIPTION
## Goal

Refactors the delivery service test to use fakes rather than mocks, as the mocks were becoming an obstacle when refactoring the delivery code.
