### PR TITLE
Add alias for Providers that take no input but return an instance of some type

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -32,6 +32,7 @@ import io.embrace.android.embracesdk.injection.StorageModule
 import io.embrace.android.embracesdk.injection.StorageModuleImpl
 import io.embrace.android.embracesdk.injection.SystemServiceModule
 import io.embrace.android.embracesdk.injection.SystemServiceModuleImpl
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
@@ -80,7 +81,7 @@ import org.junit.rules.ExternalResource
  * production.
  */
 internal class IntegrationTestRule(
-    private val harnessSupplier: () -> Harness = { Harness() }
+    private val harnessSupplier: Provider<Harness> = { Harness() }
 ) : ExternalResource() {
     /**
      * The [Embrace] instance that can be used for testing

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import android.app.Activity
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -106,7 +107,7 @@ internal fun internalErrorService(): InternalErrorService? = Embrace.getImpl().i
 /**
  * Return the result of [desiredValueSupplier] if [condition] is true before [waitTimeMs] elapses. Otherwise, throws [TimeoutException]
  */
-internal fun <T> returnIfConditionMet(desiredValueSupplier: () -> T, waitTimeMs: Int = 1000, condition: () -> Boolean): T {
+internal fun <T> returnIfConditionMet(desiredValueSupplier: Provider<T>, waitTimeMs: Int = 1000, condition: () -> Boolean): T {
     val tries: Int = waitTimeMs / CHECK_INTERVAL_MS
     val countDownLatch = CountDownLatch(1)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.internal.utils.Provider
+
 /**
  * Holds the current state of the service. This class automatically handles changes in config
  * that enable/disable the service, and creates new instances of the service as required.
@@ -12,13 +14,13 @@ internal class DataSourceState(
      * that extends [DataSource] for orchestration. This helps enforce testability
      * by making it impossible to register data capture without defining a testable interface.
      */
-    factory: () -> DataSource,
+    factory: Provider<DataSource>,
 
     /**
      * Predicate that determines if the service should be enabled or not, via a config value.
      * Defaults to true if not provided.
      */
-    private val configGate: () -> Boolean = { true },
+    private val configGate: Provider<Boolean> = { true },
 
     /**
      * The type of session that contains the data.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
@@ -20,6 +20,7 @@ import io.embrace.android.embracesdk.config.behavior.WebViewVitalsBehavior
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
@@ -60,7 +61,7 @@ internal class EmbraceConfigService @JvmOverloads constructor(
     @Volatile
     private var configRetrySafeWindow = DEFAULT_RETRY_WAIT_TIME.toDouble()
 
-    private val remoteSupplier: () -> RemoteConfig? = { getConfig() }
+    private val remoteSupplier: Provider<RemoteConfig?> = { getConfig() }
 
     override val backgroundActivityBehavior: BackgroundActivityBehavior =
         BackgroundActivityBehavior(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AnrBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AnrBehavior.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.config.behavior
 import io.embrace.android.embracesdk.config.local.AnrLocalConfig
 import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig.Unwinder
+import io.embrace.android.embracesdk.internal.utils.Provider
 import java.util.regex.Pattern
 
 /**
@@ -10,8 +11,8 @@ import java.util.regex.Pattern
  */
 internal class AnrBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> AnrLocalConfig?,
-    remoteSupplier: () -> AnrRemoteConfig?
+    localSupplier: Provider<AnrLocalConfig?>,
+    remoteSupplier: Provider<AnrRemoteConfig?>
 ) : MergedConfigBehavior<AnrLocalConfig, AnrRemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AppExitInfoBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AppExitInfoBehavior.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.local.AppExitInfoLocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Provides the behavior that should be followed for select services that automatically
@@ -9,8 +10,8 @@ import io.embrace.android.embracesdk.config.remote.RemoteConfig
  */
 internal class AppExitInfoBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> AppExitInfoLocalConfig?,
-    remoteSupplier: () -> RemoteConfig?
+    localSupplier: Provider<AppExitInfoLocalConfig?>,
+    remoteSupplier: Provider<RemoteConfig?>
 ) : MergedConfigBehavior<AppExitInfoLocalConfig, RemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/AutoDataCaptureBehavior.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.config.behavior
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Provides the behavior that should be followed for select services that automatically
@@ -10,8 +11,8 @@ import io.embrace.android.embracesdk.internal.ApkToolsConfig
  */
 internal class AutoDataCaptureBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> LocalConfig?,
-    remoteSupplier: () -> RemoteConfig?
+    localSupplier: Provider<LocalConfig?>,
+    remoteSupplier: Provider<RemoteConfig?>
 ) : MergedConfigBehavior<LocalConfig, RemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BackgroundActivityBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BackgroundActivityBehavior.kt
