### PR TITLE
Change release GH actions to create and release from release branch

### DIFF
--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -12,8 +12,11 @@ env:
 on:
   workflow_dispatch:
     inputs:
-      current_version:
-        description: 'Version to release'
+      version_to_release:
+        description: 'Version to release. A new branch called `release/<version>` will be created for it where the release-specific changes will be committed.'
+        required: true
+      next_version:
+        description: 'Next Version (Do NOT include -SNAPSHOT, will be added automatically)'
         required: true
 
 jobs:
@@ -31,9 +34,11 @@ jobs:
           echo $mavenSigningKeyRingFileEncoded | base64 -di > "$RUNNER_TEMP"/keystore/2DE631C1.gpg
           echo "mavenSigningKeyRingFile=$RUNNER_TEMP/keystore/2DE631C1.gpg" >> $GITHUB_ENV
 
-      - name: Checkout Branch
+      - name: Create and Checkout Branch
         uses: actions/checkout@v3
         with:
+          run: | 
+            git checkout -b release/${{ github.event.inputs.version_to_release }}
           fetch-depth: 0
           token: ${{ secrets.CD_GITHUB_TOKEN }}
 
@@ -83,11 +88,19 @@ jobs:
 
       - name: Gradlew Pre-Release
         run: |
-          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.current_version }}#" gradle.properties
+          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.version_to_release }}#" gradle.properties
           git add gradle.properties
-          git commit -m "CI/CD: change version to be released: ${{ github.event.inputs.current_version }}"
+          git commit -m "CI/CD: change version to be released: ${{ github.event.inputs.version_to_release }}"
           git push
           ./gradlew clean publishReleasePublicationToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --stacktrace
+
+      - name: Set next SDK version
+        run: |
+          git checkout master
+          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}-SNAPSHOT#" gradle.properties
+          git add gradle.properties
+          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}"
+          git push
 
       - name: Checkout Swazzler
         uses: actions/checkout@v3
@@ -100,7 +113,7 @@ jobs:
       - name: Swazzler Release
         run: |
           cd ./embrace-swazzler3
-          ./gradlew clean release -Dorg.gradle.parallel=false -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${{ github.event.inputs.current_version }} -Prelease.newVersion=${{ github.event.inputs.next_version }}-SNAPSHOT --stacktrace
+          ./gradlew clean release -Dorg.gradle.parallel=false -Prelease.useAutomaticVersion=true -Prelease.pushReleaseVersionBranch=release/${{ github.event.inputs.version_to_release }} -Prelease.releaseVersion=${{ github.event.inputs.version_to_release }} -Prelease.newVersion=${{ github.event.inputs.next_version }}-SNAPSHOT --stacktrace
 
       - name: Cleanup Gradle Cache
         # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies
@@ -109,17 +122,3 @@ jobs:
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
-          
-#  measure-sdk-size:
-#    uses: embrace-io/android-size-measure/.github/workflows/analyze-sdk-size.yml@main
-#    needs: release
-#    with:
-#      sdk_version: ${{ github.event.inputs.current_version }}
-#      token: ${{ secrets.CD_GITHUB_TOKEN }}
-#
-#  measure-startup-time:
-#    uses: embrace-io/android-sdk-benchmark/.github/workflows/macrobenchmark.yml@main
-#    needs: release
-#    with:
-#      sdk_version: ${{ github.event.inputs.current_version }}
-#      token: ${{ secrets.CD_GITHUB_TOKEN }}

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -13,10 +13,10 @@ on:
   workflow_dispatch:
     inputs:
       version_to_release:
-        description: 'Version to release. A new branch called `release/<version>` will be created for it where the release-specific changes will be committed.'
+        description: 'Version to release. Specify <major.minor> only, without the patch number, e.g. `6.3`. A new branch called `release/<version>` will be created for it where the release-specific changes will be committed.'
         required: true
       next_version:
-        description: 'Next Version (Do NOT include -SNAPSHOT, will be added automatically)'
+        description: 'Next Version. Specify <major.minor.patch>, e.g. `6.4.0` (Do NOT include -SNAPSHOT, will be added automatically)'
         required: true
 
 jobs:
@@ -88,9 +88,9 @@ jobs:
 
       - name: Gradlew Pre-Release
         run: |
-          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.version_to_release }}#" gradle.properties
+          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.version_to_release }}.0#" gradle.properties
           git add gradle.properties
-          git commit -m "CI/CD: change version to be released: ${{ github.event.inputs.version_to_release }}"
+          git commit -m "CI/CD: change version to be released: ${{ github.event.inputs.version_to_release }}.0"
           git push
           ./gradlew clean publishReleasePublicationToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --stacktrace
 
@@ -113,7 +113,7 @@ jobs:
       - name: Swazzler Release
         run: |
           cd ./embrace-swazzler3
-          ./gradlew clean release -Dorg.gradle.parallel=false -Prelease.useAutomaticVersion=true -Prelease.pushReleaseVersionBranch=release/${{ github.event.inputs.version_to_release }} -Prelease.releaseVersion=${{ github.event.inputs.version_to_release }} -Prelease.newVersion=${{ github.event.inputs.next_version }}-SNAPSHOT --stacktrace
+          ./gradlew clean release -Dorg.gradle.parallel=false -Prelease.useAutomaticVersion=true -Prelease.pushReleaseVersionBranch=release/${{ github.event.inputs.version_to_release }} -Prelease.releaseVersion=${{ github.event.inputs.version_to_release }}.0 -Prelease.newVersion=${{ github.event.inputs.next_version }}-SNAPSHOT --stacktrace
 
       - name: Cleanup Gradle Cache
         # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -12,6 +12,9 @@ env:
 on:
   workflow_dispatch:
     inputs:
