### PR TITLE
Add data sink interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+
+/**
+ * A function that acts on an [EmbraceSpan] and mutates its state.
+ */
+internal typealias SpanMutator = EmbraceSpan.() -> Unit
+
+/**
+ * A function that provides a [DataSink] instance.
+ */
+internal typealias DataSinkProvider = () -> DataSink
+
+/**
+ * A [DataSource] can write information to a [DataSink] that will ultimately be added to a session.
+ */
+internal interface DataSink

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -1,10 +1,20 @@
 package io.embrace.android.embracesdk.arch
 
 /**
+ * A function that acts on a [DataSink] and mutates its state.
+ */
+internal typealias DataSinkMutator = DataSink.() -> Unit
+
+/**
  * Defines a 'data source'. This should be responsible for capturing a specific type
  * of data that will be sent to Embrace.
  */
 internal interface DataSource {
+
+    /**
+     * All captured data should be written to the data sink within the action of this function.
+     */
+    fun captureData(action: DataSinkMutator)
 
     /**
      * Register any listeners that are required for capturing data.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+/**
+ * An abstract implementation of [DataSource] that captures data and writes it to a [DataSink].
+ * This base class contains convenience functions for capturing data that makes the syntax nicer
+ * in subclasses.
+ */
+internal abstract class DataSourceImpl(
+    private val sink: DataSinkProvider,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataSource {
+
+    override fun captureData(action: DataSinkMutator) {
+        try {
+            action(sink())
+        } catch (exc: Throwable) {
+            logger.logError("Failed to capture data", exc)
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
 /**
  * Holds the current state of the service. This class automatically handles changes in config
  * that enable/disable the service, and creates new instances of the service as required.
@@ -29,7 +32,9 @@ internal class DataSourceState(
      * A session type where data capture should be disabled. For example,
      * background activities capture a subset of sessions.
      */
-    private val disabledSessionType: SessionType? = null
+    private val disabledSessionType: SessionType? = null,
+
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) {
 
     private val enabledDataSource by lazy(factory)
@@ -60,10 +65,18 @@ internal class DataSourceState(
 
         if (enabled && dataSource == null) {
             dataSource = enabledDataSource.apply {
-                registerListeners()
+                try {
+                    registerListeners()
+                } catch (exc: Throwable) {
+                    logger.logError("Failed to register listener", exc)
+                }
             }
         } else if (!enabled && dataSource != null) {
-            dataSource?.unregisterListeners()
+            try {
+                dataSource?.unregisterListeners()
+            } catch (exc: Throwable) {
+                logger.logError("Failed to unregister listener", exc)
+            }
             dataSource = null
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -1,11 +1,16 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.arch.DataSinkMutator
 import io.embrace.android.embracesdk.arch.DataSource
 import io.embrace.android.embracesdk.arch.DataSourceState
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
 internal class PlaceholderDataSource : DataSource {
+
+    override fun captureData(action: DataSinkMutator) {
+    }
+
     override fun registerListeners() {
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
@@ -1,0 +1,37 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.content.res.Configuration
+import io.embrace.android.embracesdk.arch.DataSinkProvider
+import io.embrace.android.embracesdk.arch.DataSourceImpl
+
+/**
+ * An example of a DataSource that captures the orientation of the device. It provides functions
+ * to register/deregister itself for callbacks.
+ */
+internal class ExampleOrientationDataSource(
+    private val ctx: Context,
+    sink: DataSinkProvider
+) : DataSourceImpl(sink), ComponentCallbacks2 {
+
+    override fun registerListeners() {
+        ctx.registerComponentCallbacks(this)
+    }
+
+    override fun unregisterListeners() {
+        ctx.unregisterComponentCallbacks(this)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        captureData {
+            // TODO: add functions for capturing data here.
+        }
+    }
+
+    override fun onTrimMemory(level: Int) {
+    }
+
+    override fun onLowMemory() {
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -1,10 +1,14 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.arch.DataSinkMutator
 import io.embrace.android.embracesdk.arch.DataSource
 
 internal class FakeDataSource : DataSource {
     var registerCount = 0
     var unregisterCount = 0
+
+    override fun captureData(action: DataSinkMutator) {
+    }
 
     override fun registerListeners() {
         registerCount++


### PR DESCRIPTION
## Goal

Adds a `DataSink` interface where `DataSource` implementations will write data to spans.

Currently this interface does not have any functions. It is meant to be the starting point for a DSL where developers add events & spans to the session span. Internal APIs to do this will be added in future changesets by writing to the `SpansService/CurrentSessionSpan` as in the arch diagram.

This was broken out of #368 as I believe the overall concept is one we want to pursue, but the actual functions that form the interface required more consideration.

