### PR TITLE
Avoid unnecessary serialisation of background activity

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -115,7 +115,7 @@ internal class PayloadFactoryBaTest {
 
         // there should be 1 completed span: the session span
         assertEquals(1, msg.spans?.size)
-        assertEquals(0, spansSink.completedSpans()?.size)
+        assertEquals(0, spansSink.completedSpans().size)
     }
 
     @Test
@@ -126,7 +126,7 @@ internal class PayloadFactoryBaTest {
 
         // there should be 1 completed span: the session span
         assertEquals(1, msg.spans?.size)
-        assertEquals(0, spansSink.completedSpans()?.size)
+        assertEquals(0, spansSink.completedSpans().size)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -14,12 +14,12 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.AfterClass
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import java.util.concurrent.ExecutorService
+import org.junit.Assert.assertEquals
 
 internal class PayloadFactorySessionTest {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -14,12 +14,12 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.AfterClass
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import java.util.concurrent.ExecutorService
-import org.junit.Assert.assertEquals
 
 internal class PayloadFactorySessionTest {
 


### PR DESCRIPTION
## Goal

Avoids serializing if there is back pressure on the background activity snapshotting & something has recently been serialized.
