### PR TITLE
Added crashNumber to the Crash payload

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -290,7 +290,7 @@ final class EmbraceImpl {
                 @NonNull Function3<InitModule, CoreModule, WorkerThreadModule, AndroidServicesModule> androidServiceModuleSupplier,
                 @NonNull Function3<WorkerThreadModule, InitModule, CoreModule, StorageModule> storageModuleSupplier,
                 @NonNull Function12<InitModule, CoreModule, WorkerThreadModule, SystemServiceModule, AndroidServicesModule, StorageModule, BuildInfo,
-                                    String, Boolean, Function0<Unit>, Function0<ConfigService>, DeviceArchitecture, EssentialServiceModule>
+                    String, Boolean, Function0<Unit>, Function0<ConfigService>, DeviceArchitecture, EssentialServiceModule>
                     essentialServiceModuleSupplier,
                 @NonNull Function5<InitModule, CoreModule, SystemServiceModule, EssentialServiceModule, WorkerThreadModule,
                     DataCaptureServiceModule> dataCaptureServiceModuleSupplier,
@@ -543,6 +543,7 @@ final class EmbraceImpl {
             storageModule,
             essentialServiceModule,
             deliveryModule,
+            androidServicesModule,
             sessionProperties,
             nonNullWorkerThreadModule
         );

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -626,7 +626,8 @@ final class EmbraceImpl {
             nativeModule,
             sessionModule,
             anrModule,
-            dataContainerModule
+            dataContainerModule,
+            androidServicesModule
         );
 
         loadCrashVerifier(crashModule, nonNullWorkerThreadModule);

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.payload.extensions.CrashFactory
+import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
@@ -38,6 +39,7 @@ internal class EmbraceCrashService(
     private val ndkService: NdkService,
     private val gatingService: GatingService,
     private val backgroundActivityService: BackgroundActivityService?,
+    private val preferencesService: PreferencesService,
     private val crashMarker: CrashFileMarker,
     private val clock: Clock
 ) : CrashService {
@@ -76,14 +78,15 @@ internal class EmbraceCrashService(
             // is enabled for an Unity build. When a native crash occurs and the NDK sends an
             // uncaught exception the SDK assign the unity crash id as the java crash id.
             val unityCrashId = ndkService.getUnityCrashId()
+            val crashNumber = preferencesService.incrementAndGetCrashNumber()
             val crash = if (unityCrashId != null) {
                 logDeveloper(
                     "EmbraceCrashService",
                     "unityCrashId is $unityCrashId"
                 )
-                CrashFactory.ofThrowable(exception, jsException, unityCrashId)
+                CrashFactory.ofThrowable(exception, jsException, crashNumber, unityCrashId)
             } else {
-                CrashFactory.ofThrowable(exception, jsException)
+                CrashFactory.ofThrowable(exception, jsException, crashNumber)
             }
             logDeveloper("EmbraceCrashService", "crashId = " + crash.crashId)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
@@ -24,7 +24,8 @@ internal class CrashModuleImpl(
     nativeModule: NativeModule,
     sessionModule: SessionModule,
     anrModule: AnrModule,
-    dataContainerModule: DataContainerModule
+    dataContainerModule: DataContainerModule,
+    androidServicesModule: AndroidServicesModule
 ) : CrashModule {
 
     private val crashMarker: CrashFileMarker by singleton {
@@ -51,6 +52,7 @@ internal class CrashModuleImpl(
             nativeModule.ndkService,
             essentialServiceModule.gatingService,
             sessionModule.backgroundActivityService,
+            androidServicesModule.preferencesService,
             crashMarker,
             initModule.clock
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -26,6 +26,7 @@ import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.embrace.android.embracesdk.payload.NativeCrashDataError
 import io.embrace.android.embracesdk.payload.NativeCrashMetadata
 import io.embrace.android.embracesdk.payload.NativeSymbols
+import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -49,6 +50,7 @@ internal class EmbraceNdkService(
     private val configService: ConfigService,
     private val deliveryService: DeliveryService,
     private val userService: UserService,
+    private val preferencesService: PreferencesService,
     private val sessionProperties: EmbraceSessionProperties,
     appFramework: AppFramework,
     private val sharedObjectLoader: SharedObjectLoader,
@@ -543,6 +545,7 @@ internal class EmbraceNdkService(
             null,
             null
         )
+        val nativeCrashNumber = preferencesService.incrementAndGetNativeCrashNumber()
         val nativeCrashMessageEvent = EventMessage(
             nativeCrashEvent,
             null,
@@ -552,7 +555,7 @@ internal class EmbraceNdkService(
             null,
             null,
             ApiClient.MESSAGE_VERSION,
-            nativeCrash.getCrash()
+            nativeCrash.getCrash(nativeCrashNumber)
         )
         try {
             logger.logDeveloper(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.anr.ndk.EmbraceNativeThreadSamplerService
 import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerInstaller
 import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.injection.DeliveryModule
 import io.embrace.android.embracesdk.injection.EssentialServiceModule
@@ -25,6 +26,7 @@ internal class NativeModuleImpl(
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
     deliveryModule: DeliveryModule,
+    androidServicesModule: AndroidServicesModule,
     sessionProperties: EmbraceSessionProperties,
     workerThreadModule: WorkerThreadModule
 ) : NativeModule {
@@ -38,6 +40,7 @@ internal class NativeModuleImpl(
             essentialServiceModule.configService,
             deliveryModule.deliveryService,
             essentialServiceModule.userService,
+            androidServicesModule.preferencesService,
             sessionProperties,
             coreModule.appFramework,
             essentialServiceModule.sharedObjectLoader,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Crash.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Crash.kt
@@ -16,5 +16,8 @@ internal data class Crash(
     val jsExceptions: List<String>? = null,
 
     @Json(name = "th")
-    val threads: List<ThreadInfo>? = null
+    val threads: List<ThreadInfo>? = null,
+
+    @Json(name = "crash_number")
+    val crashNumber: Int? = null
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/NativeCrash.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/NativeCrash.kt
@@ -10,5 +10,6 @@ internal class NativeCrash(
     @Json(name = "sb") val symbols: Map<String?, String?>?,
     @Json(name = "er") val errors: List<NativeCrashDataError?>?,
     @Json(name = "ue") val unwindError: Int?,
-    @Json(name = "ma") val map: String?
+    @Json(name = "ma") val map: String?,
+    @Json(name = "crash_number") val crashNumber: Int? = null
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/NativeCrashData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/NativeCrashData.kt
@@ -17,5 +17,5 @@ internal class NativeCrashData(
     @Json(name = "map") var map: String?
 ) {
 
-    fun getCrash() = NativeCrash(nativeCrashId, crash, symbols, errors, unwindError, map)
+    fun getCrash(crashNumber: Int) = NativeCrash(nativeCrashId, crash, symbols, errors, unwindError, map, crashNumber)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
@@ -25,13 +25,15 @@ internal object CrashFactory {
     fun ofThrowable(
         throwable: Throwable?,
         jsException: JsException?,
+        crashNumber: Int,
         crashId: String = Uuid.getEmbUuid()
     ): Crash {
         return Crash(
             crashId,
             exceptionInfo(throwable),
             jsExceptions(jsException),
-            threadsInfo()
+            threadsInfo(),
+            crashNumber
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -236,9 +236,14 @@ internal class EmbracePreferencesService(
     }
 
     private fun incrementAndGetOrdinal(key: String): Int {
-        val ordinal = (prefs.getIntegerPreference(key) ?: 0) + 1
-        prefs.setIntegerPreference(key, ordinal)
-        return ordinal
+        return try {
+            val ordinal = (prefs.getIntegerPreference(key) ?: 0) + 1
+            prefs.setIntegerPreference(key, ordinal)
+            ordinal
+        } catch (tr: Throwable) {
+            logDeveloper("EmbracePreferencesService", "Error incrementing $key", tr)
+            -1
+        }
     }
 
     override var javaScriptBundleURL: String?

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -231,6 +231,10 @@ internal class EmbracePreferencesService(
         return incrementAndGetOrdinal(LAST_CRASH_NUMBER_KEY)
     }
 
+    override fun incrementAndGetNativeCrashNumber(): Int {
+        return incrementAndGetOrdinal(LAST_NATIVE_CRASH_NUMBER_KEY)
+    }
+
     private fun incrementAndGetOrdinal(key: String): Int {
         val ordinal = (prefs.getIntegerPreference(key) ?: 0) + 1
         prefs.setIntegerPreference(key, ordinal)
@@ -346,6 +350,7 @@ internal class EmbracePreferencesService(
         private const val LAST_SESSION_NUMBER_KEY = "io.embrace.sessionnumber"
         private const val LAST_BACKGROUND_ACTIVITY_NUMBER_KEY = "io.embrace.bgactivitynumber"
         private const val LAST_CRASH_NUMBER_KEY = "io.embrace.crashnumber"
+        private const val LAST_NATIVE_CRASH_NUMBER_KEY = "io.embrace.nativecrashnumber"
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"
         private const val JAVA_SCRIPT_PATCH_NUMBER_KEY = "io.embrace.javascript.patch"
         private const val REACT_NATIVE_VERSION_KEY = "io.embrace.reactnative.version"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -227,6 +227,10 @@ internal class EmbracePreferencesService(
         return incrementAndGetOrdinal(LAST_BACKGROUND_ACTIVITY_NUMBER_KEY)
     }
 
+    override fun incrementAndGetCrashNumber(): Int {
+        return incrementAndGetOrdinal(LAST_CRASH_NUMBER_KEY)
+    }
+
     private fun incrementAndGetOrdinal(key: String): Int {
         val ordinal = (prefs.getIntegerPreference(key) ?: 0) + 1
         prefs.setIntegerPreference(key, ordinal)
@@ -341,6 +345,7 @@ internal class EmbracePreferencesService(
         private const val LAST_USER_MESSAGE_FAILED_KEY = "io.embrace.userupdatefailed"
         private const val LAST_SESSION_NUMBER_KEY = "io.embrace.sessionnumber"
         private const val LAST_BACKGROUND_ACTIVITY_NUMBER_KEY = "io.embrace.bgactivitynumber"
+        private const val LAST_CRASH_NUMBER_KEY = "io.embrace.crashnumber"
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"
         private const val JAVA_SCRIPT_PATCH_NUMBER_KEY = "io.embrace.javascript.patch"
         private const val REACT_NATIVE_VERSION_KEY = "io.embrace.reactnative.version"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
@@ -99,10 +99,17 @@ internal interface PreferencesService {
 
     /**
      * Increments and returns the crash number ordinal. This is an integer that
-     * increments at every crash. This allows us to check the % of crashes that
+     * increments on every crash. It allows us to check the % of crashes that
      * didn't get delivered to the backend.
      */
     fun incrementAndGetCrashNumber(): Int
+
+    /**
+     * Increments and returns the native crash number ordinal. This is an integer that
+     * increments on every native crash. It allows us to check the % of native crashes that
+     * didn't get delivered to the backend.
+     */
+    fun incrementAndGetNativeCrashNumber(): Int
 
     /**
      * Last javaScript bundle string url.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
@@ -98,6 +98,13 @@ internal interface PreferencesService {
     fun incrementAndGetBackgroundActivityNumber(): Int
 
     /**
+     * Increments and returns the crash number ordinal. This is an integer that
+     * increments at every crash. This allows us to check the % of crashes that
+     * didn't get delivered to the backend.
+     */
+    fun incrementAndGetCrashNumber(): Int
+
+    /**
      * Last javaScript bundle string url.
      */
     var javaScriptBundleURL: String?

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -60,5 +60,9 @@ internal class FakePreferenceService(
         return 1
     }
 
+    override fun incrementAndGetNativeCrashNumber(): Int {
+        return 1
+    }
+
     override fun isUsersFirstDay(): Boolean = firstDay
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -56,5 +56,9 @@ internal class FakePreferenceService(
 
     override fun incrementAndGetBackgroundActivityNumber(): Int = bgActivityNumber()
 
+    override fun incrementAndGetCrashNumber(): Int {
+        return 1
+    }
+
     override fun isUsersFirstDay(): Boolean = firstDay
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataContainerModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
@@ -22,7 +23,8 @@ internal class CrashModuleImplTest {
             FakeNativeModule(),
             FakeSessionModule(),
             FakeAnrModule(),
-            FakeDataContainerModule()
+            FakeDataContainerModule(),
+            FakeAndroidServicesModule()
         )
         assertNotNull(module.lastRunCrashVerifier)
         assertNotNull(module.crashService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -64,6 +64,7 @@ internal class EmbraceNdkServiceTest {
         private lateinit var localConfig: LocalConfig
         private lateinit var deliveryService: FakeDeliveryService
         private lateinit var userService: UserService
+        private lateinit var preferencesService: FakePreferenceService
         private lateinit var sessionProperties: EmbraceSessionProperties
         private lateinit var appFramework: Embrace.AppFramework
         private lateinit var sharedObjectLoader: SharedObjectLoader
@@ -93,7 +94,8 @@ internal class EmbraceNdkServiceTest {
             activityService = FakeProcessStateService()
             deliveryService = FakeDeliveryService()
             userService = FakeUserService()
-            sessionProperties = EmbraceSessionProperties(FakePreferenceService(), configService)
+            preferencesService = FakePreferenceService()
+            sessionProperties = EmbraceSessionProperties(preferencesService, configService)
             appFramework = Embrace.AppFramework.NATIVE
             sharedObjectLoader = mockk()
             logger = InternalEmbraceLogger()
@@ -136,6 +138,7 @@ internal class EmbraceNdkServiceTest {
             configService,
             deliveryService,
             userService,
+            preferencesService,
             sessionProperties,
             appFramework,
             sharedObjectLoader,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.ndk
 
 import io.embrace.android.embracesdk.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
+import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -19,6 +20,7 @@ internal class NativeModuleImplTest {
             FakeStorageModule(),
             FakeEssentialServiceModule(),
             FakeDeliveryModule(),
+            FakeAndroidServicesModule(),
             fakeEmbraceSessionProperties(),
             FakeWorkerThreadModule()
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/NativeCrashDataTest.kt
@@ -47,7 +47,7 @@ internal class NativeCrashDataTest {
         assertEquals("app_state", obj.appState)
         assertNotNull(obj.metadata)
         assertEquals(2, obj.unwindError)
-        assertNotNull(obj.getCrash())
+        assertNotNull(obj.getCrash(1))
         assertEquals(mapOf("key" to "value"), obj.symbols)
         assertEquals(1, obj.errors?.size)
         assertEquals("map", obj.map)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
@@ -212,6 +212,33 @@ internal class EmbracePreferencesServiceTest {
     }
 
     @Test
+    fun `test crash number is saved`() {
+        assertEquals(1, service.incrementAndGetCrashNumber())
+        assertEquals(2, service.incrementAndGetCrashNumber())
+        assertEquals(3, service.incrementAndGetCrashNumber())
+        assertEquals(4, service.incrementAndGetCrashNumber())
+    }
+
+    @Test
+    fun `test native crash number is saved`() {
+        assertEquals(1, service.incrementAndGetNativeCrashNumber())
+        assertEquals(2, service.incrementAndGetNativeCrashNumber())
+        assertEquals(3, service.incrementAndGetNativeCrashNumber())
+        assertEquals(4, service.incrementAndGetNativeCrashNumber())
+    }
+
+    @Test
+    fun `test incrementAndGet returns -1 on an exception`() {
+        service = EmbracePreferencesService(
+            executorService,
+            lazy { FakeSharedPreferences(throwExceptionOnGet = true) },
+            fakeClock,
+            EmbraceSerializer()
+        )
+        assertEquals(-1, service.incrementAndGetSessionNumber())
+    }
+
+    @Test
     fun `test java script bundle url is saved`() {
         assertNull(service.javaScriptBundleURL)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/FakeSharedPreferences.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/FakeSharedPreferences.kt
@@ -1,0 +1,103 @@
+package io.embrace.android.embracesdk.prefs
+
+import android.content.SharedPreferences
+
+internal class FakeSharedPreferences(private val throwExceptionOnGet: Boolean = false) : SharedPreferences {
+    override fun getAll() = if (throwExceptionOnGet) {
+        throw Exception("test exception")
+    } else {
+        mutableMapOf("testKey" to "testValue")
+    }
+
+    override fun getString(key: String?, defValue: String?) = if (throwExceptionOnGet) {
+        throw Exception("test exception")
+    } else {
+        "testString"
+    }
+
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?) = if (throwExceptionOnGet) {
+        throw Exception("test exception")
+    } else {
+        mutableSetOf("testString")
+    }
+
+    override fun getInt(key: String?, defValue: Int) = if (throwExceptionOnGet) {
+        throw Exception("test exception")
+    } else {
+        1
+    }
+
+    override fun getLong(key: String?, defValue: Long) = if (throwExceptionOnGet) {
+        throw Exception("test exception")
+    } else {
+        1L
+    }
+
+    override fun getFloat(key: String?, defValue: Float) = if (throwExceptionOnGet) {
+        throw Exception("test exception")
+    } else {
+        1f
+    }
+
+    override fun getBoolean(key: String?, defValue: Boolean) = if (throwExceptionOnGet) {
+        throw Exception("test exception")
+    } else {
+        true
+    }
+
+    override fun contains(key: String?) = true
+
+    override fun edit(): SharedPreferences.Editor = FakeSharedPreferencesEditor()
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        // no-op
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener?
+    ) {
+        // no-op
+    }
+}
+
+internal class FakeSharedPreferencesEditor : SharedPreferences.Editor {
+    override fun putString(key: String?, value: String?): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun putStringSet(key: String?, values: MutableSet<String>?): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun putInt(key: String?, value: Int): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun putLong(key: String?, value: Long): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun putFloat(key: String?, value: Float): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun remove(key: String?): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun clear(): SharedPreferences.Editor {
+        return this
+    }
+
+    override fun commit(): Boolean {
+        return true
+    }
+
+    override fun apply() {
+        // no-op
+    }
+}


### PR DESCRIPTION
## Goal

The idea is to number every crash so we know if there are crashes that do not arrive at the backend, similar to `session.session_number`

## Testing

Verified that crash_number is added to the crash payload on the android-test-suite, using proxyman
