### PR TITLE
Update OTel SDK to version 1.35

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -39,7 +39,7 @@ object Versions {
     val ndk = "21.4.7075529"
 
     @JvmField
-    val openTelemetry = "1.29.0"
+    val openTelemetry = "1.35.0"
 
     @JvmField
     val moshi = "1.12.0"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanProcessor.kt
@@ -11,13 +11,10 @@ import java.util.concurrent.atomic.AtomicLong
 
 /**
  * [SpanProcessor] that adds custom attributes to a [Span] when it starts, and exports it to the given [SpanExporter] when it finishes
- *
- * Note: no explicit tests exist for this as its functionality is tested via the tests for [SpansServiceImpl]
  */
 @InternalApi
 internal class EmbraceSpanProcessor(private val spanExporter: SpanExporter) : SpanProcessor {
 
-    // TODO: sequence-id should be persisted across cold starts to better gauge data loss
     private val counter = AtomicLong(1)
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
@@ -25,11 +22,10 @@ internal class EmbraceSpanProcessor(private val spanExporter: SpanExporter) : Sp
     }
 
     override fun onEnd(span: ReadableSpan) {
-        // TODO: consider exporting this to a buffer that will export the collected Spans in bulk for performance reasons
         spanExporter.export(mutableListOf(span.toSpanData()))
     }
 
-    override fun isStartRequired() = false
+    override fun isStartRequired() = true
 
     override fun isEndRequired() = true
 }


### PR DESCRIPTION
## Goal

Update OTel to the latest version. Fixed `EmbraceSpanProcessor` to ensure the `onStart` method is always run

## Testing

Manually tested on an app that has the minimum requirements, and existing tests pass
