### PR TITLE
Update detekt version

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
     // TODO: future - these versions must be kept in sync when updating buildscript deps.
     implementation("com.android.tools.build:gradle:7.4.2")
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.12.1")
 }

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -24,7 +24,7 @@ object Versions {
     val dokka = "1.7.10"
 
     @JvmField
-    val detekt = "1.22.0"
+    val detekt = "1.23.0" // kotlin 1.9 required before any further upgrades
 
     @JvmField
     val binaryCompatValidator = "0.12.1"

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -56,8 +56,10 @@ style:
     maxLineLength: 140
   ReturnCount:
     active: false
-  MandatoryBracesIfStatements:
+  BracesOnIfStatements:
     active: true
+    singleLine: 'consistent'
+    multiLine: 'always'
   MandatoryBracesLoops:
     active: true
   SpacingBetweenPackageAndImports:

--- a/embrace-android-okhttp3/src/test/kotlin/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3InterceptorsTest.kt
+++ b/embrace-android-okhttp3/src/test/kotlin/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3InterceptorsTest.kt
@@ -328,7 +328,9 @@ internal class EmbraceOkHttp3InterceptorsTest {
     @Test
     fun `EmbraceCustomPathException records incomplete network request with custom path and the correct error type and message`() {
         postRequestBuilder.header("x-emb-path", customPath)
-        preNetworkInterceptorBeforeRequestSupplier = { throw EmbraceCustomPathException(customPath, IllegalStateException("Burned")) }
+        preNetworkInterceptorBeforeRequestSupplier = {
+            throw EmbraceCustomPathException(customPath, IllegalStateException("Burned"))
+        }
         assertThrows(EmbraceCustomPathException::class.java) { runPostRequest() }
         with(capturedEmbraceNetworkRequest.captured) {
             assertEquals(IllegalStateException::class.java.canonicalName, errorType)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
@@ -18,7 +18,8 @@ internal class EmbraceInternalInterfaceImpl(
     private val embraceImpl: EmbraceImpl,
     private val initModule: InitModule,
     private val configService: ConfigService,
-    internalTracer: InternalTracer = InternalTracer(initModule.spansRepository, initModule.embraceTracer, initModule.clock)
+    internalTracer: InternalTracer =
+        InternalTracer(initModule.spansRepository, initModule.embraceTracer, initModule.clock)
 ) : EmbraceInternalInterface, InternalTracingApi by internalTracer {
 
     override fun logInfo(message: String, properties: Map<String, Any>?) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
@@ -12,7 +12,6 @@ internal class EmbraceUserService(
 ) : UserService {
 
     @Volatile
-
     internal var info: UserInfo = ofStored(preferencesService)
 
     override fun loadUserInfoFromDisk(): UserInfo? {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/AnrRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/AnrRemoteConfig.kt
@@ -93,7 +93,7 @@ internal data class AnrRemoteConfig(
 
     enum class Unwinder(internal val code: Int) {
         LIBUNWIND(0),
-        LIBUNWINDSTACK(1);
+        LIBUNWINDSTACK(1)
     }
 
     @JsonClass(generateAdapter = true)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -66,7 +66,8 @@ internal interface InitModule {
 }
 
 internal class InitModuleImpl(
-    override val clock: io.embrace.android.embracesdk.internal.clock.Clock = NormalizedIntervalClock(systemClock = SystemClock()),
+    override val clock: io.embrace.android.embracesdk.internal.clock.Clock =
+        NormalizedIntervalClock(systemClock = SystemClock()),
     openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(clock)
 ) : InitModule {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -54,7 +54,6 @@ internal class SessionModuleImpl(
             androidServicesModule.preferencesService,
             initModule.spansSink,
             initModule.currentSessionSpan,
-            initModule.clock,
             sessionPropertiesService,
             dataCaptureServiceModule.startupService
         )
@@ -75,10 +74,7 @@ internal class SessionModuleImpl(
     }
 
     override val periodicSessionCacher: PeriodicSessionCacher by singleton {
-        PeriodicSessionCacher(
-            initModule.clock,
-            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
-        )
+        PeriodicSessionCacher(workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE))
     }
 
     override val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/ConstantNameThreadFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/ConstantNameThreadFactory.kt
@@ -13,7 +13,7 @@ internal class ConstantNameThreadFactory(
     uniquePerInstance: Boolean = false
 ) : ThreadFactory {
     private val defaultFactory: ThreadFactory = Executors.defaultThreadFactory()
-    private val threadName = "emb-$namePrefix${if (uniquePerInstance) {"-${hashCode()}"} else ""}"
+    private val threadName = "emb-$namePrefix${if (uniquePerInstance) "-${hashCode()}" else ""}"
 
     override fun newThread(r: Runnable?): Thread = defaultFactory.newThread(r).apply { name = threadName }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ThreadState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/ThreadState.kt
@@ -18,5 +18,5 @@ internal enum class ThreadState(internal val code: Int) {
     BLOCKED(2),
     WAITING(3),
     TIMED_WAITING(4),
-    TERMINATED(5);
+    TERMINATED(5)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.session.caching
 
 import io.embrace.android.embracesdk.internal.Systrace
-import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -10,7 +9,6 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
 internal class PeriodicSessionCacher(
-    private val clock: Clock,
     private val sessionPeriodicCacheScheduledWorker: ScheduledWorker,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.capture.webview.WebViewService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
@@ -40,7 +39,6 @@ internal class PayloadMessageCollator(
     private val preferencesService: PreferencesService,
     private val spansSink: SpansSink,
     private val currentSessionSpan: CurrentSessionSpan,
-    private val clock: Clock,
     private val sessionPropertiesService: SessionPropertiesService,
     private val startupService: StartupService
 ) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
@@ -30,5 +30,5 @@ internal enum class SessionSnapshotType(
     /**
      * The end session is being constructed because of a JVM crash.
      */
-    JVM_CRASH(false, false);
+    JVM_CRASH(false, false)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/PriorityRunnable.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/PriorityRunnable.kt
@@ -51,5 +51,5 @@ internal enum class TaskPriority(
     CRITICAL(0),
     HIGH(5_000),
     NORMAL(30_000),
-    LOW(60_000);
+    LOW(60_000)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
@@ -127,9 +127,9 @@ internal class EmbraceCrashServiceTest {
         assertEquals(crash.crashId, sessionOrchestrator.crashId)
 
         /*
-        * Verify mainCrashHandled is true after the first execution
-        * by testing that a second execution of handleCrash wont run anything
-        */
+         * Verify mainCrashHandled is true after the first execution
+         * by testing that a second execution of handleCrash wont run anything
+         */
         embraceCrashService.handleCrash(Thread.currentThread(), testException)
         assertEquals(1, anrService.forceAnrTrackingStopOnCrashCount)
         assertNotNull(deliveryService.lastSentCrash)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/ApplicationExitInfoRemoteConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/ApplicationExitInfoRemoteConfigTest.kt
@@ -29,7 +29,8 @@ internal class ApplicationExitInfoRemoteConfigTest {
 
     @Test
     fun testDeserialization() {
-        val appExitInfoConfig = deserializeJsonFromResource<AppExitInfoConfig>("application_exit_info_remote_config.json")
+        val appExitInfoConfig =
+            deserializeJsonFromResource<AppExitInfoConfig>("application_exit_info_remote_config.json")
         assertEquals(100, appExitInfoConfig.appExitInfoTracesLimit)
         assertEquals(100f, appExitInfoConfig.pctAeiCaptureEnabled)
         assertEquals(50, appExitInfoConfig.aeiMaxNum)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalErrorLoggerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalErrorLoggerTest.kt
@@ -142,7 +142,9 @@ internal class InternalErrorLoggerTest {
         val exceptionMessage = "root cause"
         val exception = Exception()
         val msg = "message"
-        every { internalErrorService.handleInternalError(any() as InternalErrorLogger.LogStrictModeException) } throws RuntimeException(
+        every {
+            internalErrorService.handleInternalError(any() as InternalErrorLogger.LogStrictModeException)
+        } throws RuntimeException(
             exceptionMessage
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -165,7 +165,6 @@ internal class PayloadFactoryBaTest {
             preferencesService,
             spansSink,
             currentSessionSpan,
-            clock,
             FakeSessionPropertiesService(),
             FakeStartupService()
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
@@ -58,7 +57,6 @@ internal class PayloadMessageCollatorTest {
             performanceInfoService = FakePerformanceInfoService(),
             spansSink = initModule.spansSink,
             currentSessionSpan = initModule.currentSessionSpan,
-            clock = FakeClock(),
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService()
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -149,7 +149,6 @@ internal class SessionHandlerTest {
             preferencesService,
             initModule.spansSink,
             initModule.currentSessionSpan,
-            clock,
             FakeSessionPropertiesService(),
             FakeStartupService()
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -64,7 +64,7 @@ internal class SessionOrchestratorTest {
         sessionIdTracker = FakeSessionIdTracker()
         sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)
         baCacheExecutor = BlockingScheduledExecutorService(clock, true)
-        periodicSessionCacher = PeriodicSessionCacher(clock, ScheduledWorker(sessionCacheExecutor))
+        periodicSessionCacher = PeriodicSessionCacher(ScheduledWorker(sessionCacheExecutor))
         periodicBackgroundActivityCacher =
             PeriodicBackgroundActivityCacher(clock, ScheduledWorker(baCacheExecutor))
 


### PR DESCRIPTION
## Goal

Updates detekt to 1.23.0, which is the last version we can update to without updating kotlin to 1.9 first.

