### PR TITLE
Allow a list of attributes and events to be passed in when creating span via lambda

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -64,7 +64,9 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;)Z
 	public fun recordCompletedSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;)Z
 	public fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
+	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun recordSpan (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun recordSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun removeSessionProperty (Ljava/lang/String;)Z
 	public fun setAppId (Ljava/lang/String;)Z

--- a/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
+++ b/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
@@ -266,10 +266,26 @@ public class NullParametersTest {
     }
 
     @Test
-    public void testRecordSpan3Parameters() {
+    public void testRecordSpanWithAttributesAndEvents() {
+        assertTrue(embrace.recordSpan(null, null, null, () -> true));
+        assertError("recordSpan");
+        assertNull(embrace.recordSpan("test-span", null, null, null));
+        assertError("recordSpan");
+    }
+
+    @Test
+    public void testRecordSpanWithParent() {
         assertTrue(embrace.recordSpan(null, null, () -> true));
         assertError("recordSpan");
         assertNull(embrace.recordSpan("test-span", null, null));
+        assertError("recordSpan");
+    }
+
+    @Test
+    public void testRecordSpanWithParentAttributesAndEvents() {
+        assertTrue(embrace.recordSpan(null, null, null, null, () -> true));
+        assertError("recordSpan");
+        assertNull(embrace.recordSpan("test-span", null, null, null, null));
         assertError("recordSpan");
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -443,17 +443,25 @@ public final class Embrace implements EmbraceAndroidApi {
 
     @Override
     public <T> T recordSpan(@NonNull String name, @NonNull Function0<? extends T> code) {
-        if (verifyNonNullParameters("recordSpan", name, code)) {
-            return impl.tracer.recordSpan(name, code);
-        }
-
-        return code != null ? code.invoke() : null;
+        return recordSpan(name, null, null, null, code);
     }
 
     @Override
     public <T> T recordSpan(@NonNull String name, @Nullable EmbraceSpan parent, @NonNull Function0<? extends T> code) {
+        return recordSpan(name, parent, null, null, code);
+    }
+
+    @Override
+    public <T> T recordSpan(@NonNull String name, @Nullable Map<String, String> attributes,
+                            @Nullable List<EmbraceSpanEvent> events, @NonNull Function0<? extends T> code) {
+        return recordSpan(name, null, attributes, events, code);
+    }
+
+    @Override
+    public <T> T recordSpan(@NonNull String name, @Nullable EmbraceSpan parent, @Nullable Map<String, String> attributes,
+                            @Nullable List<EmbraceSpanEvent> events, @NonNull Function0<? extends T> code) {
         if (verifyNonNullParameters("recordSpan", name, code)) {
-            return impl.tracer.recordSpan(name, parent, code);
+            return impl.tracer.recordSpan(name, parent, attributes, events, code);
         }
 
         return code != null ? code.invoke() : null;
@@ -472,49 +480,29 @@ public final class Embrace implements EmbraceAndroidApi {
 
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos) {
-        if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos);
-        }
-
-        return false;
+        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, null, null, null, null);
     }
 
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable ErrorCode errorCode) {
-        if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode);
-        }
-
-        return false;
+        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, null, null, null);
     }
 
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable EmbraceSpan parent) {
-        if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, parent);
-        }
-
-        return false;
+        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, null, parent, null, null);
     }
 
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable ErrorCode errorCode,
                                        @Nullable EmbraceSpan parent) {
-        if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent);
-        }
-
-        return false;
+        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent, null, null);
     }
 
     @Override
     public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos,
                                        @Nullable Map<String, String> attributes, @Nullable List<EmbraceSpanEvent> events) {
-        if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, attributes, events);
-        }
-
-        return false;
+        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, null, null, attributes, events);
     }
 
     @Nullable

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
@@ -49,8 +49,18 @@ internal class EmbraceSpansService(
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean,
+        attributes: Map<String, String>,
+        events: List<EmbraceSpanEvent>,
         code: () -> T
-    ): T = currentDelegate.recordSpan(name = name, parent = parent, type = type, internal = internal, code = code)
+    ): T = currentDelegate.recordSpan(
+        name = name,
+        parent = parent,
+        type = type,
+        internal = internal,
+        attributes = attributes,
+        events = events,
+        code = code
+    )
 
     override fun recordCompletedSpan(
         name: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -20,15 +20,38 @@ internal class EmbraceTracer(
             internal = false
         )
 
-    override fun <T> recordSpan(name: String, code: () -> T): T = recordSpan(name = name, parent = null, code = code)
+    override fun <T> recordSpan(
+        name: String,
+        code: () -> T
+    ): T = recordSpan(name = name, parent = null, attributes = null, events = null, code = code)
 
-    override fun <T> recordSpan(name: String, parent: EmbraceSpan?, code: () -> T): T =
-        spansService.recordSpan(
-            name = name,
-            parent = parent,
-            internal = false,
-            code = code
-        )
+    override fun <T> recordSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        code: () -> T
+    ): T = recordSpan(name = name, parent = parent, attributes = null, events = null, code = code)
+
+    override fun <T> recordSpan(
+        name: String,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?,
+        code: () -> T
+    ): T = recordSpan(name = name, parent = null, attributes = attributes, events = events, code = code)
+
+    override fun <T> recordSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?,
+        code: () -> T
+    ): T = spansService.recordSpan(
+        name = name,
+        parent = parent,
+        attributes = attributes ?: emptyMap(),
+        events = events ?: emptyList(),
+        internal = false,
+        code = code
+    )
 
     override fun recordCompletedSpan(name: String, startTimeNanos: Long, endTimeNanos: Long): Boolean =
         recordCompletedSpan(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -40,6 +40,8 @@ internal class InternalTracer(
             embraceTracer.recordSpan(
                 name = name,
                 parent = parent.spanReference,
+                attributes = attributes,
+                events = events?.mapNotNull { mapToEvent(it) },
                 code = code
             )
         } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpansService.kt
@@ -29,6 +29,8 @@ internal interface SpansService : Initializable {
         parent: EmbraceSpan? = null,
         type: EmbraceAttributes.Type = EmbraceAttributes.Type.PERFORMANCE,
         internal: Boolean = true,
+        attributes: Map<String, String> = emptyMap(),
+        events: List<EmbraceSpanEvent> = emptyList(),
         code: () -> T
     ): T
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpansService.kt
@@ -26,6 +26,8 @@ internal class UninitializedSdkSpansService : SpansService {
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean,
+        attributes: Map<String, String>,
+        events: List<EmbraceSpanEvent>,
         code: () -> T
     ) = code()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -53,6 +53,35 @@ internal interface TracingApi {
     ): T
 
     /**
+     * Execute the given block of code and record a new trace around it with optional attributes and list of [EmbraceSpanEvent]. If the span
+     * cannot be created, the block of code will still run and return correctly. If an exception or error is thrown inside the block,
+     * the span will end at the point of the throw and the [Throwable] will be rethrown.
+     */
+    @BetaApi
+    fun <T> recordSpan(
+        name: String,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?,
+        code: () -> T
+    ): T
+
+    /**
+     * Execute the given block of code and record a new span around it with the given parent with optional attributes and list
+     * of [EmbraceSpanEvent]. Passing in a parent that is null will result in a new trace with the new span as its root. If the span
+     * cannot be created, the block of code will still run and return correctly. If an exception or error is thrown inside the block,
+     * the span will end at the point of the throw and the
+     * [Throwable] will be rethrown.
+     */
+    @BetaApi
+    fun <T> recordSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?,
+        code: () -> T
+    ): T
+
+    /**
      * Record a span with the given name as well as start and end times, which will be the root span of a new trace.
      */
     @BetaApi

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpansService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpansService.kt
@@ -27,6 +27,8 @@ internal class FakeSpansService : SpansService {
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean,
+        attributes: Map<String, String>,
+        events: List<EmbraceSpanEvent>,
         code: () -> T
     ): T {
         return code()


### PR DESCRIPTION
## Goal

Add the ability to pass in attributes and events in the public API and internal tracing API used by hosted SDKs.  `SpansService` already supports it - so it's about plumbing this through the APIs

## Testing

Added appropriate tests in the layers where new APIs were introduced.

