### PR TITLE
Add SpansRepository to track started spans

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansRepository.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansRepository.kt
@@ -1,0 +1,62 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Allows the tracking of [EmbraceSpan] instances so that their references can be retrieved with its associated spanId
+ */
+internal class SpansRepository {
+    private val activeSpans: MutableMap<String, EmbraceSpan> = ConcurrentHashMap()
+    private val completedSpans: MutableMap<String, EmbraceSpan> = ConcurrentHashMap()
+
+    /**
+     * Track the [EmbraceSpan] if it has been started and it's not already tracked.
+     */
+    fun started(embraceSpan: EmbraceSpan) {
+        embraceSpan.spanId?.let { spanId ->
+            if (activeSpans[spanId] == null && completedSpans[spanId] == null) {
+                synchronized(activeSpans) {
+                    if (activeSpans[spanId] == null && completedSpans[spanId] == null) {
+                        if (embraceSpan.isRecording) {
+                            activeSpans[spanId] = embraceSpan
+                        } else {
+                            completedSpans[spanId] = embraceSpan
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Transition active span to completed span if the span is tracked and the span is actually stopped.
+     */
+    fun stopped(spanId: String) {
+        synchronized(activeSpans) {
+            activeSpans[spanId]?.takeIf { !it.isRecording }?.let { activeSpans.remove(spanId) }?.let { span ->
+                completedSpans[spanId] = span
+            }
+        }
+    }
+
+    /**
+     * Return the [EmbraceSpan] with the corresponding [spanId] if it's tracked. Return null otherwise.
+     */
+    fun getSpan(spanId: String): EmbraceSpan? {
+        synchronized(activeSpans) {
+            activeSpans[spanId]?.let { return it }
+        }
+        return completedSpans[spanId]
+    }
+
+    /**
+     * Get a list of active spans that are being tracked
+     */
+    fun getActiveSpans(): List<EmbraceSpan> = synchronized(activeSpans) { activeSpans.values.toList() }
+
+    /**
+     * Get a list of completed spans that are being tracked.
+     */
+    fun getCompletedSpans(): List<EmbraceSpan> = completedSpans.values.toList()
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
@@ -1,0 +1,72 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.ErrorCode
+import io.opentelemetry.sdk.trace.IdGenerator
+
+internal class FakeEmbraceSpan private constructor(
+    override val parent: EmbraceSpan?
+) : EmbraceSpan {
+
+    private var started = false
+    private var stopped = false
+    private var errorCode: ErrorCode? = null
+
+    override var traceId: String? = parent?.traceId
+
+    override var spanId: String? = null
+    override val isRecording: Boolean
+        get() = started && !stopped
+
+    override fun start(): Boolean {
+        if (!started) {
+            spanId = IdGenerator.random().generateSpanId()
+            if (parent == null) {
+                traceId = IdGenerator.random().generateTraceId()
+            }
+            started = true
+        }
+        return true
+    }
+
+    override fun stop(): Boolean {
+        stop(errorCode = null)
+        return true
+    }
+
+    override fun stop(errorCode: ErrorCode?): Boolean {
+        if (!stopped) {
+            this.errorCode = errorCode
+            stopped = true
+        }
+        return true
+    }
+
+    override fun addEvent(name: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun addEvent(name: String, time: Long?, attributes: Map<String, String>?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun addAttribute(key: String, value: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    companion object {
+        fun notStarted(parent: EmbraceSpan? = null): FakeEmbraceSpan = FakeEmbraceSpan(parent)
+
+        fun started(parent: EmbraceSpan? = null): FakeEmbraceSpan {
+            val span = notStarted(parent)
+            span.start()
+            return span
+        }
+
+        fun stopped(parent: EmbraceSpan? = null): FakeEmbraceSpan {
+            val span = started(parent)
+            span.stop()
+            return span
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansRepositoryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansRepositoryTest.kt
@@ -26,7 +26,7 @@ internal class SpansRepositoryTest {
     @Test
     fun `started span tracked`() {
         val startedSpan = FakeEmbraceSpan.started()
-        repository.started(startedSpan)
+        repository.trackStartedSpan(startedSpan)
         assertSame(startedSpan, checkNotNull(repository.getSpan(checkNotNull(startedSpan.spanId))))
         assertEquals(1, repository.getActiveSpans().size)
         assertEquals(0, repository.getCompletedSpans().size)
@@ -35,7 +35,7 @@ internal class SpansRepositoryTest {
     @Test
     fun `completed span tracked`() {
         val completedSpan = FakeEmbraceSpan.stopped()
-        repository.started(completedSpan)
+        repository.trackStartedSpan(completedSpan)
         assertSame(completedSpan, checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId))))
         assertEquals(0, repository.getActiveSpans().size)
         assertEquals(1, repository.getCompletedSpans().size)
@@ -43,7 +43,7 @@ internal class SpansRepositoryTest {
 
     @Test
     fun `not started span not tracked`() {
-        repository.started(FakeEmbraceSpan.notStarted())
+        repository.trackStartedSpan(FakeEmbraceSpan.notStarted())
         assertEquals(0, repository.getActiveSpans().size)
         assertEquals(0, repository.getCompletedSpans().size)
     }
@@ -52,14 +52,14 @@ internal class SpansRepositoryTest {
     fun `tracked span moved to complete only if it is actually complete`() {
         val span = FakeEmbraceSpan.started()
         val spanId = checkNotNull(span.spanId)
-        repository.started(span)
-        repository.stopped(spanId)
+        repository.trackStartedSpan(span)
+        repository.trackedSpanStopped(spanId)
         assertEquals(1, repository.getActiveSpans().size)
         assertEquals(0, repository.getCompletedSpans().size)
         span.stop()
         assertEquals(1, repository.getActiveSpans().size)
         assertEquals(0, repository.getCompletedSpans().size)
-        repository.stopped(spanId)
+        repository.trackedSpanStopped(spanId)
         assertEquals(0, repository.getActiveSpans().size)
         assertEquals(1, repository.getCompletedSpans().size)
     }
@@ -68,13 +68,13 @@ internal class SpansRepositoryTest {
     fun `spans not tracked twice`() {
         val span = FakeEmbraceSpan.started()
         val spanId = checkNotNull(span.spanId)
-        repository.started(span)
-        repository.started(span)
+        repository.trackStartedSpan(span)
+        repository.trackStartedSpan(span)
         assertEquals(1, repository.getActiveSpans().size)
         assertEquals(0, repository.getCompletedSpans().size)
         span.stop()
-        repository.stopped(spanId)
-        repository.stopped(spanId)
+        repository.trackedSpanStopped(spanId)
+        repository.trackedSpanStopped(spanId)
         assertEquals(0, repository.getActiveSpans().size)
         assertEquals(1, repository.getCompletedSpans().size)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansRepositoryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansRepositoryTest.kt
@@ -1,0 +1,81 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSpan
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class SpansRepositoryTest {
+    private lateinit var repository: SpansRepository
+
+    @Before
+    fun setup() {
+        repository = SpansRepository()
+    }
+
+    @Test
+    fun `new repository not tracking any spans`() {
+        assertEquals(0, repository.getActiveSpans().size)
+        assertEquals(0, repository.getCompletedSpans().size)
+    }
+
+    @Test
+    fun `started span tracked`() {
+        val startedSpan = FakeEmbraceSpan.started()
+        repository.started(startedSpan)
+        assertSame(startedSpan, checkNotNull(repository.getSpan(checkNotNull(startedSpan.spanId))))
+        assertEquals(1, repository.getActiveSpans().size)
+        assertEquals(0, repository.getCompletedSpans().size)
+    }
+
+    @Test
+    fun `completed span tracked`() {
+        val completedSpan = FakeEmbraceSpan.stopped()
+        repository.started(completedSpan)
+        assertSame(completedSpan, checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId))))
+        assertEquals(0, repository.getActiveSpans().size)
+        assertEquals(1, repository.getCompletedSpans().size)
+    }
+
+    @Test
+    fun `not started span not tracked`() {
+        repository.started(FakeEmbraceSpan.notStarted())
+        assertEquals(0, repository.getActiveSpans().size)
+        assertEquals(0, repository.getCompletedSpans().size)
+    }
+
+    @Test
+    fun `tracked span moved to complete only if it is actually complete`() {
+        val span = FakeEmbraceSpan.started()
+        val spanId = checkNotNull(span.spanId)
+        repository.started(span)
+        repository.stopped(spanId)
+        assertEquals(1, repository.getActiveSpans().size)
+        assertEquals(0, repository.getCompletedSpans().size)
+        span.stop()
+        assertEquals(1, repository.getActiveSpans().size)
+        assertEquals(0, repository.getCompletedSpans().size)
+        repository.stopped(spanId)
+        assertEquals(0, repository.getActiveSpans().size)
+        assertEquals(1, repository.getCompletedSpans().size)
+    }
+
+    @Test
+    fun `spans not tracked twice`() {
+        val span = FakeEmbraceSpan.started()
+        val spanId = checkNotNull(span.spanId)
+        repository.started(span)
+        repository.started(span)
+        assertEquals(1, repository.getActiveSpans().size)
+        assertEquals(0, repository.getCompletedSpans().size)
+        span.stop()
+        repository.stopped(spanId)
+        repository.stopped(spanId)
+        assertEquals(0, repository.getActiveSpans().size)
+        assertEquals(1, repository.getCompletedSpans().size)
+    }
+}


### PR DESCRIPTION
## Goal

Add a component to keep track of spans that have been started so their reference can be obtained later using just a spanId

## Testing

Added unit tests

