### PR TITLE
Prepare for hoisting params into session orchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1537,8 +1537,9 @@ final class EmbraceImpl {
     }
 
     private void onActivityReported() {
-        if (backgroundActivityService != null) {
-            backgroundActivityService.saveBackgroundActivitySnapshot();
+        SessionOrchestrator orchestrator = sessionOrchestrator;
+        if (orchestrator != null) {
+            orchestrator.reportBackgroundActivityStateChange();
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.session
 
+import io.embrace.android.embracesdk.payload.Session
+
 /**
  * Service that captures and sends information when the app is in background
  */
@@ -8,7 +10,7 @@ internal interface BackgroundActivityService {
     /**
      * Ends a background activity in response to a state event.
      */
-    fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): String
+    fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): Session
 
     /**
      * Handles an uncaught exception, ending the session and saving the activity to disk.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityService.kt
@@ -20,7 +20,7 @@ internal class EmbraceBackgroundActivityService(
     @Volatile
     private var backgroundActivity: Session? = null
 
-    override fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): String {
+    override fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): Session {
         // kept for backwards compat. the backend expects the start time to be 1 ms greater
         // than the adjacent session, and manually adjusts.
         val time = when {
@@ -36,7 +36,7 @@ internal class EmbraceBackgroundActivityService(
         )
         backgroundActivity = activity
         saveBackgroundActivitySnapshot()
-        return activity.sessionId
+        return activity
     }
 
     override fun endBackgroundActivityWithState(timestamp: Long) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceSessionService.kt
@@ -21,7 +21,7 @@ internal class EmbraceSessionService(
     @Volatile
     override var activeSession: Session? = null
 
-    override fun startSessionWithState(timestamp: Long, coldStart: Boolean): String {
+    override fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session {
         return startSession(
             InitialEnvelopeParams.SessionParams(
                 coldStart,
@@ -31,7 +31,7 @@ internal class EmbraceSessionService(
         )
     }
 
-    override fun startSessionWithManual(timestamp: Long): String {
+    override fun startSessionWithManual(timestamp: Long): Session {
         return startSession(
             InitialEnvelopeParams.SessionParams(
                 false,
@@ -84,11 +84,11 @@ internal class EmbraceSessionService(
     /**
      * It performs all corresponding operations in order to start a session.
      */
-    private fun startSession(params: InitialEnvelopeParams.SessionParams): String {
+    private fun startSession(params: InitialEnvelopeParams.SessionParams): Session {
         val session = payloadMessageCollator.buildInitialSession(params)
         activeSession = session
         periodicSessionCacher.start { onPeriodicCacheActiveSessionImpl(clock.now()) }
-        return session.sessionId
+        return session
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -9,12 +9,12 @@ internal interface SessionService {
     /**
      * Starts a session in response to a state event.
      */
-    fun startSessionWithState(timestamp: Long, coldStart: Boolean): String
+    fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session
 
     /**
      * Starts a session manually.
      */
-    fun startSessionWithManual(timestamp: Long): String
+    fun startSessionWithManual(timestamp: Long): Session
 
     /**
      * Ends a session in response to a state event.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestrator.kt
@@ -18,4 +18,10 @@ internal interface SessionOrchestrator : ProcessStateListener {
      * Handles an uncaught exception, ending the active session and saving it to disk.
      */
     fun endSessionWithCrash(crashId: String)
+
+    /**
+     * Reports a change that means we should schedule snapshotting & writing to disk of the
+     * current snapshot. This function is kept for legacy reasons and will eventually be removed.
+     */
+    fun reportBackgroundActivityStateChange()
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -13,16 +13,16 @@ internal class FakeSessionService : SessionService {
 
     override var activeSession: Session? = null
 
-    override fun startSessionWithState(timestamp: Long, coldStart: Boolean): String {
+    override fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session {
         startTimestamps.add(timestamp)
         activeSession = fakeSession(startMs = timestamp)
-        return activeSession?.sessionId ?: ""
+        return checkNotNull(activeSession)
     }
 
-    override fun startSessionWithManual(timestamp: Long): String {
+    override fun startSessionWithManual(timestamp: Long): Session {
         manualStartCount++
         activeSession = fakeSession()
-        return activeSession?.sessionId ?: ""
+        return checkNotNull(activeSession)
     }
 
     override fun endSessionWithState(timestamp: Long) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.fakeBackgroundActivity
+import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.BackgroundActivityService
 
 internal class FakeBackgroundActivityService : BackgroundActivityService {
@@ -8,9 +10,9 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
     val startTimestamps = mutableListOf<Long>()
     var crashId: String? = null
 
-    override fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): String {
+    override fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): Session {
         startTimestamps.add(timestamp)
-        return "fakeBackgroundActivityId"
+        return fakeBackgroundActivity()
     }
 
     override fun endBackgroundActivityWithState(timestamp: Long) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
@@ -14,4 +14,7 @@ internal class FakeSessionOrchestrator : SessionOrchestrator {
     override fun endSessionWithCrash(crashId: String) {
         this.crashId = crashId
     }
+
+    override fun reportBackgroundActivityStateChange() {
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -402,7 +402,7 @@ internal class SessionHandlerTest {
         assertEquals(1, sessions.count { it.second == SessionSnapshotType.NORMAL_END })
     }
 
-    private fun startFakeSession(): String {
+    private fun startFakeSession(): Session {
         return sessionService.startSessionWithState(now, true)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -82,7 +82,7 @@ internal class SessionOrchestratorTest {
         assertEquals(orchestrator, processStateService.listeners.single())
         assertEquals(0, sessionService.startTimestamps.size)
         assertEquals(1, backgroundActivityService.startTimestamps.size)
-        assertEquals("fakeBackgroundActivityId", sessionIdTracker.sessionId)
+        assertEquals("fake-activity", sessionIdTracker.sessionId)
     }
 
     @Test
@@ -110,7 +110,7 @@ internal class SessionOrchestratorTest {
         assertEquals(2, memoryCleanerService.callCount)
         assertEquals(TIMESTAMP, sessionService.endTimestamps.single())
         assertEquals(TIMESTAMP, backgroundActivityService.startTimestamps.single())
-        assertEquals("fakeBackgroundActivityId", sessionIdTracker.sessionId)
+        assertEquals("fake-activity", sessionIdTracker.sessionId)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Preparatory refactor for hoisting the `session/backgroundActivity` properties into the `SessionOrchestrator` class. This changeset involves returning `Session` rather than string when creating a session, and miscellaneous other pre-requisite changes.

## Testing

Relied on existing test coverage.

