### PR TITLE
Rename functions on data source interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -21,14 +21,20 @@ internal interface DataSource<T> {
     fun captureData(action: T.() -> Unit)
 
     /**
-     * Register any listeners that are required for capturing data.
+     * Enables data capture. This should include registering any listeners, and resetting
+     * any state (if applicable).
+     *
+     * You should NOT attempt to track state within the [DataSource] with a boolean flag.
      */
-    fun registerListeners()
+    fun enableDataCapture()
 
     /**
-     * Unregister any listeners that might be capturing data.
+     * Disables data capture. This should include unregistering any listeners, and resetting
+     * any state (if applicable).
+     *
+     * You should NOT attempt to track state within the [DataSource] with a boolean flag.
      */
-    fun unregisterListeners()
+    fun disableDataCapture()
 }
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -62,10 +62,10 @@ internal class DataSourceState(
 
         if (enabled && dataSource == null) {
             dataSource = enabledDataSource.apply {
-                registerListeners()
+                enableDataCapture()
             }
         } else if (!enabled && dataSource != null) {
-            dataSource?.unregisterListeners()
+            dataSource?.disableDataCapture()
             dataSource = null
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
+import io.embrace.android.embracesdk.fakes.system.mockContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -14,7 +15,7 @@ internal class DataCaptureOrchestratorTest {
 
     @Before
     fun setUp() {
-        dataSource = FakeDataSource()
+        dataSource = FakeDataSource(mockContext())
         orchestrator = DataCaptureOrchestrator(
             listOf(
                 DataSourceState(
@@ -28,19 +29,19 @@ internal class DataCaptureOrchestratorTest {
 
     @Test
     fun `config changes are propagated`() {
-        assertEquals(0, dataSource.registerCount)
+        assertEquals(0, dataSource.enableDataCaptureCount)
         orchestrator.onSessionTypeChange(SessionType.FOREGROUND)
-        assertEquals(1, dataSource.registerCount)
+        assertEquals(1, dataSource.enableDataCaptureCount)
 
         enabled = false
         orchestrator.onConfigChange(FakeConfigService())
-        assertEquals(1, dataSource.unregisterCount)
+        assertEquals(1, dataSource.disableDataCaptureCount)
     }
 
     @Test
     fun `session type change is propagated`() {
-        assertEquals(0, dataSource.registerCount)
+        assertEquals(0, dataSource.enableDataCaptureCount)
         orchestrator.onSessionTypeChange(SessionType.FOREGROUND)
-        assertEquals(1, dataSource.registerCount)
+        assertEquals(1, dataSource.enableDataCaptureCount)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -29,8 +29,10 @@ internal class DataSourceImplTest {
     private class FakeDataSourceImpl(dst: FakeCurrentSessionSpan) :
         DataSourceImpl<FakeCurrentSessionSpan>(dst) {
 
-        override fun registerListeners() {}
+        override fun enableDataCapture() {
+        }
 
-        override fun unregisterListeners() {}
+        override fun disableDataCapture() {
+        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -1,14 +1,17 @@
 package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.fakes.FakeDataSource
+import io.embrace.android.embracesdk.fakes.system.mockContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class DataSourceStateTest {
 
+    private val ctx = mockContext()
+
     @Test
     fun `null session type is never enabled`() {
-        val source = FakeDataSource()
+        val source = FakeDataSource(ctx)
         val state = DataSourceState(
             factory = { source },
             configGate = { true },
@@ -18,42 +21,42 @@ internal class DataSourceStateTest {
         // data capture is enabled by default.
         state.onConfigChange()
         state.onSessionTypeChange(null)
-        assertEquals(0, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(0, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
 
         // data capture enabled for a session
         state.onSessionTypeChange(SessionType.FOREGROUND)
-        assertEquals(1, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
 
         // data capture disabled for no session
         state.onSessionTypeChange(null)
-        assertEquals(1, source.registerCount)
-        assertEquals(1, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(1, source.disableDataCaptureCount)
 
         // functions can be called multiple times without issue
         state.onSessionTypeChange(SessionType.FOREGROUND)
         state.onSessionTypeChange(null)
-        assertEquals(2, source.registerCount)
-        assertEquals(2, source.unregisterCount)
+        assertEquals(2, source.enableDataCaptureCount)
+        assertEquals(2, source.disableDataCaptureCount)
     }
 
     @Test
     fun `test config gate defaults to enabled`() {
-        val source = FakeDataSource()
+        val source = FakeDataSource(ctx)
         DataSourceState(
             factory = { source },
             currentSessionType = SessionType.FOREGROUND
         )
 
         // data capture is enabled by default.
-        assertEquals(1, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
     }
 
     @Test
     fun `test config gate enabled by default`() {
-        val source = FakeDataSource()
+        val source = FakeDataSource(ctx)
         DataSourceState(
             factory = { source },
             configGate = { true },
@@ -61,13 +64,13 @@ internal class DataSourceStateTest {
         )
 
         // data capture is enabled by default.
-        assertEquals(1, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
     }
 
     @Test
     fun `test config gate affects data capture`() {
-        val source = FakeDataSource()
+        val source = FakeDataSource(ctx)
         var enabled = false
         val state = DataSourceState(
             factory = { source },
@@ -76,38 +79,38 @@ internal class DataSourceStateTest {
         )
 
         // data capture is disabled by default.
-        assertEquals(0, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(0, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
 
         // enabling the config gate should enable data capture
         enabled = true
         state.onConfigChange()
-        assertEquals(1, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
 
         // another config change should not reregister listeners
         state.onConfigChange()
-        assertEquals(1, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
 
         // deregistering works
         enabled = false
         state.onConfigChange()
-        assertEquals(1, source.registerCount)
-        assertEquals(1, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(1, source.disableDataCaptureCount)
 
         // functions can be called multiple times without issue
         enabled = true
         state.onConfigChange()
         enabled = false
         state.onConfigChange()
-        assertEquals(2, source.registerCount)
-        assertEquals(2, source.unregisterCount)
+        assertEquals(2, source.enableDataCaptureCount)
+        assertEquals(2, source.disableDataCaptureCount)
     }
 
     @Test
     fun `test session type affects data capture`() {
-        val source = FakeDataSource()
+        val source = FakeDataSource(ctx)
         val state = DataSourceState(
             factory = { source },
             configGate = { true },
@@ -116,25 +119,25 @@ internal class DataSourceStateTest {
         )
 
         // data capture is always disabled by default.
-        assertEquals(0, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(0, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
 
         // new session should enable data capture
         state.onSessionTypeChange(SessionType.FOREGROUND)
         state.onSessionTypeChange(SessionType.FOREGROUND)
-        assertEquals(1, source.registerCount)
-        assertEquals(0, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(0, source.disableDataCaptureCount)
 
         // extra payload types should not re-register listeners
         state.onSessionTypeChange(SessionType.BACKGROUND)
         state.onSessionTypeChange(SessionType.BACKGROUND)
-        assertEquals(1, source.registerCount)
-        assertEquals(1, source.unregisterCount)
+        assertEquals(1, source.enableDataCaptureCount)
+        assertEquals(1, source.disableDataCaptureCount)
 
         // functions can be called multiple times without issue
         state.onSessionTypeChange(SessionType.FOREGROUND)
         state.onSessionTypeChange(SessionType.BACKGROUND)
-        assertEquals(2, source.registerCount)
-        assertEquals(2, source.unregisterCount)
+        assertEquals(2, source.enableDataCaptureCount)
+        assertEquals(2, source.disableDataCaptureCount)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -1,24 +1,41 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.arch.DataSource
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.content.res.Configuration
+import io.embrace.android.embracesdk.arch.EventDataSource
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 
-internal class FakeDataSource : DataSource<CurrentSessionSpan> {
-    var registerCount = 0
-    var unregisterCount = 0
+internal class FakeDataSource(
+    private val ctx: Context
+) : EventDataSource, ComponentCallbacks2 {
+
+    var enableDataCaptureCount = 0
+    var disableDataCaptureCount = 0
 
     override fun captureData(action: CurrentSessionSpan.() -> Unit) {
         action(FakeCurrentSessionSpan())
     }
 
-    override fun registerListeners() {
+    override fun enableDataCapture() {
+        ctx.registerComponentCallbacks(this)
+        enableDataCaptureCount++
+    }
+
+    override fun disableDataCapture() {
+        ctx.unregisterComponentCallbacks(this)
+        disableDataCaptureCount++
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
         captureData {
             // TODO: interact with span here.
         }
-        registerCount++
     }
 
-    override fun unregisterListeners() {
-        unregisterCount++
+    override fun onLowMemory() {
+    }
+
+    override fun onTrimMemory(level: Int) {
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -20,6 +20,7 @@ import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.system.mockContext
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -72,7 +73,7 @@ internal class SessionOrchestratorTest {
         periodicSessionCacher = PeriodicSessionCacher(ScheduledWorker(sessionCacheExecutor))
         periodicBackgroundActivityCacher =
             PeriodicBackgroundActivityCacher(clock, ScheduledWorker(baCacheExecutor))
-        fakeDataSource = FakeDataSource()
+        fakeDataSource = FakeDataSource(mockContext())
         dataCaptureOrchestrator = DataCaptureOrchestrator(
             listOf(
                 DataSourceState(
@@ -115,7 +116,7 @@ internal class SessionOrchestratorTest {
         assertEquals(1, payloadFactory.startBaTimestamps.size)
         assertEquals("fake-activity", sessionIdTracker.sessionId)
         assertEquals(0, deliveryService.lastSentSessions.size)
-        assertEquals(1, fakeDataSource.registerCount)
+        assertEquals(1, fakeDataSource.enableDataCaptureCount)
     }
 
     @Test
@@ -126,7 +127,7 @@ internal class SessionOrchestratorTest {
         assertEquals(0, payloadFactory.startBaTimestamps.size)
         assertEquals("fakeSessionId", sessionIdTracker.sessionId)
         assertEquals(0, deliveryService.lastSentSessions.size)
-        assertEquals(1, fakeDataSource.registerCount)
+        assertEquals(1, fakeDataSource.enableDataCaptureCount)
     }
 
     @Test
@@ -138,7 +139,7 @@ internal class SessionOrchestratorTest {
         assertEquals(TIMESTAMP, payloadFactory.endBaTimestamps.single())
         assertEquals("fakeSessionId", sessionIdTracker.sessionId)
         assertEquals(1, deliveryService.lastSentSessions.size)
-        assertEquals(1, fakeDataSource.registerCount)
+        assertEquals(1, fakeDataSource.enableDataCaptureCount)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Renames functions on the `DataSource` interface to `enableDataCapture` and `disableDataCapture`. This is to better reflect their true function.

In this scheme the `DataSourceState` checks whether a single `DataSource` should be enabled, by calculating the current values of the remote config, and the current payload type (session vs background). It then calls `enableDataCapture` or `disableDataCapture` if required.

The `DataSource` implementation should register listeners & start capturing data after `enableDataCapture` is called, and do the opposite when `disableDataCapture` is called. I've added a warning that implementations should _not_ attempt to track the enabled state.

