### PR TITLE
Avoid rejected execution exceptions

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/EmbraceApplicationExitInfoService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/EmbraceApplicationExitInfoService.kt
@@ -22,11 +22,10 @@ import io.embrace.android.embracesdk.prefs.PreferencesService
 import java.io.IOException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 @RequiresApi(VERSION_CODES.R)
-internal class EmbraceApplicationExitInfoService constructor(
+internal class EmbraceApplicationExitInfoService(
     private val executorService: ExecutorService,
     private val configService: ConfigService,
     private val activityManager: ActivityManager?,
@@ -55,21 +54,16 @@ internal class EmbraceApplicationExitInfoService constructor(
     }
 
     private fun startService() {
-        backgroundExecution = try {
-            executorService.submit {
-                try {
-                    processApplicationExitInfo()
-                } catch (exc: Throwable) {
-                    logWarningWithException(
-                        "AEI - Failed to process AEIs due to unexpected error",
-                        exc,
-                        true
-                    )
-                }
+        backgroundExecution = executorService.submit {
+            try {
+                processApplicationExitInfo()
+            } catch (exc: Throwable) {
+                logWarningWithException(
+                    "AEI - Failed to process AEIs due to unexpected error",
+                    exc,
+                    true
+                )
             }
-        } catch (exc: RejectedExecutionException) {
-            logWarningWithException("AEI - Failed to schedule AEI processing", exc, true)
-            null
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/Endpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/Endpoint.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.comms.api
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -44,18 +42,11 @@ internal enum class Endpoint(val path: String) {
         retryAfter: Long?,
         retryMethod: () -> Unit
     ) {
-        try {
-            val retryTask = Runnable {
-                retryMethod()
-            }
-            val delay = calculateDelay(retryAfter)
-            scheduledExecutorService.schedule(retryTask, delay, TimeUnit.SECONDS)
-        } catch (e: RejectedExecutionException) {
-            InternalStaticEmbraceLogger.logger.logError(
-                "Cannot schedule clear rate limit failed calls.",
-                e
-            )
+        val retryTask = Runnable {
+            retryMethod()
         }
+        val delay = calculateDelay(retryAfter)
+        scheduledExecutorService.schedule(retryTask, delay, TimeUnit.SECONDS)
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
@@ -27,7 +27,6 @@ import io.embrace.android.embracesdk.utils.stream
 import java.util.concurrent.Callable
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.RejectedExecutionException
 import kotlin.math.min
 
 /**
@@ -167,16 +166,7 @@ internal class EmbraceConfigService @JvmOverloads constructor(
      */
     private fun performInitialConfigLoad() {
         logger.logDeveloper("EmbraceConfigService", "performInitialConfigLoad")
-        try {
-            executorService.submit(
-                Callable<Any?> {
-                    loadConfigFromCache()
-                    null
-                }
-            )
-        } catch (ex: RejectedExecutionException) {
-            logger.logDebug("Failed to schedule initial config load from cache.", ex)
-        }
+        executorService.submit(::loadConfigFromCache)
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifier.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifier.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.crash
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 /**
  * Verifies if the last run crashed.
@@ -19,7 +20,7 @@ internal class LastRunCrashVerifier(private val crashFileMarker: CrashFileMarker
     fun didLastRunCrash(): Boolean {
         return didLastRunCrash ?: didLastRunCrashFuture?.let { future ->
             try {
-                future.get()
+                future.get(2, TimeUnit.SECONDS)
             } catch (e: Throwable) {
                 InternalStaticEmbraceLogger.logError("[Embrace] didLastRunCrash: error while getting the result", e)
                 null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 internal class EmbracePreferencesService(
     registrationExecutorService: ExecutorService,
@@ -49,7 +50,7 @@ internal class EmbracePreferencesService(
     // fallback from this very unlikely case by just loading on the main thread
     private val prefs: SharedPreferences
         get() = try {
-            preferences.get()
+            preferences.get(2, TimeUnit.SECONDS)
         } catch (exc: Throwable) {
             // fallback from this very unlikely case by just loading on the main thread
             lazyPrefs.value

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -13,8 +13,6 @@ import io.embrace.android.embracesdk.payload.BackgroundActivity
 import io.embrace.android.embracesdk.payload.BackgroundActivity.LifeEventType
 import io.embrace.android.embracesdk.payload.BackgroundActivityMessage
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
-import io.embrace.android.embracesdk.utils.submitSafe
-import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -123,12 +121,7 @@ internal class EmbraceBackgroundActivityService(
     }
 
     private fun saveNow() {
-        cacheExecutorService.submitSafe(
-            Callable<Any?> {
-                cacheBackgroundActivity()
-                null
-            }
-        )
+        cacheExecutorService.submit(::cacheBackgroundActivity)
         willBeSaved = false
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -23,7 +23,6 @@ import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import java.io.Closeable
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -361,18 +360,13 @@ internal class SessionHandler(
             return
         }
 
-        try {
-            closerFuture?.cancel(true)
-            closerFuture = this.automaticSessionStopper.schedule(
-                automaticSessionStopperCallback,
-                maxSessionSeconds.toLong(),
-                TimeUnit.SECONDS
-            )
-            logger.logDebug("Automatic session stopper successfully scheduled.")
-        } catch (e: RejectedExecutionException) {
-            // This happens if the executor has shutdown previous to the schedule call
-            logger.logError("Cannot schedule Automatic session stopper.", e)
-        }
+        closerFuture?.cancel(true)
+        closerFuture = this.automaticSessionStopper.schedule(
+            automaticSessionStopperCallback,
+            maxSessionSeconds.toLong(),
+            TimeUnit.SECONDS
+        )
+        logger.logDebug("Automatic session stopper successfully scheduled.")
     }
 
     /**
@@ -409,17 +403,12 @@ internal class SessionHandler(
      * It starts a background job that will schedule a callback to do periodic caching.
      */
     private fun startPeriodicCaching(cacheCallback: Runnable) {
-        try {
-            scheduledFuture = this.sessionPeriodicCacheExecutorService.scheduleWithFixedDelay(
-                cacheCallback,
-                0,
-                SESSION_CACHING_INTERVAL.toLong(),
-                TimeUnit.SECONDS
-            )
-            logger.logDebug("Periodic session cache successfully scheduled.")
-        } catch (e: RejectedExecutionException) {
-            // This happens if the executor has shutdown previous to the schedule call
-            logger.logError("Cannot schedule Periodic session cache.", e)
-        }
+        scheduledFuture = this.sessionPeriodicCacheExecutorService.scheduleWithFixedDelay(
+            cacheCallback,
+            0,
+            SESSION_CACHING_INTERVAL.toLong(),
+            TimeUnit.SECONDS
+        )
+        logger.logDebug("Periodic session cache successfully scheduled.")
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/ExecutorServiceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/ExecutorServiceExtensions.kt
@@ -3,20 +3,6 @@ package io.embrace.android.embracesdk.utils
 import io.embrace.android.embracesdk.annotation.InternalApi
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Future
-import java.util.concurrent.RejectedExecutionException
-
-/**
- * Submit a [Callable] such that if the submit fails due to a [RejectedExecutionException], it simply does nothing
- */
-@InternalApi
-internal fun <T> ExecutorService.submitSafe(task: Callable<T>): Future<T>? {
-    return try {
-        submit(task)
-    } catch (e: RejectedExecutionException) {
-        null
-    }
-}
 
 /**
  * Eagerly loads the value returned by a Lazy property on a background thread.
@@ -26,7 +12,7 @@ internal fun <T> ExecutorService.submitSafe(task: Callable<T>): Future<T>? {
  */
 @InternalApi
 internal fun <T> ExecutorService.eagerLazyLoad(task: Callable<T>): Lazy<T> {
-    val future = submitSafe(task)
+    val future = submit(task)
     return lazy {
         if (future != null) {
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
@@ -1,17 +1,23 @@
 package io.embrace.android.embracesdk.worker
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.PriorityBlockingQueue
+import java.util.concurrent.RejectedExecutionHandler
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 // This lint error seems spurious as it only flags methods annotated with @JvmStatic even though the accessor is generated regardless
 // for lazily initialized members
-internal class WorkerThreadModuleImpl : WorkerThreadModule {
+internal class WorkerThreadModuleImpl(
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : WorkerThreadModule, RejectedExecutionHandler {
 
     private val executors: MutableMap<ExecutorName, ExecutorService> = ConcurrentHashMap()
 
@@ -32,18 +38,35 @@ internal class WorkerThreadModuleImpl : WorkerThreadModule {
     private fun fetchExecutor(executorName: ExecutorName): ExecutorService {
         return executors.getOrPut(executorName) {
             val threadFactory = createThreadFactory(executorName.threadName)
+
             when (executorName) {
-                ExecutorName.NETWORK_REQUEST -> ThreadPoolExecutor(
-                    1,
-                    1,
-                    60L,
-                    TimeUnit.SECONDS,
-                    createNetworkRequestQueue(),
-                    threadFactory
-                )
-                else -> Executors.newSingleThreadScheduledExecutor(threadFactory)
+                ExecutorName.NETWORK_REQUEST -> {
+                    ThreadPoolExecutor(
+                        1,
+                        1,
+                        60L,
+                        TimeUnit.SECONDS,
+                        createNetworkRequestQueue(),
+                        threadFactory,
+                        this
+                    )
+                }
+                else -> ScheduledThreadPoolExecutor(1, threadFactory, this)
             }
         }
+    }
+
+    /**
+     * Handles a rejected task by logging a warning and ignoring the task. Generally speaking
+     * the executor will either have been shutdown directly (which should not happen outside of)
+     * [WorkerThreadModuleImpl] or the process is terminating.
+     *
+     * The difference with this policy is that a Future will be returned when the executor is
+     * shut down, and the caller must handle any TimeoutExceptions for the Future (that will)
+     * never return a value.
+     */
+    override fun rejectedExecution(runnable: Runnable, executor: ThreadPoolExecutor) {
+        logger.logWarning("Rejected execution of $runnable on $executor. Ignoring - the process is likely terminating.")
     }
 
     private fun createThreadFactory(name: String): ThreadFactory =

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/utils/ExecutorExtensionsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/utils/ExecutorExtensionsTest.kt
@@ -2,24 +2,10 @@ package io.embrace.android.embracesdk.utils
 
 import com.google.common.util.concurrent.MoreExecutors
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 import java.util.concurrent.Callable
 
 internal class ExecutorExtensionsTest {
-
-    @Test
-    fun testSubmitSafe() {
-        val executor = MoreExecutors.newDirectExecutorService()
-        assertEquals(1, executor.submitSafe(Callable { 1 })?.get())
-    }
-
-    @Test
-    fun testSubmitSafeClosed() {
-        val executor = MoreExecutors.newDirectExecutorService()
-        executor.shutdown()
-        assertNull(executor.submitSafe(Callable { 1 }))
-    }
 
     @Test
     fun testEagerLazyLoadNormal() {
@@ -31,12 +17,5 @@ internal class ExecutorExtensionsTest {
     fun testEagerLazyLoadException() {
         val executor = MoreExecutors.newDirectExecutorService()
         executor.eagerLazyLoad(Callable { error("Whoops") }).value
-    }
-
-    @Test
-    fun testEagerLazyLoadClosed() {
-        val executor = MoreExecutors.newDirectExecutorService()
-        executor.shutdown()
-        assertEquals(1, executor.eagerLazyLoad(Callable { 1 }).value)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.worker
 
+import io.embrace.android.embracesdk.fakes.FakeLoggerAction
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -36,5 +38,20 @@ internal class WorkerThreadModuleImplTest {
     fun `network request scheduled executor fails`() {
         val module = WorkerThreadModuleImpl()
         assertTrue(module.scheduledExecutor(ExecutorName.NETWORK_REQUEST) is ThreadPoolExecutor)
+    }
+
+    @Test
+    fun `rejected execution policy`() {
+        val action = FakeLoggerAction()
+        val logger = InternalEmbraceLogger().apply { addLoggerAction(action) }
+        val module = WorkerThreadModuleImpl(logger)
+
+        val executor = module.backgroundExecutor(ExecutorName.PERIODIC_CACHE)
+        executor.shutdown()
+
+        val future = executor.submit {}
+        val msg = action.msgQueue.single().msg
+        assertTrue(msg.startsWith("Rejected execution of"))
+        assertNotNull(future)
     }
 }


### PR DESCRIPTION
## Goal

Adds a RejectedExecutionHandler that logs a warning when instantiating any executors. This avoids throwing `RejectedExecutionException` when the executor is shutdown (i.e. the process is terminating) or the task is rejected for whatever reason.

Previously catching the exception was left as a choice for the individual caller - the codebase is inconsistent in whether the exception is properly handled or not. Adopting a consistent policy will avoid any chance of crashes in customer apps.

This causes a difference in behavior in that a `Future` will always be returned now when submitting a task. Waiting for the `Future` using `get()` will still block but will obviously never return a value if the executor is shutdown.

## Testing

Updated existing test coverage. I also visually verified that every point in the codebase that holds a reference to a Future handles it appropriately with a timeout on the `get()`. This resulted in adding arbitrary timeouts to a couple of places in the codebase that did not have any.

