### PR TITLE
[POC] Mutate current session span

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.Initializable
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.opentelemetry.api.trace.Span
 
 /**
  * Abstraction of the current session span
@@ -16,4 +17,10 @@ internal interface CurrentSessionSpan : Initializable {
      * Returns true if a span with the given parameters can be started in the current session
      */
     fun canStartNewSpan(parent: EmbraceSpan?, internal: Boolean): Boolean
+
+    /**
+     * Retrieves the current session span If a session span does not exist this will return
+     * null.
+     */
+    fun retrieveSessionSpan(): Span?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -123,6 +123,8 @@ internal class CurrentSessionSpanImpl(
         }
     }
 
+    override fun retrieveSessionSpan(): Span? = sessionSpan.get()
+
     /**
      * This method should always be used when starting a new session span
      */

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -4,11 +4,15 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.opentelemetry.api.trace.Span
 
 internal class FakeCurrentSessionSpan : CurrentSessionSpan {
 
     var initializedCallCount = 0
     override fun initializeService(sdkInitStartTimeNanos: Long) {
+    }
+
+    override fun retrieveSessionSpan(): Span? {
     }
 
     override fun initialized(): Boolean {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -29,7 +29,9 @@ internal class FakeDataSource(
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         captureData {
-            // TODO: interact with span here.
+            mutateSessionSpan {
+                setAttribute("orientation", newConfig.orientation.toString())
+            }
         }
     }
 


### PR DESCRIPTION
## Goal

This is a POC changeset that mutates the current session span. It is incomplete but it would be useful to answer the following questions:

1. Is this the sort of internal API that we would like to provide?
2. Is this the right way to obtain the current session span? If not, how should it be obtained?
3. Is synchronisation required when mutating? (I assume not for speed but added this in for completeness)
4. Should the internal API return a `Span`, or an `EmbraceSpan`? If an `EmbraceSpan`, what is the path forward to support converting the two types?

