### PR TITLE
Detach the use of SpansSink interface from SpansService usage

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -40,9 +40,6 @@ internal class TracingApiTest {
             harness.fakeClock.tick(100L)
             embrace.start(harness.fakeCoreModule.context)
             harness.recordSession {
-                assertTrue(
-                    returnIfConditionMet(desiredValueSupplier = { true }, waitTimeMs = 1000) { embrace.isTracingAvailable() }
-                )
                 val parentSpan = checkNotNull(embrace.createSpan(name = "test-trace-root"))
                 assertTrue(parentSpan.start())
                 assertTrue(parentSpan.addAttribute("oMg", "OmG"))
@@ -91,7 +88,7 @@ internal class TracingApiTest {
                 val backgroundActivitySpansCount = getSdkInitSpanFromBackgroundActivity().size
                 assertTrue(
                     returnIfConditionMet(desiredValueSupplier = { true }, waitTimeMs = 1000) {
-                        checkNotNull(harness.initModule.spansService.completedSpans()).size == (5 - backgroundActivitySpansCount)
+                        checkNotNull(harness.initModule.spansSink.completedSpans()).size == (5 - backgroundActivitySpansCount)
                     }
                 )
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -82,5 +82,8 @@ internal class InitModuleImpl(
         currentSessionSpan = currentSessionSpan,
         tracer = tracer,
     ),
-    override val embraceTracer: EmbraceTracer = EmbraceTracer(spansService)
+    override val embraceTracer: EmbraceTracer = EmbraceTracer(
+        spansSink = spansSink,
+        spansService = spansService
+    )
 ) : InitModule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
@@ -53,8 +53,7 @@ internal class EmbraceSpansService(
         type: EmbraceAttributes.Type,
         internal: Boolean,
         code: () -> T
-    ): T =
-        currentDelegate.recordSpan(name = name, parent = parent, type = type, internal = internal, code = code)
+    ): T = currentDelegate.recordSpan(name = name, parent = parent, type = type, internal = internal, code = code)
 
     override fun recordCompletedSpan(
         name: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -5,7 +5,10 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.TracingApi
 
-internal class EmbraceTracer(private val spansService: SpansService) : TracingApi {
+internal class EmbraceTracer(
+    private val spansSink: SpansSink,
+    private val spansService: SpansService,
+) : TracingApi {
     override fun createSpan(name: String): EmbraceSpan? =
         createSpan(name = name, parent = null)
 
@@ -111,7 +114,7 @@ internal class EmbraceTracer(private val spansService: SpansService) : TracingAp
             errorCode = errorCode
         )
 
-    fun getSpan(spanId: String): EmbraceSpan? = spansService.getSpan(spanId = spanId)
+    fun getSpan(spanId: String): EmbraceSpan? = spansSink.getSpan(spanId = spanId)
 
     @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
     override fun isTracingAvailable(): Boolean = spansService.initialized()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -50,5 +50,8 @@ internal class FakeInitModule(
         currentSessionSpan = currentSessionSpan,
         tracer = tracer,
     ),
-    override val embraceTracer: EmbraceTracer = EmbraceTracer(spansService)
+    override val embraceTracer: EmbraceTracer = EmbraceTracer(
+        spansSink = spansSink,
+        spansService = spansService
+    )
 ) : InitModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -27,9 +27,10 @@ import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.internal.spans.SpansSink
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
@@ -43,7 +44,6 @@ import java.util.concurrent.TimeUnit
 internal class PayloadFactoryBaTest {
 
     private val initial = fakeBackgroundActivity()
-    private lateinit var initModule: InitModule
     private lateinit var service: PayloadFactoryImpl
     private lateinit var clock: FakeClock
     private lateinit var performanceInfoService: FakePerformanceInfoService
@@ -59,7 +59,9 @@ internal class PayloadFactoryBaTest {
     private lateinit var ndkService: FakeNdkService
     private lateinit var configService: FakeConfigService
     private lateinit var localConfig: LocalConfig
-    private lateinit var spansService: EmbraceSpansService
+    private lateinit var spansSink: SpansSink
+    private lateinit var currentSessionSpan: CurrentSessionSpan
+    private lateinit var spansService: SpansService
     private lateinit var preferencesService: FakePreferenceService
     private lateinit var blockingExecutorService: BlockingScheduledExecutorService
 
@@ -78,12 +80,10 @@ internal class PayloadFactoryBaTest {
         ndkService = FakeNdkService()
         preferencesService = FakePreferenceService(backgroundActivityEnabled = true)
         userService = FakeUserService()
-        initModule = FakeInitModule(clock = clock)
-        spansService = EmbraceSpansService(
-            spansSink = initModule.spansSink,
-            currentSessionSpan = initModule.currentSessionSpan,
-            tracer = initModule.tracer
-        )
+        val initModule = FakeInitModule(clock = clock)
+        spansSink = initModule.spansSink
+        currentSessionSpan = initModule.currentSessionSpan
+        spansService = initModule.spansService
         configService = FakeConfigService(
             backgroundActivityCaptureEnabled = true
         )
@@ -118,7 +118,7 @@ internal class PayloadFactoryBaTest {
         // there should be 1 completed span: the session span
         assertEquals(1, deliveryService.saveBackgroundActivityInvokedCount)
         assertEquals(1, deliveryService.lastSavedBackgroundActivities.single().spans?.size)
-        assertEquals(0, spansService.completedSpans().size)
+        assertEquals(0, spansSink.completedSpans().size)
     }
 
     @Test
@@ -130,7 +130,7 @@ internal class PayloadFactoryBaTest {
 
         // there should be 1 completed span: the session span
         assertEquals(1, deliveryService.lastSavedBackgroundActivities.last().spans?.size)
-        assertEquals(0, spansService.completedSpans().size)
+        assertEquals(0, spansSink.completedSpans().size)
     }
 
     @Test
@@ -143,7 +143,7 @@ internal class PayloadFactoryBaTest {
 
         // there should be 1 completed span: the session span
         assertEquals(1, msg.spans?.size)
-        assertEquals(0, spansService.completedSpans().size)
+        assertEquals(0, spansSink.completedSpans().size)
     }
 
     @Test
@@ -169,7 +169,7 @@ internal class PayloadFactoryBaTest {
             breadcrumbService,
             userService,
             preferencesService,
-            initModule.currentSessionSpan,
+            currentSessionSpan,
             clock,
             FakeSessionPropertiesService(),
             FakeStartupService()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -6,8 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.injection.InitModule
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.SpansSink
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
 import io.mockk.clearAllMocks
@@ -26,10 +25,9 @@ import java.util.concurrent.ExecutorService
 internal class PayloadFactorySessionTest {
 
     private val initial = fakeSession()
-    private lateinit var initModule: InitModule
+    private lateinit var spansSink: SpansSink
     private lateinit var service: PayloadFactory
     private lateinit var deliveryService: FakeDeliveryService
-    private lateinit var spansService: EmbraceSpansService
     private lateinit var configService: FakeConfigService
 
     companion object {
@@ -54,12 +52,7 @@ internal class PayloadFactorySessionTest {
     fun before() {
         deliveryService = FakeDeliveryService()
         configService = FakeConfigService()
-        initModule = FakeInitModule(clock = clock)
-        spansService = EmbraceSpansService(
-            spansSink = initModule.spansSink,
-            currentSessionSpan = initModule.currentSessionSpan,
-            tracer = initModule.tracer
-        )
+        spansSink = FakeInitModule(clock = clock).spansSink
     }
 
     @After
@@ -85,7 +78,7 @@ internal class PayloadFactorySessionTest {
     @Test
     fun `spanService that is not initialized will not result in any complete spans`() {
         initializeSessionService()
-        assertEquals(0, spansService.completedSpans().size)
+        assertEquals(0, spansSink.completedSpans().size)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Change tests to get and refer to the right interface when calling methods in `SpansService`. This will enable ripping it and its implementations apart easier.
