### PR TITLE
Reduce SDK usage of threads

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
@@ -35,7 +35,7 @@ internal class PeriodicSessionCacheTest {
         val clock = FakeClock(IntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
         IntegrationTestRule.Harness(
             fakeClock = clock,
-            workerThreadModule = FakeWorkerThreadModule(clock, SESSION_CACHING)
+            workerThreadModule = FakeWorkerThreadModule(clock, PERIODIC_CACHE)
         )
     }
 
@@ -43,7 +43,7 @@ internal class PeriodicSessionCacheTest {
     fun `session is periodically cached`() {
         with(testRule) {
             val executor =
-                harness.workerThreadModule.scheduledExecutor(SESSION_CACHING) as BlockingScheduledExecutorService
+                harness.workerThreadModule.scheduledExecutor(PERIODIC_CACHE) as BlockingScheduledExecutorService
 
             harness.recordSession {
                 executor.runCurrentlyBlocked()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/TimedSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/TimedSessionTest.kt
@@ -35,7 +35,7 @@ internal class TimedSessionTest {
         val clock = FakeClock(IntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
         IntegrationTestRule.Harness(
             fakeClock = clock,
-            workerThreadModule = FakeWorkerThreadModule(clock, SESSION_CLOSER),
+            workerThreadModule = FakeWorkerThreadModule(clock, BACKGROUND_REGISTRATION),
         )
     }
 
@@ -43,7 +43,7 @@ internal class TimedSessionTest {
     fun `timed session automatically ends session`() {
         with(testRule) {
             val executor =
-                harness.workerThreadModule.scheduledExecutor(SESSION_CLOSER) as BlockingScheduledExecutorService
+                harness.workerThreadModule.scheduledExecutor(BACKGROUND_REGISTRATION) as BlockingScheduledExecutorService
             harness.fakeConfigService.sessionBehavior = fakeSessionBehavior(
                 localCfg = { SessionLocalConfig(90) }) {
                 RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true))
@@ -68,7 +68,7 @@ internal class TimedSessionTest {
     fun `timed session has no effect when config disabled`() {
         with(testRule) {
             val executor =
-                harness.workerThreadModule.scheduledExecutor(SESSION_CLOSER) as BlockingScheduledExecutorService
+                harness.workerThreadModule.scheduledExecutor(BACKGROUND_REGISTRATION) as BlockingScheduledExecutorService
             harness.fakeConfigService.sessionBehavior = fakeSessionBehavior {
                 RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true))
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -77,7 +77,7 @@ internal class EmbraceEventService(
             deliveryService,
             logger,
             clock,
-            workerThreadModule.scheduledExecutor(ExecutorName.SCHEDULED_REGISTRATION)
+            workerThreadModule.scheduledExecutor(ExecutorName.BACKGROUND_REGISTRATION)
         )
         executorService =
             workerThreadModule.backgroundExecutor(ExecutorName.BACKGROUND_REGISTRATION)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -75,7 +75,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
 ) : DataCaptureServiceModule {
 
     private val backgroundExecutorService = workerThreadModule.backgroundExecutor(ExecutorName.BACKGROUND_REGISTRATION)
-    private val scheduledExecutor = workerThreadModule.scheduledExecutor(ExecutorName.SCHEDULED_REGISTRATION)
+    private val scheduledExecutor = workerThreadModule.scheduledExecutor(ExecutorName.BACKGROUND_REGISTRATION)
     private val configService = essentialServiceModule.configService
 
     override val memoryService: MemoryService by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -73,8 +73,8 @@ internal class SessionModuleImpl(
             sessionProperties,
             initModule.clock,
             initModule.spansService,
-            workerThreadModule.scheduledExecutor(ExecutorName.SESSION_CLOSER),
-            workerThreadModule.scheduledExecutor(ExecutorName.SESSION_CACHING)
+            workerThreadModule.scheduledExecutor(ExecutorName.BACKGROUND_REGISTRATION),
+            workerThreadModule.scheduledExecutor(ExecutorName.PERIODIC_CACHE)
         )
     }
 
@@ -108,7 +108,7 @@ internal class SessionModuleImpl(
                 nativeModule.ndkService,
                 initModule.clock,
                 backgroundActivityCollator,
-                lazy { workerThreadModule.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR) }
+                lazy { workerThreadModule.backgroundExecutor(ExecutorName.PERIODIC_CACHE) }
             )
         } else {
             null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
@@ -42,8 +42,8 @@ internal class NativeModuleImpl(
             coreModule.logger,
             embraceNdkServiceRepository,
             NdkDelegateImpl(),
-            workerThreadModule.backgroundExecutor(ExecutorName.NATIVE_CRASH_CLEANER),
-            workerThreadModule.backgroundExecutor(ExecutorName.NATIVE_STARTUP),
+            workerThreadModule.backgroundExecutor(ExecutorName.BACKGROUND_REGISTRATION),
+            workerThreadModule.backgroundExecutor(ExecutorName.BACKGROUND_REGISTRATION),
             essentialServiceModule.deviceArchitecture,
             coreModule.jsonSerializer
         )
@@ -54,7 +54,7 @@ internal class NativeModuleImpl(
             EmbraceNativeThreadSamplerService(
                 essentialServiceModule.configService,
                 lazy { ndkService.getSymbolsForCurrentArch() },
-                executorService = workerThreadModule.scheduledExecutor(ExecutorName.SCHEDULED_REGISTRATION),
+                executorService = workerThreadModule.scheduledExecutor(ExecutorName.BACKGROUND_REGISTRATION),
                 deviceArchitecture = essentialServiceModule.deviceArchitecture
             )
         } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
@@ -31,15 +31,10 @@ internal interface WorkerThreadModule : Closeable {
  */
 internal enum class ExecutorName(internal val threadName: String) {
     BACKGROUND_REGISTRATION("background-reg"),
-    SCHEDULED_REGISTRATION("scheduled-reg"),
     CACHED_SESSIONS("cached-sessions"),
     SEND_SESSIONS("send-sessions"),
     DELIVERY_CACHE("delivery-cache"),
     NETWORK_REQUEST("network-request"),
-    NATIVE_CRASH_CLEANER("native-crash-cleaner"),
-    NATIVE_STARTUP("native-startup"),
-    SESSION_CACHE_EXECUTOR("session-cache"),
+    PERIODIC_CACHE("periodic-cache"),
     REMOTE_LOGGING("remote-logging"),
-    SESSION_CLOSER("session-closer"),
-    SESSION_CACHING("session-caching"),
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -122,7 +122,7 @@ internal class EmbraceEventServiceTest {
             deliveryService = deliveryService,
             logger = logger,
             clock = fakeClock,
-            scheduledExecutor = fakeWorkerThreadModule.scheduledExecutor(ExecutorName.SCHEDULED_REGISTRATION)
+            scheduledExecutor = fakeWorkerThreadModule.scheduledExecutor(ExecutorName.BACKGROUND_REGISTRATION)
         )
         eventService = EmbraceEventService(
             1,
@@ -473,8 +473,7 @@ internal class EmbraceEventServiceTest {
         eventService.sendStartupMoment()
         assertNull(eventService.getStartupMomentInfo())
         fakeClock.tick(10000L)
-        fakeWorkerThreadModule.backgroundExecutor(ExecutorName.BACKGROUND_REGISTRATION).runCurrentlyBlocked()
-        fakeWorkerThreadModule.scheduledExecutor(ExecutorName.SCHEDULED_REGISTRATION).runCurrentlyBlocked()
+        fakeWorkerThreadModule.scheduledExecutor(ExecutorName.BACKGROUND_REGISTRATION).runCurrentlyBlocked()
         assertNotNull(eventService.getStartupMomentInfo())
         val completedSpans = checkNotNull(spansService.completedSpans())
         assertEquals(0, completedSpans.size)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
@@ -13,13 +13,13 @@ internal class WorkerThreadModuleImplTest {
         val module = WorkerThreadModuleImpl()
         assertNotNull(module)
 
-        val backgroundExecutor = module.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR)
+        val backgroundExecutor = module.backgroundExecutor(ExecutorName.PERIODIC_CACHE)
         assertNotNull(backgroundExecutor)
-        val scheduledExecutor = module.scheduledExecutor(ExecutorName.SESSION_CACHE_EXECUTOR)
+        val scheduledExecutor = module.scheduledExecutor(ExecutorName.PERIODIC_CACHE)
         assertNotNull(scheduledExecutor)
 
         // test caching
-        assertSame(backgroundExecutor, module.backgroundExecutor(ExecutorName.SESSION_CACHE_EXECUTOR))
+        assertSame(backgroundExecutor, module.backgroundExecutor(ExecutorName.PERIODIC_CACHE))
         assertSame(backgroundExecutor, scheduledExecutor)
 
         // test shutting down module


### PR DESCRIPTION
## Goal

Removes some underutilised threads that were generally only used to submit one Runnable in each class they were used. The `BACKGROUND_REGISTRATION` is used instead, so we can get rid of unnecessary threads.

Thread count can be reduced further but this will require a bit of extra refactoring of the caching + delivery layers.

## Testing

Relied on existing test coverage & manually checked sessions + NDK crashes were sent from the NDK test app.
