### PR TITLE
Remove unused startupTime parameter

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAutomaticVerification.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAutomaticVerification.kt
@@ -206,7 +206,7 @@ internal class EmbraceAutomaticVerification(
         }
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         foregroundEventTriggered = true
         val activity = activityLifecycleTracker.foregroundActivity
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
@@ -153,7 +153,7 @@ internal class EmbraceAnrService(
      * When app goes to foreground, we need to monitor the target thread again to
      * capture ANRs.
      */
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         this.anrMonitorWorker.submit {
             enforceThread(anrMonitorThread)
             state.resetState()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/EmbracePowerSaveModeService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/EmbracePowerSaveModeService.kt
@@ -49,7 +49,7 @@ internal class EmbracePowerSaveModeService(
         }
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         if (powerManager?.isPowerSaveMode == true) {
             addPowerChange(PowerChange(timestamp, Kind.START))
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
@@ -266,7 +266,7 @@ internal class EmbraceConfigService @JvmOverloads constructor(
         listeners.add(configListener)
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         // Refresh the config on resume if it has expired
         getConfig()
         if (Embrace.getInstance().isStarted && isSdkDisabled()) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -83,7 +83,7 @@ internal class EmbraceEventService(
             workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         logDeveloper("EmbraceEventService", "coldStart: $coldStart")
         if (coldStart) {
             // Using the system current timestamp here as the startup timestamp is related to the

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -140,7 +140,7 @@ internal class EmbraceNdkService(
         }
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         synchronized(lock) {
             if (isInstalled) {
                 updateAppState(APPLICATION_STATE_ACTIVE)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.session.lifecycle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
-import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
@@ -34,12 +33,6 @@ internal class EmbraceProcessStateService(
      */
     @Volatile
     private var coldStart = true
-
-    /**
-     * States the initialization time of the EmbraceProcessStateService, inferring it is initialized
-     * from the [Embrace.start] method.
-     */
-    private val startTime: Long = clock.now()
 
     /**
      * Returns if the app's in background or not.
@@ -76,11 +69,11 @@ internal class EmbraceProcessStateService(
         isInBackground = false
         val timestamp = clock.now()
 
-        invokeCallbackSafely { sessionOrchestrator?.onForeground(coldStart, startTime, timestamp) }
+        invokeCallbackSafely { sessionOrchestrator?.onForeground(coldStart, timestamp) }
 
         stream<ProcessStateListener>(listeners) { listener: ProcessStateListener ->
             invokeCallbackSafely {
-                listener.onForeground(coldStart, startTime, timestamp)
+                listener.onForeground(coldStart, timestamp)
             }
         }
         coldStart = false

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ProcessStateListener.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ProcessStateListener.kt
@@ -14,7 +14,7 @@ internal interface ProcessStateListener {
      * Triggered when the application is resumed.
      *
      * @param coldStart   whether this is a cold start
-     * @param startupTime the timestamp at which the application started
+     * @param timestamp the timestamp at which the application entered the foreground
      */
-    fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {}
+    fun onForeground(coldStart: Boolean, timestamp: Long) {}
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -26,7 +26,7 @@ internal class SessionOrchestratorImpl(
         }
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         backgroundActivityService?.endBackgroundActivityWithState(timestamp)
         sessionService.startSessionWithState(coldStart, timestamp)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceTest.kt
@@ -83,7 +83,7 @@ internal class EmbraceAnrServiceTest {
         with(rule) {
             // cold starts should always be ignored
             state.lastTargetThreadResponseMs = 1
-            anrService.onForeground(true, 0L, 0L)
+            anrService.onForeground(true, 0L)
 
             // assert no ANR interval was added
             assertEquals(0, anrService.stacktraceSampler.anrIntervals.size)
@@ -219,10 +219,10 @@ internal class EmbraceAnrServiceTest {
         val anrEndTs = 15023000L
         with(rule) {
             clock.setCurrentTime(anrStartTs)
-            anrService.onForeground(false, anrStartTs, anrInProgressTs)
+            anrService.onForeground(false, anrInProgressTs)
             anrService.onBackground(anrEndTs)
             clock.setCurrentTime(anrEndTs)
-            anrService.onForeground(false, anrEndTs, anrEndTs)
+            anrService.onForeground(false, anrEndTs)
             // Since Looper is a mock, we execute this operation to
             // ensure onMainThreadUnblocked runs and lastTargetThreadResponseMs gets updated
             targetThreadHandler.onIdleThread()
@@ -239,10 +239,10 @@ internal class EmbraceAnrServiceTest {
 
         with(rule) {
             clock.setCurrentTime(anrStartTs)
-            anrService.onForeground(false, anrStartTs, anrInProgressTs)
+            anrService.onForeground(false, anrInProgressTs)
             anrService.onBackground(anrEndTs)
             clock.setCurrentTime(anrEndTs)
-            anrService.onForeground(false, anrEndTs, anrEndTs)
+            anrService.onForeground(false, anrEndTs)
             targetThreadHandler.onIdleThread()
             val intervals = anrService.getCapturedData()
             assertEquals(0, intervals.size)
@@ -421,7 +421,7 @@ internal class EmbraceAnrServiceTest {
         with(rule) {
             clock.setCurrentTime(14000000L)
             cfg = cfg.copy(pctBgEnabled = 100)
-            anrService.onForeground(true, clock.now(), clock.now())
+            anrService.onForeground(true, clock.now())
             anrExecutorService.submit {
                 assertTrue(state.started.get())
             }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceTimingTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceTimingTest.kt
@@ -61,7 +61,7 @@ internal class EmbraceAnrServiceTimingTest {
             anrExecutorService.runCurrentlyBlocked()
             anrExecutorService.runCurrentlyBlocked()
             assertEquals(1, anrExecutorService.scheduledTasksCount())
-            anrService.onForeground(true, clock.now(), clock.now() + 1)
+            anrService.onForeground(true, clock.now() + 1)
             anrExecutorService.runCurrentlyBlocked()
             anrExecutorService.runCurrentlyBlocked()
             assertEquals(1, anrExecutorService.scheduledTasksCount())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
@@ -240,7 +240,7 @@ internal class EmbraceConfigServiceTest {
         fakePreferenceService.sdkDisabled = false
         service.addListener(mockConfigListener)
 
-        service.onForeground(true, 1000L, 1100L)
+        service.onForeground(true, 1100L)
 
         verify(exactly = 1) { mockConfigListener.onConfigChange(service) }
     }
@@ -251,7 +251,7 @@ internal class EmbraceConfigServiceTest {
         every { Embrace.getImpl().isStarted } returns true
         fakePreferenceService.sdkDisabled = true
 
-        service.onForeground(true, 1000L, 1100L)
+        service.onForeground(true, 1100L)
 
         verify(exactly = 1) { Embrace.getImpl().stop() }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
@@ -117,7 +117,7 @@ internal class EmbracePowerSaveModeServiceTest {
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
         val startTime = fakeClock.now()
-        service.onForeground(true, startTime, startTime)
+        service.onForeground(true, startTime)
 
         val intervals = service.getCapturedData()
         assertEquals(1, intervals.size)
@@ -131,7 +131,7 @@ internal class EmbracePowerSaveModeServiceTest {
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
         val startTime = fakeClock.now()
-        service.onForeground(true, startTime, startTime)
+        service.onForeground(true, startTime)
 
         every { intent.action } returns ACTION_POWER_SAVE_MODE_CHANGED
         every { powerManager.isPowerSaveMode } returns false
@@ -164,7 +164,7 @@ internal class EmbracePowerSaveModeServiceTest {
         every { powerManager.isPowerSaveMode } returns true
         fakeClock.setCurrentTime(111111L)
         val startTime = fakeClock.now()
-        service.onForeground(true, startTime, startTime)
+        service.onForeground(true, startTime)
 
         assertEquals(1, service.getCapturedData().size)
         service.cleanCollections()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -291,7 +291,7 @@ internal class EmbraceEventServiceTest {
 
     @Test
     fun `verify onForeground for a cold start sends a startup moment`() {
-        eventService.onForeground(true, 123, 456)
+        eventService.onForeground(true, 456)
         assertNotNull(eventService.getActiveEvent(STARTUP_EVENT_NAME, null))
         val lastEvent = deliveryService.lastEventSentAsync
         assertEquals(1, deliveryService.eventSentAsyncInvokedCount)
@@ -302,7 +302,7 @@ internal class EmbraceEventServiceTest {
 
     @Test
     fun `verify onForeground for a non cold start does not do anything`() {
-        eventService.onForeground(false, 123, 456)
+        eventService.onForeground(false, 456)
         assertNull(eventService.getActiveEvent(STARTUP_EVENT_NAME, null))
         assertNull(deliveryService.lastEventSentAsync)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeProcessStateListener.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeProcessStateListener.kt
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 internal class FakeProcessStateListener : ProcessStateListener {
     var coldStart: Boolean = false
-    var startupTime: Long = -1
     var timestamp: Long = -1
 
     val foregroundCount = AtomicInteger(0)
@@ -16,10 +15,9 @@ internal class FakeProcessStateListener : ProcessStateListener {
         backgroundCount.incrementAndGet()
     }
 
-    override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
         this.coldStart = coldStart
         this.timestamp = timestamp
-        this.startupTime = startupTime
         foregroundCount.incrementAndGet()
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -386,7 +386,7 @@ internal class EmbraceNdkServiceTest {
         enableNdk(true)
         every { sharedObjectLoader.loadEmbraceNative() } returns true
         initializeService()
-        embraceNdkService.onForeground(true, 1, 10)
+        embraceNdkService.onForeground(true, 10)
         verify(exactly = 1) { delegate._updateAppState("active") }
     }
 
@@ -394,7 +394,7 @@ internal class EmbraceNdkServiceTest {
     fun `test onForeground doesn't run _updateAppState when _updateMetaData was not executed and isInstalled false`() {
         enableNdk(false)
         initializeService()
-        embraceNdkService.onForeground(true, 1, 100)
+        embraceNdkService.onForeground(true, 100)
         verify(exactly = 0) { delegate._updateAppState("active") }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
@@ -87,7 +87,6 @@ internal class EmbraceProcessStateServiceTest {
         stateService.addListener(listener)
         stateService.onForeground()
         assertTrue(listener.coldStart)
-        assertEquals(listener.startupTime, fakeClock.now())
         assertEquals(listener.timestamp, fakeClock.now())
         assertEquals(1, listener.foregroundCount.get())
     }
@@ -250,7 +249,7 @@ internal class EmbraceProcessStateServiceTest {
             invocations.add(javaClass.simpleName)
         }
 
-        override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+        override fun onForeground(coldStart: Boolean, timestamp: Long) {
             invocations.add(javaClass.simpleName)
         }
     }
@@ -264,7 +263,7 @@ internal class EmbraceProcessStateServiceTest {
             invocations.add(javaClass.simpleName)
         }
 
-        override fun onForeground(coldStart: Boolean, startupTime: Long, timestamp: Long) {
+        override fun onForeground(coldStart: Boolean, timestamp: Long) {
             invocations.add(javaClass.simpleName)
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -52,7 +52,7 @@ internal class SessionOrchestratorTest {
     @Test
     fun `test on foreground call`() {
         createOrchestratorInBackground()
-        orchestrator.onForeground(true, 0, TIMESTAMP)
+        orchestrator.onForeground(true, TIMESTAMP)
         assertEquals(TIMESTAMP, sessionService.startTimestamps.single())
         assertEquals(TIMESTAMP, backgroundActivityService.endTimestamps.single())
     }


### PR DESCRIPTION
## Goal

Removes an unused parameter that is tracked & inserted into the session payload via other means.

## Testing

Relied on existing test coverage.

