### PR TITLE
Create mapping interface for span events & attributes

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionSpanWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionSpanWriter.kt
@@ -14,16 +14,29 @@ internal interface SessionSpanWriter {
      *
      * Returns true if the event was added, otherwise false.
      */
-    fun addEvent(
-        name: String,
-        timeNanos: Long? = null,
-        attributes: Map<String, String>? = null
-    ): Boolean
+    fun addEvent(event: SpanEventData): Boolean
 
     /**
      * Add the given key-value pair as an Attribute to the Event.
      *
      * Returns true if the attribute was added, otherwise false.
      */
-    fun addAttribute(key: String, value: String): Boolean
+    fun addAttribute(attribute: SpanAttributeData): Boolean
 }
+
+/**
+ * Represents a span event that can be added to the current session span.
+ */
+internal class SpanEventData(
+    val name: String,
+    val timeNanos: Long,
+    val attributes: Map<String, String>?
+)
+
+/**
+ * Represents a span attribute that can be added to the current session span.
+ */
+internal class SpanAttributeData(
+    val key: String,
+    val value: String
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanAttributeMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanAttributeMapper.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.arch
+
+/**
+ * Converts an object of type T to a [SpanAttributeData]
+ */
+internal fun interface SpanAttributeMapper<T> {
+    fun T.toSpanAttributeData(): SpanAttributeData
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanEventMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanEventMapper.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.arch
+
+/**
+ * Converts an object of type T to a [SpanEventData]
+ */
+internal fun interface SpanEventMapper<T> {
+    fun T.toSpanEventData(): SpanEventData
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.arch.SessionSpanWriter
+import io.embrace.android.embracesdk.arch.SpanAttributeData
+import io.embrace.android.embracesdk.arch.SpanEventData
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.telemetry.TelemetryService
@@ -87,18 +89,14 @@ internal class CurrentSessionSpanImpl(
         }
     }
 
-    override fun addEvent(
-        name: String,
-        timeNanos: Long?,
-        attributes: Map<String, String>?
-    ): Boolean {
+    override fun addEvent(event: SpanEventData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
-        return currentSession.addEvent(name, timeNanos, attributes)
+        return currentSession.addEvent(event.name, event.timeNanos, event.attributes)
     }
 
-    override fun addAttribute(key: String, value: String): Boolean {
+    override fun addAttribute(attribute: SpanAttributeData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
-        return currentSession.addAttribute(key, value)
+        return currentSession.addAttribute(attribute.key, attribute.value)
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.arch.SpanAttributeData
+import io.embrace.android.embracesdk.arch.SpanEventData
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
@@ -8,18 +10,15 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 internal class FakeCurrentSessionSpan : CurrentSessionSpan {
 
     var initializedCallCount = 0
+
     override fun initializeService(sdkInitStartTimeNanos: Long) {
     }
 
-    override fun addEvent(
-        name: String,
-        timeNanos: Long?,
-        attributes: Map<String, String>?
-    ): Boolean {
+    override fun addEvent(event: SpanEventData): Boolean {
         return true
     }
 
-    override fun addAttribute(key: String, value: String): Boolean {
+    override fun addAttribute(attribute: SpanAttributeData): Boolean {
         return true
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.res.Configuration
 import io.embrace.android.embracesdk.arch.EventDataSource
 import io.embrace.android.embracesdk.arch.SessionSpanWriter
+import io.embrace.android.embracesdk.arch.SpanAttributeData
 
 internal class FakeDataSource(
     private val ctx: Context
@@ -33,7 +34,7 @@ internal class FakeDataSource(
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         captureData {
-            // TODO: interact with span here.
+            addAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.SpanAttributeData
+import io.embrace.android.embracesdk.arch.SpanEventData
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -177,7 +179,7 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add event forwarded to span`() {
-        currentSessionSpan.addEvent("test-event", 1000L, mapOf("key" to "value"))
+        currentSessionSpan.addEvent(SpanEventData("test-event", 1000L, mapOf("key" to "value")))
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session-span", span.name)
 
@@ -190,7 +192,7 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add attribute forwarded to span`() {
-        currentSessionSpan.addAttribute("my_key", "my_value")
+        currentSessionSpan.addAttribute(SpanAttributeData("my_key", "my_value"))
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session-span", span.name)
 


### PR DESCRIPTION
## Goal

Creates an interface for converting POJOs to span events/attributes. I've created a simple Kotlin class that represents the values required to create a span/event.

## Testing

Updated existing unit test coverage.
