### PR TITLE
Test out new m1 macs for ci

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   gradle-test:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 30
     strategy:
       matrix:
         jdk-version: ["11"]
-        ndk-version: ["21.4.7075529"]
+#        ndk-version: ["21.4.7075529"]
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
@@ -39,12 +39,14 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.jdk-version }}
 
-      - name: Setup NDK ${{ matrix.ndk-version }}
-        run: |
-          export ANDROID_ROOT=/usr/local/lib/android
-          export ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-          export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-          ln -sfn $ANDROID_SDK_ROOT/ndk/${{ matrix.ndk-version }} $ANDROID_NDK_ROOT
+#      - name: Setup NDK ${{ matrix.ndk-version }}
+#        run: |
+#          echo "Android home: $ANDROID_HOME"
+#          echo "Android Root: $ANDROID_ROOT"
+#          export ANDROID_ROOT=/usr/local/lib/android
+#          export ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+#          export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+#          ln -sfn $ANDROID_SDK_ROOT/ndk/${{ matrix.ndk-version }} $ANDROID_NDK_ROOT
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -16,12 +16,12 @@ env:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 45
     strategy:
       matrix:
         jdk-version: ["11"]
-        ndk-version: ["21.4.7075529"]
+#        ndk-version: ["21.4.7075529"]
         api-level: [29]
         target: [default]
 


### PR DESCRIPTION
## Goal

Tests using the [new M1 macs](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) that are available on Github to see if they improve our build times.

