### PR TITLE
Extra OTel components into OTel module and delay SDK init until SDK starts up

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.injection.AndroidServicesModuleImpl
-import io.embrace.android.embracesdk.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.injection.DataCaptureServiceModule
 import io.embrace.android.embracesdk.injection.DataCaptureServiceModuleImpl
@@ -27,6 +26,8 @@ import io.embrace.android.embracesdk.injection.DeliveryModule
 import io.embrace.android.embracesdk.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.injection.InitModule
+import io.embrace.android.embracesdk.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.injection.StorageModule
 import io.embrace.android.embracesdk.injection.StorageModuleImpl
 import io.embrace.android.embracesdk.injection.SystemServiceModule
@@ -100,13 +101,14 @@ internal class IntegrationTestRule(
             val embraceImpl = EmbraceImpl(
                 ModuleInitBootstrapper(
                     initModule = initModule,
+                    openTelemetryModule  = initModule.openTelemetryModule,
                     coreModuleSupplier = { _, _ -> fakeCoreModule },
                     workerThreadModuleSupplier = { workerThreadModule },
                     systemServiceModuleSupplier = { _, _ -> systemServiceModule },
                     androidServicesModuleSupplier = { _, _, _ -> androidServicesModule },
                     storageModuleSupplier = { _, _, _ -> storageModule },
                     essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _ -> essentialServiceModule },
-                    dataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> dataCaptureServiceModule },
+                    dataCaptureServiceModuleSupplier = { _, _, _, _, _, _, _ -> dataCaptureServiceModule },
                     deliveryModuleSupplier = { _, _, _, _ -> fakeDeliveryModule }
                 )
             )
