### PR TITLE
Reorganise session code into separate packages

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.returnIfConditionMet
-import io.embrace.android.embracesdk.session.SessionSnapshotType
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -91,8 +91,6 @@ import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb;
 import io.embrace.android.embracesdk.payload.TapBreadcrumb;
 import io.embrace.android.embracesdk.prefs.PreferencesService;
 import io.embrace.android.embracesdk.registry.ServiceRegistry;
-import io.embrace.android.embracesdk.session.BackgroundActivityService;
-import io.embrace.android.embracesdk.session.SessionService;
 import io.embrace.android.embracesdk.session.id.SessionIdTracker;
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker;
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService;
@@ -200,16 +198,10 @@ final class EmbraceImpl {
     private volatile BreadcrumbService breadcrumbService;
 
     @Nullable
-    private volatile SessionService sessionService;
-
-    @Nullable
     private volatile SessionOrchestrator sessionOrchestrator;
 
     @Nullable
     private volatile SessionPropertiesService sessionPropertiesService;
-
-    @Nullable
-    private volatile BackgroundActivityService backgroundActivityService;
 
     @Nullable
     private volatile MetadataService metadataService;
@@ -623,11 +615,8 @@ final class EmbraceImpl {
             nonNullWorkerThreadModule
         );
 
-        sessionService = sessionModule.getSessionService();
         sessionOrchestrator = sessionModule.getSessionOrchestrator();
         sessionPropertiesService = sessionModule.getSessionPropertiesService();
-        backgroundActivityService = sessionModule.getBackgroundActivityService();
-        serviceRegistry.registerServices(sessionService, backgroundActivityService);
 
         if (configService.getAutoDataCaptureBehavior().isNdkEnabled()) {
             sessionIdTracker.setNdkService(nativeModule.getNdkService());

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.comms.delivery
 import io.embrace.android.embracesdk.comms.api.SerializationAction
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal interface DeliveryCacheManager {
     fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal interface DeliveryService {
     fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.TaskPriority
 import java.io.Closeable

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -12,8 +12,8 @@ import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.TaskPriority
 import java.util.concurrent.TimeUnit

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.ndk.NativeModule
-import io.embrace.android.embracesdk.session.BackgroundActivityService
-import io.embrace.android.embracesdk.session.EmbraceBackgroundActivityService
-import io.embrace.android.embracesdk.session.EmbraceSessionService
-import io.embrace.android.embracesdk.session.PayloadMessageCollator
-import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
+import io.embrace.android.embracesdk.session.message.BackgroundActivityService
+import io.embrace.android.embracesdk.session.message.EmbraceBackgroundActivityService
+import io.embrace.android.embracesdk.session.message.EmbraceSessionService
+import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
+import io.embrace.android.embracesdk.session.message.SessionService
 import io.embrace.android.embracesdk.session.orchestrator.OrchestratorBoundaryDelegate
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestratorImpl
@@ -124,7 +124,7 @@ internal class SessionModuleImpl(
         )
     }
 
-    override val sessionOrchestrator: SessionOrchestrator by singleton {
+    override val sessionOrchestrator: SessionOrchestrator by singleton(LoadType.EAGER) {
         SessionOrchestratorImpl(
             essentialServiceModule.processStateService,
             sessionService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.capture.orientation.OrientationService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
-import io.embrace.android.embracesdk.session.SessionService
+import io.embrace.android.embracesdk.session.message.SessionService
 import io.embrace.android.embracesdk.utils.stream
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/BackgroundActivityService.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.payload.Session
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/EmbraceBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/EmbraceBackgroundActivityService.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.clock.Clock

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/EmbraceSessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/EmbraceSessionService.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal class EmbraceSessionService(
     private val deliveryService: DeliveryService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -1,8 +1,10 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.session.captureDataSafely
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 /**
  * Holds the parameters & logic needed to create a final session object that can be

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/InitialEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/InitialEnvelopeParams.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.prefs.PreferencesService

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
@@ -21,6 +21,7 @@ import io.embrace.android.embracesdk.payload.BetaFeatures
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.prefs.PreferencesService
+import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 internal class PayloadMessageCollator(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/SessionService.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.payload.Session
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -5,12 +5,12 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
-import io.embrace.android.embracesdk.session.BackgroundActivityService
 import io.embrace.android.embracesdk.session.ConfigGate
-import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
+import io.embrace.android.embracesdk.session.message.BackgroundActivityService
+import io.embrace.android.embracesdk.session.message.SessionService
 
 internal class SessionOrchestratorImpl(
     private val processStateService: ProcessStateService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.session
+package io.embrace.android.embracesdk.session.orchestrator
 
 /**
  * Defines the states in which a session can end.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -12,9 +12,9 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType.JVM_CRASH
-import io.embrace.android.embracesdk.session.SessionSnapshotType.NORMAL_END
-import io.embrace.android.embracesdk.session.SessionSnapshotType.PERIODIC_CACHE
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.JVM_CRASH
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.NORMAL_END
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.PERIODIC_CACHE
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.clearAllMocks
 import io.mockk.every

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -6,8 +6,8 @@ import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 /**
  * A [DeliveryService] that records the last parameters used to invoke each method, and for the ones that need it, count the number of

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.payload.Session
-import io.embrace.android.embracesdk.session.SessionService
+import io.embrace.android.embracesdk.session.message.SessionService
 
 internal class FakeSessionService : SessionService {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -14,9 +14,9 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType.JVM_CRASH
-import io.embrace.android.embracesdk.session.SessionSnapshotType.NORMAL_END
-import io.embrace.android.embracesdk.session.SessionSnapshotType.PERIODIC_CACHE
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.JVM_CRASH
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.NORMAL_END
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.PERIODIC_CACHE
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.fakeBackgroundActivity
 import io.embrace.android.embracesdk.payload.Session
-import io.embrace.android.embracesdk.session.BackgroundActivityService
+import io.embrace.android.embracesdk.session.message.BackgroundActivityService
 
 internal class FakeBackgroundActivityService : BackgroundActivityService {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputS
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.session.SessionSnapshotType
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal class FakeDeliveryCacheManager : DeliveryCacheManager {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -4,11 +4,11 @@ import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.FakeSessionService
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.injection.SessionModule
-import io.embrace.android.embracesdk.session.BackgroundActivityService
-import io.embrace.android.embracesdk.session.PayloadMessageCollator
-import io.embrace.android.embracesdk.session.SessionService
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
+import io.embrace.android.embracesdk.session.message.BackgroundActivityService
+import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
+import io.embrace.android.embracesdk.session.message.SessionService
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceBackgroundActivityServiceTest.kt
@@ -33,6 +33,8 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
+import io.embrace.android.embracesdk.session.message.EmbraceBackgroundActivityService
+import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
+import io.embrace.android.embracesdk.session.message.EmbraceSessionService
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.clearAllMocks
 import io.mockk.mockk

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -19,6 +19,10 @@ import io.embrace.android.embracesdk.payload.ExceptionError
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams
+import io.embrace.android.embracesdk.session.message.InitialEnvelopeParams
+import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -41,6 +41,9 @@ import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.UserInfo
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
+import io.embrace.android.embracesdk.session.message.EmbraceSessionService
+import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.clearAllMocks


### PR DESCRIPTION
## Goal

Alters the session code into distinct sub packages. As part of this I removed all references to `SessionService` and `BackgroundActivityService` within the main sourceSet - this requires eagerly loading the orchestrator class within its module.
