### PR TITLE
Add class and extension methods to make obtaining nanosecond time easier

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -219,6 +219,15 @@ public final class io/embrace/android/embracesdk/internal/InternalTracingApi$Def
 
 public abstract interface class io/embrace/android/embracesdk/internal/clock/Clock {
 	public abstract fun now ()J
+	public abstract fun nowInNanos ()J
+}
+
+public final class io/embrace/android/embracesdk/internal/clock/Clock$DefaultImpls {
+	public static fun nowInNanos (Lio/embrace/android/embracesdk/internal/clock/Clock;)J
+}
+
+public final class io/embrace/android/embracesdk/internal/clock/ClockKt {
+	public static final fun millisToNanos (J)J
 }
 
 public class io/embrace/android/embracesdk/internal/network/http/EmbraceHttpPathOverride {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.assertions
 
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.isKey
 import io.embrace.android.embracesdk.internal.spans.isPrivate
@@ -7,7 +8,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
-import java.util.concurrent.TimeUnit
 
 /**
  * Assert the [EmbraceSpanData] is as expected
@@ -27,8 +27,8 @@ internal fun assertEmbraceSpanData(
 ) {
     checkNotNull(span)
     with(span) {
-        assertEquals(TimeUnit.MILLISECONDS.toNanos(expectedStartTimeMs), startTimeNanos)
-        assertEquals(TimeUnit.MILLISECONDS.toNanos(expectedEndTimeMs), endTimeNanos)
+        assertEquals(expectedStartTimeMs.millisToNanos(), startTimeNanos)
+        assertEquals(expectedEndTimeMs.millisToNanos(), endTimeNanos)
         assertEquals(expectedParentId, parentSpanId)
         if (expectedTraceId != null) {
             assertEquals(expectedTraceId, traceId)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.LogType
 import io.embrace.android.embracesdk.assertions.assertLogMessageReceived
 import io.embrace.android.embracesdk.getSentLogMessages
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.recordSession
@@ -290,8 +291,8 @@ internal class EmbraceInternalInterfaceTest {
                     recordSpan(name = "tz-another-span", parentSpanId = parentSpanId) { }
                     recordCompletedSpan(
                         name = "tz-old-span",
-                        startTimeNanos = TimeUnit.MILLISECONDS.toNanos(harness.fakeClock.now() - 1),
-                        endTimeNanos = TimeUnit.MILLISECONDS.toNanos(harness.fakeClock.now()),
+                        startTimeNanos = (harness.fakeClock.now() - 1L).millisToNanos(),
+                        endTimeNanos = harness.fakeClock.now().millisToNanos(),
                     )
                     stopSpan(spanId = childSpanId, errorCode = ErrorCode.USER_ABANDON)
                     stopSpan(parentSpanId)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.getSentBackgroundActivities
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.returnIfConditionMet
@@ -21,7 +22,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.util.concurrent.TimeUnit
 
 @Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
@@ -76,8 +76,8 @@ internal class TracingApiTest {
                 assertTrue(
                     embrace.recordCompletedSpan(
                         name = "completed-span",
-                        startTimeNanos = TimeUnit.MILLISECONDS.toNanos(failedOpStartTime),
-                        endTimeNanos = TimeUnit.MILLISECONDS.toNanos(failedOpEndTime),
+                        startTimeNanos = failedOpStartTime.millisToNanos(),
+                        endTimeNanos = failedOpEndTime.millisToNanos(),
                         errorCode = ErrorCode.FAILURE,
                         parent = parentSpan,
                         attributes = attributes,
@@ -127,14 +127,14 @@ internal class TracingApiTest {
                     checkNotNull(
                         EmbraceSpanEvent.create(
                             name = "parent event",
-                            timestampNanos = TimeUnit.MILLISECONDS.toNanos(testStartTime + 200),
+                            timestampNanos = (testStartTime + 200).millisToNanos(),
                             attributes = null
                         )
                     ),
                     checkNotNull(
                         EmbraceSpanEvent.create(
                             name = "delayed event",
-                            timestampNanos = TimeUnit.MILLISECONDS.toNanos(testStartTime + 350),
+                            timestampNanos = (testStartTime + 350).millisToNanos(),
                             attributes = null
                         ),
                     )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.capture.startup
 
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.SpansService
-import java.util.concurrent.TimeUnit
 
 internal class StartupServiceImpl(
     private val spansService: SpansService
@@ -17,8 +17,8 @@ internal class StartupServiceImpl(
         if (sdkStartupDuration == null) {
             spansService.recordCompletedSpan(
                 name = "sdk-init",
-                startTimeNanos = TimeUnit.MILLISECONDS.toNanos(startTimeMs),
-                endTimeNanos = TimeUnit.MILLISECONDS.toNanos(endTimeMs)
+                startTimeNanos = startTimeMs.millisToNanos(),
+                endTimeNanos = endTimeMs.millisToNanos()
             )
         }
         sdkStartupDuration = endTimeMs - startTimeMs

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.CacheableValue
 import io.embrace.android.embracesdk.internal.EventDescription
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanName
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
@@ -27,7 +28,6 @@ import java.util.NavigableMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.ConcurrentSkipListMap
-import java.util.concurrent.TimeUnit
 
 /**
  * Handles the lifecycle of events (moments).
@@ -290,8 +290,8 @@ internal class EmbraceEventService(
         backgroundWorker.submit {
             spansService.recordCompletedSpan(
                 name = STARTUP_SPAN_NAME,
-                startTimeNanos = TimeUnit.MILLISECONDS.toNanos(startupStartTime),
-                endTimeNanos = TimeUnit.MILLISECONDS.toNanos(startupEndTimeMillis),
+                startTimeNanos = startupStartTime.millisToNanos(),
+                endTimeNanos = startupEndTimeMillis.millisToNanos(),
                 internal = false
             )
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/OpenTelemetryClock.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/OpenTelemetryClock.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.internal
 
 import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.utils.BuildVersionChecker
-import java.util.concurrent.TimeUnit
 
 /**
  * A clock that is compatible with the OpenTelemetry SDK that defers to the internal clock used by Embrace. This allows the times recorded
@@ -17,13 +17,13 @@ internal class OpenTelemetryClock(
     private val embraceClock: Clock
 ) : io.opentelemetry.sdk.common.Clock {
 
-    override fun now(): Long = TimeUnit.MILLISECONDS.toNanos(embraceClock.now())
+    override fun now(): Long = embraceClock.nowInNanos()
 
     override fun nanoTime(): Long {
         return if (BuildVersionChecker.isAtLeast(17)) {
             SystemClock.elapsedRealtimeNanos()
         } else {
-            TimeUnit.MILLISECONDS.toNanos(SystemClock.elapsedRealtime())
+            SystemClock.elapsedRealtime().millisToNanos()
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/clock/Clock.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/clock/Clock.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.clock
 
 import io.embrace.android.embracesdk.annotation.InternalApi
+import java.util.concurrent.TimeUnit
 
 @InternalApi
 public fun interface Clock {
@@ -9,4 +10,15 @@ public fun interface Clock {
      * Returns the current milliseconds from epoch.
      */
     public fun now(): Long
+
+    /**
+     * Returns the current nanoseconds from epoch
+     */
+    public fun nowInNanos(): Long = now().millisToNanos()
 }
