### PR TITLE
[POC] Add functions to DataSink

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  * place to coordinate everything in one place.
  */
 internal class DataCaptureOrchestrator(
-    private val dataSourceState: List<DataSourceState>,
+    private val dataSourceState: List<DataSourceState<*, *>>,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : ConfigListener {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSink.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch
 
+import androidx.annotation.CheckResult
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
@@ -10,9 +11,35 @@ internal typealias SpanMutator = EmbraceSpan.() -> Unit
 /**
  * A function that provides a [DataSink] instance.
  */
-internal typealias DataSinkProvider = () -> DataSink
+internal typealias DataSinkProvider<T, S> = () -> DataSink<T, S>
 
 /**
  * A [DataSource] can write information to a [DataSink] that will ultimately be added to a session.
  */
-internal interface DataSink
+internal interface DataSink<in T : SpanEventMapper, out S> {
+
+    /**
+     * Adds an event that is stored in the sink as part of the session span.
+     */
+    fun addEvent(dataToStore: T)
+
+    /**
+     * Gets a snapshot of the current state of the sink.
+     */
+    @CheckResult
+    fun getSnapshot(): S
+
+    /**
+     * Gets a snapshot of the current state of the sink & clears the sink.
+     */
+    @CheckResult
+    fun flush(): S
+}
+
+/**
+ * Defines the possible states for adding to the store.
+ */
+internal enum class StoreResult {
+    SUCCESS,
+    FAILURE
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSinkImpl.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.internal.OpenTelemetryClock
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+internal class DataSinkImpl<in T : SpanEventMapper, S>(
+    private val openTelemetryClock: OpenTelemetryClock,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataSink<T, S> {
+
+    override fun addEvent(dataToStore: T) {
+        try {
+            dataToStore.toSpanEvent(openTelemetryClock.nanoTime())
+            // TODO: add to the session span here.
+        } catch (exc: Throwable) {
+            logger.logError("Failed to store data", exc)
+        }
+    }
+
+    override fun getSnapshot(): S {
+        try {
+            TODO("Not yet implemented")
+        } catch (exc: Throwable) {
+            logger.logError("Failed to generated snapshot", exc)
+            throw exc
+        }
+    }
+
+    override fun flush(): S {
+        try {
+            TODO("Not yet implemented")
+        } catch (exc: Throwable) {
+            logger.logError("Failed to flush data", exc)
+            throw exc
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -3,18 +3,18 @@ package io.embrace.android.embracesdk.arch
 /**
  * A function that acts on a [DataSink] and mutates its state.
  */
-internal typealias DataSinkMutator = DataSink.() -> Unit
+internal typealias DataSinkMutator<T, S> = DataSink<T, S>.() -> Unit
 
 /**
  * Defines a 'data source'. This should be responsible for capturing a specific type
  * of data that will be sent to Embrace.
  */
-internal interface DataSource {
+internal interface DataSource<T : SpanEventMapper, S> {
 
     /**
      * All captured data should be written to the data sink within the action of this function.
      */
-    fun captureData(action: DataSinkMutator)
+    fun captureData(action: DataSinkMutator<T, S>)
 
     /**
      * Register any listeners that are required for capturing data.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -8,12 +8,12 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  * This base class contains convenience functions for capturing data that makes the syntax nicer
  * in subclasses.
  */
-internal abstract class DataSourceImpl(
-    private val sink: DataSinkProvider,
+internal abstract class DataSourceImpl<T : SpanEventMapper, S>(
+    private val sink: DataSinkProvider<T, S>,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
-) : DataSource {
+) : DataSource<T, S> {
 
-    override fun captureData(action: DataSinkMutator) {
+    override fun captureData(action: DataSinkMutator<T, S>) {
         try {
             action(sink())
         } catch (exc: Throwable) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -8,14 +8,14 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  * that enable/disable the service, and creates new instances of the service as required.
  * It also is capable of disabling the service if the [SessionType] is not supported.
  */
-internal class DataSourceState(
+internal class DataSourceState<T : SpanEventMapper, S>(
 
     /**
      * Provides instances of services. A service must define an interface
      * that extends [DataSource] for orchestration. This helps enforce testability
      * by making it impossible to register data capture without defining a testable interface.
      */
-    factory: () -> DataSource,
+    factory: () -> DataSource<T, S>,
 
     /**
      * Predicate that determines if the service should be enabled or not, via a config value.
@@ -38,7 +38,7 @@ internal class DataSourceState(
 ) {
 
     private val enabledDataSource by lazy(factory)
-    private var dataSource: DataSource? = null
+    private var dataSource: DataSource<T, S>? = null
 
     init {
         updateDataSource()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanEventMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanEventMapper.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+
+internal fun interface SpanEventMapper {
+
+    /**
+     * A function that maps an object to an [EmbraceSpanEvent].
+     */
+    fun toSpanEvent(timestampNanos: Long): EmbraceSpanEvent
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/ExampleOrientationDataSource.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.res.Configuration
 import io.embrace.android.embracesdk.arch.DataSinkProvider
 import io.embrace.android.embracesdk.arch.DataSourceImpl
+import io.embrace.android.embracesdk.arch.SpanEventMapper
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 /**
  * An example of a DataSource that captures the orientation of the device. It provides functions
@@ -12,8 +14,8 @@ import io.embrace.android.embracesdk.arch.DataSourceImpl
  */
 internal class ExampleOrientationDataSource(
     private val ctx: Context,
-    sink: DataSinkProvider
-) : DataSourceImpl(sink), ComponentCallbacks2 {
+    sink: DataSinkProvider<OrientationEvent, List<EmbraceSpanEvent>>
+) : DataSourceImpl<OrientationEvent, List<EmbraceSpanEvent>>(sink), ComponentCallbacks2 {
 
     override fun registerListeners() {
         ctx.registerComponentCallbacks(this)
@@ -25,7 +27,11 @@ internal class ExampleOrientationDataSource(
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         captureData {
-            // TODO: add functions for capturing data here.
+            val orientation: String = when (newConfig.orientation) {
+                Configuration.ORIENTATION_PORTRAIT -> "portrait"
+                else -> "landscape"
+            }
+            addEvent(OrientationEvent(orientation))
         }
     }
 
@@ -34,4 +40,15 @@ internal class ExampleOrientationDataSource(
 
     override fun onLowMemory() {
     }
+}
+
+internal class OrientationEvent(
+    private val orientation: String
+) : SpanEventMapper {
+
+    override fun toSpanEvent(timestampNanos: Long) = EmbraceSpanEvent(
+        "orientation_change",
+        timestampNanos,
+        mapOf("orientation" to orientation),
+    )
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -2,12 +2,14 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.DataSinkMutator
 import io.embrace.android.embracesdk.arch.DataSource
+import io.embrace.android.embracesdk.arch.SpanEventMapper
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
-internal class FakeDataSource : DataSource {
+internal class FakeDataSource : DataSource<FakeData, Any> {
     var registerCount = 0
     var unregisterCount = 0
 
-    override fun captureData(action: DataSinkMutator) {
+    override fun captureData(action: DataSinkMutator<FakeData, Any>) {
     }
 
     override fun registerListeners() {
@@ -17,4 +19,12 @@ internal class FakeDataSource : DataSource {
     override fun unregisterListeners() {
         unregisterCount++
     }
+}
+
+internal class FakeData : SpanEventMapper {
+    override fun toSpanEvent(timestampNanos: Long) = EmbraceSpanEvent(
+        "fake_event",
+        timestampNanos,
+        mapOf("fake" to "fake")
+    )
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class DataSourceModuleImplTest {
@@ -10,8 +9,6 @@ internal class DataSourceModuleImplTest {
     @Test
     fun `test default behavior`() {
         val module = DataSourceModuleImpl(FakeEssentialServiceModule())
-        val dataSource = module.placeholderDataSource
-        assertNotNull(dataSource)
-        assertTrue(module.getDataSources().contains(dataSource))
+        assertNotNull(module.getDataSources())
     }
 }


### PR DESCRIPTION
## Goal

Adds functions to the `DataSink` interface that suggest how data should be written in a `DataSource`. This adds 3 functions: 1 which writes data to the sink, 1 that retrieves a snapshot, and 1 that flushes the data.

I've also provided an example of mapping a Kotlin model class to an `EmbraceSpanEvent`. The idea is the `DataSink` can be responsible for creating this object from the input data without needing to know too much about its internals. I don't feel too strongly about this layer but thought it would probably map well onto the OpenAPI work. If necessary we could use another type, or even just deal directly with primitive values (name + attrs).

I think this concept works best for event-based data. It will be necessary to add extra functions for starting/stopping spans (which will just call directly onto the SpansService).

