### PR TITLE
Remove unnecessary code in session control

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -90,8 +90,7 @@ internal class SessionModuleImpl(
             sessionHandler,
             deliveryModule.deliveryService,
             essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled(),
-            initModule.clock,
-            coreModule.logger
+            initModule.clock
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionHandler.kt
@@ -23,7 +23,6 @@ import io.embrace.android.embracesdk.session.PayloadMessageCollator.PayloadType
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.ScheduledWorker
-import java.io.Closeable
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
@@ -44,7 +43,7 @@ internal class SessionHandler(
     private val clock: Clock,
     private val spansService: SpansService,
     private val sessionPeriodicCacheScheduledWorker: ScheduledWorker
-) : Closeable {
+) {
 
     companion object {
 
@@ -232,10 +231,6 @@ internal class SessionHandler(
             msg?.let { deliveryService.sendSession(it, SessionSnapshotType.PERIODIC_CACHE) }
             return msg
         }
-    }
-
-    override fun close() {
-        stopPeriodicSessionCaching()
     }
 
     private fun stopPeriodicSessionCaching() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -1,28 +1,13 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
-import java.io.Closeable
 
-internal interface SessionService : ProcessStateListener, Closeable {
+internal interface SessionService : ProcessStateListener {
 
     /**
-     * Starts a new session.
-     *
-     * @param coldStart whether this is a cold start of the application
-     * @param startType the origin of the event that starts the session.
+     * Ends a session manually. If [clearUserInfo] is true, the user info will be cleared.
      */
-    fun startSession(coldStart: Boolean, startType: LifeEventType, startTime: Long)
-
     fun endSessionManually(clearUserInfo: Boolean)
-
-    /**
-     * This is responsible for the current session to be cached, ended and sent to the server and
-     * immediately starting a new session after that.
-     *
-     * @param endType the origin of the event that ends the session.
-     */
-    fun triggerStatelessSessionEnd(endType: LifeEventType, clearUserInfo: Boolean = false)
 
     /**
      * Handles an uncaught exception, ending the session and saving the session to disk.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -1,36 +1,16 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.SessionService
 
 internal class FakeSessionService : SessionService {
 
     var crashId: String? = null
 
-    override fun startSession(
-        coldStart: Boolean,
-        startType: Session.LifeEventType,
-        startTime: Long
-    ) {
-        TODO("Not yet implemented")
-    }
-
-    override fun triggerStatelessSessionEnd(
-        endType: Session.LifeEventType,
-        clearUserInfo: Boolean
-    ) {
-        TODO("Not yet implemented")
-    }
-
     override fun handleCrash(crashId: String) {
         this.crashId = crashId
     }
 
     override fun endSessionManually(clearUserInfo: Boolean) {
-        TODO("Not yet implemented")
-    }
-
-    override fun close() {
         TODO("Not yet implemented")
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -20,7 +20,6 @@ import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -88,7 +87,7 @@ internal class EmbraceSessionServiceTest {
         val crashId = "crash-id"
 
         // let's start session first so we have an active session
-        service.startSession(true, LifeEventType.STATE, clock.now())
+        service.onForeground(true, 0, clock.now())
 
         service.handleCrash(crashId)
 
@@ -164,7 +163,7 @@ internal class EmbraceSessionServiceTest {
         startDefaultSession()
         val endType = LifeEventType.MANUAL
 
-        service.triggerStatelessSessionEnd(endType)
+        service.endSessionManually(false)
 
         // verify session is ended
         verify { mockSessionHandler.onSessionEnded(endType, 0, false) }
@@ -176,21 +175,6 @@ internal class EmbraceSessionServiceTest {
                 any()
             )
         }
-    }
-
-    @Test
-    fun `trigger stateless end session for a STATE session end type should not do anything`() {
-        initializeSessionService()
-        service.triggerStatelessSessionEnd(LifeEventType.STATE)
-        assertTrue(deliveryService.lastSentSessions.isEmpty())
-    }
-
-    @Test
-    fun `close successfully`() {
-        initializeSessionService()
-        service.close()
-
-        verify { mockSessionHandler.close() }
     }
 
     @Test
@@ -216,6 +200,6 @@ internal class EmbraceSessionServiceTest {
     }
 
     private fun startDefaultSession() {
-        service.startSession(true, LifeEventType.STATE, clock.now())
+        service.onForeground(true, 0, clock.now())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -421,14 +421,6 @@ internal class SessionHandlerTest {
     }
 
     @Test
-    fun `verify close stops everything successfully`() {
-        startFakeSession()
-        sessionHandler.scheduledFuture = mockk(relaxed = true)
-        sessionHandler.close()
-        verify { sessionHandler.scheduledFuture?.cancel(false) }
-    }
-
-    @Test
     fun `endSession includes completed spans in message`() {
         startFakeSession()
         initializeServices()


### PR DESCRIPTION
## Goal

Removes `triggerStatelessSessionEnd`, `startSession` and `close` from the internal `SessionService` interface. `triggerStatelessSessionEnd/startSession` are not called apart from within the service itself, and `close()` is not necessary to call - the executor is shutdown via the `WorkerThreadModule`.

There are also some style tweaks I made during these changes.

## Testing

Relied on existing test coverage.
