### PR TITLE
Fix slow startup

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/FakeWorkerThreadModule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/FakeWorkerThreadModule.kt
@@ -2,25 +2,35 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.injection.InitModuleImpl
-import io.embrace.android.embracesdk.worker.WorkerName
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.ScheduledWorker
+import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 
 internal class FakeWorkerThreadModule(
-    fakeClock: FakeClock,
+    fakeInitModule: FakeInitModule,
     private val name: WorkerName,
-    private val base: WorkerThreadModule = WorkerThreadModuleImpl(InitModuleImpl(fakeClock))
+    private val base: WorkerThreadModule = WorkerThreadModuleImpl(fakeInitModule)
 ) : WorkerThreadModule by base {
 
-    val executor = BlockingScheduledExecutorService(fakeClock)
+    val executorClock = fakeInitModule.getFakeClock() ?: FakeClock()
+    val executor = BlockingScheduledExecutorService(fakeClock = executorClock)
 
-    private val worker = ScheduledWorker(executor)
+    private val backgroundWorker = BackgroundWorker(executor)
+    private val scheduledWorker = ScheduledWorker(executor)
+
+    override fun backgroundWorker(workerName: WorkerName): BackgroundWorker {
+        return when (workerName) {
+            name -> backgroundWorker
+            else -> base.backgroundWorker(workerName)
+        }
+    }
 
     override fun scheduledWorker(workerName: WorkerName): ScheduledWorker {
         return when (workerName) {
-            name -> worker
+            name -> scheduledWorker
             else -> base.scheduledWorker(workerName)
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.getLastSavedSessionMessage
 import io.embrace.android.embracesdk.getLastSentSessionMessage
 import io.embrace.android.embracesdk.recordSession
@@ -24,9 +24,11 @@ internal class PeriodicSessionCacheTest {
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
         val clock = FakeClock(IntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
+        val fakeInitModule = FakeInitModule(clock = clock)
         IntegrationTestRule.Harness(
             fakeClock = clock,
-            workerThreadModule = FakeWorkerThreadModule(clock, PERIODIC_CACHE)
+            initModule = fakeInitModule,
+            workerThreadModule = FakeWorkerThreadModule(fakeInitModule, PERIODIC_CACHE)
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes.injection
 
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.injection.InitModuleImpl
@@ -15,4 +16,6 @@ internal class FakeInitModule(
     initModule: InitModule = InitModuleImpl(clock = clock, openTelemetryClock = openTelemetryClock)
 ) : InitModule by initModule {
     val openTelemetryModule: OpenTelemetryModule = OpenTelemetryModuleImpl(initModule)
+
+    fun getFakeClock(): FakeClock? = clock as? FakeClock
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -3,14 +3,21 @@ package io.embrace.android.embracesdk.injection
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.session.FakeWorkerThreadModule
+import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 @RunWith(AndroidJUnit4::class)
 internal class ModuleInitBootstrapperTest {
@@ -28,7 +35,7 @@ internal class ModuleInitBootstrapperTest {
     fun `test default implementation`() {
         val moduleInitBootstrapper = ModuleInitBootstrapper(coreModuleSupplier = { _, _ -> FakeCoreModule() })
         with(moduleInitBootstrapper) {
-            assertTrue(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE))
+            assertTrue(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE, 0L))
             assertTrue(initModule is InitModuleImpl)
             assertTrue(openTelemetryModule is OpenTelemetryModuleImpl)
             assertTrue(workerThreadModule is WorkerThreadModuleImpl)
@@ -43,7 +50,31 @@ internal class ModuleInitBootstrapperTest {
 
     @Test
     fun `cannot initialize twice`() {
-        assertTrue(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE))
-        assertFalse(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE))
+        assertTrue(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE, 0L))
+        assertFalse(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE, 0L))
+    }
+
+    @Test
+    fun `async init returns normally and without failure`() {
+        assertTrue(moduleInitBootstrapper.init(context, false, Embrace.AppFramework.NATIVE, 0L))
+        moduleInitBootstrapper.waitForAsyncInit()
+    }
+
+    @Test
+    fun `async init throws exception if it waiting for too long`() {
+        val fakeClock = FakeClock()
+        val fakeInitModule = FakeInitModule(clock = fakeClock)
+        val fakeCoreModule = FakeCoreModule()
+        val fakeWorkerThreadModule =
+            FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = WorkerName.BACKGROUND_REGISTRATION)
+        val bootstrapper = ModuleInitBootstrapper(
+            initModule = fakeInitModule,
+            coreModuleSupplier = { _, _ -> fakeCoreModule },
+            workerThreadModuleSupplier = { _ -> fakeWorkerThreadModule }
+        )
+        assertTrue(bootstrapper.init(context, false, Embrace.AppFramework.NATIVE, 0L))
+        assertThrows(TimeoutException::class.java) {
+            bootstrapper.waitForAsyncInit(500L, TimeUnit.MILLISECONDS)
+        }
     }
 }


### PR DESCRIPTION
## Goal

A refactor pushed the spans service startup to much later, which led to additional tasks being run before it that took a lot longer. Fixed this by restoring the early service initialization so that it most likely ends before all the synchronous service inits are finished
