### PR TITLE
Add a wrapper object to instantiate and configure the OTel SDK

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.embrace.android.embracesdk.BuildConfig
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.SpanProcessor
+
+/**
+ * Wrapper that instantiates a copy of the OpenTelemetry SDK configured with the appropriate settings and the given components so
+ * the Embrace SDK can hook into its lifecycle. From this, the Embrace SDK can obtain an implementations of the OpenTelemetry API to
+ * create OpenTelemetry primitives that it can use internally or export to any OpenTelemetry Collectors.
+ */
+internal class OpenTelemetrySdk(
+    openTelemetryClock: Clock,
+    spanProcessor: SpanProcessor
+) {
+    private val sdk = OpenTelemetrySdk
+        .builder()
+        .setTracerProvider(
+            SdkTracerProvider
+                .builder()
+                .addSpanProcessor(spanProcessor)
+                .setClock(openTelemetryClock)
+                .build()
+        ).build()
+
+    private val tracer = sdk.getTracer(BuildConfig.LIBRARY_PACKAGE_NAME, BuildConfig.VERSION_NAME)
+
+    fun getOpenTelemetryTracer(): Tracer = tracer
+}


### PR DESCRIPTION
## Goal

Wrap the OTel SDK and provide an interface to obtain the relevant APIs. Doing this now to prepare for the ability to provide a wrapped interface for creating Logs as well as configure other Processors and Exporters.

## Testing

Existing tests over this.
