### PR TITLE
Model session span as Embrace Span

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -3,8 +3,6 @@ package io.embrace.android.embracesdk.internal.spans
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.telemetry.TelemetryService
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.TimeUnit
@@ -26,7 +24,7 @@ internal class CurrentSessionSpanImpl(
     /**
      * The span that models the lifetime of the current session or background activity
      */
-    private val sessionSpan: AtomicReference<Span?> = AtomicReference(null)
+    private val sessionSpan: AtomicReference<EmbraceSpan?> = AtomicReference(null)
 
     override fun initializeService(sdkInitStartTimeNanos: Long) {
         synchronized(sessionSpan) {
@@ -67,15 +65,21 @@ internal class CurrentSessionSpanImpl(
             // Right now, session spans don't survive native crashes and sudden process terminations,
             // so telemetry will not be recorded in those cases, for now.
             val telemetryAttributes = telemetryService.getAndClearTelemetryAttributes()
-            endingSessionSpan.setAllAttributes(Attributes.builder().fromMap(telemetryAttributes).build())
+
+            telemetryAttributes.forEach {
+                endingSessionSpan.addAttribute(it.key, it.value)
+            }
 
             if (appTerminationCause == null) {
-                endingSessionSpan.endSpan()
+                endingSessionSpan.stop()
                 spansRepository.clearCompletedSpans()
                 sessionSpan.set(startSessionSpan(clock.now()))
             } else {
-                endingSessionSpan.setAttribute(appTerminationCause.keyName(), appTerminationCause.name)
-                endingSessionSpan.endSpan()
+                endingSessionSpan.addAttribute(
+                    appTerminationCause.keyName(),
+                    appTerminationCause.name
+                )
+                endingSessionSpan.stop()
             }
             return spansSink.flushSpans()
         }
@@ -84,11 +88,19 @@ internal class CurrentSessionSpanImpl(
     /**
      * This method should always be used when starting a new session span
      */
-    private fun startSessionSpan(startTimeNanos: Long): Span {
+    private fun startSessionSpan(startTimeNanos: Long): EmbraceSpan {
         traceCount.set(0)
-        return createEmbraceSpanBuilder(tracer = tracerSupplier(), name = "session-span", type = EmbraceAttributes.Type.SESSION)
+
+        val spanBuilder = createEmbraceSpanBuilder(
+            tracer = tracerSupplier(),
+            name = "session-span",
+            type = EmbraceAttributes.Type.SESSION
+        )
             .setNoParent()
             .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
-            .startSpan()
+
+        return EmbraceSpanImpl(spanBuilder, sessionSpan = true).apply {
+            start()
+        }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -14,11 +14,14 @@ import java.util.concurrent.atomic.AtomicReference
 internal class EmbraceSpanImpl(
     private val spanBuilder: SpanBuilder,
     override val parent: EmbraceSpan? = null,
-    private val spansRepository: SpansRepository? = null
+    private val spansRepository: SpansRepository? = null,
+    sessionSpan: Boolean = false
 ) : EmbraceSpan {
 
     init {
-        spanBuilder.updateParent(parent)
+        if (!sessionSpan) {
+            spanBuilder.updateParent(parent)
+        }
     }
 
     private val startedSpan: AtomicReference<Span?> = AtomicReference(null)


### PR DESCRIPTION
## Goal

Models the session span as an `EmbraceSpan` rather than a `Span`. This will allow us to use the `EmbraceSpan` internally when capturing span events + attributes from data sources.

This was mostly a 1:1 conversion of switching out function names, with the exception of adding an optional param to `EmbraceSpanImpl` that prevents an undesired attribute from being added to the span. I also purposely avoided tracking the session span in the `SpansRepository` as I assume this might have undesirable consequences.

## Testing

I relied on existing test coverage.
