### PR TITLE
No-op data capture functions by default

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -11,6 +11,14 @@ internal abstract class DataSourceImpl<T>(
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataSource<T> {
 
+    override fun enableDataCapture() {
+        // no-op
+    }
+
+    override fun disableDataCapture() {
+        // no-op
+    }
+
     override fun captureData(action: T.() -> Unit) {
         try {
             destination.action()


### PR DESCRIPTION
## Goal

Makes the `enableDataCapture/disableDataCapture` functions no-op by default, as there is a lot of telemetry that we capture that isn't possible to disable (e.g. breadcrumbs submitted by developers). It is still possible for data sources to override this behavior by overriding the functions as required.

## Testing

Relied on existing test coverage.