@@ -2,14 +2,15 @@ package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.local.BackgroundActivityLocalConfig
 import io.embrace.android.embracesdk.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Provides the behavior that the Background Activity feature should follow.
  */
 internal class BackgroundActivityBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> BackgroundActivityLocalConfig?,
-    remoteSupplier: () -> BackgroundActivityRemoteConfig?
+    localSupplier: Provider<BackgroundActivityLocalConfig?>,
+    remoteSupplier: Provider<BackgroundActivityRemoteConfig?>
 ) : MergedConfigBehavior<BackgroundActivityLocalConfig, BackgroundActivityRemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BehaviorThresholdCheck.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BehaviorThresholdCheck.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.config.behavior
 
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logger
 import kotlin.math.pow
 
@@ -7,7 +8,7 @@ import kotlin.math.pow
  * Checks whether a percent-based config value is over a threshold where it should be enabled.
  */
 internal class BehaviorThresholdCheck(
-    private val deviceIdProvider: () -> String
+    private val deviceIdProvider: Provider<String>
 ) {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BreadcrumbBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BreadcrumbBehavior.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Provides the behavior that should be followed for select services that automatically
@@ -9,8 +10,8 @@ import io.embrace.android.embracesdk.config.remote.RemoteConfig
  */
 internal class BreadcrumbBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> SdkLocalConfig?,
-    remoteSupplier: () -> RemoteConfig?
+    localSupplier: Provider<SdkLocalConfig?>,
+    remoteSupplier: Provider<RemoteConfig?>
 ) : MergedConfigBehavior<SdkLocalConfig, RemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehavior.kt
@@ -2,11 +2,12 @@ package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.PatternCache
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
 
 internal class DataCaptureEventBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    remoteSupplier: () -> RemoteConfig? = { null }
+    remoteSupplier: Provider<RemoteConfig?> = { null }
 ) : MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
     thresholdCheck,
     { null },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/LogMessageBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/LogMessageBehavior.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
 
 /**
@@ -8,7 +9,7 @@ import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
  */
 internal class LogMessageBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    remoteSupplier: () -> LogRemoteConfig?
+    remoteSupplier: Provider<LogRemoteConfig?>
 ) : MergedConfigBehavior<UnimplementedConfig, LogRemoteConfig>(
     thresholdCheck,
     { null },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/MergedConfigBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/MergedConfigBehavior.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.config.behavior
 
+import io.embrace.android.embracesdk.internal.utils.Provider
+
 /**
  * Merges multiple sources of config and tells the SDK how its functionality should behave. This
  * means the caller doesn't need to worry about whether the remote config has been fetched or its
@@ -24,12 +26,12 @@ internal open class MergedConfigBehavior<L, R>(
     /**
      * Supplier for local config, from the embrace-config.json file.
      */
-    private val localSupplier: () -> L? = { null },
+    private val localSupplier: Provider<L?> = { null },
 
     /**
      * Supplier for remote config, from the config endpoint.
      */
-    private val remoteSupplier: () -> R? = { null }
+    private val remoteSupplier: Provider<R?> = { null }
 ) {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/NetworkBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/NetworkBehavior.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.config.behavior
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import java.util.regex.Pattern
 import kotlin.math.min
 
@@ -11,8 +12,8 @@ import kotlin.math.min
  */
 internal class NetworkBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> SdkLocalConfig?,
-    remoteSupplier: () -> RemoteConfig?
+    localSupplier: Provider<SdkLocalConfig?>,
+    remoteSupplier: Provider<RemoteConfig?>
 ) : MergedConfigBehavior<SdkLocalConfig, RemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/NetworkSpanForwardingBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/NetworkSpanForwardingBehavior.kt
