### PR TITLE
Extract tracking of active session to orchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/BackgroundActivityService.kt
@@ -15,15 +15,15 @@ internal interface BackgroundActivityService {
     /**
      * Handles an uncaught exception, ending the session and saving the activity to disk.
      */
-    fun endBackgroundActivityWithCrash(timestamp: Long, crashId: String)
+    fun endBackgroundActivityWithCrash(initial: Session, timestamp: Long, crashId: String)
 
     /**
      * Starts a background activity in response to a state event.
      */
-    fun endBackgroundActivityWithState(timestamp: Long)
+    fun endBackgroundActivityWithState(initial: Session, timestamp: Long)
 
     /**
      * Save the current background activity to disk
      */
-    fun saveBackgroundActivitySnapshot()
+    fun saveBackgroundActivitySnapshot(initial: Session,)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SessionService.kt
@@ -4,8 +4,6 @@ import io.embrace.android.embracesdk.payload.Session
 
 internal interface SessionService {
 
-    val activeSession: Session?
-
     /**
      * Starts a session in response to a state event.
      */
@@ -19,15 +17,15 @@ internal interface SessionService {
     /**
      * Ends a session in response to a state event.
      */
-    fun endSessionWithState(timestamp: Long)
+    fun endSessionWithState(initial: Session, timestamp: Long)
 
     /**
      * Ends a session manually.
      */
-    fun endSessionWithManual(timestamp: Long)
+    fun endSessionWithManual(initial: Session, timestamp: Long)
 
     /**
      * Handles an uncaught exception, ending the session and saving the session to disk.
      */
-    fun endSessionWithCrash(timestamp: Long, crashId: String)
+    fun endSessionWithCrash(initial: Session, timestamp: Long, crashId: String)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -66,7 +66,6 @@ internal class EmbraceProcessStateService(
             logger.logError(msg, InternalError(msg))
         }
 
-        isInBackground = false
         val timestamp = clock.now()
 
         invokeCallbackSafely { sessionOrchestrator?.onForeground(coldStart, timestamp) }
@@ -76,6 +75,7 @@ internal class EmbraceProcessStateService(
                 listener.onForeground(coldStart, timestamp)
             }
         }
+        isInBackground = false
         coldStart = false
     }
 
@@ -86,7 +86,6 @@ internal class EmbraceProcessStateService(
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     override fun onBackground() {
         logDebug("AppState: App entered background")
-        isInBackground = true
         val timestamp = clock.now()
         invokeCallbackSafely { sessionOrchestrator?.onBackground(timestamp) }
 
@@ -95,6 +94,7 @@ internal class EmbraceProcessStateService(
                 listener.onBackground(timestamp)
             }
         }
+        isInBackground = true
     }
 
     private inline fun invokeCallbackSafely(action: () -> Unit) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -10,8 +10,7 @@ internal class FakeSessionService : SessionService {
     val endTimestamps = mutableListOf<Long>()
     var manualEndCount = 0
     var manualStartCount = 0
-
-    override var activeSession: Session? = null
+    var activeSession: Session? = null
 
     override fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session {
         startTimestamps.add(timestamp)
@@ -25,19 +24,19 @@ internal class FakeSessionService : SessionService {
         return checkNotNull(activeSession)
     }
 
-    override fun endSessionWithState(timestamp: Long) {
+    override fun endSessionWithState(initial: Session, timestamp: Long) {
         endTimestamps.add(timestamp)
         activeSession = null
     }
 
     var crashId: String? = null
 
-    override fun endSessionWithCrash(timestamp: Long, crashId: String) {
+    override fun endSessionWithCrash(initial: Session, timestamp: Long, crashId: String) {
         this.crashId = crashId
         activeSession = null
     }
 
-    override fun endSessionWithManual(timestamp: Long) {
+    override fun endSessionWithManual(initial: Session, timestamp: Long) {
         manualEndCount++
         activeSession = null
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -15,14 +15,14 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
         return fakeBackgroundActivity()
     }
 
-    override fun endBackgroundActivityWithState(timestamp: Long) {
+    override fun endBackgroundActivityWithState(initial: Session, timestamp: Long) {
         endTimestamps.add(timestamp)
     }
 
-    override fun endBackgroundActivityWithCrash(timestamp: Long, crashId: String) {
+    override fun endBackgroundActivityWithCrash(initial: Session, timestamp: Long, crashId: String) {
         this.crashId = crashId
     }
 
-    override fun saveBackgroundActivitySnapshot() {
+    override fun saveBackgroundActivitySnapshot(initial: Session) {
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
@@ -25,6 +26,7 @@ import java.util.concurrent.ExecutorService
 
 internal class EmbraceSessionServiceTest {
 
+    private val initial = fakeSession()
     private lateinit var service: EmbraceSessionService
     private lateinit var deliveryService: FakeDeliveryService
     private lateinit var spansService: EmbraceSpansService
@@ -85,23 +87,6 @@ internal class EmbraceSessionServiceTest {
     }
 
     @Test
-    fun `simulate session capture enabled after onForeground`() {
-        initializeSessionService()
-
-        // missing start call simulates service being enabled halfway through.
-        service.endSessionWithState(clock.now())
-
-        // nothing is delivered
-        assertEquals(0, deliveryService.lastSentSessions.size)
-
-        // next session is recorded correctly
-        service.startSessionWithState(clock.now(), false)
-        clock.tick(10000L)
-        service.endSessionWithState(clock.now())
-        assertEquals(1, deliveryService.lastSentSessions.size)
-    }
-
-    @Test
     fun `session capture disabled after onForeground`() {
         initializeSessionService()
 
@@ -114,7 +99,7 @@ internal class EmbraceSessionServiceTest {
 
         service.startSessionWithState(clock.now(), false)
         clock.tick(10000L)
-        service.endSessionWithState(clock.now())
+        service.endSessionWithState(initial, clock.now())
         assertEquals(1, deliveryService.lastSentSessions.size)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -135,7 +135,7 @@ internal class SessionOrchestratorTest {
     @Test
     fun `test background activity capture disabled`() {
         configService = FakeConfigService(backgroundActivityCaptureEnabled = false)
-        createOrchestrator(true)
+        createOrchestrator(false)
         orchestrator.onBackground(TIMESTAMP)
         assertEquals(2, memoryCleanerService.callCount)
         assertTrue(backgroundActivityService.startTimestamps.isEmpty())


### PR DESCRIPTION
## Goal

Extracts the tracking of the active session/background activity state to the `SessionOrchestrator`. The active session is now passed into the services as a parameter, meaning they effectively just create a final payload & instruct where it should be delivered.

I plan on creating a 'transitionState' function in the `SessionOrchestratorImpl` class to better model these state transitions, as the code is getting somewhat complex. That will come in a future changeset.

## Testing

Updated unit test coverage. Some test cases are deleted as they are covered by `SessionOrchestratorTest`, others are no longer necessary due to reduced complexity.
