### PR TITLE
Instantiate EmbraceTracer in init module and expose interface to get span

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -415,14 +415,14 @@ public final class Embrace implements EmbraceAndroidApi {
 
     @Override
     public boolean isTracingAvailable() {
-        return impl.tracer.getValue().isTracingAvailable();
+        return impl.tracer.isTracingAvailable();
     }
 
     @Nullable
     @Override
     public EmbraceSpan createSpan(@NonNull String name) {
         if (verifyNonNullParameters("createSpan", name)) {
-            return impl.tracer.getValue().createSpan(name);
+            return impl.tracer.createSpan(name);
         }
 
         return null;
@@ -432,7 +432,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public EmbraceSpan createSpan(@NonNull String name, @Nullable EmbraceSpan parent) {
         if (verifyNonNullParameters("createSpan", name)) {
-            return impl.tracer.getValue().createSpan(name, parent);
+            return impl.tracer.createSpan(name, parent);
         }
 
         return null;
@@ -441,7 +441,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public <T> T recordSpan(@NonNull String name, @NonNull Function0<? extends T> code) {
         if (verifyNonNullParameters("recordSpan", name, code)) {
-            return impl.tracer.getValue().recordSpan(name, code);
+            return impl.tracer.recordSpan(name, code);
         }
 
         return code != null ? code.invoke() : null;
@@ -450,7 +450,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public <T> T recordSpan(@NonNull String name, @Nullable EmbraceSpan parent, @NonNull Function0<? extends T> code) {
         if (verifyNonNullParameters("recordSpan", name, code)) {
-            return impl.tracer.getValue().recordSpan(name, parent, code);
+            return impl.tracer.recordSpan(name, parent, code);
         }
 
         return code != null ? code.invoke() : null;
@@ -461,7 +461,7 @@ public final class Embrace implements EmbraceAndroidApi {
                                        @Nullable EmbraceSpan parent, @Nullable Map<String, String> attributes,
                                        @Nullable List<EmbraceSpanEvent> events) {
         if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.getValue().recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent, attributes, events);
+            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent, attributes, events);
         }
 
         return false;
@@ -470,7 +470,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos) {
         if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.getValue().recordCompletedSpan(name, startTimeNanos, endTimeNanos);
+            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos);
         }
 
         return false;
@@ -479,7 +479,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable ErrorCode errorCode) {
         if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.getValue().recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode);
+            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode);
         }
 
         return false;
@@ -488,7 +488,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable EmbraceSpan parent) {
         if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.getValue().recordCompletedSpan(name, startTimeNanos, endTimeNanos, parent);
+            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, parent);
         }
 
         return false;
@@ -498,7 +498,7 @@ public final class Embrace implements EmbraceAndroidApi {
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable ErrorCode errorCode,
                                        @Nullable EmbraceSpan parent) {
         if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.getValue().recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent);
+            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent);
         }
 
         return false;
@@ -508,7 +508,7 @@ public final class Embrace implements EmbraceAndroidApi {
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos,
                                        @Nullable Map<String, String> attributes, @Nullable List<EmbraceSpanEvent> events) {
         if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.getValue().recordCompletedSpan(name, startTimeNanos, endTimeNanos, attributes, events);
+            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, attributes, events);
         }
 
         return false;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -128,7 +128,7 @@ final class EmbraceImpl {
     private static final Pattern appIdPattern = Pattern.compile("^[A-Za-z0-9]{5}$");
 
     @NonNull
-    final Lazy<EmbraceTracer> tracer;
+    final EmbraceTracer tracer;
 
     /**
      * Whether the Embrace SDK has been started yet.
@@ -314,7 +314,7 @@ final class EmbraceImpl {
         this.essentialServiceModuleSupplier = essentialServiceModuleSupplier;
         this.dataCaptureServiceModuleSupplier = dataCaptureServiceModuleSupplier;
         this.deliveryModuleSupplier = deliveryModuleSupplier;
-        this.tracer = LazyKt.lazy(() -> new EmbraceTracer(initModule.getSpansService()));
+        this.tracer = initModule.getTracer();
     }
 
     EmbraceImpl() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import io.embrace.android.embracesdk.telemetry.TelemetryService
@@ -27,10 +28,16 @@ internal interface InitModule {
      * Service to log traces
      */
     val spansService: SpansService
+
+    /**
+     * Implementation of public tracing API
+     */
+    val tracer: EmbraceTracer
 }
 
 internal class InitModuleImpl(
     override val clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
     override val telemetryService: TelemetryService = EmbraceTelemetryService(),
-    override val spansService: SpansService = EmbraceSpansService(OpenTelemetryClock(clock), telemetryService)
+    override val spansService: SpansService = EmbraceSpansService(OpenTelemetryClock(clock), telemetryService),
+    override val tracer: EmbraceTracer = EmbraceTracer(spansService)
 ) : InitModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import io.embrace.android.embracesdk.telemetry.TelemetryService
@@ -13,5 +14,6 @@ import io.embrace.android.embracesdk.telemetry.TelemetryService
 internal class FakeInitModule(
     override val clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
     override val telemetryService: TelemetryService = EmbraceTelemetryService(),
-    override val spansService: SpansService = EmbraceSpansService(FakeOpenTelemetryClock(clock), telemetryService)
+    override val spansService: SpansService = EmbraceSpansService(FakeOpenTelemetryClock(clock), telemetryService),
+    override val tracer: EmbraceTracer = EmbraceTracer(spansService)
 ) : InitModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -24,11 +25,14 @@ internal class InitModuleImplTest {
     fun testInitModuleImplOverrideComponents() {
         val clock = FakeClock()
         val spansService = SpansService.featureDisabledSpansService
+        val embraceTracer = EmbraceTracer(spansService)
         val initModule = InitModuleImpl(
             clock = clock,
-            spansService = spansService
+            spansService = spansService,
+            tracer = embraceTracer
         )
         assertSame(clock, initModule.clock)
         assertSame(spansService, initModule.spansService)
+        assertSame(embraceTracer, initModule.tracer)
     }
 }


### PR DESCRIPTION
## Goal

Instantiate `EmbraceTracer` synchronously. This is needed right away anyway since spans is always on, so making it lazy doesn't add any value. 

## Testing

Updated module tests

