### PR TITLE
Fix the test fixture and code problem that made integration tests fail intermittently

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
@@ -44,7 +44,7 @@ internal class FakeSpanExporter : SpanExporter {
     fun awaitSpanExport(count: Int = 1, timeout: Long = 1, unit: TimeUnit = TimeUnit.SECONDS): Boolean {
         val latch = synchronized(exportedSpans) {
             return@synchronized if (count > totalExported) {
-                val newLatch = CountDownLatch(count)
+                val newLatch = CountDownLatch(count - totalExported)
                 latches.add(newLatch)
                 newLatch
             } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpansService.kt
@@ -25,15 +25,16 @@ internal class EmbraceSpansService(
         if (!initialized()) {
             synchronized(currentDelegate) {
                 if (!initialized()) {
-                    currentDelegate = SpansServiceImpl(
+                    val realSpansService = SpansServiceImpl(
                         spansRepository = spansRepository,
                         currentSessionSpan = currentSessionSpan,
                         tracer = tracerSupplier(),
                     )
-                    currentDelegate.initializeService(sdkInitStartTimeNanos)
-                    if (currentDelegate.initialized()) {
-                        uninitializedSdkSpansService.recordBufferedCalls(this)
+                    realSpansService.initializeService(sdkInitStartTimeNanos)
+                    if (realSpansService.initialized()) {
+                        uninitializedSdkSpansService.triggerBufferedSpanRecording(realSpansService)
                     }
+                    currentDelegate = realSpansService
                 }
             }
         }


### PR DESCRIPTION
## Goal

Fix the real and test problems that made the tests flakey:
- `FakeSpanExporter`'s countdown latch value was incorrectly set
- The EmbraceSpansService init logic to swap out the implementations wasn't clean in terms of setting what the "current" delegate is, leading to an awkward period during init when `recordCompleteSpan` calls being made on the wrapper
- The buffered span replay logic was flaw and left a small window where spans can be buffered and not replayed

## Testing

The tests that were flakey found these issues and should no longer be flakey

