### PR TITLE
Refactor ANR detection to use ScheduledWorker

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -444,7 +444,8 @@ final class EmbraceImpl {
         AnrModuleImpl anrModule = new AnrModuleImpl(
             initModule,
             coreModule,
-            essentialServiceModule
+            essentialServiceModule,
+            workerThreadModule
         );
         AnrService nonNullAnrService = anrModule.getAnrService();
         anrService = nonNullAnrService;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrStacktraceSampler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrStacktraceSampler.kt
@@ -12,8 +12,8 @@ import io.embrace.android.embracesdk.payload.extensions.deepCopy
 import io.embrace.android.embracesdk.payload.extensions.duration
 import io.embrace.android.embracesdk.payload.extensions.hasSamples
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -24,7 +24,7 @@ internal class AnrStacktraceSampler(
     private val clock: Clock,
     targetThread: Thread,
     private val anrMonitorThread: AtomicReference<Thread>,
-    private val anrExecutorService: ExecutorService
+    private val anrMonitorWorker: ScheduledWorker
 ) : BlockedThreadListener, MemoryCleanerListener {
 
     internal val anrIntervals = CopyOnWriteArrayList<AnrInterval>()
@@ -97,7 +97,7 @@ internal class AnrStacktraceSampler(
         findIntervalsWithSamples().minByOrNull(AnrInterval::duration)
 
     override fun cleanCollections() {
-        anrExecutorService.submit {
+        anrMonitorWorker.submit {
             enforceThread(anrMonitorThread)
             anrIntervals.clear()
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logError
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicReference
 
@@ -25,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference
  */
 internal class TargetThreadHandler(
     looper: Looper,
-    private val anrExecutorService: ExecutorService,
+    private val anrMonitorWorker: ScheduledWorker,
     private val anrMonitorThread: AtomicReference<Thread>,
     private val configService: ConfigService,
     private val messageQueue: MessageQueue? = LooperCompat.getMessageQueue(looper),
@@ -70,7 +71,7 @@ internal class TargetThreadHandler(
 
     private fun onMainThreadUnblocked() {
         val timestamp = clock.now()
-        anrExecutorService.submit {
+        anrMonitorWorker.submit {
             enforceThread(anrMonitorThread)
             action.invoke(timestamp)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/ScheduledWorker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/ScheduledWorker.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.worker
 
+import java.util.concurrent.Callable
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
@@ -43,4 +44,19 @@ internal class ScheduledWorker(
      * Submits a task for execution and returns a [Future].
      */
     fun submit(runnable: Runnable): Future<*> = impl.submit(runnable)
+
+    /**
+     * Submits a task for execution and returns a [Future].
+     */
+    fun <T> submit(callable: Callable<T>): Future<T> = impl.submit(callable)
+
+    @Deprecated(
+        "Use scheduleWithFixedDelay instead.",
+    )
+    fun scheduleAtFixedRate(
+        runnable: Runnable,
+        initialDelay: Long,
+        intervalMs: Long,
+        unit: TimeUnit
+    ): ScheduledFuture<*> = impl.scheduleAtFixedRate(runnable, initialDelay, intervalMs, unit)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.worker
 
 import java.io.Closeable
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A set of shared executors to be used throughout the SDK
@@ -16,6 +17,11 @@ internal interface WorkerThreadModule : Closeable {
      * Return the [ScheduledWorker] given the [workerName]
      */
     fun scheduledWorker(workerName: WorkerName): ScheduledWorker
+
+    /**
+     * Returns the thread that monitors the main thread for ANRs
+     */
+    val anrMonitorThread: AtomicReference<Thread>
 
     /**
      * This should only be invoked when the SDK is shutting down. Closing all the worker threads in production means the
@@ -61,4 +67,9 @@ internal enum class WorkerName(internal val threadName: String) {
      * the intention behind this is to offload unnecessary CPU work from the main thread.
      */
     REMOTE_LOGGING("remote-logging"),
+
+    /**
+     * Monitor thread that checks the main thread for ANRs.
+     */
+    ANR_MONITOR("anr-monitor"),
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.mockk
 import org.junit.rules.ExternalResource
 import java.util.concurrent.ScheduledExecutorService
@@ -49,9 +50,10 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
         fakeConfigService = FakeConfigService(anrBehavior = fakeAnrBehavior { cfg })
         anrExecutorService = scheduledExecutorSupplier.invoke()
         state = ThreadMonitoringState(clock)
+        val worker = ScheduledWorker(anrExecutorService)
         targetThreadHandler = TargetThreadHandler(
             looper = looper,
-            anrExecutorService = anrExecutorService,
+            anrMonitorWorker = worker,
             anrMonitorThread = anrMonitorThread,
             configService = fakeConfigService,
             clock = clock
@@ -65,7 +67,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
         )
         livenessCheckScheduler = LivenessCheckScheduler(
             configService = fakeConfigService,
-            anrExecutor = anrExecutorService,
+            anrMonitorWorker = worker,
             clock = clock,
             state = state,
             targetThreadHandler = targetThreadHandler,
@@ -79,7 +81,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             logger = logger,
             sigquitDetectionService = mockSigquitDetectionService,
             livenessCheckScheduler = livenessCheckScheduler,
-            anrExecutorService = anrExecutorService,
+            anrMonitorWorker = worker,
             state = state,
             clock = clock,
             anrMonitorThread = anrMonitorThread

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeWorkerThreadModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeWorkerThreadModule.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KFunction1
 import kotlin.reflect.KFunction2
 
@@ -48,6 +49,8 @@ internal class FakeWorkerThreadModule(
     fun scheduledExecutor(workerName: WorkerName): BlockingScheduledExecutorService {
         return checkNotNull(scheduledExecutorServices[workerName])
     }
+
+    override val anrMonitorThread: AtomicReference<Thread> = AtomicReference(Thread.currentThread())
 
     override fun close() {
         executorServices.values.forEach { it.shutdown() }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrStacktraceSamplerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrStacktraceSamplerTest.kt
@@ -1,13 +1,14 @@
 package io.embrace.android.embracesdk.anr
 
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.anr.detection.ThreadMonitoringState
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.embrace.android.embracesdk.payload.AnrSampleList
 import io.embrace.android.embracesdk.payload.extensions.size
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -23,11 +24,11 @@ internal class AnrStacktraceSamplerTest {
     private val clock = FakeClock()
     private val configService = FakeConfigService()
     private val state = ThreadMonitoringState(clock)
-    private val executor = MoreExecutors.newDirectExecutorService()
+    private val worker = ScheduledWorker(BlockingScheduledExecutorService())
 
     @Test
     fun testLeastValuableInterval() {
-        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, executor)
+        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, worker)
         assertNull(sampler.findLeastValuableIntervalWithSamples())
         val interval1 = AnrInterval(
             startTime = BASELINE_MS,
@@ -78,7 +79,7 @@ internal class AnrStacktraceSamplerTest {
         clock.setCurrentTime(BASELINE_MS)
         val repeatCount = 100
         val intervalMs: Long = 100
-        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, executor)
+        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, worker)
 
         // simulate one ANR with 100 intervals
         sampler.onThreadBlocked(thread, clock.now())
@@ -126,7 +127,7 @@ internal class AnrStacktraceSamplerTest {
         val anrRepeatCount = 15
         val intervalRepeatCount = 100
         val intervalMs: Long = 100
-        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, executor)
+        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, worker)
 
         // simulate multiple ANRs with intervals
         repeat(anrRepeatCount) { index ->
@@ -169,7 +170,7 @@ internal class AnrStacktraceSamplerTest {
         clock.setCurrentTime(BASELINE_MS)
         val anrRepeatCount = 110
         val intervalMs: Long = 100
-        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, executor)
+        val sampler = AnrStacktraceSampler(configService, clock, thread, anrMonitorThread, worker)
 
         // simulate 110 ANRs with intervals
         repeat(anrRepeatCount) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -66,7 +67,7 @@ internal class LivenessCheckSchedulerTest {
 
         scheduler = LivenessCheckScheduler(
             configService,
-            anrExecutorService,
+            ScheduledWorker(anrExecutorService),
             fakeClock,
             state,
             fakeTargetThreadHandler,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.anr.detection
 import android.os.Message
 import android.os.MessageQueue
 import io.embrace.android.embracesdk.anr.detection.TargetThreadHandler.Companion.HEARTBEAT_REQUEST
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.fakes.system.mockMessage
 import io.embrace.android.embracesdk.fakes.system.mockMessageQueue
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -26,7 +27,7 @@ internal class TargetThreadHandlerTest {
     private val clock = { FAKE_TIME_MS }
     private val state = ThreadMonitoringState(clock)
     private lateinit var runnable: Runnable
-    private lateinit var executorService: BlockableExecutorService
+    private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var anrMonitorThread: AtomicReference<Thread>
     private lateinit var handler: TargetThreadHandler
     private lateinit var configService: ConfigService
@@ -36,7 +37,7 @@ internal class TargetThreadHandlerTest {
         runnable = Runnable {}
         configService = FakeConfigService()
         anrMonitorThread = AtomicReference()
-        executorService = BlockableExecutorService(blockingMode = true)
+        executorService = BlockingScheduledExecutorService(blockingMode = true)
         executorService.submit { anrMonitorThread.set(Thread.currentThread()) }
         executorService.runCurrentlyBlocked()
         handler = createHandler(null)
@@ -46,7 +47,7 @@ internal class TargetThreadHandlerTest {
     private fun createHandler(messageQueue: MessageQueue?): TargetThreadHandler {
         return TargetThreadHandler(
             mockLooper(),
-            executorService,
+            ScheduledWorker(executorService),
             anrMonitorThread = anrMonitorThread,
             configService,
             messageQueue
@@ -74,7 +75,7 @@ internal class TargetThreadHandlerTest {
         val msg = mockk<Message>()
         msg.what = HEARTBEAT_REQUEST
         handler.handleMessage(msg)
-        assertEquals(1, executorService.tasksBlockedCount())
+        assertEquals(2, executorService.submitCount)
     }
 
     @Test
@@ -87,7 +88,7 @@ internal class TargetThreadHandlerTest {
         val msg = mockk<Message>()
         msg.what = HEARTBEAT_REQUEST
         handler.handleMessage(msg)
-        assertEquals(1, executorService.tasksBlockedCount())
+        assertEquals(2, executorService.submitCount)
         executorService.runCurrentlyBlocked()
         verify { handler.action.invoke(FAKE_TIME_MS) }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
@@ -90,12 +90,15 @@ internal class BlockingScheduledExecutorService(
 
     fun scheduledTasksCount(): Int = scheduledTasks.size
 
+    var submitCount = 0
+
     override fun execute(command: Runnable?) {
         requireNotNull(command)
         delegateExecutorService.execute(command)
     }
 
     override fun submit(task: Runnable?): Future<*> {
+        submitCount++
         requireNotNull(task)
         return delegateExecutorService.submit(task)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import android.os.Looper
+import io.embrace.android.embracesdk.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.anr.NoOpAnrService
 import io.embrace.android.embracesdk.capture.monitor.NoOpResponsivenessMonitorService
 import io.embrace.android.embracesdk.config.local.AutomaticDataCaptureLocalConfig
@@ -31,7 +32,8 @@ internal class AnrModuleImplTest {
         val module = AnrModuleImpl(
             InitModuleImpl(),
             FakeCoreModule(),
-            FakeEssentialServiceModule()
+            FakeEssentialServiceModule(),
+            FakeWorkerThreadModule()
         )
         assertNotNull(module.anrService)
         assertNotNull(module.googleAnrTimestampRepository)
@@ -45,7 +47,8 @@ internal class AnrModuleImplTest {
             FakeCoreModule(),
             FakeEssentialServiceModule(
                 configService = createConfigServiceWithAnrDisabled()
-            )
+            ),
+            FakeWorkerThreadModule()
         )
         assertTrue(module.anrService is NoOpAnrService)
         assertTrue(module.responsivenessMonitorService is NoOpResponsivenessMonitorService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/ScheduledWorkerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/ScheduledWorkerTest.kt
@@ -37,6 +37,22 @@ internal class ScheduledWorkerTest {
         }
     }
 
+    @Suppress("DEPRECATION")
+    @Test
+    fun testScheduleAtFixedRate() {
+        val impl = BlockingScheduledExecutorService()
+        var count = 0
+        val runnable = Runnable {
+            count++
+        }
+        ScheduledWorker(impl).scheduleAtFixedRate(runnable, 2, 2, TimeUnit.SECONDS)
+
+        repeat(3) {
+            impl.moveForwardAndRunBlocked(2000)
+            assertEquals(it + 1, count)
+        }
+    }
+
     @Test
     fun testSubmitRunnable() {
         val impl = BlockingScheduledExecutorService()


### PR DESCRIPTION
## Goal

Refactored the ANR detection to use `ScheduledWorker`, so that thread creation in the core SDK module remains in one place.

## Testing

Updated existing test coverage.

