### PR TITLE
Track session ID in SessionOrchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -86,7 +86,6 @@ internal class SessionModuleImpl(
         EmbraceSessionService(
             coreModule.logger,
             essentialServiceModule.networkConnectivityService,
-            essentialServiceModule.sessionIdTracker,
             dataCaptureServiceModule.breadcrumbService,
             deliveryModule.deliveryService,
             payloadMessageCollator,
@@ -97,7 +96,6 @@ internal class SessionModuleImpl(
 
     override val backgroundActivityService: BackgroundActivityService? by singleton {
         EmbraceBackgroundActivityService(
-            essentialServiceModule.sessionIdTracker,
             deliveryModule.deliveryService,
             initModule.clock,
             payloadMessageCollator,
@@ -122,6 +120,7 @@ internal class SessionModuleImpl(
             backgroundActivityService,
             initModule.clock,
             essentialServiceModule.configService,
+            essentialServiceModule.sessionIdTracker,
             boundaryDelegate
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
@@ -6,22 +6,22 @@ package io.embrace.android.embracesdk.session
 internal interface BackgroundActivityService {
 
     /**
+     * Ends a background activity in response to a state event.
+     */
+    fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long): String
+
+    /**
      * Handles an uncaught exception, ending the session and saving the activity to disk.
      */
     fun endBackgroundActivityWithCrash(crashId: String)
 
     /**
-     * Save the current background activity to disk
-     */
-    fun save()
-
-    /**
-     * Ends a background activity in response to a state event.
-     */
-    fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long)
-
-    /**
      * Starts a background activity in response to a state event.
      */
     fun endBackgroundActivityWithState(timestamp: Long)
+
+    /**
+     * Save the current background activity to disk
+     */
+    fun save()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -9,7 +9,12 @@ internal interface SessionService {
     /**
      * Starts a session in response to a state event.
      */
-    fun startSessionWithState(coldStart: Boolean, timestamp: Long)
+    fun startSessionWithState(coldStart: Boolean, timestamp: Long): String
+
+    /**
+     * Starts a session manually.
+     */
+    fun startSessionWithManual(): String
 
     /**
      * Ends a session in response to a state event.
@@ -17,17 +22,12 @@ internal interface SessionService {
     fun endSessionWithState(timestamp: Long)
 
     /**
-     * Handles an uncaught exception, ending the session and saving the session to disk.
-     */
-    fun endSessionWithCrash(crashId: String)
-
-    /**
-     * Starts a session manually.
-     */
-    fun startSessionWithManual()
-
-    /**
      * Ends a session manually.
      */
     fun endSessionWithManual()
+
+    /**
+     * Handles an uncaught exception, ending the session and saving the session to disk.
+     */
+    fun endSessionWithCrash(crashId: String)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -13,9 +13,16 @@ internal class FakeSessionService : SessionService {
 
     override var activeSession: Session? = null
 
-    override fun startSessionWithState(coldStart: Boolean, timestamp: Long) {
+    override fun startSessionWithState(coldStart: Boolean, timestamp: Long): String {
         startTimestamps.add(timestamp)
         activeSession = fakeSession(startMs = timestamp)
+        return activeSession?.sessionId ?: ""
+    }
+
+    override fun startSessionWithManual(): String {
+        manualStartCount++
+        activeSession = fakeSession()
+        return activeSession?.sessionId ?: ""
     }
 
     override fun endSessionWithState(timestamp: Long) {
@@ -33,10 +40,5 @@ internal class FakeSessionService : SessionService {
     override fun endSessionWithManual() {
         manualEndCount++
         activeSession = null
-    }
-
-    override fun startSessionWithManual() {
-        manualStartCount++
-        activeSession = fakeSession()
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -7,8 +7,9 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
     val endTimestamps = mutableListOf<Long>()
     val startTimestamps = mutableListOf<Long>()
 
-    override fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long) {
+    override fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long): String {
         startTimestamps.add(timestamp)
+        return "fakeBackgroundActivityId"
     }
 
     override fun endBackgroundActivityWithState(timestamp: Long) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -104,7 +104,6 @@ internal class EmbraceBackgroundActivityServiceTest {
         val payload = checkNotNull(service.backgroundActivity)
         assertEquals(Session.LifeEventType.BKGND_STATE, payload.startType)
         assertEquals(5, payload.number)
-        assertEquals(payload.sessionId, sessionIdTracker.getActiveSessionId())
         assertFalse(payload.isColdStart)
     }
 
@@ -367,7 +366,6 @@ internal class EmbraceBackgroundActivityServiceTest {
             FakeStartupService()
         )
         return EmbraceBackgroundActivityService(
-            sessionIdTracker,
             deliveryService,
             clock,
             collator,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
-import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
@@ -130,7 +129,6 @@ internal class EmbraceSessionServiceTest {
         service = EmbraceSessionService(
             InternalEmbraceLogger(),
             FakeNetworkConnectivityService(),
-            FakeSessionIdTracker(),
             FakeBreadcrumbService(),
             deliveryService,
             mockk(relaxed = true),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -180,7 +180,6 @@ internal class SessionHandlerTest {
         sessionService = EmbraceSessionService(
             logger,
             networkConnectivityService,
-            sessionIdTracker,
             breadcrumbService,
             deliveryService,
             payloadMessageCollator,
@@ -206,8 +205,6 @@ internal class SessionHandlerTest {
 
         // verify record connection type
         verify { networkConnectivityService.networkStatusOnSessionStarted(now) }
-        // verify active session is set
-        assertEquals(sessionUuid, sessionIdTracker.getActiveSessionId())
         // verify periodic caching worker has been scheduled
         assertEquals(1, executorService.submitCount)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
@@ -36,6 +37,7 @@ internal class SessionOrchestratorTest {
     private lateinit var userService: FakeUserService
     private lateinit var ndkService: FakeNdkService
     private lateinit var sessionProperties: EmbraceSessionProperties
+    private lateinit var sessionIdTracker: FakeSessionIdTracker
 
     @Before
     fun setUp() {
@@ -49,12 +51,14 @@ internal class SessionOrchestratorTest {
         sessionProperties = fakeEmbraceSessionProperties()
         userService = FakeUserService()
         ndkService = FakeNdkService()
+        sessionIdTracker = FakeSessionIdTracker()
         orchestrator = SessionOrchestratorImpl(
             processStateService,
             sessionService,
             backgroundActivityService,
             clock,
             configService,
+            sessionIdTracker,
             OrchestratorBoundaryDelegate(
                 memoryCleanerService,
                 userService,
@@ -73,6 +77,7 @@ internal class SessionOrchestratorTest {
         assertEquals(orchestrator, processStateService.listeners.single())
         assertEquals(0, sessionService.startTimestamps.size)
         assertEquals(1, backgroundActivityService.startTimestamps.size)
+        assertEquals("fakeBackgroundActivityId", sessionIdTracker.sessionId)
     }
 
     @Test
@@ -81,6 +86,7 @@ internal class SessionOrchestratorTest {
         assertEquals(orchestrator, processStateService.listeners.single())
         assertEquals(1, sessionService.startTimestamps.size)
         assertEquals(0, backgroundActivityService.startTimestamps.size)
+        assertEquals("fakeSessionId", sessionIdTracker.sessionId)
     }
 
     @Test
@@ -90,6 +96,7 @@ internal class SessionOrchestratorTest {
         verifyPrepareEnvelopeCalled()
         assertEquals(TIMESTAMP, sessionService.startTimestamps.single())
         assertEquals(TIMESTAMP, backgroundActivityService.endTimestamps.single())
+        assertEquals("fakeSessionId", sessionIdTracker.sessionId)
     }
 
     @Test
@@ -98,6 +105,7 @@ internal class SessionOrchestratorTest {
         verifyPrepareEnvelopeCalled()
         assertEquals(TIMESTAMP, sessionService.endTimestamps.single())
         assertEquals(TIMESTAMP, backgroundActivityService.startTimestamps.single())
+        assertEquals("fakeBackgroundActivityId", sessionIdTracker.sessionId)
     }
 
     @Test
@@ -107,6 +115,7 @@ internal class SessionOrchestratorTest {
         verifyPrepareEnvelopeCalled()
         assertEquals(1, sessionService.manualEndCount)
         assertEquals(1, sessionService.manualStartCount)
+        assertEquals("fakeSessionId", sessionIdTracker.sessionId)
     }
 
     @Test
@@ -214,6 +223,7 @@ internal class SessionOrchestratorTest {
             backgroundActivityService,
             clock,
             configService,
+            sessionIdTracker,
             OrchestratorBoundaryDelegate(
                 memoryCleanerService,
                 userService,


### PR DESCRIPTION
## Goal

Tracks the session ID in `SessionOrchestrator` rather than the individual session/BA services.
