### PR TITLE
Resolve test failures in session orchestration layer

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/internal/EmbraceContext.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/internal/EmbraceContext.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.os.Debug
 import android.os.Handler
 import android.os.Looper
 import androidx.lifecycle.Lifecycle
@@ -60,8 +61,12 @@ public class EmbraceContext(public val context: Context) : Application() {
             activity.setContext(context)
         }
 
-        val latch = FailureLatch(2000)
-        val pauseLatch = FailureLatch(3000)
+        val factor = when {
+            Debug.isDebuggerConnected() -> 10L
+            else -> 1L
+        }
+        val latch = FailureLatch(2000 * factor)
+        val pauseLatch = FailureLatch(3000 * factor)
 
         // invoke Activity callbacks on the Main Thread, like it would in a real application.
         //

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -65,7 +65,7 @@ internal class EmbraceProcessStateService(
             val msg = "Unbalanced call to onForeground(). This will contribute to session loss."
             logger.logError(msg, InternalError(msg))
         }
-
+        isInBackground = false
         val timestamp = clock.now()
 
         invokeCallbackSafely { sessionOrchestrator?.onForeground(coldStart, timestamp) }
@@ -75,7 +75,6 @@ internal class EmbraceProcessStateService(
                 listener.onForeground(coldStart, timestamp)
             }
         }
-        isInBackground = false
         coldStart = false
     }
 
@@ -86,6 +85,7 @@ internal class EmbraceProcessStateService(
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     override fun onBackground() {
         logDebug("AppState: App entered background")
+        isInBackground = true
         val timestamp = clock.now()
         invokeCallbackSafely { sessionOrchestrator?.onBackground(timestamp) }
 
@@ -94,7 +94,6 @@ internal class EmbraceProcessStateService(
                 listener.onBackground(timestamp)
             }
         }
-        isInBackground = true
     }
 
     private inline fun invokeCallbackSafely(action: () -> Unit) {


### PR DESCRIPTION
## Goal

Fixes some test failures in the functional tests of the session orchestration. This was initially caused by altering `ProcessStateService` to set `isInBackground` before the listener was invoked, which broke the startup moment & other callbacks that relied on this order.

My fix is to reinstate the previous behavior & track state internally within the `SessionOrchestrator` class as required.

