### PR TITLE
Store logcat logs as artefact for CI test failures

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -82,7 +82,7 @@ jobs:
           profile: Nexus 6
           # Grab the failures from the device so we can include them in results.
           # Exit with non-zero so GH checks still fail.
-          script: ./gradlew connectedCheck --stacktrace || (adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/ && exit 127)
+          script: ./gradlew connectedCheck --stacktrace || (adb logcat '[Embrace]:d' '*:S' -t 100000 > emulator_logcat.log && adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/ && exit 127)
 
       - name: Retry Functional Tests
         uses: embrace-io/android-emulator-runner@v2
@@ -95,7 +95,7 @@ jobs:
           profile: Nexus 6
           # Grab the failures from the device so we can include them in results.
           # Exit with non-zero so GH checks still fail.
-          script: ./gradlew connectedCheck --stacktrace || (adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/ && exit 127)
+          script: ./gradlew connectedCheck --stacktrace || (adb logcat '[Embrace]:d' '*:S' -t 100000 > emulator_logcat.log && adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/ && exit 127)
 
       - name: Archive Test Results
         if: ${{ always() }}
@@ -105,6 +105,7 @@ jobs:
           path: |
             embrace-android-sdk/build/reports/androidTests/connected
             test_failure
+            emulator_logcat.log
 
       - name: Post workflow result
         id: slack