@@ -133,7 +135,8 @@ internal class IntegrationTestRule(
         val fakeClock: FakeClock = FakeClock(currentTime = currentTimeMs),
         val enableIntegrationTesting: Boolean = false,
         val appFramework: Embrace.AppFramework = Embrace.AppFramework.NATIVE,
-        val initModule: InitModule = FakeInitModule(clock = fakeClock),
+        val initModule: FakeInitModule = FakeInitModule(clock = fakeClock),
+        val openTelemetryModule: OpenTelemetryModule = initModule.openTelemetryModule,
         val fakeCoreModule: FakeCoreModule = FakeCoreModule(),
         val workerThreadModule: WorkerThreadModule = WorkerThreadModuleImpl(initModule),
         val fakeConfigService: FakeConfigService = FakeConfigService(
@@ -187,6 +190,7 @@ internal class IntegrationTestRule(
         val dataCaptureServiceModule: DataCaptureServiceModule =
             DataCaptureServiceModuleImpl(
                 initModule = initModule,
+                openTelemetryModule = initModule.openTelemetryModule,
                 coreModule = fakeCoreModule,
                 systemServiceModule = systemServiceModule,
                 essentialServiceModule = essentialServiceModule,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -89,7 +89,7 @@ internal class TracingApiTest {
                 val backgroundActivitySpansCount = getSdkInitSpanFromBackgroundActivity().size
                 assertTrue(
                     returnIfConditionMet(desiredValueSupplier = { true }, waitTimeMs = 1000) {
-                        checkNotNull(harness.initModule.spansSink.completedSpans()).size == (5 - backgroundActivitySpansCount)
+                        checkNotNull(harness.openTelemetryModule.spansSink.completedSpans()).size == (5 - backgroundActivitySpansCount)
                     }
                 )
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/InternalInterfaceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/InternalInterfaceModule.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.injection.CrashModule
 import io.embrace.android.embracesdk.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.injection.InitModule
+import io.embrace.android.embracesdk.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.injection.singleton
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 
@@ -17,6 +18,7 @@ internal interface InternalInterfaceModule {
 
 internal class InternalInterfaceModuleImpl(
     initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
     coreModule: CoreModule,
     androidServicesModule: AndroidServicesModule,
     essentialServiceModule: EssentialServiceModule,
@@ -25,7 +27,7 @@ internal class InternalInterfaceModuleImpl(
 ) : InternalInterfaceModule {
 
     override val embraceInternalInterface: EmbraceInternalInterface by singleton {
-        EmbraceInternalInterfaceImpl(embrace, initModule, essentialServiceModule.configService, initModule.internalTracer)
+        EmbraceInternalInterfaceImpl(embrace, initModule, essentialServiceModule.configService, openTelemetryModule.internalTracer)
     }
 
     override val reactNativeInternalInterface: ReactNativeInternalInterface by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -75,6 +75,7 @@ internal interface DataCaptureServiceModule {
 
 internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
     coreModule: CoreModule,
     systemServiceModule: SystemServiceModule,
     essentialServiceModule: EssentialServiceModule,
@@ -152,6 +153,6 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     }
 
     override val startupService: StartupService by singleton {
-        StartupServiceImpl(initModule.spansService)
+        StartupServiceImpl(openTelemetryModule.spansService)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
@@ -26,6 +26,7 @@ internal interface DataContainerModule {
 
 internal class DataContainerModuleImpl(
     initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
     coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
     systemServiceModule: SystemServiceModule,
@@ -85,7 +86,7 @@ internal class DataContainerModuleImpl(
             coreModule.logger,
             workerThreadModule,
             initModule.clock,
-            initModule.spansService
+            openTelemetryModule.spansService
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
@@ -11,9 +11,9 @@ internal interface DeliveryModule {
 
 internal class DeliveryModuleImpl(
     coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
-    workerThreadModule: WorkerThreadModule
 ) : DeliveryModule {
 
     override val deliveryService: DeliveryService by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -3,21 +3,8 @@ package io.embrace.android.embracesdk.injection
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
-import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
-import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanExporter
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanProcessor
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
-import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
-import io.embrace.android.embracesdk.internal.spans.InternalTracer
-import io.embrace.android.embracesdk.internal.spans.SpansRepository
-import io.embrace.android.embracesdk.internal.spans.SpansService
-import io.embrace.android.embracesdk.internal.spans.SpansSink
-import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
-import io.embrace.android.embracesdk.opentelemetry.OpenTelemetrySdk
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import io.embrace.android.embracesdk.telemetry.TelemetryService
-import io.opentelemetry.api.trace.Tracer
 
 /**
  * A module of components and services required at [EmbraceImpl] instantiation time, i.e. before the SDK evens starts
@@ -29,100 +16,23 @@ internal interface InitModule {
     val clock: io.embrace.android.embracesdk.internal.clock.Clock
 
     /**
+     * OpenTelemetry SDK compatible clock based on [clock]
+     */
+    val openTelemetryClock: io.opentelemetry.sdk.common.Clock
+
+    /**
      * Service to track usage of public APIs and other internal metrics
      */
     val telemetryService: TelemetryService
-
-    /**
-     * Caches [EmbraceSpan] instances that are in progress or completed in the current session
-     */
-    val spansRepository: SpansRepository
-
-    /**
-     * Provides storage for completed spans that have not been sent off-device
-     */
-    val spansSink: SpansSink
-
-    /**
-     * An instance of the OpenTelemetry component obtained from the wrapped SDK to create spans
-     */
-    val tracer: Tracer
-
-    /**
-     * Component that manages and provides access to the current session span
-     */
-    val currentSessionSpan: CurrentSessionSpan
-
-    /**
-     * Service to record spans
-     */
-    val spansService: SpansService
-
-    /**
-     * Implementation of public tracing API
-     */
-    val embraceTracer: EmbraceTracer
-
-    /**
-     * Implementation of internal tracing API
-     */
-    val internalTracer: InternalTracer
 }
 
 internal class InitModuleImpl(
     override val clock: io.embrace.android.embracesdk.internal.clock.Clock =
         NormalizedIntervalClock(systemClock = SystemClock()),
-    openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(clock)
+    override val openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(embraceClock = clock)
 ) : InitModule {
 
     override val telemetryService: TelemetryService by singleton {
         EmbraceTelemetryService()
-    }
-
-    override val spansRepository: SpansRepository by singleton {
-        SpansRepository()
-    }
-
-    override val spansSink: SpansSink by singleton {
-        SpansSinkImpl()
-    }
-
-    private val openTelemetrySdk: OpenTelemetrySdk by singleton {
-        OpenTelemetrySdk(
-            openTelemetryClock = openTelemetryClock,
-            spanProcessor = EmbraceSpanProcessor(EmbraceSpanExporter(spansSink))
-        )
-    }
-
-    override val tracer: Tracer by singleton {
-        openTelemetrySdk.getOpenTelemetryTracer()
-    }
-
-    override val currentSessionSpan: CurrentSessionSpan by singleton {
-        CurrentSessionSpanImpl(
-            clock = openTelemetryClock,
-            telemetryService = telemetryService,
-            spansRepository = spansRepository,
-            spansSink = spansSink,
-            tracer = tracer
-        )
-    }
-
-    override val spansService: SpansService by singleton {
-        EmbraceSpansService(
-            spansRepository = spansRepository,
-            currentSessionSpan = currentSessionSpan,
-            tracer = tracer,
-        )
-    }
-
-    override val embraceTracer: EmbraceTracer by singleton {
-        EmbraceTracer(
-            spansService = spansService
-        )
-    }
-
-    override val internalTracer: InternalTracer by singleton {
-        InternalTracer(clock = clock, spansRepository = spansRepository, embraceTracer = embraceTracer)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/OpenTelemetryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/OpenTelemetryModule.kt
@@ -1,0 +1,111 @@
+package io.embrace.android.embracesdk.injection
+
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanExporter
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanProcessor
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
+import io.embrace.android.embracesdk.internal.spans.InternalTracer
+import io.embrace.android.embracesdk.internal.spans.SpansRepository
+import io.embrace.android.embracesdk.internal.spans.SpansService
+import io.embrace.android.embracesdk.internal.spans.SpansSink
+import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
+import io.embrace.android.embracesdk.opentelemetry.OpenTelemetrySdk
+import io.opentelemetry.api.trace.Tracer
+
+/**
+ * Module that instantiates various OpenTelemetry related components
+ */
+internal interface OpenTelemetryModule {
+    /**
+     * Caches [EmbraceSpan] instances that are in progress or completed in the current session
+     */
+    val spansRepository: SpansRepository
+
+    /**
+     * Provides storage for completed spans that have not been sent off-device
+     */
+    val spansSink: SpansSink
+
+    /**
+     * An instance of the OpenTelemetry component obtained from the wrapped SDK to create spans
+     */
+    val tracer: Tracer
+
+    /**
+     * Component that manages and provides access to the current session span
+     */
+    val currentSessionSpan: CurrentSessionSpan
+
+    /**
+     * Service to record spans
+     */
+    val spansService: SpansService
+
+    /**
+     * Implementation of public tracing API
+     */
+    val embraceTracer: EmbraceTracer
+
+    /**
+     * Implementation of internal tracing API
+     */
+    val internalTracer: InternalTracer
+}
+
+internal class OpenTelemetryModuleImpl(
+    private val initModule: InitModule
+) : OpenTelemetryModule {
+
+    override val spansRepository: SpansRepository by lazy {
+        SpansRepository()
+    }
+
+    override val spansSink: SpansSink by lazy {
+        SpansSinkImpl()
+    }
+
+    private val openTelemetrySdk: OpenTelemetrySdk by lazy {
+        OpenTelemetrySdk(
+            openTelemetryClock = initModule.openTelemetryClock,
+            spanProcessor = EmbraceSpanProcessor(EmbraceSpanExporter(spansSink))
+        )
+    }
+
+    override val tracer: Tracer by lazy {
+        openTelemetrySdk.getOpenTelemetryTracer()
+    }
+
+    override val currentSessionSpan: CurrentSessionSpan by lazy {
+        CurrentSessionSpanImpl(
+            clock = initModule.openTelemetryClock,
+            telemetryService = initModule.telemetryService,
+            spansRepository = spansRepository,
+            spansSink = spansSink,
+            tracerSupplier = { tracer }
+        )
+    }
+
+    override val spansService: SpansService by singleton {
+        EmbraceSpansService(
+            spansRepository = spansRepository,
+            currentSessionSpan = currentSessionSpan,
+            tracerSupplier = { tracer },
+        )
+    }
+
+    override val embraceTracer: EmbraceTracer by singleton {
+        EmbraceTracer(
+            spansService = spansService
+        )
+    }
+
+    override val internalTracer: InternalTracer by lazy {
+        InternalTracer(
+            clock = initModule.clock,
+            spansRepository = spansRepository,
+            embraceTracer = embraceTracer
+        )
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -28,6 +28,7 @@ internal interface SessionModule {
 
 internal class SessionModuleImpl(
     initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
     androidServicesModule: AndroidServicesModule,
     essentialServiceModule: EssentialServiceModule,
     nativeModule: NativeModule,
@@ -54,8 +55,8 @@ internal class SessionModuleImpl(
             dataCaptureServiceModule.breadcrumbService,
             essentialServiceModule.userService,
             androidServicesModule.preferencesService,
-            initModule.spansSink,
-            initModule.currentSessionSpan,
+            openTelemetryModule.spansSink,
+            openTelemetryModule.currentSessionSpan,
             sessionPropertiesService,
             dataCaptureServiceModule.startupService
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
@@ -23,9 +23,9 @@ internal interface StorageModule {
 }
 
 internal class StorageModuleImpl(
-    workerThreadModule: WorkerThreadModule,
     initModule: InitModule,
     coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
 ) : StorageModule {
 
     override val storageService: StorageService by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -17,7 +17,7 @@ internal class CurrentSessionSpanImpl(
     private val telemetryService: TelemetryService,
     private val spansRepository: SpansRepository,
     private val spansSink: SpansSink,
-    private val tracer: Tracer,
+    private val tracerSupplier: () -> Tracer,
 ) : CurrentSessionSpan {
     /**
      * Number of traces created in the current session. This value will be reset when a new session is created.
@@ -127,7 +127,7 @@ internal class CurrentSessionSpanImpl(
      */
     private fun startSessionSpan(startTimeNanos: Long): Span {
         traceCount.set(0)
-        return createEmbraceSpanBuilder(tracer = tracer, name = "session-span", type = EmbraceAttributes.Type.SESSION)
+        return createEmbraceSpanBuilder(tracer = tracerSupplier(), name = "session-span", type = EmbraceAttributes.Type.SESSION)
             .setNoParent()
             .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
             .startSpan()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
@@ -13,7 +13,7 @@ import io.opentelemetry.api.trace.Tracer
 internal class EmbraceSpansService(
     private val spansRepository: SpansRepository,
     private val currentSessionSpan: CurrentSessionSpan,
-    private val tracer: Tracer,
+    private val tracerSupplier: () -> Tracer,
 ) : SpansService {
     private val uninitializedSdkSpansService: UninitializedSdkSpansService = UninitializedSdkSpansService()
 
@@ -27,7 +27,7 @@ internal class EmbraceSpansService(
                     currentDelegate = SpansServiceImpl(
                         spansRepository = spansRepository,
                         currentSessionSpan = currentSessionSpan,
-                        tracer = tracer,
+                        tracer = tracerSupplier(),
                     )
                     currentDelegate.initializeService(sdkInitStartTimeNanos)
                     if (currentDelegate.initialized()) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
@@ -47,7 +47,7 @@ internal class EmbraceInternalInterfaceImplTest {
             embraceImpl,
             initModule,
             fakeConfigService,
-            InternalTracer(initModule.clock, initModule.spansRepository, initModule.embraceTracer)
+            initModule.openTelemetryModule.internalTracer
         )
         ApkToolsConfig.IS_NETWORK_CAPTURE_DISABLED = false
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/InternalInterfaceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/InternalInterfaceModuleImplTest.kt
@@ -12,8 +12,10 @@ internal class InternalInterfaceModuleImplTest {
 
     @Test
     fun testModule() {
+        val initModule = FakeInitModule()
         val module: InternalInterfaceModule = InternalInterfaceModuleImpl(
-            FakeInitModule(),
+            initModule,
+            initModule.openTelemetryModule,
             FakeCoreModule(),
             FakeAndroidServicesModule(),
             FakeEssentialServiceModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.injection.InitModule
+import io.embrace.android.embracesdk.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
@@ -15,16 +15,18 @@ import java.net.SocketException
 internal class UninitializedSdkInternalInterfaceImplTest {
 
     private lateinit var impl: UninitializedSdkInternalInterfaceImpl
-    private lateinit var initModule: InitModule
+    private lateinit var initModule: FakeInitModule
+    private lateinit var openTelemetryModule: OpenTelemetryModule
 
     @Before
     fun setUp() {
         initModule = FakeInitModule(clock = FakeClock(currentTime = beforeObjectInitTime))
+        openTelemetryModule = initModule.openTelemetryModule
         impl = UninitializedSdkInternalInterfaceImpl(
             InternalTracer(
                 initModule.clock,
-                initModule.spansRepository,
-                initModule.embraceTracer
+                openTelemetryModule.spansRepository,
+                openTelemetryModule.embraceTracer
             )
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -24,8 +24,8 @@ internal class StartupServiceImplTest {
     fun setUp() {
         clock = FakeClock(10000000)
         val initModule = FakeInitModule(clock = clock)
-        spansSink = initModule.spansSink
-        spansService = initModule.spansService
+        spansSink = initModule.openTelemetryModule.spansSink
+        spansService = initModule.openTelemetryModule.spansService
         spansService.initializeService(clock.nowInNanos())
         startupService = StartupServiceImpl(spansService)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -20,8 +20,8 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeStartupBehavior
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.gating.GatingService
-import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.SpansService
 import io.embrace.android.embracesdk.internal.spans.SpansSink
@@ -115,10 +115,10 @@ internal class EmbraceEventServiceTest {
         )
         gatingService = FakeGatingService(configService)
         fakeWorkerThreadModule = FakeWorkerThreadModule(clock = fakeClock, blockingMode = true)
-        val initModule = InitModuleImpl(clock = fakeClock)
-        spansSink = initModule.spansSink
-        currentSessionSpan = initModule.currentSessionSpan
-        spansService = initModule.spansService
+        val initModule = FakeInitModule(clock = fakeClock)
+        spansSink = initModule.openTelemetryModule.spansSink
+        currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
+        spansService = initModule.openTelemetryModule.spansService
         spansService.initializeService(fakeClock.nowInNanos())
         eventHandler = EventHandler(
             metadataService = metadataService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.fakes.injection
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.injection.InitModuleImpl
+import io.embrace.android.embracesdk.injection.OpenTelemetryModule
+import io.embrace.android.embracesdk.injection.OpenTelemetryModuleImpl
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
@@ -11,4 +13,6 @@ internal class FakeInitModule(
     clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
     openTelemetryClock: io.opentelemetry.sdk.common.Clock = FakeOpenTelemetryClock(clock),
     initModule: InitModule = InitModuleImpl(clock = clock, openTelemetryClock = openTelemetryClock)
-) : InitModule by initModule
+) : InitModule by initModule {
+    val openTelemetryModule: OpenTelemetryModule = OpenTelemetryModuleImpl(initModule)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
@@ -21,6 +21,7 @@ import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeSdkModeBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -28,13 +29,16 @@ import org.junit.Test
 
 internal class DataCaptureServiceModuleImplTest {
 
+    private val initModule = FakeInitModule()
+    private val openTelemetryModule = initModule.openTelemetryModule
     private val coreModule = FakeCoreModule()
     private val systemServiceModule = FakeSystemServiceModule()
 
     @Test
     fun testDefaultImplementations() {
         val module = DataCaptureServiceModuleImpl(
-            InitModuleImpl(),
+            initModule,
+            openTelemetryModule,
             coreModule,
             systemServiceModule,
             createEnabledBehavior(),
@@ -55,7 +59,8 @@ internal class DataCaptureServiceModuleImplTest {
     @Test
     fun testOldVersionChecks() {
         val module = DataCaptureServiceModuleImpl(
-            InitModuleImpl(),
+            initModule,
+            openTelemetryModule,
             coreModule,
             systemServiceModule,
             FakeEssentialServiceModule(),
@@ -70,7 +75,8 @@ internal class DataCaptureServiceModuleImplTest {
     @Test
     fun testDisabledImplementations() {
         val module = DataCaptureServiceModuleImpl(
-            InitModuleImpl(),
+            initModule,
+            openTelemetryModule,
             coreModule,
             systemServiceModule,
             createDisabledBehavior(),
@@ -116,6 +122,7 @@ internal class DataCaptureServiceModuleImplTest {
                 sdkModeBehavior = fakeSdkModeBehavior(
                     remoteCfg = { RemoteConfig(pctBetaFeaturesEnabled = 0.0f) }
                 ),
+
             )
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataContainerModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataContainerModuleImplTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeCustomerLogModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataCaptureServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
 import org.junit.Assert.assertNotNull
@@ -18,8 +19,10 @@ internal class DataContainerModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
+        val initModule = FakeInitModule()
         val module = DataContainerModuleImpl(
-            InitModuleImpl(),
+            initModule,
+            initModule.openTelemetryModule,
             FakeCoreModule(),
             FakeWorkerThreadModule(),
             FakeSystemServiceModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DeliveryModuleImplTest.kt
@@ -13,9 +13,9 @@ internal class DeliveryModuleImplTest {
     fun testDefaultImplementations() {
         val module = DeliveryModuleImpl(
             FakeCoreModule(),
+            FakeWorkerThreadModule(),
             FakeStorageModule(),
             FakeEssentialServiceModule(),
-            FakeWorkerThreadModule()
         )
 
         assertNotNull(module.deliveryService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/InitModuleImplTest.kt
@@ -4,9 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
-import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
-import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -21,9 +18,6 @@ internal class InitModuleImplTest {
         val initModule = InitModuleImpl()
         assertTrue(initModule.clock is NormalizedIntervalClock)
         assertTrue(initModule.telemetryService is EmbraceTelemetryService)
-        assertTrue(initModule.spansSink is SpansSinkImpl)
-        assertTrue(initModule.spansService is EmbraceSpansService)
-        assertTrue(initModule.currentSessionSpan is CurrentSessionSpanImpl)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -30,6 +30,7 @@ internal class ModuleInitBootstrapperTest {
         with(moduleInitBootstrapper) {
             assertTrue(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE))
             assertTrue(initModule is InitModuleImpl)
+            assertTrue(openTelemetryModule is OpenTelemetryModuleImpl)
             assertTrue(workerThreadModule is WorkerThreadModuleImpl)
             assertTrue(systemServiceModule is SystemServiceModuleImpl)
             assertTrue(androidServicesModule is AndroidServicesModuleImpl)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/OpenTelemetryModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/OpenTelemetryModuleImplTest.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.injection
+
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpansService
+import io.embrace.android.embracesdk.internal.spans.SpansSinkImpl
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class OpenTelemetryModuleImplTest {
+    @Test
+    fun testInitModuleImplDefaults() {
+        val openTelemetryModule = OpenTelemetryModuleImpl(InitModuleImpl())
+        assertTrue(openTelemetryModule.spansSink is SpansSinkImpl)
+        assertTrue(openTelemetryModule.spansService is EmbraceSpansService)
+        assertTrue(openTelemetryModule.currentSessionSpan is CurrentSessionSpanImpl)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/StorageModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/StorageModuleImplTest.kt
@@ -15,9 +15,9 @@ internal class StorageModuleImplTest {
     fun testDefaultImplementations() {
         val initModule = InitModuleImpl()
         val module = StorageModuleImpl(
-            workerThreadModule = WorkerThreadModuleImpl(initModule),
             initModule = initModule,
             coreModule = FakeCoreModule(),
+            workerThreadModule = WorkerThreadModuleImpl(initModule),
         )
 
         assertNotNull(module.storageService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -22,16 +22,16 @@ internal class CurrentSessionSpanImplTests {
     @Before
     fun setup() {
         val initModule = FakeInitModule(clock = clock)
-        spansRepository = initModule.spansRepository
-        spansSink = initModule.spansSink
-        currentSessionSpan = initModule.currentSessionSpan
-        spansService = initModule.spansService
+        spansRepository = initModule.openTelemetryModule.spansRepository
+        spansSink = initModule.openTelemetryModule.spansSink
+        currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
+        spansService = initModule.openTelemetryModule.spansService
         spansService.initializeService(clock.now())
     }
 
     @Test
     fun `cannot create span before session is created`() {
-        assertFalse(FakeInitModule(clock = clock).currentSessionSpan.canStartNewSpan(null, true))
+        assertFalse(FakeInitModule(clock = clock).openTelemetryModule.currentSessionSpan.canStartNewSpan(null, true))
     }
 
     @Test
@@ -129,8 +129,8 @@ internal class CurrentSessionSpanImplTests {
     fun `flushing with app termination and termination reason flushes session span with right termination type`() {
         EmbraceAttributes.AppTerminationCause.values().forEach {
             val module = FakeInitModule(clock = clock)
-            val sessionSpan = module.currentSessionSpan
-            module.spansService.initializeService(clock.now())
+            val sessionSpan = module.openTelemetryModule.currentSessionSpan
+            module.openTelemetryModule.spansService.initializeService(clock.now())
             val flushedSpans = sessionSpan.endSession(it)
             assertEquals(1, flushedSpans.size)
 
@@ -146,7 +146,7 @@ internal class CurrentSessionSpanImplTests {
                 assertEquals(it.name, attributes[it.keyName()])
             }
 
-            assertEquals(0, module.spansSink.completedSpans().size)
+            assertEquals(0, module.openTelemetryModule.spansSink.completedSpans().size)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansServiceTest.kt
@@ -19,15 +19,15 @@ internal class EmbraceSpansServiceTest {
     @Before
     fun setup() {
         val initModule = FakeInitModule(clock = clock)
-        spansSink = initModule.spansSink
-        currentSessionSpan = initModule.currentSessionSpan
-        spansService = initModule.spansService
+        spansSink = initModule.openTelemetryModule.spansSink
+        currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
+        spansService = initModule.openTelemetryModule.spansService
         spansService.initializeService(clock.now())
     }
 
     @Test
     fun `verify default behaviour before initialization`() {
-        val uninitializedService = FakeInitModule(clock = clock).spansService
+        val uninitializedService = FakeInitModule(clock = clock).openTelemetryModule.spansService
         assertFalse(uninitializedService.initialized())
         assertNull(uninitializedService.createSpan("test-span"))
         assertTrue(uninitializedService.recordCompletedSpan("test-span", 10, 20))
@@ -170,17 +170,17 @@ internal class EmbraceSpansServiceTest {
     @Test
     fun `completed spans recorded before initialization will saved and recorded upon initialization`() {
         val module = FakeInitModule(clock = clock)
-        val service = module.spansService
+        val service = module.openTelemetryModule.spansService
         assertFalse(service.initialized())
         assertTrue(service.recordCompletedSpan("test-span", 10, 20))
         assertTrue(service.recordCompletedSpan("test-span", 15, 25))
         service.initializeService(clock.now())
-        assertEquals(2, module.spansSink.completedSpans().size)
+        assertEquals(2, module.openTelemetryModule.spansSink.completedSpans().size)
     }
 
     @Test
     fun `verify ceiling to how many recordCompleteSpan calls can be buffered`() {
-        val service = FakeInitModule(clock = clock).spansService
+        val service = FakeInitModule(clock = clock).openTelemetryModule.spansService
         repeat(1000) {
             assertTrue(service.recordCompletedSpan("test-span", 10, 20))
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -24,11 +24,11 @@ internal class EmbraceTracerTest {
     @Before
     fun setup() {
         val initModule = FakeInitModule(clock = clock)
-        spansRepository = initModule.spansRepository
-        spansSink = initModule.spansSink
-        spansService = initModule.spansService
+        spansRepository = initModule.openTelemetryModule.spansRepository
+        spansSink = initModule.openTelemetryModule.spansSink
+        spansService = initModule.openTelemetryModule.spansService
         spansService.initializeService(clock.now().millisToNanos())
-        embraceTracer = initModule.embraceTracer
+        embraceTracer = initModule.openTelemetryModule.embraceTracer
         spansSink.flushSpans()
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
@@ -23,14 +23,14 @@ internal class InternalTracerTest {
     @Before
     fun setup() {
         val initModule = FakeInitModule(clock = clock)
-        spansSink = initModule.spansSink
-        currentSessionSpan = initModule.currentSessionSpan
-        spansService = initModule.spansService
+        spansSink = initModule.openTelemetryModule.spansSink
+        currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
+        spansService = initModule.openTelemetryModule.spansService
         spansService.initializeService(clock.nowInNanos())
         internalTracer = InternalTracer(
             clock,
-            initModule.spansRepository,
-            initModule.embraceTracer,
+            initModule.openTelemetryModule.spansRepository,
+            initModule.openTelemetryModule.embraceTracer,
         )
         spansSink.flushSpans()
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpansServiceImplTest.kt
@@ -34,12 +34,12 @@ internal class SpansServiceImplTest {
     @Before
     fun setup() {
         val initModule = FakeInitModule(clock = clock)
-        spansSink = initModule.spansSink
-        currentSessionSpan = initModule.currentSessionSpan
+        spansSink = initModule.openTelemetryModule.spansSink
+        currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
         spansService = SpansServiceImpl(
-            spansRepository = initModule.spansRepository,
+            spansRepository = initModule.openTelemetryModule.spansRepository,
             currentSessionSpan = currentSessionSpan,
-            tracer = initModule.tracer
+            tracer = initModule.openTelemetryModule.tracer
         )
         spansService.initializeService(clock.nowInNanos())
     }
@@ -122,7 +122,7 @@ internal class SpansServiceImplTest {
 
     @Test
     fun `cannot create span before initialization`() {
-        assertNull(FakeInitModule(clock = clock).spansService.createSpan(name = "test"))
+        assertNull(FakeInitModule(clock = clock).openTelemetryModule.spansService.createSpan(name = "test"))
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -79,9 +79,9 @@ internal class PayloadFactoryBaTest {
         preferencesService = FakePreferenceService(backgroundActivityEnabled = true)
         userService = FakeUserService()
         val initModule = FakeInitModule(clock = clock)
-        spansSink = initModule.spansSink
-        currentSessionSpan = initModule.currentSessionSpan
-        spansService = initModule.spansService
+        spansSink = initModule.openTelemetryModule.spansSink
+        currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
+        spansService = initModule.openTelemetryModule.spansService
         configService = FakeConfigService(
             backgroundActivityCaptureEnabled = true
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -50,7 +50,7 @@ internal class PayloadFactorySessionTest {
     fun before() {
         deliveryService = FakeDeliveryService()
         configService = FakeConfigService()
-        spansSink = FakeInitModule(clock = clock).spansSink
+        spansSink = FakeInitModule(clock = clock).openTelemetryModule.spansSink
     }
 
     @After

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -14,7 +14,6 @@ import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.payload.ExceptionError
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
@@ -31,7 +30,7 @@ import org.junit.Test
 
 internal class PayloadMessageCollatorTest {
 
-    private lateinit var initModule: InitModule
+    private lateinit var initModule: FakeInitModule
     private lateinit var collator: PayloadMessageCollator
 
     private enum class PayloadType {
@@ -55,8 +54,8 @@ internal class PayloadMessageCollatorTest {
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),
-            spansSink = initModule.spansSink,
-            currentSessionSpan = initModule.currentSessionSpan,
+            spansSink = initModule.openTelemetryModule.spansSink,
+            currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService()
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -132,8 +132,8 @@ internal class SessionHandlerTest {
         preferencesService = FakePreferenceService()
         deliveryService = FakeDeliveryService()
         val initModule = FakeInitModule(clock = clock)
-        spansSink = initModule.spansSink
-        spansService = initModule.spansService
+        spansSink = initModule.openTelemetryModule.spansSink
+        spansService = initModule.openTelemetryModule.spansService
         val payloadMessageCollator = PayloadMessageCollator(
             configService,
             metadataService,
@@ -147,8 +147,8 @@ internal class SessionHandlerTest {
             breadcrumbService,
             userService,
             preferencesService,
-            initModule.spansSink,
-            initModule.currentSessionSpan,
+            initModule.openTelemetryModule.spansSink,
+            initModule.openTelemetryModule.currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService()
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -11,15 +11,17 @@ import io.embrace.android.embracesdk.fakes.injection.FakeDataCaptureServiceModul
 import io.embrace.android.embracesdk.fakes.injection.FakeDataContainerModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSdkObservabilityModule
-import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.injection.SessionModuleImpl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionModuleImplTest {
+
+    private val fakeInitModule = FakeInitModule()
 
     private val workerThreadModule =
         FakeWorkerThreadModule(
@@ -32,7 +34,8 @@ internal class SessionModuleImplTest {
     @Test
     fun testDefaultImplementations() {
         val module = SessionModuleImpl(
-            InitModuleImpl(),
+            fakeInitModule,
+            fakeInitModule.openTelemetryModule,
             FakeAndroidServicesModule(),
             FakeEssentialServiceModule(configService = configService),
             FakeNativeModule(),
@@ -56,7 +59,8 @@ internal class SessionModuleImplTest {
     @Test
     fun testEnabledBehaviors() {
         val module = SessionModuleImpl(
-            InitModuleImpl(),
+            fakeInitModule,
+            fakeInitModule.openTelemetryModule,
             FakeAndroidServicesModule(),
             createEnabledBehavior(),
             FakeNativeModule(),


### PR DESCRIPTION
## Goal

Extract OTel components into its own module and delay the OTel SDK init until the SDK starts. This allows the SDK instance to be configured programmatically before the SDK start, like adding resources and Exporters. Most of the changes are test updates. I also added an OpenTelemetryModule implementation instance in `FakeInitModule` for ease of use since they need to be tied together anyway.