### PR TITLE
[POC] Data sink implementation

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSinkImpl.kt
@@ -1,0 +1,65 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
+import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.spans.ErrorCode
+
+internal class DataSinkImpl(
+    private val tracer: EmbraceTracer,
+    private val spansService: SpansService,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataSink {
+
+    override fun mutateSpan(spanId: String, action: SpanMutator) {
+        val span = tracer.getSpan(spanId)
+
+        if (span == null) {
+            logger.logWarning("Span not found for id: $spanId")
+            return
+        }
+        try {
+            action(span)
+        } catch (exc: Throwable) {
+            logger.logError("Exception thrown while mutating span", exc)
+        }
+    }
+
+    override fun mutateSessionSpan(action: SpanMutator) {
+        val sessionSpanId = "FIXME" // TODO: pass the correct session span ID
+        mutateSpan(sessionSpanId, action)
+    }
+
+    override fun startSpan(name: String, action: SpanMutator): String? {
+        val span = tracer.createSpan(name)
+
+        if (span == null) {
+            logger.logWarning("Failed to create span named: $name")
+            return null
+        }
+        try {
+            action(span)
+        } catch (exc: Throwable) {
+            logger.logError("Exception thrown while starting span", exc)
+        }
+        return span.spanId
+    }
+
+    override fun stopSpan(spanId: String, action: SpanMutator): Boolean {
+        val span = tracer.getSpan(spanId)
+
+        if (span == null) {
+            logger.logWarning("Failed to find & stop span: $spanId")
+            return false
+        }
+        return try {
+            action(span)
+            span.stop()
+        } catch (exc: Throwable) {
+            logger.logError("Exception thrown while stopping span", exc)
+            span.stop(ErrorCode.FAILURE)
+            false
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -110,7 +110,7 @@ internal class EmbraceSpanImpl(
         return false
     }
 
-    internal fun wrappedSpan(): Span? = startedSpan.get()
+    internal fun wrappe,dSpan(): Span? = startedSpan.get()
 
     /**
      * Returns the underlying [Span] if it's currently recording


### PR DESCRIPTION
## Goal

This is a POC implementation of `DataSink` that intends to demonstrate some of the questions I have around how spans/session spans are structured. My main questions are:

1. Should we be using `Span` or `EmbraceSpan` for these internal APIs?
2. If we want to allow ingestion of custom data out-of-the-box, then presumably our internal APIs will need to support the `Span` interface directly, rather than `EmbraceSpan`?
3. Does it make sense to always call into `EmbraceTracer` when creating a span? Does this just get attached to the session span?
4. Is there an easy way of converting the `sessionSpan` property in `CurrentSessionSpanImpl` to an `EmbraceSpan`? (If we're using `Span` for internal APIs, this does not require an answer)
5. Is there any downside to exposing the `sessionSpan: Span?` property as part of the `CurrentSessionSpan` interface? Would it be preferable to expose this somewhere else?

