### PR TITLE
Extract background activity caching to separate class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1538,7 +1538,7 @@ final class EmbraceImpl {
 
     private void onActivityReported() {
         if (backgroundActivityService != null) {
-            backgroundActivityService.save();
+            backgroundActivityService.saveBackgroundActivitySnapshot();
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
@@ -23,5 +23,5 @@ internal interface BackgroundActivityService {
     /**
      * Save the current background activity to disk
      */
-    fun save()
+    fun saveBackgroundActivitySnapshot()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
@@ -1,0 +1,53 @@
+package io.embrace.android.embracesdk.session.caching
+
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.worker.ScheduledWorker
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
+
+internal class PeriodicBackgroundActivityCacher(
+    private val clock: Clock,
+    private val scheduledWorker: ScheduledWorker,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) {
+
+    companion object {
+
+        /**
+         * Minimum time between writes of the background activity to disk
+         */
+        private const val MIN_INTERVAL_BETWEEN_SAVES: Long = 5000
+    }
+
+    private var lastSaved: Long = 0
+    private var scheduledFuture: ScheduledFuture<*>? = null
+
+    /**
+     * Save the background activity to disk
+     */
+    fun scheduleSave(provider: () -> SessionMessage?) {
+        val delta = clock.now() - lastSaved
+        val delay = max(0, MIN_INTERVAL_BETWEEN_SAVES - delta)
+        val action: () -> Unit = {
+            try {
+                provider()
+                lastSaved = clock.now()
+            } catch (ex: Exception) {
+                logger.logDebug("Error while caching active session", ex)
+            }
+        }
+        scheduledFuture = scheduledWorker.schedule<Unit>(
+            action,
+            delay,
+            TimeUnit.MILLISECONDS
+        )
+    }
+
+    fun stop() {
+        scheduledFuture?.cancel(false)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -21,7 +21,6 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
         this.crashId = crashId
     }
 
-    override fun save() {
-        TODO("Not yet implemented")
+    override fun saveBackgroundActivitySnapshot() {
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.injection.SessionModule
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.PayloadMessageCollator
 import io.embrace.android.embracesdk.session.SessionService
+import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
@@ -22,5 +23,8 @@ internal class FakeSessionModule(
         get() = TODO("Not yet implemented")
 
     override val periodicSessionCacher: PeriodicSessionCacher
+        get() = TODO("Not yet implemented")
+
+    override val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher
         get() = TODO("Not yet implemented")
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -46,6 +46,8 @@ internal class SessionModuleImplTest {
         assertNotNull(module.sessionPropertiesService)
         assertNotNull(module.backgroundActivityService)
         assertNotNull(module.sessionOrchestrator)
+        assertNotNull(module.periodicSessionCacher)
+        assertNotNull(module.periodicBackgroundActivityCacher)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Extracts the caching of the background activity to a separate class. Additionally this now cancels any scheduled snapshot that happens after a background activity was ended.

