### PR TITLE
Extract custom breadcrumb capture to separate class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
@@ -41,11 +41,9 @@ internal interface BreadcrumbService {
      * Gets the Custom breadcrumbs in the specified time window.
      * If the number of elements exceeds the limit, this will return the newest (latest) ones.
      *
-     * @param start the start time
-     * @param end   the end time
      * @return the list of Breadcrumbs
      */
-    fun getCustomBreadcrumbsForSession(start: Long, end: Long): List<CustomBreadcrumb?>
+    fun getCustomBreadcrumbsForSession(): List<CustomBreadcrumb>
 
     /**
      * Gets the WebView breadcrumbs in the specified time window.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
@@ -1,0 +1,47 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import android.text.TextUtils
+import io.embrace.android.embracesdk.arch.DataCaptureService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.CustomBreadcrumb
+import java.util.concurrent.LinkedBlockingDeque
+
+/**
+ * Captures custom breadcrumbs.
+ */
+internal class CustomBreadcrumbDataSource(
+    private val configService: ConfigService,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataCaptureService<List<CustomBreadcrumb>> {
+
+    private val customBreadcrumbs = LinkedBlockingDeque<CustomBreadcrumb>()
+
+    fun logCustom(message: String, timestamp: Long) {
+        if (TextUtils.isEmpty(message)) {
+            logger.logWarning("Breadcrumb message must not be blank")
+            return
+        }
+        try {
+            val limit = configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
+            tryAddBreadcrumb(customBreadcrumbs, CustomBreadcrumb(message, timestamp), limit)
+        } catch (ex: Exception) {
+            logger.logError("Failed to log custom breadcrumb with message $message", ex)
+        }
+    }
+
+    private fun <T> tryAddBreadcrumb(
+        breadcrumbs: LinkedBlockingDeque<T>,
+        breadcrumb: T,
+        limit: Int
+    ) {
+        if (!breadcrumbs.isEmpty() && breadcrumbs.size >= limit) {
+            breadcrumbs.removeLast()
+        }
+        breadcrumbs.push(breadcrumb)
+    }
+
+    override fun getCapturedData(): List<CustomBreadcrumb> = customBreadcrumbs.toList()
+    override fun cleanCollections() = customBreadcrumbs.clear()
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
@@ -23,8 +23,7 @@ internal class FakeBreadcrumbService : BreadcrumbService {
     override fun getTapBreadcrumbsForSession(start: Long, end: Long): List<TapBreadcrumb?> =
         emptyList()
 
-    override fun getCustomBreadcrumbsForSession(start: Long, end: Long): List<CustomBreadcrumb?> =
-        emptyList()
+    override fun getCustomBreadcrumbsForSession(): List<CustomBreadcrumb> = emptyList()
 
     override fun getWebViewBreadcrumbsForSession(start: Long, end: Long): List<WebViewBreadcrumb?> =
         emptyList()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -120,7 +120,7 @@ internal class EmbraceBreadcrumbServiceTest {
     fun testBreadcrumbCreate() {
         val service = initializeBreadcrumbService()
         service.logCustom("breadcrumb", clock.now())
-        val breadcrumbs = service.customBreadcrumbs
+        val breadcrumbs = service.getCustomBreadcrumbsForSession()
         assertEquals("one breadcrumb captured", 1, breadcrumbs.size)
         assertJsonMessage(service, "breadcrumb_custom.json")
     }
@@ -452,7 +452,7 @@ internal class EmbraceBreadcrumbServiceTest {
         service.startView("b")
         clock.tickSecond()
         service.logCustom("breadcrumb", clock.now())
-        val breadcrumbs = service.customBreadcrumbs
+        val breadcrumbs = service.getCustomBreadcrumbsForSession()
         assertEquals("one breadcrumb captured", 1, breadcrumbs.size)
 
         service.onViewClose(activity)


### PR DESCRIPTION
## Goal

Extracts custom breadcrumb capture to a separate class that implements the `DataCaptureService` interface. This is an intermediate step - I'd like to refactor this to be the first example of a `DataSource` implementation, but that will come in a separate PR.

## Testing

Relied on existing unit test coverage.

