### PR TITLE
Add function that resets data capture limits

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -36,6 +36,11 @@ internal interface DataSource<T> {
      * You should NOT attempt to track state within the [DataSource] with a boolean flag.
      */
     fun disableDataCapture()
+
+    /**
+     * Resets any data capture limits since the last time [enableDataCapture] was called.
+     */
+    fun resetDataCaptureLimits()
 }
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -19,6 +19,10 @@ internal abstract class DataSourceImpl<T>(
         // no-op
     }
 
+    override fun resetDataCaptureLimits() {
+        // no-op
+    }
+
     override fun captureData(action: T.() -> Unit) {
         try {
             destination.action()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceState.kt
@@ -47,6 +47,7 @@ internal class DataSourceState(
     fun onSessionTypeChange(sessionType: SessionType?) {
         this.currentSessionType = sessionType
         updateDataSource()
+        enabledDataSource.resetDataCaptureLimits()
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -52,6 +52,7 @@ internal class DataSourceStateTest {
         // data capture is enabled by default.
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
+        assertEquals(0, source.resetCount)
     }
 
     @Test
@@ -121,23 +122,27 @@ internal class DataSourceStateTest {
         // data capture is always disabled by default.
         assertEquals(0, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
+        assertEquals(0, source.resetCount)
 
         // new session should enable data capture
         state.onSessionTypeChange(SessionType.FOREGROUND)
         state.onSessionTypeChange(SessionType.FOREGROUND)
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
+        assertEquals(2, source.resetCount)
 
         // extra payload types should not re-register listeners
         state.onSessionTypeChange(SessionType.BACKGROUND)
         state.onSessionTypeChange(SessionType.BACKGROUND)
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(1, source.disableDataCaptureCount)
+        assertEquals(4, source.resetCount)
 
         // functions can be called multiple times without issue
         state.onSessionTypeChange(SessionType.FOREGROUND)
         state.onSessionTypeChange(SessionType.BACKGROUND)
         assertEquals(2, source.enableDataCaptureCount)
         assertEquals(2, source.disableDataCaptureCount)
+        assertEquals(6, source.resetCount)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -12,6 +12,7 @@ internal class FakeDataSource(
 
     var enableDataCaptureCount = 0
     var disableDataCaptureCount = 0
+    var resetCount = 0
 
     override fun captureData(action: SessionSpanWriter.() -> Unit) {
     }
@@ -24,6 +25,10 @@ internal class FakeDataSource(
     override fun disableDataCapture() {
         ctx.unregisterComponentCallbacks(this)
         disableDataCaptureCount++
+    }
+
+    override fun resetDataCaptureLimits() {
+        resetCount++
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {


### PR DESCRIPTION
## Goal

Adds a function that resets data capture limits for `DataSource` implementations. By default this is a no-op. The limit is reset whenever there is a new session.

## Testing

Added unit test coverage.
