### PR TITLE
Improve test failure message

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -223,6 +223,9 @@ internal class EmbraceBreadcrumbService(
      * Close all open fragments when the activity closes
      */
     override fun onViewClose(activity: Activity) {
+        if (!configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled()) {
+            return
+        }
         viewBreadcrumbDataSource.onViewClose()
         if (fragmentStack.size == 0) {
             return


### PR DESCRIPTION
## Goal

Improves the quality of the functional test failure message. It now gives information on why the JSON validation failed in the test run & details on how to get the observed JSON from the CI artefacts.

```
java.lang.AssertionError: Request /v1/log/sessions differs from golden-files/session-end.json.
JSON validation failure reason: Different arrays size.
Match failed for key: vb
Match failed for key: br
Please check logcat output for further information. Logcat output and the expected/observed output is saved as an upload artefact if this ran on CI. You can compare the difference on https://www.jsondiff.com/ by pulling the expected/observed files with adb (if running locally:
adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/session-end.json.expected
adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/session-end.json.observed

Full observed JSON: {"s":{"id":"62CE56439A5A4C948ED20B2D94214F44","st":1708089313167,"sn":699,"ty":"en","as":"foreground","cs":true,"et":1708089318853,"ht":1708089318853,"ce":true,"ss":["F2471F05699F4EABAD202F97D1ADB564"],"il":[],"wl":[],"el":[],"nc":[],"lic":0,"lwc":0,"lec":0,"em":"s","sm":"s","sp":{},"sd":5023,"sdt":5000,"si":39,"ue":0,"bf":{"ts":[]},"wvi_beta":[{"t":"myWebView","vt":[{"t":"LCP","n":"layout-shift","st":2222,"d":10,"s":0.0},{"t":"CLS","n":"layout-shift","st":1111,"d":10,"s":0.1}],"u":"https://embrace.io/","ts":1111}]},"u":{"id":"some id","em":"user@email.com","un":"John Doe","per":["first_day"]},"a":{"v":"1.1.2","f":1,"bi":"default test build id","bt":"default test build type","fl":"default test build flavor","e":"dev","vu":false,"vul":false,"bv":"5","ou":false,"oul":false,"sdk":"6.4.0-SNAPSHOT","sdc":"53"},"d":{"dm":"Google","do":"sdk_gphone64_arm64","da":"arm64-v8a","jb":false,"lc":"en_US","ms":6228115456,"os":"Android OS","ov":"13","oc":33,"sr":"1080x2209","tz":"Europe/London","nc":4,"pt":"","gp":"emulation"},"p":{"ds":{"as":12935168,"fs":5213892608},"mw":[],"ns":[],"anr":[],"ga":[],"aei":[{"sid":"","side":"","im":125,"pss":0,"rs":10,"rss":0,"st":0,"ts":1708089296421,"ds":"stop io.embrace.android.embracesdk.test due to finished inst"}],"lp":[],"nr":{"v2":{"r":[],"c":{}}},"rms":[{"name":"heartbeatSend","first":1708089313248,"last":1708089318849,"gaps":{"B1":56,"B2":0,"B3":0,"B4":0,"B5":0,"B6":0},"outliers":[],"errors":0},{"name":"heartbeatResponse","first":1708089313248,"last":1708089318850,"gaps":{"B1":56,"B2":0,"B3":0,"B4":0,"B5":0,"B6":0},"outliers":[],"errors":0}]},"br":{"vb":[],"tb":[],"cb":[{"m":"a message","ts":1708089313181}],"wv":[],"cv":[],"rna":[],"pn":[]},"spans":[{"trace_id":"34c691d30a8c10270ddb8f111f66ff31","span_id":"b69a86a37bb7e667","parent_span_id":"0000000000000000","name":"emb-sdk-init","start_time_unix_nano":1708089313119000000,"end_time_unix_nano":1708089313158000000,"status":"OK","events":[],"attributes":{"emb.private":"true","emb.type":"PERFORMANCE","emb.sequence_id":"2","emb.key":"true"}},{"trace_id":"58d8547ea01c3f94c4fbdc04947bea45","span_id":"3b950d9448fc62f3","parent_span_id":"0000000000000000","name":"emb-startup-moment","start_time_unix_nano":1708089313119000000,"end_time_unix_nano":1708089318142000000,"status":"OK","events":[],"attributes":{"emb.type":"PERFORMANCE","emb.sequence_id":"3","emb.key":"true"}},{"trace_id":"f014434419c0e6d6124ddb0d2037c3e2","span_id":"1f3ac46e1de3d76c","parent_span_id":"0000000000000000","name":"emb-session-span","start_time_unix_nano":1708089313119000000,"end_time_unix_nano":1708089318855309503,"status":"OK","events":[],"attributes":{"emb.is_emulator":"true","emb.private":"true","emb.type":"SESSION","emb.usage.set_user_identifier":"1","emb.okhttp3":"true","emb.kotlin_on_classpath":"1.4.32","emb.usage.set_user_email":"1","emb.sequence_id":"1","emb.usage.add_breadcrumb":"1","emb.usage.add_user_persona":"1","emb.usage.set_username":"1","emb.okhttp3_on_classpath":"4.9.3"}}],"v":13}
```
