### PR TITLE
Extract config service from session service

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -72,7 +72,6 @@ internal class SessionModuleImpl(
         }
         EmbraceSessionService(
             coreModule.logger,
-            essentialServiceModule.configService,
             essentialServiceModule.userService,
             essentialServiceModule.networkConnectivityService,
             essentialServiceModule.sessionIdTracker,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivitySer
 import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
-import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -21,7 +20,6 @@ import java.util.concurrent.TimeUnit
 
 internal class EmbraceSessionService(
     private val logger: InternalEmbraceLogger,
-    private val configService: ConfigService,
     private val userService: UserService,
     private val networkConnectivityService: NetworkConnectivityService,
     private val sessionIdTracker: SessionIdTracker,
@@ -105,20 +103,10 @@ internal class EmbraceSessionService(
     }
 
     override fun endSessionWithManual(clearUserInfo: Boolean) {
-        if (configService.sessionBehavior.isSessionControlEnabled()) {
-            return
-        }
-
-        // Ends active session.
         endSessionImpl(LifeEventType.MANUAL, clock.now(), clearUserInfo) ?: return
     }
 
     override fun startSessionWithManual() {
-        if (configService.sessionBehavior.isSessionControlEnabled()) {
-            return
-        }
-
-        // Starts a new session.
         startSession(
             InitialEnvelopeParams.SessionParams(
                 false,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -15,7 +15,7 @@ internal class SessionOrchestratorImpl(
     private val sessionService: SessionService,
     backgroundActivityServiceImpl: BackgroundActivityService?,
     clock: Clock,
-    configService: ConfigService,
+    private val configService: ConfigService,
     private val memoryCleanerService: MemoryCleanerService,
     private val internalErrorService: InternalErrorService,
     private val sessionProperties: EmbraceSessionProperties
@@ -56,6 +56,9 @@ internal class SessionOrchestratorImpl(
 
     override fun endSessionWithManual(clearUserInfo: Boolean) {
         if (processStateService.isInBackground) {
+            return
+        }
+        if (configService.sessionBehavior.isSessionControlEnabled()) {
             return
         }
         sessionService.endSessionWithManual(clearUserInfo)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -133,7 +133,6 @@ internal class EmbraceSessionServiceTest {
 
         service = EmbraceSessionService(
             InternalEmbraceLogger(),
-            configService,
             FakeUserService(),
             FakeNetworkConnectivityService(),
             FakeSessionIdTracker(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -181,7 +181,6 @@ internal class SessionHandlerTest {
         )
         sessionService = EmbraceSessionService(
             logger,
-            configService,
             userService,
             networkConnectivityService,
             sessionIdTracker,


### PR DESCRIPTION
## Goal

Moves the responsibility for checking a config flag from the session service to the `SessionOrchestrator`.

## Testing

Updated unit test coverage.

