### PR TITLE
Avoid creating useless background activity

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -75,13 +75,6 @@ internal class EmbraceBackgroundActivityService(
             )
         )
         deliveryService.saveBackgroundActivity(message)
-        startCapture(
-            InitialEnvelopeParams.BackgroundActivityParams(
-                false,
-                LifeEventType.BKGND_STATE,
-                clock.now()
-            )
-        )
     }
 
     /**


### PR DESCRIPTION
## Goal

Avoids creating a new background activity _after_ a crash has happened, as no useful information will be captured or persisted.
