### PR TITLE
Simplifies session orchestration state change logic

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/TransitionType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/TransitionType.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.session.orchestrator
+
+import io.embrace.android.embracesdk.session.lifecycle.ProcessState
+
+internal enum class TransitionType {
+    INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH;
+
+    fun endState(currentState: ProcessState): ProcessState = when (this) {
+        ON_FOREGROUND -> ProcessState.FOREGROUND
+        ON_BACKGROUND -> ProcessState.BACKGROUND
+        else -> currentState
+    }
+}


### PR DESCRIPTION
## Goal

Simplifies the session orchestration state change logic by introducing a `TransitionType` enum that helps calculate the final state of the process for each transition type. This avoids having to manually specify the type for each invocation of `transitionState` and reduces the parameter count.

## Testing

Relied on existing test coverage.
