### PR TITLE
Refactor session handler test to avoid mocks

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
@@ -13,6 +13,8 @@ import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
 
 internal class FakeBreadcrumbService : BreadcrumbService {
 
+    val logViewCalls = mutableListOf<String?>()
+
     override fun getViewBreadcrumbsForSession(start: Long, end: Long): List<ViewBreadcrumb?> =
         emptyList()
 
@@ -52,6 +54,7 @@ internal class FakeBreadcrumbService : BreadcrumbService {
     }
 
     override fun forceLogView(screen: String?, timestamp: Long) {
+        logViewCalls.add(screen)
     }
 
     override fun replaceFirstSessionView(screen: String?, timestamp: Long) {
@@ -89,8 +92,10 @@ internal class FakeBreadcrumbService : BreadcrumbService {
     override fun logWebView(url: String?, startTime: Long) {
     }
 
+    var viewBreadcrumbScreenName: String? = null
+
     override fun getLastViewBreadcrumbScreenName(): String? {
-        return null
+        return viewBreadcrumbScreenName
     }
 
     override fun logPushNotification(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
@@ -7,8 +7,10 @@ internal class FakeNdkService : NdkService {
     var checkForNativeCrashCount: Int = 0
     val propUpdates = mutableListOf<Map<String, String>>()
 
+    var sessionId: String? = null
+
     override fun updateSessionId(newSessionId: String) {
-        TODO("Not yet implemented")
+        sessionId = newSessionId
     }
 
     override fun onSessionPropertiesUpdate(properties: Map<String, String>) {
@@ -16,7 +18,6 @@ internal class FakeNdkService : NdkService {
     }
 
     override fun onUserInfoUpdate() {
-        TODO("Not yet implemented")
     }
 
     override fun getUnityCrashId(): String? {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
@@ -34,7 +34,7 @@ internal class BlockingScheduledExecutorService(
     private val fakeClock: FakeClock = FakeClock(),
     blockingMode: Boolean = true
 ) : AbstractExecutorService(), ScheduledExecutorService {
-    private val scheduledTasks = PriorityBlockingQueue(10, BlockedScheduledFutureTaskComparator())
+    val scheduledTasks = PriorityBlockingQueue(10, BlockedScheduledFutureTaskComparator())
     private val delegateExecutorService = BlockableExecutorService(blockingMode = blockingMode)
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMemoryCleanerService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMemoryCleanerService.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.session.MemoryCleanerService
 
 internal class FakeMemoryCleanerService : MemoryCleanerService {
 
+    var callCount: Int = 0
     val listeners = mutableListOf<MemoryCleanerListener>()
 
     override fun addListener(listener: MemoryCleanerListener) {
@@ -15,5 +16,6 @@ internal class FakeMemoryCleanerService : MemoryCleanerService {
     override fun cleanServicesCollections(
         exceptionService: EmbraceInternalErrorService
     ) {
+        callCount++
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -40,6 +40,7 @@ internal class FakePreferenceService(
 
     var networkCaptureRuleOver = false
     var firstDay: Boolean = false
+    var incrementAndGetSessionNumberCount = 0
 
     override fun isNetworkCaptureRuleOver(id: String): Boolean {
         return networkCaptureRuleOver
@@ -48,7 +49,10 @@ internal class FakePreferenceService(
     override fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int) {
     }
 
-    override fun incrementAndGetSessionNumber(): Int = sessionNumber()
+    override fun incrementAndGetSessionNumber(): Int {
+        incrementAndGetSessionNumberCount++
+        return sessionNumber()
+    }
 
     override fun incrementAndGetBackgroundActivityNumber(): Int = bgActivityNumber()
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -1,14 +1,15 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.FakeDeliveryService
+import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.fakeSessionMessage
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.ndk.NdkService
-import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.SessionLifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.mockk.clearAllMocks
@@ -38,9 +39,8 @@ internal class EmbraceSessionServiceTest {
     companion object {
 
         private val processStateService = FakeProcessStateService()
-        private val mockNdkService: NdkService = mockk(relaxUnitFun = true)
-        private val mockSession: Session = mockk(relaxed = true)
-        private val mockSessionMessage: SessionMessage = mockk(relaxed = true)
+        private val ndkService: NdkService = FakeNdkService()
+        private val sessionMessage: SessionMessage = fakeSessionMessage()
         private val mockSessionHandler: SessionHandler = mockk(relaxed = true)
         private val clock = FakeClock()
 
@@ -48,7 +48,6 @@ internal class EmbraceSessionServiceTest {
         @JvmStatic
         fun beforeClass() {
             mockkStatic(ExecutorService::class)
-            every { mockSessionMessage.session } returns mockSession
         }
 
         @AfterClass
@@ -102,7 +101,7 @@ internal class EmbraceSessionServiceTest {
                 any(),
                 any()
             )
-        } returns mockSessionMessage
+        } returns sessionMessage
         service.startSession(true, SessionLifeEventType.STATE, clock.now())
 
         service.handleCrash(crashId)
@@ -226,7 +225,7 @@ internal class EmbraceSessionServiceTest {
 
         service = EmbraceSessionService(
             processStateService,
-            mockNdkService,
+            ndkService,
             mockSessionHandler,
             deliveryService,
             ndkEnabled,
@@ -243,7 +242,7 @@ internal class EmbraceSessionServiceTest {
                 any(),
                 any()
             )
-        } returns mockSessionMessage
+        } returns sessionMessage
         service.startSession(true, SessionLifeEventType.STATE, clock.now())
     }
 }


### PR DESCRIPTION
## Goal

Removes some mocks from the SessionHandlerTest that were an obstacle when refactoring session code.
