### PR TITLE
Use tracing api rather than embrace tracer

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
+import io.embrace.android.embracesdk.spans.TracingApi
 
 /**
  * Defines a 'data source'. This should be responsible for capturing a specific type
@@ -46,7 +47,7 @@ internal typealias EventDataSource = DataSource<SessionSpanWriter>
 /**
  * A [DataSource] that adds or alters a new span on the [SpansService]
  */
-internal typealias SpanDataSource = DataSource<EmbraceTracer>
+internal typealias SpanDataSource = DataSource<TracingApi>
 
 /**
  * A [DataSource] that adds a new log to the log service.


### PR DESCRIPTION
## Goal

Use the `TracingApi` rather than the `EmbraceTracer` directly, as we don't get anything extra from using the concrete implementation.

