### PR TITLE
Add data capture orchestrator class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.config.ConfigListener
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+/**
+ * Orchestrates all data sources that could potentially be used in the SDK. This is a convenient
+ * place to coordinate everything in one place.
+ */
+internal class DataCaptureOrchestrator(
+    private val dataSourceState: List<DataSourceState<*, *>>,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : ConfigListener {
+
+    override fun onConfigChange(configService: ConfigService) {
+        dataSourceState.forEach { state ->
+            try {
+                state.onConfigChange()
+            } catch (exc: Throwable) {
+                logger.logError("Exception thrown starting data capture", exc)
+            }
+        }
+    }
+
+    /**
+     * Callback that is invoked when the envelope type changes.
+     */
+    fun onEnvelopeChange(envelopeType: EnvelopeType) {
+        dataSourceState.forEach { state ->
+            try {
+                // alter the envelope type - some data sources don't capture for background activities.
+                state.onEnvelopeTypeChange(envelopeType)
+            } catch (exc: Throwable) {
+                logger.logError("Exception thrown starting data capture", exc)
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -22,7 +22,7 @@ internal class DataSourceState<T : DataSource<R>, R>(
     /**
      * The type of envelope that contains the data.
      */
-    private var currentEnvelope: EnvelopeType,
+    private var currentEnvelope: EnvelopeType? = null,
 
     /**
      * An envelope type where data capture should be disabled. For example,
@@ -41,7 +41,7 @@ internal class DataSourceState<T : DataSource<R>, R>(
     /**
      * Callback that is invoked when the envelope type changes.
      */
-    fun onEnvelopeTypeChange(envelopeType: EnvelopeType) {
+    fun onEnvelopeTypeChange(envelopeType: EnvelopeType?) {
         this.currentEnvelope = envelopeType
         updateDataSource()
     }
@@ -54,7 +54,7 @@ internal class DataSourceState<T : DataSource<R>, R>(
     }
 
     private fun updateDataSource() {
-        val enabled = currentEnvelope != disabledEnvelopeType && configGate()
+        val enabled = currentEnvelope != null && currentEnvelope != disabledEnvelopeType && configGate()
 
         if (enabled && dataSource == null) {
             dataSource = enabledDataSource.apply {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.ndk.NativeModule
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
@@ -22,6 +23,7 @@ internal interface SessionModule {
     val sessionOrchestrator: SessionOrchestrator
     val periodicSessionCacher: PeriodicSessionCacher
     val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher
+    val dataCaptureOrchestrator: DataCaptureOrchestrator
 }
 
 internal class SessionModuleImpl(
@@ -100,6 +102,13 @@ internal class SessionModuleImpl(
         )
     }
 
+    override val dataCaptureOrchestrator: DataCaptureOrchestrator by singleton {
+        // orchestrates data capture (an empty list of data sources is passed for now)
+        DataCaptureOrchestrator(emptyList()).apply {
+            essentialServiceModule.configService.addListener(this)
+        }
+    }
+
     override val sessionOrchestrator: SessionOrchestrator by singleton(LoadType.EAGER) {
         SessionOrchestratorImpl(
             essentialServiceModule.processStateService,
@@ -110,7 +119,8 @@ internal class SessionModuleImpl(
             boundaryDelegate,
             deliveryModule.deliveryService,
             periodicSessionCacher,
-            periodicBackgroundActivityCacher
+            periodicBackgroundActivityCacher,
+            dataCaptureOrchestrator
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.session.orchestrator
 
+import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
+import io.embrace.android.embracesdk.arch.EnvelopeType
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -25,6 +27,7 @@ internal class SessionOrchestratorImpl(
     private val deliveryService: DeliveryService,
     private val periodicSessionCacher: PeriodicSessionCacher,
     private val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher,
+    private val dataCaptureOrchestrator: DataCaptureOrchestrator,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : SessionOrchestrator {
 
@@ -212,6 +215,13 @@ internal class SessionOrchestratorImpl(
 
             // update the current state
             state = endProcessState
+
+            // update data capture orchestrator
+            val envelopeType = when (endProcessState) {
+                ProcessState.FOREGROUND -> EnvelopeType.SESSION
+                ProcessState.BACKGROUND -> EnvelopeType.BACKGROUND_ACTIVITY
+            }
+            dataCaptureOrchestrator.onEnvelopeChange(envelopeType)
 
             // log the state change
             logSessionStateChange(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeDataSource
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class DataCaptureOrchestratorTest {
+
+    private lateinit var orchestrator: DataCaptureOrchestrator
+    private lateinit var dataSource: FakeDataSource
+    private var enabled: Boolean = true
+
+    @Before
+    fun setUp() {
+        dataSource = FakeDataSource()
+        orchestrator = DataCaptureOrchestrator(
+            listOf(
+                DataSourceState(
+                    factory = { dataSource },
+                    configGate = { enabled },
+                    currentEnvelope = null
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `config changes are propagated`() {
+        assertEquals(0, dataSource.registerCount)
+        orchestrator.onEnvelopeChange(EnvelopeType.SESSION)
+        assertEquals(1, dataSource.registerCount)
+
+        enabled = false
+        orchestrator.onConfigChange(FakeConfigService())
+        assertEquals(1, dataSource.unregisterCount)
+    }
+
+    @Test
+    fun `envelope type change is propagated`() {
+        assertEquals(0, dataSource.registerCount)
+        orchestrator.onEnvelopeChange(EnvelopeType.SESSION)
+        assertEquals(1, dataSource.registerCount)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.arch.DataSource
+
+internal class FakeDataSource : DataSource<String> {
+    var registerCount = 0
+    var unregisterCount = 0
+
+    override fun registerListeners() {
+        registerCount++
+    }
+
+    override fun unregisterListeners() {
+        unregisterCount++
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.FakePayloadFactory
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.injection.SessionModule
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
@@ -25,4 +26,7 @@ internal class FakeSessionModule(
 
     override val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher
         get() = TODO("Not yet implemented")
+
+    override val dataCaptureOrchestrator: DataCaptureOrchestrator =
+        DataCaptureOrchestrator(emptyList())
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeSdkObservabilityModule
 import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.injection.SessionModuleImpl
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionModuleImplTest {
@@ -26,12 +27,14 @@ internal class SessionModuleImplTest {
             executorProvider = ::BlockableExecutorService
         )
 
+    private val configService = FakeConfigService()
+
     @Test
     fun testDefaultImplementations() {
         val module = SessionModuleImpl(
             InitModuleImpl(),
             FakeAndroidServicesModule(),
-            FakeEssentialServiceModule(),
+            FakeEssentialServiceModule(configService = configService),
             FakeNativeModule(),
             FakeDataContainerModule(),
             FakeDeliveryModule(),
@@ -47,6 +50,7 @@ internal class SessionModuleImplTest {
         assertNotNull(module.sessionOrchestrator)
         assertNotNull(module.periodicSessionCacher)
         assertNotNull(module.periodicBackgroundActivityCacher)
+        assertTrue(configService.listeners.contains(module.dataCaptureOrchestrator))
     }
 
     @Test
@@ -68,6 +72,7 @@ internal class SessionModuleImplTest {
         assertNotNull(module.sessionPropertiesService)
         assertNotNull(module.payloadFactory)
         assertNotNull(module.sessionOrchestrator)
+        assertNotNull(module.dataCaptureOrchestrator)
     }
 
     private fun createEnabledBehavior(): FakeEssentialServiceModule {


### PR DESCRIPTION
## Goal

Adds a `DataCaptureOrchestrator` class. This is responsible for relaying config state/envelope changes to all the data sources in the SDK.

## Testing

Added unit test coverage.
