### PR TITLE
Resolve test failure on missing view breadcrumb

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataStore.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataStore.kt
@@ -9,12 +9,13 @@ internal class BreadcrumbDataStore<T>(
 
     private val breadcrumbs = LinkedBlockingDeque<T>()
 
-    fun tryAddBreadcrumb(breadcrumb: T): T {
+    fun peek(): T? = breadcrumbs.peek()
+
+    fun tryAddBreadcrumb(breadcrumb: T) {
         if (!breadcrumbs.isEmpty() && breadcrumbs.size >= limit()) {
             breadcrumbs.removeLast()
         }
         breadcrumbs.push(breadcrumb)
-        return breadcrumb
     }
 
     override fun getCapturedData(): List<T> = breadcrumbs.toList()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbService.kt
@@ -20,12 +20,8 @@ internal interface BreadcrumbService {
     /**
      * Gets the view breadcrumbs in the specified time window.
      * If the number of elements exceeds the limit, this will return the newest (latest) ones.
-     *
-     * @param start the start time
-     * @param end   the end time
-     * @return the list of Breadcrumbs
      */
-    fun getViewBreadcrumbsForSession(start: Long, end: Long): List<ViewBreadcrumb?>
+    fun getViewBreadcrumbsForSession(): List<ViewBreadcrumb>
 
     /**
      * Gets the Taps breadcrumbs in the specified time window.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -129,10 +129,7 @@ internal class EmbraceBreadcrumbService(
         webViewBreadcrumbDataSource.logWebView(url, startTime)
     }
 
-    override fun getViewBreadcrumbsForSession(
-        start: Long,
-        end: Long
-    ): List<ViewBreadcrumb?> {
+    override fun getViewBreadcrumbsForSession(): List<ViewBreadcrumb> {
         return viewBreadcrumbDataSource.getCapturedData()
     }
 
@@ -173,7 +170,7 @@ internal class EmbraceBreadcrumbService(
         return Breadcrumbs(
             customBreadcrumbs = getCustomBreadcrumbsForSession(),
             tapBreadcrumbs = getTapBreadcrumbsForSession(),
-            viewBreadcrumbs = getViewBreadcrumbsForSession(start, end).filterNotNull(),
+            viewBreadcrumbs = getViewBreadcrumbsForSession(),
             webViewBreadcrumbs = getWebViewBreadcrumbsForSession(),
             fragmentBreadcrumbs = getFragmentBreadcrumbsForSession(start, end).filterNotNull(),
             rnActionBreadcrumbs = getRnActionBreadcrumbForSession(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBreadcrumbService.kt
@@ -17,8 +17,7 @@ internal class FakeBreadcrumbService : BreadcrumbService {
     val pushNotifications = mutableListOf<PushNotificationBreadcrumb>()
     var flushCount: Int = 0
 
-    override fun getViewBreadcrumbsForSession(start: Long, end: Long): List<ViewBreadcrumb?> =
-        emptyList()
+    override fun getViewBreadcrumbsForSession(): List<ViewBreadcrumb> = emptyList()
 
     override fun getTapBreadcrumbsForSession(): List<TapBreadcrumb> = emptyList()
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -473,7 +473,7 @@ internal class EmbraceBreadcrumbServiceTest {
     fun testForceLogView() {
         val service = initializeBreadcrumbService()
         service.forceLogView("a", 0)
-        val crumbs = service.getViewBreadcrumbsForSession(0, Long.MAX_VALUE)
+        val crumbs = service.getViewBreadcrumbsForSession()
         val breadcrumb = checkNotNull(crumbs.single())
         assertEquals("a", breadcrumb.screen)
     }
@@ -484,7 +484,7 @@ internal class EmbraceBreadcrumbServiceTest {
         service.logView("a", 0)
         service.replaceFirstSessionView("b", 2)
 
-        val crumbs = service.getViewBreadcrumbsForSession(0, Long.MAX_VALUE)
+        val crumbs = service.getViewBreadcrumbsForSession()
         val breadcrumb = checkNotNull(crumbs.single())
         assertEquals("b", breadcrumb.screen)
     }
@@ -548,7 +548,7 @@ internal class EmbraceBreadcrumbServiceTest {
         val service = initializeBreadcrumbService()
         service.onView(mockActivity())
 
-        val crumbs = service.getViewBreadcrumbsForSession(0, Long.MAX_VALUE)
+        val crumbs = service.getViewBreadcrumbsForSession()
         val breadcrumb = checkNotNull(crumbs.single())
         assertEquals("android.app.Activity", breadcrumb.screen)
     }
@@ -560,7 +560,7 @@ internal class EmbraceBreadcrumbServiceTest {
             service.logView("a$count", count.toLong())
         }
 
-        val crumbs = service.getViewBreadcrumbsForSession(0, Long.MAX_VALUE)
+        val crumbs = service.getViewBreadcrumbsForSession()
         assertEquals(100, crumbs.size)
         assertEquals("a109", crumbs.first()?.screen)
         assertEquals("a10", crumbs.last()?.screen)
@@ -570,7 +570,7 @@ internal class EmbraceBreadcrumbServiceTest {
     fun `addFirstViewBreadcrumbForSession empty`() {
         val service = initializeBreadcrumbService()
         service.addFirstViewBreadcrumbForSession(0)
-        assertTrue(service.getViewBreadcrumbsForSession(0, 10).isEmpty())
+        assertTrue(service.getViewBreadcrumbsForSession().isEmpty())
     }
 
     @Test
@@ -578,7 +578,7 @@ internal class EmbraceBreadcrumbServiceTest {
         val service = initializeBreadcrumbService()
         service.logView("MyView", 0)
         service.addFirstViewBreadcrumbForSession(5)
-        val crumb = checkNotNull(service.getViewBreadcrumbsForSession(0, 10).single())
+        val crumb = checkNotNull(service.getViewBreadcrumbsForSession().single())
         assertEquals("MyView", crumb.screen)
         assertEquals(5L, crumb.start)
     }
@@ -594,7 +594,7 @@ internal class EmbraceBreadcrumbServiceTest {
             activityTracker
         )
         service.addFirstViewBreadcrumbForSession(5)
-        val crumb = checkNotNull(service.getViewBreadcrumbsForSession(0, 10).single())
+        val crumb = checkNotNull(service.getViewBreadcrumbsForSession().single())
         assertEquals("MyMockActivity", crumb.screen)
         assertEquals(5L, crumb.start)
     }


### PR DESCRIPTION
## Goal

Fixes a very subtle bug with view breadcrumbs where state was not being cleared between session boundaries. A refactor meant `lastBreadcrumb` was cached in the `ViewBreadcrumbDataSource` which altered the codepath of `addToViewLogsQueue`, preventing a breadcrumb being added & failing a functional test.

## Testing

Functional tests are now passing.
