### PR TITLE
Simplify worker module

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.worker
 
 import io.embrace.android.embracesdk.injection.InitModule
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
@@ -15,9 +14,8 @@ import java.util.concurrent.atomic.AtomicReference
 
 // This lint error seems spurious as it only flags methods annotated with @JvmStatic even though the accessor is generated regardless
 // for lazily initialized members
-internal class WorkerThreadModuleImpl @JvmOverloads constructor(
-    initModule: InitModule,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+internal class WorkerThreadModuleImpl(
+    initModule: InitModule
 ) : WorkerThreadModule, RejectedExecutionHandler {
 
     private val clock = initModule.clock
@@ -66,7 +64,9 @@ internal class WorkerThreadModuleImpl @JvmOverloads constructor(
      * never return a value.
      */
     override fun rejectedExecution(runnable: Runnable, executor: ThreadPoolExecutor) {
-        logger.logWarning("Rejected execution of $runnable on $executor. Ignoring - the process is likely terminating.")
+        InternalStaticEmbraceLogger.logger.logWarning(
+            "Rejected execution of $runnable on $executor. Ignoring - the process is likely terminating."
+        )
     }
 
     private fun createThreadFactory(name: WorkerName): ThreadFactory {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.worker
 
 import io.embrace.android.embracesdk.fakes.FakeLoggerAction
 import io.embrace.android.embracesdk.injection.InitModuleImpl
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -45,9 +45,8 @@ internal class WorkerThreadModuleImplTest {
     @Test
     fun `rejected execution policy`() {
         val action = FakeLoggerAction()
-        val logger = InternalEmbraceLogger().apply { addLoggerAction(action) }
-        val module = WorkerThreadModuleImpl(initModule, logger)
-
+        InternalStaticEmbraceLogger.logger.addLoggerAction(action)
+        val module = WorkerThreadModuleImpl(initModule)
         val worker = module.backgroundWorker(WorkerName.PERIODIC_CACHE)
         module.close()
 
@@ -55,5 +54,6 @@ internal class WorkerThreadModuleImplTest {
         val msg = action.msgQueue.single().msg
         assertTrue(msg.startsWith("Rejected execution of"))
         assertNotNull(future)
+        InternalStaticEmbraceLogger.logger.setToDefault()
     }
 }


### PR DESCRIPTION
## Goal

The logger parameter is never used in production, only in tests. Rewrote the test so that this isn't necessary

## Testing

Existing tests pass