### PR TITLE
Extract session id tracking

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -108,7 +108,7 @@ internal class PublicApiTest {
         with(testRule) {
             embrace.start(harness.fakeCoreModule.context)
             harness.recordSession {
-                assertEquals(embrace.currentSessionId, harness.essentialServiceModule.metadataService.activeSessionId)
+                assertEquals(embrace.currentSessionId, harness.essentialServiceModule.sessionIdTracker.getActiveSessionId())
                 assertNotNull(embrace.currentSessionId)
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -90,6 +90,7 @@ import io.embrace.android.embracesdk.prefs.PreferencesService;
 import io.embrace.android.embracesdk.registry.ServiceRegistry;
 import io.embrace.android.embracesdk.session.BackgroundActivityService;
 import io.embrace.android.embracesdk.session.SessionService;
+import io.embrace.android.embracesdk.session.id.SessionIdTracker;
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker;
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService;
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator;
@@ -208,6 +209,9 @@ final class EmbraceImpl {
 
     @Nullable
     private volatile MetadataService metadataService;
+
+    @Nullable
+    private volatile SessionIdTracker sessionIdTracker;
 
     @Nullable
     private volatile ProcessStateService processStateService;
@@ -420,6 +424,7 @@ final class EmbraceImpl {
         processStateService = nonNullProcessStateService;
         final MetadataService nonNullMetadataService = essentialServiceModule.getMetadataService();
         metadataService = nonNullMetadataService;
+        sessionIdTracker = essentialServiceModule.getSessionIdTracker();
         final ConfigService nonNullConfigService = essentialServiceModule.getConfigService();
         configService = nonNullConfigService;
 
@@ -1370,9 +1375,9 @@ final class EmbraceImpl {
      */
     @Nullable
     String getCurrentSessionId() {
-        MetadataService localMetaDataService = metadataService;
-        if (localMetaDataService != null && checkSdkStarted("get_current_session_id", false)) {
-            String sessionId = localMetaDataService.getActiveSessionId();
+        SessionIdTracker localSessionIdTracker = sessionIdTracker;
+        if (localSessionIdTracker != null && checkSdkStarted("get_current_session_id", false)) {
+            String sessionId = localSessionIdTracker.getActiveSessionId();
             if (sessionId != null) {
                 return sessionId;
             } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/EmbraceApplicationExitInfoService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/EmbraceApplicationExitInfoService.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.BlobSession
 import io.embrace.android.embracesdk.prefs.PreferencesService
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.io.IOException
 import java.util.concurrent.Future
@@ -32,6 +33,7 @@ internal class EmbraceApplicationExitInfoService(
     private val preferencesService: PreferencesService,
     private val deliveryService: DeliveryService,
     private val metadataService: MetadataService,
+    private val sessionIdTracker: SessionIdTracker,
     private val userService: UserService,
     private val buildVersionChecker: VersionChecker = BuildVersionChecker
 ) : ApplicationExitInfoService, ConfigListener {
@@ -182,7 +184,7 @@ internal class EmbraceApplicationExitInfoService(
                 metadataService.getAppInfo(),
                 appExitInfoWithTraces,
                 metadataService.getDeviceInfo(),
-                BlobSession(metadataService.activeSessionId),
+                BlobSession(sessionIdTracker.getActiveSessionId()),
                 userService.getUserInfo()
             )
             deliveryService.sendAEIBlob(blob)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
@@ -22,6 +22,7 @@ import io.embrace.android.embracesdk.payload.extensions.CrashFactory
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.SessionService
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 /**
@@ -32,6 +33,7 @@ internal class EmbraceCrashService(
     private val sessionService: SessionService,
     private val sessionPropertiesService: SessionPropertiesService,
     private val metadataService: MetadataService,
+    private val sessionIdTracker: SessionIdTracker,
     private val deliveryService: DeliveryService,
     private val userService: UserService,
     private val eventService: EventService,
@@ -90,14 +92,7 @@ internal class EmbraceCrashService(
             }
             logDeveloper("EmbraceCrashService", "crashId = " + crash.crashId)
 
-            val optionalSessionId = metadataService.activeSessionId
-            val sessionId = if (optionalSessionId != null) {
-                logDeveloper("EmbraceCrashService", "Session id is present:$optionalSessionId")
-                optionalSessionId
-            } else {
-                logDeveloper("EmbraceCrashService", "Session id is not present:")
-                null
-            }
+            val sessionId = sessionIdTracker.getActiveSessionId()
 
             val event = Event(
                 CRASH_REPORT_EVENT_NAME,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -82,9 +82,6 @@ internal class EmbraceMetadataService private constructor(
     private var reactNativeBundleId: Lazy<String?>
 
     @Volatile
-    private var sessionId: String? = null
-
-    @Volatile
     private var diskUsage: DiskUsage? = null
 
     @Volatile
@@ -358,43 +355,6 @@ internal class EmbraceMetadataService private constructor(
     override fun isAppUpdated(): Boolean = appUpdated.value
 
     override fun isOsUpdated(): Boolean = osUpdated.value
-
-    override val activeSessionId: String?
-        get() = sessionId
-
-    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
-        logDeveloper("EmbraceMetadataService", "Active session Id: $sessionId")
-        this.sessionId = sessionId
-
-        if (isSession) {
-            setSessionIdToProcessStateSummary(this.sessionId)
-        }
-    }
-
-    override fun removeActiveSessionId(sessionId: String?) {
-        if (this.sessionId != null && this.sessionId == sessionId) {
-            logDeveloper("EmbraceMetadataService", "Nulling active session Id")
-            setActiveSessionId(null, false)
-        }
-    }
-
-    /**
-     * On android 11+, we use ActivityManager#setProcessStateSummary to store sessionId
-     * Then, this information will be included in the record of ApplicationExitInfo on the death of the current calling process
-     *
-     * @param sessionId current session id
-     */
-    private fun setSessionIdToProcessStateSummary(sessionId: String?) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            if (sessionId != null) {
-                try {
-                    activityManager?.setProcessStateSummary(sessionId.toByteArray())
-                } catch (e: Throwable) {
-                    logError("Couldn't set Process State Summary", e)
-                }
-            }
-        }
-    }
 
     override fun getAppState(): String {
         return if (processStateService.isInBackground) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
@@ -103,29 +103,6 @@ internal interface MetadataService {
     fun isOsUpdated(): Boolean
 
     /**
-     * Gets the currently active session ID, if present.
-     *
-     * @return an optional containing the currently active session ID
-     */
-    val activeSessionId: String?
-
-    /**
-     * Sets the currently active session ID.
-     *
-     * @param sessionId the session ID that is currently active
-     * @param isSession true if it's a session, false if it's a background activity
-     */
-    fun setActiveSessionId(sessionId: String?, isSession: Boolean)
-
-    /**
-     * If the currently active session ID is @param sessionId, set it to null
-     * If the currently active session is different, do nothing
-     *
-     * @param sessionId null current session id only if it euals this one
-     */
-    fun removeActiveSessionId(sessionId: String?)
-
-    /**
      * Returns 'active' if the application is in the foreground, or 'background' if the app is in
      * the background.
      *

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -40,6 +41,7 @@ internal class EmbraceEventService(
     deliveryService: DeliveryService,
     private val configService: ConfigService,
     metadataService: MetadataService,
+    sessionIdTracker: SessionIdTracker,
     performanceInfoService: PerformanceInfoService,
     userService: UserService,
     private val sessionProperties: EmbraceSessionProperties,
@@ -71,6 +73,7 @@ internal class EmbraceEventService(
         // Session properties
         eventHandler = EventHandler(
             metadataService,
+            sessionIdTracker,
             configService,
             userService,
             performanceInfoService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.TimeUnit
@@ -26,6 +27,7 @@ private const val DEFAULT_LATE_THRESHOLD_MILLIS = 5000L
  */
 internal class EventHandler(
     private val metadataService: MetadataService,
+    private val sessionIdTracker: SessionIdTracker,
     private val configService: ConfigService,
     private val userService: UserService,
     private val performanceInfoService: PerformanceInfoService,
@@ -169,7 +171,7 @@ internal class EventHandler(
     ): Event {
         return Event(
             name = eventName,
-            sessionId = metadataService.activeSessionId,
+            sessionId = sessionIdTracker.getActiveSessionId(),
             eventId = eventId,
             type = EmbraceEvent.Type.START,
             appState = metadataService.getAppState(),
@@ -191,7 +193,7 @@ internal class EventHandler(
         return Event(
             name = originEvent.name,
             eventId = originEvent.eventId,
-            sessionId = metadataService.activeSessionId,
+            sessionId = sessionIdTracker.getActiveSessionId(),
             timestamp = endTime,
             duration = duration,
             appState = metadataService.getAppState(),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
@@ -45,6 +45,7 @@ internal class CrashModuleImpl(
             sessionModule.sessionService,
             sessionModule.sessionPropertiesService,
             essentialServiceModule.metadataService,
+            essentialServiceModule.sessionIdTracker,
             deliveryModule.deliveryService,
             essentialServiceModule.userService,
             dataContainerModule.eventService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -32,6 +32,7 @@ internal class CustomerLogModuleImpl(
     override val networkCaptureService: NetworkCaptureService by singleton {
         EmbraceNetworkCaptureService(
             essentialServiceModule.metadataService,
+            essentialServiceModule.sessionIdTracker,
             androidServicesModule.preferencesService,
             logMessageService,
             essentialServiceModule.configService,
@@ -50,6 +51,7 @@ internal class CustomerLogModuleImpl(
     override val logMessageService: LogMessageService by singleton {
         EmbraceLogMessageService(
             essentialServiceModule.metadataService,
+            essentialServiceModule.sessionIdTracker,
             deliveryModule.deliveryService,
             essentialServiceModule.userService,
             essentialServiceModule.configService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
@@ -49,6 +49,7 @@ internal class DataContainerModuleImpl(
                 androidServicesModule.preferencesService,
                 deliveryModule.deliveryService,
                 essentialServiceModule.metadataService,
+                essentialServiceModule.sessionIdTracker,
                 essentialServiceModule.userService
             )
         } else {
@@ -77,6 +78,7 @@ internal class DataContainerModuleImpl(
             deliveryModule.deliveryService,
             essentialServiceModule.configService,
             essentialServiceModule.metadataService,
+            essentialServiceModule.sessionIdTracker,
             performanceInfoService,
             essentialServiceModule.userService,
             sessionProperties,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -35,6 +35,8 @@ import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.session.EmbraceMemoryCleanerService
 import io.embrace.android.embracesdk.session.MemoryCleanerService
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.session.id.SessionIdTrackerImpl
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleTracker
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.session.lifecycle.EmbraceProcessStateService
@@ -63,6 +65,7 @@ internal interface EssentialServiceModule {
     val deviceArchitecture: DeviceArchitecture
     val networkConnectivityService: NetworkConnectivityService
     val pendingApiCallsSender: PendingApiCallsSender
+    val sessionIdTracker: SessionIdTracker
 }
 
 internal class EssentialServiceModuleImpl(
@@ -275,6 +278,10 @@ internal class EssentialServiceModuleImpl(
         ApiClientImpl(
             coreModule.logger
         )
+    }
+
+    override val sessionIdTracker: SessionIdTracker by singleton {
+        SessionIdTrackerImpl()
     }
 }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -75,7 +75,7 @@ internal class SessionModuleImpl(
             essentialServiceModule.configService,
             essentialServiceModule.userService,
             essentialServiceModule.networkConnectivityService,
-            essentialServiceModule.metadataService,
+            essentialServiceModule.sessionIdTracker,
             dataCaptureServiceModule.breadcrumbService,
             ndkService,
             deliveryModule.deliveryService,
@@ -87,7 +87,7 @@ internal class SessionModuleImpl(
 
     override val backgroundActivityService: BackgroundActivityService? by singleton {
         EmbraceBackgroundActivityService(
-            essentialServiceModule.metadataService,
+            essentialServiceModule.sessionIdTracker,
             deliveryModule.deliveryService,
             essentialServiceModule.configService,
             nativeModule.ndkService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureService.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.prefs.PreferencesService
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import kotlin.math.max
 
 /**
@@ -16,6 +17,7 @@ import kotlin.math.max
  */
 internal class EmbraceNetworkCaptureService(
     private val metadataService: MetadataService,
+    private val sessionIdTracker: SessionIdTracker,
     private val preferencesService: PreferencesService,
     private val logMessageService: LogMessageService,
     private val configService: ConfigService,
@@ -101,7 +103,7 @@ internal class EmbraceNetworkCaptureService(
                     responseHeaders = networkCaptureData?.responseHeaders,
                     responseSize = networkCaptureData?.responseBodySize,
                     responseStatus = statusCode,
-                    sessionId = metadataService.activeSessionId,
+                    sessionId = sessionIdTracker.getActiveSessionId(),
                     startTime = startTime,
                     url = url,
                     errorMessage = errorMessage

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -10,13 +9,14 @@ import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 
 internal class EmbraceBackgroundActivityService(
-    private val metadataService: MetadataService,
+    private val sessionIdTracker: SessionIdTracker,
     private val deliveryService: DeliveryService,
     private val configService: ConfigService,
     private val ndkService: NdkService,
@@ -134,7 +134,7 @@ internal class EmbraceBackgroundActivityService(
     private fun startCapture(params: InitialEnvelopeParams.BackgroundActivityParams) {
         val activity = payloadMessageCollator.buildInitialSession(params)
         backgroundActivity = activity
-        metadataService.setActiveSessionId(activity.sessionId, false)
+        sessionIdTracker.setActiveSessionId(activity.sessionId, false)
         if (configService.autoDataCaptureBehavior.isNdkEnabled()) {
             ndkService.updateSessionId(activity.sessionId)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.session
 import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
-import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.config.ConfigService
@@ -15,6 +14,7 @@ import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -24,7 +24,7 @@ internal class EmbraceSessionService(
     private val configService: ConfigService,
     private val userService: UserService,
     private val networkConnectivityService: NetworkConnectivityService,
-    private val metadataService: MetadataService,
+    private val sessionIdTracker: SessionIdTracker,
     private val breadcrumbService: BreadcrumbService,
     private val ndkService: NdkService?,
     private val deliveryService: DeliveryService,
@@ -148,7 +148,7 @@ internal class EmbraceSessionService(
             )
 
             // Record the connection type at the start of the session.
-            metadataService.setActiveSessionId(session.sessionId, true)
+            sessionIdTracker.setActiveSessionId(session.sessionId, true)
             ndkService?.updateSessionId(session.sessionId)
             networkConnectivityService.networkStatusOnSessionStarted(session.startTime)
             breadcrumbService.addFirstViewBreadcrumbForSession(params.startTime)
@@ -177,7 +177,7 @@ internal class EmbraceSessionService(
             ) ?: return null
 
             // Clean every collection of those services which have collections in memory.
-            metadataService.removeActiveSessionId(session.sessionId)
+            sessionIdTracker.setActiveSessionId(null, false)
             deliveryService.sendSession(fullEndSessionMessage, SessionSnapshotType.NORMAL_END)
 
             if (endType == LifeEventType.MANUAL && clearUserInfo) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTracker.kt
@@ -1,0 +1,19 @@
+package io.embrace.android.embracesdk.session.id
+
+internal interface SessionIdTracker {
+
+    /**
+     * Gets the currently active session ID, if present.
+     *
+     * @return an optional containing the currently active session ID
+     */
+    fun getActiveSessionId(): String?
+
+    /**
+     * Sets the currently active session ID.
+     *
+     * @param sessionId the session ID that is currently active
+     * @param isSession true if it's a session, false if it's a background activity
+     */
+    fun setActiveSessionId(sessionId: String?, isSession: Boolean)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.embracesdk.session.id
+
+import android.app.ActivityManager
+import android.os.Build
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+internal class SessionIdTrackerImpl(
+    private val activityManager: ActivityManager? = null
+) : SessionIdTracker {
+
+    @Volatile
+    private var sessionId: String? = null
+
+    override fun getActiveSessionId(): String? = sessionId
+
+    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
+        this.sessionId = sessionId
+
+        if (isSession) {
+            setSessionIdToProcessStateSummary(this.sessionId)
+        }
+    }
+
+    /**
+     * On android 11+, we use ActivityManager#setProcessStateSummary to store sessionId
+     * Then, this information will be included in the record of ApplicationExitInfo on the death of the current calling process
+     *
+     * @param sessionId current session id
+     */
+    private fun setSessionIdToProcessStateSummary(sessionId: String?) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (sessionId != null) {
+                try {
+                    activityManager?.setProcessStateSummary(sessionId.toByteArray())
+                } catch (e: Throwable) {
+                    InternalStaticEmbraceLogger.logError("Couldn't set Process State Summary", e)
+                }
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceApplicationExitInfoServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceApplicationExitInfoServiceTest.kt
@@ -6,9 +6,10 @@ import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.capture.aei.EmbraceApplicationExitInfoService
 import io.embrace.android.embracesdk.config.remote.AppExitInfoConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -49,7 +50,8 @@ internal class EmbraceApplicationExitInfoServiceTest {
 
     private val deliveryService = FakeDeliveryService()
     private val preferenceService = FakePreferenceService()
-    private val metadataService = FakeAndroidMetadataService()
+    private val metadataService = FakeMetadataService()
+    private val sessionIdTracker = FakeSessionIdTracker()
     private val userService = FakeUserService()
 
     private val mockActivityManager: ActivityManager = mockk {
@@ -85,6 +87,7 @@ internal class EmbraceApplicationExitInfoServiceTest {
             preferenceService,
             deliveryService,
             metadataService,
+            sessionIdTracker,
             userService
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
@@ -5,12 +5,13 @@ import io.embrace.android.embracesdk.capture.crash.EmbraceUncaughtExceptionHandl
 import io.embrace.android.embracesdk.config.local.CrashHandlerLocalConfig
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
@@ -40,7 +41,8 @@ internal class EmbraceCrashServiceTest {
     private lateinit var embraceCrashService: EmbraceCrashService
     private lateinit var sessionService: FakeSessionService
     private lateinit var sessionPropertiesService: SessionPropertiesService
-    private lateinit var metadataService: FakeAndroidMetadataService
+    private lateinit var metadataService: FakeMetadataService
+    private lateinit var sessionIdTracker: FakeSessionIdTracker
     private lateinit var deliveryService: FakeDeliveryService
     private lateinit var userService: FakeUserService
     private lateinit var eventService: FakeEventService
@@ -62,7 +64,8 @@ internal class EmbraceCrashServiceTest {
 
         sessionService = FakeSessionService()
         sessionPropertiesService = FakeSessionPropertiesService()
-        metadataService = FakeAndroidMetadataService()
+        metadataService = FakeMetadataService()
+        sessionIdTracker = FakeSessionIdTracker()
         deliveryService = FakeDeliveryService()
         userService = FakeUserService()
         eventService = FakeEventService()
@@ -95,6 +98,7 @@ internal class EmbraceCrashServiceTest {
             sessionService,
             sessionPropertiesService,
             metadataService,
+            sessionIdTracker,
             deliveryService,
             userService,
             eventService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
@@ -3,10 +3,10 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.anr.sigquit.GoogleAnrTimestampRepository
 import io.embrace.android.embracesdk.capture.EmbracePerformanceInfoService
 import io.embrace.android.embracesdk.capture.monitor.NoOpResponsivenessMonitorService
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeApplicationExitInfoService
 import io.embrace.android.embracesdk.fakes.FakeMemoryService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
 import io.embrace.android.embracesdk.fakes.FakePowerSaveModeService
@@ -29,7 +29,7 @@ internal class EmbracePerformanceInfoServiceTest {
     private val networkLoggingService = FakeNetworkLoggingService()
     private val powerSaveModeService = FakePowerSaveModeService()
     private val memoryService = FakeMemoryService()
-    private val metadataService = FakeAndroidMetadataService()
+    private val metadataService = FakeMetadataService()
     private val googleAnrTimestampRepository = GoogleAnrTimestampRepository(InternalEmbraceLogger())
     private val applicationExitInfoService = FakeApplicationExitInfoService()
     private val monitoringServiceRule = NoOpResponsivenessMonitorService()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
@@ -61,6 +61,7 @@ internal class EssentialServiceModuleImplTest {
         assertNotNull(module.apiService)
         assertNotNull(module.activityLifecycleTracker)
         assertNotNull(module.sharedObjectLoader)
+        assertNotNull(module.sessionIdTracker)
         assertTrue(module.userService is EmbraceUserService)
         assertTrue(module.configService is EmbraceConfigService)
         assertTrue(module.gatingService is EmbraceGatingService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FlutterInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FlutterInternalInterfaceImplTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.mockk.every
 import io.mockk.mockk
@@ -14,12 +14,12 @@ internal class FlutterInternalInterfaceImplTest {
     private lateinit var impl: FlutterInternalInterfaceImpl
     private lateinit var embrace: EmbraceImpl
     private lateinit var logger: InternalEmbraceLogger
-    private lateinit var metadataService: FakeAndroidMetadataService
+    private lateinit var metadataService: FakeMetadataService
 
     @Before
     fun setUp() {
         embrace = mockk(relaxed = true)
-        metadataService = FakeAndroidMetadataService()
+        metadataService = FakeMetadataService()
         logger = mockk(relaxed = true)
         impl = FlutterInternalInterfaceImpl(embrace, mockk(), metadataService, logger)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import io.embrace.android.embracesdk.Embrace.AppFramework.FLUTTER
 import io.embrace.android.embracesdk.Embrace.AppFramework.REACT_NATIVE
 import io.embrace.android.embracesdk.capture.crash.CrashService
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.system.mockContext
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -24,7 +24,7 @@ internal class ReactNativeInternalInterfaceImplTest {
     private lateinit var embrace: EmbraceImpl
     private lateinit var preferencesService: PreferencesService
     private lateinit var crashService: CrashService
-    private lateinit var metadataService: FakeAndroidMetadataService
+    private lateinit var metadataService: FakeMetadataService
     private lateinit var logger: InternalEmbraceLogger
     private lateinit var context: Context
 
@@ -33,7 +33,7 @@ internal class ReactNativeInternalInterfaceImplTest {
         embrace = mockk(relaxed = true)
         preferencesService = FakePreferenceService()
         crashService = mockk(relaxed = true)
-        metadataService = FakeAndroidMetadataService()
+        metadataService = FakeMetadataService()
         logger = mockk(relaxed = true)
         context = mockContext()
         impl = ReactNativeInternalInterfaceImpl(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
@@ -7,9 +7,10 @@ import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.config.local.AppExitInfoLocalConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
@@ -141,6 +142,8 @@ internal class AeiNdkCrashProtobufSendTest {
             stream,
             reason
         )
+        val metadataService = FakeMetadataService()
+        val sessionIdTracker = FakeSessionIdTracker()
         EmbraceApplicationExitInfoService(
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
             FakeConfigService(
@@ -153,7 +156,8 @@ internal class AeiNdkCrashProtobufSendTest {
             activityManager,
             FakePreferenceService(),
             deliveryService,
-            FakeAndroidMetadataService(),
+            metadataService,
+            sessionIdTracker,
             FakeUserService(),
             VersionChecker { ndkTraceFile }
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -322,9 +322,6 @@ internal class EmbraceMetadataServiceTest {
         activityService.isInBackground = false
         assertEquals("active", metadataService.getAppState())
 
-        metadataService.setActiveSessionId("123", true)
-        assertEquals("123", metadataService.activeSessionId)
-
         assertEquals("appId", metadataService.getAppId())
         assertEquals("10", metadataService.getAppVersionCode())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -10,13 +10,14 @@ import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.config.local.StartupMomentLocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.event.EmbraceEventService.Companion.STARTUP_EVENT_NAME
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeGatingService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeStartupBehavior
@@ -58,6 +59,7 @@ internal class EmbraceEventServiceTest {
 
     companion object {
         private lateinit var metadataService: MetadataService
+        private lateinit var sessionIdTracker: FakeSessionIdTracker
         private lateinit var preferenceService: PreferencesService
         private lateinit var performanceInfoService: PerformanceInfoService
         private lateinit var userService: UserService
@@ -67,7 +69,8 @@ internal class EmbraceEventServiceTest {
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            metadataService = FakeAndroidMetadataService()
+            metadataService = FakeMetadataService()
+            sessionIdTracker = FakeSessionIdTracker()
             preferenceService = FakePreferenceService()
             performanceInfoService = FakePerformanceInfoService()
             processStateService = FakeProcessStateService()
@@ -116,6 +119,7 @@ internal class EmbraceEventServiceTest {
         )
         eventHandler = EventHandler(
             metadataService = metadataService,
+            sessionIdTracker = sessionIdTracker,
             configService = configService,
             userService = userService,
             performanceInfoService = performanceInfoService,
@@ -129,6 +133,7 @@ internal class EmbraceEventServiceTest {
             deliveryService,
             configService,
             metadataService,
+            sessionIdTracker,
             performanceInfoService,
             userService,
             sessionProperties,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
@@ -10,10 +10,11 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeLogMessageBehavior
@@ -48,7 +49,8 @@ internal class EmbraceLogMessageServiceTest {
 
     companion object {
         private lateinit var logMessageService: EmbraceLogMessageService
-        private lateinit var metadataService: FakeAndroidMetadataService
+        private lateinit var metadataService: FakeMetadataService
+        private lateinit var sessionIdTracker: FakeSessionIdTracker
         private lateinit var deliveryService: FakeDeliveryService
         private lateinit var userService: UserService
         private lateinit var configService: ConfigService
@@ -62,7 +64,8 @@ internal class EmbraceLogMessageServiceTest {
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            metadataService = FakeAndroidMetadataService()
+            metadataService = FakeMetadataService()
+            sessionIdTracker = FakeSessionIdTracker()
             userService = FakeUserService()
             logcat = InternalEmbraceLogger()
             executor = Executors.newSingleThreadExecutor()
@@ -105,7 +108,7 @@ internal class EmbraceLogMessageServiceTest {
             }
         )
         gatingService = EmbraceGatingService(configService)
-        metadataService.setActiveSessionId("session-123", true)
+        sessionIdTracker.setActiveSessionId("session-123", true)
         metadataService.setAppForeground()
         metadataService.setAppId("appId")
         sessionProperties = EmbraceSessionProperties(FakePreferenceService(), configService)
@@ -114,6 +117,7 @@ internal class EmbraceLogMessageServiceTest {
     private fun getLogMessageService(): EmbraceLogMessageService {
         return EmbraceLogMessageService(
             metadataService,
+            sessionIdTracker,
             deliveryService,
             userService,
             configService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
@@ -7,12 +7,13 @@ import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorServic
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeGatingService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
@@ -57,7 +58,8 @@ internal class EventHandlerTest {
         private lateinit var mockStartup: StartupEventInfo
         private lateinit var mockLateTimer: ScheduledFuture<*>
         private lateinit var userInfo: UserInfo
-        private lateinit var fakeMetadataService: FakeAndroidMetadataService
+        private lateinit var fakeMetadataService: FakeMetadataService
+        private lateinit var sessionIdTracker: FakeSessionIdTracker
         private lateinit var blockingScheduledExecutorService: BlockingScheduledExecutorService
         private lateinit var scheduledExecutorService: ScheduledExecutorService
 
@@ -88,9 +90,11 @@ internal class EventHandlerTest {
         clock = FakeClock()
         blockingScheduledExecutorService = BlockingScheduledExecutorService()
         scheduledExecutorService = blockingScheduledExecutorService
-        fakeMetadataService = FakeAndroidMetadataService(sessionId = "session-id")
+        fakeMetadataService = FakeMetadataService(sessionId = "session-id")
+        sessionIdTracker = FakeSessionIdTracker()
         eventHandler = EventHandler(
             fakeMetadataService,
+            sessionIdTracker,
             configService,
             userService,
             performanceService,
@@ -187,7 +191,7 @@ internal class EventHandlerTest {
             timestamp = endTime,
             customProperties = customPropertiesMap,
             sessionProperties = sessionPropertiesMap,
-            sessionId = fakeMetadataService.activeSessionId,
+            sessionId = sessionIdTracker.getActiveSessionId(),
             duration = endTime - startTime
         )
 
@@ -236,7 +240,7 @@ internal class EventHandlerTest {
             timestamp = endTime,
             customProperties = customPropertiesMap,
             sessionProperties = sessionPropertiesMap,
-            sessionId = fakeMetadataService.activeSessionId,
+            sessionId = sessionIdTracker.getActiveSessionId(),
             duration = endTime - startTime
         )
         val builtEndEventMessage = EventMessage(
@@ -275,7 +279,7 @@ internal class EventHandlerTest {
             timestamp = startTime,
             sessionProperties = sessionPropertiesMap,
             customProperties = customProperties,
-            sessionId = fakeMetadataService.activeSessionId
+            sessionId = sessionIdTracker.getActiveSessionId()
         )
 
         clock.setCurrentTime(456)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.payload.DiskUsage
  * Fake implementation of [MetadataService] that represents an Android device. A [UnsupportedOperationException] will be thrown
  * if you attempt set info about Flutter/Unity/ReactNative on this fake, which is decided for an Android device.
  */
-internal class FakeAndroidMetadataService(sessionId: String? = null) : MetadataService {
+internal class FakeMetadataService(sessionId: String? = null) : MetadataService {
     companion object {
         private val androidAppInfo = AppInfo(
             appVersion = "1.0.0",
@@ -93,19 +93,6 @@ internal class FakeAndroidMetadataService(sessionId: String? = null) : MetadataS
     override fun isAppUpdated(): Boolean = appUpdated
 
     override fun isOsUpdated(): Boolean = osUpdated
-
-    override val activeSessionId: String?
-        get() = appSessionId
-
-    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
-        appSessionId = sessionId
-    }
-
-    override fun removeActiveSessionId(sessionId: String?) {
-        if (appSessionId == sessionId) {
-            appSessionId = null
-        }
-    }
 
     override fun getAppState(): String = appState
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
+
+internal class FakeSessionIdTracker : SessionIdTracker {
+
+    var sessionId: String? = null
+
+    override fun getActiveSessionId(): String? {
+        return sessionId
+    }
+
+    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
+        this.sessionId = sessionId
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCustomerLogModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCustomerLogModule.kt
@@ -5,11 +5,12 @@ import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.capture.connectivity.NoOpNetworkConnectivityService
 import io.embrace.android.embracesdk.event.EmbraceLogMessageService
 import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeGatingService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.injection.CustomerLogModule
@@ -22,7 +23,8 @@ internal class FakeCustomerLogModule(
     override val networkLoggingService: NetworkLoggingService = FakeNetworkLoggingService(),
 
     override val logMessageService: LogMessageService = EmbraceLogMessageService(
-        FakeAndroidMetadataService(),
+        FakeMetadataService(),
+        FakeSessionIdTracker(),
         FakeDeliveryService(),
         FakeUserService(),
         FakeConfigService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.comms.api.ApiUrlBuilder
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCallsSender
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeApiClient
 import io.embrace.android.embracesdk.fakes.FakeApiService
 import io.embrace.android.embracesdk.fakes.FakeApiUrlBuilder
@@ -22,21 +21,25 @@ import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePendingApiCallsSender
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.session.MemoryCleanerService
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 
 internal class FakeEssentialServiceModule(
     override val processStateService: ProcessStateService = FakeProcessStateService(),
     override val activityLifecycleTracker: ActivityTracker = FakeActivityTracker(),
-    override val metadataService: MetadataService = FakeAndroidMetadataService(),
+    override val metadataService: MetadataService = FakeMetadataService(),
+    override val sessionIdTracker: SessionIdTracker = FakeSessionIdTracker(),
     override val configService: ConfigService = FakeConfigService(),
     override val memoryCleanerService: MemoryCleanerService = FakeMemoryCleanerService(),
     override val gatingService: GatingService = FakeGatingService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -13,9 +13,9 @@ import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeStorageService
@@ -83,7 +83,7 @@ internal class EmbraceNdkServiceTest {
             mockkStatic(Embrace::class)
             context = mockContext()
             storageManager = FakeStorageService()
-            metadataService = FakeAndroidMetadataService()
+            metadataService = FakeMetadataService()
             localConfig = LocalConfig("", false, SdkLocalConfig())
             configService =
                 FakeConfigService(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -5,10 +5,11 @@ import io.embrace.android.embracesdk.config.local.BaseUrlLocalConfig
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.fakes.fakeSdkEndpointBehavior
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
@@ -28,7 +29,8 @@ internal class EmbraceNetworkCaptureServiceTest {
 
     companion object {
         private var cfg: RemoteConfig = RemoteConfig()
-        private val metadataService: FakeAndroidMetadataService = FakeAndroidMetadataService()
+        private val metadataService: FakeMetadataService = FakeMetadataService()
+        private val sessionIdTracker: FakeSessionIdTracker = FakeSessionIdTracker()
         private lateinit var logMessageService: FakeLogMessageService
         private val configService: FakeConfigService = FakeConfigService(
             networkBehavior = fakeNetworkBehavior { cfg },
@@ -68,7 +70,7 @@ internal class EmbraceNetworkCaptureServiceTest {
         clearAllMocks()
         preferenceService = FakePreferenceService()
         logMessageService = FakeLogMessageService()
-        metadataService.setActiveSessionId("session-123", true)
+        sessionIdTracker.setActiveSessionId("session-123", true)
     }
 
     @Test
@@ -220,6 +222,7 @@ internal class EmbraceNetworkCaptureServiceTest {
 
     private fun getService() = EmbraceNetworkCaptureService(
         metadataService,
+        sessionIdTracker,
         preferenceService,
         logMessageService,
         configService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -12,15 +12,16 @@ import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
@@ -48,6 +49,7 @@ internal class EmbraceBackgroundActivityServiceTest {
     private lateinit var clock: FakeClock
     private lateinit var performanceInfoService: FakePerformanceInfoService
     private lateinit var metadataService: MetadataService
+    private lateinit var sessionIdTracker: FakeSessionIdTracker
     private lateinit var breadcrumbService: FakeBreadcrumbService
     private lateinit var activityService: FakeProcessStateService
     private lateinit var eventService: EventService
@@ -66,7 +68,8 @@ internal class EmbraceBackgroundActivityServiceTest {
     fun init() {
         clock = FakeClock(10000L)
         performanceInfoService = FakePerformanceInfoService()
-        metadataService = FakeAndroidMetadataService()
+        metadataService = FakeMetadataService()
+        sessionIdTracker = FakeSessionIdTracker()
         breadcrumbService = FakeBreadcrumbService()
         activityService = FakeProcessStateService(isInBackground = true)
         eventService = FakeEventService()
@@ -103,7 +106,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         val payload = checkNotNull(service.backgroundActivity)
         assertEquals(Session.LifeEventType.BKGND_STATE, payload.startType)
         assertEquals(5, payload.number)
-        assertEquals(payload.sessionId, metadataService.activeSessionId)
+        assertEquals(payload.sessionId, sessionIdTracker.getActiveSessionId())
         assertFalse(payload.isColdStart)
     }
 
@@ -383,7 +386,7 @@ internal class EmbraceBackgroundActivityServiceTest {
             FakeStartupService()
         )
         return EmbraceBackgroundActivityService(
-            metadataService,
+            sessionIdTracker,
             deliveryService,
             configService,
             ndkService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -4,11 +4,11 @@ import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
@@ -136,7 +136,7 @@ internal class EmbraceSessionServiceTest {
             configService,
             FakeUserService(),
             FakeNetworkConnectivityService(),
-            FakeAndroidMetadataService(),
+            FakeSessionIdTracker(),
             FakeBreadcrumbService(),
             ndkService,
             deliveryService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -2,12 +2,12 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeStartupService
@@ -47,7 +47,7 @@ internal class PayloadMessageCollatorTest {
             logMessageService = FakeLogMessageService(),
             internalErrorService = FakeInternalErrorService().apply { currentExceptionError = ExceptionError() },
             breadcrumbService = FakeBreadcrumbService(),
-            metadataService = FakeAndroidMetadataService(),
+            metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),
             spansService = SpansService.Companion.featureDisabledSpansService,
             clock = FakeClock(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -17,16 +17,17 @@ import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
-import io.embrace.android.embracesdk.fakes.FakeAndroidMetadataService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.FakeUserService
@@ -110,7 +111,8 @@ internal class SessionHandlerTest {
     private var activeSession: Session = fakeSession()
 
     private lateinit var preferencesService: FakePreferenceService
-    private lateinit var metadataService: FakeAndroidMetadataService
+    private lateinit var sessionIdTracker: FakeSessionIdTracker
+    private lateinit var metadataService: FakeMetadataService
     private lateinit var localConfig: LocalConfig
     private lateinit var remoteConfig: RemoteConfig
     private lateinit var sessionLocalConfig: SessionLocalConfig
@@ -129,7 +131,8 @@ internal class SessionHandlerTest {
         activeSession = fakeSession()
         every { sessionProperties.get() } returns emptyMapSessionProperties
         ndkService = FakeNdkService()
-        metadataService = FakeAndroidMetadataService()
+        metadataService = FakeMetadataService()
+        sessionIdTracker = FakeSessionIdTracker()
         breadcrumbService = FakeBreadcrumbService()
         breadcrumbService.viewBreadcrumbScreenName = "screen"
         memoryCleanerService = FakeMemoryCleanerService()
@@ -181,7 +184,7 @@ internal class SessionHandlerTest {
             configService,
             userService,
             networkConnectivityService,
-            metadataService,
+            sessionIdTracker,
             breadcrumbService,
             ndkService,
             deliveryService,
@@ -215,7 +218,7 @@ internal class SessionHandlerTest {
         // verify record connection type
         verify { networkConnectivityService.networkStatusOnSessionStarted(now) }
         // verify active session is set
-        assertEquals(sessionUuid, metadataService.activeSessionId)
+        assertEquals(sessionUuid, sessionIdTracker.getActiveSessionId())
         // verify periodic caching worker has been scheduled
         verify {
             sessionPeriodicCacheExecutorService.scheduleWithFixedDelay(


### PR DESCRIPTION
## Goal

Extracts the tracking of session ID from the `MetadataService` to a separate class. This helps breakdown the monolithic `MetadataService` and is the first step in moving the session ID tracking to be controlled via `SessionOrchestrator`.

## Testing

Updated existing test coverage.
