### PR TITLE
Consolidate mock creation for system apis

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
@@ -11,8 +11,8 @@ import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
+import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.mockk.every
 import io.mockk.mockk
 import org.junit.rules.ExternalResource
 import java.util.concurrent.ScheduledExecutorService
@@ -43,15 +43,14 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
 
     override fun before() {
         clock.setCurrentTime(0)
-        val mockLooper: Looper = mockk(relaxed = true)
-        every { mockLooper.thread } returns Thread.currentThread()
+        val looper: Looper = mockLooper()
         cfg = AnrRemoteConfig()
         anrMonitorThread = AtomicReference(Thread.currentThread())
         fakeConfigService = FakeConfigService(anrBehavior = fakeAnrBehavior { cfg })
         anrExecutorService = scheduledExecutorSupplier.invoke()
         state = ThreadMonitoringState(clock)
         targetThreadHandler = TargetThreadHandler(
-            looper = mockLooper,
+            looper = looper,
             anrExecutorService = anrExecutorService,
             anrMonitorThread = anrMonitorThread,
             configService = fakeConfigService,
@@ -76,7 +75,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
         )
         anrService = EmbraceAnrService(
             configService = fakeConfigService,
-            looper = mockLooper,
+            looper = looper,
             logger = logger,
             sigquitDetectionService = mockSigquitDetectionService,
             livenessCheckScheduler = livenessCheckScheduler,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAutomaticVerificationTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAutomaticVerificationTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk
 
 import android.app.Activity
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
+import io.embrace.android.embracesdk.fakes.system.mockActivity
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -23,7 +24,7 @@ internal class EmbraceAutomaticVerificationTest {
 
     companion object {
         private lateinit var embraceSamples: EmbraceAutomaticVerification
-        private val activity: Activity = mockk(relaxed = true)
+        private val activity: Activity = mockActivity()
         private val scheduledExecutorService: ScheduledExecutorService = mockk(relaxed = true)
 
         @BeforeClass

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceMemoryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceMemoryServiceTest.kt
@@ -4,8 +4,8 @@ import android.app.ActivityManager
 import io.embrace.android.embracesdk.capture.memory.EmbraceMemoryService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
+import io.embrace.android.embracesdk.fakes.system.mockActivityManager
 import io.embrace.android.embracesdk.session.MemoryCleanerService
-import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -22,7 +22,7 @@ internal class EmbraceMemoryServiceTest {
 
     @Before
     fun setUp() {
-        activityManager = mockk(relaxUnitFun = true)
+        activityManager = mockActivityManager()
         memoryCleanerService = FakeMemoryCleanerService()
         fakeClock.setCurrentTime(100L)
         embraceMemoryService = EmbraceMemoryService(fakeClock)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
@@ -7,9 +7,11 @@ import android.os.PowerManager.ACTION_POWER_SAVE_MODE_CHANGED
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.capture.powersave.EmbracePowerSaveModeService
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.system.mockContext
+import io.embrace.android.embracesdk.fakes.system.mockIntent
+import io.embrace.android.embracesdk.fakes.system.mockPowerManager
 import io.mockk.clearAllMocks
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
@@ -27,8 +29,8 @@ internal class EmbracePowerSaveModeServiceTest {
     private lateinit var service: EmbracePowerSaveModeService
 
     companion object {
-        private lateinit var mockContext: Context
-        private lateinit var mockIntent: Intent
+        private lateinit var context: Context
+        private lateinit var intent: Intent
         private lateinit var executor: ExecutorService
         private lateinit var fakeClock: FakeClock
         private lateinit var powerManager: PowerManager
@@ -39,11 +41,11 @@ internal class EmbracePowerSaveModeServiceTest {
         @BeforeClass
         @JvmStatic
         fun setupBeforeAll() {
-            mockContext = mockk(relaxUnitFun = true)
-            mockIntent = mockk()
+            context = mockContext()
+            intent = mockIntent()
             executor = MoreExecutors.newDirectExecutorService()
             fakeClock = FakeClock()
-            powerManager = mockk()
+            powerManager = mockPowerManager()
         }
 
         /**
@@ -62,7 +64,7 @@ internal class EmbracePowerSaveModeServiceTest {
     @Before
     fun setup() {
         service = EmbracePowerSaveModeService(
-            mockContext,
+            context,
             executor,
             fakeClock,
             powerManager
@@ -79,15 +81,15 @@ internal class EmbracePowerSaveModeServiceTest {
 
     @Test
     fun `test onReceive adds a low battery interval correctly`() {
-        every { mockContext.getSystemService(Context.POWER_SERVICE) } returns powerManager
-        every { mockIntent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
+        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
+        every { intent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
 
-        service.onReceive(mockContext, mockIntent)
+        service.onReceive(context, intent)
         every { powerManager.isPowerSaveMode } returns false
 
-        service.onReceive(mockContext, mockIntent)
+        service.onReceive(context, intent)
         val intervals = service.getCapturedData()
 
         assertEquals(1, intervals.size)
@@ -97,11 +99,11 @@ internal class EmbracePowerSaveModeServiceTest {
 
     @Test
     fun `test onReceive start interval no end`() {
-        every { mockContext.getSystemService(Context.POWER_SERVICE) } returns powerManager
-        every { mockIntent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
+        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
+        every { intent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
-        service.onReceive(mockContext, mockIntent)
+        service.onReceive(context, intent)
 
         val intervals = service.getCapturedData()
         assertEquals(1, intervals.size)
@@ -111,7 +113,7 @@ internal class EmbracePowerSaveModeServiceTest {
 
     @Test
     fun `test start session on power save mode no end`() {
-        every { mockContext.getSystemService(Context.POWER_SERVICE) } returns powerManager
+        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
         val startTime = fakeClock.now()
@@ -125,15 +127,15 @@ internal class EmbracePowerSaveModeServiceTest {
 
     @Test
     fun `test start session on power save mode end saving mode in session`() {
-        every { mockContext.getSystemService(Context.POWER_SERVICE) } returns powerManager
+        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
         val startTime = fakeClock.now()
         service.onForeground(true, startTime, startTime)
 
-        every { mockIntent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
+        every { intent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
         every { powerManager.isPowerSaveMode } returns false
-        service.onReceive(mockContext, mockIntent)
+        service.onReceive(context, intent)
 
         val intervals = service.getCapturedData()
         assertEquals(1, intervals.size)
@@ -143,22 +145,22 @@ internal class EmbracePowerSaveModeServiceTest {
 
     @Test
     fun `test onReceive throws an exception`() {
-        every { mockIntent.action } throws Exception()
+        every { intent.action } throws Exception()
         fakeClock.setCurrentTime(111111L)
-        assertThrows(Exception::class.java) { service.onReceive(mockContext, mockIntent) }
+        assertThrows(Exception::class.java) { service.onReceive(context, intent) }
     }
 
     @Test
     @Throws(InterruptedException::class)
     fun `test receiver can be registered and unregistered`() {
-        verify { mockContext.registerReceiver(service, any()) }
+        verify { context.registerReceiver(service, any()) }
         service.close()
-        verify { mockContext.unregisterReceiver(service) }
+        verify { context.unregisterReceiver(service) }
     }
 
     @Test
     fun testCleanCollections() {
-        every { mockContext.getSystemService(Context.POWER_SERVICE) } returns powerManager
+        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
         val startTime = fakeClock.now()
@@ -171,12 +173,12 @@ internal class EmbracePowerSaveModeServiceTest {
 
     @Test
     fun `test limit exceeded`() {
-        every { mockContext.getSystemService(Context.POWER_SERVICE) } returns powerManager
-        every { mockIntent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
+        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
+        every { intent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
         every { powerManager.isPowerSaveMode } returns false
 
         repeat(150) {
-            service.onReceive(mockContext, mockIntent)
+            service.onReceive(context, intent)
         }
         assertEquals(100, service.getCapturedData().size)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceThermalStatusServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceThermalStatusServiceTest.kt
@@ -3,9 +3,9 @@ package io.embrace.android.embracesdk
 import android.os.PowerManager
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.capture.thermalstate.EmbraceThermalStatusService
+import io.embrace.android.embracesdk.fakes.system.mockPowerManager
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.ThermalState
-import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -20,7 +20,7 @@ internal class EmbraceThermalStatusServiceTest {
             MoreExecutors.directExecutor(),
             { 0 },
             InternalEmbraceLogger(),
-            mockk(relaxed = true)
+            mockPowerManager()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.Embrace.AppFramework.REACT_NATIVE
 import io.embrace.android.embracesdk.capture.crash.CrashService
 import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.system.mockContext
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.prefs.PreferencesService
@@ -34,7 +35,7 @@ internal class ReactNativeInternalInterfaceImplTest {
         crashService = mockk(relaxed = true)
         metadataService = FakeAndroidMetadataService()
         logger = mockk(relaxed = true)
-        context = mockk(relaxed = true)
+        context = mockContext()
         impl = ReactNativeInternalInterfaceImpl(
             embrace,
             mockk(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
@@ -8,6 +8,9 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
+import io.embrace.android.embracesdk.fakes.system.mockLooper
+import io.embrace.android.embracesdk.fakes.system.mockMessage
+import io.embrace.android.embracesdk.fakes.system.mockMessageQueue
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -42,7 +45,7 @@ internal class TargetThreadHandlerTest {
 
     private fun createHandler(messageQueue: MessageQueue?): TargetThreadHandler {
         return TargetThreadHandler(
-            mockk(),
+            mockLooper(),
             executorService,
             anrMonitorThread = anrMonitorThread,
             configService,
@@ -58,7 +61,7 @@ internal class TargetThreadHandlerTest {
         state.lastTargetThreadResponseMs = 0L
 
         // process a message
-        handler.handleMessage(mockk())
+        handler.handleMessage(mockMessage())
         verify(exactly = 0) { handler.action.invoke(any()) }
     }
 
@@ -91,7 +94,7 @@ internal class TargetThreadHandlerTest {
 
     @Test
     fun testCorrectMsgNonNullQueue() {
-        handler = createHandler(mockk())
+        handler = createHandler(mockMessageQueue())
         handler.installed = true
         assertNotNull(handler)
         state.lastTargetThreadResponseMs = 0L
@@ -110,13 +113,13 @@ internal class TargetThreadHandlerTest {
         state.lastTargetThreadResponseMs = 0L
 
         // RejectedExecutionException ignored as ScheduledExecutorService will be shutting down.
-        handler.handleMessage(mockk())
+        handler.handleMessage(mockMessage())
         assertEquals(0L, state.lastTargetThreadResponseMs)
     }
 
     @Test
     fun testStartIdleHandlerEnabled() {
-        val messageQueue = mockk<MessageQueue>(relaxUnitFun = true)
+        val messageQueue = mockMessageQueue()
         configService = FakeConfigService(
             anrBehavior = fakeAnrBehavior {
                 AnrRemoteConfig(pctIdleHandlerEnabled = 100f)
@@ -129,7 +132,7 @@ internal class TargetThreadHandlerTest {
 
     @Test
     fun testStartIdleHandlerDisabled() {
-        val messageQueue = mockk<MessageQueue>(relaxUnitFun = true)
+        val messageQueue = mockMessageQueue()
         configService = FakeConfigService(
             anrBehavior = fakeAnrBehavior {
                 AnrRemoteConfig(pctIdleHandlerEnabled = 0f)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -12,13 +12,13 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.fakes.fakeSession
+import io.embrace.android.embracesdk.fakes.system.mockActivity
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.TapBreadcrumb
 import io.embrace.android.embracesdk.session.EmbraceMemoryCleanerService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
-import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -53,7 +53,7 @@ internal class EmbraceBreadcrumbServiceTest {
             )
         )
         processStateService = FakeProcessStateService()
-        activity = mockk()
+        activity = mockActivity()
         memoryCleanerService = EmbraceMemoryCleanerService()
         clock.setCurrentTime(MILLIS_FOR_2020_01_01)
         clock.tickSecond()
@@ -547,7 +547,7 @@ internal class EmbraceBreadcrumbServiceTest {
     @Test
     fun testOnViewEnabled() {
         val service = initializeBreadcrumbService()
-        service.onView(mockk(relaxed = true))
+        service.onView(mockActivity())
 
         val crumbs = service.getViewBreadcrumbsForSession(0, Long.MAX_VALUE)
         val breadcrumb = checkNotNull(crumbs.single())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureServiceTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.capture.crumbs
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import io.embrace.android.embracesdk.fakes.system.mockBundle
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 import io.mockk.Called
@@ -23,7 +24,7 @@ internal class PushNotificationCaptureServiceTest {
     companion object {
         private val mockBreadCrumbService: BreadcrumbService = mockk(relaxUnitFun = true)
         private val logger: InternalEmbraceLogger = InternalEmbraceLogger()
-        private val mockBundle: Bundle = mockk()
+        private val mockBundle: Bundle = mockBundle()
         private val mockIntent: Intent = mockk {
             every { extras } returns mockBundle
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackServiceTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.ComponentCallbacks2
 import android.content.Context
 import io.embrace.android.embracesdk.fakes.FakeMemoryService
+import io.embrace.android.embracesdk.fakes.system.mockContext
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -15,18 +16,18 @@ import org.junit.Test
 internal class ComponentCallbackServiceTest {
 
     private lateinit var service: ComponentCallbackService
-    private lateinit var mockApplication: Application
+    private lateinit var application: Application
     private lateinit var memoryService: FakeMemoryService
     private lateinit var ctx: Context
 
     @Before
     fun setup() {
-        ctx = mockk(relaxed = true)
-        mockApplication = mockk(relaxed = true) {
+        ctx = mockContext()
+        application = mockk(relaxed = true) {
             every { applicationContext } returns ctx
         }
         memoryService = FakeMemoryService()
-        every { mockApplication.registerActivityLifecycleCallbacks(any()) } returns Unit
+        every { application.registerActivityLifecycleCallbacks(any()) } returns Unit
     }
 
     @Before
@@ -39,7 +40,7 @@ internal class ComponentCallbackServiceTest {
         )
 
         service = ComponentCallbackService(
-            mockApplication,
+            application,
             memoryService
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
@@ -12,6 +12,9 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.system.mockActivityManager
+import io.embrace.android.embracesdk.fakes.system.mockStorageStatsManager
+import io.embrace.android.embracesdk.fakes.system.mockWindowManager
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -68,9 +71,9 @@ internal class EmbraceMetadataReactNativeTest {
         preferencesService,
         processStateService,
         MoreExecutors.newDirectExecutorService(),
-        mockk(),
-        mockk(),
-        mockk(),
+        mockStorageStatsManager(),
+        mockWindowManager(),
+        mockActivityManager(),
         fakeClock,
         cpuInfoDelegate,
         deviceArchitecture,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -20,6 +20,10 @@ import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeSdkModeBehavior
+import io.embrace.android.embracesdk.fakes.system.mockActivityManager
+import io.embrace.android.embracesdk.fakes.system.mockContext
+import io.embrace.android.embracesdk.fakes.system.mockStorageStatsManager
+import io.embrace.android.embracesdk.fakes.system.mockWindowManager
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
@@ -40,7 +44,7 @@ import java.io.File
 internal class EmbraceMetadataServiceTest {
 
     companion object {
-        private val context: Context = mockk(relaxed = true)
+        private val context: Context = mockContext()
         private val packageInfo = PackageInfo()
         private val serializer = EmbraceSerializer()
         private val preferencesService: EmbracePreferencesService = mockk(relaxed = true)
@@ -283,9 +287,9 @@ internal class EmbraceMetadataServiceTest {
             preferencesService,
             activityService,
             mockk(relaxed = true), // No background worker to run async calculations
-            mockk(),
-            mockk(),
-            mockk(),
+            mockStorageStatsManager(),
+            mockWindowManager(),
+            mockActivityManager(),
             fakeClock,
             cpuInfoDelegate,
             fakeArchitecture,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataUnityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataUnityTest.kt
@@ -15,6 +15,10 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.system.mockActivityManager
+import io.embrace.android.embracesdk.fakes.system.mockContext
+import io.embrace.android.embracesdk.fakes.system.mockStorageStatsManager
+import io.embrace.android.embracesdk.fakes.system.mockWindowManager
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
@@ -51,7 +55,7 @@ internal class EmbraceMetadataUnityTest {
             mockkStatic(MetadataUtils::class)
             mockkStatic(Environment::class)
 
-            context = mockk(relaxed = true)
+            context = mockContext()
             buildInfo = mockk()
             configService = mockk(relaxed = true)
             preferencesService = FakePreferenceService()
@@ -109,9 +113,9 @@ internal class EmbraceMetadataUnityTest {
         preferencesService,
         processStateService,
         MoreExecutors.newDirectExecutorService(),
-        mockk(),
-        mockk(),
-        mockk(),
+        mockStorageStatsManager(),
+        mockWindowManager(),
+        mockActivityManager(),
         fakeClock,
         cpuInfoDelegate,
         deviceArchitecture,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/system/SystemMocks.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/system/SystemMocks.kt
@@ -1,0 +1,37 @@
+package io.embrace.android.embracesdk.fakes.system
+
+import android.app.Activity
+import android.app.ActivityManager
+import android.app.Application
+import android.app.usage.StorageStatsManager
+import android.content.Context
+import android.content.Intent
+import android.content.res.Resources
+import android.os.Bundle
+import android.os.Looper
+import android.os.Message
+import android.os.MessageQueue
+import android.os.PowerManager
+import android.view.WindowManager
+import io.mockk.every
+import io.mockk.mockk
+
+internal fun mockLooper(): Looper = mockk(relaxed = true) {
+    every { thread } returns Thread.currentThread()
+}
+
+internal fun mockMessageQueue(): MessageQueue = mockk(relaxed = true)
+internal fun mockMessage(): Message = mockk(relaxed = true)
+internal fun mockActivity(): Activity = mockk(relaxed = true)
+internal fun mockIntent(): Intent = mockk(relaxed = true)
+internal fun mockContext(): Context = mockk(relaxed = true)
+internal fun mockApplication(): Application = mockk(relaxed = true) {
+    every { registerActivityLifecycleCallbacks(any()) } returns Unit
+}
+
+internal fun mockResources(): Resources = mockk(relaxed = true)
+internal fun mockBundle(): Bundle = mockk(relaxed = true)
+internal fun mockStorageStatsManager(): StorageStatsManager = mockk(relaxed = true)
+internal fun mockWindowManager(): WindowManager = mockk(relaxed = true)
+internal fun mockActivityManager(): ActivityManager = mockk(relaxed = true)
+internal fun mockPowerManager(): PowerManager = mockk(relaxed = true)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
@@ -10,8 +10,8 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.mockkStatic
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -23,7 +23,7 @@ internal class AnrModuleImplTest {
     @Before
     fun setUp() {
         mockkStatic(Looper::class)
-        every { Looper.getMainLooper() } returns mockk(relaxed = true)
+        every { Looper.getMainLooper() } returns mockLooper()
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -17,6 +17,8 @@ import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.system.mockContext
+import io.embrace.android.embracesdk.fakes.system.mockResources
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarker
@@ -76,7 +78,7 @@ internal class EmbraceNdkServiceTest {
             mockkStatic(ExecutorService::class)
             mockkStatic(Uuid::class)
             mockkStatic(Embrace::class)
-            context = mockk(relaxed = true)
+            context = mockContext()
             metadataService = mockk(relaxed = true)
             configService = mockk(relaxed = true)
             activityService = FakeProcessStateService()
@@ -89,7 +91,7 @@ internal class EmbraceNdkServiceTest {
             logger = InternalEmbraceLogger()
             delegate = mockk(relaxed = true)
             repository = mockk(relaxUnitFun = true)
-            resources = mockk(relaxUnitFun = true)
+            resources = mockResources()
 
             val appInfo = AppInfo(appFramework = Embrace.AppFramework.NATIVE.value)
             every { metadataService.getAppInfo() } returns appInfo

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeBackgroundActivityService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLoggerAction
 import io.embrace.android.embracesdk.fakes.FakeProcessStateListener
+import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.session.lifecycle.EmbraceProcessStateService
@@ -32,7 +33,7 @@ internal class EmbraceProcessStateServiceTest {
     private lateinit var stateService: EmbraceProcessStateService
 
     companion object {
-        private lateinit var mockLooper: Looper
+        private lateinit var looper: Looper
         private lateinit var mockLifeCycleOwner: LifecycleOwner
         private lateinit var mockLifecycle: Lifecycle
         private lateinit var mockApplication: Application
@@ -41,7 +42,7 @@ internal class EmbraceProcessStateServiceTest {
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            mockLooper = mockk()
+            looper = mockLooper()
             mockLifeCycleOwner = mockk()
             mockLifecycle = mockk(relaxed = true)
             mockkStatic(Looper::class)
@@ -50,8 +51,7 @@ internal class EmbraceProcessStateServiceTest {
 
             fakeClock.setCurrentTime(1234)
             every { mockApplication.registerActivityLifecycleCallbacks(any()) } returns Unit
-            every { Looper.getMainLooper() } returns mockLooper
-            every { mockLooper.thread } returns Thread.currentThread()
+            every { Looper.getMainLooper() } returns looper
             every { ProcessLifecycleOwner.get() } returns mockLifeCycleOwner
             every { mockLifeCycleOwner.lifecycle } returns mockLifecycle
             every { mockLifecycle.addObserver(any()) } returns Unit

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -31,6 +31,7 @@ import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.system.mockActivity
 import io.embrace.android.embracesdk.fixtures.testSpan
 import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
@@ -325,11 +326,9 @@ internal class SessionHandlerTest {
     @Test
     fun `onSession started and resuming with no previous screen name but with foregroundActivity, it should force log view breadcrumb`() {
         breadcrumbService.viewBreadcrumbScreenName = null
-        val mockActivity: Activity = mockk()
+        val mockActivity: Activity = mockActivity()
         // let's return a foreground activity
         activityLifecycleTracker.foregroundActivity = mockActivity
-        val activityClassName = "activity-class-name"
-        every { mockActivity.localClassName } returns activityClassName
         val sessionStartType = Session.SessionLifeEventType.STATE
 
         val sessionMessage = sessionHandler.onSessionStarted(
@@ -340,7 +339,7 @@ internal class SessionHandlerTest {
         )
 
         // verify we are forcing log view with foreground activity class name
-        assertEquals(activityClassName, breadcrumbService.logViewCalls.single())
+        assertEquals(mockActivity.localClassName, breadcrumbService.logViewCalls.single())
         checkNotNull(sessionMessage)
         assertNotNull(sessionMessage.session)
         // no need to verify anything else because it's already verified in another test case

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -73,7 +73,6 @@ internal class SessionHandlerTest {
     companion object {
         private val networkConnectivityService: NetworkConnectivityService =
             mockk(relaxUnitFun = true)
-
         private val eventService: EventService = mockk(relaxed = true)
         private val remoteLogger: EmbraceRemoteLogger = mockk(relaxed = true)
         private val clock = FakeClock()


### PR DESCRIPTION
## Goal

Consolidates the creation of mocks for Android framework APIs. This should restrict the point at which mocks are created to one place & allows us to perform useful setup in one place in the test code, rather than multiple places.
