### PR TITLE
[WIP] Run functional tests on m1 mac runner

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -16,12 +16,11 @@ env:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 45
     strategy:
       matrix:
         jdk-version: ["17"]
-        ndk-version: ["21.4.7075529"]
         api-level: [29]
         target: [default]
 


### PR DESCRIPTION
## Goal

#405 runs CI using M1 macs. This changeset does the same for the functional tests.
