### PR TITLE
Add initial DataSource interface and DataSourceState class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.arch
+
+/**
+ * Defines a 'data source'. This should be responsible for capturing a specific type
+ * of data that will be sent to Embrace.
+ */
+internal interface DataSource<T> {
+
+    /**
+     * Register any listeners that are required for capturing data.
+     */
+    fun registerListeners()
+
+    /**
+     * Unregister any listeners that might be capturing data.
+     */
+    fun unregisterListeners()
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -1,0 +1,68 @@
+package io.embrace.android.embracesdk.arch
+
+/**
+ * Holds the current state of the service. This class automatically handles changes in config
+ * that enable/disable the service, and creates new instances of the service as required.
+ * It also is capable of disabling the service if the [EnvelopeType] is not supported.
+ */
+internal class DataSourceState<T : DataSource<R>, R>(
+
+    /**
+     * Provides instances of services. A service must define an interface
+     * that extends [DataSource] for orchestration. This helps enforce testability
+     * by making it impossible to register data capture without defining a testable interface.
+     */
+    factory: () -> DataSource<R>,
+
+    /**
+     * Predicate that determines if the service should be enabled or not, via a config value.
+     */
+    private val configGate: () -> Boolean,
+
+    /**
+     * The type of envelope that contains the data.
+     */
+    private var currentEnvelope: EnvelopeType,
+
+    /**
+     * An envelope type where data capture should be disabled. For example,
+     * background activities capture a subset of sessions.
+     */
+    private val disabledEnvelopeType: EnvelopeType? = null
+) {
+
+    private val enabledDataSource by lazy(factory)
+    private var dataSource: DataSource<R>? = null
+
+    init {
+        updateDataSource()
+    }
+
+    /**
+     * Callback that is invoked when the envelope type changes.
+     */
+    fun onEnvelopeTypeChange(envelopeType: EnvelopeType) {
+        this.currentEnvelope = envelopeType
+        updateDataSource()
+    }
+
+    /**
+     * Callback that is invoked when the config layer experiences a change.
+     */
+    fun onConfigChange() {
+        updateDataSource()
+    }
+
+    private fun updateDataSource() {
+        val enabled = currentEnvelope != disabledEnvelopeType && configGate()
+
+        if (enabled && dataSource == null) {
+            dataSource = enabledDataSource.apply {
+                registerListeners()
+            }
+        } else if (!enabled && dataSource != null) {
+            dataSource?.unregisterListeners()
+            dataSource = null
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/EnvelopeType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/EnvelopeType.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.arch
+
+/**
+ * The type of envelope that contains the data. Currently this is either a session or a background
+ * activity.
+ */
+internal enum class EnvelopeType {
+
+    /**
+     * A period of time where the app was in the foreground.
+     */
+    SESSION,
+
+    /**
+     * A period of time where the app was in the background.
+     */
+    BACKGROUND_ACTIVITY
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -1,0 +1,107 @@
+package io.embrace.android.embracesdk.arch
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class DataSourceStateTest {
+
+    @Test
+    fun `test config gate enabled by default`() {
+        val source = ExampleDataSource()
+        DataSourceState(
+            factory = { source },
+            configGate = { true },
+            currentEnvelope = EnvelopeType.SESSION
+        )
+
+        // data capture is enabled by default.
+        assertEquals(1, source.registerCount)
+        assertEquals(0, source.unregisterCount)
+    }
+
+    @Test
+    fun `test config gate affects data capture`() {
+        val source = ExampleDataSource()
+        var enabled = false
+        val state = DataSourceState(
+            factory = { source },
+            configGate = { enabled },
+            currentEnvelope = EnvelopeType.SESSION
+        )
+
+        // data capture is disabled by default.
+        assertEquals(0, source.registerCount)
+        assertEquals(0, source.unregisterCount)
+
+        // enabling the config gate should enable data capture
+        enabled = true
+        state.onConfigChange()
+        assertEquals(1, source.registerCount)
+        assertEquals(0, source.unregisterCount)
+
+        // another config change should not reregister listeners
+        state.onConfigChange()
+        assertEquals(1, source.registerCount)
+        assertEquals(0, source.unregisterCount)
+
+        // deregistering works
+        enabled = false
+        state.onConfigChange()
+        assertEquals(1, source.registerCount)
+        assertEquals(1, source.unregisterCount)
+
+        // functions can be called multiple times without issue
+        enabled = true
+        state.onConfigChange()
+        enabled = false
+        state.onConfigChange()
+        assertEquals(2, source.registerCount)
+        assertEquals(2, source.unregisterCount)
+    }
+
+    @Test
+    fun `test envelope type affects data capture`() {
+        val source = ExampleDataSource()
+        val state = DataSourceState(
+            factory = { source },
+            configGate = { true },
+            EnvelopeType.BACKGROUND_ACTIVITY,
+            disabledEnvelopeType = EnvelopeType.BACKGROUND_ACTIVITY
+        )
+
+        // data capture is always disabled by default.
+        assertEquals(0, source.registerCount)
+        assertEquals(0, source.unregisterCount)
+
+        // new session should enable data capture
+        state.onEnvelopeTypeChange(EnvelopeType.SESSION)
+        state.onEnvelopeTypeChange(EnvelopeType.SESSION)
+        assertEquals(1, source.registerCount)
+        assertEquals(0, source.unregisterCount)
+
+        // extra payload types should not re-register listeners
+        state.onEnvelopeTypeChange(EnvelopeType.BACKGROUND_ACTIVITY)
+        state.onEnvelopeTypeChange(EnvelopeType.BACKGROUND_ACTIVITY)
+        assertEquals(1, source.registerCount)
+        assertEquals(1, source.unregisterCount)
+
+        // functions can be called multiple times without issue
+        state.onEnvelopeTypeChange(EnvelopeType.SESSION)
+        state.onEnvelopeTypeChange(EnvelopeType.BACKGROUND_ACTIVITY)
+        assertEquals(2, source.registerCount)
+        assertEquals(2, source.unregisterCount)
+    }
+
+    private class ExampleDataSource : DataSource<String> {
+        var registerCount = 0
+        var unregisterCount = 0
+
+        override fun registerListeners() {
+            registerCount++
+        }
+
+        override fun unregisterListeners() {
+            unregisterCount++
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Adds an initial interface for the `DataSource`. Currently this just contains the register/unregister calls for dealing with system API callbacks etc.

This also adds the `DataSourceState` class, which is responsible for managing the state of a single data source. This keeps track of whether the feature is currently enabled via config flags, and whether capture should be enabled for the current envelope type. This is done declaratively so that a `DataSource` implementation doesn't need to worry about tracking this state.

## Testing

Added unit test coverage.

