### PR TITLE
Always capture CPU/GL info

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -144,10 +144,6 @@ internal class EmbraceMetadataService private constructor(
     }
 
     private fun asyncRetrieveAdditionalDeviceInfo() {
-        if (!configService.autoDataCaptureBehavior.isNdkEnabled()) {
-            logDeveloper("EmbraceMetadataService", "NDK not enabled")
-            return
-        }
         if (!cpuName.isNullOrEmpty() && !egl.isNullOrEmpty()) {
             logDeveloper("EmbraceMetadataService", "Additional device info already exists")
             return


### PR DESCRIPTION
## Goal

CPU/GL information is currently only captured for customers with NDK error detection enabled, because it requires loading embrace's native library. CPU/GL information is helpful for detecting ANR outliers so this changeset alters it to always be captured.

## Testing

Manually verified in example app.