--- a/embrace-android-sdk/src/androidTest/java/TestLogger.kt
+++ b/embrace-android-sdk/src/androidTest/java/TestLogger.kt
@@ -1,0 +1,8 @@
+import android.util.Log
+
+// use same tag value so that we can filter logs in logcat on CI job
+private const val LOG_TAG = "[Embrace]"
+
+internal fun logTestMessage(message: String) {
+    Log.w(LOG_TAG, message)
+}

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/AnrIntegrationTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/AnrIntegrationTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk
 
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -11,6 +10,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPInputStream
+import logTestMessage
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -152,7 +152,7 @@ internal class AnrIntegrationTest : BaseTest() {
             }
 
             handler.post {
-                Log.i("Embrace", "Starting first ANR interval")
+                logTestMessage("Starting first ANR interval")
                 Thread.sleep(8000)
                 latch.countDown()
                 scheduleNextMainThreadWork { produceSecondAnrInterval() }
@@ -161,35 +161,35 @@ internal class AnrIntegrationTest : BaseTest() {
     }
 
     private fun produceSecondAnrInterval() {
-        Log.i("Embrace", "Starting second ANR interval")
+        logTestMessage("Starting second ANR interval")
         Thread.sleep(2000)
         latch.countDown()
         scheduleNextMainThreadWork { produceThirdAnrInterval() }
     }
 
     private fun produceThirdAnrInterval() {
-        Log.i("Embrace", "Starting third ANR interval")
+        logTestMessage("Starting third ANR interval")
         Thread.sleep(3000)
         latch.countDown()
         scheduleNextMainThreadWork { produceFourthAnrInterval() }
     }
 
     private fun produceFourthAnrInterval() {
-        Log.i("Embrace", "Starting fourth ANR interval")
+        logTestMessage("Starting fourth ANR interval")
         Thread.sleep(3000)
         latch.countDown()
         scheduleNextMainThreadWork { produceFifthAnrInterval() }
     }
 
     private fun produceFifthAnrInterval() {
-        Log.i("Embrace", "Starting fifth ANR interval")
+        logTestMessage("Starting fifth ANR interval")
         Thread.sleep(3000)
         latch.countDown()
         scheduleNextMainThreadWork { produceSixthAnrInterval() }
     }
 
     private fun produceSixthAnrInterval() {
-        Log.i("Embrace", "Starting sixth ANR interval")
+        logTestMessage("Starting sixth ANR interval")
         Thread.sleep(3000)
         latch.countDown()
     }

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import java.io.File
 import java.io.IOException
+import logTestMessage
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -25,6 +26,7 @@ internal class LogMessageTest : BaseTest() {
 
     @Test
     fun logInfoTest() {
+        logTestMessage("Adding info log to Embrace.")
         Embrace.getInstance().logInfo("Test log info")
 
         waitForRequest { request ->
@@ -34,9 +36,10 @@ internal class LogMessageTest : BaseTest() {
 
     @Test
     fun logInfoWithPropertyTest() {
+        logTestMessage("Adding info log to Embrace.")
+
         val properties = HashMap<String, Any>()
         properties["info"] = "test property"
-
         Embrace.getInstance().logMessage("Test log info with property", Severity.INFO, properties)
 
         waitForRequest { request ->
@@ -56,12 +59,13 @@ internal class LogMessageTest : BaseTest() {
             assert(pendingApiCallFileName.isNotBlank())
             readFileContent("Test log info fail", pendingApiCallFileName)
         } catch (e: IOException) {
-            fail("IOException error: ${e.message}")
+            throw IllegalStateException("Failed to validate file context", e)
         }
     }
 
     @Test
     fun logErrorTest() {
+        logTestMessage("Adding error log to Embrace.")
         Embrace.getInstance().logError("Test log error")
 
         waitForRequest { request ->
@@ -71,6 +75,7 @@ internal class LogMessageTest : BaseTest() {
 
     @Test
     fun logErrorWithPropertyTest() {
+        logTestMessage("Adding error log to Embrace.")
         val properties = HashMap<String, Any>()
         properties["error"] = "test property"
 
@@ -83,6 +88,7 @@ internal class LogMessageTest : BaseTest() {
 
     @Test
     fun logExceptionTest() {
+        logTestMessage("Adding exception log to Embrace.")
         Embrace.getInstance().logException(Exception("Another log error"))
 
         waitForRequest { request ->
@@ -92,6 +98,7 @@ internal class LogMessageTest : BaseTest() {
 
     @Test
     fun logErrorWithExceptionAndMessageTest() {
+        logTestMessage("Adding exception log to Embrace.")
         val exception = java.lang.NullPointerException("Exception message")
         Embrace.getInstance().logException(exception, Severity.ERROR, mapOf(), "log message")
 
@@ -105,6 +112,7 @@ internal class LogMessageTest : BaseTest() {
 
     @Test
     fun logWarningTest() {
+        logTestMessage("Adding warning log to Embrace.")
         Embrace.getInstance().logWarning("Test log warning")
 
         waitForRequest { request ->

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import java.io.File
 import java.io.IOException
+import logTestMessage
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -30,6 +31,7 @@ internal class MomentMessageTest : BaseTest() {
     @Test
     fun customMomentTest() {
         // Send start moment
+        logTestMessage("Starting start moment to Embrace.")
         Embrace.getInstance().startMoment(MOMENT_NAME)
 
         // Validate start moment request
@@ -38,6 +40,7 @@ internal class MomentMessageTest : BaseTest() {
         }
 
         // Send end moment
+        logTestMessage("Ending start moment to Embrace.")
         Embrace.getInstance().endMoment(MOMENT_NAME)
 
         // Validate end moment request
@@ -52,9 +55,11 @@ internal class MomentMessageTest : BaseTest() {
     @Test
     fun startMomentWithPropertiesTest() {
         // ignore startup event
+        logTestMessage("Ending appStartup moment in Embrace.")
         Embrace.getInstance().endAppStartup()
         waitForRequest()
 
+        logTestMessage("Sending moment in Embrace.")
         val properties = HashMap<String, Any>()
         properties["key1"] = "value1"
         properties["key2"] = "value2"
@@ -71,6 +76,7 @@ internal class MomentMessageTest : BaseTest() {
         }
 
         // Send end moment
+        logTestMessage("Ending moment in Embrace.")
         Embrace.getInstance().endMoment(MOMENT_NAME)
 
         // Validate end moment request

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/SessionMessageTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk
 
+import logTestMessage
 import org.junit.Before
 import org.junit.Test
 
@@ -15,6 +16,7 @@ internal class SessionMessageTest : BaseTest() {
      */
     @Test
     fun sessionEndMessageTest() {
+        logTestMessage("Adding core web vitals")
         addCoreWebVitals()
         sendBackground()
 

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/utils/JsonValidator.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/utils/JsonValidator.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.utils
 
-import android.util.Log
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
@@ -9,6 +8,7 @@ import com.google.gson.JsonPrimitive
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets
+import logTestMessage
 
 /**
  * Performs a comparison between two Json sources.
@@ -29,8 +29,7 @@ internal object JsonValidator {
     private fun areJsonStringEquals(expected: String, observed: String): Boolean {
         val expectedJson = JsonParser.parseString(expected)
         val observedJson = JsonParser.parseString(observed)
-        Log.i(
-            JsonValidator.javaClass.simpleName,
+        logTestMessage(
             "Expected JSON: $expectedJson. \n Actual JSON: $observedJson"
         )
 
@@ -73,29 +72,26 @@ internal object JsonValidator {
         if (entrySet1 != null && entrySet2 != null && entrySet2.size == entrySet1.size) {
             entrySet1.forEachIndexed { _, entry ->
                 try {
-                    Log.e(JsonValidator.javaClass.simpleName, "entry.key " + entry.key)
+                    logTestMessage("entry.key " + entry.key)
                     jsonObject2.get(entry.key)
                 } catch (ex: Exception) {
-                    Log.e(JsonValidator.javaClass.simpleName, "entry.key " + entry.key)
+                    logTestMessage("entry.key " + entry.key)
                 }
                 try {
                     if (!areJsonElementsEquals(entry.value, jsonObject2.get(entry.key))) {
-                        Log.e(
-                            JsonValidator.javaClass.simpleName,
-                            "Match failed for key: ${entry.key}"
-                        )
+                        logTestMessage("Match failed for key: ${entry.key}")
                         return false
                     }
                 } catch (ex: Exception) {
-                    Log.e(JsonValidator.javaClass.simpleName, "entry.key " + entry.key)
+                    logTestMessage("entry.key " + entry.key)
                     return false
                 }
             }
             return true
         } else {
-            Log.e(JsonValidator.javaClass.simpleName, "Different entry set size.")
-            Log.e(JsonValidator.javaClass.simpleName, "expected jsonObject1: " + jsonObject1.size() + " " + jsonObject1)
-            Log.e(JsonValidator.javaClass.simpleName, "observed jsonObject2: " + jsonObject2.size() + " " + jsonObject2)
+            logTestMessage("Different entry set size.")
+            logTestMessage("expected jsonObject1: " + jsonObject1.size() + " " + jsonObject1)
+            logTestMessage("observed jsonObject2: " + jsonObject2.size() + " " + jsonObject2)
             return false
         }
     }
@@ -106,16 +102,13 @@ internal object JsonValidator {
      */
     private fun areJsonArraysEquals(jsonArray1: JsonArray, jsonArray2: JsonArray): Boolean {
         if (jsonArray1.size() != jsonArray2.size()) {
-            Log.e(JsonValidator.javaClass.simpleName, "Different arrays size.")
+            logTestMessage("Different arrays size.")
             return false
         }
 
         jsonArray1.forEachIndexed { index, entry ->
             if (!areJsonElementsEquals(entry, jsonArray2.get(index))) {
-                Log.e(
-                    JsonValidator.javaClass.simpleName,
-                    "Different array value at position: $index."
-                )
+                logTestMessage("Different array value at position: $index.")
                 return false
             }
         }
@@ -131,8 +124,7 @@ internal object JsonValidator {
     ): Boolean {
         val arePrimitiveEquals = jsonPrimitive1 == jsonPrimitive2
         if (!arePrimitiveEquals) {
-            Log.e(
-                JsonValidator.javaClass.simpleName,
+            logTestMessage(
                 "Different values. Expected: ${jsonPrimitive1.asJsonPrimitive} " +
                     "Actual: ${jsonPrimitive2.asJsonPrimitive}"
             )


### PR DESCRIPTION
## Goal

When the functional tests fail this alters the workflow so that the logcat output is stored as an artefact. This should make it easier to debug what goes wrong, although we might need to add some additional logging of our own.

I added some extra logging & also increased the timeout for when an API call is expected to fail, as 1s seems a little low for a call to fail, be serialized to disk, and then flushed again.