+
+/**
+ * Turns a number that specifies a millisecond value to nanoseconds
+ */
+@InternalApi
+public fun Long.millisToNanos(): Long = TimeUnit.MILLISECONDS.toNanos(this)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import java.util.concurrent.TimeUnit
 
 internal class InternalTracer(
     private val spansRepository: SpansRepository,
@@ -95,7 +94,7 @@ internal class InternalTracer(
         return if (name is String && timestampNanos is Long? && attributes is Map<*, *>?) {
             EmbraceSpanEvent.create(
                 name = name,
-                timestampNanos = timestampNanos ?: TimeUnit.MILLISECONDS.toNanos(clock.now()),
+                timestampNanos = timestampNanos ?: clock.nowInNanos(),
                 attributes = attributes?.let { toStringMap(it) }
             )
         } else {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.capture.startup
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.internal.spans.SpansSink
 import io.embrace.android.embracesdk.internal.spans.isPrivate
@@ -11,7 +12,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 internal class StartupServiceImplTest {
 
@@ -26,7 +26,7 @@ internal class StartupServiceImplTest {
         val initModule = FakeInitModule(clock = clock)
         spansSink = initModule.spansSink
         spansService = initModule.spansService
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
+        spansService.initializeService(clock.nowInNanos())
         startupService = StartupServiceImpl(spansService)
     }
 
@@ -42,8 +42,8 @@ internal class StartupServiceImplTest {
         with(currentSpans[0]) {
             assertEquals("emb-sdk-init", name)
             assertEquals(SpanId.getInvalid(), parentSpanId)
-            assertEquals(TimeUnit.MILLISECONDS.toNanos(startTimeMillis), startTimeNanos)
-            assertEquals(TimeUnit.MILLISECONDS.toNanos(endTimeMillis), endTimeNanos)
+            assertEquals(startTimeMillis.millisToNanos(), startTimeNanos)
+            assertEquals(endTimeMillis.millisToNanos(), endTimeNanos)
             assertEquals(
                 io.embrace.android.embracesdk.internal.spans.EmbraceAttributes.Type.PERFORMANCE.name,
                 attributes[io.embrace.android.embracesdk.internal.spans.EmbraceAttributes.Type.PERFORMANCE.keyName()]

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -42,7 +42,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 internal class EmbraceEventServiceTest {
 
@@ -120,7 +119,7 @@ internal class EmbraceEventServiceTest {
         spansSink = initModule.spansSink
         currentSessionSpan = initModule.currentSessionSpan
         spansService = initModule.spansService
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(fakeClock.now()))
+        spansService.initializeService(fakeClock.nowInNanos())
         eventHandler = EventHandler(
             metadataService = metadataService,
             sessionIdTracker = sessionIdTracker,
@@ -427,7 +426,7 @@ internal class EmbraceEventServiceTest {
     @Test
     fun `startup logged as span if startup moment automatic end is enabled`() {
         spansService.initializeService(
-            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
+            sdkInitStartTimeNanos = 1_000_000
         )
         configService.updateListeners()
         currentSessionSpan.endSession()
@@ -439,8 +438,8 @@ internal class EmbraceEventServiceTest {
         assertEquals(1, completedSpans.size)
         with(completedSpans[0]) {
             assertEquals("emb-startup-moment", name)
-            assertEquals(TimeUnit.MILLISECONDS.toNanos(1), startTimeNanos)
-            assertEquals(TimeUnit.MILLISECONDS.toNanos(10), endTimeNanos)
+            assertEquals(1_000_000L, startTimeNanos)
+            assertEquals(10_000_000L, endTimeNanos)
         }
     }
 
@@ -448,7 +447,7 @@ internal class EmbraceEventServiceTest {
     fun `startup logged as span if when startup moment manually ends`() {
         startupMomentLocalConfig = StartupMomentLocalConfig(automaticallyEnd = false)
         spansService.initializeService(
-            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
+            sdkInitStartTimeNanos = 1_000_000
         )
         configService.updateListeners()
         currentSessionSpan.endSession()
@@ -467,15 +466,15 @@ internal class EmbraceEventServiceTest {
 
         with(completedSpansAgain[0]) {
             assertEquals("emb-startup-moment", name)
-            assertEquals(TimeUnit.MILLISECONDS.toNanos(1), startTimeNanos)
-            assertEquals(TimeUnit.MILLISECONDS.toNanos(20), endTimeNanos)
+            assertEquals(1_000_000L, startTimeNanos)
+            assertEquals(20_000_000L, endTimeNanos)
         }
     }
 
     @Test
     fun `startup not logged as span if startup moment is ended via a timeout`() {
         spansService.initializeService(
-            sdkInitStartTimeNanos = TimeUnit.MILLISECONDS.toNanos(1)
+            sdkInitStartTimeNanos = 1_000_000
         )
         configService.updateListeners()
         currentSessionSpan.endSession()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
@@ -12,7 +13,6 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 internal class EmbraceTracerTest {
     private lateinit var spansRepository: SpansRepository
@@ -27,7 +27,7 @@ internal class EmbraceTracerTest {
         spansRepository = initModule.spansRepository
         spansSink = initModule.spansSink
         spansService = initModule.spansService
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
+        spansService.initializeService(clock.now().millisToNanos())
         embraceTracer = initModule.embraceTracer
         spansSink.flushSpans()
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -11,7 +12,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 internal class InternalTracerTest {
     private lateinit var spansSink: SpansSink
@@ -26,7 +26,7 @@ internal class InternalTracerTest {
         spansSink = initModule.spansSink
         currentSessionSpan = initModule.currentSessionSpan
         spansService = initModule.spansService
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
+        spansService.initializeService(clock.nowInNanos())
         internalTracer = InternalTracer(
             initModule.spansRepository,
             initModule.embraceTracer,
@@ -118,7 +118,7 @@ internal class InternalTracerTest {
             assertEquals("correct event", events[0].name)
             assertEquals(0L, events[0].timestampNanos)
             assertEquals("correct event2", events[1].name)
-            assertEquals(TimeUnit.MILLISECONDS.toNanos(expectedStartTime), events[1].timestampNanos)
+            assertEquals(expectedStartTime.millisToNanos(), events[1].timestampNanos)
             assertEquals("partial event", events[2].name)
             assertEquals(0, events[2].attributes.size)
             assertEquals("partial event2", events[3].name)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImplTest.kt
@@ -23,7 +23,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 internal class SpansServiceImplTest {
@@ -42,7 +41,7 @@ internal class SpansServiceImplTest {
             currentSessionSpan = currentSessionSpan,
             tracer = initModule.tracer
         )
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
+        spansService.initializeService(clock.nowInNanos())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -38,7 +38,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.TimeUnit
 
 internal class PayloadFactoryBaTest {
 
@@ -109,7 +108,7 @@ internal class PayloadFactoryBaTest {
         // Prevent background thread from overwriting deliveryService.lastSavedBackgroundActivity
         blockingExecutorService = BlockingScheduledExecutorService(blockingMode = true)
         service = createService()
-        val now = TimeUnit.MILLISECONDS.toNanos(clock.now())
+        val now = clock.nowInNanos()
         spansService.initializeService(now)
         val msg = service.endBackgroundActivityWithCrash(initial, now, "crashId")
 
@@ -121,7 +120,7 @@ internal class PayloadFactoryBaTest {
     @Test
     fun `foregrounding will flush the current completed spans`() {
         service = createService()
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
+        spansService.initializeService(clock.nowInNanos())
         val msg = service.endBackgroundActivityWithState(initial, clock.now())
 
         // there should be 1 completed span: the session span
@@ -132,7 +131,7 @@ internal class PayloadFactoryBaTest {
     @Test
     fun `sending background activity will flush the current completed spans`() {
         service = createService()
-        spansService.initializeService(TimeUnit.MILLISECONDS.toNanos(clock.now()))
+        spansService.initializeService(clock.nowInNanos())
         clock.tick(1000L)
         val msg = service.endBackgroundActivityWithState(initial, clock.now())
 


### PR DESCRIPTION
## Goal

OTel deals in nanoseconds, but Embrace deals in milliseconds, so lets make it as easy as possible to convert the latter to the former
