### PR TITLE
Update AGP/Gradle to latest version (8.4/8.2.2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,6 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:${Versions.agp}")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${Versions.detekt}")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:${Versions.dokka}")
         classpath("org.jetbrains.dokka:android-documentation-plugin:${Versions.dokka}")
@@ -20,6 +18,8 @@ buildscript {
 
 plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+    id("com.android.library") apply false
+    id("org.jetbrains.kotlin.android") apply false
 }
 
 group = "io.embrace"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
@@ -21,14 +23,21 @@ dependencies {
     compileOnly(gradleApi())
 
     // NOTE: when updating any of these keep in sync with buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
-    implementation("com.android.tools.build:gradle:7.4.2")
+    implementation("com.android.tools.build:gradle:8.2.2")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.14.0")
 }
 
 // ensure the Kotlin + Java compilers both use the same language level.
-project.tasks.withType(JavaCompile::class.java) {
+project.tasks.withType(JavaCompile::class.java).configureEach {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+// ensure the Kotlin + Java compilers both use the same language level.
+project.tasks.withType(KotlinCompile::class.java).configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/InternalEmbracePlugin.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/InternalEmbracePlugin.kt
@@ -169,7 +169,7 @@ class InternalEmbracePlugin : Plugin<Project> {
     }
 
     private fun configureKotlinOptions(project: Project) {
-        project.tasks.withType(KotlinCompile::class.java).all {
+        project.tasks.withType(KotlinCompile::class.java).configureEach {
             kotlinOptions {
                 apiVersion = "1.4"
                 languageVersion = "1.4"
@@ -179,12 +179,13 @@ class InternalEmbracePlugin : Plugin<Project> {
                 // FIXME: targeting Kotlin 1.4 emits a warning that I can't find a way to suppress.
                 //  Disabling this check for now.
                 allWarningsAsErrors = false
+
             }
         }
     }
 
     private fun configureJavaOptions(project: Project) {
-        project.tasks.withType(JavaCompile::class.java).all {
+        project.tasks.withType(JavaCompile::class.java).configureEach {
             val args = listOf("-Xlint:unchecked", "-Xlint:deprecation")
             options.compilerArgs.addAll(args)
         }

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -30,7 +30,7 @@ object Versions {
 
     // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
     @JvmField
-    val agp = "7.4.2"
+    val agp = "8.2.2"
 
     @JvmField
     val lint = "30.1.0"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNetworkConnectivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNetworkConnectivityServiceTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
@@ -86,6 +87,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
     /**
      * Asserts that a network connectivity broadcast receiver can be registered/unregistered
      */
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     @Test
     @Throws(InterruptedException::class)
     fun `test connectivity broadcast receiver can register and unregister`() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.PowerManager
@@ -150,6 +151,7 @@ internal class EmbracePowerSaveModeServiceTest {
         assertThrows(Exception::class.java) { service.onReceive(context, intent) }
     }
 
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     @Test
     @Throws(InterruptedException::class)
     fun `test receiver can be registered and unregistered`() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip


### PR DESCRIPTION
## Goal

Updates the AGP/Gradle versions to the latest available ([8.4](https://docs.gradle.org/8.4/release-notes.html) for Gradle, and [8.2.2](https://developer.android.com/build/releases/gradle-plugin) for AGP). This gets us access to the configuration cache (and various other performance improvements that have happened over time).

## Testing

Confirmed an SDK published locally with this version builds fine in an app using our min supported SDK. I am otherwise relying on CI to run all the checks we care about. I have not tested release workflows.
