### PR TITLE
Add back the method to set the RN SDK version to the internal interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
@@ -31,6 +31,8 @@ internal interface ReactNativeInternalInterface : EmbraceInternalInterface {
      */
     fun setJavaScriptPatchNumber(number: String?)
 
+    fun setReactNativeSdkVersion(version: String?)
+
     /**
      * See [Embrace.setReactNativeVersionNumber]
      */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
@@ -71,6 +71,14 @@ internal class ReactNativeInternalInterfaceImpl(
         }
     }
 
+    override fun setReactNativeSdkVersion(version: String?) {
+        if (embrace.isStarted) {
+            metadataService.setRnSdkVersion(version)
+        } else {
+            logger.logSDKNotInitialized("set React Native SDK version")
+        }
+    }
+
     override fun setReactNativeVersionNumber(version: String?) {
         if (embrace.isStarted) {
             if (version == null) {


### PR DESCRIPTION
## Goal

An analogous method was removed in 6.0 because we thought we had moved it to the internal RN interface already, but it was actually missed. Adding this now so RN can continue to work.