### PR TITLE
Add more system tracing to SDK startup

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -36,6 +36,7 @@ import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KClass
 
 /**
  * A class that wires together and initializes modules in a manner that makes them work as a cohesive whole.
@@ -131,33 +132,39 @@ internal class ModuleInitBootstrapper(
 
             synchronized(asyncInitTask) {
                 return if (!isInitialized()) {
-                    coreModule = Systrace.traceSynchronous("core-init") { coreModuleSupplier(context, appFramework) }
-                    workerThreadModule = Systrace.traceSynchronous("worker-init") { workerThreadModuleSupplier(initModule) }
+                    coreModule = init(CoreModule::class) { coreModuleSupplier(context, appFramework) }
+                    workerThreadModule = init(WorkerThreadModule::class) { workerThreadModuleSupplier(initModule) }
 
-                    val initTask = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit(TaskPriority.CRITICAL) {
-                        Systrace.trace("spans-service-init") {
-                            openTelemetryModule.spanService.initializeService(sdkStartTimeNanos)
+                    val initTask = postInit(OpenTelemetryModule::class) {
+                        workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit(TaskPriority.CRITICAL) {
+                            Systrace.trace("span-service-init") {
+                                openTelemetryModule.spanService.initializeService(sdkStartTimeNanos)
+                            }
                         }
                     }
 
                     val serviceRegistry = coreModule.serviceRegistry
-                    serviceRegistry.registerService(initModule.telemetryService)
-                    serviceRegistry.registerService(openTelemetryModule.spanService)
+                    postInit(OpenTelemetryModule::class) {
+                        serviceRegistry.registerService(initModule.telemetryService)
+                        serviceRegistry.registerService(openTelemetryModule.spanService)
+                    }
 
-                    systemServiceModule = Systrace.traceSynchronous("system-service-init") {
+                    systemServiceModule = init(SystemServiceModule::class) {
                         systemServiceModuleSupplier(coreModule, versionChecker)
                     }
 
-                    androidServicesModule = Systrace.traceSynchronous("android-service-init") {
+                    androidServicesModule = init(AndroidServicesModule::class) {
                         androidServicesModuleSupplier(initModule, coreModule, workerThreadModule)
                     }
-                    serviceRegistry.registerService(androidServicesModule.preferencesService)
+                    postInit(AndroidServicesModule::class) {
+                        serviceRegistry.registerService(androidServicesModule.preferencesService)
+                    }
 
-                    storageModule = Systrace.traceSynchronous("storage-init") {
+                    storageModule = init(StorageModule::class) {
                         storageModuleSupplier(initModule, coreModule, workerThreadModule)
                     }
 
-                    essentialServiceModule = Systrace.traceSynchronous("essential-init") {
+                    essentialServiceModule = init(EssentialServiceModule::class) {
                         essentialServiceModuleSupplier(
                             initModule,
                             coreModule,
@@ -170,25 +177,26 @@ internal class ModuleInitBootstrapper(
                             configServiceProvider
                         )
                     }
+                    postInit(EssentialServiceModule::class) {
+                        serviceRegistry.registerServices(
+                            essentialServiceModule.processStateService,
+                            essentialServiceModule.metadataService,
+                            essentialServiceModule.configService,
+                            essentialServiceModule.activityLifecycleTracker,
+                            essentialServiceModule.networkConnectivityService,
+                            essentialServiceModule.userService
+                        )
 
-                    serviceRegistry.registerServices(
-                        essentialServiceModule.processStateService,
-                        essentialServiceModule.metadataService,
-                        essentialServiceModule.configService,
-                        essentialServiceModule.activityLifecycleTracker,
-                        essentialServiceModule.networkConnectivityService,
-                        essentialServiceModule.userService
-                    )
+                        val networkBehavior = essentialServiceModule.configService.networkBehavior
+                        if (networkBehavior.isNativeNetworkingMonitoringEnabled()) {
+                            registerFactory(networkBehavior.isRequestContentLengthCaptureEnabled())
+                        }
 
-                    val networkBehavior = essentialServiceModule.configService.networkBehavior
-                    if (networkBehavior.isNativeNetworkingMonitoringEnabled()) {
-                        registerFactory(networkBehavior.isRequestContentLengthCaptureEnabled())
+                        // only call after ConfigService has initialized.
+                        essentialServiceModule.metadataService.precomputeValues()
                     }
 
-                    // only call after ConfigService has initialized.
-                    essentialServiceModule.metadataService.precomputeValues()
-
-                    dataCaptureServiceModule = Systrace.traceSynchronous("data-capture-init") {
+                    dataCaptureServiceModule = init(DataCaptureServiceModule::class) {
                         dataCaptureServiceModuleSupplier(
                             initModule,
                             openTelemetryModule,
@@ -200,19 +208,25 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
-                    serviceRegistry.registerServices(
-                        dataCaptureServiceModule.webviewService,
-                        dataCaptureServiceModule.memoryService,
-                        dataCaptureServiceModule.componentCallbackService,
-                        dataCaptureServiceModule.powerSaveModeService,
-                        dataCaptureServiceModule.breadcrumbService,
-                        dataCaptureServiceModule.pushNotificationService,
-                        dataCaptureServiceModule.thermalStatusService
-                    )
-                    deliveryModule = Systrace.traceSynchronous("delivery-init") {
+                    postInit(DataCaptureServiceModule::class) {
+                        serviceRegistry.registerServices(
+                            dataCaptureServiceModule.webviewService,
+                            dataCaptureServiceModule.memoryService,
+                            dataCaptureServiceModule.componentCallbackService,
+                            dataCaptureServiceModule.powerSaveModeService,
+                            dataCaptureServiceModule.breadcrumbService,
+                            dataCaptureServiceModule.pushNotificationService,
+                            dataCaptureServiceModule.thermalStatusService
+                        )
+                    }
+
+                    deliveryModule = init(DeliveryModule::class) {
                         deliveryModuleSupplier(coreModule, workerThreadModule, storageModule, essentialServiceModule)
                     }
-                    serviceRegistry.registerService(deliveryModule.deliveryService)
+
+                    postInit(DeliveryModule::class) {
+                        serviceRegistry.registerService(deliveryModule.deliveryService)
+                    }
 
                     /** Since onForeground() is called sequential in the order that services registered for it,
                      * it is important to initialize the `EmbraceAnrService`, and thus register the `onForeground()
@@ -222,36 +236,42 @@ internal class ModuleInitBootstrapper(
                      * force a Main thread health check and close the pending ANR intervals that happened on the
                      * background before the next session is created.
                      * */
