### PR TITLE
Add input validation action

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -18,8 +18,15 @@ internal interface DataSource<T> {
     /**
      * The DataSource should call this function when it wants to capture data
      * and send it to the destination.
+     *
+     * The [inputValidation] parameter returns true if the user inputs are valid. (e.g. an empty
+     * string is not valid for a breadcrumb message).
+     *
+     * The [captureAction] parameter is a lambda that captures the data and sends it to the
+     * destination. It will be called only if [inputValidation] returns true & no data capture
+     * limits have been exceeded.
      */
-    fun captureData(captureAction: T.() -> Unit)
+    fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit)
 
     /**
      * Enables data capture. This should include registering any listeners, and resetting

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -25,11 +25,17 @@ internal abstract class DataSourceImpl<T>(
         limitStrategy.resetDataCaptureLimits()
     }
 
-    override fun captureData(captureAction: T.() -> Unit) {
+    override fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit) {
         try {
-            if (limitStrategy.shouldCapture()) {
-                destination.captureAction()
+            if (!limitStrategy.shouldCapture()) {
+                logger.logWarning("Data capture limit reached.")
+                return
             }
+            if (!inputValidation()) {
+                logger.logWarning("Input validation failed.")
+                return
+            }
+            destination.captureAction()
         } catch (exc: Throwable) {
             logger.logError("Error capturing data", exc)
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -13,7 +13,7 @@ internal class DataSourceImplTest {
     fun `capture data successfully`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        source.captureData {
+        source.captureData(inputValidation = { true }) {
             initialized()
         }
         assertEquals(1, dst.initializedCallCount)
@@ -23,7 +23,7 @@ internal class DataSourceImplTest {
     fun `capture data threw exception`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        source.captureData {
+        source.captureData(inputValidation = { true }) {
             error("Whoops!")
         }
         assertEquals(0, dst.initializedCallCount)
@@ -36,11 +36,25 @@ internal class DataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.captureData {
+            source.captureData(inputValidation = { true }) {
                 count++
             }
         }
         assertEquals(2, count)
+    }
+
+    @Test
+    fun `capture data respects validation`() {
+        val dst = FakeCurrentSessionSpan()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.captureData(inputValidation = { false }) {
+                count++
+            }
+        }
+        assertEquals(0, count)
     }
 
     private class FakeDataSourceImpl(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -15,7 +15,10 @@ internal class FakeDataSource(
     var disableDataCaptureCount = 0
     var resetCount = 0
 
-    override fun captureData(captureAction: SessionSpanWriter.() -> Unit) {
+    override fun captureData(
+        inputValidation: () -> Boolean,
+        captureAction: SessionSpanWriter.() -> Unit
+    ) {
     }
 
     override fun enableDataCapture() {
@@ -33,7 +36,7 @@ internal class FakeDataSource(
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
-        captureData {
+        captureData(inputValidation = { true }) {
             addAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }


### PR DESCRIPTION
## Goal

Adds an `inputValidation` action that returns true if inputs are valid for capturing data, and otherwise returns false. This is a mandatory parameter in `captureData` so should force us to think about how we want to sanitise our inputs, and provide a single codepath for any logic where inputs are invalid.

An example of how this looks in practice can be found in #406.

## Testing

Added unit test coverage.
