### PR TITLE
Add tests for constructing final payload

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
@@ -124,10 +124,7 @@ internal data class Session @JvmOverloads internal constructor(
     val symbols: Map<String, String>? = null,
 
     @Json(name = "wvi_beta")
-    val webViewInfo: List<WebViewInfo>? = null,
-
-    @Transient
-    val user: UserInfo? = null
+    val webViewInfo: List<WebViewInfo>? = null
 ) {
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.payload.ExceptionError
 import io.embrace.android.embracesdk.payload.Orientation
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
-import io.embrace.android.embracesdk.payload.UserInfo
 import io.embrace.android.embracesdk.payload.WebViewInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -42,7 +41,6 @@ internal class SessionTest {
         startupThreshold = 5000,
         sdkStartupDuration = 109,
         unhandledExceptions = 1,
-        user = UserInfo("fake-user-id", "fake-user-name"),
         exceptionError = ExceptionError(false),
         orientations = listOf(Orientation(1, 16092342200)),
         properties = mapOf("fake-key" to "fake-value"),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalErrorService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalErrorService.kt
@@ -22,5 +22,5 @@ internal class FakeInternalErrorService : InternalErrorService {
         resetCallCount++
     }
 
-    override val currentExceptionError: ExceptionError? = null
+    override var currentExceptionError: ExceptionError? = null
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -14,8 +14,7 @@ internal fun fakeSession(
     isColdStart = true,
     startType = Session.LifeEventType.STATE,
     properties = mapOf(),
-    messageType = Session.MESSAGE_TYPE_END,
-    user = null
+    messageType = Session.MESSAGE_TYPE_END
 )
 
 internal fun fakeSessionMessage(): SessionMessage = SessionMessage(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
@@ -32,8 +32,7 @@ internal class BackgroundActivityTest {
         endType = Session.LifeEventType.BKGND_STATE,
         startType = Session.LifeEventType.BKGND_STATE,
         properties = mapOf("fake-key" to "fake-value"),
-        unhandledExceptions = 1,
-        user = UserInfo("fake-user-id", "fake-user-name")
+        unhandledExceptions = 1
     )
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -242,7 +242,6 @@ internal class SessionHandlerTest {
             assertEquals(emptyMapSessionProperties, properties)
             assertEquals("en", messageType)
             assertEquals("foreground", appState)
-            assertEquals(userInfo, user)
         }
         assertEquals(1, preferencesService.incrementAndGetSessionNumberCount)
     }


### PR DESCRIPTION
## Goal

Adds some tests for constructing the final session/background activity payloads. This allowed for us to remove some repetition in how the session message was built, by using the background activity message as a base.