@@ -1,11 +1,12 @@
 package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.remote.NetworkSpanForwardingRemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
 
 internal class NetworkSpanForwardingBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    remoteSupplier: () -> NetworkSpanForwardingRemoteConfig?
+    remoteSupplier: Provider<NetworkSpanForwardingRemoteConfig?>
 ) : MergedConfigBehavior<UnimplementedConfig, NetworkSpanForwardingRemoteConfig>(
     thresholdCheck,
     { null },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehavior.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.local.BaseUrlLocalConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
 
 /**
@@ -8,7 +9,7 @@ import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
  */
 internal class SdkEndpointBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> BaseUrlLocalConfig?,
+    localSupplier: Provider<BaseUrlLocalConfig?>,
 ) : MergedConfigBehavior<BaseUrlLocalConfig, UnimplementedConfig>(
     thresholdCheck,
     localSupplier

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import kotlin.math.max
 import kotlin.math.min
 
@@ -11,8 +12,8 @@ import kotlin.math.min
 internal class SdkModeBehavior(
     private val isDebug: Boolean,
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> LocalConfig?,
-    remoteSupplier: () -> RemoteConfig?
+    localSupplier: Provider<LocalConfig?>,
+    remoteSupplier: Provider<RemoteConfig?>
 ) : MergedConfigBehavior<LocalConfig, RemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.EventType
 import io.embrace.android.embracesdk.config.local.SessionLocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.payload.EventMessage
 import java.util.Locale
 
@@ -12,8 +13,8 @@ import java.util.Locale
  */
 internal class SessionBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> SessionLocalConfig?,
-    remoteSupplier: () -> RemoteConfig?
+    localSupplier: Provider<SessionLocalConfig?>,
+    remoteSupplier: Provider<RemoteConfig?>
 ) : MergedConfigBehavior<SessionLocalConfig, RemoteConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/StartupBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/StartupBehavior.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.local.StartupMomentLocalConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
 
 /**
@@ -8,7 +9,7 @@ import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
  */
 internal class StartupBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: () -> StartupMomentLocalConfig?
