### PR TITLE
Populate DataCaptureOrchestrator with data source states

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -43,6 +43,8 @@ import io.embrace.android.embracesdk.injection.CustomerLogModuleImpl;
 import io.embrace.android.embracesdk.injection.DataCaptureServiceModule;
 import io.embrace.android.embracesdk.injection.DataContainerModule;
 import io.embrace.android.embracesdk.injection.DataContainerModuleImpl;
+import io.embrace.android.embracesdk.injection.DataSourceModule;
+import io.embrace.android.embracesdk.injection.DataSourceModuleImpl;
 import io.embrace.android.embracesdk.injection.DeliveryModule;
 import io.embrace.android.embracesdk.injection.EssentialServiceModule;
 import io.embrace.android.embracesdk.injection.InitModule;
@@ -480,6 +482,8 @@ final class EmbraceImpl {
             internalEmbraceLogger.logWarning("Failed to load SO file embrace-native");
         }
 
+        DataSourceModule dataSourceModule = new DataSourceModuleImpl(essentialServiceModule);
+
         final SessionModule sessionModule = new SessionModuleImpl(
             initModule,
             openTelemetryModule,
@@ -492,7 +496,8 @@ final class EmbraceImpl {
             dataCaptureServiceModule,
             customerLogModule,
             sdkObservabilityModule,
-            workerThreadModule
+            workerThreadModule,
+            dataSourceModule
         );
 
         sessionOrchestrator = sessionModule.getSessionOrchestrator();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  * place to coordinate everything in one place.
  */
 internal class DataCaptureOrchestrator(
-    private val dataSourceState: List<DataSourceState<*, *>>,
+    private val dataSourceState: List<DataSourceState>,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : ConfigListener {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -4,7 +4,7 @@ package io.embrace.android.embracesdk.arch
  * Defines a 'data source'. This should be responsible for capturing a specific type
  * of data that will be sent to Embrace.
  */
-internal interface DataSource<T> {
+internal interface DataSource {
 
     /**
      * Register any listeners that are required for capturing data.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -5,19 +5,20 @@ package io.embrace.android.embracesdk.arch
  * that enable/disable the service, and creates new instances of the service as required.
  * It also is capable of disabling the service if the [SessionType] is not supported.
  */
-internal class DataSourceState<T : DataSource<R>, R>(
+internal class DataSourceState(
 
     /**
      * Provides instances of services. A service must define an interface
      * that extends [DataSource] for orchestration. This helps enforce testability
      * by making it impossible to register data capture without defining a testable interface.
      */
-    factory: () -> DataSource<R>,
+    factory: () -> DataSource,
 
     /**
      * Predicate that determines if the service should be enabled or not, via a config value.
+     * Defaults to true if not provided.
      */
-    private val configGate: () -> Boolean,
+    private val configGate: () -> Boolean = { true },
 
     /**
      * The type of session that contains the data.
@@ -32,7 +33,7 @@ internal class DataSourceState<T : DataSource<R>, R>(
 ) {
 
     private val enabledDataSource by lazy(factory)
-    private var dataSource: DataSource<R>? = null
+    private var dataSource: DataSource? = null
 
     init {
         updateDataSource()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -1,0 +1,69 @@
+package io.embrace.android.embracesdk.injection
+
+import io.embrace.android.embracesdk.arch.DataSource
+import io.embrace.android.embracesdk.arch.DataSourceState
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+internal class PlaceholderDataSource : DataSource {
+    override fun registerListeners() {
+    }
+
+    override fun unregisterListeners() {
+    }
+}
+
+/**
+ * Declares all the data sources that are used by the Embrace SDK.
+ *
+ * To add a new data source, simply define a new property of type [DataSourceState] using
+ * the [dataSource] property delegate. It is important that you use this delegate as otherwise
+ * the property won't be propagated to the [DataCaptureOrchestrator].
+ *
+ * Data will then automatically be captured by the SDK.
+ */
+internal interface DataSourceModule {
+
+    /**
+     * Returns a list of all the data sources that are defined in this module.
+     */
+    fun getDataSources(): List<DataSourceState>
+
+    val placeholderDataSource: DataSourceState
+}
+
+internal class DataSourceModuleImpl(
+    essentialServiceModule: EssentialServiceModule,
+) : DataSourceModule {
+    private val values: MutableList<DataSourceState> = mutableListOf()
+
+    override val placeholderDataSource by dataSource {
+        DataSourceState(::PlaceholderDataSource)
+    }
+
+    /* Implementation details */
+
+    private val configService = essentialServiceModule.configService
+    override fun getDataSources(): List<DataSourceState> = values
+
+    /**
+     * Property delegate that adds the value to a
+     * list on its creation. That list is then used by the [DataCaptureOrchestrator] to control
+     * the data sources.
+     */
+    private fun dataSource(provider: () -> DataSourceState) = DataSourceDelegate(provider, values)
+}
+
+private class DataSourceDelegate(
+    provider: () -> DataSourceState,
+    values: MutableList<DataSourceState>,
+) : ReadOnlyProperty<Any?, DataSourceState> {
+
+    private val value = provider()
+
+    init {
+        values.add(value)
+    }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>) = value
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -38,7 +38,8 @@ internal class SessionModuleImpl(
     dataCaptureServiceModule: DataCaptureServiceModule,
     customerLogModule: CustomerLogModule,
     sdkObservabilityModule: SdkObservabilityModule,
-    workerThreadModule: WorkerThreadModule
+    workerThreadModule: WorkerThreadModule,
+    dataSourceModule: DataSourceModule
 ) : SessionModule {
 
     override val payloadMessageCollator: PayloadMessageCollator by singleton {
@@ -104,8 +105,8 @@ internal class SessionModuleImpl(
     }
 
     override val dataCaptureOrchestrator: DataCaptureOrchestrator by singleton {
-        // orchestrates data capture (an empty list of data sources is passed for now)
-        DataCaptureOrchestrator(emptyList()).apply {
+        val dataSources = dataSourceModule.getDataSources()
+        DataCaptureOrchestrator(dataSources).apply {
             essentialServiceModule.configService.addListener(this)
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -39,6 +39,19 @@ internal class DataSourceStateTest {
     }
 
     @Test
+    fun `test config gate defaults to enabled`() {
+        val source = FakeDataSource()
+        DataSourceState(
+            factory = { source },
+            currentSessionType = SessionType.FOREGROUND
+        )
+
+        // data capture is enabled by default.
+        assertEquals(1, source.registerCount)
+        assertEquals(0, source.unregisterCount)
+    }
+
+    @Test
     fun `test config gate enabled by default`() {
         val source = FakeDataSource()
         DataSourceState(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.DataSource
 
-internal class FakeDataSource : DataSource<String> {
+internal class FakeDataSource : DataSource {
     var registerCount = 0
     var unregisterCount = 0
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.injection
+
+import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class DataSourceModuleImplTest {
+
+    @Test
+    fun `test default behavior`() {
+        val module = DataSourceModuleImpl(FakeEssentialServiceModule())
+        val dataSource = module.placeholderDataSource
+        assertNotNull(dataSource)
+        assertTrue(module.getDataSources().contains(dataSource))
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSdkObservabilityModule
+import io.embrace.android.embracesdk.injection.DataSourceModuleImpl
 import io.embrace.android.embracesdk.injection.SessionModuleImpl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -33,11 +34,13 @@ internal class SessionModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
+        val essentialServiceModule = FakeEssentialServiceModule(configService = configService)
+        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule)
         val module = SessionModuleImpl(
             fakeInitModule,
             fakeInitModule.openTelemetryModule,
             FakeAndroidServicesModule(),
-            FakeEssentialServiceModule(configService = configService),
+            essentialServiceModule,
             FakeNativeModule(),
             FakeDataContainerModule(),
             FakeDeliveryModule(),
@@ -45,7 +48,8 @@ internal class SessionModuleImplTest {
             FakeDataCaptureServiceModule(),
             FakeCustomerLogModule(),
             FakeSdkObservabilityModule(),
-            workerThreadModule
+            workerThreadModule,
+            dataSourceModule
         )
         assertNotNull(module.payloadMessageCollator)
         assertNotNull(module.sessionPropertiesService)
@@ -58,11 +62,14 @@ internal class SessionModuleImplTest {
 
     @Test
     fun testEnabledBehaviors() {
+        val essentialServiceModule = createEnabledBehavior()
+        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule)
+
         val module = SessionModuleImpl(
             fakeInitModule,
             fakeInitModule.openTelemetryModule,
             FakeAndroidServicesModule(),
-            createEnabledBehavior(),
+            essentialServiceModule,
             FakeNativeModule(),
             FakeDataContainerModule(),
             FakeDeliveryModule(),
@@ -70,7 +77,8 @@ internal class SessionModuleImplTest {
             FakeDataCaptureServiceModule(),
             FakeCustomerLogModule(),
             FakeSdkObservabilityModule(),
-            workerThreadModule
+            workerThreadModule,
+            dataSourceModule
         )
         assertNotNull(module.payloadMessageCollator)
         assertNotNull(module.sessionPropertiesService)


### PR DESCRIPTION
## Goal

The `DataCaptureOrchestrator` is responsible for propagating envelope/config changes to the data sources. Previously it was just supplied an empty list. This changeset creates a new module named `DataSourceModule` that contains a list of data sources that are used by the Embrace SDK, and hooks it up to the orchestrator.

I have included an empty placeholder implementation to demonstrate what this would look like. In terms of scaling this approach to the many data sources the SDK probably uses, it should be possible to group ~10 data sources into modules based on feature & concatenate the lists.

To alleviate the concern that developers might forget to add a property to the list I created a delegate that will automagically add values to the collection.

## Testing

Updated unit test coverage.
