### PR TITLE
Extract initial session/BA params into separate class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -52,7 +52,8 @@ internal class SessionModuleImpl(
             essentialServiceModule.userService,
             androidServicesModule.preferencesService,
             initModule.spansService,
-            initModule.clock
+            initModule.clock,
+            sessionPropertiesService
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.PayloadMessageCollator.PayloadType
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -112,11 +111,11 @@ internal class EmbraceBackgroundActivityService(
         startType: LifeEventType
     ) {
         val activity = payloadMessageCollator.buildInitialSession(
-            PayloadType.BACKGROUND_ACTIVITY,
-            coldStart,
-            startType,
-            startTime,
-            null
+            InitialEnvelopeParams.BackgroundActivityParams(
+                coldStart,
+                startType,
+                startTime
+            )
         )
         backgroundActivity = activity
         metadataService.setActiveSessionId(activity.sessionId, false)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -131,11 +131,11 @@ internal class EmbraceSessionService(
             )
 
             val session = payloadMessageCollator.buildInitialSession(
-                PayloadMessageCollator.PayloadType.SESSION,
-                coldStart,
-                startType,
-                startTime,
-                sessionProperties.get()
+                InitialEnvelopeParams.SessionParams(
+                    coldStart,
+                    startType,
+                    startTime
+                )
             )
             activeSession = session
             InternalStaticEmbraceLogger.logDeveloper(
@@ -169,7 +169,6 @@ internal class EmbraceSessionService(
             val fullEndSessionMessage = createSessionSnapshot(
                 SessionSnapshotType.NORMAL_END,
                 session,
-                sessionProperties,
                 spansService.flushSpans(),
                 endType,
                 endTime
@@ -207,7 +206,6 @@ internal class EmbraceSessionService(
             val fullEndSessionMessage = createSessionSnapshot(
                 SessionSnapshotType.JVM_CRASH,
                 session,
-                sessionProperties,
                 spansService.flushSpans(EmbraceAttributes.AppTerminationCause.CRASH),
                 LifeEventType.STATE,
                 clock.now(),
@@ -249,7 +247,6 @@ internal class EmbraceSessionService(
             val msg = createSessionSnapshot(
                 SessionSnapshotType.PERIODIC_CACHE,
                 session,
-                sessionProperties,
                 completedSpans,
                 LifeEventType.STATE,
                 clock.now()
@@ -281,7 +278,6 @@ internal class EmbraceSessionService(
     private fun createSessionSnapshot(
         endType: SessionSnapshotType,
         activeSession: Session,
-        sessionProperties: EmbraceSessionProperties,
         completedSpans: List<EmbraceSpanData>?,
         lifeEventType: LifeEventType,
         endTime: Long,
@@ -302,7 +298,6 @@ internal class EmbraceSessionService(
             forceQuit = endType.forceQuit,
             crashId = crashId,
             endType = lifeEventType,
-            sessionProperties = sessionProperties,
             sdkStartupDuration = sdkStartupDuration ?: 0,
             endTime = endTime,
             spans = completedSpans

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/InitialEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/InitialEnvelopeParams.kt
@@ -1,0 +1,51 @@
+package io.embrace.android.embracesdk.session
+
+import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.prefs.PreferencesService
+import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
+
+/**
+ * Holds the parameters & logic needed to create an initial session object.
+ */
+internal sealed class InitialEnvelopeParams(
+    val coldStart: Boolean,
+    val startType: Session.LifeEventType,
+    val startTime: Long
+) {
+    abstract val appState: String
+    abstract fun getSessionNumber(service: PreferencesService): Int
+    abstract fun getProperties(service: SessionPropertiesService): Map<String, String>?
+
+    /**
+     * Initial parameters required to create a session object.
+     */
+    internal class SessionParams(
+        coldStart: Boolean,
+        startType: Session.LifeEventType,
+        startTime: Long
+    ) : InitialEnvelopeParams(coldStart, startType, startTime) {
+
+        override val appState: String = Session.APPLICATION_STATE_FOREGROUND
+        override fun getSessionNumber(service: PreferencesService): Int =
+            service.incrementAndGetSessionNumber()
+
+        override fun getProperties(service: SessionPropertiesService): Map<String, String> =
+            service.getProperties()
+    }
+
+    /**
+     * Initial parameters required to create a background activity object.
+     */
+    internal class BackgroundActivityParams(
+        coldStart: Boolean,
+        startType: Session.LifeEventType,
+        startTime: Long
+    ) : InitialEnvelopeParams(coldStart, startType, startTime) {
+
+        override val appState: String = Session.APPLICATION_STATE_BACKGROUND
+        override fun getSessionNumber(service: PreferencesService): Int =
+            service.incrementAndGetBackgroundActivityNumber()
+
+        override fun getProperties(service: SessionPropertiesService): Map<String, String>? = null
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.session
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
+import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
@@ -376,7 +377,8 @@ internal class EmbraceBackgroundActivityServiceTest {
             userService,
             preferencesService,
             spansService,
-            clock
+            clock,
+            FakeSessionPropertiesService()
         )
         return EmbraceBackgroundActivityService(
             metadataService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
+import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
@@ -174,7 +175,8 @@ internal class SessionHandlerTest {
             userService,
             preferencesService,
             spansService,
-            clock
+            clock,
+            FakeSessionPropertiesService()
         )
         spansService = EmbraceSpansService(OpenTelemetryClock(embraceClock = clock), FakeTelemetryService())
         sessionService = EmbraceSessionService(


### PR DESCRIPTION
## Goal

Extracts the parameters required to create an initial session/background activity object into a sealed class hierarchy. This should make it clearer what the differences are between session/background activity & improve testability. A future changeset will attempt the same for the end session message.

## Testing

Updated existing test coverage.

