### PR TITLE
Add functions to DataSink that stop + start spans

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
@@ -32,4 +32,27 @@ internal interface DataSink {
      * The [EmbraceSpan] should NOT be cached and used outside of the action.
      */
     fun mutateSessionSpan(action: SpanMutator)
+
+    /**
+     * Start a new span and mutates it with the given action.
+     * The returned span ID can be retained & used either to further alter the span
+     * via [mutateSpan] or to stop it via [stopSpan]. If the span couldn't be created,
+     * the return value will be null, and the action will not be executed.
+     */
+    fun startSpan(
+        name: String,
+        action: SpanMutator
+    ): String?
+
+    /**
+     * Mutates a span with the given action and then stops it. If the span cannot be found
+     * the action will not be executed. If the span cannot be stopped this function will return
+     * false.
+     *
+     * Attempting to stop the root session span is disallowed & will be a no-op.
+     */
+    fun stopSpan(
+        spanId: String,
+        action: SpanMutator
+    ): Boolean
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -1,15 +1,23 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
 /**
  * An abstract implementation of [DataSource] that captures data and writes it to a [DataSink].
  * This base class contains convenience functions for capturing data that makes the syntax nicer
  * in subclasses.
  */
 internal abstract class DataSourceImpl(
-    private val sink: DataSinkProvider
+    private val sink: DataSinkProvider,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataSource {
 
     override fun captureData(action: DataSinkMutator) {
-        action(sink())
+        try {
+            action(sink())
+        } catch (exc: Throwable) {
+            logger.logError("Exception thrown while capturing data", exc)
+        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
@@ -16,6 +16,10 @@ internal class ExampleOrientationDataSource(
     sink: DataSinkProvider
 ) : DataSourceImpl(sink), ComponentCallbacks2 {
 
+    companion object {
+        const val SPAN_NAME = "emb_orientation"
+    }
+
     override fun registerListeners() {
         ctx.registerComponentCallbacks(this)
     }
@@ -33,6 +37,26 @@ internal class ExampleOrientationDataSource(
     }
 
     override fun onTrimMemory(level: Int) {
+        captureData {
+            val runtime = Runtime.getRuntime()
+
+            // start a span.
+            val spanId = startSpan(SPAN_NAME) {
+                addAttribute("trimMemory", level.toString())
+            } ?: return@captureData
+
+            // mutate the span. in an ordinary implementation spanId would be held in a property
+            // and this would be called at a later date.
+            mutateSpan(spanId) {
+                addAttribute("freeMemory", runtime.freeMemory().toString())
+            }
+
+            // stop the span. in an ordinary implementation spanId would be held in a property
+            // and this would be called at a later date.
+            stopSpan(spanId) {
+                addAttribute("maxMemory", runtime.maxMemory().toString())
+            }
+        }
     }
 
     override fun onLowMemory() {


### PR DESCRIPTION
## Goal

Builds on #368 by adding functions that start/stop spans. By default I think these will just be added to the session span. I've included an example of what usage would look like on `ExampleOrientationDataSource`.

