### PR TITLE
Remove deprecated async end flag

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
@@ -23,24 +23,12 @@ internal class SessionBehavior(
     companion object {
 
         /**
-         * Do not use async mode for session end messages by default.
-         */
-        const val ASYNC_END_DEFAULT = false
-
-        /**
          * By default, prevents to capture internal error logs as part of session payload
          */
         const val ERROR_LOG_STRICT_MODE_DEFAULT = false
 
         const val SESSION_PROPERTY_LIMIT = 10
     }
-
-    /**
-     * Whether sessions are allowed to be persisted async or not.
-     */
-    @Deprecated("This flag is obsolete and is no longer respected.")
-    fun isAsyncEndEnabled(): Boolean =
-        remote?.sessionConfig?.endAsync ?: local?.asyncEnd ?: ASYNC_END_DEFAULT
 
     /**
      * Whether the limit on the number of internal exceptions in the payload should be increased

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/local/SessionLocalConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/local/SessionLocalConfig.kt
@@ -10,13 +10,6 @@ import com.squareup.moshi.JsonClass
 internal class SessionLocalConfig(
 
     /**
-     * End session messages are sent asynchronously.
-     */
-    @Json(name = "async_end")
-    @Deprecated("This flag is obsolete and is no longer respected.")
-    val asyncEnd: Boolean? = null,
-
-    /**
      * A whitelist of session components (i.e. Breadcrumbs, Session properties, etc) that should be
      * included in the session payload. The presence of this property denotes that the gating
      * feature is enabled.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
@@ -13,10 +13,6 @@ internal data class SessionRemoteConfig(
     @Json(name = "enable")
     val isEnabled: Boolean? = null,
 
-    @Json(name = "async_end")
-    @Deprecated("This flag is obsolete and is no longer respected.")
-    val endAsync: Boolean? = null,
-
     /**
      * A list of session components (i.e. Breadcrumbs, Session properties, etc) that will be
      * included in the session payload. If components list exists, the services should restrict

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -90,7 +90,6 @@ internal class SessionModuleImpl(
             sessionHandler,
             deliveryModule.deliveryService,
             essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled(),
-            essentialServiceModule.configService,
             initModule.clock,
             coreModule.logger
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
-import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
@@ -16,7 +14,6 @@ internal class EmbraceSessionService(
     private val sessionHandler: SessionHandler,
     deliveryService: DeliveryService,
     isNdkEnabled: Boolean,
-    private val configService: ConfigService,
     private val clock: Clock,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : SessionService {
@@ -86,12 +83,6 @@ internal class EmbraceSessionService(
     }
 
     override fun endSessionManually(clearUserInfo: Boolean) {
-        val sessionBehavior: SessionBehavior = configService.sessionBehavior
-
-        if (sessionBehavior.isAsyncEndEnabled()) {
-            logger.logWarning("Can't close the session, session ending in background thread enabled.")
-            return
-        }
         triggerStatelessSessionEnd(Session.LifeEventType.MANUAL, clearUserInfo)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
@@ -479,7 +479,6 @@ internal class EmbraceGatingServiceTest {
         RemoteConfig(
             sessionConfig = SessionRemoteConfig(
                 true,
-                false,
                 components,
                 fullSessionEvents
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
@@ -144,15 +144,9 @@ internal class LocalConfigTest {
         assertFalse(localConfig.ndkEnabled)
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun testSessionOnlyConfig() {
-        var localConfig =
-            LocalConfigParser.buildConfig("GrCPU", false, "{\"session\": {\"async_end\": true}}", serializer)
-        assertTrue(checkNotNull(localConfig.sdkConfig.sessionConfig?.asyncEnd))
-
-        // error_log_strict_mode is true
-        localConfig = LocalConfigParser.buildConfig(
+        var localConfig = LocalConfigParser.buildConfig(
             "GrCPU",
             false,
             "{\"session\": {\"error_log_strict_mode\": true}}",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionRemoteConfigTest.kt
@@ -10,9 +10,8 @@ internal class SessionRemoteConfigTest {
     @Suppress("DEPRECATION")
     @Test
     fun testDefaults() {
-        val cfg = SessionRemoteConfig(false, false, null, null)
+        val cfg = SessionRemoteConfig(false, null, null)
         assertFalse(checkNotNull(cfg.isEnabled))
-        assertFalse(checkNotNull(cfg.endAsync))
         assertNull(cfg.sessionComponents)
         assertNull(cfg.fullSessionEvents)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -90,7 +90,6 @@ internal class EmbraceApiServiceTest {
         // verify a few fields were serialized correctly.
         checkNotNull(remoteConfig)
         assertTrue(checkNotNull(remoteConfig.sessionConfig?.isEnabled))
-        assertFalse(checkNotNull(remoteConfig.sessionConfig?.endAsync))
         assertEquals(100, remoteConfig.threshold)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
@@ -13,7 +13,6 @@ import org.junit.Test
 internal class SessionBehaviorTest {
 
     private val local = SessionLocalConfig(
-        asyncEnd = true,
         sessionComponents = setOf("breadcrumbs"),
         fullSessionEvents = setOf("crash"),
         sessionEnableErrorLogStrictMode = true
@@ -22,18 +21,15 @@ internal class SessionBehaviorTest {
     private val remote = RemoteConfig(
         sessionConfig = SessionRemoteConfig(
             isEnabled = true,
-            endAsync = false,
             sessionComponents = setOf("test"),
             fullSessionEvents = setOf("test2")
         ),
         maxSessionProperties = 57,
     )
 
-    @Suppress("DEPRECATION")
     @Test
     fun testDefaults() {
         with(fakeSessionBehavior()) {
-            assertFalse(isAsyncEndEnabled())
             assertFalse(isSessionErrorLogStrictModeEnabled())
             assertEquals(emptySet<String>(), getFullSessionEvents())
             assertNull(getSessionComponents())
@@ -43,11 +39,9 @@ internal class SessionBehaviorTest {
         }
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun testLocalOnly() {
         with(fakeSessionBehavior(localCfg = { local })) {
-            assertTrue(isAsyncEndEnabled())
             assertTrue(isSessionErrorLogStrictModeEnabled())
             assertEquals(setOf("breadcrumbs"), getSessionComponents())
             assertEquals(setOf("crash"), getFullSessionEvents())
@@ -55,11 +49,9 @@ internal class SessionBehaviorTest {
         }
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun testRemoteAndLocal() {
         with(fakeSessionBehavior(localCfg = { local }, remoteCfg = { remote })) {
-            assertFalse(isAsyncEndEnabled())
             assertTrue(isGatingFeatureEnabled())
             assertTrue(isSessionControlEnabled())
             assertEquals(setOf("test"), getSessionComponents())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/local/SessionLocalConfigTest.kt
@@ -15,11 +15,9 @@ internal class SessionLocalConfigTest {
         verifyDefaults(cfg)
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun testDeserialization() {
         val obj = deserializeJsonFromResource<SessionLocalConfig>("session_config.json")
-        assertTrue(checkNotNull(obj.asyncEnd))
         assertTrue(checkNotNull(obj.sessionEnableErrorLogStrictMode))
         assertEquals(setOf("breadcrumbs"), obj.sessionComponents)
         assertEquals(setOf("crash"), obj.fullSessionEvents)
@@ -31,9 +29,7 @@ internal class SessionLocalConfigTest {
         verifyDefaults(obj)
     }
 
-    @Suppress("DEPRECATION")
     private fun verifyDefaults(cfg: SessionLocalConfig) {
-        assertNull(cfg.asyncEnd)
         assertNull(cfg.sessionEnableErrorLogStrictMode)
         assertNull(cfg.sessionComponents)
         assertNull(cfg.fullSessionEvents)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
@@ -402,7 +402,6 @@ internal class EmbraceLogMessageServiceTest {
         RemoteConfig(
             sessionConfig = SessionRemoteConfig(
                 isEnabled = true,
-                endAsync = false,
                 sessionComponents = components,
                 fullSessionEvents = fullSessionEvents
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.session
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
@@ -212,7 +211,6 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler,
             deliveryService,
             ndkEnabled,
-            FakeConfigService(),
             clock
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -206,7 +206,7 @@ internal class SessionHandlerTest {
 
     @Test
     fun `onSession started successfully`() {
-        sessionLocalConfig = SessionLocalConfig(asyncEnd = false)
+        sessionLocalConfig = SessionLocalConfig()
         userService.obj = userInfo
 
         val sessionStartType = Session.LifeEventType.STATE
@@ -272,7 +272,7 @@ internal class SessionHandlerTest {
     fun `onSession started successfully with no preference service session number`() {
         // return absent session number
         sessionNumber = 0
-        sessionLocalConfig = SessionLocalConfig(asyncEnd = false)
+        sessionLocalConfig = SessionLocalConfig()
         val sessionStartType = Session.LifeEventType.STATE
         // this is needed so session handler creates automatic session stopper
 


### PR DESCRIPTION
## Goal

Removes a deprecated flag `asyncEnd` that is no longer respected, as it was increasing complexity in session handling code. Users who have specified this in their `embrace-config.json` file won't be affected by this change - the warning simply won't show up anymore
