### PR TITLE
Remove unnecessary executor for background activity + moments

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
@@ -24,13 +24,7 @@ internal class BackgroundActivityTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        val clock = FakeClock(IntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
-        IntegrationTestRule.Harness(
-            fakeClock = clock,
-            workerThreadModule = FakeWorkerThreadModule(clock, ExecutorName.SEND_SESSIONS)
-        )
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `bg activity messages are recorded`() {
@@ -38,10 +32,6 @@ internal class BackgroundActivityTest {
             harness.recordSession()
             harness.fakeClock.tick(30000)
             harness.recordSession()
-
-            val executor =
-                harness.workerThreadModule.scheduledExecutor(ExecutorName.SEND_SESSIONS) as BlockingScheduledExecutorService
-            executor.runCurrentlyBlocked()
 
             // filter out dupes from overwritten saves
             val bgActivities = harness.getSentBackgroundActivities().distinctBy { it.session.sessionId }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
@@ -16,7 +16,6 @@ internal class DeliveryModuleImpl(
 ) : DeliveryModule {
 
     private val cachedSessionsExecutorService = workerThreadModule.backgroundExecutor(ExecutorName.CACHED_SESSIONS)
-    private val sendSessionsExecutorService = workerThreadModule.backgroundExecutor(ExecutorName.SEND_SESSIONS)
 
     override val deliveryService: DeliveryService by singleton {
         EmbraceDeliveryService(
@@ -24,7 +23,6 @@ internal class DeliveryModuleImpl(
             essentialServiceModule.apiService,
             essentialServiceModule.gatingService,
             cachedSessionsExecutorService,
-            sendSessionsExecutorService,
             coreModule.jsonSerializer,
             coreModule.logger
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
@@ -44,11 +44,6 @@ internal enum class ExecutorName(internal val threadName: String) {
     CACHED_SESSIONS("cached-sessions"),
 
     /**
-     * Loads background activities & moments from disk.
-     */
-    SEND_SESSIONS("send-sessions"),
-
-    /**
      * Saves/loads request information from files cached on disk.
      */
     DELIVERY_CACHE("delivery-cache"),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -60,7 +60,6 @@ internal class EmbraceDeliveryServiceTest {
             apiService,
             gatingService,
             executor,
-            executor,
             EmbraceSerializer(),
             logger
         )


### PR DESCRIPTION
## Goal

Removes an unnecessary executor that was being used in the delivery service for background activities + moments.

Previously this was required because the delivery service loaded the payload before calling the ApiService. This now happens in a lambda function that is executed within the ApiService on its executor, therefore the `SEND_SESSIONS` executor isn't necessary.

## Testing

Updated existing test coverage, and manually verified with debugger that the calls are still made on the updated executors.

