### PR TITLE
Remove disabled message type

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SequentialSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SequentialSessionTest.kt
@@ -25,18 +25,6 @@ internal class SequentialSessionTest {
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
-    fun `session message type disabled`() {
-        with(testRule) {
-            harness.fakeConfigService.dataCaptureEventBehavior = fakeDataCaptureEventBehavior {
-                RemoteConfig(disabledMessageTypes = setOf("session"))
-            }
-            harness.recordSession()
-            val messages = harness.getSentSessionMessages()
-            assertEquals(0, messages.size)
-        }
-    }
-
-    @Test
     fun `cold start and session number are recorded correctly`() {
         with(testRule) {
             val first = checkNotNull(harness.recordSession())

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -798,10 +798,6 @@ final class EmbraceImpl {
      */
     void setUserIdentifier(@Nullable String userId) {
         if (checkSdkStartedAndLogPublicApiUsage("set_user_identifier")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring identifier update.");
-                return;
-            }
             userService.setUserIdentifier(userId);
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -813,10 +809,6 @@ final class EmbraceImpl {
      */
     void clearUserIdentifier() {
         if (checkSdkStartedAndLogPublicApiUsage("clear_user_identifier")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring identifier update.");
-                return;
-            }
             userService.clearUserIdentifier();
         }
     }
@@ -828,10 +820,6 @@ final class EmbraceImpl {
      */
     void setUserEmail(@Nullable String email) {
         if (checkSdkStartedAndLogPublicApiUsage("set_user_email")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring email update.");
-                return;
-            }
             userService.setUserEmail(email);
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -843,10 +831,6 @@ final class EmbraceImpl {
      */
     void clearUserEmail() {
         if (checkSdkStartedAndLogPublicApiUsage("clear_user_email")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring email update.");
-                return;
-            }
             userService.clearUserEmail();
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -858,10 +842,6 @@ final class EmbraceImpl {
      */
     void setUserAsPayer() {
         if (checkSdkStartedAndLogPublicApiUsage("set_user_as_payer")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring payer user update.");
-                return;
-            }
             userService.setUserAsPayer();
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -874,10 +854,6 @@ final class EmbraceImpl {
      */
     void clearUserAsPayer() {
         if (checkSdkStartedAndLogPublicApiUsage("clear_user_as_payer")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring payer user update.");
-                return;
-            }
             userService.clearUserAsPayer();
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -891,10 +867,6 @@ final class EmbraceImpl {
      */
     void addUserPersona(@NonNull String persona) {
         if (checkSdkStartedAndLogPublicApiUsage("add_user_persona")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning(ERROR_USER_UPDATES_DISABLED);
-                return;
-            }
             userService.addUserPersona(persona);
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -908,10 +880,6 @@ final class EmbraceImpl {
      */
     void clearUserPersona(@NonNull String persona) {
         if (checkSdkStartedAndLogPublicApiUsage("clear_user_persona")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning(ERROR_USER_UPDATES_DISABLED);
-                return;
-            }
             userService.clearUserPersona(persona);
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -923,10 +891,6 @@ final class EmbraceImpl {
      */
     void clearAllUserPersonas() {
         if (checkSdkStartedAndLogPublicApiUsage("clear_user_personas")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning(ERROR_USER_UPDATES_DISABLED);
-                return;
-            }
             userService.clearAllUserPersonas();
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -971,10 +935,6 @@ final class EmbraceImpl {
      */
     void setUsername(@Nullable String username) {
         if (checkSdkStartedAndLogPublicApiUsage("set_username")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring username update.");
-                return;
-            }
             userService.setUsername(username);
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();
@@ -986,10 +946,6 @@ final class EmbraceImpl {
      */
     void clearUsername() {
         if (checkSdkStartedAndLogPublicApiUsage("clear_username")) {
-            if (!configService.getDataCaptureEventBehavior().isMessageTypeEnabled(MessageType.USER)) {
-                internalEmbraceLogger.logWarning("User updates are disabled, ignoring username update.");
-                return;
-            }
             userService.clearUsername();
             // Update user info in NDK service
             ndkService.onUserInfoUpdate();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehavior.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.PatternCache
-import java.util.Locale
 
 internal class DataCaptureEventBehavior(
     thresholdCheck: BehaviorThresholdCheck,
@@ -19,13 +17,6 @@ internal class DataCaptureEventBehavior(
     }
 
     private val patternCache = PatternCache()
-
-    fun isMessageTypeEnabled(type: MessageType): Boolean {
-        return when (val disabledTypes = remote?.disabledMessageTypes) {
-            null -> true
-            else -> !disabledTypes.contains(type.name.toLowerCase(Locale.getDefault()))
-        }
-    }
 
     fun isInternalExceptionCaptureEnabled(): Boolean =
         remote?.internalExceptionCaptureEnabled ?: DEFAULT_INTERNAL_EXCEPTION_CAPTURE

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/RemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/RemoteConfig.kt
@@ -30,12 +30,6 @@ internal data class RemoteConfig(
     val eventLimits: Map<String, Long>? = null,
 
     /**
-     * The list of [io.embrace.android.embracesdk.MessageType] which are disabled.
-     */
-    @Json(name = "disabled_message_types")
-    val disabledMessageTypes: Set<String>? = null,
-
-    /**
      * List of regular expressions matching event names and log messages which should be disabled.
      */
     @Json(name = "disabled_event_and_log_patterns")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -210,10 +210,6 @@ internal class EmbraceEventService(
     ) {
         try {
             logDeveloper("EmbraceEventService", "Ending event: $name")
-            if (!eventHandler.isAllowedToEnd()) {
-                logDeveloper("EmbraceEventService", "Event handler not allowed to end")
-                return
-            }
             val eventKey = getInternalEventKey(name, identifier)
             val originEventDescription: EventDescription? = when {
                 late -> activeEvents[eventKey]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceLogMessageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceLogMessageService.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.behavior.LogMessageBehavior
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.CacheableValue
-import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -172,10 +171,6 @@ internal class EmbraceLogMessageService(
             synchronized(lock) {
                 if (!configService.dataCaptureEventBehavior.isLogMessageEnabled(message)) {
                     logger.logWarning("Log message disabled. Ignoring log with message $message")
-                    return@submit
-                }
-                if (!configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.LOG)) {
-                    logger.logWarning("Log message disabled. Ignoring all Logs.")
                     return@submit
                 }
                 val id = getEmbUuid()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.EventDescription
-import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -118,21 +117,6 @@ internal class EventHandler(
             false
         } else if (!configService.dataCaptureEventBehavior.isEventEnabled(eventName)) {
             logger.logWarning("Event disabled. Ignoring event with name $eventName")
-            false
-        } else if (!configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.EVENT)) {
-            logger.logWarning("Event message disabled. Ignoring all Events.")
-            false
-        } else {
-            true
-        }
-    }
-
-    /**
-     * It determines the handler is allowed to end
-     */
-    fun isAllowedToEnd(): Boolean {
-        return if (!configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.EVENT)) {
-            logger.logWarning("Event message disabled. Ignoring all Events.")
             false
         } else {
             true

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.session.orchestrator
 
 import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.ConfigGate
@@ -10,26 +9,20 @@ import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 
 internal class SessionOrchestratorImpl(
     private val processStateService: ProcessStateService,
-    sessionServiceImpl: SessionService,
+    private val sessionService: SessionService,
     backgroundActivityServiceImpl: BackgroundActivityService?,
     clock: Clock,
     configService: ConfigService
 ) : SessionOrchestrator {
 
-    private val sessionGate = ConfigGate(sessionServiceImpl) {
-        configService.dataCaptureEventBehavior.isMessageTypeEnabled(MessageType.SESSION)
-    }
     private val backgroundActivityGate = ConfigGate(backgroundActivityServiceImpl) {
         configService.isBackgroundActivityCaptureEnabled()
     }
-    private val sessionService: SessionService?
-        get() = sessionGate.getService()
     private val backgroundActivityService: BackgroundActivityService?
         get() = backgroundActivityGate.getService()
 
     init {
         processStateService.addListener(this)
-        configService.addListener(sessionGate)
         configService.addListener(backgroundActivityGate)
 
         if (processStateService.isInBackground) {
@@ -39,17 +32,17 @@ internal class SessionOrchestratorImpl(
             // the session service will not be registered to the activity listener and will not
             // start the cold session.
             // If so, force a cold session start.
-            sessionService?.startSessionWithState(true, clock.now())
+            sessionService.startSessionWithState(true, clock.now())
         }
     }
 
     override fun onForeground(coldStart: Boolean, timestamp: Long) {
         backgroundActivityService?.endBackgroundActivityWithState(timestamp)
-        sessionService?.startSessionWithState(coldStart, timestamp)
+        sessionService.startSessionWithState(coldStart, timestamp)
     }
 
     override fun onBackground(timestamp: Long) {
-        sessionService?.endSessionWithState(timestamp)
+        sessionService.endSessionWithState(timestamp)
         backgroundActivityService?.startBackgroundActivityWithState(false, timestamp)
     }
 
@@ -57,6 +50,6 @@ internal class SessionOrchestratorImpl(
         if (processStateService.isInBackground) {
             return
         }
-        sessionService?.endSessionWithManual(clearUserInfo)
+        sessionService.endSessionWithManual(clearUserInfo)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehaviorTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
-import io.embrace.android.embracesdk.internal.MessageType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -12,7 +11,6 @@ internal class DataCaptureEventBehaviorTest {
 
     private val remote = RemoteConfig(
         internalExceptionCaptureEnabled = false,
-        disabledMessageTypes = setOf("event"),
         disabledEventAndLogPatterns = setOf("my_event", "my_log"),
         eventLimits = mapOf("test" to 100)
     )
@@ -20,7 +18,6 @@ internal class DataCaptureEventBehaviorTest {
     @Test
     fun testDefaults() {
         with(fakeDataCaptureEventBehavior()) {
-            assertTrue(isMessageTypeEnabled(MessageType.EVENT))
             assertTrue(isInternalExceptionCaptureEnabled())
             assertTrue(isEventEnabled("my_event"))
             assertTrue(isEventEnabled("other_event"))
@@ -33,7 +30,6 @@ internal class DataCaptureEventBehaviorTest {
     @Test
     fun testRemoteOnly() {
         with(fakeDataCaptureEventBehavior(remoteCfg = { remote })) {
-            assertFalse(isMessageTypeEnabled(MessageType.EVENT))
             assertFalse(isInternalExceptionCaptureEnabled())
             assertFalse(isEventEnabled("my_event"))
             assertTrue(isEventEnabled("other_event"))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
@@ -20,7 +20,6 @@ import io.embrace.android.embracesdk.fakes.fakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
-import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -271,15 +270,6 @@ internal class EmbraceLogMessageServiceTest {
         deliveryService.lastSentLogs.single().let {
             assertEquals("Another", it.event.name)
         }
-    }
-
-    @Test
-    fun testMessageTypeEnabled() {
-        cfg = cfg.copy(disabledMessageTypes = setOf(MessageType.LOG.name.toLowerCase()))
-        logMessageService = getLogMessageService()
-
-        logMessageService.log("Hello World", EmbraceEvent.Type.INFO_LOG, null)
-        assertEquals(0, deliveryService.lastSentLogs.size)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.EventDescription
-import io.embrace.android.embracesdk.internal.MessageType
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -123,15 +122,6 @@ internal class EventHandlerTest {
     }
 
     @Test
-    fun `if event type is disabled then event should not be allowed to start`() {
-        val event = "event"
-        cfg = cfg.copy(disabledMessageTypes = setOf(MessageType.EVENT.name.toLowerCase()))
-        val allowed = eventHandler.isAllowedToStart(event)
-
-        assertFalse(allowed)
-    }
-
-    @Test
     fun `if worker is shut down, then event should be allowed to start`() {
         val event = "event"
         scheduledExecutorService.shutdown()
@@ -143,21 +133,6 @@ internal class EventHandlerTest {
     fun `if none of the above, event should be allowed to start`() {
         val event = "event"
         val allowed = eventHandler.isAllowedToStart(event)
-
-        assertTrue(allowed)
-    }
-
-    @Test
-    fun `if event type is disabled then event should not be allowed to end`() {
-        cfg = cfg.copy(disabledMessageTypes = setOf(MessageType.EVENT.name.toLowerCase()))
-        val allowed = eventHandler.isAllowedToEnd()
-
-        assertFalse(allowed)
-    }
-
-    @Test
-    fun `verify event is allowed to end`() {
-        val allowed = eventHandler.isAllowedToEnd()
 
         assertTrue(allowed)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -1,12 +1,10 @@
 package io.embrace.android.embracesdk.session.orchestrator
 
 import io.embrace.android.embracesdk.FakeSessionService
-import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeBackgroundActivityService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
-import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -89,18 +87,6 @@ internal class SessionOrchestratorTest {
         configService = FakeConfigService(backgroundActivityCaptureEnabled = false)
         createOrchestratorInBackground()
         orchestrator.onBackground(TIMESTAMP)
-        assertTrue(backgroundActivityService.startTimestamps.isEmpty())
-    }
-
-    @Test
-    fun `test session capture disabled`() {
-        configService = FakeConfigService(
-            sessionBehavior = fakeSessionBehavior {
-                RemoteConfig(disabledMessageTypes = setOf("session"))
-            }
-        )
-        createOrchestratorInBackground()
-        orchestrator.onForeground(true, 0, TIMESTAMP)
         assertTrue(backgroundActivityService.startTimestamps.isEmpty())
     }
 


### PR DESCRIPTION
## Goal

Removes the `disabledMessagesType` remote config field as Fredric ran queries that showed this was only used for one (deleted) appId. Getting rid of this simplifies our session & event capture logic.
