### PR TITLE
Add functions for writing to the session span

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -41,7 +41,7 @@ internal interface DataSource<T> {
  * A [DataSource] that adds either a [EmbraceSpanEvent] or [EmbraceSpanAttribute]
  * to the current session span.
  */
-internal typealias EventDataSource = DataSource<CurrentSessionSpan>
+internal typealias EventDataSource = DataSource<SessionSpanWriter>
 
 /**
  * A [DataSource] that adds or alters a new span on the [SpansService]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionSpanWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionSpanWriter.kt
@@ -1,0 +1,29 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+
+/**
+ * Declares functions for writing an [EmbraceSpanEvent] or attributes to the current session span.
+ */
+internal interface SessionSpanWriter {
+
+    /**
+     * Add an [EmbraceSpanEvent] with the given [name]. If [timeNanos] is null, the
+     * current time will be used. Optionally, the specific
+     * time of the event and a set of attributes can be passed in associated with the event.
+     *
+     * Returns true if the event was added, otherwise false.
+     */
+    fun addEvent(
+        name: String,
+        timeNanos: Long? = null,
+        attributes: Map<String, String>? = null
+    ): Boolean
+
+    /**
+     * Add the given key-value pair as an Attribute to the Event.
+     *
+     * Returns true if the attribute was added, otherwise false.
+     */
+    fun addAttribute(key: String, value: String): Boolean
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -1,12 +1,13 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.Initializable
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
  * Abstraction of the current session span
  */
-internal interface CurrentSessionSpan : Initializable {
+internal interface CurrentSessionSpan : Initializable, SessionSpanWriter {
     /**
      * End the current session span and start a new one if the app is not terminating
      */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.telemetry.TelemetryService
@@ -15,7 +16,8 @@ internal class CurrentSessionSpanImpl(
     private val spansRepository: SpansRepository,
     private val spansSink: SpansSink,
     private val tracerSupplier: Provider<Tracer>,
-) : CurrentSessionSpan {
+) : CurrentSessionSpan, SessionSpanWriter {
+
     /**
      * Number of traces created in the current session. This value will be reset when a new session is created.
      */
@@ -83,6 +85,20 @@ internal class CurrentSessionSpanImpl(
             }
             return spansSink.flushSpans()
         }
+    }
+
+    override fun addEvent(
+        name: String,
+        timeNanos: Long?,
+        attributes: Map<String, String>?
+    ): Boolean {
+        val currentSession = sessionSpan.get() ?: return false
+        return currentSession.addEvent(name, timeNanos, attributes)
+    }
+
+    override fun addAttribute(key: String, value: String): Boolean {
+        val currentSession = sessionSpan.get() ?: return false
+        return currentSession.addAttribute(key, value)
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -11,6 +11,18 @@ internal class FakeCurrentSessionSpan : CurrentSessionSpan {
     override fun initializeService(sdkInitStartTimeNanos: Long) {
     }
 
+    override fun addEvent(
+        name: String,
+        timeNanos: Long?,
+        attributes: Map<String, String>?
+    ): Boolean {
+        return true
+    }
+
+    override fun addAttribute(key: String, value: String): Boolean {
+        return true
+    }
+
     override fun initialized(): Boolean {
         initializedCallCount++
         return true

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -4,7 +4,7 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import android.content.res.Configuration
 import io.embrace.android.embracesdk.arch.EventDataSource
-import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.arch.SessionSpanWriter
 
 internal class FakeDataSource(
     private val ctx: Context
@@ -13,8 +13,7 @@ internal class FakeDataSource(
     var enableDataCaptureCount = 0
     var disableDataCaptureCount = 0
 
-    override fun captureData(action: CurrentSessionSpan.() -> Unit) {
-        action(FakeCurrentSessionSpan())
+    override fun captureData(action: SessionSpanWriter.() -> Unit) {
     }
 
     override fun enableDataCapture() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -174,4 +174,27 @@ internal class CurrentSessionSpanImplTests {
         assertEquals(1, currentSpans.size)
         assertEquals("emb-test-span", currentSpans[0].name)
     }
+
+    @Test
+    fun `add event forwarded to span`() {
+        currentSessionSpan.addEvent("test-event", 1000L, mapOf("key" to "value"))
+        val span = currentSessionSpan.endSession(null).single()
+        assertEquals("emb-session-span", span.name)
+
+        // verify event was added to the span
+        val testEvent = span.events.single()
+        assertEquals("test-event", testEvent.name)
+        assertEquals(1000, testEvent.timestampNanos)
+        assertEquals(mapOf("key" to "value"), testEvent.attributes)
+    }
+
+    @Test
+    fun `add attribute forwarded to span`() {
+        currentSessionSpan.addAttribute("my_key", "my_value")
+        val span = currentSessionSpan.endSession(null).single()
+        assertEquals("emb-session-span", span.name)
+
+        // verify attribute was added to the span
+        assertEquals("my_value", span.attributes["my_key"])
+    }
 }


### PR DESCRIPTION
## Goal

Adds functions that are capable of writing events + attributes onto the session span. This builds on #413.

I have chosen a fairly straightfoward approach of adding two functions: one that writes an event, and another that writes an attribute. These will be exposed via the `SessionSpanWriter` interface. I've chosen this instead of exposing the `CurrentSessionSpan` directly to the `DataSource` because as far as the data source is concerned, the rest of the functions on `CurrentSessionSpan` are an implementation detail.

## Testing

Added unit test coverage.

