### PR TITLE
Avoid using callable when submitting to executor

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -14,7 +14,6 @@ import java.net.Inet4Address
 import java.net.NetworkInterface
 import java.util.NavigableMap
 import java.util.TreeMap
-import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 
 @Suppress("DEPRECATION") // uses deprecated APIs for backwards compat
@@ -132,20 +131,17 @@ internal class EmbraceNetworkConnectivityService(
         lastNetworkStatus == null || lastNetworkStatus != newNetworkStatus
 
     private fun registerConnectivityActionReceiver() {
-        registrationExecutorService.submit(
-            Callable<Any?> {
-                try {
-                    context.registerReceiver(this, intentFilter)
-                } catch (ex: Exception) {
-                    logger.logDebug(
-                        "Failed to register EmbraceNetworkConnectivityService " +
-                            "broadcast receiver. Connectivity status will be unavailable.",
-                        ex
-                    )
-                }
-                null
+        registrationExecutorService.submit {
+            try {
+                context.registerReceiver(this, intentFilter)
+            } catch (ex: Exception) {
+                logger.logDebug(
+                    "Failed to register EmbraceNetworkConnectivityService " +
+                        "broadcast receiver. Connectivity status will be unavailable.",
+                    ex
+                )
             }
-        )
+        }
     }
 
     override fun close() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceLogMessageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceLogMessageService.kt
@@ -26,7 +26,6 @@ import io.embrace.android.embracesdk.payload.Stacktraces
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import java.sql.Timestamp
 import java.util.NavigableMap
-import java.util.concurrent.Callable
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicInteger
@@ -34,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger
 /**
  * Logs messages remotely, so that they can be viewed as events during a user's session.
  */
-internal class EmbraceLogMessageService constructor(
+internal class EmbraceLogMessageService(
     private val metadataService: MetadataService,
     private val deliveryService: DeliveryService,
     private val userService: UserService,
@@ -93,32 +92,29 @@ internal class EmbraceLogMessageService constructor(
         }
         try {
             logDeveloper("EmbraceRemoteLogger", "Attempting to log network data")
-            executorService.submit<Any?>(
-                Callable<Any?> {
-                    synchronized(lock) {
-                        val id = getEmbUuid()
-                        networkLogIds[networkEventTimestamp] = id
-                        val optionalSessionId = metadataService.activeSessionId
-                        val networkEvent = NetworkEvent(
-                            metadataService.getAppId(),
-                            metadataService.getAppInfo(),
-                            metadataService.getDeviceId(),
-                            id,
-                            networkCaptureCall,
-                            Timestamp(networkEventTimestamp).toString(),
-                            networkConnectivityService.ipAddress,
-                            optionalSessionId
-                        )
-                        logDeveloper("EmbraceRemoteLogger", "Attempt to Send NETWORK Event")
-                        deliveryService.sendNetworkCall(networkEvent)
-                        logDeveloper(
-                            "EmbraceRemoteLogger",
-                            "LogNetwork api call running in background job"
-                        )
-                    }
-                    null
+            executorService.submit {
+                synchronized(lock) {
+                    val id = getEmbUuid()
+                    networkLogIds[networkEventTimestamp] = id
+                    val optionalSessionId = metadataService.activeSessionId
+                    val networkEvent = NetworkEvent(
+                        metadataService.getAppId(),
+                        metadataService.getAppInfo(),
+                        metadataService.getDeviceId(),
+                        id,
+                        networkCaptureCall,
+                        Timestamp(networkEventTimestamp).toString(),
+                        networkConnectivityService.ipAddress,
+                        optionalSessionId
+                    )
+                    logDeveloper("EmbraceRemoteLogger", "Attempt to Send NETWORK Event")
+                    deliveryService.sendNetworkCall(networkEvent)
+                    logDeveloper(
+                        "EmbraceRemoteLogger",
+                        "LogNetwork api call running in background job"
+                    )
                 }
-            )
+            }
         } catch (ex: Exception) {
             logDebug("Failed to log network call using Embrace SDK.", ex)
         }
@@ -172,130 +168,127 @@ internal class EmbraceLogMessageService constructor(
         // at the time of the log call
         val logUserInfo = userService.getUserInfo()
         logDeveloper("EmbraceRemoteLogger", "Added user info to log")
-        executorService.submit<Any?>(
-            Callable<Any?> {
-                synchronized(lock) {
-                    if (!configService.dataCaptureEventBehavior.isLogMessageEnabled(message)) {
-                        logger.logWarning("Log message disabled. Ignoring log with message $message")
-                        return@Callable null
-                    }
-                    if (!configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.LOG)) {
-                        logger.logWarning("Log message disabled. Ignoring all Logs.")
-                        return@Callable null
-                    }
-                    val id = getEmbUuid()
-                    if (type == EmbraceEvent.Type.INFO_LOG) {
-                        logDeveloper("EmbraceRemoteLogger", "New INFO log")
-                        logsInfoCount.incrementAndGet()
-                        if (infoLogIds.size < configService.logMessageBehavior.getInfoLogLimit()) {
-                            logDeveloper(
-                                "EmbraceRemoteLogger",
-                                "Logging INFO log number $logsInfoCount"
-                            )
-                            infoLogIds[timestamp] = id
-                        } else {
-                            logger.logWarning("Info Log limit has been reached.")
-                            return@Callable null
-                        }
-                    } else if (type == EmbraceEvent.Type.WARNING_LOG) {
-                        logsWarnCount.incrementAndGet()
-                        if (warningLogIds.size < configService.logMessageBehavior.getWarnLogLimit()) {
-                            logDeveloper(
-                                "EmbraceRemoteLogger",
-                                "Logging WARNING log number $logsWarnCount"
-                            )
-                            warningLogIds[timestamp] = id
-                        } else {
-                            logger.logWarning("Warning Log limit has been reached.")
-                            return@Callable null
-                        }
-                    } else if (type == EmbraceEvent.Type.ERROR_LOG) {
-                        logsErrorCount.incrementAndGet()
-                        if (errorLogIds.size < configService.logMessageBehavior.getErrorLogLimit()) {
-                            logDeveloper(
-                                "EmbraceRemoteLogger",
-                                "Logging ERROR log number $logsErrorCount"
-                            )
-                            errorLogIds[timestamp] = id
-                        } else {
-                            logger.logWarning("Error Log limit has been reached.")
-                            return@Callable null
-                        }
-                    } else {
-                        logger.logWarning("Unknown log level $type")
-                        return@Callable null
-                    }
-                    val processedMessage: String
-                    if (framework == AppFramework.UNITY) {
-                        logDeveloper("EmbraceRemoteLogger", "Process Unity Log message")
-                        processedMessage = processUnityLogMessage(message)
-                        if (logExceptionType == LogExceptionType.UNHANDLED) {
-                            unhandledExceptionCount.incrementAndGet()
-                        }
-                    } else if (framework == AppFramework.FLUTTER) {
-                        logDeveloper("EmbraceRemoteLogger", "Process Flutter Log message")
-                        processedMessage = processLogMessage(message)
-                        if (logExceptionType == LogExceptionType.UNHANDLED) {
-                            unhandledExceptionCount.incrementAndGet()
-                        }
-                    } else {
-                        logDeveloper("EmbraceRemoteLogger", "Process simple Log message")
-                        processedMessage = processLogMessage(message)
-                    }
-
-                    // TODO validate event metadata here!
-                    var sessionId: String? = null
-                    val optionalSessionId = metadataService.activeSessionId
-                    if (optionalSessionId != null) {
-                        logDeveloper("EmbraceRemoteLogger", "Adding SessionId to event")
-                        sessionId = optionalSessionId
-                    }
-                    val event = Event(
-                        processedMessage,
-                        id,
-                        getEmbUuid(),
-                        sessionId,
-                        type,
-                        clock.now(),
-                        null,
-                        screenshotTaken = false,
-                        null,
-                        metadataService.getAppState(),
-                        properties,
-                        sessionProperties.get(),
-                        null,
-                        logExceptionType.value,
-                        exceptionName,
-                        exceptionMessage,
-                        framework.value
-                    )
-
-                    // Build event message
-                    val eventMessage = EventMessage(
-                        event,
-                        null,
-                        metadataService.getDeviceInfo(),
-                        metadataService.getAppInfo(),
-                        logUserInfo,
-                        null,
-                        stacktraces,
-                        ApiClient.MESSAGE_VERSION,
-                        null
-                    )
-                    if (checkIfShouldGateLog(type)) {
-                        logger.logDebug("$type was gated by config. The event wasnot sent.")
-                        return@Callable null
-                    }
-
-                    // Sanitize log event
-                    val logEvent = gatingService.gateEventMessage(eventMessage)
-                    logDeveloper("EmbraceRemoteLogger", "Attempt to Send log Event")
-                    deliveryService.sendLog(logEvent)
-                    logDeveloper("EmbraceRemoteLogger", "LogEvent api call running in background job")
+        executorService.submit {
+            synchronized(lock) {
+                if (!configService.dataCaptureEventBehavior.isLogMessageEnabled(message)) {
+                    logger.logWarning("Log message disabled. Ignoring log with message $message")
+                    return@submit
                 }
-                null
+                if (!configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.LOG)) {
+                    logger.logWarning("Log message disabled. Ignoring all Logs.")
+                    return@submit
+                }
+                val id = getEmbUuid()
+                if (type == EmbraceEvent.Type.INFO_LOG) {
+                    logDeveloper("EmbraceRemoteLogger", "New INFO log")
+                    logsInfoCount.incrementAndGet()
+                    if (infoLogIds.size < configService.logMessageBehavior.getInfoLogLimit()) {
+                        logDeveloper(
+                            "EmbraceRemoteLogger",
+                            "Logging INFO log number $logsInfoCount"
+                        )
+                        infoLogIds[timestamp] = id
+                    } else {
+                        logger.logWarning("Info Log limit has been reached.")
+                        return@submit
+                    }
+                } else if (type == EmbraceEvent.Type.WARNING_LOG) {
+                    logsWarnCount.incrementAndGet()
+                    if (warningLogIds.size < configService.logMessageBehavior.getWarnLogLimit()) {
+                        logDeveloper(
+                            "EmbraceRemoteLogger",
+                            "Logging WARNING log number $logsWarnCount"
+                        )
+                        warningLogIds[timestamp] = id
+                    } else {
+                        logger.logWarning("Warning Log limit has been reached.")
+                        return@submit
+                    }
+                } else if (type == EmbraceEvent.Type.ERROR_LOG) {
+                    logsErrorCount.incrementAndGet()
+                    if (errorLogIds.size < configService.logMessageBehavior.getErrorLogLimit()) {
+                        logDeveloper(
+                            "EmbraceRemoteLogger",
+                            "Logging ERROR log number $logsErrorCount"
+                        )
+                        errorLogIds[timestamp] = id
+                    } else {
+                        logger.logWarning("Error Log limit has been reached.")
+                        return@submit
+                    }
+                } else {
+                    logger.logWarning("Unknown log level $type")
+                    return@submit
+                }
+                val processedMessage: String
+                if (framework == AppFramework.UNITY) {
+                    logDeveloper("EmbraceRemoteLogger", "Process Unity Log message")
+                    processedMessage = processUnityLogMessage(message)
+                    if (logExceptionType == LogExceptionType.UNHANDLED) {
+                        unhandledExceptionCount.incrementAndGet()
+                    }
+                } else if (framework == AppFramework.FLUTTER) {
+                    logDeveloper("EmbraceRemoteLogger", "Process Flutter Log message")
+                    processedMessage = processLogMessage(message)
+                    if (logExceptionType == LogExceptionType.UNHANDLED) {
+                        unhandledExceptionCount.incrementAndGet()
+                    }
+                } else {
+                    logDeveloper("EmbraceRemoteLogger", "Process simple Log message")
+                    processedMessage = processLogMessage(message)
+                }
+
+                // TODO validate event metadata here!
+                var sessionId: String? = null
+                val optionalSessionId = metadataService.activeSessionId
+                if (optionalSessionId != null) {
+                    logDeveloper("EmbraceRemoteLogger", "Adding SessionId to event")
+                    sessionId = optionalSessionId
+                }
+                val event = Event(
+                    processedMessage,
+                    id,
+                    getEmbUuid(),
+                    sessionId,
+                    type,
+                    clock.now(),
+                    null,
+                    screenshotTaken = false,
+                    null,
+                    metadataService.getAppState(),
+                    properties,
+                    sessionProperties.get(),
+                    null,
+                    logExceptionType.value,
+                    exceptionName,
+                    exceptionMessage,
+                    framework.value
+                )
+
+                // Build event message
+                val eventMessage = EventMessage(
+                    event,
+                    null,
+                    metadataService.getDeviceInfo(),
+                    metadataService.getAppInfo(),
+                    logUserInfo,
+                    null,
+                    stacktraces,
+                    ApiClient.MESSAGE_VERSION,
+                    null
+                )
+                if (checkIfShouldGateLog(type)) {
+                    logger.logDebug("$type was gated by config. The event wasnot sent.")
+                    return@submit
+                }
+
+                // Sanitize log event
+                val logEvent = gatingService.gateEventMessage(eventMessage)
+                logDeveloper("EmbraceRemoteLogger", "Attempt to Send log Event")
+                deliveryService.sendLog(logEvent)
+                logDeveloper("EmbraceRemoteLogger", "LogEvent api call running in background job")
             }
-        )
+        }
     }
 
     override fun findInfoLogIds(startTime: Long, endTime: Long): List<String> {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -108,7 +108,7 @@ internal class SessionModuleImpl(
                 nativeModule.ndkService,
                 initModule.clock,
                 backgroundActivityCollator,
-                lazy { workerThreadModule.backgroundExecutor(ExecutorName.PERIODIC_CACHE) }
+                workerThreadModule.backgroundExecutor(ExecutorName.PERIODIC_CACHE)
             )
         } else {
             null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
-import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -38,13 +37,10 @@ internal class EmbracePreferencesService(
     override fun applicationStartupComplete() = alterStartupStatus(SDK_STARTUP_COMPLETED)
 
     private fun alterStartupStatus(status: String) {
-        registrationExecutorService.submit(
-            Callable<Any?> {
-                logDeveloper("EmbracePreferencesService", "Startup key: $status")
-                prefs.setStringPreference(SDK_STARTUP_STATUS_KEY, status)
-                null
-            }
-        )
+        registrationExecutorService.submit {
+            logDeveloper("EmbracePreferencesService", "Startup key: $status")
+            prefs.setStringPreference(SDK_STARTUP_STATUS_KEY, status)
+        }
     }
 
     // fallback from this very unlikely case by just loading on the main thread

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -27,11 +27,9 @@ internal class EmbraceBackgroundActivityService(
      */
     private val clock: Clock,
     private val backgroundActivityCollator: BackgroundActivityCollator,
-    private val executorServiceSupplier: Lazy<ExecutorService>
+    private val executorService: ExecutorService
 ) : BackgroundActivityService, ConfigListener {
 
-    @get:Synchronized
-    private val cacheExecutorService: ExecutorService by lazy { executorServiceSupplier.value }
     private var lastSaved: Long = 0
     private var willBeSaved = false
 
@@ -121,7 +119,7 @@ internal class EmbraceBackgroundActivityService(
     }
 
     private fun saveNow() {
-        cacheExecutorService.submit(::cacheBackgroundActivity)
+        executorService.submit(::cacheBackgroundActivity)
         willBeSaved = false
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -316,7 +316,7 @@ internal class EmbraceBackgroundActivityServiceTest {
             ndkService,
             clock,
             collator,
-            lazy { blockableExecutorService }
+            blockableExecutorService
         )
     }
 }


### PR DESCRIPTION
## Goal

Some old code was using `Callable` rather than `Runnable` when submitting to executors. This wasn't necessary & made the indent longer than it had to be, and complicated in-progress refactoring of our threading model. Therefore I've removed the usages where unnecessary.

## Testing

Relied on existing test coverage.