+      version_to_release:
+        description: 'SDK version this workflow run will release. It will use the branch `release/<version>`.'
+        required: true
       next_version:
         description: 'Next Version (Do NOT include -SNAPSHOT, will be added automatically)'
         required: true
@@ -28,6 +31,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v3
         with:
+          ref: release/${{ github.event.inputs.version_to_release }}
           fetch-depth: 0
           token: ${{ secrets.CD_GITHUB_TOKEN }}
 
@@ -56,24 +60,16 @@ jobs:
           mv .docs-newly-generated docs
           date > docs/version.txt
           echo ${{ github.sha }} >> docs/version.txt
-          echo ${{ github.event.release.tag_name }} >> docs/version.txt
+          echo ${{ github.event.inputs.version_to_release }} >> docs/version.txt
           git add -f docs
           git config --global user.name "embrace-ci"
           git config --global user.email "embrace-ci@users.noreply.github.com"
-          git commit --allow-empty --message 'CI/CD: Automatically generated documentation for ${{ github.event.release.tag_name }}' docs/
+          git commit --allow-empty --message 'CI/CD: Automatically generated documentation for ${{ github.event.inputs.version_to_release }}' docs/
           git push --force origin gh-pages
 
-      - name: Record SDK Version History (${{ github.event.inputs.current_version }})
+      - name: Record SDK Version History (${{ github.event.inputs.version_to_release }})
         run: |
-          curl -X POST ${{ vars.SDK_VERSION_URL }}/android/version/ -H 'X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}' -H 'Content-Type: application/json' -d '{"version": "${{ github.event.inputs.current_version }}"}'
-
-      - name: Set next SDK version
-        run: |
-          git checkout master
-          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}-SNAPSHOT#" gradle.properties
-          git add gradle.properties
-          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}"
-          git push
+          curl -X POST ${{ vars.SDK_VERSION_URL }}/android/version/ -H 'X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}' -H 'Content-Type: application/json' -d '{"version": "${{ github.event.inputs.version_to_release }}"}'
 
       - name: Cleanup Gradle Cache
         # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -13,11 +13,12 @@ on:
   workflow_dispatch:
     inputs:
       version_to_release:
-        description: 'SDK version this workflow run will release. It will use the branch `release/<version>`.'
+        description: 'SDK version this workflow run will release. Specify <major.minor> only, without the patch number, e.g. `6.3`. It will use the branch `release/<version>`.'
         required: true
-      next_version:
-        description: 'Next Version (Do NOT include -SNAPSHOT, will be added automatically)'
+      patch_version_of_release:
+        description: 'The patch version for this release, i.e. the third number per semantic versioning <major.minor.patch>. If it is not a hotfix, use the default of 0'
         required: true
+        default: '0'
 
 jobs:
   release:
@@ -60,16 +61,16 @@ jobs:
           mv .docs-newly-generated docs
           date > docs/version.txt
           echo ${{ github.sha }} >> docs/version.txt
-          echo ${{ github.event.inputs.version_to_release }} >> docs/version.txt
+          echo ${{ github.event.inputs.version_to_release }}.${{ github.event.inputs.patch_version_of_release }} >> docs/version.txt
           git add -f docs
           git config --global user.name "embrace-ci"
           git config --global user.email "embrace-ci@users.noreply.github.com"
-          git commit --allow-empty --message 'CI/CD: Automatically generated documentation for ${{ github.event.inputs.version_to_release }}' docs/
+          git commit --allow-empty --message 'CI/CD: Automatically generated documentation for ${{ github.event.inputs.version_to_release }}.${{ github.event.inputs.patch_version_of_release }}' docs/
           git push --force origin gh-pages
 
-      - name: Record SDK Version History (${{ github.event.inputs.version_to_release }})
+      - name: Record SDK Version History (${{ github.event.inputs.version_to_release }}.${{ github.event.inputs.patch_version_of_release }})
         run: |
-          curl -X POST ${{ vars.SDK_VERSION_URL }}/android/version/ -H 'X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}' -H 'Content-Type: application/json' -d '{"version": "${{ github.event.inputs.version_to_release }}"}'
+          curl -X POST ${{ vars.SDK_VERSION_URL }}/android/version/ -H 'X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}' -H 'Content-Type: application/json' -d '{"version": "${{ github.event.inputs.version_to_release }}.${{ github.event.inputs.patch_version_of_release }}"}'
 
       - name: Cleanup Gradle Cache
         # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies


### PR DESCRIPTION
## Goal

Create a release branch to make any version-specific modifications on and make the release from there. The version number of the SDK will incremented when the release branch is cut, and commits after that will be de facto in the next release. The Swazzler will be updated in the pre-release workflow as it does before.

If there are additional changes that need to go into the release branch, they can be done first in master, then cherrypicked into the release branch.

For hotfixes, the same cherrypicking process will be done, but we will need to add additional GH Actions to ensure to automate the release.
