### PR TITLE
Extract SDK startup duration capture to separate service

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -65,7 +65,6 @@ import io.embrace.android.embracesdk.internal.DeviceArchitecture;
 import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl;
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface;
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterfaceKt;
-import io.embrace.android.embracesdk.internal.MessageType;
 import io.embrace.android.embracesdk.internal.TraceparentGenerator;
 import io.embrace.android.embracesdk.internal.clock.Clock;
 import io.embrace.android.embracesdk.internal.crash.LastRunCrashVerifier;
@@ -668,9 +667,7 @@ final class EmbraceImpl {
 
         final long endTime = sdkClock.now();
         started.set(true);
-
-        sessionModule.getSessionService().setSdkStartupInfo(startTime, endTime);
-        internalEmbraceLogger.logDeveloper("Embrace", "Startup duration: " + (endTime - startTime) + " millis");
+        dataCaptureServiceModule.getStartupService().setSdkStartupInfo(startTime, endTime);
 
         // Sets up the registered services. This method is called after the SDK has been started and
         // no more services can be added to the registry. It sets listeners for any services that were

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupService.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.capture.startup
+
+/**
+ * Service to track the SDK startup time.
+ */
+internal interface StartupService {
+
+    /**
+     * Sets the SDK startup info. This is called when the SDK is initialized.
+     */
+    fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long)
+
+    /**
+     * Returns the SDK startup info. This is called when the session ends.
+     */
+    fun getSdkStartupInfo(coldStart: Boolean): Long?
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
@@ -1,0 +1,31 @@
+package io.embrace.android.embracesdk.capture.startup
+
+import io.embrace.android.embracesdk.internal.spans.SpansService
+import java.util.concurrent.TimeUnit
+
+internal class StartupServiceImpl(
+    private val spansService: SpansService
+) : StartupService {
+
+    /**
+     * SDK startup time. Only set for cold start sessions.
+     */
+    @Volatile
+    private var sdkStartupDuration: Long? = null
+
+    override fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long) {
+        if (sdkStartupDuration == null) {
+            spansService.recordCompletedSpan(
+                name = "sdk-init",
+                startTimeNanos = TimeUnit.MILLISECONDS.toNanos(startTimeMs),
+                endTimeNanos = TimeUnit.MILLISECONDS.toNanos(endTimeMs)
+            )
+        }
+        sdkStartupDuration = endTimeMs - startTimeMs
+    }
+
+    override fun getSdkStartupInfo(coldStart: Boolean): Long? = when (coldStart) {
+        true -> sdkStartupDuration
+        false -> null
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -11,6 +11,8 @@ import io.embrace.android.embracesdk.capture.memory.NoOpMemoryService
 import io.embrace.android.embracesdk.capture.powersave.EmbracePowerSaveModeService
 import io.embrace.android.embracesdk.capture.powersave.NoOpPowerSaveModeService
 import io.embrace.android.embracesdk.capture.powersave.PowerSaveModeService
+import io.embrace.android.embracesdk.capture.startup.StartupService
+import io.embrace.android.embracesdk.capture.startup.StartupServiceImpl
 import io.embrace.android.embracesdk.capture.thermalstate.EmbraceThermalStatusService
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
 import io.embrace.android.embracesdk.capture.thermalstate.ThermalStatusService
@@ -64,6 +66,11 @@ internal interface DataCaptureServiceModule {
      * Registers for the component callback to capture memory events
      */
     val componentCallbackService: ComponentCallbackService
+
+    /**
+     * Captures the startup time of the SDK
+     */
+    val startupService: StartupService
 }
 
 internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
@@ -145,5 +152,9 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         } else {
             NoOpThermalStatusService()
         }
+    }
+
+    override val startupService: StartupService by singleton {
+        StartupServiceImpl(initModule.spansService)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -53,7 +53,8 @@ internal class SessionModuleImpl(
             androidServicesModule.preferencesService,
             initModule.spansService,
             initModule.clock,
-            sessionPropertiesService
+            sessionPropertiesService,
+            dataCaptureServiceModule.startupService
         )
     }
 
