### PR TITLE
Consolidate logging in SessionOrchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -609,7 +609,6 @@ final class EmbraceImpl {
 
         SessionModule sessionModule = new SessionModuleImpl(
             initModule,
-            coreModule,
             androidServicesModule,
             essentialServiceModule,
             nativeModule,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -27,7 +27,6 @@ internal interface SessionModule {
 
 internal class SessionModuleImpl(
     initModule: InitModule,
-    coreModule: CoreModule,
     androidServicesModule: AndroidServicesModule,
     essentialServiceModule: EssentialServiceModule,
     nativeModule: NativeModule,
@@ -86,7 +85,6 @@ internal class SessionModuleImpl(
 
     override val sessionService: SessionService by singleton {
         EmbraceSessionService(
-            coreModule.logger,
             deliveryModule.deliveryService,
             payloadMessageCollator,
             initModule.clock,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -2,14 +2,12 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 
 internal class EmbraceSessionService(
-    private val logger: InternalEmbraceLogger,
     private val deliveryService: DeliveryService,
     private val payloadMessageCollator: PayloadMessageCollator,
     private val clock: Clock,
@@ -52,11 +50,10 @@ internal class EmbraceSessionService(
     }
 
     override fun endSessionWithCrash(timestamp: Long, crashId: String) {
-        val session = activeSession ?: return
-        logger.logDebug("SessionHandler: running onCrash for $crashId")
+        val initial = activeSession ?: return
         createAndProcessSessionSnapshot(
             FinalEnvelopeParams.SessionParams(
-                initial = session,
+                initial = initial,
                 endTime = timestamp,
                 lifeEventType = LifeEventType.STATE,
                 crashId = crashId,
@@ -70,20 +67,8 @@ internal class EmbraceSessionService(
      * It performs all corresponding operations in order to start a session.
      */
     private fun startSession(params: InitialEnvelopeParams.SessionParams): String {
-        logger.logDebug(
-            "SessionHandler: running onSessionStarted. coldStart=${params.coldStart}," +
-                " startType=${params.startType}, startTime=${params.startTime}"
-        )
-
-        val session = payloadMessageCollator.buildInitialSession(
-            params
-        )
+        val session = payloadMessageCollator.buildInitialSession(params)
         activeSession = session
-        logger.logDeveloper(
-            "SessionHandler",
-            "Started new session. ID=${session.sessionId}"
-        )
-
         periodicSessionCacher.start(::onPeriodicCacheActiveSessionImpl)
         return session.sessionId
     }
@@ -95,18 +80,16 @@ internal class EmbraceSessionService(
         endType: LifeEventType,
         endTime: Long
     ): SessionMessage? {
-        val session = activeSession ?: return null
-        logger.logDebug("SessionHandler: running onSessionEnded. endType=$endType, endTime=$endTime")
+        val initial = activeSession ?: return null
         val fullEndSessionMessage = createAndProcessSessionSnapshot(
             FinalEnvelopeParams.SessionParams(
-                initial = session,
+                initial = initial,
                 endTime = endTime,
                 lifeEventType = endType,
                 endType = SessionSnapshotType.NORMAL_END
             ),
         )
         activeSession = null
-        logger.logDebug("SessionHandler: cleared active session")
         return fullEndSessionMessage
     }
 
@@ -129,10 +112,10 @@ internal class EmbraceSessionService(
      */
     private fun onPeriodicCacheActiveSessionImpl(): SessionMessage? {
         synchronized(orchestrationLock) {
-            val session = activeSession ?: return null
+            val initial = activeSession ?: return null
             return createAndProcessSessionSnapshot(
                 FinalEnvelopeParams.SessionParams(
-                    initial = session,
+                    initial = initial,
                     endTime = clock.now(),
                     lifeEventType = LifeEventType.STATE,
                     endType = SessionSnapshotType.PERIODIC_CACHE

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -97,11 +97,10 @@ internal class EmbraceBackgroundActivityServiceTest {
 
     @Test
     fun `test background activity state when going to the background`() {
-        this.service = createService()
-
+        this.service = createService(createInitialSession = false)
         service.startBackgroundActivityWithState(clock.now(), false)
 
-        val payload = checkNotNull(service.backgroundActivity)
+        val payload = deliveryService.lastSavedBackgroundActivities.single().session
         assertEquals(Session.LifeEventType.BKGND_STATE, payload.startType)
         assertEquals(5, payload.number)
         assertFalse(payload.isColdStart)
@@ -110,12 +109,8 @@ internal class EmbraceBackgroundActivityServiceTest {
     @Test
     fun `test background activity state when going to the foreground`() {
         this.service = createService()
-
         val timestamp = 1669392000L
-
         service.endBackgroundActivityWithState(timestamp)
-
-        assertNull(service.backgroundActivity)
 
         assertEquals(2, deliveryService.saveBackgroundActivityInvokedCount)
         assertEquals(1, deliveryService.sendBackgroundActivitiesInvokedCount)
@@ -128,7 +123,7 @@ internal class EmbraceBackgroundActivityServiceTest {
     fun `background activity is not started whn the service initializes in the foreground`() {
         activityService.isInBackground = false
         this.service = createService(false)
-        assertNull(service.backgroundActivity)
+        assertTrue(deliveryService.lastSavedBackgroundActivities.isEmpty())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.clearAllMocks
@@ -125,7 +124,6 @@ internal class EmbraceSessionServiceTest {
         processStateService.isInBackground = isActivityInBackground
 
         service = EmbraceSessionService(
-            InternalEmbraceLogger(),
             deliveryService,
             mockk(relaxed = true),
             FakeClock(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorServic
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
-import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCustomerLogModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataCaptureServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataContainerModule
@@ -31,7 +30,6 @@ internal class SessionModuleImplTest {
     fun testDefaultImplementations() {
         val module = SessionModuleImpl(
             InitModuleImpl(),
-            FakeCoreModule(),
             FakeAndroidServicesModule(),
             FakeEssentialServiceModule(),
             FakeNativeModule(),
@@ -54,7 +52,6 @@ internal class SessionModuleImplTest {
     fun testEnabledBehaviors() {
         val module = SessionModuleImpl(
             InitModuleImpl(),
-            FakeCoreModule(),
             FakeAndroidServicesModule(),
             createEnabledBehavior(),
             FakeNativeModule(),


### PR DESCRIPTION
## Goal

Consolidates logging into the `SessionOrchestrator & makes the `session` property private in the `BackgroundActivityService`.

## Testing

Relied on existing test coverage.

