### PR TITLE
Improve concurrency and simplify validation logic

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -1,17 +1,12 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.internal.Initializable
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
  * Abstraction of the current session span
  */
-internal interface CurrentSessionSpan {
-
-    /**
-     * Initialize this with its first session span
-     */
-    fun startInitialSession(sdkInitStartTimeNanos: Long)
-
+internal interface CurrentSessionSpan : Initializable {
     /**
      * End the current session span and start a new one if the app is not terminating
      */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImpl.kt
@@ -20,7 +20,7 @@ internal class SpansServiceImpl(
 
     override fun initializeService(sdkInitStartTimeNanos: Long) {
         synchronized(initialized) {
-            currentSessionSpan.startInitialSession(sdkInitStartTimeNanos)
+            currentSessionSpan.initializeService(sdkInitStartTimeNanos)
             initialized.set(true)
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -30,6 +30,11 @@ internal class CurrentSessionSpanImplTests {
     }
 
     @Test
+    fun `cannot create span before session is created`() {
+        assertFalse(FakeInitModule(clock = clock).currentSessionSpan.canStartNewSpan(null, true))
+    }
+
+    @Test
     fun `check trace limits with maximum not started traces`() {
         repeat(SpansServiceImpl.MAX_TRACE_COUNT_PER_SESSION) {
             assertNotNull(spansService.createSpan(name = "spanzzz$it", internal = false))


### PR DESCRIPTION
## Goal

Refactored `CurrentSessionSpanImpl` in the following ways: spans for unrelated traces can be validated concurrently; made this an `Initializable`; simplified validation logic to be more readible.

## Testing

Added extra test to validate the state when the component is not initialized.