### PR TITLE
Extract logic for restricting manual ending of sessions

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -1,6 +1,10 @@
 package io.embrace.android.embracesdk.session
 
+import io.embrace.android.embracesdk.payload.Session
+
 internal interface SessionService {
+
+    val activeSession: Session?
 
     /**
      * Starts a session in response to a state event.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk
 
+import io.embrace.android.embracesdk.fakes.fakeSession
+import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.SessionService
 
 internal class FakeSessionService : SessionService {
@@ -9,25 +11,32 @@ internal class FakeSessionService : SessionService {
     var manualEndCount = 0
     var manualStartCount = 0
 
+    override var activeSession: Session? = null
+
     override fun startSessionWithState(coldStart: Boolean, timestamp: Long) {
         startTimestamps.add(timestamp)
+        activeSession = fakeSession(startMs = timestamp)
     }
 
     override fun endSessionWithState(timestamp: Long) {
         endTimestamps.add(timestamp)
+        activeSession = null
     }
 
     var crashId: String? = null
 
     override fun endSessionWithCrash(crashId: String) {
         this.crashId = crashId
+        activeSession = null
     }
 
     override fun endSessionWithManual() {
         manualEndCount++
+        activeSession = null
     }
 
     override fun startSessionWithManual() {
         manualStartCount++
+        activeSession = fakeSession()
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -6,9 +6,10 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal fun fakeSession(
     sessionId: String = "fakeSessionId",
+    startMs: Long = 160000000000L,
 ): Session = Session(
     sessionId = sessionId,
-    startTime = 160000000000L,
+    startTime = startMs,
     number = 1,
     appState = APPLICATION_STATE_FOREGROUND,
     isColdStart = true,


### PR DESCRIPTION
## Goal

Extracts the logic for restricting manual ending of sessions to the `SessionOrchestrator`. We restrict this so that sessions must be >5s to avoid poor instrumentation accidentally sending too many sessions.

## Testing

Added unit test coverage.

