### PR TITLE
Create session orchestrator class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -93,6 +93,7 @@ import io.embrace.android.embracesdk.session.BackgroundActivityService;
 import io.embrace.android.embracesdk.session.SessionService;
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker;
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService;
+import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator;
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties;
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService;
 import io.embrace.android.embracesdk.telemetry.TelemetryService;
@@ -196,6 +197,9 @@ final class EmbraceImpl {
 
     @Nullable
     private volatile SessionService sessionService;
+
+    @Nullable
+    private volatile SessionOrchestrator sessionOrchestrator;
 
     @Nullable
     private volatile SessionPropertiesService sessionPropertiesService;
@@ -609,6 +613,7 @@ final class EmbraceImpl {
         );
 
         sessionService = sessionModule.getSessionService();
+        sessionOrchestrator = sessionModule.getSessionOrchestrator();
         sessionPropertiesService = sessionModule.getSessionPropertiesService();
         backgroundActivityService = sessionModule.getBackgroundActivityService();
         serviceRegistry.registerServices(sessionService, backgroundActivityService);
@@ -1282,7 +1287,7 @@ final class EmbraceImpl {
      */
     void endSession(boolean clearUserInfo) {
         if (checkSdkStartedAndLogPublicApiUsage("end_session")) {
-            sessionService.endSessionManually(clearUserInfo);
+            sessionOrchestrator.endSessionWithManual(clearUserInfo);
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
@@ -138,8 +138,8 @@ internal class EmbraceCrashService(
             deliveryService.sendCrash(crashEvent, true)
 
             // End, cache and send the session
-            sessionService.handleCrash(crash.crashId)
-            backgroundActivityService?.handleCrash(crash.crashId)
+            sessionService.endSessionWithCrash(crash.crashId)
+            backgroundActivityService?.endBackgroundActivityWithCrash(crash.crashId)
 
             // Indicate that a crash happened so we can know that in the next launch
             crashMarker.mark()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -7,6 +7,8 @@ import io.embrace.android.embracesdk.session.EmbraceSessionService
 import io.embrace.android.embracesdk.session.PayloadMessageCollator
 import io.embrace.android.embracesdk.session.SessionHandler
 import io.embrace.android.embracesdk.session.SessionService
+import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
+import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionPropertiesService
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
@@ -19,6 +21,7 @@ internal interface SessionModule {
     val backgroundActivityService: BackgroundActivityService?
     val payloadMessageCollator: PayloadMessageCollator
     val sessionPropertiesService: SessionPropertiesService
+    val sessionOrchestrator: SessionOrchestrator
 }
 
 internal class SessionModuleImpl(
@@ -88,7 +91,6 @@ internal class SessionModuleImpl(
 
     override val sessionService: SessionService by singleton {
         EmbraceSessionService(
-            essentialServiceModule.processStateService,
             nativeModule.ndkService,
             sessionHandler,
             deliveryModule.deliveryService,
@@ -102,7 +104,6 @@ internal class SessionModuleImpl(
         if (essentialServiceModule.configService.isBackgroundActivityCaptureEnabled()) {
             EmbraceBackgroundActivityService(
                 essentialServiceModule.metadataService,
-                essentialServiceModule.processStateService,
                 deliveryModule.deliveryService,
                 essentialServiceModule.configService,
                 nativeModule.ndkService,
@@ -113,5 +114,14 @@ internal class SessionModuleImpl(
         } else {
             null
         }
+    }
+
+    override val sessionOrchestrator: SessionOrchestrator by singleton {
+        SessionOrchestratorImpl(
+            essentialServiceModule.processStateService,
+            sessionService,
+            backgroundActivityService,
+            initModule.clock
+        )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
@@ -1,11 +1,9 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
-
 /**
  * Service that captures and sends information when the app is in background
  */
-internal interface BackgroundActivityService : ProcessStateListener {
+internal interface BackgroundActivityService {
 
     /**
      * Stops the current background activity session and sends the session message to the backend
@@ -15,10 +13,20 @@ internal interface BackgroundActivityService : ProcessStateListener {
     /**
      * Handles an uncaught exception, ending the session and saving the activity to disk.
      */
-    fun handleCrash(crashId: String)
+    fun endBackgroundActivityWithCrash(crashId: String)
 
     /**
      * Save the current background activity to disk
      */
     fun save()
+
+    /**
+     * Ends a background activity in response to a state event.
+     */
+    fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long)
+
+    /**
+     * Starts a background activity in response to a state event.
+     */
+    fun endBackgroundActivityWithState(timestamp: Long)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -5,10 +5,8 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
-import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 
 internal class EmbraceSessionService(
-    private val processStateService: ProcessStateService,
     ndkService: NdkService,
     private val sessionHandler: SessionHandler,
     deliveryService: DeliveryService,
@@ -18,31 +16,23 @@ internal class EmbraceSessionService(
 ) : SessionService {
 
     init {
-        if (!this.processStateService.isInBackground) {
-            // If the app goes to foreground before the SDK finishes its startup,
-            // the session service will not be registered to the activity listener and will not
-            // start the cold session.
-            // If so, force a cold session start.
-            sessionHandler.onSessionStarted(true, LifeEventType.STATE, clock.now())
-        }
-
         // Send any sessions that were cached and not yet sent.
         deliveryService.sendCachedSessions(isNdkEnabled, ndkService, sessionHandler.getSessionId())
     }
 
-    override fun handleCrash(crashId: String) {
+    override fun endSessionWithCrash(crashId: String) {
         sessionHandler.onCrash(crashId)
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun startSessionWithState(coldStart: Boolean, timestamp: Long) {
         sessionHandler.onSessionStarted(coldStart, LifeEventType.STATE, timestamp)
     }
 
-    override fun onBackground(timestamp: Long) {
+    override fun endSessionWithState(timestamp: Long) {
         sessionHandler.onSessionEnded(LifeEventType.STATE, timestamp, false)
     }
 
-    override fun endSessionManually(clearUserInfo: Boolean) {
+    override fun endSessionWithManual(clearUserInfo: Boolean) {
         if (configService.sessionBehavior.isSessionControlEnabled()) {
             return
         }
@@ -51,8 +41,6 @@ internal class EmbraceSessionService(
         sessionHandler.onSessionEnded(LifeEventType.MANUAL, clock.now(), clearUserInfo) ?: return
 
         // Starts a new session.
-        if (!processStateService.isInBackground) {
-            sessionHandler.onSessionStarted(false, LifeEventType.MANUAL, clock.now())
-        }
+        sessionHandler.onSessionStarted(false, LifeEventType.MANUAL, clock.now())
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -1,16 +1,24 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
-
-internal interface SessionService : ProcessStateListener {
+internal interface SessionService {
 
     /**
-     * Ends a session manually. If [clearUserInfo] is true, the user info will be cleared.
+     * Starts a session in response to a state event.
      */
-    fun endSessionManually(clearUserInfo: Boolean)
+    fun startSessionWithState(coldStart: Boolean, timestamp: Long)
+
+    /**
+     * Ends a session in response to a state event.
+     */
+    fun endSessionWithState(timestamp: Long)
 
     /**
      * Handles an uncaught exception, ending the session and saving the session to disk.
      */
-    fun handleCrash(crashId: String)
+    fun endSessionWithCrash(crashId: String)
+
+    /**
+     * Ends a session manually. If [clearUserInfo] is true, the user info will be cleared.
+     */
+    fun endSessionWithManual(clearUserInfo: Boolean)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestrator.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.session.orchestrator
+
+import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
+
+/**
+ * Orchestrates the session and background activities in response to state changes and manual
+ * requests to end sessions.
+ */
+internal interface SessionOrchestrator : ProcessStateListener {
+
+    /**
+     * Ends the current session (if any) manually. If [clearUserInfo] is true,
+     * the user info will be cleared. This has no effect on background activities.
+     */
+    fun endSessionWithManual(clearUserInfo: Boolean)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.embracesdk.session.orchestrator
+
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.session.BackgroundActivityService
+import io.embrace.android.embracesdk.session.SessionService
+import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
+
+internal class SessionOrchestratorImpl(
+    private val processStateService: ProcessStateService,
+    private val sessionService: SessionService,
+    private val backgroundActivityService: BackgroundActivityService?,
+    clock: Clock
+) : SessionOrchestrator {
+
+    init {
+        processStateService.addListener(this)
+
+        if (processStateService.isInBackground) {
+            backgroundActivityService?.startBackgroundActivityWithState(true, clock.now())
+        } else {
+            // If the app goes to foreground before the SDK finishes its startup,
+            // the session service will not be registered to the activity listener and will not
+            // start the cold session.
+            // If so, force a cold session start.
+            sessionService.startSessionWithState(true, clock.now())
+        }
+    }
+
+    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+        backgroundActivityService?.endBackgroundActivityWithState(timestamp)
+        sessionService.startSessionWithState(coldStart, timestamp)
+    }
+
+    override fun onBackground(timestamp: Long) {
+        sessionService.endSessionWithState(timestamp)
+        backgroundActivityService?.startBackgroundActivityWithState(false, timestamp)
+    }
+
+    override fun endSessionWithManual(clearUserInfo: Boolean) {
+        if (processStateService.isInBackground) {
+            return
+        }
+        sessionService.endSessionWithManual(clearUserInfo)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -4,13 +4,25 @@ import io.embrace.android.embracesdk.session.SessionService
 
 internal class FakeSessionService : SessionService {
 
+    val startTimestamps = mutableListOf<Long>()
+    val endTimestamps = mutableListOf<Long>()
+    var manualEndCount = 0
+
+    override fun startSessionWithState(coldStart: Boolean, timestamp: Long) {
+        startTimestamps.add(timestamp)
+    }
+
+    override fun endSessionWithState(timestamp: Long) {
+        endTimestamps.add(timestamp)
+    }
+
     var crashId: String? = null
 
-    override fun handleCrash(crashId: String) {
+    override fun endSessionWithCrash(crashId: String) {
         this.crashId = crashId
     }
 
-    override fun endSessionManually(clearUserInfo: Boolean) {
-        TODO("Not yet implemented")
+    override fun endSessionWithManual(clearUserInfo: Boolean) {
+        manualEndCount++
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -4,11 +4,22 @@ import io.embrace.android.embracesdk.session.BackgroundActivityService
 
 internal class FakeBackgroundActivityService : BackgroundActivityService {
 
+    val endTimestamps = mutableListOf<Long>()
+    val startTimestamps = mutableListOf<Long>()
+
+    override fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long) {
+        startTimestamps.add(timestamp)
+    }
+
+    override fun endBackgroundActivityWithState(timestamp: Long) {
+        endTimestamps.add(timestamp)
+    }
+
     override fun sendBackgroundActivity() {
         TODO("Not yet implemented")
     }
 
-    override fun handleCrash(crashId: String) {
+    override fun endBackgroundActivityWithCrash(crashId: String) {
     }
 
     override fun save() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
+
+internal class FakeSessionOrchestrator : SessionOrchestrator {
+
+    var manualEndCount = 0
+
+    override fun endSessionWithManual(clearUserInfo: Boolean) {
+        manualEndCount++
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.PayloadMessageCollator
 import io.embrace.android.embracesdk.session.SessionHandler
 import io.embrace.android.embracesdk.session.SessionService
+import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 internal class FakeSessionModule(
@@ -18,5 +19,8 @@ internal class FakeSessionModule(
         get() = TODO("Not yet implemented")
 
     override val payloadMessageCollator: PayloadMessageCollator
+        get() = TODO("Not yet implemented")
+
+    override val sessionOrchestrator: SessionOrchestratorImpl
         get() = TODO("Not yet implemented")
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -49,6 +49,7 @@ internal class SessionModuleImplTest {
         assertNotNull(module.payloadMessageCollator)
         assertNotNull(module.sessionPropertiesService)
         assertNull(module.backgroundActivityService)
+        assertNotNull(module.sessionOrchestrator)
     }
 
     @Test
@@ -72,6 +73,7 @@ internal class SessionModuleImplTest {
         assertNotNull(module.payloadMessageCollator)
         assertNotNull(module.sessionPropertiesService)
         assertNotNull(module.backgroundActivityService)
+        assertNotNull(module.sessionOrchestrator)
     }
 
     private fun createEnabledBehavior(): FakeEssentialServiceModule {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -1,0 +1,92 @@
+package io.embrace.android.embracesdk.session.orchestrator
+
+import io.embrace.android.embracesdk.FakeSessionService
+import io.embrace.android.embracesdk.fakes.FakeBackgroundActivityService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class SessionOrchestratorTest {
+
+    companion object {
+        private const val TIMESTAMP = 1000L
+    }
+
+    private lateinit var orchestrator: SessionOrchestratorImpl
+    private lateinit var sessionService: FakeSessionService
+    private lateinit var backgroundActivityService: FakeBackgroundActivityService
+    private lateinit var processStateService: FakeProcessStateService
+    private lateinit var clock: FakeClock
+
+    @Before
+    fun setUp() {
+        processStateService = FakeProcessStateService()
+        sessionService = FakeSessionService()
+        backgroundActivityService = FakeBackgroundActivityService()
+        clock = FakeClock()
+        orchestrator = SessionOrchestratorImpl(
+            processStateService,
+            sessionService,
+            backgroundActivityService,
+            clock
+        )
+    }
+
+    @Test
+    fun `test initial behavior in background`() {
+        createOrchestratorInBackground()
+        assertEquals(orchestrator, processStateService.listeners.single())
+        assertEquals(0, sessionService.startTimestamps.size)
+        assertEquals(1, backgroundActivityService.startTimestamps.size)
+    }
+
+    @Test
+    fun `test initial behavior in foreground`() {
+        assertEquals(orchestrator, processStateService.listeners.single())
+        assertEquals(1, sessionService.startTimestamps.size)
+        assertEquals(0, backgroundActivityService.startTimestamps.size)
+    }
+
+    @Test
+    fun `test on foreground call`() {
+        createOrchestratorInBackground()
+        orchestrator.onForeground(true, 0, TIMESTAMP)
+        assertEquals(TIMESTAMP, sessionService.startTimestamps.single())
+        assertEquals(TIMESTAMP, backgroundActivityService.endTimestamps.single())
+    }
+
+    @Test
+    fun `test on background call`() {
+        orchestrator.onBackground(TIMESTAMP)
+        assertEquals(TIMESTAMP, sessionService.endTimestamps.single())
+        assertEquals(TIMESTAMP, backgroundActivityService.startTimestamps.single())
+    }
+
+    @Test
+    fun `end session with manual in foreground`() {
+        orchestrator.endSessionWithManual(true)
+        assertEquals(1, sessionService.manualEndCount)
+    }
+
+    @Test
+    fun `end session with manual in background`() {
+        processStateService.isInBackground = true
+        orchestrator.endSessionWithManual(true)
+        assertEquals(0, sessionService.manualEndCount)
+    }
+
+    private fun createOrchestratorInBackground() {
+        processStateService.listeners.clear()
+        processStateService.isInBackground = true
+        sessionService.startTimestamps.clear()
+        backgroundActivityService.startTimestamps.clear()
+        orchestrator = SessionOrchestratorImpl(
+            processStateService,
+            sessionService,
+            backgroundActivityService,
+            clock
+        )
+    }
+}


### PR DESCRIPTION
## Goal

This changeset creates a `SessionOrchestrator` class that is meant to be the sole class that is responsible for controlling when sessions + background activities start/end. This does not fully achieve the intended architecture changes that have been discussed internally but is a good first step towards combining some of this logic.

The `SessionOrchestrator` registers for a callback on the `ProcessStateService`, which notifies its listeners when the app enters/exits the foreground/background. Additionally, the `SessionOrchestrator` is notified when a developer requests to manually end a session. Finally, `SessionOrchestrator` also contains logic for starting an initial background activity/session depending on the process state.

I took this opportunity to rename functions on the `SessionService` and `BackgroundActivityService` so that they are a bit more consistent. This should help us eventually unify the two.

## Testing

Updated & added to existing test coverage.

