### PR TITLE
Fix test that is potentially flakey because spans wasn't enabled in time

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -184,7 +184,6 @@ internal class TracingApiTest {
     private fun getSdkInitSpanFromBackgroundActivity(): List<EmbraceSpanData> {
         val sentBackgroundActivities = testRule.harness.fakeDeliveryModule.deliveryService.lastSentBackgroundActivities
         val lastSentBackgroundActivity = sentBackgroundActivities.last()
-        val spans = checkNotNull(lastSentBackgroundActivity.spans)
-        return spans.filter { it.name == "emb-sdk-init" }
+        return lastSentBackgroundActivity.spans?.filter { it.name == "emb-sdk-init" } ?: emptyList()
     }
 }


### PR DESCRIPTION
## Goal

The spans attribute is sometimes null which indicates that the spans feature wasn't enabled in time for the background activity to pick it up. Modified this to assume that can happen.