### PR TITLE
Return from SDK init only if Spans Service is initialized

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -363,7 +364,7 @@ final class EmbraceImpl {
 
     private void startImpl(@NonNull Context context,
                            boolean enableIntegrationTesting,
-                           @NonNull Embrace.AppFramework framework) throws ExecutionException, InterruptedException {
+                           @NonNull Embrace.AppFramework framework) throws ExecutionException, InterruptedException, TimeoutException {
         if (application != null) {
             // We don't hard fail if the SDK has been already initialized.
             InternalStaticEmbraceLogger.logWarning("Embrace SDK has already been initialized");
@@ -706,8 +707,9 @@ final class EmbraceImpl {
             nonNullEventService.sendStartupMoment();
         }
 
-        // This should return immediately given that EmbraceSpansService initialization should be fished at this point
-        spansInitTask.get();
+        // This should return immediately given that EmbraceSpansService initialization should be finished at this point
+        // Put in emergency timeout just in case something unexpected happens so as to fail the SDK startup.
+        spansInitTask.get(5, TimeUnit.SECONDS);
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -13,6 +13,8 @@ import androidx.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
@@ -122,8 +124,6 @@ import kotlin.jvm.functions.Function5;
  */
 @SuppressLint("EmbracePublicApiPackageRule")
 final class EmbraceImpl {
-
-    private static final String ERROR_USER_UPDATES_DISABLED = "User updates are disabled, ignoring user persona update.";
 
     private static final Pattern appIdPattern = Pattern.compile("^[A-Za-z0-9]{5}$");
 
@@ -363,7 +363,7 @@ final class EmbraceImpl {
 
     private void startImpl(@NonNull Context context,
                            boolean enableIntegrationTesting,
-                           @NonNull Embrace.AppFramework framework) {
+                           @NonNull Embrace.AppFramework framework) throws ExecutionException, InterruptedException {
         if (application != null) {
             // We don't hard fail if the SDK has been already initialized.
             InternalStaticEmbraceLogger.logWarning("Embrace SDK has already been initialized");
@@ -387,13 +387,14 @@ final class EmbraceImpl {
         final WorkerThreadModule nonNullWorkerThreadModule = workerThreadModuleSupplier.invoke(initModule);
         workerThreadModule = nonNullWorkerThreadModule;
 
-        nonNullWorkerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit(TaskPriority.NORMAL, () -> {
-            final SpansService spansService = initModule.getSpansService();
-            if (spansService instanceof Initializable) {
-                ((Initializable) spansService).initializeService(TimeUnit.MILLISECONDS.toNanos(startTime));
-            }
-            return null;
-        });
+        final Future<?> spansInitTask =
+            nonNullWorkerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit(TaskPriority.CRITICAL, () -> {
+                final SpansService spansService = initModule.getSpansService();
+                if (spansService instanceof Initializable) {
+                    ((Initializable) spansService).initializeService(TimeUnit.MILLISECONDS.toNanos(startTime));
+                }
+                return null;
+            });
 
         final SystemServiceModule systemServiceModule = systemServiceModuleSupplier.invoke(coreModule);
         final AndroidServicesModule androidServicesModule =
@@ -704,6 +705,9 @@ final class EmbraceImpl {
             internalEmbraceLogger.logDeveloper("Embrace", "Sending startup moment");
             nonNullEventService.sendStartupMoment();
         }
+
+        // This should return immediately given that EmbraceSpansService initialization should be fished at this point
+        spansInitTask.get();
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -6,8 +6,6 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.TracingApi
 
 internal class EmbraceTracer(private val spansService: SpansService) : TracingApi {
-    override fun isTracingAvailable(): Boolean = spansService is Initializable && spansService.initialized()
-
     override fun createSpan(name: String): EmbraceSpan? =
         createSpan(name = name, parent = null)
 
@@ -114,4 +112,7 @@ internal class EmbraceTracer(private val spansService: SpansService) : TracingAp
         )
 
     fun getSpan(spanId: String): EmbraceSpan? = spansService.getSpan(spanId = spanId)
+
+    @Deprecated("No required. Use Embrace.isStarted() to know when the full tracing API is available")
+    override fun isTracingAvailable(): Boolean = spansService is Initializable && spansService.initialized()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -113,6 +113,6 @@ internal class EmbraceTracer(private val spansService: SpansService) : TracingAp
 
     fun getSpan(spanId: String): EmbraceSpan? = spansService.getSpan(spanId = spanId)
 
-    @Deprecated("No required. Use Embrace.isStarted() to know when the full tracing API is available")
+    @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
     override fun isTracingAvailable(): Boolean = spansService is Initializable && spansService.initialized()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -135,6 +135,6 @@ internal interface TracingApi {
     /**
      * @see [Embrace.isStarted]
      */
-    @Deprecated("No required. Use Embrace.isStarted() to know when the full tracing API is available")
+    @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
     fun isTracingAvailable(): Boolean
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -3,22 +3,11 @@ package io.embrace.android.embracesdk.spans
 import io.embrace.android.embracesdk.annotation.BetaApi
 
 /**
- * The public API used to add traces to your application. Use [isTracingAvailable] to determine if the SDK is ready log traces. Note that
- * [recordCompletedSpan] methods can still be invoked successfully before the [isTracingAvailable] returns true - the actual trace won't
- * be recorded until the system is ready, but the SDK will buffer the call and record it once it is. The other tracing methods, however,
- * will not work until [isTracingAvailable] returns true.
+ * The public API used to add traces to your application. Note that [recordCompletedSpan] can be used before the SDK is initialized.
+ * The actual trace won't be recorded until the SDK is started, but it's safe to use this prior to SDK initialization.
  */
 @BetaApi
 internal interface TracingApi {
-    /**
-     * Returns true if the tracing API is fully initialized so that [createSpan] and [recordSpan] methods will work. This is different than
-     * what [Embrace.isStarted] returned as the tracing service is initialized asynchronously shortly after the SDK is initialized. Until
-     * this returns true, the [recordCompletedSpan] method can be used as invocations to it will be buffered and replayed when tracing
-     * service is ready to be used.
-     */
-    @BetaApi
-    fun isTracingAvailable(): Boolean
-
     /**
      * Create an [EmbraceSpan] with the given name that will be the root span of a new trace. Returns null if the [EmbraceSpan] cannot
      * be created given the current conditions of the SDK or an invalid name.
@@ -142,4 +131,10 @@ internal interface TracingApi {
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?
     ): Boolean
+
+    /**
+     * @see [Embrace.isStarted]
+     */
+    @Deprecated("No required. Use Embrace.isStarted() to know when the full tracing API is available")
+    fun isTracingAvailable(): Boolean
 }


### PR DESCRIPTION
## Goal

Make it a condition that the `EmbraceSpansService` is initialized before returning from the start method. In practice, this should almost always true by the time the SDK initialization gets to the end.
