### PR TITLE
Additional interface and component refactors to the Spans related services

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -310,7 +310,9 @@ final class EmbraceImpl {
         this.deliveryModuleSupplier = deliveryModuleSupplier;
         this.tracer = initModule.getEmbraceTracer();
         uninitializedSdkInternalInterface =
-            LazyKt.lazy(() -> new UninitializedSdkInternalInterfaceImpl(new InternalTracer(tracer, sdkClock)));
+            LazyKt.lazy(
+                () -> new UninitializedSdkInternalInterfaceImpl(new InternalTracer(initModule.getSpansRepository(), tracer, sdkClock))
+            );
     }
 
     EmbraceImpl() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
@@ -18,7 +18,7 @@ internal class EmbraceInternalInterfaceImpl(
     private val embraceImpl: EmbraceImpl,
     private val initModule: InitModule,
     private val configService: ConfigService,
-    internalTracer: InternalTracer = InternalTracer(initModule.embraceTracer, initModule.clock)
+    internalTracer: InternalTracer = InternalTracer(initModule.spansRepository, initModule.embraceTracer, initModule.clock)
 ) : EmbraceInternalInterface, InternalTracingApi by internalTracer {
 
     override fun logInfo(message: String, properties: Map<String, Any>?) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -52,6 +52,7 @@ internal class SessionModuleImpl(
             dataCaptureServiceModule.breadcrumbService,
             essentialServiceModule.userService,
             androidServicesModule.preferencesService,
+            initModule.spansSink,
             initModule.currentSessionSpan,
             initModule.clock,
             sessionPropertiesService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -2,13 +2,23 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
+/**
+ * Abstraction of the current session span
+ */
 internal interface CurrentSessionSpan {
 
+    /**
+     * Initialize this with its first session span
+     */
     fun startInitialSession(sdkInitStartTimeNanos: Long)
 
+    /**
+     * End the current session span and start a new one if the app is not terminating
+     */
     fun endSession(appTerminationCause: EmbraceAttributes.AppTerminationCause? = null): List<EmbraceSpanData>
 
-    fun completedSpans(): List<EmbraceSpanData>
-
-    fun validateAndUpdateContext(parent: EmbraceSpan?, internal: Boolean): Boolean
+    /**
+     * Returns true if a span with the given parameters can be started in the current session
+     */
+    fun canStartNewSpan(parent: EmbraceSpan?, internal: Boolean): Boolean
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.TracingApi
 
 internal class EmbraceTracer(
-    private val spansSink: SpansSink,
+    private val spansRepository: SpansRepository,
     private val spansService: SpansService,
 ) : TracingApi {
     override fun createSpan(name: String): EmbraceSpan? =
@@ -114,7 +114,7 @@ internal class EmbraceTracer(
             errorCode = errorCode
         )
 
-    fun getSpan(spanId: String): EmbraceSpan? = spansSink.getSpan(spanId = spanId)
+    fun getSpan(spanId: String): EmbraceSpan? = spansRepository.getSpan(spanId = spanId)
 
     @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
     override fun isTracingAvailable(): Boolean = spansService.initialized()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import java.util.concurrent.TimeUnit
 
 internal class InternalTracer(
+    private val spansRepository: SpansRepository,
     private val embraceTracer: EmbraceTracer,
     private val clock: Clock
 ) : InternalTracingApi {
@@ -28,7 +29,7 @@ internal class InternalTracer(
     }
 
     override fun stopSpan(spanId: String, errorCode: ErrorCode?): Boolean =
-        embraceTracer.getSpan(spanId = spanId)?.stop(errorCode = errorCode) ?: false
+        spansRepository.getSpan(spanId = spanId)?.stop(errorCode = errorCode) ?: false
 
     override fun <T> recordSpan(
         name: String,
@@ -75,14 +76,14 @@ internal class InternalTracer(
     }
 
     override fun addSpanEvent(spanId: String, name: String, time: Long?, attributes: Map<String, String>?): Boolean =
-        embraceTracer.getSpan(spanId = spanId)?.addEvent(
+        spansRepository.getSpan(spanId = spanId)?.addEvent(
             name = name,
             time = time,
             attributes = attributes
         ) ?: false
 
     override fun addSpanAttribute(spanId: String, key: String, value: String): Boolean =
-        embraceTracer.getSpan(spanId = spanId)?.addAttribute(
+        spansRepository.getSpan(spanId = spanId)?.addAttribute(
             key = key,
             value = value
         ) ?: false
@@ -103,7 +104,7 @@ internal class InternalTracer(
     }
 
     private fun validateParent(parentSpanId: String?): Parent {
-        val parentSpan = parentSpanId?.let { embraceTracer.getSpan(spanId = parentSpanId) }
+        val parentSpan = parentSpanId?.let { spansRepository.getSpan(spanId = parentSpanId) }
         return Parent(isValid = parentSpanId == null || parentSpan != null, spanReference = parentSpan)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansService.kt
@@ -4,14 +4,14 @@ import io.embrace.android.embracesdk.internal.Initializable
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.Span
 
 /**
- * Public interface for an internal service that manages the recording, storage, and propagation of Spans
+ * Internal service that supports the creation and recording of [EmbraceSpan]
  */
-internal interface SpansService : Initializable, SpansSink {
+internal interface SpansService : Initializable {
     /**
-     * Return an [EmbraceSpan] that can be started and stopped
+     * Return an [EmbraceSpan] instance that can be used to record spans. Returns null if at least one input parameter is not valid or if
+     * the SDK or session is not in a state where a new span can be recorded.
      */
     fun createSpan(
         name: String,
@@ -21,10 +21,8 @@ internal interface SpansService : Initializable, SpansSink {
     ): EmbraceSpan?
 
     /**
-     * Record a key span around the given lambda with the current session span as its parent where the start time will be when the lambda
-     * starts and the end time will be when the lambda ends. If the lambda throws an exception, it will be recorded as a
-     * [ErrorCode.FAILURE]. The name of the span will be the provided name with the appropriate prefix prepended to it
-     * if [internal] is true.
+     * Records a span around the execution of the given lambda. If the lambda throws an uncaught exception, it will be recorded as a
+     * [ErrorCode.FAILURE]. The span will be the provided name, and the appropriate prefix will be prepended to it if [internal] is true.
      */
     fun <T> recordSpan(
         name: String,
@@ -35,8 +33,8 @@ internal interface SpansService : Initializable, SpansSink {
     ): T
 
     /**
-     * Record a completed [Span] for work that has already been done. Returns true if the span was recorded or queued to be recorded,
-     * false if it wasn't.
+     * Record a completed span for an operation with the given start and end times. Returns true if the span was recorded or queued to be
+     * recorded, false if it wasn't.
      */
     fun recordCompletedSpan(
         name: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSink.kt
@@ -1,30 +1,26 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.trace.data.SpanData
 
+/**
+ * A service that stores all the spans that are completed and exported via [EmbraceSpanExporter], and provides access to them so they
+ * can be sent off-device at the appropriate cadence.
+ */
 internal interface SpansSink {
     /**
-     * Store the given list of completed Spans to be sent to the backend at the next available time
+     * Stores spans that have been completed. Implementations must support concurrent invocations.
      */
     fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode
 
     /**
-     * Return the list of the currently stored completed Spans that have not been sent to the backend
+     * Returns the list of the currently stored completed spans.
      */
     fun completedSpans(): List<EmbraceSpanData>
 
     /**
-     * Flush and return all of the stored completed Spans. This should be called when the stored completed spans are ready to be sent to
-     * the backend.
+     * Returns and clears the currently stored completed Spans. Implementations of this method must make sure the clearing and returning is
+     * atomic, i.e. spans cannot be added during this operation.
      */
     fun flushSpans(): List<EmbraceSpanData>
-
-    /**
-     * Return the [EmbraceSpan] for the given [spanId] if it's available
-     */
-    fun getSpan(spanId: String): EmbraceSpan?
-
-    fun getSpansRepository(): SpansRepository?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansSinkImpl.kt
@@ -1,22 +1,10 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.trace.data.SpanData
 
 internal class SpansSinkImpl : SpansSink {
-
-    private val spansRepository = SpansRepository()
-
-    /**
-     * Spans that have finished, successfully or not, that will be sent with the next session or background activity payload. These
-     * should be cached along with the other data in the payload.
-     */
     private val completedSpans: MutableList<EmbraceSpanData> = mutableListOf()
-
-    override fun getSpan(spanId: String): EmbraceSpan? = spansRepository.getSpan(spanId)
-
-    override fun getSpansRepository(): SpansRepository = spansRepository
 
     override fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode {
         try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
@@ -4,20 +4,18 @@ import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * An implementation of [SpansService] used when the SDK is not enabled
+ * An implementation of [SpansService] used when the SDK has not been started.
  */
 @InternalApi
 internal class UninitializedSdkSpansService : SpansService {
     private val bufferedCalls = ConcurrentLinkedQueue<BufferedRecordCompletedSpan>()
     private val bufferedCallsCount = AtomicInteger(0)
 
-    override fun initializeService(sdkInitStartTimeNanos: Long) { }
+    override fun initializeService(sdkInitStartTimeNanos: Long) {}
 
     override fun initialized(): Boolean = true
 
@@ -64,16 +62,6 @@ internal class UninitializedSdkSpansService : SpansService {
         }
     }
 
-    override fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode = CompletableResultCode.ofFailure()
-
-    override fun completedSpans(): List<EmbraceSpanData> = emptyList()
-
-    override fun flushSpans(): List<EmbraceSpanData> = emptyList()
-
-    override fun getSpan(spanId: String): EmbraceSpan? = null
-
-    override fun getSpansRepository(): SpansRepository? = null
-
     fun recordBufferedCalls(delegateSpansService: SpansService) {
         synchronized(bufferedCalls) {
             do {
@@ -99,7 +87,7 @@ internal class UninitializedSdkSpansService : SpansService {
     }
 
     /**
-     * Represents a call to [EmbraceSpansService.recordCompletedSpan] that is saved to be invoked later when the service is initialized
+     * Represents a call to [SpansService.recordCompletedSpan] that can be saved and replayed later when the SDK is initialized.
      */
     data class BufferedRecordCompletedSpan(
         val name: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.spans.SpansSink
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.payload.BetaFeatures
@@ -37,6 +38,7 @@ internal class PayloadMessageCollator(
     private val breadcrumbService: BreadcrumbService,
     private val userService: UserService,
     private val preferencesService: PreferencesService,
+    private val spansSink: SpansSink,
     private val currentSessionSpan: CurrentSessionSpan,
     private val clock: Clock,
     private val sessionPropertiesService: SessionPropertiesService,
@@ -165,7 +167,7 @@ internal class PayloadMessageCollator(
                     }
                     currentSessionSpan.endSession(appTerminationCause)
                 }
-                else -> currentSessionSpan.completedSpans()
+                else -> spansSink.completedSpans()
             }
         }
         val breadcrumbs = captureDataSafely {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
@@ -20,7 +20,13 @@ internal class UninitializedSdkInternalInterfaceImplTest {
     @Before
     fun setUp() {
         initModule = FakeInitModule(clock = FakeClock(currentTime = beforeObjectInitTime))
-        impl = UninitializedSdkInternalInterfaceImpl(InternalTracer(initModule.embraceTracer, initModule.clock))
+        impl = UninitializedSdkInternalInterfaceImpl(
+            InternalTracer(
+                initModule.spansRepository,
+                initModule.embraceTracer,
+                initModule.clock
+            )
+        )
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanExporter
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanProcessor
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
+import io.embrace.android.embracesdk.internal.spans.SpansRepository
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.internal.spans.SpansSink
 import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
@@ -26,6 +27,7 @@ internal class FakeInitModule(
     override val clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
     fakeOpenTelemetryClock: FakeOpenTelemetryClock = FakeOpenTelemetryClock(clock),
     override val telemetryService: TelemetryService = EmbraceTelemetryService(),
+    override val spansRepository: SpansRepository = SpansRepository(),
     override val spansSink: SpansSink = SpansSinkImpl(),
     override val openTelemetrySdk: OpenTelemetry =
         OpenTelemetrySdk.builder()
@@ -42,16 +44,17 @@ internal class FakeInitModule(
         CurrentSessionSpanImpl(
             clock = fakeOpenTelemetryClock,
             telemetryService = telemetryService,
+            spansRepository = spansRepository,
             spansSink = spansSink,
             tracer = tracer
         ),
     override val spansService: SpansService = EmbraceSpansService(
-        spansSink = spansSink,
+        spansRepository = spansRepository,
         currentSessionSpan = currentSessionSpan,
         tracer = tracer,
     ),
     override val embraceTracer: EmbraceTracer = EmbraceTracer(
-        spansSink = spansSink,
+        spansRepository = spansRepository,
         spansService = spansService
     )
 ) : InitModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 
 internal class EmbraceSpansServiceTest {
+    private lateinit var spansRepository: SpansRepository
     private lateinit var spansSink: SpansSink
     private lateinit var currentSessionSpan: CurrentSessionSpan
     private lateinit var spansService: SpansService
@@ -21,6 +22,7 @@ internal class EmbraceSpansServiceTest {
     @Before
     fun setup() {
         val initModule = FakeInitModule(clock = clock)
+        spansRepository = initModule.spansRepository
         spansSink = initModule.spansSink
         currentSessionSpan = initModule.currentSessionSpan
         spansService = initModule.spansService
@@ -37,7 +39,7 @@ internal class EmbraceSpansServiceTest {
         assertEquals(0, spansSink.completedSpans().size)
         assertEquals(0, spansSink.flushSpans().size)
         assertEquals(CompletableResultCode.ofSuccess(), spansSink.storeCompletedSpans(listOf()))
-        assertNull(spansSink.getSpan("some-span-id"))
+        assertNull(spansRepository.getSpan("some-span-id"))
     }
 
     @Test
@@ -197,12 +199,12 @@ internal class EmbraceSpansServiceTest {
 
     @Test
     fun `can get span with spanId`() {
-        assertNull(spansSink.getSpan("blah"))
+        assertNull(spansRepository.getSpan("blah"))
         initializeService()
         val span = checkNotNull(spansService.createSpan("test-span"))
         assertTrue(span.start())
         val spanId = checkNotNull(span.spanId)
-        val spanFromId = spansSink.getSpan(spanId)
+        val spanFromId = spansRepository.getSpan(spanId)
         assertSame(spanFromId, span)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import java.util.concurrent.TimeUnit
 
 internal class EmbraceTracerTest {
+    private lateinit var spansRepository: SpansRepository
     private lateinit var spansSink: SpansSink
     private lateinit var spansService: SpansService
     private lateinit var embraceTracer: EmbraceTracer
@@ -23,11 +24,12 @@ internal class EmbraceTracerTest {
     @Before
     fun setup() {
         val initModule = FakeInitModule(clock = clock)
+        spansRepository = initModule.spansRepository
         spansSink = initModule.spansSink
         spansService = initModule.spansService
         spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
         embraceTracer = EmbraceTracer(
-            spansSink = spansSink,
+            spansRepository = spansRepository,
             spansService = spansService
         )
         spansSink.flushSpans()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
@@ -14,7 +14,6 @@ import org.junit.Test
 import java.util.concurrent.TimeUnit
 
 internal class InternalTracerTest {
-
     private lateinit var spansSink: SpansSink
     private lateinit var currentSessionSpan: CurrentSessionSpan
     private lateinit var spansService: SpansService
@@ -28,7 +27,11 @@ internal class InternalTracerTest {
         currentSessionSpan = initModule.currentSessionSpan
         spansService = initModule.spansService
         spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
-        internalTracer = InternalTracer(EmbraceTracer(spansSink, spansService), clock)
+        internalTracer = InternalTracer(
+            initModule.spansRepository,
+            initModule.embraceTracer,
+            clock
+        )
         spansSink.flushSpans()
     }
 
@@ -224,7 +227,6 @@ internal class InternalTracerTest {
         assertFalse(internalTracer.addSpanAttribute(spanId = NON_EXISTENT_SPAN_ID, key = "key", value = "value"))
         assertFalse(internalTracer.addSpanEvent(spanId = NON_EXISTENT_SPAN_ID, name = "even1"))
         assertEquals(2, internalTracer.recordSpan(name = "test-span", parentSpanId = NON_EXISTENT_SPAN_ID) { 1 + 1 })
-        assertNull(spansSink.getSpan(spanId = NON_EXISTENT_SPAN_ID))
         assertFalse(
             internalTracer.recordCompletedSpan(
                 name = "test-span",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -169,6 +169,7 @@ internal class PayloadFactoryBaTest {
             breadcrumbService,
             userService,
             preferencesService,
+            spansSink,
             currentSessionSpan,
             clock,
             FakeSessionPropertiesService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -56,6 +56,7 @@ internal class PayloadMessageCollatorTest {
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),
+            spansSink = initModule.spansSink,
             currentSessionSpan = initModule.currentSessionSpan,
             clock = FakeClock(),
             sessionPropertiesService = FakeSessionPropertiesService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -148,6 +148,7 @@ internal class SessionHandlerTest {
             breadcrumbService,
             userService,
             preferencesService,
+            initModule.spansSink,
             initModule.currentSessionSpan,
             clock,
             FakeSessionPropertiesService(),


### PR DESCRIPTION
## Goal

Initialize SpansRepository in the InitModule so the instance can be shared explicitly rather than being passed around via a method.
