### PR TITLE
Reduce responsibilities of session handler

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -44,7 +44,7 @@ internal class ManualSessionTest {
     }
 
     @Test
-    fun `calling endSession when session control enabled ends sessions`() {
+    fun `calling endSession when session control enabled does not end sessions`() {
         with(testRule) {
             harness.fakeConfigService.sessionBehavior = fakeSessionBehavior {
                 RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true))
@@ -54,10 +54,8 @@ internal class ManualSessionTest {
                 embrace.endSession()
             }
             val messages = harness.getSentSessionMessages()
-            assertEquals(2, messages.size)
+            assertEquals(1, messages.size)
             verifySessionHappened(messages[0])
-            verifySessionHappened(messages[1])
-            assertNotEquals(messages[0].session.sessionId, messages[1].session.sessionId)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
@@ -226,4 +226,11 @@ internal interface BreadcrumbService {
         messageDeliveredPriority: Int,
         type: NotificationType
     )
+
+    /**
+     * This function adds the current view breadcrumb if the app comes from background to foreground
+     * or replaces the first session view breadcrumb possibly created before the session in order to
+     * have it in the session scope time.
+     */
+    fun addFirstViewBreadcrumbForSession(startTime: Long)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -114,6 +114,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         EmbraceBreadcrumbService(
             initModule.clock,
             configService,
+            essentialServiceModule.activityLifecycleTracker,
             coreModule.logger
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -56,6 +56,10 @@ internal class SessionModuleImpl(
     }
 
     override val sessionHandler: SessionHandler by singleton {
+        val ndkService = when {
+            essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled() -> nativeModule.ndkService
+            else -> null
+        }
         SessionHandler(
             coreModule.logger,
             essentialServiceModule.configService,
@@ -63,8 +67,7 @@ internal class SessionModuleImpl(
             essentialServiceModule.networkConnectivityService,
             essentialServiceModule.metadataService,
             dataCaptureServiceModule.breadcrumbService,
-            essentialServiceModule.activityLifecycleTracker,
-            nativeModule.ndkService,
+            ndkService,
             sdkObservabilityModule.internalErrorService,
             essentialServiceModule.memoryCleanerService,
             deliveryModule.deliveryService,
@@ -90,7 +93,8 @@ internal class SessionModuleImpl(
             sessionHandler,
             deliveryModule.deliveryService,
             essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled(),
-            initModule.clock
+            initModule.clock,
+            essentialServiceModule.configService
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
+import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
@@ -12,7 +13,8 @@ internal class EmbraceSessionService(
     private val sessionHandler: SessionHandler,
     deliveryService: DeliveryService,
     isNdkEnabled: Boolean,
-    private val clock: Clock
+    private val clock: Clock,
+    private val configService: ConfigService
 ) : SessionService {
 
     init {
@@ -41,6 +43,10 @@ internal class EmbraceSessionService(
     }
 
     override fun endSessionManually(clearUserInfo: Boolean) {
+        if (configService.sessionBehavior.isSessionControlEnabled()) {
+            return
+        }
+
         // Ends active session.
         sessionHandler.onSessionEnded(LifeEventType.MANUAL, clock.now(), clearUserInfo) ?: return
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
@@ -122,4 +122,10 @@ internal class FakeBreadcrumbService : BreadcrumbService {
             )
         )
     }
+
+    val firstViewBreadcrumbCalls = mutableListOf<Long>()
+
+    override fun addFirstViewBreadcrumbForSession(startTime: Long) {
+        firstViewBreadcrumbCalls.add(startTime)
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/system/SystemMocks.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/system/SystemMocks.kt
@@ -22,7 +22,9 @@ internal fun mockLooper(): Looper = mockk(relaxed = true) {
 
 internal fun mockMessageQueue(): MessageQueue = mockk(relaxed = true)
 internal fun mockMessage(): Message = mockk(relaxed = true)
-internal fun mockActivity(): Activity = mockk(relaxed = true)
+internal fun mockActivity(): Activity = mockk(relaxed = true) {
+    every { localClassName } returns "MyMockActivity"
+}
 internal fun mockIntent(): Intent = mockk(relaxed = true)
 internal fun mockContext(): Context = mockk(relaxed = true)
 internal fun mockApplication(): Application = mockk(relaxed = true) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.session
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
@@ -195,7 +196,8 @@ internal class EmbraceSessionServiceTest {
             mockSessionHandler,
             deliveryService,
             ndkEnabled,
-            clock
+            clock,
+            FakeConfigService()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -186,7 +186,6 @@ internal class SessionHandlerTest {
             networkConnectivityService,
             metadataService,
             breadcrumbService,
-            activityLifecycleTracker,
             ndkService,
             internalErrorService,
             memoryCleanerService,
@@ -295,14 +294,14 @@ internal class SessionHandlerTest {
         activityLifecycleTracker.foregroundActivity = mockActivity
         val sessionStartType = Session.LifeEventType.STATE
 
-        val sessionMessage = sessionHandler.onSessionStarted(
+        sessionHandler.onSessionStarted(
             true,
             sessionStartType,
             now
         )
 
         // verify we are forcing log view with foreground activity class name
-        assertEquals(mockActivity.localClassName, breadcrumbService.logViewCalls.single())
+        assertEquals(now, breadcrumbService.firstViewBreadcrumbCalls.single())
         checkNotNull(sessionHandler.activeSession)
         // no need to verify anything else because it's already verified in another test case
     }


### PR DESCRIPTION
## Goal

Reduces the responsibilities of the `SessionHandler` class. This moves `addFirstViewBreadcrumbForSession` to `BreadcrumbService` and moves where the `ConfigService` is called to check behavior.

## Testing

Updated unit test coverage & fixed a bug with the `ManualSessionTest` assertions.

