### PR TITLE
Add new endpoint for OTel logs.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.comms.api
 
 import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.EventType
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -14,7 +15,7 @@ internal class ApiRequestMapper(
 ) {
 
     private val apiUrlBuilders = Endpoint.values().associateWith {
-        urlBuilder.getEmbraceUrlWithSuffix(it.path)
+        urlBuilder.getEmbraceUrlWithSuffix(it.version, it.path)
     }
 
     private fun Endpoint.asEmbraceUrl(): EmbraceUrl {
@@ -51,6 +52,14 @@ internal class ApiRequestMapper(
         val abbreviation = type.abbreviation
         val logIdentifier = abbreviation + ":" + event.messageId
         return requestBuilder(url).copy(logId = logIdentifier)
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun logsRequest(
+        logPayload: LogPayload
+    ): ApiRequest {
+        val url = Endpoint.LOGS.asEmbraceUrl()
+        return requestBuilder(url)
     }
 
     fun sessionRequest(): ApiRequest {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.comms.api
 
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -11,6 +12,7 @@ internal interface ApiService {
     fun getConfig(): RemoteConfig?
     fun getCachedConfig(): CachedConfig
     fun sendLog(eventMessage: EventMessage)
+    fun sendLogs(logPayload: LogPayload)
     fun sendNetworkCall(networkEvent: NetworkEvent)
     fun sendEvent(eventMessage: EventMessage)
     fun sendCrash(crash: EventMessage): Future<*>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiUrlBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiUrlBuilder.kt
@@ -13,5 +13,5 @@ internal interface ApiUrlBuilder {
     /**
      * Returns the url used to send data to Embrace.
      */
-    fun getEmbraceUrlWithSuffix(suffix: String): String
+    fun getEmbraceUrlWithSuffix(apiVersion: String, suffix: String): String
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCallsSender
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -116,6 +117,16 @@ internal class EmbraceApiService(
      */
     override fun sendLog(eventMessage: EventMessage) {
         post(eventMessage, mapper::logRequest)
+    }
+
+    /**
+     * Sends a list of OTel Logs to the API.
+     *
+     * @param logPayload the list of OTel logs
+     * @return a future containing the response body from the server
+     */
+    override fun sendLogs(logPayload: LogPayload) {
+        post(logPayload, mapper::logsRequest)
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiUrlBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiUrlBuilder.kt
@@ -11,7 +11,6 @@ internal class EmbraceApiUrlBuilder(
     private val lazyAppVersionName: Lazy<String>
 ) : ApiUrlBuilder {
     companion object {
-        private const val API_VERSION = 1
         private const val CONFIG_API_VERSION = 2
     }
 
@@ -24,11 +23,11 @@ internal class EmbraceApiUrlBuilder(
             "&appVersion=${lazyAppVersionName.value}&deviceId=${lazyDeviceId.value}"
     }
 
-    override fun getEmbraceUrlWithSuffix(suffix: String): String {
+    override fun getEmbraceUrlWithSuffix(apiVersion: String, suffix: String): String {
         InternalStaticEmbraceLogger.logDeveloper(
             "ApiUrlBuilder",
-            "getEmbraceUrlWithSuffix - suffix: $suffix"
+            "getEmbraceUrlWithSuffix - apiVersion: $apiVersion - suffix: $suffix"
         )
-        return "$coreBaseUrl/v$API_VERSION/log/$suffix"
+        return "$coreBaseUrl/$apiVersion/log/$suffix"
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceUrl.kt
@@ -16,6 +16,7 @@ internal class EmbraceUrl(val url: URL) {
             Endpoint.EVENTS.path -> Endpoint.EVENTS
             Endpoint.BLOBS.path -> Endpoint.BLOBS
             Endpoint.LOGGING.path -> Endpoint.LOGGING
+            Endpoint.LOGS.path -> Endpoint.LOGS
             Endpoint.NETWORK.path -> Endpoint.NETWORK
             Endpoint.SESSIONS.path -> Endpoint.SESSIONS
             else -> Endpoint.UNKNOWN

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/Endpoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/Endpoint.kt
@@ -5,13 +5,14 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.pow
 
-internal enum class Endpoint(val path: String) {
-    EVENTS("events"),
-    BLOBS("blobs"),
-    LOGGING("logging"),
-    NETWORK("network"),
-    SESSIONS("sessions"),
-    UNKNOWN("unknown");
+internal enum class Endpoint(val path: String, val version: String) {
+    EVENTS("events", "v1"),
+    BLOBS("blobs", "v1"),
+    LOGGING("logging", "v1"),
+    LOGS("logs", "v2"),
+    NETWORK("network", "v1"),
+    SESSIONS("sessions", "v1"),
+    UNKNOWN("unknown", "v1");
 
     private var rateLimitRetryCount = AtomicInteger(0)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -12,6 +13,7 @@ internal interface DeliveryService {
     fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker)
     fun sendLog(eventMessage: EventMessage)
+    fun sendLogs(logPayload: LogPayload)
     fun sendNetworkCall(networkEvent: NetworkEvent)
     fun sendCrash(crash: EventMessage, processTerminating: Boolean)
     fun sendAEIBlob(blobMessage: BlobMessage)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.comms.delivery
 import io.embrace.android.embracesdk.comms.api.ApiService
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
@@ -68,6 +69,10 @@ internal class EmbraceDeliveryService(
 
     override fun sendLog(eventMessage: EventMessage) {
         apiService.sendLog(eventMessage)
+    }
+
+    override fun sendLogs(logPayload: LogPayload) {
+        apiService.sendLogs(logPayload)
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCalls.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCalls.kt
@@ -89,6 +89,7 @@ internal class PendingApiCalls(
             Endpoint.EVENTS -> 100
             Endpoint.BLOBS -> 50
             Endpoint.LOGGING -> 100
+            Endpoint.LOGS -> 10
             Endpoint.NETWORK -> 50
             Endpoint.SESSIONS -> 100
             Endpoint.UNKNOWN -> 50

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
@@ -21,7 +21,7 @@ internal interface LogSink {
 
     /**
      * Returns and clears the currently stored Logs. Implementations of this method must make sure the clearing and returning is
-     * atomic, i.e. spans cannot be added during this operation.
+     * atomic, i.e. logs cannot be added during this operation.
      */
     fun flushLogs(): List<EmbraceLogRecordData>
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceApiUrlBuilderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceApiUrlBuilderTest.kt
@@ -40,7 +40,7 @@ internal class EmbraceApiUrlBuilderTest {
         )
         assertEquals(
             "https://a-$APP_ID.data.emb-api.com/v1/log/suffix",
-            apiUrlBuilder.getEmbraceUrlWithSuffix("suffix")
+            apiUrlBuilder.getEmbraceUrlWithSuffix("v1", "suffix")
         )
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -18,6 +19,7 @@ internal class FakeDeliveryService : DeliveryService {
     var lastSentCrash: EventMessage? = null
     var lastSentEvent: EventMessage? = null
     val lastSentLogs: MutableList<EventMessage> = mutableListOf()
+    val lastSentLogPayloads: MutableList<LogPayload> = mutableListOf()
     val sentMoments: MutableList<EventMessage> = mutableListOf()
     var sendBackgroundActivitiesInvokedCount: Int = 0
     var lastSentBackgroundActivities: MutableList<SessionMessage> = mutableListOf()
@@ -52,6 +54,10 @@ internal class FakeDeliveryService : DeliveryService {
 
     override fun sendLog(eventMessage: EventMessage) {
         lastSentLogs.add(eventMessage)
+    }
+
+    override fun sendLogs(logPayload: LogPayload) {
+        lastSentLogPayloads.add(logPayload)
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
@@ -1,6 +1,9 @@
 package io.embrace.android.embracesdk.comms.api
 
 import io.embrace.android.embracesdk.EventType
+import io.embrace.android.embracesdk.internal.logs.EmbraceLogBody
+import io.embrace.android.embracesdk.internal.logs.EmbraceLogRecordData
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.AppInfo
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -56,6 +59,26 @@ internal class ApiRequestMapperTest {
         )
         request.assertCoreFieldsPopulated("/v1/log/logging")
         assertEquals("il:messageId", request.logId)
+    }
+
+    @Test
+    fun testLogsRequest() {
+        val request = mapper.logsRequest(
+            LogPayload(
+                logs = listOf(
+                    EmbraceLogRecordData(
+                        traceId = "traceId",
+                        spanId = "spanId",
+                        timeUnixNanos = 1234567890,
+                        severityText = "severityText",
+                        severityNumber = 1,
+                        body = EmbraceLogBody("a message"),
+                        attributes = mapOf("key" to "value")
+                    )
+                )
+            )
+        )
+        request.assertCoreFieldsPopulated("/v2/log/logs")
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -254,7 +254,7 @@ internal class EmbraceApiServiceTest {
         Endpoint.values().forEach {
             assertEquals(
                 "https://a-$fakeAppId.data.emb-api.com/v1/log/${it.path}",
-                apiUrlBuilder.getEmbraceUrlWithSuffix(it.path)
+                apiUrlBuilder.getEmbraceUrlWithSuffix("v1", it.path)
             )
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceUrlTest.kt
@@ -12,6 +12,7 @@ internal class EmbraceUrlTest {
         val embraceUrlEvents = EmbraceUrl.create("https://embrace.io/events")
         val embraceUrlBlobs = EmbraceUrl.create("https://embrace.io/blobs")
         val embraceUrlLogging = EmbraceUrl.create("https://embrace.io/logging")
+        val embraceUrlLogs = EmbraceUrl.create("https://embrace.io/logs")
         val embraceUrlNetwork = EmbraceUrl.create("https://embrace.io/network")
         val embraceUrlOther = EmbraceUrl.create("https://embrace.io/other")
 
@@ -19,6 +20,7 @@ internal class EmbraceUrlTest {
         assertEquals(Endpoint.EVENTS, embraceUrlEvents.endpoint())
         assertEquals(Endpoint.BLOBS, embraceUrlBlobs.endpoint())
         assertEquals(Endpoint.LOGGING, embraceUrlLogging.endpoint())
+        assertEquals(Endpoint.LOGS, embraceUrlLogs.endpoint())
         assertEquals(Endpoint.NETWORK, embraceUrlNetwork.endpoint())
         assertEquals(Endpoint.UNKNOWN, embraceUrlOther.endpoint())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCallsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/PendingApiCallsTest.kt
@@ -178,6 +178,7 @@ internal class PendingApiCallsTest {
             Endpoint.EVENTS -> 100
             Endpoint.BLOBS -> 50
             Endpoint.LOGGING -> 100
+            Endpoint.LOGS -> 10
             Endpoint.NETWORK -> 50
             Endpoint.SESSIONS -> 100
             Endpoint.UNKNOWN -> 50

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.comms.api.ApiService
 import io.embrace.android.embracesdk.comms.api.CachedConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.logs.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -20,6 +21,7 @@ internal class FakeApiService : ApiService {
     var throwExceptionSendSession: Boolean = false
     private val serializer = EmbraceSerializer()
     val logRequests = mutableListOf<EventMessage>()
+    val logPayloads = mutableListOf<LogPayload>()
     val networkCallRequests = mutableListOf<NetworkEvent>()
     val eventRequests = mutableListOf<EventMessage>()
     val crashRequests = mutableListOf<EventMessage>()
@@ -37,6 +39,10 @@ internal class FakeApiService : ApiService {
 
     override fun sendLog(eventMessage: EventMessage) {
         logRequests.add(eventMessage)
+    }
+
+    override fun sendLogs(logPayload: LogPayload) {
+        logPayloads.add(logPayload)
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiUrlBuilder.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiUrlBuilder.kt
@@ -7,7 +7,7 @@ internal class FakeApiUrlBuilder : ApiUrlBuilder {
         return ""
     }
 
-    override fun getEmbraceUrlWithSuffix(suffix: String): String {
+    override fun getEmbraceUrlWithSuffix(apiVersion: String, suffix: String): String {
         return ""
     }
 }


### PR DESCRIPTION
## Goal

- Added new endpoint `${BASE_URL}/v2/log/logs` for sending OTel logs. 

- sendLogs() method is not yet finished. This will be added in another PR. The intention of this PR is to add the endpoint and build the new URL for logs.

## Testing

Added and updated unit tests. 

