### PR TITLE
Added telemetry to track how much storage we use

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
@@ -27,7 +27,11 @@ internal class StorageModuleImpl(
 ) : StorageModule {
 
     override val storageService: StorageService by singleton {
-        EmbraceStorageService(coreModule.context)
+        EmbraceStorageService(
+            coreModule.context,
+            initModule.telemetryService,
+            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
+        )
     }
 
     override val cache by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.storage.EmbraceStorageService
 import io.embrace.android.embracesdk.storage.StorageService
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
+import java.util.concurrent.TimeUnit
 
 /**
  * Contains dependencies that are used to store data in the device's storage.
@@ -29,8 +30,7 @@ internal class StorageModuleImpl(
     override val storageService: StorageService by singleton {
         EmbraceStorageService(
             coreModule.context,
-            initModule.telemetryService,
-            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
+            initModule.telemetryService
         )
     }
 
@@ -53,5 +53,11 @@ internal class StorageModuleImpl(
             initModule.clock,
             coreModule.jsonSerializer
         )
+    }
+
+    init {
+        workerThreadModule
+            .scheduledWorker(WorkerName.PERIODIC_CACHE)
+            .schedule<Unit>({ storageService.logStorageTelemetry() }, 1, TimeUnit.MINUTES)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.comms.delivery.DeliveryCacheManager
 import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService
 import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryCacheManager
 import io.embrace.android.embracesdk.storage.EmbraceStorageService
+import io.embrace.android.embracesdk.storage.StatFsAvailabilityChecker
 import io.embrace.android.embracesdk.storage.StorageService
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
@@ -30,7 +31,8 @@ internal class StorageModuleImpl(
     override val storageService: StorageService by singleton {
         EmbraceStorageService(
             coreModule.context,
-            initModule.telemetryService
+            initModule.telemetryService,
+            StatFsAvailabilityChecker(coreModule.context)
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
@@ -59,7 +59,7 @@ internal class StorageModuleImpl(
 
     init {
         workerThreadModule
-            .scheduledWorker(WorkerName.PERIODIC_CACHE)
+            .scheduledWorker(WorkerName.BACKGROUND_REGISTRATION)
             .schedule<Unit>({ storageService.logStorageTelemetry() }, 1, TimeUnit.MINUTES)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -33,11 +33,6 @@ private const val EMBRACE_ATTRIBUTE_NAME_PREFIX = "emb."
 private const val EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX = "emb.usage."
 
 /**
- * Prefix added to all [Span] attribute keys for all storage attributes added by the SDK
- */
-private const val EMBRACE_STORAGE_TELEMETRY_ATTRIBUTE_NAME_PREFIX = "emb.storage."
-
-/**
  * Attribute name for the monotonically increasing sequence ID given to completed [Span] that expected to sent to the server
  */
 private const val SEQUENCE_ID_ATTRIBUTE_NAME = EMBRACE_ATTRIBUTE_NAME_PREFIX + "sequence_id"
@@ -186,11 +181,6 @@ internal fun String.toEmbraceAttributeName(): String = EMBRACE_ATTRIBUTE_NAME_PR
  * Return the appropriate internal Embrace attribute usage name given the current string
  */
 internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX + this
-
-/**
- * Return the appropriate internal Embrace storage attribute name given the current string
- */
-internal fun String.toEmbraceStorageAttributeName(): String = EMBRACE_STORAGE_TELEMETRY_ATTRIBUTE_NAME_PREFIX + this
 
 /**
  * Contains the set of attributes (i.e. implementers of the [Attribute] interface) set on a [Span] by the SDK that has special meaning

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -33,6 +33,11 @@ private const val EMBRACE_ATTRIBUTE_NAME_PREFIX = "emb."
 private const val EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX = "emb.usage."
 
 /**
+ * Prefix added to all [Span] attribute keys for all storage attributes added by the SDK
+ */
+private const val EMBRACE_STORAGE_TELEMETRY_ATTRIBUTE_NAME_PREFIX = "emb.storage."
+
+/**
  * Attribute name for the monotonically increasing sequence ID given to completed [Span] that expected to sent to the server
  */
 private const val SEQUENCE_ID_ATTRIBUTE_NAME = EMBRACE_ATTRIBUTE_NAME_PREFIX + "sequence_id"
@@ -181,6 +186,11 @@ internal fun String.toEmbraceAttributeName(): String = EMBRACE_ATTRIBUTE_NAME_PR
  * Return the appropriate internal Embrace attribute usage name given the current string
  */
 internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX + this
+
+/**
+ * Return the appropriate internal Embrace storage attribute name given the current string
+ */
+internal fun String.toEmbraceStorageAttributeName(): String = EMBRACE_STORAGE_TELEMETRY_ATTRIBUTE_NAME_PREFIX + this
 
 /**
  * Contains the set of attributes (i.e. implementers of the [Attribute] interface) set on a [Span] by the SDK that has special meaning

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/EmbraceStorageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/EmbraceStorageService.kt
@@ -61,7 +61,7 @@ internal class EmbraceStorageService(
         val storageUsed = listFiles { _, _ -> true }
             .filter { it.isFile }
             .sumOf { it.length() }
-        val storageTelemetryMap = mapOf("emb.storage.used" to storageUsed.toString())
+        val storageTelemetryMap = mapOf(EMBRACE_TELEMETRY_STORAGE_USE_NAME to storageUsed.toString())
         telemetryService.logStorageTelemetry(storageTelemetryMap)
     }
 
@@ -88,6 +88,11 @@ private const val EMBRACE_DIRECTORY = "embrace"
  * Directory name for the config files that are stored in the cache directory.
  */
 private const val EMBRACE_CONFIG_CACHE_DIRECTORY = "emb_config_cache"
+
+/**
+ * Telemetry attribute name for the storage used by Embrace.
+ */
+private const val EMBRACE_TELEMETRY_STORAGE_USE_NAME = "emb.storage.used"
 
 /**
  * Directory name for the native crash files that are stored in the files directory.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/EmbraceStorageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/EmbraceStorageService.kt
@@ -13,7 +13,8 @@ import java.io.FilenameFilter
  */
 internal class EmbraceStorageService(
     private val context: Context,
-    private val telemetryService: TelemetryService
+    private val telemetryService: TelemetryService,
+    private val storageAvailabilityChecker: StorageAvailabilityChecker
 ) : StorageService {
 
     private val cacheDirectory: File by lazy {
@@ -58,10 +59,14 @@ internal class EmbraceStorageService(
      * Logs storage telemetry, including the current size utilized by Embrace.
      */
     override fun logStorageTelemetry() {
+        val availableStorage = storageAvailabilityChecker.getAvailableBytes()
         val storageUsed = listFiles { _, _ -> true }
             .filter { it.isFile }
             .sumOf { it.length() }
-        val storageTelemetryMap = mapOf(EMBRACE_TELEMETRY_STORAGE_USE_NAME to storageUsed.toString())
+        val storageTelemetryMap = mapOf(
+            EMBRACE_TELEMETRY_USED_STORAGE_NAME to storageUsed.toString(),
+            EMBRACE_TELEMETRY_AVAILABLE_STORAGE_NAME to availableStorage.toString()
+        )
         telemetryService.logStorageTelemetry(storageTelemetryMap)
     }
 
@@ -92,7 +97,12 @@ private const val EMBRACE_CONFIG_CACHE_DIRECTORY = "emb_config_cache"
 /**
  * Telemetry attribute name for the storage used by Embrace.
  */
-private const val EMBRACE_TELEMETRY_STORAGE_USE_NAME = "emb.storage.used"
+private const val EMBRACE_TELEMETRY_USED_STORAGE_NAME = "emb.storage.used"
+
+/**
+ * Telemetry attribute name for the storage used by Embrace.
+ */
+private const val EMBRACE_TELEMETRY_AVAILABLE_STORAGE_NAME = "emb.storage.available"
 
 /**
  * Directory name for the native crash files that are stored in the files directory.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageAvailabilityChecker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageAvailabilityChecker.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.storage
+
+import android.content.Context
+import android.os.StatFs
+
+internal interface StorageAvailabilityChecker {
+    fun getAvailableBytes(): Long
+}
+
+internal class StatFsAvailabilityChecker(
+    context: Context
+) : StorageAvailabilityChecker {
+    private val statFs: StatFs by lazy {
+        StatFs(context.filesDir.path)
+    }
+
+    override fun getAvailableBytes(): Long {
+        return statFs.availableBytes
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageService.kt
@@ -34,4 +34,9 @@ internal interface StorageService {
      * Returns a list of files from the files and cache directories that match the [filter].
      */
     fun listFiles(filter: FilenameFilter): List<File>
+
+    /**
+     * Logs storage telemetry such as the currently used size.
+     */
+    fun logStorageTelemetry()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/EmbraceTelemetryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/EmbraceTelemetryService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.telemetry
 
 import io.embrace.android.embracesdk.capture.metadata.EmbraceMetadataService
 import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
-import io.embrace.android.embracesdk.internal.spans.toEmbraceStorageAttributeName
 import io.embrace.android.embracesdk.internal.spans.toEmbraceUsageAttributeName
 import java.util.concurrent.ConcurrentHashMap
 
@@ -14,7 +13,7 @@ internal class EmbraceTelemetryService(
 ) : TelemetryService {
 
     private val usageCountMap = ConcurrentHashMap<String, Int>()
-    private val fileToSizeMap = ConcurrentHashMap<String, Int>()
+    private val storageTelemetryMap = ConcurrentHashMap<String, String>()
     private val appAttributes: Map<String, String> by lazy { computeAppAttributes() }
 
     override fun onPublicApiCalled(name: String) {
@@ -23,8 +22,8 @@ internal class EmbraceTelemetryService(
         }
     }
 
-    override fun logStorageTelemetry(fileToSizeMap: Map<String, Int>) {
-        this.fileToSizeMap.putAll(fileToSizeMap)
+    override fun logStorageTelemetry(storageTelemetry: Map<String, String>) {
+        this.storageTelemetryMap.putAll(storageTelemetry)
     }
 
     override fun getAndClearTelemetryAttributes(): Map<String, String> {
@@ -44,11 +43,9 @@ internal class EmbraceTelemetryService(
     }
 
     private fun getAndClearStorageTelemetry(): Map<String, String> {
-        val storageTelemetryMap = fileToSizeMap.entries.associate {
-            it.key.toEmbraceStorageAttributeName() to it.value.toString()
-        }
-        fileToSizeMap.clear()
-        return storageTelemetryMap
+        val result = storageTelemetryMap.toMap()
+        storageTelemetryMap.clear()
+        return result
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/TelemetryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/TelemetryService.kt
@@ -9,9 +9,10 @@ internal interface TelemetryService {
     fun onPublicApiCalled(name: String)
 
     /**
-     * Tracks the storage being used. storageSizeMap is a map of file names and their size in bytes.
+     * Tracks the storage being used. storageTelemetry is a map of storage telemetry names and their values, such as:
+     * emb.storage.usage -> "1234"
      */
-    fun logStorageTelemetry(fileToSizeMap: Map<String, Int>)
+    fun logStorageTelemetry(storageTelemetry: Map<String, String>)
 
     /**
      * Returns a map with every telemetry value. This is called when the session ends.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/TelemetryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/TelemetryService.kt
@@ -9,6 +9,11 @@ internal interface TelemetryService {
     fun onPublicApiCalled(name: String)
 
     /**
+     * Tracks the storage being used. storageSizeMap is a map of file names and their size in bytes.
+     */
+    fun logStorageTelemetry(fileToSizeMap: Map<String, Int>)
+
+    /**
      * Returns a map with every telemetry value. This is called when the session ends.
      * We clear the usage count map so we don't count the same usages in the next session.
      */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/TelemetryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/telemetry/TelemetryService.kt
@@ -9,8 +9,8 @@ internal interface TelemetryService {
     fun onPublicApiCalled(name: String)
 
     /**
-     * Tracks the storage being used. storageTelemetry is a map of storage telemetry names and their values, such as:
-     * emb.storage.usage -> "1234"
+     * Tracks the storage being used, in bytes. storageTelemetry is a map of storage telemetry names and their values in bytes,
+     * such as: emb.storage.usage -> "1234"
      */
     fun logStorageTelemetry(storageTelemetry: Map<String, String>)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
@@ -31,4 +31,8 @@ internal class FakeStorageService : StorageService {
         val cacheDir = cacheDirectory.listFiles(filter) ?: emptyArray()
         return filesDir.toList() + cacheDir.toList()
     }
+
+    override fun logStorageTelemetry() {
+        // no-op
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTelemetryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTelemetryService.kt
@@ -10,7 +10,7 @@ internal class FakeTelemetryService : TelemetryService {
     }
 
     override fun logStorageTelemetry(storageTelemetry: Map<String, String>) {
-        this.storageTelemetryMap.putAll(storageTelemetry)
+        storageTelemetryMap.putAll(storageTelemetry)
     }
 
     override fun getAndClearTelemetryAttributes(): Map<String, String> {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTelemetryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTelemetryService.kt
@@ -3,8 +3,14 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.telemetry.TelemetryService
 
 internal class FakeTelemetryService : TelemetryService {
+
+    val storageTelemetryMap = mutableMapOf<String, Int>()
     override fun onPublicApiCalled(name: String) {
         // no-op
+    }
+
+    override fun logStorageTelemetry(fileToSizeMap: Map<String, Int>) {
+        this.storageTelemetryMap.putAll(fileToSizeMap)
     }
 
     override fun getAndClearTelemetryAttributes(): Map<String, String> {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTelemetryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTelemetryService.kt
@@ -4,13 +4,13 @@ import io.embrace.android.embracesdk.telemetry.TelemetryService
 
 internal class FakeTelemetryService : TelemetryService {
 
-    val storageTelemetryMap = mutableMapOf<String, Int>()
+    val storageTelemetryMap = mutableMapOf<String, String>()
     override fun onPublicApiCalled(name: String) {
         // no-op
     }
 
-    override fun logStorageTelemetry(fileToSizeMap: Map<String, Int>) {
-        this.storageTelemetryMap.putAll(fileToSizeMap)
+    override fun logStorageTelemetry(storageTelemetry: Map<String, String>) {
+        this.storageTelemetryMap.putAll(storageTelemetry)
     }
 
     override fun getAndClearTelemetryAttributes(): Map<String, String> {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.storage
 
 import android.content.Context
-import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.mockk.every
 import io.mockk.mockk
@@ -20,14 +19,12 @@ internal class EmbraceStorageServiceTest {
     private lateinit var cacheDir: File
     private lateinit var filesDir: File
     private lateinit var embraceFilesDir: String
-    private lateinit var blockingScheduledExecutorService: BlockingScheduledExecutorService
     private lateinit var fakeTelemetryService: FakeTelemetryService
 
     @Before
     fun setUp() {
         cacheDir = Files.createTempDirectory("cache_temp").toFile()
         filesDir = Files.createTempDirectory("files_temp").toFile()
-        blockingScheduledExecutorService = BlockingScheduledExecutorService()
         val embraceFilesPath = Files.createDirectory(
             Paths.get(filesDir.absolutePath, "embrace")
         ).toFile()
@@ -111,6 +108,6 @@ internal class EmbraceStorageServiceTest {
         storageManager.logStorageTelemetry()
 
         val expectedSize = fileInCache.length().toInt() + fileInFiles.length().toInt()
-        assertEquals(expectedSize, fakeTelemetryService.storageTelemetryMap["emb.storage.used"])
+        assertEquals(expectedSize.toString(), fakeTelemetryService.storageTelemetryMap["emb.storage.used"])
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
@@ -1,6 +1,9 @@
 package io.embrace.android.embracesdk.storage
 
 import android.content.Context
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -18,11 +21,13 @@ internal class EmbraceStorageServiceTest {
     private lateinit var cacheDir: File
     private lateinit var filesDir: File
     private lateinit var embraceFilesDir: String
+    private lateinit var blockingScheduledExecutorService: BlockingScheduledExecutorService
 
     @Before
     fun setUp() {
         cacheDir = Files.createTempDirectory("cache_temp").toFile()
         filesDir = Files.createTempDirectory("files_temp").toFile()
+        blockingScheduledExecutorService = BlockingScheduledExecutorService()
         val embraceFilesPath = Files.createDirectory(
             Paths.get(filesDir.absolutePath, "embrace")
         ).toFile()
@@ -30,7 +35,7 @@ internal class EmbraceStorageServiceTest {
         val ctx = mockk<Context>()
         every { ctx.cacheDir } returns cacheDir
         every { ctx.filesDir } returns filesDir
-        storageManager = EmbraceStorageService(ctx)
+        storageManager = EmbraceStorageService(ctx, FakeTelemetryService(), ScheduledWorker(blockingScheduledExecutorService))
     }
 
     @Test
@@ -77,7 +82,7 @@ internal class EmbraceStorageServiceTest {
         val ctx = mockk<Context>()
         every { ctx.cacheDir } returns cacheDir
         every { ctx.filesDir } returns filesDir
-        storageManager = EmbraceStorageService(ctx)
+        storageManager = EmbraceStorageService(ctx, FakeTelemetryService(), ScheduledWorker(blockingScheduledExecutorService))
         val files = storageManager.listFiles { _, _ -> true }
         assertEquals(0, files.size)
     }
@@ -94,5 +99,10 @@ internal class EmbraceStorageServiceTest {
         val storageDirForNativeCrash = storageManager.getNativeCrashDir()
         assertNotNull(storageDirForNativeCrash)
         assertEquals("$embraceFilesDir/ndk", storageDirForNativeCrash.absolutePath)
+    }
+
+    @Test
+    fun `test storageTelemetry is logged correctly`() {
+        // to be done
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
@@ -109,7 +109,7 @@ internal class EmbraceStorageServiceTest {
 
         storageManager.logStorageTelemetry()
 
-        val expectedSize = fileInCache.length().toInt() + fileInFiles.length().toInt()
+        val expectedSize = fileInCache.length() + fileInFiles.length()
         assertEquals(expectedSize.toString(), fakeTelemetryService.storageTelemetryMap["emb.storage.used"])
         assertEquals("1000", fakeTelemetryService.storageTelemetryMap["emb.storage.available"])
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/EmbraceStorageServiceTest.kt
@@ -20,6 +20,7 @@ internal class EmbraceStorageServiceTest {
     private lateinit var filesDir: File
     private lateinit var embraceFilesDir: String
     private lateinit var fakeTelemetryService: FakeTelemetryService
+    private lateinit var fakeStorageAvailabilityChecker: FakeStorageAvailabilityChecker
 
     @Before
     fun setUp() {
@@ -33,8 +34,9 @@ internal class EmbraceStorageServiceTest {
         every { ctx.cacheDir } returns cacheDir
         every { ctx.filesDir } returns filesDir
         fakeTelemetryService = FakeTelemetryService()
+        fakeStorageAvailabilityChecker = FakeStorageAvailabilityChecker()
 
-        storageManager = EmbraceStorageService(ctx, fakeTelemetryService)
+        storageManager = EmbraceStorageService(ctx, fakeTelemetryService, fakeStorageAvailabilityChecker)
     }
 
     @Test
@@ -81,7 +83,7 @@ internal class EmbraceStorageServiceTest {
         val ctx = mockk<Context>()
         every { ctx.cacheDir } returns cacheDir
         every { ctx.filesDir } returns filesDir
-        storageManager = EmbraceStorageService(ctx, fakeTelemetryService)
+        storageManager = EmbraceStorageService(ctx, fakeTelemetryService, fakeStorageAvailabilityChecker)
         val files = storageManager.listFiles { _, _ -> true }
         assertEquals(0, files.size)
     }
@@ -109,5 +111,6 @@ internal class EmbraceStorageServiceTest {
 
         val expectedSize = fileInCache.length().toInt() + fileInFiles.length().toInt()
         assertEquals(expectedSize.toString(), fakeTelemetryService.storageTelemetryMap["emb.storage.used"])
+        assertEquals("1000", fakeTelemetryService.storageTelemetryMap["emb.storage.available"])
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/FakeStorageAvailabilityChecker.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/storage/FakeStorageAvailabilityChecker.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.storage
+
+internal class FakeStorageAvailabilityChecker : StorageAvailabilityChecker {
+    override fun getAvailableBytes(): Long {
+        return 1000
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/telemetry/EmbraceTelemetryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/telemetry/EmbraceTelemetryServiceTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.telemetry
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -47,5 +48,65 @@ internal class EmbraceTelemetryServiceTest {
 
         // That method isn't in the map anymore
         assertEquals(null, embraceTelemetryService.getAndClearTelemetryAttributes().getOrDefault("emb.usage.a_method", null))
+    }
+
+    @Test
+    fun `logStorageTelemetry adds sizes to the telemetry attributes`() {
+        // Given some file sizes are added
+        embraceTelemetryService.logStorageTelemetry(
+            mapOf(
+                "a_file" to 1,
+                "another_file" to 2,
+                "yet_another_file" to 3
+            )
+        )
+
+        // When getting telemetry attributes
+        val telemetryAttributes = embraceTelemetryService.getAndClearTelemetryAttributes()
+
+        // Then the file sizes are in the map
+        assertEquals("1", telemetryAttributes["emb.storage.a_file"])
+        assertEquals("2", telemetryAttributes["emb.storage.another_file"])
+        assertEquals("3", telemetryAttributes["emb.storage.yet_another_file"])
+    }
+
+    @Test
+    fun `getTelemetryAttributes clears the storage map`() {
+        // Given a method is in the map
+        embraceTelemetryService.logStorageTelemetry(mapOf("a_file" to 1))
+
+        // When getting telemetry attributes
+        embraceTelemetryService.getAndClearTelemetryAttributes()
+
+        // That method isn't in the map anymore
+        assertEquals(null, embraceTelemetryService.getAndClearTelemetryAttributes().getOrDefault("emb.storage.a_file", null))
+    }
+
+    @Test
+    fun `getTelemetryAttributes adds app attributes`() {
+        // When getting telemetry attributes
+        val telemetryAttributes = embraceTelemetryService.getAndClearTelemetryAttributes()
+
+        // Then the app attributes are in the map
+        assertEquals("true", telemetryAttributes["emb.okhttp3"])
+        assertTrue(telemetryAttributes.containsKey("emb.okhttp3_on_classpath"))
+        assertTrue(telemetryAttributes.containsKey("emb.is_emulator"))
+        assertTrue(telemetryAttributes.containsKey("emb.kotlin_on_classpath"))
+    }
+
+    @Test
+    fun `usage, storage and app attributes are added correctly`() {
+        // Given some usage and storage attributes are added
+        embraceTelemetryService.onPublicApiCalled("a_method")
+        embraceTelemetryService.logStorageTelemetry(mapOf("a_file" to 1))
+
+        // When getting telemetry attributes
+        val telemetryAttributes = embraceTelemetryService.getAndClearTelemetryAttributes()
+
+        // Then the usage, storage, and app attributes are in the map
+        assertEquals("1", telemetryAttributes["emb.usage.a_method"])
+        assertEquals("1", telemetryAttributes["emb.storage.a_file"])
+        assertTrue(telemetryAttributes.containsKey("emb.okhttp3"))
+        assertTrue(telemetryAttributes.containsKey("emb.okhttp3_on_classpath"))
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/telemetry/EmbraceTelemetryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/telemetry/EmbraceTelemetryServiceTest.kt
@@ -39,41 +39,36 @@ internal class EmbraceTelemetryServiceTest {
     }
 
     @Test
-    fun `getTelemetryAttributes clears the usage map`() {
+    fun `getTelemetryAttributes clears maps`() {
         // Given a method is in the map
         embraceTelemetryService.onPublicApiCalled("a_method")
+        embraceTelemetryService.logStorageTelemetry(mapOf("emb.storage.used" to "12"))
 
-        // When getting telemetry attributes
+        // After getting telemetry attributes
         embraceTelemetryService.getAndClearTelemetryAttributes()
+        val attributes = embraceTelemetryService.getAndClearTelemetryAttributes()
 
         // That method isn't in the map anymore
-        assertEquals(null, embraceTelemetryService.getAndClearTelemetryAttributes().getOrDefault("emb.usage.a_method", null))
+        assertEquals(null, attributes.getOrDefault("emb.usage.a_method", null))
+        assertEquals(null, attributes.getOrDefault("emb.storage.used", null))
     }
 
     @Test
-    fun `logStorageTelemetry adds sizes to the telemetry attributes`() {
-        // Given some file sizes are added
-        embraceTelemetryService.logStorageTelemetry(
-            mapOf(
-                "a_file" to 1,
-                "another_file" to 2,
-                "yet_another_file" to 3
-            )
-        )
+    fun `logStorageTelemetry adds usage to the telemetry attributes`() {
+        // Given storage telemetry is added
+        embraceTelemetryService.logStorageTelemetry(mapOf("emb.storage.used" to "1231"))
 
         // When getting telemetry attributes
         val telemetryAttributes = embraceTelemetryService.getAndClearTelemetryAttributes()
 
-        // Then the file sizes are in the map
-        assertEquals("1", telemetryAttributes["emb.storage.a_file"])
-        assertEquals("2", telemetryAttributes["emb.storage.another_file"])
-        assertEquals("3", telemetryAttributes["emb.storage.yet_another_file"])
+        // Then storage telemetry is in the map
+        assertEquals("1231", telemetryAttributes["emb.storage.used"])
     }
 
     @Test
     fun `getTelemetryAttributes clears the storage map`() {
         // Given a method is in the map
-        embraceTelemetryService.logStorageTelemetry(mapOf("a_file" to 1))
+        embraceTelemetryService.logStorageTelemetry(mapOf("emb.storage.used" to "1"))
 
         // When getting telemetry attributes
         embraceTelemetryService.getAndClearTelemetryAttributes()
@@ -98,14 +93,14 @@ internal class EmbraceTelemetryServiceTest {
     fun `usage, storage and app attributes are added correctly`() {
         // Given some usage and storage attributes are added
         embraceTelemetryService.onPublicApiCalled("a_method")
-        embraceTelemetryService.logStorageTelemetry(mapOf("a_file" to 1))
+        embraceTelemetryService.logStorageTelemetry(mapOf("emb.storage.used" to "12"))
 
         // When getting telemetry attributes
         val telemetryAttributes = embraceTelemetryService.getAndClearTelemetryAttributes()
 
         // Then the usage, storage, and app attributes are in the map
         assertEquals("1", telemetryAttributes["emb.usage.a_method"])
-        assertEquals("1", telemetryAttributes["emb.storage.a_file"])
+        assertEquals("12", telemetryAttributes["emb.storage.used"])
         assertTrue(telemetryAttributes.containsKey("emb.okhttp3"))
         assertTrue(telemetryAttributes.containsKey("emb.okhttp3_on_classpath"))
     }


### PR DESCRIPTION
## Goal

After a minute, we will track how much space the files on the StorageService are taking, and how much available space is left

![image](https://github.com/embrace-io/embrace-android-sdk/assets/26326883/7606a0fe-28b8-4be3-864b-6620d4a56015)
