### PR TITLE
Extract sending of cached sessions

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -623,6 +623,12 @@ final class EmbraceImpl {
         backgroundActivityService = sessionModule.getBackgroundActivityService();
         serviceRegistry.registerServices(sessionService, backgroundActivityService);
 
+        // Send any sessions that were cached and not yet sent.
+        deliveryModule.getDeliveryService().sendCachedSessions(
+            nativeModule.getNdkService(),
+            essentialServiceModule.getSessionIdTracker()
+        );
+
         CrashModule crashModule = new CrashModuleImpl(
             initModule,
             storageModule,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -6,10 +6,11 @@ import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.SessionSnapshotType
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 
 internal interface DeliveryService {
     fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
-    fun sendCachedSessions(ndkService: NdkService?, currentSession: String?)
+    fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker)
     fun saveBackgroundActivity(backgroundActivityMessage: SessionMessage)
     fun sendBackgroundActivity(backgroundActivityMessage: SessionMessage)
     fun sendBackgroundActivities()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.SessionSnapshotType
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.TaskPriority
 import java.util.concurrent.TimeUnit
@@ -143,10 +144,7 @@ internal class EmbraceDeliveryService(
         apiService.sendAEIBlob(blobMessage)
     }
 
-    override fun sendCachedSessions(
-        ndkService: NdkService?,
-        currentSession: String?
-    ) {
+    override fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker) {
         sendCachedCrash()
         backgroundWorker.submit(TaskPriority.HIGH) {
             val allSessions = cacheManager.getAllCachedSessionIds()
@@ -157,7 +155,7 @@ internal class EmbraceDeliveryService(
                     addCrashDataToCachedSession(nativeCrashData)
                 }
             }
-            sendCachedSessions(allSessions, currentSession)
+            sendCachedSessions(allSessions, sessionIdTracker.getActiveSessionId())
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -58,11 +58,6 @@ internal class EmbraceSessionService(
      */
     private val lock = Any()
 
-    init {
-        // Send any sessions that were cached and not yet sent.
-        deliveryService.sendCachedSessions(ndkService, getSessionId())
-    }
-
     override fun endSessionWithCrash(crashId: String) {
         synchronized(lock) {
             val session = activeSession ?: return

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.SessionSnapshotType
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 
 /**
  * A [DeliveryService] that records the last parameters used to invoke each method, and for the ones that need it, count the number of
@@ -39,8 +40,8 @@ internal class FakeDeliveryService : DeliveryService {
         lastSnapshotType = snapshotType
     }
 
-    override fun sendCachedSessions(ndkService: NdkService?, currentSession: String?) {
-        lastSentCachedSession = currentSession
+    override fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker) {
+        lastSentCachedSession = sessionIdTracker.getActiveSessionId()
     }
 
     override fun sendMoment(eventMessage: EventMessage) {


### PR DESCRIPTION
## Goal

Extracts the sending of cached sessions from `SessionService` into `EmbraceImpl` to avoid side-effects when initializing the session service. Longer-term it would be good to consolidate this in `DeliveryService` but for now there are circular dependencies (`DeliveryService` initialises before `NdkService` but needs `NdkService` to check files exist).

## Testing

Updated existing test coverage.

