### PR TITLE
Refactor how session/background services are gated

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -619,12 +619,6 @@ final class EmbraceImpl {
         backgroundActivityService = sessionModule.getBackgroundActivityService();
         serviceRegistry.registerServices(sessionService, backgroundActivityService);
 
-        if (backgroundActivityService != null) {
-            internalEmbraceLogger.logInfo("Background activity capture enabled");
-        } else {
-            internalEmbraceLogger.logInfo("Background activity capture disabled");
-        }
-
         CrashModule crashModule = new CrashModuleImpl(
             initModule,
             storageModule,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -101,19 +101,15 @@ internal class SessionModuleImpl(
     }
 
     override val backgroundActivityService: BackgroundActivityService? by singleton {
-        if (essentialServiceModule.configService.isBackgroundActivityCaptureEnabled()) {
-            EmbraceBackgroundActivityService(
-                essentialServiceModule.metadataService,
-                deliveryModule.deliveryService,
-                essentialServiceModule.configService,
-                nativeModule.ndkService,
-                initModule.clock,
-                payloadMessageCollator,
-                workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
-            )
-        } else {
-            null
-        }
+        EmbraceBackgroundActivityService(
+            essentialServiceModule.metadataService,
+            deliveryModule.deliveryService,
+            essentialServiceModule.configService,
+            nativeModule.ndkService,
+            initModule.clock,
+            payloadMessageCollator,
+            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
+        )
     }
 
     override val sessionOrchestrator: SessionOrchestrator by singleton {
@@ -121,7 +117,8 @@ internal class SessionModuleImpl(
             essentialServiceModule.processStateService,
             sessionService,
             backgroundActivityService,
-            initModule.clock
+            initModule.clock,
+            essentialServiceModule.configService
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/ConfigGate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/ConfigGate.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.session
+
+import io.embrace.android.embracesdk.config.ConfigListener
+import io.embrace.android.embracesdk.config.ConfigService
+
+/**
+ * Gate that controls access to a service based on a config value. This
+ * returns the service when it is enabled, or null if it is not.
+ */
+internal class ConfigGate<T>(
+    private val impl: T,
+
+    /**
+     * Predicate that determines if the service should be enabled or not, via a config value.
+     */
+    private val predicate: () -> Boolean,
+) : ConfigListener {
+
+    private var configState: Boolean = predicate()
+
+    /**
+     * Returns the service when it is enabled, or null if it is not.
+     */
+    fun getService(): T? = when {
+        configState -> impl
+        else -> null
+    }
+
+    override fun onConfigChange(configService: ConfigService) {
+        configState = predicate()
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -1,19 +1,36 @@
 package io.embrace.android.embracesdk.session.orchestrator
 
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.session.BackgroundActivityService
+import io.embrace.android.embracesdk.session.ConfigGate
 import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 
 internal class SessionOrchestratorImpl(
     private val processStateService: ProcessStateService,
-    private val sessionService: SessionService,
-    private val backgroundActivityService: BackgroundActivityService?,
-    clock: Clock
+    sessionServiceImpl: SessionService,
+    backgroundActivityServiceImpl: BackgroundActivityService?,
+    clock: Clock,
+    configService: ConfigService
 ) : SessionOrchestrator {
+
+    private val sessionGate = ConfigGate(sessionServiceImpl) {
+        configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.SESSION)
+    }
+    private val backgroundActivityGate = ConfigGate(backgroundActivityServiceImpl) {
+        configService.isBackgroundActivityCaptureEnabled()
+    }
+    private val sessionService: SessionService?
+        get() = sessionGate.getService()
+    private val backgroundActivityService: BackgroundActivityService?
+        get() = backgroundActivityGate.getService()
 
     init {
         processStateService.addListener(this)
+        configService.addListener(sessionGate)
+        configService.addListener(backgroundActivityGate)
 
         if (processStateService.isInBackground) {
             backgroundActivityService?.startBackgroundActivityWithState(true, clock.now())
@@ -22,17 +39,17 @@ internal class SessionOrchestratorImpl(
             // the session service will not be registered to the activity listener and will not
             // start the cold session.
             // If so, force a cold session start.
-            sessionService.startSessionWithState(true, clock.now())
+            sessionService?.startSessionWithState(true, clock.now())
         }
     }
 
     override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
         backgroundActivityService?.endBackgroundActivityWithState(timestamp)
-        sessionService.startSessionWithState(coldStart, timestamp)
+        sessionService?.startSessionWithState(coldStart, timestamp)
     }
 
     override fun onBackground(timestamp: Long) {
-        sessionService.endSessionWithState(timestamp)
+        sessionService?.endSessionWithState(timestamp)
         backgroundActivityService?.startBackgroundActivityWithState(false, timestamp)
     }
 
@@ -40,6 +57,6 @@ internal class SessionOrchestratorImpl(
         if (processStateService.isInBackground) {
             return
         }
-        sessionService.endSessionWithManual(clearUserInfo)
+        sessionService?.endSessionWithManual(clearUserInfo)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ConfigGateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ConfigGateTest.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.session
+
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+internal class ConfigGateTest {
+
+    @Test
+    fun `test config gate`() {
+        var value = true
+        val gate = ConfigGate("test") { value }
+        assertEquals("test", gate.getService())
+
+        value = false
+        gate.onConfigChange(FakeConfigService())
+        assertNull(gate.getService())
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceUnbalancedSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceUnbalancedSessionServiceTest.kt
@@ -1,0 +1,118 @@
+package io.embrace.android.embracesdk.session
+
+import io.embrace.android.embracesdk.FakeBreadcrumbService
+import io.embrace.android.embracesdk.FakeDeliveryService
+import io.embrace.android.embracesdk.FakeNdkService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
+import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
+import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.internal.OpenTelemetryClock
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.ndk.NdkService
+import io.embrace.android.embracesdk.worker.ScheduledWorker
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class EmbraceUnbalancedSessionServiceTest {
+
+    private val processStateService = FakeProcessStateService()
+    private val ndkService: NdkService = FakeNdkService()
+    private val clock = FakeClock()
+    private lateinit var service: EmbraceSessionService
+    private lateinit var deliveryService: FakeDeliveryService
+    private lateinit var spansService: EmbraceSpansService
+    private lateinit var configService: FakeConfigService
+
+    @Before
+    fun before() {
+        deliveryService = FakeDeliveryService()
+        configService = FakeConfigService()
+        spansService = EmbraceSpansService(
+            clock = OpenTelemetryClock(embraceClock = clock),
+            telemetryService = FakeTelemetryService()
+        )
+    }
+
+    @Test
+    fun `simulate session capture enabled after onForeground`() {
+        initializeSessionService(sessionHandler = fakeSessionHandler(configService))
+
+        // missing start call simulates service being enabled halfway through.
+        service.endSessionWithState(clock.now())
+
+        // nothing is delivered
+        assertEquals(0, deliveryService.lastSentSessions.size)
+
+        // next session is recorded correctly
+        service.startSessionWithState(false, clock.now())
+        clock.tick(10000L)
+        service.endSessionWithState(clock.now())
+        assertEquals(1, deliveryService.lastSentSessions.size)
+    }
+
+    @Test
+    fun `session capture disabled after onForeground`() {
+        initializeSessionService(sessionHandler = fakeSessionHandler(configService))
+
+        service.startSessionWithState(true, clock.now())
+        clock.tick(10000)
+        // missing end call simulates service being disabled halfway through.
+
+        // nothing is delivered
+        assertEquals(0, deliveryService.lastSentSessions.size)
+
+        service.startSessionWithState(false, clock.now())
+        clock.tick(10000L)
+        service.endSessionWithState(clock.now())
+        assertEquals(1, deliveryService.lastSentSessions.size)
+    }
+
+    private fun fakeSessionHandler(configService: ConfigService): SessionHandler {
+        return SessionHandler(
+            InternalEmbraceLogger(),
+            configService,
+            FakeUserService(),
+            FakeNetworkConnectivityService(),
+            FakeAndroidMetadataService(),
+            FakeBreadcrumbService(),
+            null,
+            FakeInternalErrorService(),
+            FakeMemoryCleanerService(),
+            deliveryService,
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            FakeClock(),
+            SpansService.featureDisabledSpansService,
+            ScheduledWorker(BlockingScheduledExecutorService())
+        )
+    }
+
+    private fun initializeSessionService(
+        ndkEnabled: Boolean = false,
+        isActivityInBackground: Boolean = true,
+        sessionHandler: SessionHandler
+    ) {
+        processStateService.isInBackground = isActivityInBackground
+
+        service = EmbraceSessionService(
+            ndkService,
+            sessionHandler,
+            deliveryService,
+            ndkEnabled,
+            clock,
+            configService
+        )
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -17,7 +17,6 @@ import io.embrace.android.embracesdk.fakes.injection.FakeSdkObservabilityModule
 import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.injection.SessionModuleImpl
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class SessionModuleImplTest {
@@ -48,7 +47,7 @@ internal class SessionModuleImplTest {
         assertNotNull(module.sessionService)
         assertNotNull(module.payloadMessageCollator)
         assertNotNull(module.sessionPropertiesService)
-        assertNull(module.backgroundActivityService)
+        assertNotNull(module.backgroundActivityService)
         assertNotNull(module.sessionOrchestrator)
     }
 


### PR DESCRIPTION
## Goal

Refactors how the session/background activity services are gated by creating a `ConfigGate` class. This is responsible for checking whether a feature is enabled & holding state so that either a service is returned, or `null` is returned if not. The aim is to free up the session & background activity service from having to hold state about whether it's enabled or not & gate every single function call.

This is a little problematic in that the service can be disabled at any time in the process lifecycle, so it'd be great to get a detailed review to see whether I've missed anywhere this might cause us state management pain. Having said that, the existing services don't do a great job of this either. Ultimately I'd like to change this so that there's a register/deregister call on every service.

## Testing

Added to existing test coverage.
