### PR TITLE
Remove unnecessary thread used for loading sessions

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -110,9 +110,7 @@ internal class EmbraceDeliveryCacheManager(
                 previousSdkSession?.also {
                     // When saved, the new session filename is also added to cachedSessions
                     saveSession(it, SessionSnapshotType.NORMAL_END)
-                    backgroundWorker.submit {
-                        cacheService.deleteFile(filename)
-                    }
+                    cacheService.deleteFile(filename)
                 }
             }
             val values = filename.split('.')

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -19,7 +19,7 @@ internal class EmbraceDeliveryService(
     private val cacheManager: DeliveryCacheManager,
     private val apiService: ApiService,
     private val gatingService: GatingService,
-    private val cachedSessionsBackgroundWorker: BackgroundWorker,
+    private val backgroundWorker: BackgroundWorker,
     private val serializer: EmbraceSerializer,
     private val logger: InternalEmbraceLogger
 ) : DeliveryService {
@@ -163,13 +163,13 @@ internal class EmbraceDeliveryService(
     }
 
     private fun sendCachedSessionsWithoutNdk(currentSession: String?) {
-        cachedSessionsBackgroundWorker.submit {
+        backgroundWorker.submit {
             sendCachedSessions(cacheManager.getAllCachedSessionIds(), currentSession)
         }
     }
 
     private fun sendCachedSessionsWithNdk(ndkService: NdkService, currentSession: String?) {
-        cachedSessionsBackgroundWorker.submit {
+        backgroundWorker.submit {
             val allSessions = cacheManager.getAllCachedSessionIds()
             logger.logDeveloper(TAG, "NDK enabled, checking for native crashes")
             val nativeCrashData = ndkService.checkForNativeCrash()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
@@ -15,14 +15,12 @@ internal class DeliveryModuleImpl(
     workerThreadModule: WorkerThreadModule
 ) : DeliveryModule {
 
-    private val cachedSessionsWorker = workerThreadModule.backgroundWorker(WorkerName.CACHED_SESSIONS)
-
     override val deliveryService: DeliveryService by singleton {
         EmbraceDeliveryService(
             essentialServiceModule.deliveryCacheManager,
             essentialServiceModule.apiService,
             essentialServiceModule.gatingService,
-            cachedSessionsWorker,
+            workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
             coreModule.jsonSerializer,
             coreModule.logger
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
@@ -36,12 +36,6 @@ internal enum class WorkerName(internal val threadName: String) {
     BACKGROUND_REGISTRATION("background-reg"),
 
     /**
-     * Reads any sessions that are cached on disk & loads then sends them to the server.
-     * Runnables are only added to this during SDK initialization.
-     */
-    CACHED_SESSIONS("cached-sessions"),
-
-    /**
      * Saves/loads request information from files cached on disk.
      */
     DELIVERY_CACHE("delivery-cache"),


### PR DESCRIPTION
## Goal

Removes the `CACHED_SESSIONS` worker that was only used for transforming the cached session from the previous process into a request that can be sent to the Embrace API. I have altered this to use the `DELIVERY_CACHE` worker instead as it does perform some I/O, but it will be a one-off during SDK initialization that should be fairly short-lived. I also removed an unnecessary use of a worker in the `DeliveryCacheManager` as it's always called from the thread that a job was being submitted to.

## Testing

Relied on existing test coverage & confirmed sessions still show in dashboard