### PR TITLE
Hide internal functions in SessionService

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -95,7 +95,7 @@ internal class EmbraceSessionService(
     /**
      * It performs all corresponding operations in order to start a session.
      */
-    internal fun startSession(params: InitialEnvelopeParams.SessionParams) {
+    private fun startSession(params: InitialEnvelopeParams.SessionParams) {
         synchronized(lock) {
             logger.logDebug(
                 "SessionHandler: running onSessionStarted. coldStart=${params.coldStart}," +
@@ -122,7 +122,7 @@ internal class EmbraceSessionService(
     /**
      * It performs all corresponding operations in order to end a session.
      */
-    internal fun endSessionImpl(
+    private fun endSessionImpl(
         endType: LifeEventType,
         endTime: Long
     ): SessionMessage? {
@@ -165,7 +165,7 @@ internal class EmbraceSessionService(
      *
      * Note that the session message will not be sent to our servers.
      */
-    internal fun onPeriodicCacheActiveSessionImpl(): SessionMessage? {
+    private fun onPeriodicCacheActiveSessionImpl(): SessionMessage? {
         synchronized(lock) {
             val session = activeSession ?: return null
             logger.logDeveloper("SessionHandler", "Running periodic cache of active session.")


### PR DESCRIPTION
## Goal

Makes some internal functions private by altering the unit tests so they check the end result, rather than the internal implementation.