+    localSupplier: Provider<StartupMomentLocalConfig?>
 ) : MergedConfigBehavior<StartupMomentLocalConfig, UnimplementedConfig>(
     thresholdCheck,
     localSupplier,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/WebViewVitalsBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/WebViewVitalsBehavior.kt
@@ -1,11 +1,12 @@
 package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.UnimplementedConfig
 
 internal class WebViewVitalsBehavior(
     thresholdCheck: BehaviorThresholdCheck,
-    remoteSupplier: () -> RemoteConfig?
+    remoteSupplier: Provider<RemoteConfig?>
 ) : MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
     thresholdCheck,
     { null },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DependencyInjection.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DependencyInjection.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.internal.utils.Provider
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -28,7 +29,7 @@ internal enum class LoadType {
  */
 internal inline fun <reified T> singleton(
     loadType: LoadType = LoadType.LAZY,
-    noinline provider: () -> T
+    noinline provider: Provider<T>
 ): ReadOnlyProperty<Any?, T> = SingletonDelegate(loadType, provider)
 
 /**
@@ -36,17 +37,17 @@ internal inline fun <reified T> singleton(
  * new object will be created.
  */
 internal inline fun <reified T> factory(
-    noinline provider: () -> T
+    noinline provider: Provider<T>
 ): ReadOnlyProperty<Any?, T> = FactoryDelegate(provider)
 
-internal class FactoryDelegate<T>(private inline val provider: () -> T) : ReadOnlyProperty<Any?, T> {
+internal class FactoryDelegate<T>(private inline val provider: Provider<T>) : ReadOnlyProperty<Any?, T> {
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): T = provider()
 }
 
 internal class SingletonDelegate<T>(
     loadType: LoadType,
-    provider: () -> T
+    provider: Provider<T>
 ) : ReadOnlyProperty<Any?, T> {
 
     // optimization: use atomic checks rather than synchronized in lazy.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -31,6 +31,7 @@ import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.session.EmbraceMemoryCleanerService
 import io.embrace.android.embracesdk.session.MemoryCleanerService
@@ -76,7 +77,7 @@ internal class EssentialServiceModuleImpl(
     storageModule: StorageModule,
     customAppId: String?,
     enableIntegrationTesting: Boolean,
-    private val configServiceProvider: () -> ConfigService? = { null },
+    private val configServiceProvider: Provider<ConfigService?> = { null },
 ) : EssentialServiceModule {
 
     // Many of these properties are temporarily here to break a circular dependency between services.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.utils.CoreModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.DataCaptureServiceModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.DeliveryModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.EssentialServiceModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.StorageModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.SystemServiceModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
@@ -64,7 +65,7 @@ internal class ModuleInitBootstrapper(
         enableIntegrationTesting: Boolean,
         appFramework: AppFramework,
         customAppId: String? = null,
-        configServiceProvider: () -> ConfigService? = { null },
+        configServiceProvider: Provider<ConfigService?> = { null },
         versionChecker: VersionChecker = BuildVersionChecker,
     ): Boolean {
         if (initialized.get()) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/CacheableValue.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/CacheableValue.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal
 
+import io.embrace.android.embracesdk.internal.utils.Provider
+
 /**
  * Holds a property whose value can be cached (if its inputs do not change).
  */
@@ -14,7 +16,7 @@ internal class CacheableValue<T>(
      * won't change if new objects are added, so you need to be wary of accidentally
      * returning stale values.
      */
-    private val input: () -> Any
+    private val input: Provider<Any>
 ) {
 
     private var initialized = false
@@ -29,7 +31,7 @@ internal class CacheableValue<T>(
      * If inputs are changed or no cached value is present, then [action] will be invoked
      * to calculate a value that is placed in the cache.
      */
-    fun value(action: () -> T): T {
+    fun value(action: Provider<T>): T {
         val hashCode = input().hashCode()
 
         if (prevHashCode != hashCode || !initialized) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Systrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Systrace.kt
@@ -5,6 +5,7 @@ import android.os.Build.VERSION_CODES
 import android.os.Trace
 import androidx.annotation.ChecksSdkIntAtLeast
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanName
+import io.embrace.android.embracesdk.internal.utils.Provider
 import kotlin.random.Random
 
 /**
@@ -46,7 +47,7 @@ internal class Systrace private constructor() {
          * Note: rethrowing the same [Throwable] that was caught is appropriate here because use of this should not change the code path.
          */
         @Suppress("RethrowCaughtException")
-        inline fun <T> trace(sectionName: String, code: () -> T): T {
+        inline fun <T> trace(sectionName: String, code: Provider<T>): T {
             val returnValue: T
             var instance: Instance? = null
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.telemetry.TelemetryService
 import io.embrace.android.embracesdk.utils.lockAndRun
@@ -17,7 +18,7 @@ internal class CurrentSessionSpanImpl(
     private val telemetryService: TelemetryService,
     private val spansRepository: SpansRepository,
     private val spansSink: SpansSink,
-    private val tracerSupplier: () -> Tracer,
+    private val tracerSupplier: Provider<Tracer>,
 ) : CurrentSessionSpan {
     /**
      * Number of traces created in the current session. This value will be reset when a new session is created.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes.Attribute
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.common.AttributesBuilder
@@ -122,7 +123,7 @@ internal fun SpanBuilder.updateParent(parent: EmbraceSpan?): SpanBuilder {
 /**
  * Allow a [SpanBuilder] to take in a lambda around which a span will be created for its execution
  */
-internal fun <T> SpanBuilder.record(code: () -> T): T {
+internal fun <T> SpanBuilder.record(code: Provider<T>): T {
     val returnValue: T
     var span: Span? = null
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -13,7 +14,7 @@ import io.opentelemetry.api.trace.Tracer
 internal class EmbraceSpansService(
     private val spansRepository: SpansRepository,
     private val currentSessionSpan: CurrentSessionSpan,
-    private val tracerSupplier: () -> Tracer,
+    private val tracerSupplier: Provider<Tracer>,
 ) : SpansService {
     private val uninitializedSdkSpansService: UninitializedSdkSpansService = UninitializedSdkSpansService()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/ThreadLocalExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/ThreadLocalExtensions.kt
@@ -8,11 +8,11 @@ import kotlin.reflect.KProperty
  * a ThreadLocal.
  */
 internal inline fun <reified T> threadLocal(
-    noinline provider: () -> T
+    noinline provider: Provider<T>
 ): ReadOnlyProperty<Any?, T> = ThreadLocalDelegate(provider)
 
 internal class ThreadLocalDelegate<T>(
-    provider: () -> T
+    provider: Provider<T>
 ) : ReadOnlyProperty<Any?, T> {
 
     private val threadLocal: ThreadLocal<T> = object : ThreadLocal<T>() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -63,7 +63,7 @@ internal typealias EssentialServiceModuleSupplier = (
     StorageModule,
     String?,
     Boolean,
-    () -> ConfigService?
+    Provider<ConfigService?>
 ) -> EssentialServiceModule
 
 /**
@@ -83,3 +83,5 @@ internal typealias DataCaptureServiceModuleSupplier = (
  * Defines the constructor for [DeliveryModuleImpl]
  */
 internal typealias DeliveryModuleSupplier = (CoreModule, WorkerThreadModule, StorageModule, EssentialServiceModule) -> DeliveryModule
+
+internal typealias Provider<T> = () -> T

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.session
 
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
 /**
@@ -7,7 +8,7 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  * This is intended for use when building the session/background activity payloads. If an
  * exception is thrown during capture, then we still want to send the request.
  */
-internal inline fun <R> captureDataSafely(result: () -> R): R? {
+internal inline fun <R> captureDataSafely(result: Provider<R>): R? {
     return try {
         result()
     } catch (exc: Throwable) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session.caching
 
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -29,7 +30,7 @@ internal class PeriodicBackgroundActivityCacher(
     /**
      * Save the background activity to disk
      */
-    fun scheduleSave(provider: () -> SessionMessage?) {
+    fun scheduleSave(provider: Provider<SessionMessage?>) {
         val delay = calculateDelay()
         val action: () -> Unit = {
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session.caching
 
 import io.embrace.android.embracesdk.internal.Systrace
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -26,7 +27,7 @@ internal class PeriodicSessionCacher(
     /**
      * It starts a background job that will schedule a callback to do periodic caching.
      */
-    fun start(provider: () -> SessionMessage?) {
+    fun start(provider: Provider<SessionMessage?>) {
         scheduledFuture = this.sessionPeriodicCacheScheduledWorker.scheduleWithFixedDelay(
             onPeriodicCache(provider),
             0,
@@ -35,7 +36,7 @@ internal class PeriodicSessionCacher(
         )
     }
 
-    private fun onPeriodicCache(provider: () -> SessionMessage?) = Runnable {
+    private fun onPeriodicCache(provider: Provider<SessionMessage?>) = Runnable {
         Systrace.trace("snapshot-session") {
             try {
                 provider()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.SessionType
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
@@ -170,7 +171,7 @@ internal class SessionOrchestratorImpl(
         transitionType: TransitionType,
         timestamp: Long,
         oldSessionAction: ((initial: Session) -> SessionMessage?)? = null,
-        newSessionAction: (() -> Session?)? = null,
+        newSessionAction: (Provider<Session?>)? = null,
         earlyTerminationCondition: () -> Boolean = { false },
         clearUserInfo: Boolean = false,
     ) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.system.mockLooper
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.mockk
@@ -27,7 +28,7 @@ import java.util.concurrent.atomic.AtomicReference
  */
 internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
     val clock: FakeClock = FakeClock(),
-    private val scheduledExecutorSupplier: () -> T
+    private val scheduledExecutorSupplier: Provider<T>
 ) : ExternalResource() {
     val logger = InternalEmbraceLogger()
     val mockSigquitDetectionService: SigquitDetectionService = mockk(relaxed = true)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
@@ -72,7 +73,7 @@ internal class EmbraceConfigServiceTest {
             )
         }
 
-        fun createLocalConfig(action: () -> SdkLocalConfig = { SdkLocalConfig() }): LocalConfig {
+        fun createLocalConfig(action: Provider<SdkLocalConfig> = { SdkLocalConfig() }): LocalConfig {
             return LocalConfig("abcde", false, action())
         }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/BehaviorFakes.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/BehaviorFakes.kt
@@ -28,6 +28,7 @@ import io.embrace.android.embracesdk.config.remote.BackgroundActivityRemoteConfi
 import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
 import io.embrace.android.embracesdk.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.Uuid
 
 private val behaviorThresholdCheck = BehaviorThresholdCheck { Uuid.getEmbUuid() }
@@ -37,8 +38,8 @@ private val behaviorThresholdCheck = BehaviorThresholdCheck { Uuid.getEmbUuid() 
  */
 internal fun fakeAnrBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> AnrLocalConfig? = { null },
-    remoteCfg: () -> AnrRemoteConfig? = { null }
+    localCfg: Provider<AnrLocalConfig?> = { null },
+    remoteCfg: Provider<AnrRemoteConfig?> = { null }
 ) = AnrBehavior(thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -46,8 +47,8 @@ internal fun fakeAnrBehavior(
  */
 internal fun fakeSessionBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> SessionLocalConfig? = { null },
-    remoteCfg: () -> RemoteConfig? = { null }
+    localCfg: Provider<SessionLocalConfig?> = { null },
+    remoteCfg: Provider<RemoteConfig?> = { null }
 ) = SessionBehavior(thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -55,8 +56,8 @@ internal fun fakeSessionBehavior(
  */
 internal fun fakeNetworkBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> SdkLocalConfig? = { null },
-    remoteCfg: () -> RemoteConfig? = { null }
+    localCfg: Provider<SdkLocalConfig?> = { null },
+    remoteCfg: Provider<RemoteConfig?> = { null }
 ) = NetworkBehavior(thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -64,8 +65,8 @@ internal fun fakeNetworkBehavior(
  */
 internal fun fakeBackgroundActivityBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> BackgroundActivityLocalConfig? = { null },
-    remoteCfg: () -> BackgroundActivityRemoteConfig? = { null }
+    localCfg: Provider<BackgroundActivityLocalConfig?> = { null },
+    remoteCfg: Provider<BackgroundActivityRemoteConfig?> = { null }
 ) = BackgroundActivityBehavior(thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -73,8 +74,8 @@ internal fun fakeBackgroundActivityBehavior(
  */
 internal fun fakeAutoDataCaptureBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> LocalConfig? = { null },
-    remoteCfg: () -> RemoteConfig? = { null }
+    localCfg: Provider<LocalConfig?> = { null },
+    remoteCfg: Provider<RemoteConfig?> = { null }
 ) = AutoDataCaptureBehavior(thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -82,8 +83,8 @@ internal fun fakeAutoDataCaptureBehavior(
  */
 internal fun fakeBreadcrumbBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> SdkLocalConfig? = { null },
-    remoteCfg: () -> RemoteConfig? = { null }
+    localCfg: Provider<SdkLocalConfig?> = { null },
+    remoteCfg: Provider<RemoteConfig?> = { null }
 ) = BreadcrumbBehavior(thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -91,7 +92,7 @@ internal fun fakeBreadcrumbBehavior(
  */
 internal fun fakeLogMessageBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    remoteCfg: () -> LogRemoteConfig? = { null }
+    remoteCfg: Provider<LogRemoteConfig?> = { null }
 ) = LogMessageBehavior(thresholdCheck, remoteCfg)
 
 /**
@@ -99,7 +100,7 @@ internal fun fakeLogMessageBehavior(
  */
 internal fun fakeStartupBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> StartupMomentLocalConfig? = { null }
+    localCfg: Provider<StartupMomentLocalConfig?> = { null }
 ) = StartupBehavior(thresholdCheck, localCfg)
 
 /**
@@ -107,7 +108,7 @@ internal fun fakeStartupBehavior(
  */
 internal fun fakeDataCaptureEventBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    remoteCfg: () -> RemoteConfig? = { null }
+    remoteCfg: Provider<RemoteConfig?> = { null }
 ) = DataCaptureEventBehavior(thresholdCheck, remoteCfg)
 
 /**
@@ -116,8 +117,8 @@ internal fun fakeDataCaptureEventBehavior(
 internal fun fakeSdkModeBehavior(
     isDebug: Boolean = false,
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> LocalConfig? = { null },
-    remoteCfg: () -> RemoteConfig? = { null }
+    localCfg: Provider<LocalConfig?> = { null },
+    remoteCfg: Provider<RemoteConfig?> = { null }
 ) = SdkModeBehavior(isDebug, thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -125,7 +126,7 @@ internal fun fakeSdkModeBehavior(
  */
 internal fun fakeSdkEndpointBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> BaseUrlLocalConfig? = { null },
+    localCfg: Provider<BaseUrlLocalConfig?> = { null },
 ) = SdkEndpointBehavior(thresholdCheck, localCfg)
 
 /**
@@ -133,8 +134,8 @@ internal fun fakeSdkEndpointBehavior(
  */
 internal fun fakeAppExitInfoBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: () -> AppExitInfoLocalConfig? = { null },
-    remoteCfg: () -> RemoteConfig? = { null },
+    localCfg: Provider<AppExitInfoLocalConfig?> = { null },
+    remoteCfg: Provider<RemoteConfig?> = { null },
 ) = AppExitInfoBehavior(thresholdCheck, localCfg, remoteCfg)
 
 /**
@@ -142,10 +143,10 @@ internal fun fakeAppExitInfoBehavior(
  */
 internal fun fakeNetworkSpanForwardingBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    remoteConfig: () -> NetworkSpanForwardingRemoteConfig? = { null }
+    remoteConfig: Provider<NetworkSpanForwardingRemoteConfig?> = { null }
 ) = NetworkSpanForwardingBehavior(thresholdCheck, remoteConfig)
 
 internal fun fakeWebViewVitalsBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    remoteCfg: () -> RemoteConfig? = { null },
+    remoteCfg: Provider<RemoteConfig?> = { null },
 ) = WebViewVitalsBehavior(thresholdCheck, remoteCfg)


### PR DESCRIPTION
## Goal

Add alias for Providers that take no input but return an instance of some type. We use this everywhere and this makes the code more readable. Note: I'm going changing instances of `() -> T` to use this if it fits the provider/supplier semantic meaning. 

