### PR TITLE
Alter how session boundary is cleared

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.getSentSessionMessages
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifySessionHappened
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -35,11 +34,17 @@ internal class ManualSessionTest {
     fun `calling endSession ends stateful session`() {
         with(testRule) {
             harness.recordSession {
+                harness.fakeClock.tick(10000) // enough to trigger new session
                 embrace.endSession()
             }
-            val message = harness.getSentSessionMessages().single()
-            verifySessionHappened(message)
-            assertEquals(1, message.session.number)
+            val messages = harness.getSentSessionMessages()
+            assertEquals(2, messages.size)
+            val stateSession = messages[0] // started via state, ended manually
+            val manualSession = messages[1] // started manually, ended via state
+            verifySessionHappened(stateSession)
+            verifySessionHappened(manualSession)
+            assertEquals(1, stateSession.session.number)
+            assertEquals(2, manualSession.session.number)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -78,8 +78,6 @@ internal class SessionModuleImpl(
             essentialServiceModule.metadataService,
             dataCaptureServiceModule.breadcrumbService,
             ndkService,
-            sdkObservabilityModule.internalErrorService,
-            essentialServiceModule.memoryCleanerService,
             deliveryModule.deliveryService,
             payloadMessageCollator,
             sessionProperties,
@@ -106,7 +104,10 @@ internal class SessionModuleImpl(
             sessionService,
             backgroundActivityService,
             initModule.clock,
-            essentialServiceModule.configService
+            essentialServiceModule.configService,
+            essentialServiceModule.memoryCleanerService,
+            sdkObservabilityModule.internalErrorService,
+
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -18,6 +18,11 @@ internal interface SessionService {
     fun endSessionWithCrash(crashId: String)
 
     /**
+     * Starts a session manually.
+     */
+    fun startSessionWithManual()
+
+    /**
      * Ends a session manually. If [clearUserInfo] is true, the user info will be cleared.
      */
     fun endSessionWithManual(clearUserInfo: Boolean)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -7,6 +7,7 @@ internal class FakeSessionService : SessionService {
     val startTimestamps = mutableListOf<Long>()
     val endTimestamps = mutableListOf<Long>()
     var manualEndCount = 0
+    var manualStartCount = 0
 
     override fun startSessionWithState(coldStart: Boolean, timestamp: Long) {
         startTimestamps.add(timestamp)
@@ -24,5 +25,9 @@ internal class FakeSessionService : SessionService {
 
     override fun endSessionWithManual(clearUserInfo: Boolean) {
         manualEndCount++
+    }
+
+    override fun startSessionWithManual() {
+        manualStartCount++
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -7,8 +7,6 @@ import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorServic
 import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
-import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
@@ -141,8 +139,6 @@ internal class EmbraceSessionServiceTest {
             FakeAndroidMetadataService(),
             FakeBreadcrumbService(),
             ndkService,
-            FakeInternalErrorService(),
-            FakeMemoryCleanerService(),
             deliveryService,
             mockk(relaxed = true),
             mockk(relaxed = true),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -184,8 +184,6 @@ internal class SessionHandlerTest {
             metadataService,
             breadcrumbService,
             ndkService,
-            internalErrorService,
-            memoryCleanerService,
             deliveryService,
             payloadMessageCollator,
             sessionProperties,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -4,6 +4,8 @@ import io.embrace.android.embracesdk.FakeSessionService
 import io.embrace.android.embracesdk.fakes.FakeBackgroundActivityService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -22,6 +24,8 @@ internal class SessionOrchestratorTest {
     private lateinit var processStateService: FakeProcessStateService
     private lateinit var clock: FakeClock
     private lateinit var configService: FakeConfigService
+    private lateinit var memoryCleanerService: FakeMemoryCleanerService
+    private lateinit var internalErrorService: FakeInternalErrorService
 
     @Before
     fun setUp() {
@@ -30,18 +34,23 @@ internal class SessionOrchestratorTest {
         backgroundActivityService = FakeBackgroundActivityService()
         clock = FakeClock()
         configService = FakeConfigService(backgroundActivityCaptureEnabled = true)
+        memoryCleanerService = FakeMemoryCleanerService()
+        internalErrorService = FakeInternalErrorService()
         orchestrator = SessionOrchestratorImpl(
             processStateService,
             sessionService,
             backgroundActivityService,
             clock,
-            configService
+            configService,
+            memoryCleanerService,
+            internalErrorService
         )
     }
 
     @Test
     fun `test initial behavior in background`() {
         createOrchestratorInBackground()
+        verifyPrepareEnvelopeCalled(0)
         assertEquals(orchestrator, processStateService.listeners.single())
         assertEquals(0, sessionService.startTimestamps.size)
         assertEquals(1, backgroundActivityService.startTimestamps.size)
@@ -49,6 +58,7 @@ internal class SessionOrchestratorTest {
 
     @Test
     fun `test initial behavior in foreground`() {
+        verifyPrepareEnvelopeCalled(0)
         assertEquals(orchestrator, processStateService.listeners.single())
         assertEquals(1, sessionService.startTimestamps.size)
         assertEquals(0, backgroundActivityService.startTimestamps.size)
@@ -58,6 +68,7 @@ internal class SessionOrchestratorTest {
     fun `test on foreground call`() {
         createOrchestratorInBackground()
         orchestrator.onForeground(true, TIMESTAMP)
+        verifyPrepareEnvelopeCalled()
         assertEquals(TIMESTAMP, sessionService.startTimestamps.single())
         assertEquals(TIMESTAMP, backgroundActivityService.endTimestamps.single())
     }
@@ -65,6 +76,7 @@ internal class SessionOrchestratorTest {
     @Test
     fun `test on background call`() {
         orchestrator.onBackground(TIMESTAMP)
+        verifyPrepareEnvelopeCalled()
         assertEquals(TIMESTAMP, sessionService.endTimestamps.single())
         assertEquals(TIMESTAMP, backgroundActivityService.startTimestamps.single())
     }
@@ -72,14 +84,18 @@ internal class SessionOrchestratorTest {
     @Test
     fun `end session with manual in foreground`() {
         orchestrator.endSessionWithManual(true)
+        verifyPrepareEnvelopeCalled()
         assertEquals(1, sessionService.manualEndCount)
+        assertEquals(1, sessionService.manualStartCount)
     }
 
     @Test
     fun `end session with manual in background`() {
         processStateService.isInBackground = true
         orchestrator.endSessionWithManual(true)
+        verifyPrepareEnvelopeCalled(0)
         assertEquals(0, sessionService.manualEndCount)
+        assertEquals(0, sessionService.manualStartCount)
     }
 
     @Test
@@ -87,7 +103,12 @@ internal class SessionOrchestratorTest {
         configService = FakeConfigService(backgroundActivityCaptureEnabled = false)
         createOrchestratorInBackground()
         orchestrator.onBackground(TIMESTAMP)
+        verifyPrepareEnvelopeCalled()
         assertTrue(backgroundActivityService.startTimestamps.isEmpty())
+    }
+
+    private fun verifyPrepareEnvelopeCalled(expectedCount: Int = 1) {
+        assertEquals(expectedCount, memoryCleanerService.callCount)
     }
 
     private fun createOrchestratorInBackground() {
@@ -100,7 +121,9 @@ internal class SessionOrchestratorTest {
             sessionService,
             backgroundActivityService,
             clock,
-            configService
+            configService,
+            memoryCleanerService,
+            internalErrorService
         )
     }
 }


### PR DESCRIPTION
## Goal

Extracts the logic for clearing the session boundary to the `SessionOrchestrator` so that it is responsible for resetting `MemoryCleanerListener` services.

## Testing

Updated existing test coverage.
