### PR TITLE
Enable thermal status capture by default

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -4,11 +4,13 @@ import io.embrace.android.embracesdk.IntegrationTestRule.Harness
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.NetworkLocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.config.remote.DataRemoteConfig
 import io.embrace.android.embracesdk.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.fakes.fakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.fakeSdkModeBehavior
@@ -144,7 +146,13 @@ internal class IntegrationTestRule(
             ),
             networkSpanForwardingBehavior = fakeNetworkSpanForwardingBehavior {
                 NetworkSpanForwardingRemoteConfig(pctEnabled = 100.0f)
-            }
+            },
+            autoDataCaptureBehavior = fakeAutoDataCaptureBehavior(
+                remoteCfg = { DEFAULT_SDK_REMOTE_CONFIG.copy(
+                    // disable thermal status capture as it interfes with unit tests
+                    dataConfig = DataRemoteConfig(pctThermalStatusEnabled = 0.0f)
+                ) }
+            )
         ),
         val systemServiceModule: SystemServiceModule =
             SystemServiceModuleImpl(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AutoDataCaptureBehavior.kt
@@ -20,6 +20,7 @@ internal class AutoDataCaptureBehavior(
 
     companion object {
         const val MEMORY_SERVICE_ENABLED_DEFAULT = true
+        const val THERMAL_STATUS_ENABLED_DEFAULT = true
         const val POWER_SAVE_MODE_SERVICE_ENABLED_DEFAULT = true
         const val NETWORK_CONNECTIVITY_SERVICE_ENABLED_DEFAULT = true
         const val ANR_SERVICE_ENABLED_DEFAULT = true
@@ -35,6 +36,14 @@ internal class AutoDataCaptureBehavior(
     fun isMemoryServiceEnabled(): Boolean {
         return local?.sdkConfig?.automaticDataCaptureConfig?.memoryServiceEnabled
             ?: MEMORY_SERVICE_ENABLED_DEFAULT
+    }
+
+    /**
+     * Returns true if SDK should automatically capture thermal status data
+     */
+    fun isThermalStatusCaptureEnabled(): Boolean {
+        return thresholdCheck.isBehaviorEnabled(remote?.dataConfig?.pctThermalStatusEnabled)
+            ?: THERMAL_STATUS_ENABLED_DEFAULT
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/DataRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/DataRemoteConfig.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.config.remote
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Configuration values relating to data capture of the SDK
+ */
+@JsonClass(generateAdapter = true)
+internal data class DataRemoteConfig(
+
+    @Json(name = "pct_thermal_status_enabled")
+    val pctThermalStatusEnabled: Float? = null
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/RemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/RemoteConfig.kt
@@ -80,6 +80,9 @@ internal data class RemoteConfig(
     @Json(name = "anr")
     val anrConfig: AnrRemoteConfig? = null,
 
+    @Json(name = "data")
+    val dataConfig: DataRemoteConfig? = null,
+
     @Json(name = "killswitch")
     val killSwitchConfig: KillSwitchRemoteConfig? = null,
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -126,7 +126,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     }
 
     override val thermalStatusService: ThermalStatusService by singleton {
-        if (configService.sdkModeBehavior.isBetaFeaturesEnabled() && versionChecker.isAtLeast(Build.VERSION_CODES.Q)) {
+        if (configService.autoDataCaptureBehavior.isThermalStatusCaptureEnabled() && versionChecker.isAtLeast(Build.VERSION_CODES.Q)) {
             // Android API only accepts an executor. We don't want to directly expose those
             // to everything in the codebase so we decorate the BackgroundWorker here as an
             // alternative

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/AutoDataCaptureBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/AutoDataCaptureBehaviorTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.config.local.ComposeLocalConfig
 import io.embrace.android.embracesdk.config.local.CrashHandlerLocalConfig
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.config.remote.DataRemoteConfig
 import io.embrace.android.embracesdk.config.remote.KillSwitchRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
@@ -33,7 +34,8 @@ internal class AutoDataCaptureBehaviorTest {
     )
 
     private val remote = RemoteConfig(
-        killSwitchConfig = KillSwitchRemoteConfig(sigHandlerDetection = false, jetpackCompose = false)
+        killSwitchConfig = KillSwitchRemoteConfig(sigHandlerDetection = false, jetpackCompose = false),
+        dataConfig = DataRemoteConfig(pctThermalStatusEnabled = 0.0f)
     )
 
     @Test
@@ -48,6 +50,7 @@ internal class AutoDataCaptureBehaviorTest {
             assertTrue(isSigHandlerDetectionEnabled())
             assertFalse(isNdkEnabled())
             assertTrue(isDiskUsageReportingEnabled())
+            assertTrue(isThermalStatusCaptureEnabled())
         }
     }
 
@@ -71,6 +74,7 @@ internal class AutoDataCaptureBehaviorTest {
         with(fakeAutoDataCaptureBehavior(localCfg = { local }, remoteCfg = { remote })) {
             assertFalse(isSigHandlerDetectionEnabled())
             assertFalse(isComposeOnClickEnabled())
+            assertFalse(isThermalStatusCaptureEnabled())
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
@@ -79,7 +79,7 @@ internal class DataCaptureServiceModuleImplTest {
 
         assertTrue(module.memoryService is NoOpMemoryService)
         assertTrue(module.powerSaveModeService is NoOpPowerSaveModeService)
-        assertTrue(module.thermalStatusService is NoOpThermalStatusService)
+        assertTrue(module.thermalStatusService is EmbraceThermalStatusService)
     }
 
     private fun createEnabledBehavior(): FakeEssentialServiceModule {


### PR DESCRIPTION
## Goal

Enables thermal status capture by default, as the data will be helpful for finding ANR outliers.

## Testing

Added unit test coverage.

