### PR TITLE
Rename SpansService implementation used when SDK not initialized

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.android.embracesdk.spans.ErrorCode
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+
+/**
+ * An implementation of [SpansService] used when the SDK is not enabled
+ */
+@InternalApi
+internal class UninitializedSdkSpansService : SpansService {
+    override fun createSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean): EmbraceSpan? = null
+
+    override fun <T> recordSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        type: EmbraceAttributes.Type,
+        internal: Boolean,
+        code: () -> T
+    ) = code()
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeNanos: Long,
+        endTimeNanos: Long,
+        parent: EmbraceSpan?,
+        type: EmbraceAttributes.Type,
+        internal: Boolean,
+        attributes: Map<String, String>,
+        events: List<EmbraceSpanEvent>,
+        errorCode: ErrorCode?
+    ): Boolean = false
+
+    override fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode = CompletableResultCode.ofFailure()
+
+    override fun completedSpans(): List<EmbraceSpanData>? = null
+
+    override fun flushSpans(appTerminationCause: EmbraceAttributes.AppTerminationCause?): List<EmbraceSpanData>? = null
+
+    override fun getSpan(spanId: String): EmbraceSpan? = null
+}


### PR DESCRIPTION
## Goal

Renaming class to match what it's doing.

