### PR TITLE
Make session orchestrator responsible for crashes

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
@@ -20,9 +20,8 @@ import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.payload.extensions.CrashFactory
 import io.embrace.android.embracesdk.prefs.PreferencesService
-import io.embrace.android.embracesdk.session.BackgroundActivityService
-import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 /**
@@ -30,7 +29,7 @@ import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
  */
 internal class EmbraceCrashService(
     configService: ConfigService,
-    private val sessionService: SessionService,
+    private val sessionOrchestrator: SessionOrchestrator,
     private val sessionPropertiesService: SessionPropertiesService,
     private val metadataService: MetadataService,
     private val sessionIdTracker: SessionIdTracker,
@@ -40,7 +39,6 @@ internal class EmbraceCrashService(
     private val anrService: AnrService?,
     private val ndkService: NdkService,
     private val gatingService: GatingService,
-    private val backgroundActivityService: BackgroundActivityService?,
     private val preferencesService: PreferencesService,
     private val crashMarker: CrashFileMarker,
     private val clock: Clock
@@ -136,8 +134,7 @@ internal class EmbraceCrashService(
             deliveryService.sendCrash(crashEvent, true)
 
             // End, cache and send the session
-            sessionService.endSessionWithCrash(crash.crashId)
-            backgroundActivityService?.endBackgroundActivityWithCrash(crash.crashId)
+            sessionOrchestrator.endSessionWithCrash(crash.crashId)
 
             // Indicate that a crash happened so we can know that in the next launch
             crashMarker.mark()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
@@ -42,7 +42,7 @@ internal class CrashModuleImpl(
     override val crashService: CrashService by singleton {
         EmbraceCrashService(
             essentialServiceModule.configService,
-            sessionModule.sessionService,
+            sessionModule.sessionOrchestrator,
             sessionModule.sessionPropertiesService,
             essentialServiceModule.metadataService,
             essentialServiceModule.sessionIdTracker,
@@ -52,7 +52,6 @@ internal class CrashModuleImpl(
             anrModule.anrService,
             nativeModule.ndkService,
             essentialServiceModule.gatingService,
-            sessionModule.backgroundActivityService,
             androidServicesModule.preferencesService,
             crashMarker,
             initModule.clock

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestrator.kt
@@ -13,4 +13,9 @@ internal interface SessionOrchestrator : ProcessStateListener {
      * the user info will be cleared. This has no effect on background activities.
      */
     fun endSessionWithManual(clearUserInfo: Boolean)
+
+    /**
+     * Handles an uncaught exception, ending the active session and saving it to disk.
+     */
+    fun endSessionWithCrash(crashId: String)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -85,4 +85,9 @@ internal class SessionOrchestratorImpl(
         val sessionId = sessionService.startSessionWithManual()
         sessionIdTracker.setActiveSessionId(sessionId, true)
     }
+
+    override fun endSessionWithCrash(crashId: String) {
+        sessionService.endSessionWithCrash(crashId)
+        backgroundActivityService?.endBackgroundActivityWithCrash(crashId)
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
@@ -39,7 +40,7 @@ import org.junit.Test
 internal class EmbraceCrashServiceTest {
 
     private lateinit var embraceCrashService: EmbraceCrashService
-    private lateinit var sessionService: FakeSessionService
+    private lateinit var sessionOrchestrator: FakeSessionOrchestrator
     private lateinit var sessionPropertiesService: SessionPropertiesService
     private lateinit var metadataService: FakeMetadataService
     private lateinit var sessionIdTracker: FakeSessionIdTracker
@@ -62,7 +63,7 @@ internal class EmbraceCrashServiceTest {
         mockkStatic(Crash::class)
         mockkObject(CrashFactory)
 
-        sessionService = FakeSessionService()
+        sessionOrchestrator = FakeSessionOrchestrator()
         sessionPropertiesService = FakeSessionPropertiesService()
         metadataService = FakeMetadataService()
         sessionIdTracker = FakeSessionIdTracker()
@@ -95,7 +96,7 @@ internal class EmbraceCrashServiceTest {
 
         embraceCrashService = EmbraceCrashService(
             configService,
-            sessionService,
+            sessionOrchestrator,
             sessionPropertiesService,
             metadataService,
             sessionIdTracker,
@@ -105,7 +106,6 @@ internal class EmbraceCrashServiceTest {
             anrService,
             ndkService,
             gatingService,
-            null,
             preferencesService,
             crashMarker,
             fakeClock
@@ -124,7 +124,7 @@ internal class EmbraceCrashServiceTest {
         assertEquals(1, anrService.forceAnrTrackingStopOnCrashCount)
         val lastSentCrash = deliveryService.lastSentCrash
         assertNotNull(lastSentCrash)
-        assertEquals(crash.crashId, sessionService.crashId)
+        assertEquals(crash.crashId, sessionOrchestrator.crashId)
 
         /*
         * Verify mainCrashHandled is true after the first execution
@@ -134,7 +134,7 @@ internal class EmbraceCrashServiceTest {
         assertEquals(1, anrService.forceAnrTrackingStopOnCrashCount)
         assertNotNull(deliveryService.lastSentCrash)
         assertSame(lastSentCrash, deliveryService.lastSentCrash)
-        assertEquals(crash.crashId, sessionService.crashId)
+        assertEquals(crash.crashId, sessionOrchestrator.crashId)
     }
 
     @Test
@@ -148,7 +148,7 @@ internal class EmbraceCrashServiceTest {
         verify { CrashFactory.ofThrowable(testException, localJsException, 1, "Unity123") }
         assertEquals(1, anrService.forceAnrTrackingStopOnCrashCount)
         assertNotNull(deliveryService.lastSentCrash)
-        assertEquals(crash.crashId, sessionService.crashId)
+        assertEquals(crash.crashId, sessionOrchestrator.crashId)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -6,6 +6,7 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
 
     val endTimestamps = mutableListOf<Long>()
     val startTimestamps = mutableListOf<Long>()
+    var crashId: String? = null
 
     override fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long): String {
         startTimestamps.add(timestamp)
@@ -17,6 +18,7 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
     }
 
     override fun endBackgroundActivityWithCrash(crashId: String) {
+        this.crashId = crashId
     }
 
     override fun save() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
@@ -4,9 +4,14 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 
 internal class FakeSessionOrchestrator : SessionOrchestrator {
 
+    var crashId: String? = null
     var manualEndCount = 0
 
     override fun endSessionWithManual(clearUserInfo: Boolean) {
         manualEndCount++
+    }
+
+    override fun endSessionWithCrash(crashId: String) {
+        this.crashId = crashId
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -2,24 +2,23 @@ package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.FakeSessionService
+import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.injection.SessionModule
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.PayloadMessageCollator
 import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
-import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestratorImpl
+import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 internal class FakeSessionModule(
     override val backgroundActivityService: BackgroundActivityService? = null,
     override val sessionService: SessionService = FakeSessionService(),
-    override val sessionPropertiesService: SessionPropertiesService = FakeSessionPropertiesService()
+    override val sessionPropertiesService: SessionPropertiesService = FakeSessionPropertiesService(),
+    override val sessionOrchestrator: SessionOrchestrator = FakeSessionOrchestrator()
 ) : SessionModule {
 
     override val payloadMessageCollator: PayloadMessageCollator
-        get() = TODO("Not yet implemented")
-
-    override val sessionOrchestrator: SessionOrchestratorImpl
         get() = TODO("Not yet implemented")
 
     override val periodicSessionCacher: PeriodicSessionCacher

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -203,6 +203,22 @@ internal class SessionOrchestratorTest {
         assertEquals(0, sessionService.manualEndCount)
     }
 
+    @Test
+    fun `end with crash in background`() {
+        configService = FakeConfigService(backgroundActivityCaptureEnabled = true)
+        createOrchestrator(true)
+        orchestrator.endSessionWithCrash("crashId")
+        assertEquals("crashId", backgroundActivityService.crashId)
+    }
+
+    @Test
+    fun `end with crash in foreground`() {
+        configService = FakeConfigService(backgroundActivityCaptureEnabled = true)
+        createOrchestrator(false)
+        orchestrator.endSessionWithCrash("crashId")
+        assertEquals("crashId", sessionService.crashId)
+    }
+
     private fun verifyPrepareEnvelopeCalled(expectedCount: Int = 1) {
         assertEquals(expectedCount, memoryCleanerService.callCount)
         val expectedPropCount = when (expectedCount) {


### PR DESCRIPTION
## Goal

Alters the `CrashService` so it calls into the `SessionOrchestrator` rather than individual services.

## Testing

Updated unit tests.

