### PR TITLE
Simplify EssentialServiceModule

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -207,6 +207,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/EmbraceIn
 	public abstract fun recordIncompleteNetworkRequest (Ljava/lang/String;Ljava/lang/String;JJLjava/lang/Throwable;Ljava/lang/String;Lio/embrace/android/embracesdk/internal/network/http/NetworkCaptureData;)V
 	public abstract fun setProcessStartedByNotification ()V
 	public abstract fun shouldCaptureNetworkBody (Ljava/lang/String;Ljava/lang/String;)Z
+	public abstract fun stopSdk ()V
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/InternalTracingApi {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -30,7 +30,6 @@ import io.embrace.android.embracesdk.injection.StorageModule
 import io.embrace.android.embracesdk.injection.StorageModuleImpl
 import io.embrace.android.embracesdk.injection.SystemServiceModule
 import io.embrace.android.embracesdk.injection.SystemServiceModuleImpl
-import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
@@ -104,7 +103,7 @@ internal class IntegrationTestRule(
                 { _ -> systemServiceModule },
                 { _, _, _ -> androidServicesModule },
                 { _, _, _ -> storageModule },
-                { _, _, _, _, _, _, _, _, _, _, _, _ -> essentialServiceModule },
+                { _, _, _, _, _, _, _, _, _ -> essentialServiceModule },
                 { _, _, _, _, _ -> dataCaptureServiceModule },
                 { _, _, _, _ -> fakeDeliveryModule }
             )
@@ -150,7 +149,7 @@ internal class IntegrationTestRule(
             autoDataCaptureBehavior = fakeAutoDataCaptureBehavior(
                 remoteCfg = {
                     DEFAULT_SDK_REMOTE_CONFIG.copy(
-                        // disable thermal status capture as it interfes with unit tests
+                        // disable thermal status capture as it interferes with unit tests
                         dataConfig = DataRemoteConfig(pctThermalStatusEnabled = 0.0f)
                     )
                 }
@@ -178,10 +177,8 @@ internal class IntegrationTestRule(
                 systemServiceModule = systemServiceModule,
                 androidServicesModule = androidServicesModule,
                 storageModule = storageModule,
-                buildInfo = BuildInfo.fromResources(fakeCoreModule.resources, fakeCoreModule.context.packageName),
                 customAppId = null,
                 enableIntegrationTesting = enableIntegrationTesting,
-                configStopAction = { Embrace.getImpl().stop() },
                 configServiceProvider = { fakeConfigService }
             ),
         val dataCaptureServiceModule: DataCaptureServiceModule =

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -63,9 +63,6 @@ import io.embrace.android.embracesdk.injection.StorageModuleImpl;
 import io.embrace.android.embracesdk.injection.SystemServiceModule;
 import io.embrace.android.embracesdk.injection.SystemServiceModuleImpl;
 import io.embrace.android.embracesdk.internal.ApkToolsConfig;
-import io.embrace.android.embracesdk.internal.BuildInfo;
-import io.embrace.android.embracesdk.internal.DeviceArchitecture;
-import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl;
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface;
 import io.embrace.android.embracesdk.internal.TraceparentGenerator;
 import io.embrace.android.embracesdk.internal.clock.Clock;
@@ -103,14 +100,13 @@ import io.embrace.android.embracesdk.worker.WorkerThreadModule;
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl;
 import kotlin.Lazy;
 import kotlin.LazyKt;
-import kotlin.Unit;
 import kotlin.jvm.functions.Function0;
 import kotlin.jvm.functions.Function1;
-import kotlin.jvm.functions.Function12;
 import kotlin.jvm.functions.Function2;
 import kotlin.jvm.functions.Function3;
 import kotlin.jvm.functions.Function4;
 import kotlin.jvm.functions.Function5;
+import kotlin.jvm.functions.Function9;
 
 /**
  * Implementation class of the SDK. Embrace.java forms our public API and calls functions in this
@@ -161,9 +157,8 @@ final class EmbraceImpl {
     private final Function3<WorkerThreadModule, InitModule, CoreModule, StorageModule> storageModuleSupplier;
 
     @NonNull
-    private final Function12<InitModule, CoreModule, WorkerThreadModule, SystemServiceModule, AndroidServicesModule,
-        StorageModule, BuildInfo, String, Boolean, Function0<Unit>, Function0<ConfigService>, DeviceArchitecture,
-        EssentialServiceModule> essentialServiceModuleSupplier;
+    private final Function9<InitModule, CoreModule, WorkerThreadModule, SystemServiceModule, AndroidServicesModule,
+        StorageModule, String, Boolean, Function0<ConfigService>, EssentialServiceModule> essentialServiceModuleSupplier;
 
     @NonNull
     private final Function5<InitModule, CoreModule, SystemServiceModule, EssentialServiceModule, WorkerThreadModule,
@@ -291,9 +286,8 @@ final class EmbraceImpl {
                 @NonNull Function1<CoreModule, SystemServiceModule> systemServiceModuleSupplier,
                 @NonNull Function3<InitModule, CoreModule, WorkerThreadModule, AndroidServicesModule> androidServiceModuleSupplier,
                 @NonNull Function3<WorkerThreadModule, InitModule, CoreModule, StorageModule> storageModuleSupplier,
-                @NonNull Function12<InitModule, CoreModule, WorkerThreadModule, SystemServiceModule, AndroidServicesModule, StorageModule, BuildInfo,
-                    String, Boolean, Function0<Unit>, Function0<ConfigService>, DeviceArchitecture, EssentialServiceModule>
-                    essentialServiceModuleSupplier,
+                @NonNull Function9<InitModule, CoreModule, WorkerThreadModule, SystemServiceModule, AndroidServicesModule, StorageModule,
+                    String, Boolean, Function0<ConfigService>, EssentialServiceModule> essentialServiceModuleSupplier,
                 @NonNull Function5<InitModule, CoreModule, SystemServiceModule, EssentialServiceModule, WorkerThreadModule,
                     DataCaptureServiceModule> dataCaptureServiceModuleSupplier,
                 @NonNull Function4<CoreModule, StorageModule, EssentialServiceModule, WorkerThreadModule,
@@ -406,15 +400,9 @@ final class EmbraceImpl {
             systemServiceModule,
             androidServicesModule,
             storageModule,
-            BuildInfo.fromResources(coreModule.getResources(), coreModule.getContext().getPackageName()),
             customAppId,
             enableIntegrationTesting,
-            () -> {
-                Embrace.getImpl().stop();
-                return null;
-            },
-            () -> null,
-            new DeviceArchitectureImpl());
+            () -> null);
 
         final ProcessStateService nonNullProcessStateService = essentialServiceModule.getProcessStateService();
         processStateService = nonNullProcessStateService;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
@@ -199,4 +199,8 @@ internal class EmbraceInternalInterfaceImpl(
     override fun logInternalError(error: Throwable) {
         embraceImpl.logInternalError(error)
     }
+
+    override fun stopSdk() {
+        embraceImpl.stop()
+    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImpl.kt
@@ -85,4 +85,6 @@ internal class UninitializedSdkInternalInterfaceImpl(
     override fun logInternalError(message: String?, details: String?) {}
 
     override fun logInternalError(error: Throwable) {}
+
+    override fun stopSdk() {}
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
@@ -39,7 +39,6 @@ internal class EmbraceConfigService @JvmOverloads constructor(
     private val logger: InternalEmbraceLogger,
     private val backgroundWorker: BackgroundWorker,
     isDebug: Boolean,
-    private val stopBehavior: () -> Unit = {},
     internal val thresholdCheck: BehaviorThresholdCheck = BehaviorThresholdCheck(preferencesService::deviceIdentifier)
 ) : ConfigService, ProcessStateListener {
 
@@ -271,7 +270,7 @@ internal class EmbraceConfigService @JvmOverloads constructor(
         getConfig()
         if (Embrace.getInstance().isStarted && isSdkDisabled()) {
             logger.logInfo("Embrace SDK disabled by config")
-            stopBehavior()
+            Embrace.getInstance().internalInterface.stopSdk()
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CoreModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CoreModule.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.internal.AndroidResourcesService
+import io.embrace.android.embracesdk.internal.BuildInfo
+import io.embrace.android.embracesdk.internal.BuildInfo.Companion.fromResources
 import io.embrace.android.embracesdk.internal.EmbraceAndroidResourcesService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -56,6 +58,8 @@ internal interface CoreModule {
      * Whether the application is a debug build
      */
     val isDebug: Boolean
+
+    val buildInfo: BuildInfo
 }
 
 internal class CoreModuleImpl(
@@ -86,7 +90,13 @@ internal class CoreModuleImpl(
         EmbraceAndroidResourcesService(context)
     }
 
-    override val isDebug: Boolean by lazy { context.applicationInfo.isDebug() }
+    override val isDebug: Boolean by lazy {
+        context.applicationInfo.isDebug()
+    }
+
+    override val buildInfo: BuildInfo by lazy {
+        fromResources(resources, context.packageName)
+    }
 }
 
 internal fun ApplicationInfo.isDebug() = flags and ApplicationInfo.FLAG_DEBUGGABLE != 0

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -28,7 +28,6 @@ import io.embrace.android.embracesdk.config.behavior.BehaviorThresholdCheck
 import io.embrace.android.embracesdk.config.behavior.SdkEndpointBehavior
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.GatingService
-import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
@@ -75,12 +74,9 @@ internal class EssentialServiceModuleImpl(
     systemServiceModule: SystemServiceModule,
     androidServicesModule: AndroidServicesModule,
     storageModule: StorageModule,
-    buildInfo: BuildInfo,
     customAppId: String?,
     enableIntegrationTesting: Boolean,
-    private val configStopAction: () -> Unit,
     private val configServiceProvider: () -> ConfigService? = { null },
-    override val deviceArchitecture: DeviceArchitecture = DeviceArchitectureImpl(),
 ) : EssentialServiceModule {
 
     // Many of these properties are temporarily here to break a circular dependency between services.
@@ -160,7 +156,6 @@ internal class EssentialServiceModuleImpl(
                 coreModule.logger,
                 backgroundWorker,
                 coreModule.isDebug,
-                configStopAction,
                 thresholdCheck
             )
     }
@@ -173,10 +168,14 @@ internal class EssentialServiceModuleImpl(
         EmbraceCpuInfoDelegate(sharedObjectLoader, coreModule.logger)
     }
 
+    override val deviceArchitecture: DeviceArchitecture by singleton {
+        DeviceArchitectureImpl()
+    }
+
     override val metadataService: MetadataService by singleton {
         EmbraceMetadataService.ofContext(
             coreModule.context,
-            buildInfo,
+            coreModule.buildInfo,
             configService,
             coreModule.appFramework,
             androidServicesModule.preferencesService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
@@ -140,8 +140,14 @@ public interface EmbraceInternalInterface : InternalTracingApi {
      */
     public fun isInternalNetworkCaptureDisabled(): Boolean
 
+    /**
+     * Whether the ANR capture service is enabled
+     */
     public fun isAnrCaptureEnabled(): Boolean
 
+    /**
+     * Whether the native crash capture is enabled
+     */
     public fun isNdkEnabled(): Boolean
 
     /**
@@ -153,4 +159,9 @@ public interface EmbraceInternalInterface : InternalTracingApi {
      * Logs an internal error to the Embrace SDK - this is not intended for public use.
      */
     public fun logInternalError(error: Throwable)
+
+    /**
+     * Stop the Embrace SDK and disable its functionality
+     */
+    public fun stopSdk()
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
@@ -247,13 +248,15 @@ internal class EmbraceConfigServiceTest {
 
     @Test
     fun `test onForeground() with sdk started and config sdkDisabled=true stops the SDK`() {
+        val mockInternalInterface: EmbraceInternalInterface = mockk(relaxed = true)
         mockkObject(Embrace.getImpl())
         every { Embrace.getImpl().isStarted } returns true
+        every { Embrace.getImpl().embraceInternalInterface } returns mockInternalInterface
         fakePreferenceService.sdkDisabled = true
 
         service.onForeground(true, 1100L)
 
-        verify(exactly = 1) { Embrace.getImpl().stop() }
+        verify(exactly = 1) { mockInternalInterface.stopSdk() }
     }
 
     @Test
@@ -309,7 +312,6 @@ internal class EmbraceConfigServiceTest {
             fakeClock,
             logger,
             worker,
-            false,
-            { Embrace.getImpl().stop() }
+            false
         )
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
@@ -263,6 +263,12 @@ internal class EmbraceInternalInterfaceImplTest {
         }
     }
 
+    @Test
+    fun `check stopping SDK`() {
+        internalImpl.stopSdk()
+        assertFalse(embraceImpl.isStarted)
+    }
+
     companion object {
         private val beforeObjectInitTime = System.currentTimeMillis() - 1
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.injection.InitModuleImpl
-import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
 import io.embrace.android.embracesdk.session.EmbraceMemoryCleanerService
 import io.embrace.android.embracesdk.session.lifecycle.EmbraceProcessStateService
@@ -45,10 +44,8 @@ internal class EssentialServiceModuleImplTest {
             systemServiceModule = FakeSystemServiceModule(),
             androidServicesModule = FakeAndroidServicesModule(),
             storageModule = FakeStorageModule(),
-            buildInfo = BuildInfo("", "", ""),
             customAppId = "abcde",
             enableIntegrationTesting = false,
-            configStopAction = {},
             configServiceProvider = { null }
         )
 
@@ -81,10 +78,8 @@ internal class EssentialServiceModuleImplTest {
             systemServiceModule = FakeSystemServiceModule(),
             androidServicesModule = FakeAndroidServicesModule(),
             storageModule = FakeStorageModule(),
-            buildInfo = BuildInfo("", "", ""),
             customAppId = null,
             enableIntegrationTesting = false,
-            configStopAction = {},
             configServiceProvider = { fakeConfigService }
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
@@ -68,6 +68,7 @@ internal class UninitializedSdkInternalInterfaceImplTest {
         )
         impl.logInternalError(SocketException())
         impl.logInternalError("err", "message")
+        impl.stopSdk()
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeAndroidResourcesService
 import io.embrace.android.embracesdk.fakes.system.mockApplication
 import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.injection.isDebug
+import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
@@ -30,8 +31,8 @@ internal class FakeCoreModule(
     override val serviceRegistry: ServiceRegistry = ServiceRegistry(),
     override val jsonSerializer: EmbraceSerializer = EmbraceSerializer(),
     override val resources: FakeAndroidResourcesService = FakeAndroidResourcesService(),
-    override val isDebug: Boolean =
-        if (isMockKMock(context)) false else context.applicationInfo.isDebug()
+    override val isDebug: Boolean = if (isMockKMock(context)) false else context.applicationInfo.isDebug(),
+    override val buildInfo: BuildInfo = BuildInfo.fromResources(resources, context.packageName)
 ) : CoreModule {
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/SystemServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/SystemServiceModuleImplTest.kt
@@ -54,6 +54,7 @@ internal class SystemServiceModuleImplTest {
     @Test
     fun testSystemServiceModuleException() {
         val ctx = mockk<Context>()
+        every { ctx.packageName } returns ""
         val module = SystemServiceModuleImpl(FakeCoreModule(context = ctx))
 
         assertNull(module.activityManager)


### PR DESCRIPTION
## Goal

Simplify EssentialServiceModuleImpl so the constructor requires fewer parameters to be passed in. To support this, I added a `stopSdk` method to the internal interface instead of having that be passed in at runtime.

## Testing

Tested the new interface method and made sure existing tests work