### PR TITLE
Add limit strategy interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -19,7 +19,7 @@ internal interface DataSource<T> {
      * The DataSource should call this function when it wants to capture data
      * and send it to the destination.
      */
-    fun captureData(action: T.() -> Unit)
+    fun captureData(captureAction: T.() -> Unit)
 
     /**
      * Enables data capture. This should include registering any listeners, and resetting

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
@@ -8,6 +9,7 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  */
 internal abstract class DataSourceImpl<T>(
     private val destination: T,
+    private val limitStrategy: LimitStrategy,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataSource<T> {
 
@@ -20,12 +22,14 @@ internal abstract class DataSourceImpl<T>(
     }
 
     override fun resetDataCaptureLimits() {
-        // no-op
+        limitStrategy.resetDataCaptureLimits()
     }
 
-    override fun captureData(action: T.() -> Unit) {
+    override fun captureData(captureAction: T.() -> Unit) {
         try {
-            destination.action()
+            if (limitStrategy.shouldCapture()) {
+                destination.captureAction()
+            }
         } catch (exc: Throwable) {
             logger.logError("Error capturing data", exc)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/LimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/LimitStrategy.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.arch.limits
+
+/**
+ * Defines a strategy for limiting the capture of data in a [DataSource].
+ */
+internal interface LimitStrategy {
+
+    /**
+     * Whether data should be captured or not. Each invocation of this increments an internal
+     * counter by one, as it assumes that data has been captured.
+     */
+    fun shouldCapture(): Boolean
+
+    /**
+     * Resets the internal count of data that has been captured.
+     */
+    fun resetDataCaptureLimits()
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/NoopLimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/NoopLimitStrategy.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.arch.limits
+
+/**
+ * This class captures whatever the hell it wants, whenever it wants
+ */
+internal object NoopLimitStrategy : LimitStrategy {
+
+    override fun shouldCapture(): Boolean = true
+
+    override fun resetDataCaptureLimits() {
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
@@ -1,0 +1,34 @@
+package io.embrace.android.embracesdk.arch.limits
+
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+/**
+ * Allows capturing data up until a limit, then stops capturing.
+ */
+internal class UpToLimitStrategy(
+    private val limitProvider: Provider<Int>,
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : LimitStrategy {
+
+    private var lock = Any()
+    private var count = 0
+
+    override fun shouldCapture(): Boolean {
+        synchronized(lock) {
+            if (count >= limitProvider()) {
+                logger.logWarning("Data capture limit reached.")
+                return false
+            }
+            count++
+            return true
+        }
+    }
+
+    override fun resetDataCaptureLimits() {
+        synchronized(lock) {
+            count = 0
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.arch.limits.LimitStrategy
+import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
+import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -26,8 +29,25 @@ internal class DataSourceImplTest {
         assertEquals(0, dst.initializedCallCount)
     }
 
-    private class FakeDataSourceImpl(dst: FakeCurrentSessionSpan) :
-        DataSourceImpl<FakeCurrentSessionSpan>(dst) {
+    @Test
+    fun `capture data respects limits`() {
+        val dst = FakeCurrentSessionSpan()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.captureData {
+                count++
+            }
+        }
+        assertEquals(2, count)
+    }
+
+    private class FakeDataSourceImpl(
+        dst: FakeCurrentSessionSpan,
+        limitStrategy: LimitStrategy = NoopLimitStrategy
+    ) :
+        DataSourceImpl<FakeCurrentSessionSpan>(dst, limitStrategy) {
 
         override fun enableDataCapture() {
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/NoopLimitStrategyTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/NoopLimitStrategyTest.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.arch.limits
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class NoopLimitStrategyTest {
+
+    @Test
+    fun shouldCapture() {
+        repeat(1000) {
+            assertTrue(NoopLimitStrategy.shouldCapture())
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
@@ -1,0 +1,31 @@
+package io.embrace.android.embracesdk.arch.limits
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class UpToLimitStrategyTest {
+
+    private val provider = { 10 }
+
+    @Test
+    fun shouldCapture() {
+        val strategy = UpToLimitStrategy(provider)
+        repeat(10) {
+            assertTrue(strategy.shouldCapture())
+        }
+        repeat(10) {
+            assertFalse(strategy.shouldCapture())
+        }
+
+        // reset & try again
+        strategy.resetDataCaptureLimits()
+
+        repeat(10) {
+            assertTrue(strategy.shouldCapture())
+        }
+        repeat(10) {
+            assertFalse(strategy.shouldCapture())
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -15,7 +15,7 @@ internal class FakeDataSource(
     var disableDataCaptureCount = 0
     var resetCount = 0
 
-    override fun captureData(action: SessionSpanWriter.() -> Unit) {
+    override fun captureData(captureAction: SessionSpanWriter.() -> Unit) {
     }
 
     override fun enableDataCapture() {


### PR DESCRIPTION
## Goal

Adds a `LimitStrategy` interface that is a required parameter of the `DataSource`. This will force us to think about how we want to limit data capture for each data source & helps enforce data limits in a standardised way.

I have implemented a simple option of a limit that captures everything up to a certain limit, but there are other strategies we use throughout our SDK that can be implemented via this interface. The limit is reset at the start of each new session boundary.

An example of how this works can be found in #406 

## Testing

Added unit test coverage.
