### PR TITLE
Make session orchestrator responsible for clearing session props

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -80,7 +80,6 @@ internal class SessionModuleImpl(
             ndkService,
             deliveryModule.deliveryService,
             payloadMessageCollator,
-            sessionProperties,
             initModule.clock,
             workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
         )
@@ -107,7 +106,7 @@ internal class SessionModuleImpl(
             essentialServiceModule.configService,
             essentialServiceModule.memoryCleanerService,
             sdkObservabilityModule.internalErrorService,
-
+            sessionProperties
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -15,7 +15,6 @@ import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -30,7 +29,6 @@ internal class EmbraceSessionService(
     private val ndkService: NdkService?,
     private val deliveryService: DeliveryService,
     private val payloadMessageCollator: PayloadMessageCollator,
-    private val sessionProperties: EmbraceSessionProperties,
     private val clock: Clock,
     private val sessionPeriodicCacheScheduledWorker: ScheduledWorker
 ) : SessionService {
@@ -180,9 +178,6 @@ internal class EmbraceSessionService(
 
             // Clean every collection of those services which have collections in memory.
             metadataService.removeActiveSessionId(session.sessionId)
-            logger.logDebug("Services collections successfully cleaned.")
-            sessionProperties.clearTemporary()
-            logger.logDebug("Session properties successfully temporary cleared.")
             deliveryService.sendSession(fullEndSessionMessage, SessionSnapshotType.NORMAL_END)
 
             if (endType == LifeEventType.MANUAL && clearUserInfo) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.session.ConfigGate
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
+import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 
 internal class SessionOrchestratorImpl(
     private val processStateService: ProcessStateService,
@@ -16,7 +17,8 @@ internal class SessionOrchestratorImpl(
     clock: Clock,
     configService: ConfigService,
     private val memoryCleanerService: MemoryCleanerService,
-    private val internalErrorService: InternalErrorService
+    private val internalErrorService: InternalErrorService,
+    private val sessionProperties: EmbraceSessionProperties
 ) : SessionOrchestrator {
 
     private val backgroundActivityGate = ConfigGate(backgroundActivityServiceImpl) {
@@ -67,5 +69,6 @@ internal class SessionOrchestratorImpl(
      */
     private fun prepareForNewEnvelope() {
         memoryCleanerService.cleanServicesCollections(internalErrorService)
+        sessionProperties.clearTemporary()
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -141,7 +141,6 @@ internal class EmbraceSessionServiceTest {
             ndkService,
             deliveryService,
             mockk(relaxed = true),
-            mockk(relaxed = true),
             FakeClock(),
             ScheduledWorker(BlockingScheduledExecutorService())
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -186,7 +186,6 @@ internal class SessionHandlerTest {
             ndkService,
             deliveryService,
             payloadMessageCollator,
-            sessionProperties,
             clock,
             sessionPeriodicCacheScheduledWorker = sessionPeriodicCacheExecutorService
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -7,6 +7,8 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
+import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -26,6 +28,7 @@ internal class SessionOrchestratorTest {
     private lateinit var configService: FakeConfigService
     private lateinit var memoryCleanerService: FakeMemoryCleanerService
     private lateinit var internalErrorService: FakeInternalErrorService
+    private lateinit var sessionProperties: EmbraceSessionProperties
 
     @Before
     fun setUp() {
@@ -36,6 +39,7 @@ internal class SessionOrchestratorTest {
         configService = FakeConfigService(backgroundActivityCaptureEnabled = true)
         memoryCleanerService = FakeMemoryCleanerService()
         internalErrorService = FakeInternalErrorService()
+        sessionProperties = fakeEmbraceSessionProperties()
         orchestrator = SessionOrchestratorImpl(
             processStateService,
             sessionService,
@@ -43,8 +47,10 @@ internal class SessionOrchestratorTest {
             clock,
             configService,
             memoryCleanerService,
-            internalErrorService
+            internalErrorService,
+            sessionProperties
         )
+        sessionProperties.add("key", "value", false)
     }
 
     @Test
@@ -109,6 +115,11 @@ internal class SessionOrchestratorTest {
 
     private fun verifyPrepareEnvelopeCalled(expectedCount: Int = 1) {
         assertEquals(expectedCount, memoryCleanerService.callCount)
+        val expectedPropCount = when (expectedCount) {
+            0 -> 1
+            else -> 0
+        }
+        assertEquals(expectedPropCount, sessionProperties.get().size)
     }
 
     private fun createOrchestratorInBackground() {
@@ -123,7 +134,8 @@ internal class SessionOrchestratorTest {
             clock,
             configService,
             memoryCleanerService,
-            internalErrorService
+            internalErrorService,
+            sessionProperties
         )
     }
 }


### PR DESCRIPTION
## Goal

Makes the session orchestrator responsible for clearing temporary session properties.

## Testing

Added to existing test coverage.

