### PR TITLE
Make session orchestrator responsible for periodic caching

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -90,25 +90,17 @@ internal class SessionModuleImpl(
         )
     }
 
-    private val orchestrationLock = Any()
-
     override val sessionService: SessionService by singleton {
         EmbraceSessionService(
             deliveryModule.deliveryService,
-            payloadMessageCollator,
-            initModule.clock,
-            periodicSessionCacher,
-            orchestrationLock
+            payloadMessageCollator
         )
     }
 
     override val backgroundActivityService: BackgroundActivityService? by singleton {
         EmbraceBackgroundActivityService(
             deliveryModule.deliveryService,
-            payloadMessageCollator,
-            initModule.clock,
-            periodicBackgroundActivityCacher,
-            orchestrationLock
+            payloadMessageCollator
         )
     }
 
@@ -132,8 +124,9 @@ internal class SessionModuleImpl(
             initModule.clock,
             essentialServiceModule.configService,
             essentialServiceModule.sessionIdTracker,
-            orchestrationLock,
-            boundaryDelegate
+            boundaryDelegate,
+            periodicSessionCacher,
+            periodicBackgroundActivityCacher
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/BackgroundActivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/BackgroundActivityService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
 
 /**
  * Service that captures and sends information when the app is in background
@@ -23,7 +24,7 @@ internal interface BackgroundActivityService {
     fun endBackgroundActivityWithState(initial: Session, timestamp: Long)
 
     /**
-     * Save the current background activity to disk
+     * Provides a snapshot of the active background activity
      */
-    fun saveBackgroundActivitySnapshot(initial: Session,)
+    fun snapshotBackgroundActivity(initial: Session, timestamp: Long): SessionMessage
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/SessionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/SessionService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal interface SessionService {
 
@@ -28,4 +29,9 @@ internal interface SessionService {
      * Handles an uncaught exception, ending the session and saving the session to disk.
      */
     fun endSessionWithCrash(initial: Session, timestamp: Long, crashId: String)
+
+    /**
+     * Provides a snapshot of the active session
+     */
+    fun snapshotSession(initial: Session, timestamp: Long): SessionMessage?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
@@ -13,27 +13,22 @@ internal enum class SessionSnapshotType(
     /**
      * Whether the session process experienced a force quit/unexpected termination.
      */
-    val forceQuit: Boolean,
-
-    /**
-     * Whether periodic caching of the session should stop or not.
-     */
-    val shouldStopCaching: Boolean
+    val forceQuit: Boolean
 ) {
 
     /**
      * The end session happened in the normal way (i.e. process state changes or manual/timed end).
      */
-    NORMAL_END(true, false, true),
+    NORMAL_END(true, false),
 
     /**
      * The end session is being constructed so that it can be periodically cached. This avoids
      * the scenario of data loss in the event of NDK crashes.
      */
-    PERIODIC_CACHE(false, true, false),
+    PERIODIC_CACHE(false, true),
 
     /**
      * The end session is being constructed because of a JVM crash.
      */
-    JVM_CRASH(false, false, true);
+    JVM_CRASH(false, false);
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionService.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.message.SessionService
 
 internal class FakeSessionService : SessionService {
@@ -10,6 +11,7 @@ internal class FakeSessionService : SessionService {
     val endTimestamps = mutableListOf<Long>()
     var manualEndCount = 0
     var manualStartCount = 0
+    var snapshotCount = 0
     var activeSession: Session? = null
 
     override fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session {
@@ -39,5 +41,10 @@ internal class FakeSessionService : SessionService {
     override fun endSessionWithManual(initial: Session, timestamp: Long) {
         manualEndCount++
         activeSession = null
+    }
+
+    override fun snapshotSession(initial: Session, timestamp: Long): SessionMessage? {
+        snapshotCount++
+        return null
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeBackgroundActivityService.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.fakeBackgroundActivity
+import io.embrace.android.embracesdk.fakeBackgroundActivityMessage
 import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.message.BackgroundActivityService
 
 internal class FakeBackgroundActivityService : BackgroundActivityService {
@@ -9,6 +11,7 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
     val endTimestamps = mutableListOf<Long>()
     val startTimestamps = mutableListOf<Long>()
     var crashId: String? = null
+    var snapshotCount: Int = 0
 
     override fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): Session {
         startTimestamps.add(timestamp)
@@ -23,6 +26,8 @@ internal class FakeBackgroundActivityService : BackgroundActivityService {
         this.crashId = crashId
     }
 
-    override fun saveBackgroundActivitySnapshot(initial: Session) {
+    override fun snapshotBackgroundActivity(initial: Session, timestamp: Long): SessionMessage {
+        snapshotCount++
+        return fakeBackgroundActivityMessage()
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceSessionServiceTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.FakeDeliveryService
-import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
@@ -9,9 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
-import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.message.EmbraceSessionService
-import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -111,10 +108,7 @@ internal class EmbraceSessionServiceTest {
 
         service = EmbraceSessionService(
             deliveryService,
-            mockk(relaxed = true),
-            FakeClock(),
-            PeriodicSessionCacher(FakeClock(), ScheduledWorker(BlockingScheduledExecutorService())),
-            Any()
+            mockk(relaxed = true)
         )
     }
 }


### PR DESCRIPTION
## Goal

This changeset makes the `SessionOrchestrator` responsible for periodic caching. This allows the removal of various parameters from the session + BA services & hides implementation details (such as the lock used by the orchestrator). 

## Testing

I've removed redundant test cases & relied on the `PeriodicSessionCacheTest` integration test case.

