### PR TITLE
Make fewer things overrideable in the InitModule

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -67,11 +67,22 @@ internal interface InitModule {
 
 internal class InitModuleImpl(
     override val clock: io.embrace.android.embracesdk.internal.clock.Clock = NormalizedIntervalClock(systemClock = SystemClock()),
-    openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(clock),
-    override val telemetryService: TelemetryService = EmbraceTelemetryService(),
-    override val spansRepository: SpansRepository = SpansRepository(),
-    override val spansSink: SpansSink = SpansSinkImpl(),
-    override val tracer: Tracer =
+    openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(clock)
+) : InitModule {
+
+    override val telemetryService: TelemetryService by singleton {
+        EmbraceTelemetryService()
+    }
+
+    override val spansRepository: SpansRepository by singleton {
+        SpansRepository()
+    }
+
+    override val spansSink: SpansSink by singleton {
+        SpansSinkImpl()
+    }
+
+    override val tracer: Tracer by singleton {
         OpenTelemetrySdk
             .builder()
             .setTracerProvider(
@@ -82,22 +93,31 @@ internal class InitModuleImpl(
                     .build()
             )
             .build()
-            .getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME),
-    override val currentSessionSpan: CurrentSessionSpan =
+            .getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME)
+    }
+
+    override val currentSessionSpan: CurrentSessionSpan by singleton {
         CurrentSessionSpanImpl(
             clock = openTelemetryClock,
             telemetryService = telemetryService,
             spansRepository = spansRepository,
             spansSink = spansSink,
             tracer = tracer
-        ),
-    override val spansService: SpansService = EmbraceSpansService(
-        spansRepository = spansRepository,
-        currentSessionSpan = currentSessionSpan,
-        tracer = tracer,
-    ),
-    override val embraceTracer: EmbraceTracer = EmbraceTracer(
-        spansRepository = spansRepository,
-        spansService = spansService
-    )
-) : InitModule
+        )
+    }
+
+    override val spansService: SpansService by singleton {
+        EmbraceSpansService(
+            spansRepository = spansRepository,
+            currentSessionSpan = currentSessionSpan,
+            tracer = tracer,
+        )
+    }
+
+    override val embraceTracer: EmbraceTracer by singleton {
+        EmbraceTracer(
+            spansRepository = spansRepository,
+            spansService = spansService
+        )
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
@@ -2,18 +2,12 @@ package io.embrace.android.embracesdk.injection
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
-import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
-import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
-import io.embrace.android.embracesdk.internal.spans.SpansRepository
 import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
-import io.embrace.android.embracesdk.internal.spans.UninitializedSdkSpansService
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
-import io.mockk.mockk
-import io.opentelemetry.api.trace.Tracer
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -35,30 +29,11 @@ internal class InitModuleImplTest {
     @Test
     fun testInitModuleImplOverrideComponents() {
         val clock = FakeClock()
-        val telemetryService = FakeTelemetryService()
-        val spansRepository = SpansRepository()
-        val spansSink = SpansSinkImpl()
-        val spansService = UninitializedSdkSpansService()
-        val tracer: Tracer = mockk()
-        val currentSessionSpan: CurrentSessionSpan = mockk()
-        val embraceTracer: EmbraceTracer = mockk()
+        val openTelemetryClock = FakeOpenTelemetryClock(clock)
         val initModule = InitModuleImpl(
             clock = clock,
-            telemetryService = telemetryService,
-            spansRepository = spansRepository,
-            spansSink = spansSink,
-            spansService = spansService,
-            tracer = tracer,
-            currentSessionSpan = currentSessionSpan,
-            embraceTracer = embraceTracer,
+            openTelemetryClock = openTelemetryClock
         )
         assertSame(clock, initModule.clock)
-        assertSame(telemetryService, initModule.telemetryService)
-        assertSame(spansRepository, initModule.spansRepository)
-        assertSame(spansSink, initModule.spansSink)
-        assertSame(spansService, initModule.spansService)
-        assertSame(tracer, initModule.tracer)
-        assertSame(currentSessionSpan, initModule.currentSessionSpan)
-        assertSame(embraceTracer, initModule.embraceTracer)
     }
 }


### PR DESCRIPTION
## Goal

Lock down the InitModule because it doesn't need to be that configurable at all.

