### PR TITLE
Rollback detekt

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
     // TODO: future - these versions must be kept in sync when updating buildscript deps.
     implementation("com.android.tools.build:gradle:7.3.0")
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.12.1")
 }

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -24,7 +24,7 @@ object Versions {
     val dokka = "1.7.10"
 
     @JvmField
-    val detekt = "1.22.0"
+    val detekt = "1.21.0"
 
     @JvmField
     val binaryCompatValidator = "0.12.1"


### PR DESCRIPTION
## Goal

The swazzler-tests are receiving a shutdown signal, and it may have something to do with the gradle wrapper we are using to publish the SDK and the swazzler. 

As the new detekt version is not compatible with the gradle 7.4 wrapper we are using in the tests, I'll roll it back, just to verify that this is the problem. 