### PR TITLE
Fix flakey tracing publicly API by asserting on the number of spans processed by the exporter

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.math.min
+
+internal class FakeSpanExporter : SpanExporter {
+    val exportedSpans = mutableListOf<SpanData>()
+
+    private val latches = mutableListOf<CountDownLatch>()
+    private var totalExported = 0
+
+    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
+        synchronized(exportedSpans) {
+            exportedSpans.addAll(spans)
+            totalExported += spans.size
+            latches.forEach { latch ->
+                repeat(min(latch.count.toInt(), spans.size)) {
+                    latch.countDown()
+                }
+            }
+            latches.removeIf { it.count == 0L }
+        }
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun flush(): CompletableResultCode {
+        synchronized(exportedSpans) {
+            exportedSpans.clear()
+        }
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun shutdown(): CompletableResultCode {
+        return CompletableResultCode.ofSuccess()
+    }
+
+    /**
+     * Block the thread until the number of spans expected have been exported by this exporter since the last flush
+     */
+    fun awaitSpanExport(count: Int = 1, timeout: Long = 1, unit: TimeUnit = TimeUnit.SECONDS): Boolean {
+        return if (count <= totalExported) {
+            true
+        } else {
+            synchronized(exportedSpans) {
+                val latch = CountDownLatch(count)
+                latches.add(latch)
+                latch
+            }.await(timeout, unit)
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -3,17 +3,12 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.export.SpanExporter
-import org.junit.Assert.assertTrue
+import io.embrace.android.embracesdk.fakes.FakeSpanExporter
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import kotlin.math.min
 
 @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
 @RunWith(AndroidJUnit4::class)
@@ -33,61 +28,9 @@ internal class SpanTest {
             embrace.addSpanExporter(fakeSpanExporter)
             embrace.start(harness.fakeCoreModule.context)
             fakeSpanExporter.awaitSpanExport()
-            assertTrue(
-                fakeSpanExporter.exportedSpans.map { it.name }.containsAll(
-                    listOf("emb-sdk-init")
-                )
-            )
-            assertTrue(
-                fakeSpanExporter.exportedSpans.all { spanData ->
-                    spanData.attributes.asMap().map { it.key.key }.contains("emb.sequence_id")
-                }
-            )
+            val exportedSpans = fakeSpanExporter.exportedSpans.filter { it.name == "emb-sdk-init" }
+            assertEquals(1, exportedSpans.size)
+            assertEquals(1, exportedSpans[0].attributes.asMap().keys.filter { it.key == "emb.sequence_id" }.size)
         }
     }
-}
-
-internal class FakeSpanExporter : SpanExporter {
-    val exportedSpans = mutableListOf<SpanData>()
-    private val latches = mutableListOf<CountDownLatch>()
-
-    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
-        synchronized(exportedSpans) {
-            exportedSpans.addAll(spans)
-            latches.forEach { latch ->
-                repeat(min(latch.count.toInt(), spans.size)) {
-                    latch.countDown()
-                }
-            }
-            latches.removeIf { it.count == 0L }
-        }
-        return CompletableResultCode.ofSuccess()
-    }
-
-    override fun flush(): CompletableResultCode {
-        synchronized(exportedSpans) {
-            exportedSpans.clear()
-        }
-        return CompletableResultCode.ofSuccess()
-    }
-
-    override fun shutdown(): CompletableResultCode {
-        return CompletableResultCode.ofSuccess()
-    }
-
-    /**
-     * Block the thread until the number of spans expected have been exported by this exporter since the last flush
-     */
-    fun awaitSpanExport(count: Int = 1, timeout: Long = 1, unit: TimeUnit = TimeUnit.SECONDS): Boolean {
-        return if (count <= exportedSpans.size) {
-            true
-        } else {
-            synchronized(exportedSpans) {
-                val latch = CountDownLatch(count)
-                latches.add(latch)
-                latch
-            }.await(timeout, unit)
-        }
-    }
-
 }


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

