### PR TITLE
Add data sink interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  * place to coordinate everything in one place.
  */
 internal class DataCaptureOrchestrator(
-    private val dataSourceState: List<DataSourceState<*, *>>,
+    private val dataSourceState: List<DataSourceState<*>>,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : ConfigListener {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
@@ -1,0 +1,35 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+
+/**
+ * A function that acts on an [EmbraceSpan] and mutates its state.
+ */
+internal typealias SpanMutator = EmbraceSpan.() -> Unit
+
+/**
+ * A function that provides a [DataSink] instance.
+ */
+internal typealias DataSinkProvider = () -> DataSink
+
+/**
+ * A [DataSource] can write information to a [DataSink] that will ultimately be added to a session.
+ */
+internal interface DataSink {
+
+    /**
+     * Given a span ID, mutate the span with the given action. If the span cannot be found,
+     * the action will not be executed.
+     *
+     * The [EmbraceSpan] should NOT be cached and used outside of the action.
+     */
+    fun mutateSpan(spanId: String, action: SpanMutator)
+
+    /**
+     * Mutate the current session span with the given action. If the span cannot be found,
+     * the action will not be executed.
+     *
+     * The [EmbraceSpan] should NOT be cached and used outside of the action.
+     */
+    fun mutateSessionSpan(action: SpanMutator)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -1,10 +1,20 @@
 package io.embrace.android.embracesdk.arch
 
 /**
+ * A function that acts on a [DataSink] and mutates its state.
+ */
+internal typealias DataSinkMutator = DataSink.() -> Unit
+
+/**
  * Defines a 'data source'. This should be responsible for capturing a specific type
  * of data that will be sent to Embrace.
  */
-internal interface DataSource<T> {
+internal interface DataSource {
+
+    /**
+     * All captured data should be written to the data sink within the action of this function.
+     */
+    fun captureData(action: DataSinkMutator)
 
     /**
      * Register any listeners that are required for capturing data.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.arch
+
+/**
+ * An abstract implementation of [DataSource] that captures data and writes it to a [DataSink].
+ * This base class contains convenience functions for capturing data that makes the syntax nicer
+ * in subclasses.
+ */
+internal abstract class DataSourceImpl(
+    private val sink: DataSinkProvider
+) : DataSource {
+
+    override fun captureData(action: DataSinkMutator) {
+        action(sink())
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -5,14 +5,14 @@ package io.embrace.android.embracesdk.arch
  * that enable/disable the service, and creates new instances of the service as required.
  * It also is capable of disabling the service if the [EnvelopeType] is not supported.
  */
-internal class DataSourceState<T : DataSource<R>, R>(
+internal class DataSourceState<T : DataSource>(
 
     /**
      * Provides instances of services. A service must define an interface
      * that extends [DataSource] for orchestration. This helps enforce testability
      * by making it impossible to register data capture without defining a testable interface.
      */
-    factory: () -> DataSource<R>,
+    factory: () -> DataSource,
 
     /**
      * Predicate that determines if the service should be enabled or not, via a config value.
@@ -32,7 +32,7 @@ internal class DataSourceState<T : DataSource<R>, R>(
 ) {
 
     private val enabledDataSource by lazy(factory)
-    private var dataSource: DataSource<R>? = null
+    private var dataSource: DataSource? = null
 
     init {
         updateDataSource()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
@@ -17,7 +17,7 @@ internal class DataCaptureOrchestratorTest {
         dataSource = FakeDataSource()
         orchestrator = DataCaptureOrchestrator(
             listOf(
-                DataSourceState(
+                DataSourceState<FakeDataSource>(
                     factory = { dataSource },
                     configGate = { enabled },
                     currentEnvelope = null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -9,7 +9,7 @@ internal class DataSourceStateTest {
     @Test
     fun `null envelope is never enabled`() {
         val source = FakeDataSource()
-        val state = DataSourceState(
+        val state = DataSourceState<FakeDataSource>(
             factory = { source },
             configGate = { true },
             currentEnvelope = null
@@ -41,7 +41,7 @@ internal class DataSourceStateTest {
     @Test
     fun `test config gate enabled by default`() {
         val source = FakeDataSource()
-        DataSourceState(
+        DataSourceState<FakeDataSource>(
             factory = { source },
             configGate = { true },
             currentEnvelope = EnvelopeType.SESSION
@@ -56,7 +56,7 @@ internal class DataSourceStateTest {
     fun `test config gate affects data capture`() {
         val source = FakeDataSource()
         var enabled = false
-        val state = DataSourceState(
+        val state = DataSourceState<FakeDataSource>(
             factory = { source },
             configGate = { enabled },
             currentEnvelope = EnvelopeType.SESSION
@@ -95,7 +95,7 @@ internal class DataSourceStateTest {
     @Test
     fun `test envelope type affects data capture`() {
         val source = FakeDataSource()
-        val state = DataSourceState(
+        val state = DataSourceState<FakeDataSource>(
             factory = { source },
             configGate = { true },
             EnvelopeType.BACKGROUND_ACTIVITY,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.content.res.Configuration
+import io.embrace.android.embracesdk.arch.DataSinkProvider
+import io.embrace.android.embracesdk.arch.DataSourceImpl
+
+/**
+ * An example of a DataSource that captures the orientation of the device. It provides functions
+ * to register/deregister itself for callbacks. It also provides an example of mutating an
+ * existing span.
+ */
+internal class ExampleOrientationDataSource(
+    private val ctx: Context,
+    sink: DataSinkProvider
+) : DataSourceImpl(sink), ComponentCallbacks2 {
+
+    override fun registerListeners() {
+        ctx.registerComponentCallbacks(this)
+    }
+
+    override fun unregisterListeners() {
+        ctx.unregisterComponentCallbacks(this)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        captureData {
+            mutateSessionSpan {
+                addAttribute("orientation", newConfig.orientation.toString())
+            }
+        }
+    }
+
+    override fun onTrimMemory(level: Int) {
+    }
+
+    override fun onLowMemory() {
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -1,10 +1,14 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.arch.DataSinkMutator
 import io.embrace.android.embracesdk.arch.DataSource
 
-internal class FakeDataSource : DataSource<String> {
+internal class FakeDataSource : DataSource {
     var registerCount = 0
     var unregisterCount = 0
+
+    override fun captureData(action: DataSinkMutator) {
+    }
 
     override fun registerListeners() {
         registerCount++

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -75,7 +75,7 @@ internal class SessionOrchestratorTest {
         fakeDataSource = FakeDataSource()
         dataCaptureOrchestrator = DataCaptureOrchestrator(
             listOf(
-                DataSourceState(
+                DataSourceState<FakeDataSource>(
                     factory = { fakeDataSource },
                     configGate = { true },
                     currentEnvelope = null


### PR DESCRIPTION
## Goal

Adds a `DataSink` interface where `DataSource` implementations will write data to spans.

Currently this only handles one use-case - adding attributes/events to pre-existing spans. This interface will also be responsible for starting/stopping new spans but that will happen in a separate changeset as I'm less sure on what the syntax should look like.

### Discussion

I've decided on a `DataSink` interface as it offers a bit of separation from the `SpansService` and `EmbraceTracer`, although the ultimate implementation will likely just be a wrapper around this. An example is provided in `ExampleOrientationDataSource`, but use of the DSL would generally look like this:

```
 fun onConfigurationChanged(newConfig: Configuration) {
    captureData { // write to the DataSink object
        mutateSessionSpan {

            // perform operations on the EmbraceSpan object
            addAttribute("orientation", newConfig.orientation.toString()) 
        }
    }
}
```

IMO this is advantageous as a DSL enforces capturing data in a consistent way. It also allows us to consolidate any error-handling logic (or synchronisation) in one place - for example, if an action throws an exception, we could trivially add internal telemetry or logging.

No implementation is provided just yet as I'd like to be confident on the interface before committing further to this.

### Future thoughts

I am less clear on how we handle state management of spans/sessions although that's for a future changeset/discussion. For example, if the `ExampleOrientationDataSource` wanted to record orientation changes as a span, then should a span persist across multiple session boundaries? I'm assuming the answer is yes, as this would substantially simplify the implementation of our `DataSource` classes.

