### PR TITLE
Move responsibility for clearing session to delegate

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -87,8 +87,6 @@ internal class SessionModuleImpl(
     override val sessionService: SessionService by singleton {
         EmbraceSessionService(
             coreModule.logger,
-            essentialServiceModule.networkConnectivityService,
-            dataCaptureServiceModule.breadcrumbService,
             deliveryModule.deliveryService,
             payloadMessageCollator,
             initModule.clock,
@@ -113,7 +111,9 @@ internal class SessionModuleImpl(
             essentialServiceModule.userService,
             ndkService,
             sessionProperties,
-            sdkObservabilityModule.internalErrorService
+            sdkObservabilityModule.internalErrorService,
+            essentialServiceModule.networkConnectivityService,
+            dataCaptureServiceModule.breadcrumbService,
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
@@ -8,12 +8,12 @@ internal interface BackgroundActivityService {
     /**
      * Ends a background activity in response to a state event.
      */
-    fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long): String
+    fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): String
 
     /**
      * Handles an uncaught exception, ending the session and saving the activity to disk.
      */
-    fun endBackgroundActivityWithCrash(crashId: String)
+    fun endBackgroundActivityWithCrash(timestamp: Long, crashId: String)
 
     /**
      * Starts a background activity in response to a state event.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -31,7 +31,7 @@ internal class EmbraceBackgroundActivityService(
     @Volatile
     var backgroundActivity: Session? = null
 
-    override fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long): String {
+    override fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): String {
         // kept for backwards compat. the backend expects the start time to be 1 ms greater
         // than the adjacent session, and manually adjusts.
         val time = when {
@@ -62,13 +62,12 @@ internal class EmbraceBackgroundActivityService(
         deliveryService.sendBackgroundActivities()
     }
 
-    override fun endBackgroundActivityWithCrash(crashId: String) {
+    override fun endBackgroundActivityWithCrash(timestamp: Long, crashId: String) {
         val activity = backgroundActivity ?: return
-        val now = clock.now()
         val message = stopCapture(
             FinalEnvelopeParams.BackgroundActivityParams(
                 initial = activity,
-                endTime = now,
+                endTime = timestamp,
                 lifeEventType = LifeEventType.BKGND_STATE,
                 crashId = crashId
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -9,12 +9,12 @@ internal interface SessionService {
     /**
      * Starts a session in response to a state event.
      */
-    fun startSessionWithState(coldStart: Boolean, timestamp: Long): String
+    fun startSessionWithState(timestamp: Long, coldStart: Boolean): String
 
     /**
      * Starts a session manually.
      */
-    fun startSessionWithManual(): String
+    fun startSessionWithManual(timestamp: Long): String
 
     /**
      * Ends a session in response to a state event.
@@ -24,10 +24,10 @@ internal interface SessionService {
     /**
      * Ends a session manually.
      */
-    fun endSessionWithManual()
+    fun endSessionWithManual(timestamp: Long)
 
     /**
      * Handles an uncaught exception, ending the session and saving the session to disk.
      */
-    fun endSessionWithCrash(crashId: String)
+    fun endSessionWithCrash(timestamp: Long, crashId: String)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegate.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.session.orchestrator
 
+import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
+import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.ndk.NdkService
@@ -19,14 +21,16 @@ internal class OrchestratorBoundaryDelegate(
     private val userService: UserService,
     private val ndkService: NdkService?,
     private val sessionProperties: EmbraceSessionProperties,
-    private val internalErrorService: InternalErrorService
+    private val internalErrorService: InternalErrorService,
+    private val networkConnectivityService: NetworkConnectivityService,
+    private val breadcrumbService: BreadcrumbService
 ) {
 
     /**
      * Prepares all services/state for a new envelope. Practically this involves
      * resetting collections in services etc.
      */
-    fun prepareForNewEnvelope(clearUserInfo: Boolean = false) {
+    fun prepareForNewEnvelope(startTime: Long, clearUserInfo: Boolean = false) {
         memoryCleanerService.cleanServicesCollections(internalErrorService)
         sessionProperties.clearTemporary()
 
@@ -34,5 +38,9 @@ internal class OrchestratorBoundaryDelegate(
             userService.clearAllUserInfo()
             ndkService?.onUserInfoUpdate()
         }
+
+        // Record the connection type at the start of the session.
+        networkConnectivityService.networkStatusOnSessionStarted(startTime)
+        breadcrumbService.addFirstViewBreadcrumbForSession(startTime)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -13,13 +13,13 @@ internal class FakeSessionService : SessionService {
 
     override var activeSession: Session? = null
 
-    override fun startSessionWithState(coldStart: Boolean, timestamp: Long): String {
+    override fun startSessionWithState(timestamp: Long, coldStart: Boolean): String {
         startTimestamps.add(timestamp)
         activeSession = fakeSession(startMs = timestamp)
         return activeSession?.sessionId ?: ""
     }
 
-    override fun startSessionWithManual(): String {
+    override fun startSessionWithManual(timestamp: Long): String {
         manualStartCount++
         activeSession = fakeSession()
         return activeSession?.sessionId ?: ""
@@ -32,12 +32,12 @@ internal class FakeSessionService : SessionService {
 
     var crashId: String? = null
 
-    override fun endSessionWithCrash(crashId: String) {
+    override fun endSessionWithCrash(timestamp: Long, crashId: String) {
         this.crashId = crashId
         activeSession = null
     }
 
-    override fun endSessionWithManual() {
+    override fun endSessionWithManual(timestamp: Long) {
         manualEndCount++
         activeSession = null
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -8,7 +8,7 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
     val startTimestamps = mutableListOf<Long>()
     var crashId: String? = null
 
-    override fun startBackgroundActivityWithState(coldStart: Boolean, timestamp: Long): String {
+    override fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): String {
         startTimestamps.add(timestamp)
         return "fakeBackgroundActivityId"
     }
@@ -17,7 +17,7 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
         endTimestamps.add(timestamp)
     }
 
-    override fun endBackgroundActivityWithCrash(crashId: String) {
+    override fun endBackgroundActivityWithCrash(timestamp: Long, crashId: String) {
         this.crashId = crashId
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
@@ -17,8 +17,11 @@ internal class FakeNetworkConnectivityService(
             notifyListeners()
         }
 
+    public var networkStatusOnSessionStartedCount = 0
+
     override fun networkStatusOnSessionStarted(startTime: Long) {
         notifyListeners()
+        networkStatusOnSessionStartedCount += 1
     }
 
     override fun addNetworkConnectivityListener(listener: NetworkConnectivityListener) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -99,7 +99,7 @@ internal class EmbraceBackgroundActivityServiceTest {
     fun `test background activity state when going to the background`() {
         this.service = createService()
 
-        service.startBackgroundActivityWithState(false, clock.now())
+        service.startBackgroundActivityWithState(clock.now(), false)
 
         val payload = checkNotNull(service.backgroundActivity)
         assertEquals(Session.LifeEventType.BKGND_STATE, payload.startType)
@@ -150,7 +150,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         assertEquals(2, deliveryService.saveBackgroundActivityInvokedCount)
 
         clock.setCurrentTime(startTime + 5000)
-        service.startBackgroundActivityWithState(false, startTime + 5000)
+        service.startBackgroundActivityWithState(startTime + 5000, false)
         assertEquals(3, deliveryService.saveBackgroundActivityInvokedCount)
     }
 
@@ -171,7 +171,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         // tick 4999 milliseconds, the activity should not be cached yet
         clock.tick(4999)
         blockingExecutorService.runCurrentlyBlocked()
-        service.startBackgroundActivityWithState(false, clock.now())
+        service.startBackgroundActivityWithState(clock.now(), false)
         assertEquals(2, deliveryService.saveBackgroundActivityInvokedCount)
 
         // tick an extra millisecond, the delayed job should execute
@@ -187,7 +187,7 @@ internal class EmbraceBackgroundActivityServiceTest {
 
         assertNull(deliveryService.lastSavedBackgroundActivities.singleOrNull())
 
-        service.startBackgroundActivityWithState(false, clock.now())
+        service.startBackgroundActivityWithState(clock.now(), false)
 
         assertNotNull(deliveryService.lastSavedBackgroundActivities.single())
     }
@@ -202,7 +202,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         assertEquals(0, deliveryService.saveBackgroundActivityInvokedCount)
 
         // start capturing background activity 10 seconds later, activity is first cached
-        service.startBackgroundActivityWithState(false, startTime + 10 * 1000)
+        service.startBackgroundActivityWithState(startTime + 10 * 1000, false)
         assertEquals(1, deliveryService.saveBackgroundActivityInvokedCount)
 
         // elapse another 10 seconds to get around the 5 seconds limitation
@@ -219,7 +219,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         this.service = createService(false)
         assertEquals(0, deliveryService.saveBackgroundActivityInvokedCount)
 
-        service.startBackgroundActivityWithState(false, clock.now())
+        service.startBackgroundActivityWithState(clock.now(), false)
         assertEquals(1, deliveryService.saveBackgroundActivityInvokedCount)
 
         // save() will not persist to disk since the last time was less than 5 seconds ago
@@ -255,7 +255,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         service = createService()
         val now = TimeUnit.MILLISECONDS.toNanos(clock.now())
         spansService.initializeService(now)
-        service.endBackgroundActivityWithCrash("crashId")
+        service.endBackgroundActivityWithCrash(now, "crashId")
         assertNotNull(deliveryService.lastSavedBackgroundActivities.single())
 
         // there should be 1 completed span: the session span
@@ -320,7 +320,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         assertEquals(0, deliveryService.lastSentBackgroundActivities.size)
 
         // next BA is recorded correctly
-        service.startBackgroundActivityWithState(false, clock.now())
+        service.startBackgroundActivityWithState(clock.now(), false)
         clock.tick(1000L)
         service.endBackgroundActivityWithState(clock.now())
         assertEquals(2, deliveryService.lastSavedBackgroundActivities.size)
@@ -331,7 +331,7 @@ internal class EmbraceBackgroundActivityServiceTest {
     fun `background activity capture disabled after onBackground`() {
         service = createService(createInitialSession = false)
 
-        service.startBackgroundActivityWithState(true, clock.now())
+        service.startBackgroundActivityWithState(clock.now(), true)
         clock.tick(1000L)
 
         // missing end call simulates service being enabled halfway through.
@@ -339,7 +339,7 @@ internal class EmbraceBackgroundActivityServiceTest {
         assertEquals(0, deliveryService.lastSentBackgroundActivities.size)
 
         // next BA is recorded correctly
-        service.startBackgroundActivityWithState(false, clock.now())
+        service.startBackgroundActivityWithState(clock.now(), false)
         clock.tick(1000L)
         service.endBackgroundActivityWithState(clock.now())
         assertEquals(2, deliveryService.lastSavedBackgroundActivities.size)
@@ -373,7 +373,7 @@ internal class EmbraceBackgroundActivityServiceTest {
             Any()
         ).apply {
             if (createInitialSession) {
-                startBackgroundActivityWithState(true, clock.now())
+                startBackgroundActivityWithState(clock.now(), true)
             }
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -1,11 +1,9 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
@@ -77,7 +75,7 @@ internal class EmbraceSessionServiceTest {
         initializeSessionService()
         val coldStart = true
 
-        service.startSessionWithState(coldStart, 456)
+        service.startSessionWithState(456, coldStart)
         assertNull(deliveryService.lastSentCachedSession)
     }
 
@@ -98,7 +96,7 @@ internal class EmbraceSessionServiceTest {
         assertEquals(0, deliveryService.lastSentSessions.size)
 
         // next session is recorded correctly
-        service.startSessionWithState(false, clock.now())
+        service.startSessionWithState(clock.now(), false)
         clock.tick(10000L)
         service.endSessionWithState(clock.now())
         assertEquals(1, deliveryService.lastSentSessions.size)
@@ -108,14 +106,14 @@ internal class EmbraceSessionServiceTest {
     fun `session capture disabled after onForeground`() {
         initializeSessionService()
 
-        service.startSessionWithState(true, clock.now())
+        service.startSessionWithState(clock.now(), true)
         clock.tick(10000)
         // missing end call simulates service being disabled halfway through.
 
         // nothing is delivered
         assertEquals(0, deliveryService.lastSentSessions.size)
 
-        service.startSessionWithState(false, clock.now())
+        service.startSessionWithState(clock.now(), false)
         clock.tick(10000L)
         service.endSessionWithState(clock.now())
         assertEquals(1, deliveryService.lastSentSessions.size)
@@ -128,8 +126,6 @@ internal class EmbraceSessionServiceTest {
 
         service = EmbraceSessionService(
             InternalEmbraceLogger(),
-            FakeNetworkConnectivityService(),
-            FakeBreadcrumbService(),
             deliveryService,
             mockk(relaxed = true),
             FakeClock(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
@@ -1,0 +1,69 @@
+package io.embrace.android.embracesdk.session.orchestrator
+
+import io.embrace.android.embracesdk.FakeBreadcrumbService
+import io.embrace.android.embracesdk.FakeNdkService
+import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
+import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
+import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
+import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class OrchestratorBoundaryDelegateTest {
+
+    private lateinit var delegate: OrchestratorBoundaryDelegate
+    private lateinit var memoryCleanerService: FakeMemoryCleanerService
+    private lateinit var userService: FakeUserService
+    private lateinit var ndkService: FakeNdkService
+    private lateinit var sessionProperties: EmbraceSessionProperties
+    private lateinit var internalErrorService: FakeInternalErrorService
+    private lateinit var networkConnectivityService: FakeNetworkConnectivityService
+    private lateinit var breadcrumbService: FakeBreadcrumbService
+
+    @Before
+    fun setUp() {
+        memoryCleanerService = FakeMemoryCleanerService()
+        userService = FakeUserService()
+        ndkService = FakeNdkService()
+        sessionProperties = fakeEmbraceSessionProperties().apply {
+            add("key", "value", false)
+        }
+        internalErrorService = FakeInternalErrorService()
+        networkConnectivityService = FakeNetworkConnectivityService()
+        breadcrumbService = FakeBreadcrumbService()
+        delegate = OrchestratorBoundaryDelegate(
+            memoryCleanerService,
+            userService,
+            ndkService,
+            sessionProperties,
+            internalErrorService,
+            networkConnectivityService,
+            breadcrumbService
+        )
+    }
+
+    @Test
+    fun `prepare new envelope clear user info true`() {
+        delegate.prepareForNewEnvelope(1000L, clearUserInfo = true)
+        assertEquals(1, memoryCleanerService.callCount)
+        assertEquals(0, sessionProperties.get().size)
+        assertEquals(1, userService.clearedCount)
+        assertEquals(1, ndkService.userUpdateCount)
+        assertEquals(1, networkConnectivityService.networkStatusOnSessionStartedCount)
+        assertEquals(1, breadcrumbService.firstViewBreadcrumbCalls.size)
+    }
+
+    @Test
+    fun `prepare new envelope clear user info false`() {
+        delegate.prepareForNewEnvelope(1000L, clearUserInfo = false)
+        assertEquals(1, memoryCleanerService.callCount)
+        assertEquals(0, sessionProperties.get().size)
+        assertEquals(0, userService.clearedCount)
+        assertEquals(0, ndkService.userUpdateCount)
+        assertEquals(1, networkConnectivityService.networkStatusOnSessionStartedCount)
+        assertEquals(1, breadcrumbService.firstViewBreadcrumbCalls.size)
+    }
+}


### PR DESCRIPTION
## Goal

Fully moves the responsibility for clearing the session to a delegate. This continues what previous refactors have done by moving the breadcrumb service/network service state reset into `SessionOrchestratorDelegate`. I also ensured that the very first session resets the boundary & that the timestamp is predominantly calculated in the `SessionOrchestrator`.

## Testing

Updated unit tests.

