### PR TITLE
Refactor tests into the appropriate test classes

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -1,0 +1,173 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.opentelemetry.api.trace.StatusCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class CurrentSessionSpanImplTests {
+    private lateinit var spansRepository: SpansRepository
+    private lateinit var spansSink: SpansSink
+    private lateinit var currentSessionSpan: CurrentSessionSpan
+    private lateinit var spansService: SpansService
+    private val clock = FakeClock(1000L)
+
+    @Before
+    fun setup() {
+        val initModule = FakeInitModule(clock = clock)
+        spansRepository = initModule.spansRepository
+        spansSink = initModule.spansSink
+        currentSessionSpan = initModule.currentSessionSpan
+        spansService = initModule.spansService
+        spansService.initializeService(clock.now())
+    }
+
+    @Test
+    fun `check trace limits with maximum not started traces`() {
+        repeat(SpansServiceImpl.MAX_TRACE_COUNT_PER_SESSION) {
+            assertNotNull(spansService.createSpan(name = "spanzzz$it", internal = false))
+        }
+        assertNull(spansService.createSpan(name = "failed-span", internal = false))
+    }
+
+    @Test
+    fun `check trace limits with maximum traces recorded around a lambda`() {
+        repeat(SpansServiceImpl.MAX_TRACE_COUNT_PER_SESSION) {
+            assertEquals("derp", spansService.recordSpan(name = "record$it", internal = false) { "derp" })
+        }
+        assertNull(spansService.createSpan(name = "failed-span", internal = false))
+    }
+
+    @Test
+    fun `check trace limits with maximum completed traces`() {
+        repeat(SpansServiceImpl.MAX_TRACE_COUNT_PER_SESSION) {
+            assertTrue(
+                spansService.recordCompletedSpan(
+                    name = "complete$it",
+                    startTimeNanos = 100L,
+                    endTimeNanos = 200L,
+                    internal = false
+                )
+            )
+        }
+        assertNull(spansService.createSpan(name = "failed-span", internal = false))
+    }
+
+    @Test
+    fun `check internal traces and child spans don't count towards limit`() {
+        val parent = checkNotNull(spansService.createSpan(name = "test-span", internal = false))
+        assertTrue(parent.start())
+        assertNotNull(spansService.createSpan(name = "child-span", parent = parent, internal = false))
+        assertNotNull(spansService.createSpan(name = "internal-span", parent = parent, internal = true))
+        repeat(SpansServiceImpl.MAX_TRACE_COUNT_PER_SESSION - 1) {
+            assertNotNull(spansService.createSpan(name = "spanzzz$it", internal = false))
+        }
+        assertNull(spansService.createSpan(name = "failed-span", internal = false))
+        assertNotNull(spansService.createSpan(name = "child-span", parent = parent, internal = false))
+        assertNotNull(spansService.createSpan(name = "internal-again", internal = true))
+    }
+
+    @Test
+    fun `check child span per trace limit`() {
+        var parentSpan: EmbraceSpan? = null
+        repeat(SpansServiceImpl.MAX_SPAN_COUNT_PER_TRACE) {
+            val span = spansService.createSpan(name = "spanzzz$it", parent = parentSpan, internal = false)
+            assertTrue(checkNotNull(span).start())
+            parentSpan = span
+        }
+        assertNull(spansService.createSpan(name = "failed-span", parent = parentSpan, internal = false))
+        assertFalse(
+            spansService.recordCompletedSpan(
+                name = "failed-span",
+                startTimeNanos = 100L,
+                endTimeNanos = 200L,
+                parent = parentSpan,
+                internal = false
+            )
+        )
+        spansSink.flushSpans()
+        assertEquals(2, spansService.recordSpan(name = "failed-span", parent = parentSpan, internal = false) { 2 })
+        assertEquals(0, spansSink.completedSpans().size)
+    }
+
+    @Test
+    fun `check internal child spans don't count towards limit`() {
+        val parentSpan = checkNotNull(spansService.createSpan(name = "parent-span", internal = true))
+        assertTrue(parentSpan.start())
+        assertNotNull(spansService.createSpan(name = "failed-span", parent = parentSpan, internal = true))
+        assertNotNull(spansService.recordSpan(name = "failed-span", parent = parentSpan, internal = true) { })
+        assertTrue(
+            spansService.recordCompletedSpan(
+                name = "failed-span",
+                startTimeNanos = 100L,
+                endTimeNanos = 200L,
+                parent = parentSpan,
+                internal = true
+            )
+        )
+
+        repeat(SpansServiceImpl.MAX_SPAN_COUNT_PER_TRACE - 1) {
+            assertNotNull(spansService.createSpan(name = "spanzzz$it", parent = parentSpan, internal = false))
+        }
+        assertNull(spansService.createSpan(name = "failed-span", parent = parentSpan, internal = false))
+        assertNotNull(spansService.createSpan(name = "internal-span", parent = parentSpan, internal = true))
+    }
+
+    @Test
+    fun `flushing with app termination and termination reason flushes session span with right termination type`() {
+        EmbraceAttributes.AppTerminationCause.values().forEach {
+            val module = FakeInitModule(clock = clock)
+            val sessionSpan = module.currentSessionSpan
+            module.spansService.initializeService(clock.now())
+            val flushedSpans = sessionSpan.endSession(it)
+            assertEquals(1, flushedSpans.size)
+
+            val lastFlushedSpan = flushedSpans[0]
+            with(lastFlushedSpan) {
+                assertEquals("emb-session-span", name)
+                assertEquals(
+                    EmbraceAttributes.Type.SESSION.name,
+                    attributes[EmbraceAttributes.Type.SESSION.keyName()]
+                )
+                assertEquals(StatusCode.OK, status)
+                assertFalse(isKey())
+                assertEquals(it.name, attributes[it.keyName()])
+            }
+
+            assertEquals(0, module.spansSink.completedSpans().size)
+        }
+    }
+
+    @Test
+    fun `validate tracked spans update when session is ended`() {
+        val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
+        assertTrue(embraceSpan.start())
+        val embraceSpanId = checkNotNull(embraceSpan.spanId)
+        val parentSpan = checkNotNull(spansService.createSpan(name = "parent-span"))
+        assertTrue(parentSpan.start())
+        val parentSpanId = checkNotNull(parentSpan.spanId)
+        val parentSpanFromService = checkNotNull(spansRepository.getSpan(parentSpanId))
+        assertTrue(parentSpanFromService.stop())
+        currentSessionSpan.endSession()
+
+        // completed span not available after flush
+        assertNull(spansRepository.getSpan(parentSpanId))
+
+        // existing reference to completed span can still be used
+        checkNotNull(spansService.createSpan(name = "child-span", parent = parentSpan))
+
+        // active span from before flush is still available and working
+        val activeSpanFromBeforeFlush = checkNotNull(spansRepository.getSpan(embraceSpanId))
+        assertTrue(activeSpanFromBeforeFlush.stop())
+        val currentSpans = spansSink.completedSpans()
+        assertEquals(1, currentSpans.size)
+        assertEquals("emb-test-span", currentSpans[0].name)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -28,10 +28,7 @@ internal class EmbraceTracerTest {
         spansSink = initModule.spansSink
         spansService = initModule.spansService
         spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
-        embraceTracer = EmbraceTracer(
-            spansRepository = spansRepository,
-            spansService = spansService
-        )
+        embraceTracer = initModule.embraceTracer
         spansSink.flushSpans()
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImplTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -12,37 +11,42 @@ import io.embrace.android.embracesdk.fixtures.maxSizeAttributes
 import io.embrace.android.embracesdk.fixtures.maxSizeEvents
 import io.embrace.android.embracesdk.fixtures.tooBigAttributes
 import io.embrace.android.embracesdk.fixtures.tooBigEvents
-import io.embrace.android.embracesdk.internal.spans.SpansServiceImpl.Companion.MAX_SPAN_COUNT_PER_TRACE
-import io.embrace.android.embracesdk.internal.spans.SpansServiceImpl.Companion.MAX_TRACE_COUNT_PER_SESSION
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import java.util.concurrent.TimeUnit
 
-@Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
 internal class SpansServiceImplTest {
     private lateinit var spansSink: SpansSink
-    private lateinit var spansRepository: SpansRepository
     private lateinit var currentSessionSpan: CurrentSessionSpan
     private lateinit var spansService: SpansServiceImpl
     private val clock = FakeClock(1000L)
 
+    @Before
+    fun setup() {
+        val initModule = FakeInitModule(clock = clock)
+        spansSink = initModule.spansSink
+        currentSessionSpan = initModule.currentSessionSpan
+        spansService = SpansServiceImpl(
+            spansRepository = initModule.spansRepository,
+            currentSessionSpan = currentSessionSpan,
+            tracer = initModule.tracer
+        )
+        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
+    }
+
     @Test
     fun `create trace with default parameters`() {
-        initAndStartNextSession()
         val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertNull(embraceSpan.parent)
         assertTrue(embraceSpan.start())
@@ -59,7 +63,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `create trace with custom type`() {
-        initAndStartNextSession()
         val embraceSpan = checkNotNull(
             spansService.createSpan(
                 name = "test-span",
@@ -80,7 +83,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `create trace with children`() {
-        initAndStartNextSession()
         val parentSpan = spansService.createSpan(name = "test-span")
         checkNotNull(parentSpan).start()
         val childSpan = spansService.createSpan(name = "child-span", parent = parentSpan)
@@ -114,29 +116,24 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `start span created from previous session`() {
-        initAndStartNextSession()
         val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
-        spansSink.flushSpans()
+        currentSessionSpan.endSession()
         assertTrue(embraceSpan.start())
     }
 
     @Test
-    fun `cannot create span with no session span`() {
-        initAndStartNextSession()
-        currentSessionSpan.endSession(appTerminationCause = EmbraceAttributes.AppTerminationCause.USER_TERMINATION)
-        assertNull(spansService.createSpan(name = "test"))
+    fun `cannot create span before initialization`() {
+        assertNull(FakeInitModule(clock = clock).spansService.createSpan(name = "test"))
     }
 
     @Test
     fun `cannot create span with blank name`() {
-        initAndStartNextSession()
         assertNull(spansService.createSpan(name = ""))
         assertNull(spansService.createSpan(name = " "))
     }
 
     @Test
     fun `cannot create child if parent not started`() {
-        initAndStartNextSession()
         val parentSpan = spansService.createSpan(name = "test-span")
         val childSpan = spansService.createSpan(name = "child-span", parent = parentSpan)
         assertNull(childSpan)
@@ -144,7 +141,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `can create child if parent has stopped`() {
-        initAndStartNextSession()
         val parentSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertTrue(parentSpan.start())
         assertTrue(parentSpan.stop())
@@ -154,7 +150,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `record internal completed span with all the fixings`() {
-        initAndStartNextSession()
         val expectedName = "test-span"
         val expectedStartTime = clock.now()
         val expectedEndTime = expectedStartTime + 100L
@@ -193,7 +188,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `record completed child span`() {
-        initAndStartNextSession()
         val expectedName = "child-span"
         val expectedStartTime = clock.now()
         val expectedEndTime = expectedStartTime + 100L
@@ -224,14 +218,13 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `record completed child span with stopped parent`() {
-        initAndStartNextSession()
         val expectedName = "child-span"
         val expectedStartTime = clock.now()
         val expectedEndTime = expectedStartTime + 100L
         val parentSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertTrue(parentSpan.start())
         assertTrue(parentSpan.stop())
-        spansSink.flushSpans()
+        currentSessionSpan.endSession()
         assertTrue(
             spansService.recordCompletedSpan(
                 name = expectedName,
@@ -244,7 +237,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `can't record completed child span with not-started parent`() {
-        initAndStartNextSession()
         val expectedName = "child-span"
         val parentSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertFalse(
@@ -259,7 +251,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `record spans with different ending error codes `() {
-        initAndStartNextSession()
         ErrorCode.values().forEach {
             assertTrue(
                 spansService.recordCompletedSpan(
@@ -278,7 +269,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `validate start and end times for a completed span`() {
-        initAndStartNextSession()
         assertFalse(
             spansService.recordCompletedSpan(
                 name = "test-pan",
@@ -290,7 +280,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `cannot record completed span if there is not current session span`() {
-        initAndStartNextSession()
         currentSessionSpan.endSession(
             appTerminationCause = EmbraceAttributes.AppTerminationCause.USER_TERMINATION
         )
@@ -305,7 +294,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `record lambda running as trace`() {
-        initAndStartNextSession()
         val returnThis = "yooooo"
         val lambdaReturn = spansService.recordSpan(name = "test-span") {
             returnThis
@@ -325,7 +313,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `record lambda running as a child span`() {
-        initAndStartNextSession()
         val parentSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertTrue(parentSpan.start())
         spansService.recordSpan(name = "child-span", parent = parentSpan) {
@@ -348,7 +335,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `lambda with not-started parent will still run and return value`() {
-        initAndStartNextSession()
         val parentSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         val returnThis = 1
         val returnValue = spansService.recordSpan(name = "child-span", parent = parentSpan) {
@@ -361,7 +347,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `lambda with stopped parent will still be recorded`() {
-        initAndStartNextSession()
         val parentSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertTrue(parentSpan.start())
         assertTrue(parentSpan.stop())
@@ -376,7 +361,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `recording span as lambda throws an exception will record a failed span and rethrows exception`() {
-        initAndStartNextSession()
         assertThrows(RuntimeException::class.java) {
             spansService.recordSpan(name = "test-span") {
                 throw RuntimeException("You done bad")
@@ -392,8 +376,7 @@ internal class SpansServiceImplTest {
     }
 
     @Test
-    fun `logging span as lambda with no current active session will run code but not log span`() {
-        initAndStartNextSession()
+    fun `recording span as lambda with no current active session will run code but not log span`() {
         currentSessionSpan.endSession(
             appTerminationCause = EmbraceAttributes.AppTerminationCause.USER_TERMINATION
         )
@@ -407,8 +390,17 @@ internal class SpansServiceImplTest {
     }
 
     @Test
+    fun `after ending session with app termination, spans cannot be recorded`() {
+        currentSessionSpan.endSession(EmbraceAttributes.AppTerminationCause.USER_TERMINATION)
+        spansService.recordSpan("test-span") {
+            // do thing
+        }
+        assertFalse(spansService.recordCompletedSpan("test-span-2", startTimeNanos = 0, endTimeNanos = 1))
+        assertEquals(0, spansSink.completedSpans().size)
+    }
+
+    @Test
     fun `check name length limit`() {
-        initAndStartNextSession()
         assertNull(spansService.createSpan(name = TOO_LONG_SPAN_NAME))
         assertFalse(spansService.recordCompletedSpan(name = TOO_LONG_SPAN_NAME, startTimeNanos = 100L, endTimeNanos = 200L))
         assertNotNull(spansService.recordSpan(name = TOO_LONG_SPAN_NAME) { 1 })
@@ -421,7 +413,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `check events limit`() {
-        initAndStartNextSession()
         assertFalse(
             spansService.recordCompletedSpan(
                 name = "too many events",
@@ -470,7 +461,6 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `check attributes limit`() {
-        initAndStartNextSession()
         assertFalse(
             spansService.recordCompletedSpan(
                 name = "too many attributes",
@@ -510,218 +500,6 @@ internal class SpansServiceImplTest {
         val completedSpans = spansSink.completedSpans()
         assertEquals(1, completedSpans.size)
         assertEquals(48, completedSpans[0].attributes.filterNot { it.key.startsWith("emb.") }.size)
-    }
-
-    @Test
-    fun `check trace limits with maximum not started traces`() {
-        initAndStartNextSession()
-        repeat(MAX_TRACE_COUNT_PER_SESSION) {
-            assertNotNull(spansService.createSpan(name = "spanzzz$it", internal = false))
-        }
-        assertNull(spansService.createSpan(name = "failed-span", internal = false))
-    }
-
-    @Test
-    fun `check trace limits with maximum traces recorded around a lambda`() {
-        initAndStartNextSession()
-        repeat(MAX_TRACE_COUNT_PER_SESSION) {
-            assertEquals("derp", spansService.recordSpan(name = "record$it", internal = false) { "derp" })
-        }
-        assertNull(spansService.createSpan(name = "failed-span", internal = false))
-    }
-
-    @Test
-    fun `check trace limits with maximum completed traces`() {
-        initAndStartNextSession()
-        repeat(MAX_TRACE_COUNT_PER_SESSION) {
-            assertTrue(
-                spansService.recordCompletedSpan(
-                    name = "complete$it",
-                    startTimeNanos = 100L,
-                    endTimeNanos = 200L,
-                    internal = false
-                )
-            )
-        }
-        assertNull(spansService.createSpan(name = "failed-span", internal = false))
-    }
-
-    @Test
-    fun `check internal traces and child spans don't count towards limit`() {
-        initAndStartNextSession()
-        val parent = checkNotNull(spansService.createSpan(name = "test-span", internal = false))
-        assertTrue(parent.start())
-        assertNotNull(spansService.createSpan(name = "child-span", parent = parent, internal = false))
-        assertNotNull(spansService.createSpan(name = "internal-span", parent = parent, internal = true))
-        repeat(MAX_TRACE_COUNT_PER_SESSION - 1) {
-            assertNotNull(spansService.createSpan(name = "spanzzz$it", internal = false))
-        }
-        assertNull(spansService.createSpan(name = "failed-span", internal = false))
-        assertNotNull(spansService.createSpan(name = "child-span", parent = parent, internal = false))
-        assertNotNull(spansService.createSpan(name = "internal-again", internal = true))
-    }
-
-    @Test
-    fun `check child span per trace limit`() {
-        initAndStartNextSession()
-        var parentSpan: EmbraceSpan? = null
-        repeat(MAX_SPAN_COUNT_PER_TRACE) {
-            val span = spansService.createSpan(name = "spanzzz$it", parent = parentSpan, internal = false)
-            assertTrue(checkNotNull(span).start())
-            parentSpan = span
-        }
-        assertNull(spansService.createSpan(name = "failed-span", parent = parentSpan, internal = false))
-        assertFalse(
-            spansService.recordCompletedSpan(
-                name = "failed-span",
-                startTimeNanos = 100L,
-                endTimeNanos = 200L,
-                parent = parentSpan,
-                internal = false
-            )
-        )
-        spansSink.flushSpans()
-        assertEquals(2, spansService.recordSpan(name = "failed-span", parent = parentSpan, internal = false) { 2 })
-        assertEquals(0, spansSink.completedSpans().size)
-    }
-
-    @Test
-    fun `check internal child spans don't count towards limit`() {
-        initAndStartNextSession()
-        val parentSpan = checkNotNull(spansService.createSpan(name = "parent-span", internal = true))
-        assertTrue(parentSpan.start())
-        assertNotNull(spansService.createSpan(name = "failed-span", parent = parentSpan, internal = true))
-        assertNotNull(spansService.recordSpan(name = "failed-span", parent = parentSpan, internal = true) { })
-        assertTrue(
-            spansService.recordCompletedSpan(
-                name = "failed-span",
-                startTimeNanos = 100L,
-                endTimeNanos = 200L,
-                parent = parentSpan,
-                internal = true
-            )
-        )
-
-        repeat(MAX_SPAN_COUNT_PER_TRACE - 1) {
-            assertNotNull(spansService.createSpan(name = "spanzzz$it", parent = parentSpan, internal = false))
-        }
-        assertNull(spansService.createSpan(name = "failed-span", parent = parentSpan, internal = false))
-        assertNotNull(spansService.createSpan(name = "internal-span", parent = parentSpan, internal = true))
-    }
-
-    @Test
-    fun `flushing clears completed spans and current session span`() {
-        initAndStartNextSession()
-        repeat(3) {
-            spansService.recordSpan("test$it") { }
-        }
-        assertEquals(3, spansSink.completedSpans().size)
-
-        val flushedSpans = currentSessionSpan.endSession()
-        assertEquals(4, flushedSpans.size)
-
-        val lastFlushedSpan = flushedSpans[3]
-        with(lastFlushedSpan) {
-            assertEquals("emb-session-span", name)
-            assertEquals(
-                EmbraceAttributes.Type.SESSION.name,
-                attributes[EmbraceAttributes.Type.SESSION.keyName()]
-            )
-            assertFalse(isKey())
-            assertEquals(StatusCode.OK, status)
-        }
-
-        assertEquals(0, spansSink.completedSpans().size)
-    }
-
-    @Test
-    fun `flushing with app termination and termination reason flushes session span with right termination type`() {
-        EmbraceAttributes.AppTerminationCause.values().forEach {
-            initAndStartNextSession()
-            val flushedSpans = currentSessionSpan.endSession(it)
-            assertEquals(1, flushedSpans.size)
-
-            val lastFlushedSpan = flushedSpans[0]
-            with(lastFlushedSpan) {
-                assertEquals("emb-session-span", name)
-                assertEquals(
-                    EmbraceAttributes.Type.SESSION.name,
-                    attributes[EmbraceAttributes.Type.SESSION.keyName()]
-                )
-                assertEquals(StatusCode.OK, status)
-                assertFalse(isKey())
-                assertEquals(it.name, attributes[it.keyName()])
-            }
-
-            assertEquals(0, spansSink.completedSpans().size)
-        }
-    }
-
-    @Test
-    fun `after flushing with app termination, spans cannot be recorded`() {
-        initService()
-        currentSessionSpan.endSession(EmbraceAttributes.AppTerminationCause.USER_TERMINATION)
-        spansService.recordSpan("test-span") {
-            // do thing
-        }
-        assertFalse(spansService.recordCompletedSpan("test-span-2", startTimeNanos = 0, endTimeNanos = 1))
-        assertEquals(0, spansSink.completedSpans().size)
-    }
-
-    @Test
-    fun `get same EmbraceSpan using spanId`() {
-        initAndStartNextSession()
-        val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
-        assertTrue(embraceSpan.start())
-        val spanId = checkNotNull(embraceSpan.spanId)
-        val spanFromService = checkNotNull(spansRepository.getSpan(spanId))
-        assertSame(spanFromService, embraceSpan)
-        assertTrue(spanFromService.stop())
-        assertFalse(embraceSpan.isRecording)
-        verifyAndReturnSoleCompletedSpan("emb-test-span")
-    }
-
-    @Test
-    fun `validate tracked spans update when service is flushed`() {
-        initService()
-        val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
-        assertTrue(embraceSpan.start())
-        val embraceSpanId = checkNotNull(embraceSpan.spanId)
-        val parentSpan = checkNotNull(spansService.createSpan(name = "parent-span"))
-        assertTrue(parentSpan.start())
-        val parentSpanId = checkNotNull(parentSpan.spanId)
-        val parentSpanFromService = checkNotNull(spansRepository.getSpan(parentSpanId))
-        assertTrue(parentSpanFromService.stop())
-        currentSessionSpan.endSession()
-
-        // completed span not available after flush
-        assertNull(spansRepository.getSpan(parentSpanId))
-
-        // existing reference to completed span can still be used
-        checkNotNull(spansService.createSpan(name = "child-span", parent = parentSpan))
-
-        // active span from before flush is still available and working
-        val activeSpanFromBeforeFlush = checkNotNull(spansRepository.getSpan(embraceSpanId))
-        assertTrue(activeSpanFromBeforeFlush.stop())
-        verifyAndReturnSoleCompletedSpan("emb-test-span")
-    }
-
-    private fun initService() {
-        val initModule = FakeInitModule(clock = clock)
-        spansSink = initModule.spansSink
-        spansRepository = initModule.spansRepository
-        currentSessionSpan = initModule.currentSessionSpan
-        spansService = SpansServiceImpl(
-            spansRepository = spansRepository,
-            currentSessionSpan = currentSessionSpan,
-            tracer = initModule.tracer
-        )
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
-    }
-
-    private fun initAndStartNextSession() {
-        initService()
-        currentSessionSpan.endSession()
     }
 
     private fun verifyAndReturnSoleCompletedSpan(name: String): EmbraceSpanData {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansSinkImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansSinkImplTests.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.mockk.mockk
+import io.opentelemetry.sdk.common.CompletableResultCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+internal class SpansSinkImplTests {
+    private lateinit var spansSink: SpansSink
+
+    @Before
+    fun setup() {
+        spansSink = SpansSinkImpl()
+    }
+
+    @Test
+    fun `verify default state`() {
+        assertEquals(0, spansSink.completedSpans().size)
+        assertEquals(0, spansSink.flushSpans().size)
+        assertEquals(CompletableResultCode.ofSuccess(), spansSink.storeCompletedSpans(listOf()))
+    }
+
+    @Test
+    fun `flushing clears completed spans and current session span`() {
+        spansSink.storeCompletedSpans(listOf(mockk(relaxed = true), mockk(relaxed = true)))
+        val snapshot = spansSink.completedSpans()
+        assertEquals(2, snapshot.size)
+
+        val flushedSpans = spansSink.flushSpans()
+        assertEquals(2, flushedSpans.size)
+        repeat(2) {
+            assertSame(snapshot[it], flushedSpans[it])
+        }
+        assertEquals(0, spansSink.completedSpans().size)
+    }
+}


### PR DESCRIPTION
## Goal

Put tests in the appropriate test classes, removing duplicates and additional additional ones needed after the component breakups
