### PR TITLE
Use correct kotlin gradle plugin version

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        jdk-version: ["11"]
+        jdk-version: ["17"]
         ndk-version: ["21.4.7075529"]
     steps:
       - name: Checkout Branch

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        jdk-version: ["11"]
+        jdk-version: ["17"]
         ndk-version: ["21.4.7075529"]
         api-level: [29]
         target: [default]

--- a/.github/workflows/generate_baseline_profile.yml
+++ b/.github/workflows/generate_baseline_profile.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        jdk-version: [ "11" ]
+        jdk-version: [ "17" ]
         ndk-version: [ "21.4.7075529" ]
         api-level: [ 29 ]
         target: [ default ]

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk-version: ["11"]
+        jdk-version: ["17"]
         ndk-version: ["21.4.7075529"]
     steps:
       - name: Decode Keystore

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        jdk-version: ["11"]
+        jdk-version: ["17"]
         ndk-version: ["21.4.7075529"]
     steps:
       - name: Checkout Branch

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,10 +20,10 @@ repositories {
 dependencies {
     compileOnly(gradleApi())
 
-    // TODO: future - these versions must be kept in sync when updating buildscript deps.
+    // NOTE: when updating any of these keep in sync with buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
     implementation("com.android.tools.build:gradle:7.4.2")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.14.0")
 }
 

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/InternalEmbracePlugin.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/InternalEmbracePlugin.kt
@@ -87,8 +87,7 @@ class InternalEmbracePlugin : Plugin<Project> {
         detekt.run {
             buildUponDefaultConfig = true
             autoCorrect = true
-            config =
-                project.files("${project.rootDir}/config/detekt/detekt.yml") // overwrite default behaviour here
+            config.from(project.files("${project.rootDir}/config/detekt/detekt.yml")) // overwrite default behaviour here
             baseline =
                 project.file("${project.projectDir}/config/detekt/baseline.xml") // suppress pre-existing issues
         }

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -13,6 +13,7 @@ object Versions {
     @JvmField
     val junit = "4.13.2"
 
+    // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
     @JvmField
     val kotlin = "1.7.21"
 
@@ -23,12 +24,11 @@ object Versions {
     @JvmField
     val dokka = "1.9.10"
 
+    // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
     @JvmField
     val detekt = "1.23.0" // kotlin 1.9 required before any further upgrades
 
-    @JvmField
-    val binaryCompatValidator = "0.14.0"
-
+    // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
     @JvmField
     val agp = "7.4.2"
 


### PR DESCRIPTION
## Goal

Our build script setup means we have to specify versions in two places. The kotlin gradle plugin version was not updated under `buildSrc` so I changed it to use the correct one. This shouldn't affect our compile-time language support.
