### PR TITLE
Remove useless session message creation

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionMessageCollator.kt
@@ -34,6 +34,34 @@ internal class SessionMessageCollator(
     private val clock: Clock
 ) {
 
+    /**
+     * Builds a new session object. This should not be sent to the backend but is used
+     * to populate essential session information (such as ID), etc
+     */
+    internal fun buildInitialSession(
+        id: String,
+        coldStart: Boolean,
+        startType: Session.LifeEventType,
+        startTime: Long,
+        sessionNumber: Int,
+        userInfo: UserInfo?,
+        sessionProperties: Map<String, String>
+    ): Session = Session(
+        sessionId = id,
+        startTime = startTime,
+        number = sessionNumber,
+        appState = Session.APPLICATION_STATE_FOREGROUND,
+        isColdStart = coldStart,
+        startType = startType,
+        properties = sessionProperties,
+        messageType = Session.MESSAGE_TYPE_END,
+        user = userInfo
+    )
+
+    /**
+     * Builds a fully populated session message. This can be sent to the backend (or stored
+     * on disk).
+     */
     @Suppress("ComplexMethod")
     internal fun buildEndSessionMessage(
         originSession: Session,
@@ -144,30 +172,4 @@ internal class SessionMessageCollator(
             spans = spans
         )
     }
-
-    internal fun buildInitialSessionMessage(session: Session) = SessionMessage(
-        session = session,
-        appInfo = captureDataSafely(metadataService::getAppInfo),
-        deviceInfo = captureDataSafely(metadataService::getDeviceInfo)
-    )
-
-    internal fun buildInitialSession(
-        id: String,
-        coldStart: Boolean,
-        startType: Session.LifeEventType,
-        startTime: Long,
-        sessionNumber: Int,
-        userInfo: UserInfo?,
-        sessionProperties: Map<String, String>
-    ): Session = Session(
-        sessionId = id,
-        startTime = startTime,
-        number = sessionNumber,
-        appState = Session.APPLICATION_STATE_FOREGROUND,
-        isColdStart = coldStart,
-        startType = startType,
-        properties = sessionProperties,
-        messageType = Session.MESSAGE_TYPE_END,
-        user = userInfo
-    )
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -6,15 +6,12 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
-import io.embrace.android.embracesdk.fakes.fakeSessionMessage
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
-import io.embrace.android.embracesdk.payload.SessionMessage
 import io.mockk.clearAllMocks
 import io.mockk.clearMocks
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
@@ -40,7 +37,6 @@ internal class EmbraceSessionServiceTest {
 
         private val processStateService = FakeProcessStateService()
         private val ndkService: NdkService = FakeNdkService()
-        private val sessionMessage: SessionMessage = fakeSessionMessage()
         private val mockSessionHandler: SessionHandler = mockk(relaxed = true)
         private val clock = FakeClock()
 
@@ -94,14 +90,6 @@ internal class EmbraceSessionServiceTest {
         val crashId = "crash-id"
 
         // let's start session first so we have an active session
-        every {
-            mockSessionHandler.onSessionStarted(
-                true,
-                LifeEventType.STATE,
-                any(),
-                any()
-            )
-        } returns sessionMessage
         service.startSession(true, LifeEventType.STATE, clock.now())
 
         service.handleCrash(crashId)
@@ -235,14 +223,6 @@ internal class EmbraceSessionServiceTest {
     }
 
     private fun startDefaultSession() {
-        every {
-            mockSessionHandler.onSessionStarted(
-                true,
-                LifeEventType.STATE,
-                any(),
-                any()
-            )
-        } returns sessionMessage
         service.startSession(true, LifeEventType.STATE, clock.now())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -210,12 +210,11 @@ internal class SessionHandlerTest {
         val maxSessionSeconds = 60
         sessionLocalConfig = SessionLocalConfig(maxSessionSeconds = 60, asyncEnd = false)
         userService.obj = userInfo
-        activeSession = fakeSession()
 
         val sessionStartType = Session.LifeEventType.STATE
         // this is needed so session handler creates automatic session stopper
 
-        val sessionMessage = sessionHandler.onSessionStarted(
+        sessionHandler.onSessionStarted(
             true,
             sessionStartType,
             now,
@@ -246,7 +245,8 @@ internal class SessionHandlerTest {
         // verify session id gets updated if ndk enabled
         assertEquals(sessionUuid, ndkService.sessionId)
         // verify session is correctly built
-        with(checkNotNull(sessionMessage?.session)) {
+
+        with(checkNotNull(sessionHandler.activeSession)) {
             assertEquals(sessionUuid, this.sessionId)
             assertEquals(startTime, now)
             assertTrue(isColdStart)
@@ -255,11 +255,6 @@ internal class SessionHandlerTest {
             assertEquals("en", messageType)
             assertEquals("foreground", appState)
             assertEquals(userInfo, user)
-        }
-        // verify session message is successfully built
-        with(checkNotNull(sessionMessage)) {
-            assertEquals(metadataService.getDeviceInfo(), deviceInfo)
-            assertEquals(metadataService.getAppInfo(), appInfo)
         }
         assertEquals(1, preferencesService.incrementAndGetSessionNumberCount)
     }
@@ -270,14 +265,14 @@ internal class SessionHandlerTest {
             disabledMessageTypes = setOf(MessageType.SESSION.name.toLowerCase(Locale.getDefault()))
         )
 
-        val sessionMessage = sessionHandler.onSessionStarted(
+        sessionHandler.onSessionStarted(
             true,
             /* any event type */ Session.LifeEventType.STATE,
             now,
             automaticSessionStopperRunnable
         )
 
-        assertNull(sessionMessage)
+        assertNull(sessionHandler.activeSession)
         verify { networkConnectivityService wasNot Called }
         assertNull(metadataService.activeSessionId)
         assertEquals(0, gatingService.sessionMessagesFiltered.size)
@@ -294,7 +289,7 @@ internal class SessionHandlerTest {
         val sessionStartType = Session.LifeEventType.STATE
         // this is needed so session handler creates automatic session stopper
 
-        val sessionMessage = sessionHandler.onSessionStarted(
+        sessionHandler.onSessionStarted(
             true,
             sessionStartType,
             now,
@@ -302,8 +297,7 @@ internal class SessionHandlerTest {
         )
 
         assertEquals(1, preferencesService.incrementAndGetSessionNumberCount)
-        checkNotNull(sessionMessage)
-        assertNotNull(sessionMessage.session)
+        checkNotNull(sessionHandler.activeSession)
         // no need to verify anything else because it's already verified in another test case
     }
 
@@ -321,8 +315,7 @@ internal class SessionHandlerTest {
 
         // verify automatic session stopper has not been scheduled
         verify { automaticSessionStopper wasNot Called }
-        checkNotNull(sessionMessage)
-        assertNotNull(sessionMessage.session)
+        checkNotNull(sessionHandler.activeSession)
         // no need to verify anything else because it's already verified in another test case
     }
 
@@ -343,8 +336,7 @@ internal class SessionHandlerTest {
 
         // verify we are forcing log view with foreground activity class name
         assertEquals(mockActivity.localClassName, breadcrumbService.logViewCalls.single())
-        checkNotNull(sessionMessage)
-        assertNotNull(sessionMessage.session)
+        checkNotNull(sessionHandler.activeSession)
         // no need to verify anything else because it's already verified in another test case
     }
 


### PR DESCRIPTION
## Goal

Removes a useless creation of a session message object that wasn't actually used within the `SessionHandler`.

## Testing

Relied on existing test coverage.

