### PR TITLE
Extract state synchronisation to session orchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -82,6 +82,8 @@ internal class SessionModuleImpl(
         )
     }
 
+    private val orchestrationLock = Any()
+
     override val sessionService: SessionService by singleton {
         EmbraceSessionService(
             coreModule.logger,
@@ -90,7 +92,8 @@ internal class SessionModuleImpl(
             deliveryModule.deliveryService,
             payloadMessageCollator,
             initModule.clock,
-            periodicSessionCacher
+            periodicSessionCacher,
+            orchestrationLock
         )
     }
 
@@ -99,7 +102,8 @@ internal class SessionModuleImpl(
             deliveryModule.deliveryService,
             initModule.clock,
             payloadMessageCollator,
-            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
+            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE),
+            orchestrationLock
         )
     }
 
@@ -121,6 +125,7 @@ internal class SessionModuleImpl(
             initModule.clock,
             essentialServiceModule.configService,
             essentialServiceModule.sessionIdTracker,
+            orchestrationLock,
             boundaryDelegate
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -369,7 +369,8 @@ internal class EmbraceBackgroundActivityServiceTest {
             deliveryService,
             clock,
             collator,
-            ScheduledWorker(blockingExecutorService)
+            ScheduledWorker(blockingExecutorService),
+            Any()
         ).apply {
             if (createInitialSession) {
                 startBackgroundActivityWithState(true, clock.now())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -133,7 +133,8 @@ internal class EmbraceSessionServiceTest {
             deliveryService,
             mockk(relaxed = true),
             FakeClock(),
-            PeriodicSessionCacher(FakeClock(), ScheduledWorker(BlockingScheduledExecutorService()))
+            PeriodicSessionCacher(FakeClock(), ScheduledWorker(BlockingScheduledExecutorService())),
+            Any()
         )
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -184,7 +184,8 @@ internal class SessionHandlerTest {
             deliveryService,
             payloadMessageCollator,
             clock,
-            PeriodicSessionCacher(FakeClock(), scheduledWorker)
+            PeriodicSessionCacher(FakeClock(), scheduledWorker),
+            Any()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -59,6 +59,7 @@ internal class SessionOrchestratorTest {
             clock,
             configService,
             sessionIdTracker,
+            Any(),
             OrchestratorBoundaryDelegate(
                 memoryCleanerService,
                 userService,
@@ -240,6 +241,7 @@ internal class SessionOrchestratorTest {
             clock,
             configService,
             sessionIdTracker,
+            Any(),
             OrchestratorBoundaryDelegate(
                 memoryCleanerService,
                 userService,


### PR DESCRIPTION
## Goal

Moves most of the existing state synchronisation to the `SessionOrchestrator`. This adds synchronisation for the background activity capture & moves it for the session capture. There are two instances that can't be migrated out of the session/BA services yet (both to do with periodic caching) so I've chosen to pass a lock as a parameter instead. As periodic session caching will eventually be removed this should be possible to simplify in future.

## Testing

Relied on existing testing.
