### PR TITLE
Add destinations to data source interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -1,10 +1,24 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
+
 /**
  * Defines a 'data source'. This should be responsible for capturing a specific type
  * of data that will be sent to Embrace.
+ *
+ * @param T The type of the destination that the data will be sent to. This could be
+ * either a [CurrentSessionSpan], [EmbraceTracer], or [LogService].
+ *
+ * See [EventDataSource], [SpanDataSource], and [LogDataSource] for more information.
  */
-internal interface DataSource {
+internal interface DataSource<T> {
+
+    /**
+     * The DataSource should call this function when it wants to capture data
+     * and send it to the destination.
+     */
+    fun captureData(action: T.() -> Unit)
 
     /**
      * Register any listeners that are required for capturing data.
@@ -16,3 +30,24 @@ internal interface DataSource {
      */
     fun unregisterListeners()
 }
+
+/**
+ * A [DataSource] that adds either a [EmbraceSpanEvent] or [EmbraceSpanAttribute]
+ * to the current session span.
+ */
+internal interface EventDataSource : DataSource<CurrentSessionSpan>
+
+/**
+ * A [DataSource] that adds or alters a new span on the [SpansService]
+ */
+internal interface SpanDataSource : DataSource<EmbraceTracer>
+
+/**
+ * A [DataSource] that adds a new log to the log service.
+ */
+internal interface LogDataSource : DataSource<LogService>
+
+/**
+ * Placeholder type for the log service.
+ */
+internal interface LogService

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+/**
+ * Base class for data sources.
+ */
+internal abstract class DataSourceImpl<T>(
+    private val destination: T,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataSource<T> {
+
+    override fun captureData(action: T.() -> Unit) {
+        try {
+            destination.action()
+        } catch (exc: Throwable) {
+            logger.logError("Error capturing data", exc)
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -14,7 +14,7 @@ internal class DataSourceState(
      * that extends [DataSource] for orchestration. This helps enforce testability
      * by making it impossible to register data capture without defining a testable interface.
      */
-    factory: Provider<DataSource>,
+    factory: Provider<DataSource<*>>,
 
     /**
      * Predicate that determines if the service should be enabled or not, via a config value.
@@ -35,7 +35,7 @@ internal class DataSourceState(
 ) {
 
     private val enabledDataSource by lazy(factory)
-    private var dataSource: DataSource? = null
+    private var dataSource: DataSource<*>? = null
 
     init {
         updateDataSource()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -1,17 +1,8 @@
 package io.embrace.android.embracesdk.injection
 
-import io.embrace.android.embracesdk.arch.DataSource
 import io.embrace.android.embracesdk.arch.DataSourceState
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
-
-internal class PlaceholderDataSource : DataSource {
-    override fun registerListeners() {
-    }
-
-    override fun unregisterListeners() {
-    }
-}
 
 /**
  * Declares all the data sources that are used by the Embrace SDK.
@@ -28,18 +19,12 @@ internal interface DataSourceModule {
      * Returns a list of all the data sources that are defined in this module.
      */
     fun getDataSources(): List<DataSourceState>
-
-    val placeholderDataSource: DataSourceState
 }
 
 internal class DataSourceModuleImpl(
     essentialServiceModule: EssentialServiceModule,
 ) : DataSourceModule {
     private val values: MutableList<DataSourceState> = mutableListOf()
-
-    override val placeholderDataSource by dataSource {
-        DataSourceState(::PlaceholderDataSource)
-    }
 
     /* Implementation details */
 
@@ -51,6 +36,7 @@ internal class DataSourceModuleImpl(
      * list on its creation. That list is then used by the [DataCaptureOrchestrator] to control
      * the data sources.
      */
+    @Suppress("unused")
     private fun dataSource(provider: () -> DataSourceState) = DataSourceDelegate(provider, values)
 }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -1,0 +1,36 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class DataSourceImplTest {
+
+    @Test
+    fun `capture data successfully`() {
+        val dst = FakeCurrentSessionSpan()
+        val source = FakeDataSourceImpl(dst)
+        source.captureData {
+            initialized()
+        }
+        assertEquals(1, dst.initializedCallCount)
+    }
+
+    @Test
+    fun `capture data threw exception`() {
+        val dst = FakeCurrentSessionSpan()
+        val source = FakeDataSourceImpl(dst)
+        source.captureData {
+            error("Whoops!")
+        }
+        assertEquals(0, dst.initializedCallCount)
+    }
+
+    private class FakeDataSourceImpl(dst: FakeCurrentSessionSpan) :
+        DataSourceImpl<FakeCurrentSessionSpan>(dst) {
+
+        override fun registerListeners() {}
+
+        override fun unregisterListeners() {}
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+
+internal class FakeCurrentSessionSpan : CurrentSessionSpan {
+
+    var initializedCallCount = 0
+    override fun initializeService(sdkInitStartTimeNanos: Long) {
+    }
+
+    override fun initialized(): Boolean {
+        initializedCallCount++
+        return true
+    }
+
+    override fun endSession(appTerminationCause: EmbraceAttributes.AppTerminationCause?): List<EmbraceSpanData> {
+        return emptyList()
+    }
+
+    override fun canStartNewSpan(parent: EmbraceSpan?, internal: Boolean): Boolean {
+        return true
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -1,12 +1,20 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.DataSource
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 
-internal class FakeDataSource : DataSource {
+internal class FakeDataSource : DataSource<CurrentSessionSpan> {
     var registerCount = 0
     var unregisterCount = 0
 
+    override fun captureData(action: CurrentSessionSpan.() -> Unit) {
+        action(FakeCurrentSessionSpan())
+    }
+
     override fun registerListeners() {
+        captureData {
+            // TODO: interact with span here.
+        }
         registerCount++
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class DataSourceModuleImplTest {
@@ -10,8 +9,6 @@ internal class DataSourceModuleImplTest {
     @Test
     fun `test default behavior`() {
         val module = DataSourceModuleImpl(FakeEssentialServiceModule())
-        val dataSource = module.placeholderDataSource
-        assertNotNull(dataSource)
-        assertTrue(module.getDataSources().contains(dataSource))
+        assertNotNull(module.getDataSources())
     }
 }


### PR DESCRIPTION
## Goal

Alters the `DataSource` interface so that it has 3 potential destinations where it can write data: spans, span events, and logs.

This ties each `DataSource` to capturing only one type of data directly (Span/SpanEvent/Logs). IMO this is preferable and in edge-cases it should be possible to create multiple implementations.

## Testing

Added unit test coverage.
