### PR TITLE
Reduce default CI timeout

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   gradle-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         jdk-version: ["11"]

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   test:
     runs-on: macos-latest
+    timeout-minutes: 45
     strategy:
       matrix:
         jdk-version: ["11"]

--- a/.github/workflows/generate_baseline_profile.yml
+++ b/.github/workflows/generate_baseline_profile.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: macos-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         jdk-version: [ "11" ]

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   release:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -24,6 +24,7 @@ jobs:
     name: Publish SDK to Maven Internal
     needs: [functional, baseline-profile]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         jdk-version: ["11"]

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         jdk-version: ["11"]


### PR DESCRIPTION
## Goal

The default timeout on CI jobs in [Github actions is 6 hours](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes). I've reduced this to 1 hour or 30 minutes depending on how long the job is reasonably expected to take. This should make it quicker to detect when a CI job has hanged indefinitely.
