### PR TITLE
Extract breadcrumb capture to separate classes

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataStore.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataStore.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import io.embrace.android.embracesdk.arch.DataCaptureService
+import java.util.concurrent.LinkedBlockingDeque
+
+internal class BreadcrumbDataStore<T>(
+    private val limit: () -> Int
+) : DataCaptureService<List<T>> {
+
+    private val breadcrumbs = LinkedBlockingDeque<T>()
+
+    fun tryAddBreadcrumb(breadcrumb: T) {
+        if (!breadcrumbs.isEmpty() && breadcrumbs.size >= limit()) {
+            breadcrumbs.removeLast()
+        }
+        breadcrumbs.push(breadcrumb)
+    }
+
+    override fun getCapturedData(): List<T> = breadcrumbs.toList()
+    override fun cleanCollections() = breadcrumbs.clear()
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
@@ -31,11 +31,9 @@ internal interface BreadcrumbService {
      * Gets the Taps breadcrumbs in the specified time window.
      * If the number of elements exceeds the limit, this will return the newest (latest) ones.
      *
-     * @param start the start time
-     * @param end   the end time
      * @return the list of Breadcrumbs
      */
-    fun getTapBreadcrumbsForSession(start: Long, end: Long): List<TapBreadcrumb?>
+    fun getTapBreadcrumbsForSession(): List<TapBreadcrumb>
 
     /**
      * Gets the Custom breadcrumbs in the specified time window.
@@ -49,11 +47,9 @@ internal interface BreadcrumbService {
      * Gets the WebView breadcrumbs in the specified time window.
      * If the number of elements exceeds the limit, this will return the newest (latest) ones.
      *
-     * @param start the start time
-     * @param end   the end time
      * @return the list of Breadcrumbs
      */
-    fun getWebViewBreadcrumbsForSession(start: Long, end: Long): List<WebViewBreadcrumb?>
+    fun getWebViewBreadcrumbsForSession(): List<WebViewBreadcrumb>
 
     /**
      * Gets the WebView breadcrumbs in the specified time window.
@@ -69,11 +65,9 @@ internal interface BreadcrumbService {
      * Gets the RN Actions breadcrumbs in the specified time window.
      * If the number of elements exceeds the limit, this will return the newest (latest) ones.
      *
-     * @param startTime the start time
-     * @param endTime   the end time
      * @return the list of Breadcrumbs
      */
-    fun getRnActionBreadcrumbForSession(startTime: Long, endTime: Long): List<RnActionBreadcrumb?>
+    fun getRnActionBreadcrumbForSession(): List<RnActionBreadcrumb>
 
     /**
      * Gets the captured Push Notifications breadcrumbs in the specified time window.
@@ -83,10 +77,7 @@ internal interface BreadcrumbService {
      * @param endTime   the end time
      * @return the list of Breadcrumbs
      */
-    fun getPushNotificationsBreadcrumbsForSession(
-        startTime: Long,
-        endTime: Long
-    ): List<PushNotificationBreadcrumb?>
+    fun getPushNotificationsBreadcrumbsForSession(): List<PushNotificationBreadcrumb>
 
     /**
      * Gets all breadcrumbs within the specified time window. If the number of elements exceeds the

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
@@ -6,17 +6,17 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.CustomBreadcrumb
-import java.util.concurrent.LinkedBlockingDeque
 
 /**
  * Captures custom breadcrumbs.
  */
 internal class CustomBreadcrumbDataSource(
     private val configService: ConfigService,
+    private val store: BreadcrumbDataStore<CustomBreadcrumb> = BreadcrumbDataStore {
+        configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
+    },
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
-) : DataCaptureService<List<CustomBreadcrumb>> {
-
-    private val customBreadcrumbs = LinkedBlockingDeque<CustomBreadcrumb>()
+) : DataCaptureService<List<CustomBreadcrumb>> by store {
 
     fun logCustom(message: String, timestamp: Long) {
         if (TextUtils.isEmpty(message)) {
@@ -24,24 +24,9 @@ internal class CustomBreadcrumbDataSource(
             return
         }
         try {
-            val limit = configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
-            tryAddBreadcrumb(customBreadcrumbs, CustomBreadcrumb(message, timestamp), limit)
+            store.tryAddBreadcrumb(CustomBreadcrumb(message, timestamp))
         } catch (ex: Exception) {
             logger.logError("Failed to log custom breadcrumb with message $message", ex)
         }
     }
-
-    private fun <T> tryAddBreadcrumb(
-        breadcrumbs: LinkedBlockingDeque<T>,
-        breadcrumb: T,
-        limit: Int
-    ) {
-        if (!breadcrumbs.isEmpty() && breadcrumbs.size >= limit) {
-            breadcrumbs.removeLast()
-        }
-        breadcrumbs.push(breadcrumb)
-    }
-
-    override fun getCapturedData(): List<CustomBreadcrumb> = customBreadcrumbs.toList()
-    override fun cleanCollections() = customBreadcrumbs.clear()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationBreadcrumbDataSource.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import io.embrace.android.embracesdk.arch.DataCaptureService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
+
+/**
+ * Captures push notification breadcrumbs.
+ */
+internal class PushNotificationBreadcrumbDataSource(
+    private val configService: ConfigService,
+    private val clock: Clock,
+    private val store: BreadcrumbDataStore<PushNotificationBreadcrumb> = BreadcrumbDataStore {
+        configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
+    },
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataCaptureService<List<PushNotificationBreadcrumb>> by store {
+
+    fun logPushNotification(
+        title: String?,
+        body: String?,
+        topic: String?,
+        id: String?,
+        notificationPriority: Int?,
+        type: PushNotificationBreadcrumb.NotificationType
+    ) {
+        try {
+            val captureFcmPiiData = configService.breadcrumbBehavior.isCaptureFcmPiiDataEnabled()
+            val pn = PushNotificationBreadcrumb(
+                if (captureFcmPiiData) title else null,
+                if (captureFcmPiiData) body else null,
+                if (captureFcmPiiData) topic else null,
+                id,
+                notificationPriority,
+                type.type,
+                clock.now()
+            )
+            store.tryAddBreadcrumb(pn)
+        } catch (ex: Exception) {
+            logger.logError("Failed to capture push notification", ex)
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnBreadcrumbDataSource.kt
@@ -1,0 +1,47 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import android.text.TextUtils
+import io.embrace.android.embracesdk.arch.DataCaptureService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.RnActionBreadcrumb
+
+/**
+ * Captures RN action breadcrumbs.
+ */
+internal class RnBreadcrumbDataSource(
+    private val configService: ConfigService,
+    private val store: BreadcrumbDataStore<RnActionBreadcrumb> = BreadcrumbDataStore {
+        configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
+    },
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataCaptureService<List<RnActionBreadcrumb>> by store {
+
+    fun logRnAction(
+        name: String,
+        startTime: Long,
+        endTime: Long,
+        properties: Map<String?, Any?>,
+        bytesSent: Int,
+        output: String
+    ) {
+        if (!RnActionBreadcrumb.validateRnBreadcrumbOutputName(output)) {
+            logger.logWarning(
+                "RN Action output is invalid, the valid values are ${RnActionBreadcrumb.getValidRnBreadcrumbOutputName()}"
+            )
+            return
+        }
+        if (TextUtils.isEmpty(name)) {
+            logger.logWarning("RN Action name must not be blank")
+            return
+        }
+        try {
+            store.tryAddBreadcrumb(
+                RnActionBreadcrumb(name, startTime, endTime, properties, bytesSent, output)
+            )
+        } catch (ex: Exception) {
+            logger.logDebug("Failed to log RN Action breadcrumb with name $name", ex)
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSource.kt
@@ -1,0 +1,39 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import android.util.Pair
+import io.embrace.android.embracesdk.arch.DataCaptureService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.TapBreadcrumb
+
+/**
+ * Captures tap breadcrumbs.
+ */
+internal class TapBreadcrumbDataSource(
+    private val configService: ConfigService,
+    private val store: BreadcrumbDataStore<TapBreadcrumb> = BreadcrumbDataStore {
+        configService.breadcrumbBehavior.getTapBreadcrumbLimit()
+    },
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataCaptureService<List<TapBreadcrumb>> by store {
+
+    fun logTap(
+        point: Pair<Float?, Float?>,
+        element: String,
+        timestamp: Long,
+        type: TapBreadcrumb.TapBreadcrumbType
+    ) {
+        try {
+            val finalPoint =
+                if (!configService.breadcrumbBehavior.isTapCoordinateCaptureEnabled()) {
+                    Pair(0.0f, 0.0f)
+                } else {
+                    point
+                }
+            store.tryAddBreadcrumb(TapBreadcrumb(finalPoint, element, timestamp, type))
+        } catch (ex: Exception) {
+            logger.logError("Failed to log tap breadcrumb for element $element", ex)
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewBreadcrumbDataSource.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import io.embrace.android.embracesdk.arch.DataCaptureService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
+
+/**
+ * Captures webview breadcrumbs.
+ */
+internal class WebViewBreadcrumbDataSource(
+    private val configService: ConfigService,
+    private val store: BreadcrumbDataStore<WebViewBreadcrumb> = BreadcrumbDataStore {
+        configService.breadcrumbBehavior.getWebViewBreadcrumbLimit()
+    },
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataCaptureService<List<WebViewBreadcrumb>> by store {
+
+    companion object {
+        private const val QUERY_PARAMETER_DELIMITER = "?"
+    }
+
+    fun logWebView(url: String?, startTime: Long) {
+        if (!configService.breadcrumbBehavior.isWebViewBreadcrumbCaptureEnabled()) {
+            return
+        }
+        if (url == null) {
+            return
+        }
+        try {
+            // Check if web view query params should be captured.
+            var parsedUrl: String = url
+            if (!configService.breadcrumbBehavior.isQueryParamCaptureEnabled()) {
+                val queryOffset = url.indexOf(QUERY_PARAMETER_DELIMITER)
+                if (queryOffset > 0) {
+                    parsedUrl = url.substring(0, queryOffset)
+                }
+            }
+            store.tryAddBreadcrumb(WebViewBreadcrumb(parsedUrl, startTime))
+        } catch (ex: Exception) {
+            logger.logError("Failed to log WebView breadcrumb for url $url")
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
@@ -20,28 +20,20 @@ internal class FakeBreadcrumbService : BreadcrumbService {
     override fun getViewBreadcrumbsForSession(start: Long, end: Long): List<ViewBreadcrumb?> =
         emptyList()
 
-    override fun getTapBreadcrumbsForSession(start: Long, end: Long): List<TapBreadcrumb?> =
-        emptyList()
+    override fun getTapBreadcrumbsForSession(): List<TapBreadcrumb> = emptyList()
 
     override fun getCustomBreadcrumbsForSession(): List<CustomBreadcrumb> = emptyList()
 
-    override fun getWebViewBreadcrumbsForSession(start: Long, end: Long): List<WebViewBreadcrumb?> =
-        emptyList()
+    override fun getWebViewBreadcrumbsForSession(): List<WebViewBreadcrumb> = emptyList()
 
     override fun getFragmentBreadcrumbsForSession(
         startTime: Long,
         endTime: Long
     ): List<FragmentBreadcrumb?> = emptyList()
 
-    override fun getRnActionBreadcrumbForSession(
-        startTime: Long,
-        endTime: Long
-    ): List<RnActionBreadcrumb?> = emptyList()
+    override fun getRnActionBreadcrumbForSession(): List<RnActionBreadcrumb> = emptyList()
 
-    override fun getPushNotificationsBreadcrumbsForSession(
-        startTime: Long,
-        endTime: Long
-    ): List<PushNotificationBreadcrumb?> = emptyList()
+    override fun getPushNotificationsBreadcrumbsForSession(): List<PushNotificationBreadcrumb> = emptyList()
 
     override fun getBreadcrumbs(start: Long, end: Long): Breadcrumbs {
         return Breadcrumbs()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -108,7 +108,7 @@ internal class EmbraceBreadcrumbServiceTest {
         service.logWebView("https://example.com/path1", clock.now())
         clock.tickSecond()
         service.logWebView("https://example.com/path2", clock.now())
-        val webViews = service.webViewBreadcrumbs
+        val webViews = service.getWebViewBreadcrumbsForSession()
         assertEquals("two webviews captured", 2, webViews.size)
         assertJsonMessage(service, "breadcrumb_webview.json")
     }
@@ -494,7 +494,7 @@ internal class EmbraceBreadcrumbServiceTest {
         val service = initializeBreadcrumbService()
         service.logTap(android.util.Pair(0f, 0f), "MyView", 0, TapBreadcrumb.TapBreadcrumbType.TAP)
 
-        val crumbs = service.getTapBreadcrumbsForSession(0, Long.MAX_VALUE)
+        val crumbs = service.getTapBreadcrumbsForSession()
         val breadcrumb = checkNotNull(crumbs.single())
         assertEquals("MyView", breadcrumb.tappedElementName)
         assertEquals(TapBreadcrumb.TapBreadcrumbType.TAP, breadcrumb.type)
@@ -505,7 +505,7 @@ internal class EmbraceBreadcrumbServiceTest {
         val service = initializeBreadcrumbService()
         service.logRnAction("MyAction", 0, 5, mapOf("key" to "value"), 100, "success")
 
-        val crumbs = service.getRnActionBreadcrumbForSession(0, Long.MAX_VALUE)
+        val crumbs = service.getRnActionBreadcrumbForSession()
         val breadcrumb = checkNotNull(crumbs.single())
         assertEquals("MyAction", breadcrumb.name)
         assertEquals("success", breadcrumb.output)
@@ -534,7 +534,7 @@ internal class EmbraceBreadcrumbServiceTest {
             PushNotificationBreadcrumb.NotificationType.NOTIFICATION
         )
 
-        val crumbs = service.getPushNotificationsBreadcrumbsForSession(0, Long.MAX_VALUE)
+        val crumbs = service.getPushNotificationsBreadcrumbsForSession()
         val breadcrumb = checkNotNull(crumbs.single())
         assertNull(breadcrumb.title)
         assertNull(breadcrumb.body)


### PR DESCRIPTION
## Goal

Refactors breadcrumb service to break the breadcrumb capture into separate classes for data capture. This will ultimately make it easier to have these classes implement `DataSource`

## Testing

Relied on existing unit test coverage.
