### PR TITLE
Move most module init into ModuleInitBootstrapper

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -89,11 +89,9 @@ public final class Embrace implements EmbraceAndroidApi {
 
     @Override
     public void start(@NonNull Context context, boolean enableIntegrationTesting, @NonNull AppFramework appFramework) {
-        Systrace.startSynchronous("start-method");
         if (verifyNonNullParameters("start", context, appFramework)) {
             impl.start(context, enableIntegrationTesting, appFramework);
         }
-        Systrace.endSynchronous();
     }
 
     @Override

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -2,19 +2,32 @@ package io.embrace.android.embracesdk.injection
 
 import android.content.Context
 import io.embrace.android.embracesdk.Embrace.AppFramework
+import io.embrace.android.embracesdk.anr.ndk.isUnityMainThread
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.utils.AndroidServicesModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.AnrModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.CoreModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.CrashModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.CustomerLogModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.DataCaptureServiceModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.DataContainerModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.DataSourceModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.DeliveryModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.EssentialServiceModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.NativeModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.internal.utils.SdkObservabilityModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.SessionModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.StorageModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.SystemServiceModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.utils.WorkerThreadModuleSupplier
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.ndk.NativeModule
+import io.embrace.android.embracesdk.ndk.NativeModuleImpl
+import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.TaskPriority
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
@@ -37,6 +50,14 @@ internal class ModuleInitBootstrapper(
     private val essentialServiceModuleSupplier: EssentialServiceModuleSupplier = ::EssentialServiceModuleImpl,
     private val dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = ::DataCaptureServiceModuleImpl,
     private val deliveryModuleSupplier: DeliveryModuleSupplier = ::DeliveryModuleImpl,
+    private val anrModuleSupplier: AnrModuleSupplier = ::AnrModuleImpl,
+    private val sdkObservabilityModuleSupplier: SdkObservabilityModuleSupplier = ::SdkObservabilityModuleImpl,
+    private val customerLogModuleSupplier: CustomerLogModuleSupplier = ::CustomerLogModuleImpl,
+    private val nativeModuleSupplier: NativeModuleSupplier = ::NativeModuleImpl,
+    private val dataContainerModuleSupplier: DataContainerModuleSupplier = ::DataContainerModuleImpl,
+    private val dataSourceModuleSupplier: DataSourceModuleSupplier = ::DataSourceModuleImpl,
+    private val sessionModuleSupplier: SessionModuleSupplier = ::SessionModuleImpl,
+    private val crashModuleSupplier: CrashModuleSupplier = ::CrashModuleImpl,
 ) {
     lateinit var coreModule: CoreModule
         private set
@@ -60,6 +81,30 @@ internal class ModuleInitBootstrapper(
         private set
 
     lateinit var deliveryModule: DeliveryModule
+        private set
+
+    lateinit var anrModule: AnrModule
+        private set
+
+    lateinit var sdkObservabilityModule: SdkObservabilityModule
+        private set
+
+    lateinit var customerLogModule: CustomerLogModule
+        private set
+
+    lateinit var nativeModule: NativeModule
+        private set
+
+    lateinit var dataContainerModule: DataContainerModule
+        private set
+
+    lateinit var dataSourceModule: DataSourceModule
+        private set
+
+    lateinit var sessionModule: SessionModule
+        private set
+
+    lateinit var crashModule: CrashModule
         private set
 
     private val asyncInitTask = AtomicReference<Future<*>?>(null)
@@ -87,20 +132,25 @@ internal class ModuleInitBootstrapper(
                 return if (asyncInitTask.get() == null) {
                     coreModule = Systrace.traceSynchronous("core-init") { coreModuleSupplier(context, appFramework) }
                     workerThreadModule = Systrace.traceSynchronous("worker-init") { workerThreadModuleSupplier(initModule) }
+
                     val initTask = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit(TaskPriority.CRITICAL) {
                         Systrace.trace("spans-service-init") {
                             openTelemetryModule.spansService.initializeService(sdkStartTimeNanos)
                         }
                     }
+
                     systemServiceModule = Systrace.traceSynchronous("system-service-init") {
                         systemServiceModuleSupplier(coreModule, versionChecker)
                     }
+
                     androidServicesModule = Systrace.traceSynchronous("android-service-init") {
                         androidServicesModuleSupplier(initModule, coreModule, workerThreadModule)
                     }
+
                     storageModule = Systrace.traceSynchronous("storage-init") {
                         storageModuleSupplier(initModule, coreModule, workerThreadModule)
                     }
+
                     essentialServiceModule = Systrace.traceSynchronous("essential-init") {
                         essentialServiceModuleSupplier(
                             initModule,
@@ -114,6 +164,7 @@ internal class ModuleInitBootstrapper(
                             configServiceProvider
                         )
                     }
+
                     dataCaptureServiceModule = Systrace.traceSynchronous("data-capture-init") {
                         dataCaptureServiceModuleSupplier(
                             initModule,
@@ -125,9 +176,148 @@ internal class ModuleInitBootstrapper(
                             versionChecker
                         )
                     }
+
                     deliveryModule = Systrace.traceSynchronous("delivery-init") {
                         deliveryModuleSupplier(coreModule, workerThreadModule, storageModule, essentialServiceModule)
                     }
+
+                    /** Since onForeground() is called sequential in the order that services registered for it,
+                     * it is important to initialize the `EmbraceAnrService`, and thus register the `onForeground()
+                     * listener for it, before the `EmbraceSessionService`.
+                     * The onForeground() call inside the EmbraceAnrService should be called before the
+                     * EmbraceSessionService call. This is necessary since the EmbraceAnrService should be able to
+                     * force a Main thread health check and close the pending ANR intervals that happened on the
+                     * background before the next session is created.
+                     * */
+                    anrModule = Systrace.traceSynchronous("anr-init") {
+                        anrModuleSupplier(initModule, coreModule, essentialServiceModule, workerThreadModule)
+                    }
+
+                    // set callbacks and pass in non-placeholder config.
+                    anrModule.anrService.finishInitialization(
+                        essentialServiceModule.configService
+                    )
+
+                    // initialize the logger early so that logged exceptions have a good chance of
+                    // being appended to the exceptions service rather than logcat
+                    sdkObservabilityModule = Systrace.traceSynchronous("sdk-observability-init") {
+                        sdkObservabilityModuleSupplier(initModule, essentialServiceModule)
+                    }
+
+                    val sessionProperties = EmbraceSessionProperties(
+                        androidServicesModule.preferencesService,
+                        essentialServiceModule.configService,
+                        coreModule.logger
+                    )
+
+                    customerLogModule = Systrace.traceSynchronous("customer-log-init") {
+                        customerLogModuleSupplier(
+                            initModule,
+                            coreModule,
+                            androidServicesModule,
+                            essentialServiceModule,
+                            deliveryModule,
+                            sessionProperties,
+                            workerThreadModule
+                        )
+                    }
+
+                    nativeModule = Systrace.traceSynchronous("native-crash-init") {
+                        nativeModuleSupplier(
+                            coreModule,
+                            storageModule,
+                            essentialServiceModule,
+                            deliveryModule,
+                            androidServicesModule,
+                            sessionProperties,
+                            workerThreadModule
+                        )
+                    }
+
+                    if (nativeModule.nativeThreadSamplerInstaller != null) {
+                        // install the native thread sampler
+                        nativeModule.nativeThreadSamplerService?.let { nativeThreadSamplerService ->
+                            nativeThreadSamplerService.setupNativeSampler()
+
+                            // In Unity this should always run on the Unity thread.
+                            if (coreModule.appFramework == AppFramework.UNITY && isUnityMainThread()) {
+                                try {
+                                    if (nativeModule.nativeThreadSamplerInstaller != null) {
+                                        nativeModule.nativeThreadSamplerInstaller?.monitorCurrentThread(
+                                            nativeThreadSamplerService,
+                                            essentialServiceModule.configService,
+                                            anrModule.anrService
+                                        )
+                                    } else {
+                                        InternalStaticEmbraceLogger.logger.logWarning(
+                                            "nativeThreadSamplerInstaller not started, cannot sample current thread"
+                                        )
+                                    }
+                                } catch (t: Throwable) {
+                                    InternalStaticEmbraceLogger.logger.logError("Failed to sample current thread during ANRs", t)
+                                }
+                            }
+                        }
+                    } else {
+                        InternalStaticEmbraceLogger.logger.logWarning("Failed to load SO file embrace-native")
+                    }
+
+                    dataContainerModule = Systrace.traceSynchronous("data-container-init") {
+                        dataContainerModuleSupplier(
+                            initModule,
+                            openTelemetryModule,
+                            coreModule,
+                            workerThreadModule,
+                            systemServiceModule,
+                            androidServicesModule,
+                            essentialServiceModule,
+                            dataCaptureServiceModule,
+                            anrModule,
+                            customerLogModule,
+                            deliveryModule,
+                            nativeModule,
+                            sessionProperties,
+                            TimeUnit.NANOSECONDS.toMillis(sdkStartTimeNanos)
+                        )
+                    }
+
+                    dataSourceModule = Systrace.traceSynchronous("data-source-init") {
+                        dataSourceModuleSupplier(essentialServiceModule)
+                    }
+
+                    sessionModule = Systrace.traceSynchronous("session-init") {
+                        sessionModuleSupplier(
+                            initModule,
+                            openTelemetryModule,
+                            androidServicesModule,
+                            essentialServiceModule,
+                            nativeModule,
+                            dataContainerModule,
+                            deliveryModule,
+                            sessionProperties,
+                            dataCaptureServiceModule,
+                            customerLogModule,
+                            sdkObservabilityModule,
+                            workerThreadModule,
+                            dataSourceModule
+                        )
+                    }
+
+                    crashModule = Systrace.traceSynchronous("crash-init") {
+                        crashModuleSupplier(
+                            initModule,
+                            storageModule,
+                            essentialServiceModule,
+                            deliveryModule,
+                            nativeModule,
+                            sessionModule,
+                            anrModule,
+                            dataContainerModule,
+                            androidServicesModule
+                        )
+                    }
+
+                    Thread.setDefaultUncaughtExceptionHandler(crashModule.automaticVerificationExceptionHandler)
                     asyncInitTask.set(initTask)
                     true
                 } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -4,14 +4,23 @@ import android.content.Context
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.injection.AndroidServicesModule
+import io.embrace.android.embracesdk.injection.AnrModule
 import io.embrace.android.embracesdk.injection.CoreModule
+import io.embrace.android.embracesdk.injection.CrashModule
+import io.embrace.android.embracesdk.injection.CustomerLogModule
 import io.embrace.android.embracesdk.injection.DataCaptureServiceModule
+import io.embrace.android.embracesdk.injection.DataContainerModule
+import io.embrace.android.embracesdk.injection.DataSourceModule
 import io.embrace.android.embracesdk.injection.DeliveryModule
 import io.embrace.android.embracesdk.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.injection.OpenTelemetryModule
+import io.embrace.android.embracesdk.injection.SdkObservabilityModule
+import io.embrace.android.embracesdk.injection.SessionModule
 import io.embrace.android.embracesdk.injection.StorageModule
 import io.embrace.android.embracesdk.injection.SystemServiceModule
+import io.embrace.android.embracesdk.ndk.NativeModule
+import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import java.io.OutputStream
 
@@ -27,61 +36,193 @@ internal typealias SerializationAction = (outputStream: OutputStream) -> Unit
 internal typealias UnimplementedConfig = Unit?
 
 /**
- * Defines the constructor for [CoreModuleImpl]
+ * Function that returns an instance of [CoreModule]. Matches the signature of the constructor for [CoreModuleImpl]
  */
-internal typealias CoreModuleSupplier = (Context, Embrace.AppFramework) -> CoreModule
+internal typealias CoreModuleSupplier = (context: Context, appFramework: Embrace.AppFramework) -> CoreModule
 
 /**
- * Defines the constructor for [WorkerThreadModuleImpl]
+ * Function that returns an instance of [WorkerThreadModule]. Matches the signature of the constructor for [WorkerThreadModuleImpl]
  */
-internal typealias WorkerThreadModuleSupplier = (InitModule) -> WorkerThreadModule
+internal typealias WorkerThreadModuleSupplier = (initModule: InitModule) -> WorkerThreadModule
 
 /**
- * Defines the constructor for [SystemServiceModuleImpl]
+ * Function that returns an instance of [SystemServiceModule]. Matches the signature of the constructor for [SystemServiceModuleImpl]
  */
-internal typealias SystemServiceModuleSupplier = (CoreModule, VersionChecker) -> SystemServiceModule
+internal typealias SystemServiceModuleSupplier = (
+    coreModule: CoreModule,
+    versionChecker: VersionChecker
+) -> SystemServiceModule
 
 /**
- * Defines the constructor for [AndroidServicesModuleImpl]
+ * Function that returns an instance of [AndroidServicesModule]. Matches the signature of the constructor for [AndroidServicesModuleImpl]
  */
-internal typealias AndroidServicesModuleSupplier = (InitModule, CoreModule, WorkerThreadModule) -> AndroidServicesModule
+internal typealias AndroidServicesModuleSupplier = (
+    initModule: InitModule,
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+) -> AndroidServicesModule
 
 /**
- * Defines the constructor for [StorageModuleImpl]
+ * Function that returns an instance of [StorageModule]. Matches the signature of the constructor for [StorageModuleImpl]
  */
-internal typealias StorageModuleSupplier = (InitModule, CoreModule, WorkerThreadModule) -> StorageModule
+internal typealias StorageModuleSupplier = (
+    initModule: InitModule,
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+) -> StorageModule
 
 /**
- * Defines the constructor for [EssentialServiceModuleImpl]
+ * Function that returns an instance of [EssentialServiceModule]. Matches the signature of the constructor for [EssentialServiceModuleImpl]
  */
 internal typealias EssentialServiceModuleSupplier = (
-    InitModule,
-    CoreModule,
-    WorkerThreadModule,
-    SystemServiceModule,
-    AndroidServicesModule,
-    StorageModule,
-    String?,
-    Boolean,
-    Provider<ConfigService?>
+    initModule: InitModule,
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+    systemServiceModule: SystemServiceModule,
+    androidServicesModule: AndroidServicesModule,
+    storageModule: StorageModule,
+    customAppId: String?,
+    enableIntegrationTesting: Boolean,
+    configServiceProvider: Provider<ConfigService?>,
 ) -> EssentialServiceModule
 
 /**
- * Defines the constructor for [DataCaptureServiceModuleImpl]
+ * Function that returns an instance of [DataCaptureServiceModule]. Matches the signature of the constructor for
+ * [DataCaptureServiceModuleImpl]
  */
 internal typealias DataCaptureServiceModuleSupplier = (
-    InitModule,
-    OpenTelemetryModule,
-    CoreModule,
-    SystemServiceModule,
-    EssentialServiceModule,
-    WorkerThreadModule,
-    VersionChecker
+    initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
+    coreModule: CoreModule,
+    systemServiceModule: SystemServiceModule,
+    essentialServiceModule: EssentialServiceModule,
+    workerThreadModule: WorkerThreadModule,
+    versionChecker: VersionChecker
 ) -> DataCaptureServiceModule
 
 /**
- * Defines the constructor for [DeliveryModuleImpl]
+ * Function that returns an instance of [DeliveryModule]. Matches the signature of the constructor for [DeliveryModuleImpl]
  */
-internal typealias DeliveryModuleSupplier = (CoreModule, WorkerThreadModule, StorageModule, EssentialServiceModule) -> DeliveryModule
+internal typealias DeliveryModuleSupplier = (
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+    storageModule: StorageModule,
+    essentialServiceModule: EssentialServiceModule,
+) -> DeliveryModule
 
+/**
+ * Function that returns an instance of [AnrModule]. Matches the signature of the constructor for [AnrModuleImpl]
+ */
+
+internal typealias AnrModuleSupplier = (
+    initModule: InitModule,
+    coreModule: CoreModule,
+    essentialServiceModule: EssentialServiceModule,
+    workerModule: WorkerThreadModule,
+) -> AnrModule
+
+/**
+ * Function that returns an instance of [SdkObservabilityModule]. Matches the signature of the constructor for [SdkObservabilityModuleImpl]
+ */
+
+internal typealias SdkObservabilityModuleSupplier = (
+    initModule: InitModule,
+    essentialServiceModule: EssentialServiceModule
+) -> SdkObservabilityModule
+
+/**
+ * Function that returns an instance of [CustomerLogModule]. Matches the signature of the constructor for [CustomerLogModuleImpl]
+ */
+
+internal typealias CustomerLogModuleSupplier = (
+    initModule: InitModule,
+    coreModule: CoreModule,
+    androidServicesModule: AndroidServicesModule,
+    essentialServiceModule: EssentialServiceModule,
+    deliveryModule: DeliveryModule,
+    sessionProperties: EmbraceSessionProperties,
+    workerThreadModule: WorkerThreadModule
+) -> CustomerLogModule
+
+/**
+ * Function that returns an instance of [NativeModule]. Matches the signature of the constructor for [NativeModuleImpl]
+ */
+
+internal typealias NativeModuleSupplier = (
+    coreModule: CoreModule,
+    storageModule: StorageModule,
+    essentialServiceModule: EssentialServiceModule,
+    deliveryModule: DeliveryModule,
+    androidServicesModule: AndroidServicesModule,
+    sessionProperties: EmbraceSessionProperties,
+    workerThreadModule: WorkerThreadModule
+) -> NativeModule
+
+/**
+ * Function that returns an instance of [DataContainerModule]. Matches the signature of the constructor for [DataContainerModuleImpl]
+ */
+internal typealias DataContainerModuleSupplier = (
+    initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+    systemServiceModule: SystemServiceModule,
+    androidServicesModule: AndroidServicesModule,
+    essentialServiceModule: EssentialServiceModule,
+    dataCaptureServiceModule: DataCaptureServiceModule,
+    anrModule: AnrModule,
+    customerLogModule: CustomerLogModule,
+    deliveryModule: DeliveryModule,
+    nativeModule: NativeModule,
+    sessionProperties: EmbraceSessionProperties,
+    startTime: Long
+) -> DataContainerModule
+
+/**
+ * Function that returns an instance of [DataSourceModule]. Matches the signature of the constructor for [DataSourceModuleImpl]
+ */
+
+internal typealias DataSourceModuleSupplier = (
+    essentialServiceModule: EssentialServiceModule,
+) -> DataSourceModule
+
+/**
+ * Function that returns an instance of [SessionModule]. Matches the signature of the constructor for [SessionModuleImpl]
+ */
+
+internal typealias SessionModuleSupplier = (
+    initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
+    androidServicesModule: AndroidServicesModule,
+    essentialServiceModule: EssentialServiceModule,
+    nativeModule: NativeModule,
+    dataContainerModule: DataContainerModule,
+    deliveryModule: DeliveryModule,
+    sessionProperties: EmbraceSessionProperties,
+    dataCaptureServiceModule: DataCaptureServiceModule,
+    customerLogModule: CustomerLogModule,
+    sdkObservabilityModule: SdkObservabilityModule,
+    workerThreadModule: WorkerThreadModule,
+    dataSourceModule: DataSourceModule
+) -> SessionModule
+
+/**
+ * Function that returns an instance of [CrashModule]. Matches the signature of the constructor for [CrashModuleImpl]
+ */
+
+internal typealias CrashModuleSupplier = (
+    initModule: InitModule,
+    storageModule: StorageModule,
+    essentialServiceModule: EssentialServiceModule,
+    deliveryModule: DeliveryModule,
+    nativeModule: NativeModule,
+    sessionModule: SessionModule,
+    anrModule: AnrModule,
+    dataContainerModule: DataContainerModule,
+    androidServicesModule: AndroidServicesModule
+) -> CrashModule
+
+/**
+ * Function that returns an instance of T meant to represent a provider/supplier that does not require any input parameters
+ */
 internal typealias Provider<T> = () -> T


### PR DESCRIPTION
## Goal

Consolidate all of the non-EmbraceImpl-wrapping module initialization in ModuleInitBootstrapper. Additional logic to initialize services within those modules are moved here too if they are wholly contained by the services and not related to state inside EmbraceImpl, and the original order that these steps were taking were preserved.

## Testing

Covered by existing tests

