### PR TITLE
Alter priority for session-related tasks

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -107,7 +107,7 @@ internal class SessionModuleImpl(
                 nativeModule.ndkService,
                 initModule.clock,
                 payloadMessageCollator,
-                workerThreadModule.backgroundWorker(WorkerName.PERIODIC_CACHE)
+                workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
             )
         } else {
             null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.PayloadMessageCollator.PayloadType
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
-import io.embrace.android.embracesdk.worker.BackgroundWorker
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.atomic.AtomicInteger
 
 internal class EmbraceBackgroundActivityService(
@@ -27,7 +27,7 @@ internal class EmbraceBackgroundActivityService(
      */
     private val clock: Clock,
     private val payloadMessageCollator: PayloadMessageCollator,
-    private val backgroundWorker: BackgroundWorker
+    private val scheduledWorker: ScheduledWorker
 ) : BackgroundActivityService, ConfigListener {
 
     private var lastSaved: Long = 0
@@ -119,7 +119,7 @@ internal class EmbraceBackgroundActivityService(
     }
 
     private fun saveNow() {
-        backgroundWorker.submit(runnable = ::cacheBackgroundActivity)
+        scheduledWorker.submit(runnable = ::cacheBackgroundActivity)
         willBeSaved = false
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.config.LocalConfigParser
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
@@ -30,7 +30,7 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.payload.Session
-import io.embrace.android.embracesdk.worker.BackgroundWorker
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -57,7 +57,7 @@ internal class EmbraceBackgroundActivityServiceTest {
     private lateinit var localConfig: LocalConfig
     private lateinit var spansService: EmbraceSpansService
     private lateinit var preferencesService: FakePreferenceService
-    private lateinit var blockableExecutorService: BlockableExecutorService
+    private lateinit var blockingExecutorService: BlockingScheduledExecutorService
 
     @Before
     fun init() {
@@ -88,7 +88,7 @@ internal class EmbraceBackgroundActivityServiceTest {
             EmbraceSerializer()
         )
 
-        blockableExecutorService = BlockableExecutorService()
+        blockingExecutorService = BlockingScheduledExecutorService(blockingMode = false)
     }
 
     @Test
@@ -244,7 +244,7 @@ internal class EmbraceBackgroundActivityServiceTest {
     @Test
     fun `crash will save and flush the current completed spans`() {
         // Prevent background thread from overwriting deliveryService.lastSavedBackgroundActivity
-        blockableExecutorService.blockingMode = true
+        blockingExecutorService = BlockingScheduledExecutorService(blockingMode = true)
         service = createService()
         val now = TimeUnit.MILLISECONDS.toNanos(clock.now())
         spansService.initializeService(now)
@@ -358,7 +358,7 @@ internal class EmbraceBackgroundActivityServiceTest {
             ndkService,
             clock,
             collator,
-            BackgroundWorker(blockableExecutorService)
+            ScheduledWorker(blockingExecutorService)
         )
     }
 }


### PR DESCRIPTION
## Goal

This changeset alters the priority of several session-related tasks in the SDK. Specifically it prioritises anything that writes a session or background activity to disk. I achieved this by reviewing the delivery/cache classes & manually checking what jobs were submitted to individual executors.

I decided to prioritise the following:

- Writing sessions to disk (Critical as if this doesn't happen, it will lead to data loss)
- Loading/sending cached sessions (High, as this is important, but is less likely to result in data loss if it doesn't get scheduled)
- Prioritising session requests over other HTTP requests (already present)

Session snapshots are deprioritised as they are less important than these other tasks.

Additionally I switched out a `BackgroundWorker` for a `ScheduledWorker` in the `BackgroundActivityService` to avoid creating an unnecessary thread.

## Testing

Relied on existing test coverage.