-                    anrModule = Systrace.traceSynchronous("anr-init") {
+                    anrModule = init(AnrModule::class) {
                         anrModuleSupplier(initModule, coreModule, essentialServiceModule, workerThreadModule)
                     }
 
-                    serviceRegistry.registerServices(
-                        anrModule.anrService,
-                        anrModule.responsivenessMonitorService
-                    )
+                    postInit(AnrModule::class) {
+                        serviceRegistry.registerServices(
+                            anrModule.anrService,
+                            anrModule.responsivenessMonitorService
+                        )
 
-                    // set callbacks and pass in non-placeholder config.
-                    anrModule.anrService.finishInitialization(
-                        essentialServiceModule.configService
-                    )
+                        // set callbacks and pass in non-placeholder config.
+                        anrModule.anrService.finishInitialization(
+                            essentialServiceModule.configService
+                        )
+                    }
 
                     // initialize the logger early so that logged exceptions have a good chance of
                     // being appended to the exceptions service rather than logcat
-                    sdkObservabilityModule = Systrace.traceSynchronous("sdk-observability-init") {
+                    sdkObservabilityModule = init(SdkObservabilityModule::class) {
                         sdkObservabilityModuleSupplier(initModule, essentialServiceModule)
                     }
 
-                    serviceRegistry.registerService(sdkObservabilityModule.internalErrorService)
-                    InternalStaticEmbraceLogger.logger.addLoggerAction(sdkObservabilityModule.internalErrorLogger)
+                    postInit(SdkObservabilityModule::class) {
+                        serviceRegistry.registerService(sdkObservabilityModule.internalErrorService)
+                        InternalStaticEmbraceLogger.logger.addLoggerAction(sdkObservabilityModule.internalErrorLogger)
+                    }
 
-                    val sessionProperties = EmbraceSessionProperties(
-                        androidServicesModule.preferencesService,
-                        essentialServiceModule.configService,
-                        coreModule.logger
-                    )
+                    val sessionProperties = Systrace.traceSynchronous("session-properties-init") {
+                        EmbraceSessionProperties(
+                            androidServicesModule.preferencesService,
+                            essentialServiceModule.configService,
+                            coreModule.logger
+                        )
+                    }
 
-                    customerLogModule = Systrace.traceSynchronous("customer-log-init") {
+                    customerLogModule = init(CustomerLogModule::class) {
                         customerLogModuleSupplier(
                             initModule,
                             coreModule,
@@ -263,13 +283,15 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
-                    serviceRegistry.registerServices(
-                        customerLogModule.logMessageService,
-                        customerLogModule.networkCaptureService,
-                        customerLogModule.networkLoggingService
-                    )
+                    postInit(CustomerLogModule::class) {
+                        serviceRegistry.registerServices(
+                            customerLogModule.logMessageService,
+                            customerLogModule.networkCaptureService,
+                            customerLogModule.networkLoggingService
+                        )
+                    }
 
-                    nativeModule = Systrace.traceSynchronous("native-crash-init") {
+                    nativeModule = init(NativeModule::class) {
                         nativeModuleSupplier(
                             coreModule,
                             storageModule,
@@ -281,44 +303,46 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
-                    serviceRegistry.registerServices(
-                        nativeModule.ndkService,
-                        nativeModule.nativeThreadSamplerService
-                    )
+                    postInit(NativeModule::class) {
+                        serviceRegistry.registerServices(
+                            nativeModule.ndkService,
+                            nativeModule.nativeThreadSamplerService
+                        )
 
-                    if (essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled()) {
-                        essentialServiceModule.sessionIdTracker.ndkService = nativeModule.ndkService
-                    }
+                        if (essentialServiceModule.configService.autoDataCaptureBehavior.isNdkEnabled()) {
+                            essentialServiceModule.sessionIdTracker.ndkService = nativeModule.ndkService
+                        }
 
-                    if (nativeModule.nativeThreadSamplerInstaller != null) {
-                        // install the native thread sampler
-                        nativeModule.nativeThreadSamplerService?.let { nativeThreadSamplerService ->
-                            nativeThreadSamplerService.setupNativeSampler()
+                        if (nativeModule.nativeThreadSamplerInstaller != null) {
+                            // install the native thread sampler
+                            nativeModule.nativeThreadSamplerService?.let { nativeThreadSamplerService ->
+                                nativeThreadSamplerService.setupNativeSampler()
 
-                            // In Unity this should always run on the Unity thread.
-                            if (coreModule.appFramework == AppFramework.UNITY && isUnityMainThread()) {
-                                try {
-                                    if (nativeModule.nativeThreadSamplerInstaller != null) {
-                                        nativeModule.nativeThreadSamplerInstaller?.monitorCurrentThread(
-                                            nativeThreadSamplerService,
-                                            essentialServiceModule.configService,
-                                            anrModule.anrService
-                                        )
-                                    } else {
-                                        InternalStaticEmbraceLogger.logger.logWarning(
-                                            "nativeThreadSamplerInstaller not started, cannot sample current thread"
-                                        )
+                                // In Unity this should always run on the Unity thread.
+                                if (coreModule.appFramework == AppFramework.UNITY && isUnityMainThread()) {
+                                    try {
+                                        if (nativeModule.nativeThreadSamplerInstaller != null) {
+                                            nativeModule.nativeThreadSamplerInstaller?.monitorCurrentThread(
+                                                nativeThreadSamplerService,
+                                                essentialServiceModule.configService,
+                                                anrModule.anrService
+                                            )
+                                        } else {
+                                            InternalStaticEmbraceLogger.logger.logWarning(
+                                                "nativeThreadSamplerInstaller not started, cannot sample current thread"
+                                            )
+                                        }
+                                    } catch (t: Throwable) {
+                                        InternalStaticEmbraceLogger.logger.logError("Failed to sample current thread during ANRs", t)
                                     }
-                                } catch (t: Throwable) {
-                                    InternalStaticEmbraceLogger.logger.logError("Failed to sample current thread during ANRs", t)
                                 }
                             }
+                        } else {
+                            InternalStaticEmbraceLogger.logger.logWarning("Failed to load SO file embrace-native")
                         }
-                    } else {
-                        InternalStaticEmbraceLogger.logger.logWarning("Failed to load SO file embrace-native")
                     }
 
-                    dataContainerModule = Systrace.traceSynchronous("data-container-init") {
+                    dataContainerModule = init(DataContainerModule::class) {
                         dataContainerModuleSupplier(
                             initModule,
                             openTelemetryModule,
@@ -337,17 +361,19 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
-                    serviceRegistry.registerServices(
-                        dataContainerModule.performanceInfoService,
-                        dataContainerModule.eventService,
-                        dataContainerModule.applicationExitInfoService
-                    )
+                    postInit(NativeModule::class) {
+                        serviceRegistry.registerServices(
+                            dataContainerModule.performanceInfoService,
+                            dataContainerModule.eventService,
+                            dataContainerModule.applicationExitInfoService
+                        )
+                    }
 
-                    dataSourceModule = Systrace.traceSynchronous("data-source-init") {
+                    dataSourceModule = init(DataSourceModule::class) {
                         dataSourceModuleSupplier(essentialServiceModule)
                     }
 
-                    sessionModule = Systrace.traceSynchronous("session-init") {
+                    sessionModule = init(SessionModule::class) {
                         sessionModuleSupplier(
                             initModule,
                             openTelemetryModule,
@@ -365,7 +391,7 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
-                    crashModule = Systrace.traceSynchronous("crash-init") {
+                    crashModule = init(CrashModule::class) {
                         crashModuleSupplier(
                             initModule,
                             storageModule,
@@ -379,8 +405,12 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
-                    Thread.setDefaultUncaughtExceptionHandler(crashModule.automaticVerificationExceptionHandler)
-                    serviceRegistry.registerService(crashModule.crashService)
+                    postInit(CrashModule::class) {
+                        Thread.setDefaultUncaughtExceptionHandler(crashModule.automaticVerificationExceptionHandler)
+                        serviceRegistry.registerService(crashModule.crashService)
+                    }
+
+                    Systrace.startSynchronous("modules-post-init")
 
                     // Sets up the registered services. This method is called after the SDK has been started and no more services can
                     // be added to the registry. It sets listeners for any services that were registered.
@@ -391,6 +421,7 @@ internal class ModuleInitBootstrapper(
                     serviceRegistry.registerActivityLifecycleListeners(essentialServiceModule.activityLifecycleTracker)
 
                     asyncInitTask.set(initTask)
+                    Systrace.endSynchronous()
                     true
                 } else {
                     false
@@ -430,4 +461,32 @@ internal class ModuleInitBootstrapper(
     }
 
     private fun isInitialized(): Boolean = asyncInitTask.get() != null
+
+    private fun <T> init(module: KClass<*>, provider: Provider<T>): T =
+        Systrace.traceSynchronous("${moduleNames[module] ?: "module"}-init") { provider() }
+
+    private fun <T> postInit(module: KClass<*>, code: () -> T): T =
+        Systrace.traceSynchronous("${moduleNames[module] ?: "module"}-post-init") { code() }
+
+    companion object {
+        private val moduleNames: Map<KClass<*>, String> = mapOf(
+            CoreModule::class to "core",
+            OpenTelemetryModule::class to "opentelemetry",
+            WorkerThreadModule::class to "worker",
+            SystemServiceModule::class to "system-service",
+            AndroidServicesModule::class to "android-service",
+            StorageModule::class to "storage",
+            EssentialServiceModule::class to "essential-service",
+            DataCaptureServiceModule::class to "data-capture-service",
+            DeliveryModule::class to "delivery",
+            AnrModule::class to "anr",
+            SdkObservabilityModule::class to "sdk-observability",
+            CustomerLogModule::class to "customer-log",
+            NativeModule::class to "native",
+            DataContainerModule::class to "data-container",
+            DataSourceModule::class to "data-source",
+            SessionModule::class to "session",
+            CrashModule::class to "crash",
+        )
+    }
 }


### PR DESCRIPTION
## Goal

Add more detail system tracing info to the SDK startup process. Pulled the module names out so they are defined in a single place, per review comment.

