### PR TITLE
Fix flakey SpanTest by allow better validation on FakeSpanExporter

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.math.min
+
+internal class FakeSpanExporter : SpanExporter {
+    val exportedSpans = mutableListOf<SpanData>()
+
+    private val latches = mutableListOf<CountDownLatch>()
+    private var totalExported = 0
+
+    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
+        synchronized(exportedSpans) {
+            exportedSpans.addAll(spans)
+            totalExported += spans.size
+            latches.forEach { latch ->
+                repeat(min(latch.count.toInt(), spans.size)) {
+                    latch.countDown()
+                }
+            }
+            latches.removeIf { it.count == 0L }
+        }
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun flush(): CompletableResultCode {
+        synchronized(exportedSpans) {
+            exportedSpans.clear()
+        }
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun shutdown(): CompletableResultCode {
+        return CompletableResultCode.ofSuccess()
+    }
+
+    /**
+     * Block the thread until the number of spans expected have been exported by this exporter since the last flush
+     */
+    fun awaitSpanExport(count: Int = 1, timeout: Long = 1, unit: TimeUnit = TimeUnit.SECONDS): Boolean {
+        return if (count <= totalExported) {
+            true
+        } else {
+            synchronized(exportedSpans) {
+                val latch = CountDownLatch(count)
+                latches.add(latch)
+                latch
+            }.await(timeout, unit)
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -3,16 +3,17 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.math.min
 
 @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
 @RunWith(AndroidJUnit4::class)
@@ -31,6 +32,7 @@ internal class SpanTest {
             val fakeSpanExporter = FakeSpanExporter()
             embrace.addSpanExporter(fakeSpanExporter)
             embrace.start(harness.fakeCoreModule.context)
+            fakeSpanExporter.awaitSpanExport()
             assertTrue(
                 fakeSpanExporter.exportedSpans.map { it.name }.containsAll(
                     listOf("emb-sdk-init")
@@ -47,17 +49,45 @@ internal class SpanTest {
 
 internal class FakeSpanExporter : SpanExporter {
     val exportedSpans = mutableListOf<SpanData>()
+    private val latches = mutableListOf<CountDownLatch>()
 
     override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
-        exportedSpans.addAll(spans)
+        synchronized(exportedSpans) {
+            exportedSpans.addAll(spans)
+            latches.forEach { latch ->
+                repeat(min(latch.count.toInt(), spans.size)) {
+                    latch.countDown()
+                }
+            }
+            latches.removeIf { it.count == 0L }
+        }
         return CompletableResultCode.ofSuccess()
     }
 
     override fun flush(): CompletableResultCode {
+        synchronized(exportedSpans) {
+            exportedSpans.clear()
+        }
         return CompletableResultCode.ofSuccess()
     }
 
     override fun shutdown(): CompletableResultCode {
         return CompletableResultCode.ofSuccess()
     }
+
+    /**
+     * Block the thread until the number of spans expected have been exported by this exporter since the last flush
+     */
+    fun awaitSpanExport(count: Int = 1, timeout: Long = 1, unit: TimeUnit = TimeUnit.SECONDS): Boolean {
+        return if (count <= exportedSpans.size) {
+            true
+        } else {
+            synchronized(exportedSpans) {
+                val latch = CountDownLatch(count)
+                latches.add(latch)
+                latch
+            }.await(timeout, unit)
+        }
+    }
+
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -3,17 +3,13 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.android.embracesdk.fakes.FakeSpanExporter
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import kotlin.math.min
 
 @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
 @RunWith(AndroidJUnit4::class)
@@ -32,62 +28,10 @@ internal class SpanTest {
             val fakeSpanExporter = FakeSpanExporter()
             embrace.addSpanExporter(fakeSpanExporter)
             embrace.start(harness.fakeCoreModule.context)
-            fakeSpanExporter.awaitSpanExport()
-            assertTrue(
-                fakeSpanExporter.exportedSpans.map { it.name }.containsAll(
-                    listOf("emb-sdk-init")
-                )
-            )
-            assertTrue(
-                fakeSpanExporter.exportedSpans.all { spanData ->
-                    spanData.attributes.asMap().map { it.key.key }.contains("emb.sequence_id")
-                }
-            )
+            assertTrue("Timed out waiting for the span to be exported", fakeSpanExporter.awaitSpanExport(1))
+            val exportedSpans = fakeSpanExporter.exportedSpans.filter { it.name == "emb-sdk-init" }
+            assertEquals(1, exportedSpans.size)
+            assertEquals(1, exportedSpans[0].attributes.asMap().keys.filter { it.key == "emb.sequence_id" }.size)
         }
     }
-}
-
-internal class FakeSpanExporter : SpanExporter {
-    val exportedSpans = mutableListOf<SpanData>()
-    private val latches = mutableListOf<CountDownLatch>()
-
-    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
-        synchronized(exportedSpans) {
-            exportedSpans.addAll(spans)
-            latches.forEach { latch ->
-                repeat(min(latch.count.toInt(), spans.size)) {
-                    latch.countDown()
-                }
-            }
-            latches.removeIf { it.count == 0L }
-        }
-        return CompletableResultCode.ofSuccess()
-    }
-
-    override fun flush(): CompletableResultCode {
-        synchronized(exportedSpans) {
-            exportedSpans.clear()
-        }
-        return CompletableResultCode.ofSuccess()
-    }
-
-    override fun shutdown(): CompletableResultCode {
-        return CompletableResultCode.ofSuccess()
-    }
-
-    /**
-     * Block the thread until the number of spans expected have been exported by this exporter since the last flush
-     */
-    fun awaitSpanExport(count: Int = 1, timeout: Long = 1, unit: TimeUnit = TimeUnit.SECONDS): Boolean {
-        return if (count <= exportedSpans.size) {
-            true
-        } else {
-            synchronized(exportedSpans) {
-                val latch = CountDownLatch(count)
-                latches.add(latch)
-                latch
-            }.await(timeout, unit)
-        }
-    }
-
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -28,7 +28,10 @@ internal class SpanTest {
             val fakeSpanExporter = FakeSpanExporter()
             embrace.addSpanExporter(fakeSpanExporter)
             embrace.start(harness.fakeCoreModule.context)
-            assertTrue("Timed out waiting for the span to be exported", fakeSpanExporter.awaitSpanExport(1))
+            assertTrue(
+                "Timed out waiting for the span to be exported: ${fakeSpanExporter.exportedSpans.map { it.name }}",
+                fakeSpanExporter.awaitSpanExport(1)
+            )
             val exportedSpans = fakeSpanExporter.exportedSpans.filter { it.name == "emb-sdk-init" }
             assertEquals(1, exportedSpans.size)
             assertEquals(1, exportedSpans[0].attributes.asMap().keys.filter { it.key == "emb.sequence_id" }.size)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.getSentBackgroundActivities
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.recordSession
-import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
@@ -35,6 +34,8 @@ internal class TracingApiTest {
         }
     )
 
+    private val results = mutableListOf<String>()
+
     @Test
     fun `check spans logged in the right session when service is initialized after a session starts`() {
         val testStartTime = testRule.harness.fakeClock.now()
@@ -43,7 +44,13 @@ internal class TracingApiTest {
             harness.fakeClock.tick(100L)
             embrace.addSpanExporter(spanExporter)
             embrace.start(harness.fakeCoreModule.context)
-            harness.recordSession {
+            results.add(
+                "\nCompleted spans in spansSink before session starts: ${
+                    harness.openTelemetryModule.spansSink.completedSpans().map { it.name }
+                }\n"
+            )
+            results.add("Spans exported before session starts: ${spanExporter.exportedSpans.toList().map { it.name }}\n")
+            val sessionMessage = harness.recordSession {
                 val parentSpan = checkNotNull(embrace.createSpan(name = "test-trace-root"))
                 assertTrue(parentSpan.start())
                 assertTrue(parentSpan.addAttribute("oMg", "OmG"))
@@ -89,23 +96,45 @@ internal class TracingApiTest {
                     )
                 )
                 harness.fakeClock.tick(300L)
+                results.add(
+                    "Completed spans in spansSink before ending startup: ${
+                        harness.openTelemetryModule.spansSink.completedSpans().map { it.name }
+                    }\n"
+                )
+                results.add("Spans exported before ending startup: ${spanExporter.exportedSpans.toList().map { it.name }}\n")
                 embrace.endAppStartup()
-                // There should be at least 5 spans exported at this point, so we wait for the startup moment span to finish up.
-                assertTrue("Timed out waiting for all the spans to be exported", spanExporter.awaitSpanExport(count = 5))
             }
+            results.add(
+                "Completed spans in spansSink after session ends: ${
+                    harness.openTelemetryModule.spansSink.completedSpans().map { it.name }
+                }\n"
+            )
+            results.add("Spans exported after session ends: ${spanExporter.exportedSpans.toList().map { it.name }}\n")
             val sessionEndTime = harness.fakeClock.now()
             assertEquals(2, harness.fakeDeliveryModule.deliveryService.lastSentSessions.size)
-            val sessionMessage = harness.fakeDeliveryModule.deliveryService.lastSentSessions[1]
-            assertEquals(SessionSnapshotType.NORMAL_END, sessionMessage.second)
             val allSpans = getSdkInitSpanFromBackgroundActivity() +
-                checkNotNull(sessionMessage.first.spans) +
+                checkNotNull(sessionMessage?.spans) +
                 checkNotNull(harness.openTelemetryModule.spansSink.completedSpans())
 
-            // There should be 6 total spans here, with the 5 from before the session ended, plus the session span
-            assertTrue("Timed out waiting for the session span to be exported", spanExporter.awaitSpanExport(count = 6))
             val spansMap = allSpans.associateBy { it.name }
             val sessionSpan = checkNotNull(spansMap["emb-session-span"])
             val traceRootSpan = checkNotNull(spansMap["test-trace-root"])
+
+            results.add("All spans to validate: ${allSpans.map { it.name }}\n")
+            results.add("Filtered set of spans to validate: ${spansMap.keys.map { it }}\n")
+            results.add("Spans exported before validation: ${spanExporter.exportedSpans.toList().map { it.name }}\n")
+            val expectedSpanName = listOf(
+                "emb-sdk-init",
+                "test-trace-root",
+                "record-span-span",
+                "completed-span",
+                "emb-startup-moment",
+                "emb-session-span",
+            )
+            expectedSpanName.forEach {
+                checkNotNull(spansMap[it]) { "$it not found: $results" }
+            }
+
             assertEmbraceSpanData(
                 span = spansMap["emb-sdk-init"],
                 expectedStartTimeMs = testStartTime + 100,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -4,6 +4,7 @@ import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
+import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.getSentBackgroundActivities
@@ -37,8 +38,10 @@ internal class TracingApiTest {
     @Test
     fun `check spans logged in the right session when service is initialized after a session starts`() {
         val testStartTime = testRule.harness.fakeClock.now()
+        val spanExporter = FakeSpanExporter()
         with(testRule) {
             harness.fakeClock.tick(100L)
+            embrace.addSpanExporter(spanExporter)
             embrace.start(harness.fakeCoreModule.context)
             harness.recordSession {
                 val parentSpan = checkNotNull(embrace.createSpan(name = "test-trace-root"))
@@ -86,13 +89,9 @@ internal class TracingApiTest {
                     )
                 )
                 harness.fakeClock.tick(300L)
-                assertEquals("Wrong number of background activity spans", 1, getSdkInitSpanFromBackgroundActivity().size)
-                assertEquals(
-                    "Wrong number of completed spans in the session",
-                    3,
-                    harness.openTelemetryModule.spansSink.completedSpans().size
-                )
                 embrace.endAppStartup()
+                // There should be at least 5 spans exported at this point, so we wait for the startup moment span to finish up.
+                assertTrue("Timed out waiting for all the spans to be exported", spanExporter.awaitSpanExport(count = 5))
             }
             val sessionEndTime = harness.fakeClock.now()
             assertEquals(2, harness.fakeDeliveryModule.deliveryService.lastSentSessions.size)
@@ -101,7 +100,9 @@ internal class TracingApiTest {
             val allSpans = getSdkInitSpanFromBackgroundActivity() +
                 checkNotNull(sessionMessage.first.spans) +
                 checkNotNull(harness.openTelemetryModule.spansSink.completedSpans())
-            assertEquals(6, allSpans.size)
+
+            // There should be 6 total spans here, with the 5 from before the session ended, plus the session span
+            assertTrue("Timed out waiting for the session span to be exported", spanExporter.awaitSpanExport(count = 6))
             val spansMap = allSpans.associateBy { it.name }
             val sessionSpan = checkNotNull(spansMap["emb-session-span"])
             val traceRootSpan = checkNotNull(spansMap["test-trace-root"])


### PR DESCRIPTION
## Goal

Track the count of the numbers of spans exported and a method that waits for that value or times out. This fixes the flakiness for SpanTest but TracingApiTest is still flakey, which actually might be pointing to an actual race condition in the code that still needs to be addressed.

## Testing

Existing tests shouldn't be flakey