### PR TITLE
Pull elements of SpansService apart for better organization and dependency management

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -310,7 +310,7 @@ final class EmbraceImpl {
         this.essentialServiceModuleSupplier = essentialServiceModuleSupplier;
         this.dataCaptureServiceModuleSupplier = dataCaptureServiceModuleSupplier;
         this.deliveryModuleSupplier = deliveryModuleSupplier;
-        this.tracer = initModule.getTracer();
+        this.tracer = initModule.getEmbraceTracer();
         uninitializedSdkInternalInterface =
             LazyKt.lazy(() -> new UninitializedSdkInternalInterfaceImpl(new InternalTracer(tracer, sdkClock)));
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
@@ -18,7 +18,7 @@ internal class EmbraceInternalInterfaceImpl(
     private val embraceImpl: EmbraceImpl,
     private val initModule: InitModule,
     private val configService: ConfigService,
-    internalTracer: InternalTracer = InternalTracer(initModule.tracer, initModule.clock)
+    internalTracer: InternalTracer = InternalTracer(initModule.embraceTracer, initModule.clock)
 ) : EmbraceInternalInterface, InternalTracingApi by internalTracer {
 
     override fun logInfo(message: String, properties: Map<String, Any>?) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -1,14 +1,25 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanExporter
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanProcessor
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.internal.spans.SpansSink
+import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import io.embrace.android.embracesdk.telemetry.TelemetryService
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.SdkTracerProvider
 
 /**
  * A module of components and services required at [EmbraceImpl] instantiation time, i.e. before the SDK evens starts
@@ -24,6 +35,14 @@ internal interface InitModule {
      */
     val telemetryService: TelemetryService
 
+    val spansSink: SpansSink
+
+    val openTelemetrySdk: OpenTelemetry
+
+    val tracer: Tracer
+
+    val currentSessionSpan: CurrentSessionSpan
+
     /**
      * Service to log traces
      */
@@ -32,12 +51,36 @@ internal interface InitModule {
     /**
      * Implementation of public tracing API
      */
-    val tracer: EmbraceTracer
+    val embraceTracer: EmbraceTracer
 }
 
 internal class InitModuleImpl(
     override val clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
+    openTelemetryClock: OpenTelemetryClock = OpenTelemetryClock(clock),
     override val telemetryService: TelemetryService = EmbraceTelemetryService(),
-    override val spansService: SpansService = EmbraceSpansService(OpenTelemetryClock(clock), telemetryService),
-    override val tracer: EmbraceTracer = EmbraceTracer(spansService)
+    override val spansSink: SpansSink = SpansSinkImpl(),
+    override val openTelemetrySdk: OpenTelemetry =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider
+                    .builder()
+                    .addSpanProcessor(EmbraceSpanProcessor(EmbraceSpanExporter(spansSink)))
+                    .setClock(openTelemetryClock)
+                    .build()
+            )
+            .build(),
+    override val tracer: Tracer = openTelemetrySdk.getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME),
+    override val currentSessionSpan: CurrentSessionSpan =
+        CurrentSessionSpanImpl(
+            clock = openTelemetryClock,
+            telemetryService = telemetryService,
+            spansSink = spansSink,
+            tracer = tracer
+        ),
+    override val spansService: SpansService = EmbraceSpansService(
+        spansSink = spansSink,
+        currentSessionSpan = currentSessionSpan,
+        tracer = tracer,
+    ),
+    override val embraceTracer: EmbraceTracer = EmbraceTracer(spansService)
 ) : InitModule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -52,7 +52,7 @@ internal class SessionModuleImpl(
             dataCaptureServiceModule.breadcrumbService,
             essentialServiceModule.userService,
             androidServicesModule.preferencesService,
-            initModule.spansService,
+            initModule.currentSessionSpan,
             initModule.clock,
             sessionPropertiesService,
             dataCaptureServiceModule.startupService

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+
+internal interface CurrentSessionSpan {
+
+    fun startInitialSession(sdkInitStartTimeNanos: Long)
+
+    fun endSession(appTerminationCause: EmbraceAttributes.AppTerminationCause? = null): List<EmbraceSpanData>
+
+    fun completedSpans(): List<EmbraceSpanData>
+
+    fun validateAndUpdateContext(parent: EmbraceSpan?, internal: Boolean): Boolean
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -17,7 +17,7 @@ internal class CurrentSessionSpanImpl(
     private val tracer: Tracer,
 ) : CurrentSessionSpan {
     /**
-     * Number of traces created in the current session. This value should be reset when a new session is created.
+     * Number of traces created in the current session. This value will be reset when a new session is created.
      */
     private val currentSessionTraceCount = AtomicInteger(0)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -1,0 +1,141 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.telemetry.TelemetryService
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.common.Clock
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+internal class CurrentSessionSpanImpl(
+    private val clock: Clock,
+    private val telemetryService: TelemetryService,
+    private val spansSink: SpansSink,
+    private val tracer: Tracer,
+) : CurrentSessionSpan {
+    /**
+     * Number of traces created in the current session. This value should be reset when a new session is created.
+     */
+    private val currentSessionTraceCount = AtomicInteger(0)
+
+    private val currentSessionChildSpansCount = mutableMapOf<String, Int>()
+
+    /**
+     * The span that models the lifetime of the current session or background activity
+     */
+    private val currentSessionSpan: AtomicReference<Span> = AtomicReference()
+
+    override fun startInitialSession(sdkInitStartTimeNanos: Long) {
+        synchronized(currentSessionSpan) {
+            currentSessionSpan.set(startSessionSpan(sdkInitStartTimeNanos))
+        }
+    }
+
+    /**
+     * Creating a new Span is only possible if the current session span is active, the parent has already been started, and the total
+     * session trace limit has not been reached. Once this method returns true, a new span is assumed to have been created and will
+     * be counted as such towards the limits, so make sure there's no case afterwards where a Span is not created.
+     */
+    override fun validateAndUpdateContext(parent: EmbraceSpan?, internal: Boolean): Boolean {
+        if (!currentSessionSpan.get().isRecording || (parent != null && parent.spanId == null)) {
+            return false
+        }
+
+        if (!internal) {
+            if (parent == null) {
+                if (currentSessionTraceCount.get() < SpansServiceImpl.MAX_TRACE_COUNT_PER_SESSION) {
+                    synchronized(currentSessionTraceCount) {
+                        if (currentSessionTraceCount.get() < SpansServiceImpl.MAX_TRACE_COUNT_PER_SESSION) {
+                            currentSessionTraceCount.incrementAndGet()
+                        } else {
+                            return false
+                        }
+                    }
+                } else {
+                    return false
+                }
+            } else {
+                val rootSpanId = getRootSpanId(parent)
+                val currentSpanCount = currentSessionChildSpansCount[rootSpanId]
+                if (currentSpanCount == null) {
+                    updateChildrenCount(rootSpanId)
+                } else if (currentSpanCount < SpansServiceImpl.MAX_SPAN_COUNT_PER_TRACE) {
+                    synchronized(currentSessionChildSpansCount) {
+                        val currentSpanCountAgain = currentSessionChildSpansCount[rootSpanId]
+                        if (currentSpanCountAgain == null || currentSpanCountAgain < SpansServiceImpl.MAX_SPAN_COUNT_PER_TRACE) {
+                            updateChildrenCount(rootSpanId)
+                        } else {
+                            return false
+                        }
+                    }
+                } else {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+
+    override fun endSession(appTerminationCause: EmbraceAttributes.AppTerminationCause?): List<EmbraceSpanData> {
+        synchronized(this) {
+            // Right now, session spans don't survive native crashes and sudden process terminations,
+            // so telemetry will not be recorded in those cases, for now.
+            val telemetryAttributes = telemetryService.getAndClearTelemetryAttributes()
+
+            currentSessionSpan.get().setAllAttributes(Attributes.builder().fromMap(telemetryAttributes).build())
+
+            if (appTerminationCause == null) {
+                currentSessionSpan.get().endSpan()
+                spansSink.getSpansRepository()?.clearCompletedSpans()
+                currentSessionSpan.set(startSessionSpan(clock.now()))
+            } else {
+                currentSessionSpan.get()?.let {
+                    it.setAttribute(appTerminationCause.keyName(), appTerminationCause.name)
+                    it.endSpan()
+                }
+            }
+
+            return spansSink.flushSpans()
+        }
+    }
+
+    override fun completedSpans(): List<EmbraceSpanData> = spansSink.completedSpans()
+
+    private fun getRootSpanId(span: EmbraceSpan): String {
+        var currentSpan: EmbraceSpan = span
+        while (currentSpan.parent != null) {
+            currentSpan.parent?.let { currentSpan = it }
+        }
+
+        return currentSpan.spanId ?: ""
+    }
+
+    private fun updateChildrenCount(rootSpanId: String) {
+        val currentCount = currentSessionChildSpansCount[rootSpanId]
+        if (currentCount == null) {
+            // The first time we'll know a root span ID is when a child is being added to it. Prior to that, when adding a prospective
+            // root span, the ID is not known yet. So the first time a root span is encountered add both it and the new child to the count.
+            //
+            // NOTE: Because we don't know whether the root span is internal or not at this point, it is assumed that it isn't.
+            // Therefore, it will count towards the limit if a non-internal span is added to the trace.
+            currentSessionChildSpansCount[rootSpanId] = 2
+        } else {
+            currentSessionChildSpansCount[rootSpanId] = currentCount + 1
+        }
+    }
+
+    /**
+     * This method should always be used when starting a new session span
+     */
+    private fun startSessionSpan(startTimeNanos: Long): Span {
+        currentSessionTraceCount.set(0)
+        return createEmbraceSpanBuilder(tracer = tracer, name = "session-span", type = EmbraceAttributes.Type.SESSION)
+            .setNoParent()
+            .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
+            .startSpan()
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -59,6 +59,9 @@ internal fun Tracer.embraceSpanBuilder(name: String, internal: Boolean): SpanBui
     }
 }
 
+/**
+ * Create a [SpanBuilder] that will create a [Span] with the appropriate custom Embrace attributes
+ */
 internal fun createEmbraceSpanBuilder(
     tracer: Tracer,
     name: String,
@@ -66,6 +69,9 @@ internal fun createEmbraceSpanBuilder(
     internal: Boolean = true
 ): SpanBuilder = tracer.embraceSpanBuilder(name, internal).setType(type)
 
+/**
+ * Create a [SpanBuilder] that will create a root [Span] with the appropriate custom Embrace attributes
+ */
 internal fun createRootSpanBuilder(
     tracer: Tracer,
     name: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -59,6 +59,20 @@ internal fun Tracer.embraceSpanBuilder(name: String, internal: Boolean): SpanBui
     }
 }
 
+internal fun createEmbraceSpanBuilder(
+    tracer: Tracer,
+    name: String,
+    type: EmbraceAttributes.Type,
+    internal: Boolean = true
+): SpanBuilder = tracer.embraceSpanBuilder(name, internal).setType(type)
+
+internal fun createRootSpanBuilder(
+    tracer: Tracer,
+    name: String,
+    type: EmbraceAttributes.Type,
+    internal: Boolean
+): SpanBuilder = createEmbraceSpanBuilder(tracer = tracer, name = name, type = type, internal = internal).setNoParent()
+
 /**
  * Sets and returns the [EmbraceAttributes.Type] attribute for the given [SpanBuilder]
  */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanExporter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanExporter.kt
@@ -12,10 +12,10 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
  * Note: no explicit tests exist for this as its functionality is tested via the tests for [SpansServiceImpl]
  */
 @InternalApi
-internal class EmbraceSpanExporter(private val spansService: SpansService) : SpanExporter {
+internal class EmbraceSpanExporter(private val spansSink: SpansSink) : SpanExporter {
     @Synchronized
     override fun export(spans: MutableCollection<SpanData>): CompletableResultCode =
-        spansService.storeCompletedSpans(spans.toList())
+        spansSink.storeCompletedSpans(spans.toList())
 
     override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansService.kt
@@ -4,13 +4,11 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
 
 /**
  * Public interface for an internal service that manages the recording, storage, and propagation of Spans
  */
-internal interface SpansService {
+internal interface SpansService : SpansSink {
     /**
      * Return an [EmbraceSpan] that can be started and stopped
      */
@@ -50,26 +48,4 @@ internal interface SpansService {
         events: List<EmbraceSpanEvent> = emptyList(),
         errorCode: ErrorCode? = null
     ): Boolean
-
-    /**
-     * Store the given list of completed Spans to be sent to the backend at the next available time
-     */
-    fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode
-
-    /**
-     * Return the list of the currently stored completed Spans that have not been sent to the backend
-     */
-    fun completedSpans(): List<EmbraceSpanData>?
-
-    /**
-     * Flush and return all of the stored completed Spans. This should be called when the stored completed spans are ready to be sent to
-     * the backend. If the flush is being triggered because the app is about to terminate, set [appTerminationCause] to the appropriate
-     * value. Setting this to null means the app is not terminating.
-     */
-    fun flushSpans(appTerminationCause: EmbraceAttributes.AppTerminationCause? = null): List<EmbraceSpanData>?
-
-    /**
-     * Return the [EmbraceSpan] for the given [spanId] if it's available
-     */
-    fun getSpan(spanId: String): EmbraceSpan?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
@@ -1,79 +1,26 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.embrace.android.embracesdk.telemetry.TelemetryService
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.sdk.OpenTelemetrySdk
-import io.opentelemetry.sdk.common.Clock
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.SdkTracerProvider
-import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Implementation of the core logic for [SpansService]
  */
 internal class SpansServiceImpl(
-    sdkInitStartTimeNanos: Long,
-    private val clock: Clock,
-    private val telemetryService: TelemetryService
-) : SpansService {
-    private val sdkTracerProvider: SdkTracerProvider
-        by lazy {
-            SdkTracerProvider
-                .builder()
-                .addSpanProcessor(EmbraceSpanProcessor(EmbraceSpanExporter(this)))
-                .setClock(clock)
-                .build()
-        }
-
-    private val openTelemetry: OpenTelemetry
-        by lazy {
-            OpenTelemetrySdk.builder()
-                .setTracerProvider(sdkTracerProvider)
-                .build()
-        }
-
-    private val tracer: Tracer
-        by lazy {
-            openTelemetry.getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME)
-        }
-
-    /**
-     * Number of traces created in the current session. This value should be reset when a new session is created.
-     */
-    private val currentSessionTraceCount = AtomicInteger(0)
-
-    private val currentSessionChildSpansCount = mutableMapOf<String, Int>()
-
-    /**
-     * The span that models the lifetime of the current session or background activity
-     */
-    private val currentSessionSpan: AtomicReference<Span> = AtomicReference(startSessionSpan(sdkInitStartTimeNanos))
-
-    /**
-     * Spans that have finished, successfully or not, that will be sent with the next session or background activity payload. These
-     * should be cached along with the other data in the payload.
-     */
-    private val completedSpans: MutableList<EmbraceSpanData> = mutableListOf()
-
-    private val spansRepository = SpansRepository()
-
+    private val spansSink: SpansSink,
+    private val currentSessionSpan: CurrentSessionSpan,
+    private val tracer: Tracer,
+) : SpansService, SpansSink by spansSink {
     override fun createSpan(name: String, parent: EmbraceSpan?, type: EmbraceAttributes.Type, internal: Boolean): EmbraceSpan? {
-        return if (EmbraceSpanImpl.inputsValid(name) && validateAndUpdateContext(parent, internal)) {
+        return if (EmbraceSpanImpl.inputsValid(name) && currentSessionSpan.validateAndUpdateContext(parent, internal)) {
             EmbraceSpanImpl(
-                spanBuilder = createRootSpanBuilder(name = name, type = type, internal = internal),
+                spanBuilder = createRootSpanBuilder(tracer = tracer, name = name, type = type, internal = internal),
                 parent = parent,
-                spansRepository = spansRepository
+                spansRepository = spansSink.getSpansRepository()
             )
         } else {
             null
@@ -87,8 +34,8 @@ internal class SpansServiceImpl(
         internal: Boolean,
         code: () -> T
     ): T {
-        return if (EmbraceSpanImpl.inputsValid(name) && validateAndUpdateContext(parent, internal)) {
-            createRootSpanBuilder(name = name, type = type, internal = internal).updateParent(parent).record(code)
+        return if (EmbraceSpanImpl.inputsValid(name) && currentSessionSpan.validateAndUpdateContext(parent, internal)) {
+            createRootSpanBuilder(tracer = tracer, name = name, type = type, internal = internal).updateParent(parent).record(code)
         } else {
             code()
         }
@@ -109,8 +56,10 @@ internal class SpansServiceImpl(
             return false
         }
 
-        return if (EmbraceSpanImpl.inputsValid(name, events, attributes) && validateAndUpdateContext(parent, internal)) {
-            val span = createRootSpanBuilder(name = name, type = type, internal = internal)
+        return if (EmbraceSpanImpl.inputsValid(name, events, attributes) &&
+            currentSessionSpan.validateAndUpdateContext(parent, internal)
+        ) {
+            val span = createRootSpanBuilder(tracer = tracer, name = name, type = type, internal = internal)
                 .updateParent(parent)
                 .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
                 .startSpan()
@@ -133,137 +82,6 @@ internal class SpansServiceImpl(
             false
         }
     }
-
-    override fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode {
-        try {
-            synchronized(completedSpans) {
-                completedSpans += spans.map { EmbraceSpanData(spanData = it) }
-            }
-        } catch (t: Throwable) {
-            return CompletableResultCode.ofFailure()
-        }
-
-        return CompletableResultCode.ofSuccess()
-    }
-
-    override fun completedSpans(): List<EmbraceSpanData> {
-        synchronized(completedSpans) {
-            return completedSpans.toList()
-        }
-    }
-
-    override fun flushSpans(appTerminationCause: EmbraceAttributes.AppTerminationCause?): List<EmbraceSpanData> {
-        synchronized(completedSpans) {
-            // Right now, session spans don't survive native crashes and sudden process terminations,
-            // so telemetry will not be recorded in those cases, for now.
-            val telemetryAttributes = telemetryService.getAndClearTelemetryAttributes()
-
-            currentSessionSpan.get().setAllAttributes(Attributes.builder().fromMap(telemetryAttributes).build())
-
-            if (appTerminationCause == null) {
-                currentSessionSpan.get().endSpan()
-                spansRepository.clearCompletedSpans()
-                currentSessionSpan.set(startSessionSpan(clock.now()))
-            } else {
-                currentSessionSpan.get()?.let {
-                    it.setAttribute(appTerminationCause.keyName(), appTerminationCause.name)
-                    it.endSpan()
-                }
-            }
-
-            val flushedSpans = completedSpans.toList()
-            completedSpans.clear()
-            return flushedSpans
-        }
-    }
-
-    override fun getSpan(spanId: String): EmbraceSpan? = spansRepository.getSpan(spanId)
-
-    /**
-     * Creating a new Span is only possible if the current session span is active, the parent has already been started, and the total
-     * session trace limit has not been reached. Once this method returns true, a new span is assumed to have been created and will
-     * be counted as such towards the limits, so make sure there's no case afterwards where a Span is not created.
-     */
-    private fun validateAndUpdateContext(parent: EmbraceSpan?, internal: Boolean): Boolean {
-        if (!currentSessionSpan.get().isRecording || (parent != null && parent.spanId == null)) {
-            return false
-        }
-
-        if (!internal) {
-            if (parent == null) {
-                if (currentSessionTraceCount.get() < MAX_TRACE_COUNT_PER_SESSION) {
-                    synchronized(currentSessionTraceCount) {
-                        if (currentSessionTraceCount.get() < MAX_TRACE_COUNT_PER_SESSION) {
-                            currentSessionTraceCount.incrementAndGet()
-                        } else {
-                            return false
-                        }
-                    }
-                } else {
-                    return false
-                }
-            } else {
-                val rootSpanId = getRootSpanId(parent)
-                val currentSpanCount = currentSessionChildSpansCount[rootSpanId]
-                if (currentSpanCount == null) {
-                    updateChildrenCount(rootSpanId)
-                } else if (currentSpanCount < MAX_SPAN_COUNT_PER_TRACE) {
-                    synchronized(currentSessionChildSpansCount) {
-                        val currentSpanCountAgain = currentSessionChildSpansCount[rootSpanId]
-                        if (currentSpanCountAgain == null || currentSpanCountAgain < MAX_SPAN_COUNT_PER_TRACE) {
-                            updateChildrenCount(rootSpanId)
-                        } else {
-                            return false
-                        }
-                    }
-                } else {
-                    return false
-                }
-            }
-        }
-
-        return true
-    }
-
-    private fun getRootSpanId(span: EmbraceSpan): String {
-        var currentSpan: EmbraceSpan = span
-        while (currentSpan.parent != null) {
-            currentSpan.parent?.let { currentSpan = it }
-        }
-
-        return currentSpan.spanId ?: ""
-    }
-
-    private fun updateChildrenCount(rootSpanId: String) {
-        val currentCount = currentSessionChildSpansCount[rootSpanId]
-        if (currentCount == null) {
-            // The first time we'll know a root span ID is when a child is being added to it. Prior to that, when adding a prospective
-            // root span, the ID is not known yet. So the first time a root span is encountered add both it and the new child to the count.
-            //
-            // NOTE: Because we don't know whether the root span is internal or not at this point, it is assumed that it isn't.
-            // Therefore, it will count towards the limit if a non-internal span is added to the trace.
-            currentSessionChildSpansCount[rootSpanId] = 2
-        } else {
-            currentSessionChildSpansCount[rootSpanId] = currentCount + 1
-        }
-    }
-
-    /**
-     * This method should always be used when starting a new session span
-     */
-    private fun startSessionSpan(startTimeNanos: Long): Span {
-        currentSessionTraceCount.set(0)
-        return createEmbraceSpanBuilder(name = "session-span", type = EmbraceAttributes.Type.SESSION)
-            .setNoParent()
-            .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
-            .startSpan()
-    }
-
-    private fun createRootSpanBuilder(name: String, type: EmbraceAttributes.Type, internal: Boolean): SpanBuilder =
-        createEmbraceSpanBuilder(name = name, type = type, internal = internal).setNoParent()
-
-    private fun createEmbraceSpanBuilder(name: String, type: EmbraceAttributes.Type, internal: Boolean = true): SpanBuilder =
-        tracer.embraceSpanBuilder(name, internal).setType(type)
 
     companion object {
         const val MAX_TRACE_COUNT_PER_SESSION = 100

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSink.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+
+internal interface SpansSink {
+    /**
+     * Store the given list of completed Spans to be sent to the backend at the next available time
+     */
+    fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode
+
+    /**
+     * Return the list of the currently stored completed Spans that have not been sent to the backend
+     */
+    fun completedSpans(): List<EmbraceSpanData>
+
+    /**
+     * Flush and return all of the stored completed Spans. This should be called when the stored completed spans are ready to be sent to
+     * the backend.
+     */
+    fun flushSpans(): List<EmbraceSpanData>
+
+    /**
+     * Return the [EmbraceSpan] for the given [spanId] if it's available
+     */
+    fun getSpan(spanId: String): EmbraceSpan?
+
+    fun getSpansRepository(): SpansRepository?
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSinkImpl.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+
+internal class SpansSinkImpl : SpansSink {
+
+    private val spansRepository = SpansRepository()
+
+    /**
+     * Spans that have finished, successfully or not, that will be sent with the next session or background activity payload. These
+     * should be cached along with the other data in the payload.
+     */
+    private val completedSpans: MutableList<EmbraceSpanData> = mutableListOf()
+
+    override fun getSpan(spanId: String): EmbraceSpan? = spansRepository.getSpan(spanId)
+
+    override fun getSpansRepository(): SpansRepository = spansRepository
+
+    override fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode {
+        try {
+            synchronized(completedSpans) {
+                completedSpans += spans.map { EmbraceSpanData(spanData = it) }
+            }
+        } catch (t: Throwable) {
+            return CompletableResultCode.ofFailure()
+        }
+
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun completedSpans(): List<EmbraceSpanData> {
+        synchronized(completedSpans) {
+            return completedSpans.toList()
+        }
+    }
+
+    override fun flushSpans(): List<EmbraceSpanData> {
+        synchronized(completedSpans) {
+            val flushedSpans = completedSpans.toList()
+            completedSpans.clear()
+            return flushedSpans
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
@@ -63,11 +63,13 @@ internal class UninitializedSdkSpansService : SpansService {
 
     override fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode = CompletableResultCode.ofFailure()
 
-    override fun completedSpans(): List<EmbraceSpanData>? = null
+    override fun completedSpans(): List<EmbraceSpanData> = emptyList()
 
-    override fun flushSpans(appTerminationCause: EmbraceAttributes.AppTerminationCause?): List<EmbraceSpanData>? = null
+    override fun flushSpans(): List<EmbraceSpanData> = emptyList()
 
     override fun getSpan(spanId: String): EmbraceSpan? = null
+
+    override fun getSpansRepository(): SpansRepository? = null
 
     fun recordBufferedCalls(delegateSpansService: SpansService) {
         synchronized(bufferedCalls) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -12,9 +12,9 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.payload.BetaFeatures
@@ -37,7 +37,7 @@ internal class PayloadMessageCollator(
     private val breadcrumbService: BreadcrumbService,
     private val userService: UserService,
     private val preferencesService: PreferencesService,
-    private val spansService: SpansService,
+    private val currentSessionSpan: CurrentSessionSpan,
     private val clock: Clock,
     private val sessionPropertiesService: SessionPropertiesService,
     private val startupService: StartupService
@@ -163,9 +163,9 @@ internal class PayloadMessageCollator(
                         finalPayload.crashReportId != null -> EmbraceAttributes.AppTerminationCause.CRASH
                         else -> null
                     }
-                    spansService.flushSpans(appTerminationCause)
+                    currentSessionSpan.endSession(appTerminationCause)
                 }
-                else -> spansService.completedSpans()
+                else -> currentSessionSpan.completedSpans()
             }
         }
         val breadcrumbs = captureDataSafely {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
@@ -20,7 +20,7 @@ internal class UninitializedSdkInternalInterfaceImplTest {
     @Before
     fun setUp() {
         initModule = FakeInitModule(clock = FakeClock(currentTime = beforeObjectInitTime))
-        impl = UninitializedSdkInternalInterfaceImpl(InternalTracer(initModule.tracer, initModule.clock))
+        impl = UninitializedSdkInternalInterfaceImpl(InternalTracer(initModule.embraceTracer, initModule.clock))
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -18,11 +18,11 @@ import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
-import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeStartupBehavior
 import io.embrace.android.embracesdk.gating.GatingService
-import io.embrace.android.embracesdk.internal.OpenTelemetryClock
+import io.embrace.android.embracesdk.injection.InitModule
+import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit
 
 internal class EmbraceEventServiceTest {
 
+    private lateinit var initModule: InitModule
     private lateinit var deliveryService: FakeDeliveryService
     private lateinit var configService: FakeConfigService
     private lateinit var gatingService: GatingService
@@ -113,10 +114,13 @@ internal class EmbraceEventServiceTest {
         )
         gatingService = FakeGatingService(configService)
         fakeWorkerThreadModule = FakeWorkerThreadModule(clock = fakeClock, blockingMode = true)
+        initModule = InitModuleImpl(clock = fakeClock)
         spansService = EmbraceSpansService(
-            clock = OpenTelemetryClock(embraceClock = fakeClock),
-            telemetryService = FakeTelemetryService()
+            spansSink = initModule.spansSink,
+            currentSessionSpan = initModule.currentSessionSpan,
+            tracer = initModule.tracer
         )
+        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(fakeClock.now()))
         eventHandler = EventHandler(
             metadataService = metadataService,
             sessionIdTracker = sessionIdTracker,
@@ -426,7 +430,7 @@ internal class EmbraceEventServiceTest {
             sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
         )
         configService.updateListeners()
-        spansService.flushSpans()
+        initModule.currentSessionSpan.endSession()
         eventService.sendStartupMoment()
         eventService.applicationStartupComplete()
         val executor = fakeWorkerThreadModule.executor(WorkerName.BACKGROUND_REGISTRATION)
@@ -447,7 +451,7 @@ internal class EmbraceEventServiceTest {
             sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
         )
         configService.updateListeners()
-        spansService.flushSpans()
+        initModule.currentSessionSpan.endSession()
         eventService.sendStartupMoment()
         eventService.applicationStartupComplete()
         val executor = fakeWorkerThreadModule.executor(WorkerName.BACKGROUND_REGISTRATION)
@@ -474,7 +478,7 @@ internal class EmbraceEventServiceTest {
             sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
         )
         configService.updateListeners()
-        spansService.flushSpans()
+        initModule.currentSessionSpan.endSession()
         eventService.sendStartupMoment()
         assertNull(eventService.getStartupMomentInfo())
         fakeClock.tick(10000L)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -1,19 +1,54 @@
 package io.embrace.android.embracesdk.fakes.injection
 
+import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanExporter
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanProcessor
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.internal.spans.SpansSink
+import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import io.embrace.android.embracesdk.telemetry.TelemetryService
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.SdkTracerProvider
 
 internal class FakeInitModule(
     override val clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
+    fakeOpenTelemetryClock: FakeOpenTelemetryClock = FakeOpenTelemetryClock(clock),
     override val telemetryService: TelemetryService = EmbraceTelemetryService(),
-    override val spansService: SpansService = EmbraceSpansService(FakeOpenTelemetryClock(clock), telemetryService),
-    override val tracer: EmbraceTracer = EmbraceTracer(spansService)
+    override val spansSink: SpansSink = SpansSinkImpl(),
+    override val openTelemetrySdk: OpenTelemetry =
+        OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider
+                    .builder()
+                    .addSpanProcessor(EmbraceSpanProcessor(EmbraceSpanExporter(spansSink)))
+                    .setClock(fakeOpenTelemetryClock)
+                    .build()
+            )
+            .build(),
+    override val tracer: Tracer = openTelemetrySdk.getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME),
+    override val currentSessionSpan: CurrentSessionSpan =
+        CurrentSessionSpanImpl(
+            clock = fakeOpenTelemetryClock,
+            telemetryService = telemetryService,
+            spansSink = spansSink,
+            tracer = tracer
+        ),
+    override val spansService: SpansService = EmbraceSpansService(
+        spansSink = spansSink,
+        currentSessionSpan = currentSessionSpan,
+        tracer = tracer,
+    ),
+    override val embraceTracer: EmbraceTracer = EmbraceTracer(spansService)
 ) : InitModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
@@ -2,10 +2,16 @@ package io.embrace.android.embracesdk.injection
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
+import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
 import io.embrace.android.embracesdk.internal.spans.UninitializedSdkSpansService
+import io.mockk.mockk
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Tracer
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -24,15 +30,30 @@ internal class InitModuleImplTest {
     @Test
     fun testInitModuleImplOverrideComponents() {
         val clock = FakeClock()
+        val telemetryService = FakeTelemetryService()
+        val spansSink = SpansSinkImpl()
         val spansService = UninitializedSdkSpansService()
-        val embraceTracer = EmbraceTracer(spansService)
+        val openTelemetrySdk: OpenTelemetry = mockk()
+        val tracer: Tracer = mockk()
+        val currentSessionSpan: CurrentSessionSpan = mockk()
+        val embraceTracer: EmbraceTracer = mockk()
         val initModule = InitModuleImpl(
             clock = clock,
+            telemetryService = telemetryService,
+            spansSink = spansSink,
+            openTelemetrySdk = openTelemetrySdk,
             spansService = spansService,
-            tracer = embraceTracer
+            tracer = tracer,
+            currentSessionSpan = currentSessionSpan,
+            embraceTracer = embraceTracer,
         )
         assertSame(clock, initModule.clock)
+        assertSame(telemetryService, initModule.telemetryService)
+        assertSame(spansSink, initModule.spansSink)
+        assertSame(openTelemetrySdk, initModule.openTelemetrySdk)
         assertSame(spansService, initModule.spansService)
-        assertSame(embraceTracer, initModule.tracer)
+        assertSame(tracer, initModule.tracer)
+        assertSame(currentSessionSpan, initModule.currentSessionSpan)
+        assertSame(embraceTracer, initModule.embraceTracer)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -14,7 +14,8 @@ import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
-import io.embrace.android.embracesdk.internal.spans.UninitializedSdkSpansService
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.payload.ExceptionError
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
@@ -31,6 +32,7 @@ import org.junit.Test
 
 internal class PayloadMessageCollatorTest {
 
+    private lateinit var initModule: InitModule
     private lateinit var collator: PayloadMessageCollator
 
     private enum class PayloadType {
@@ -40,6 +42,7 @@ internal class PayloadMessageCollatorTest {
 
     @Before
     fun setUp() {
+        initModule = FakeInitModule()
         collator = PayloadMessageCollator(
             configService = FakeConfigService(),
             nativeThreadSamplerService = null,
@@ -53,7 +56,7 @@ internal class PayloadMessageCollatorTest {
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),
-            spansService = UninitializedSdkSpansService(),
+            currentSessionSpan = initModule.currentSessionSpan,
             clock = FakeClock(),
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService()


### PR DESCRIPTION
## Goal

Pull apart the `SpansService` interface  and implementations into constituent components. This is a bit messy, but there's no easy step by step way of breaking them down, so the idea is to do it roughly first then clean up the concerns in subsequent PRs.

There's no new logic, just stuff being moved around. Tests all pass after modifications