### PR TITLE
Use new m1 mac runners for CI

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -10,12 +10,11 @@ on:
 
 jobs:
   gradle-test:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 30
     strategy:
       matrix:
         jdk-version: ["17"]
-        ndk-version: ["21.4.7075529"]
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v4
@@ -38,13 +37,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.jdk-version }}
-
-      - name: Setup NDK ${{ matrix.ndk-version }}
-        run: |
-          export ANDROID_ROOT=/usr/local/lib/android
-          export ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-          export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-          ln -sfn $ANDROID_SDK_ROOT/ndk/${{ matrix.ndk-version }} $ANDROID_NDK_ROOT
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2


### PR DESCRIPTION
## Goal

Updates the CI runner to [use M1 macs](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/). This should be faster than the existing runner & is free for public repos.