@@ -83,7 +84,6 @@ internal class SessionModuleImpl(
             payloadMessageCollator,
             sessionProperties,
             initModule.clock,
-            initModule.spansService,
             workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/FinalEnvelopeParams.kt
@@ -24,7 +24,6 @@ internal sealed class FinalEnvelopeParams(
     abstract val terminationTime: Long?
     abstract val receivedTermination: Boolean?
     abstract val endTimeVal: Long?
-    abstract val sdkStartDuration: Long?
     abstract fun getStartupEventInfo(eventService: EventService): StartupEventInfo?
 
     /**
@@ -45,7 +44,6 @@ internal sealed class FinalEnvelopeParams(
         override val terminationTime: Long? = null
         override val receivedTermination: Boolean? = null
         override val endTimeVal: Long? = null
-        override val sdkStartDuration: Long? = null
         override fun getStartupEventInfo(eventService: EventService): StartupEventInfo? = null
     }
 
@@ -57,8 +55,7 @@ internal sealed class FinalEnvelopeParams(
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         crashId: String? = null,
-        val endType: SessionSnapshotType,
-        sdkStartupDuration: Long,
+        val endType: SessionSnapshotType
     ) : FinalEnvelopeParams(
         initial,
         endTime,
@@ -81,11 +78,6 @@ internal sealed class FinalEnvelopeParams(
         override val endTimeVal: Long? = when {
             endType.forceQuit -> null
             else -> endTime
-        }
-
-        override val sdkStartDuration: Long? = when (initial.isColdStart) {
-            true -> sdkStartupDuration
-            false -> null
         }
 
         override fun getStartupEventInfo(eventService: EventService) = when {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/PayloadMessageCollator.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
 import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.capture.startup.StartupService
 import io.embrace.android.embracesdk.capture.thermalstate.ThermalStatusService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.capture.webview.WebViewService
@@ -37,7 +38,8 @@ internal class PayloadMessageCollator(
     private val preferencesService: PreferencesService,
     private val spansService: SpansService,
     private val clock: Clock,
-    private val sessionPropertiesService: SessionPropertiesService
+    private val sessionPropertiesService: SessionPropertiesService,
+    private val startupService: StartupService
 ) {
 
     /**
@@ -87,7 +89,7 @@ internal class PayloadMessageCollator(
             terminationTime = terminationTime,
             isReceivedTermination = receivedTermination,
             endTime = endTimeVal,
-            sdkStartupDuration = sdkStartDuration,
+            sdkStartupDuration = startupService.getSdkStartupInfo(initial.isColdStart),
             startupDuration = startupInfo?.duration,
             startupThreshold = startupInfo?.threshold,
             betaFeatures = betaFeatures,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/PayloadMessageCollator.kt
@@ -66,6 +66,7 @@ internal class PayloadMessageCollator(
     ): SessionMessage = with(params) {
         val base = buildFinalBackgroundActivity(params)
         val startupInfo = getStartupEventInfo(eventService)
+
         val betaFeatures = when (configService.sdkModeBehavior.isBetaFeaturesEnabled()) {
             false -> null
             else -> BetaFeatures(
@@ -161,7 +162,6 @@ internal class PayloadMessageCollator(
                     }
                     spansService.flushSpans(appTerminationCause)
                 }
-
                 else -> spansService.completedSpans()
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -21,6 +21,4 @@ internal interface SessionService {
      * Ends a session manually. If [clearUserInfo] is true, the user info will be cleared.
      */
     fun endSessionWithManual(clearUserInfo: Boolean)
-
-    fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -25,8 +25,4 @@ internal class FakeSessionService : SessionService {
     override fun endSessionWithManual(clearUserInfo: Boolean) {
         manualEndCount++
     }
-
-    override fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long) {
-        TODO("Not yet implemented")
-    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -1,0 +1,69 @@
+package io.embrace.android.embracesdk.capture.startup
+
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.internal.OpenTelemetryClock
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.isPrivate
+import io.opentelemetry.api.trace.SpanId
+import io.opentelemetry.api.trace.StatusCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+internal class StartupServiceImplTest {
+
+    private lateinit var spansService: EmbraceSpansService
+    private lateinit var startupService: StartupService
+    private lateinit var clock: FakeClock
+
+    @Before
+    fun setUp() {
+        clock = FakeClock(10000000)
+        spansService =
+            EmbraceSpansService(OpenTelemetryClock(embraceClock = clock), FakeTelemetryService())
+        startupService = StartupServiceImpl(spansService)
+    }
+
+    @Test
+    fun `initialization records SDK startup span`() {
+        val startTimeMillis = clock.now()
+        clock.tick(10L)
+        val endTimeMillis = clock.now()
+        spansService.initializeService(startTimeMillis)
+        startupService.setSdkStartupInfo(startTimeMillis, endTimeMillis)
+        val currentSpans = checkNotNull(spansService.completedSpans())
+        assertEquals(1, currentSpans.size)
+        with(currentSpans[0]) {
+            assertEquals("emb-sdk-init", name)
+            assertEquals(SpanId.getInvalid(), parentSpanId)
+            assertEquals(TimeUnit.MILLISECONDS.toNanos(startTimeMillis), startTimeNanos)
+            assertEquals(TimeUnit.MILLISECONDS.toNanos(endTimeMillis), endTimeNanos)
+            assertEquals(
+                io.embrace.android.embracesdk.internal.spans.EmbraceAttributes.Type.PERFORMANCE.name,
+                attributes[io.embrace.android.embracesdk.internal.spans.EmbraceAttributes.Type.PERFORMANCE.keyName()]
+            )
+            assertTrue(isPrivate())
+            assertEquals(StatusCode.OK, status)
+        }
+    }
+
+    @Test
+    fun `second sdk startup span will not be recorded if you try to set the startup info twice`() {
+        spansService.initializeService(10)
+        startupService.setSdkStartupInfo(10, 20)
+        assertEquals(1, spansService.completedSpans()?.size)
+        startupService.setSdkStartupInfo(10, 20)
+        startupService.setSdkStartupInfo(10, 20)
+        assertEquals(1, spansService.completedSpans()?.size)
+    }
+
+    @Test
+    fun `sdk startup span recorded if the startup info is set before span service initializes`() {
+        startupService.setSdkStartupInfo(10, 20)
+        spansService.initializeService(10)
+        assertEquals(1, spansService.completedSpans()?.size)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.capture.startup.StartupService
+
+internal class FakeStartupService : StartupService {
+
+    var sdkStartupDuration: Long? = null
+
+    override fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long) {
+        sdkStartupDuration = endTimeMs - startTimeMs
+    }
+
+    override fun getSdkStartupInfo(coldStart: Boolean): Long? {
+        return sdkStartupDuration
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
@@ -7,12 +7,14 @@ import io.embrace.android.embracesdk.capture.memory.ComponentCallbackService
 import io.embrace.android.embracesdk.capture.memory.MemoryService
 import io.embrace.android.embracesdk.capture.powersave.NoOpPowerSaveModeService
 import io.embrace.android.embracesdk.capture.powersave.PowerSaveModeService
+import io.embrace.android.embracesdk.capture.startup.StartupService
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
 import io.embrace.android.embracesdk.capture.thermalstate.ThermalStatusService
 import io.embrace.android.embracesdk.capture.webview.EmbraceWebViewService
 import io.embrace.android.embracesdk.capture.webview.WebViewService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMemoryService
+import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.injection.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 
@@ -28,4 +30,5 @@ internal class FakeDataCaptureServiceModule(
         get() = TODO("Not yet implemented")
     override val componentCallbackService: ComponentCallbackService
         get() = TODO("Not yet implemented")
+    override val startupService: StartupService = FakeStartupService()
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
@@ -49,6 +49,7 @@ internal class DataCaptureServiceModuleImplTest {
         assertTrue(module.thermalStatusService is EmbraceThermalStatusService)
         assertNotNull(module.pushNotificationService)
         assertNotNull(module.componentCallbackService)
+        assertNotNull(module.startupService)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -21,6 +21,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
@@ -378,7 +379,8 @@ internal class EmbraceBackgroundActivityServiceTest {
             preferencesService,
             spansService,
             clock,
-            FakeSessionPropertiesService()
+            FakeSessionPropertiesService(),
+            FakeStartupService()
         )
         return EmbraceBackgroundActivityService(
             metadataService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -15,7 +15,6 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
-import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.worker.ScheduledWorker
@@ -148,7 +147,6 @@ internal class EmbraceSessionServiceTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             FakeClock(),
-            SpansService.featureDisabledSpansService,
             ScheduledWorker(BlockingScheduledExecutorService())
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
@@ -50,7 +51,8 @@ internal class PayloadMessageCollatorTest {
             performanceInfoService = FakePerformanceInfoService(),
             spansService = SpansService.Companion.featureDisabledSpansService,
             clock = FakeClock(),
-            sessionPropertiesService = FakeSessionPropertiesService()
+            sessionPropertiesService = FakeSessionPropertiesService(),
+            startupService = FakeStartupService()
         )
     }
 
@@ -121,8 +123,7 @@ internal class PayloadMessageCollatorTest {
                 15000000000,
                 LifeEventType.STATE,
                 "crashId",
-                SessionSnapshotType.NORMAL_END,
-                5
+                SessionSnapshotType.NORMAL_END
             )
         )
         payload.verifyFinalFieldsPopulated(PayloadType.SESSION)


### PR DESCRIPTION
## Goal

Extracts the capture of SDK startup duration to a separate service, as it doesn't really belong in the `SessionService`.

## Testing

Updated existing test coverage.
