### PR TITLE
Expose startSpan in the public tracing API

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -80,6 +80,8 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun startMoment (Ljava/lang/String;)V
 	public fun startMoment (Ljava/lang/String;Ljava/lang/String;)V
 	public fun startMoment (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun startSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
+	public fun startSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public fun startView (Ljava/lang/String;)Z
 	public fun trackWebViewPerformance (Ljava/lang/String;Landroid/webkit/ConsoleMessage;)V
 	public fun trackWebViewPerformance (Ljava/lang/String;Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
+++ b/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
@@ -258,6 +258,18 @@ public class NullParametersTest {
     }
 
     @Test
+    public void testStartSpan() {
+        assertNull(embrace.startSpan(null));
+        assertError("startSpan");
+    }
+
+    @Test
+    public void testStartSpanWithParent() {
+        assertNull(embrace.startSpan(null, null));
+        assertError("startSpan");
+    }
+
+    @Test
     public void testRecordSpan() {
         assertTrue(embrace.recordSpan(null, () -> true));
         assertError("recordSpan");

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -96,12 +96,14 @@ internal class TracingApiTest {
                         events = events
                     )
                 )
+                val bonusSpan = checkNotNull(embrace.startSpan(name = "bonus-span", parent = parentSpan))
+                assertTrue(bonusSpan.stop())
                 harness.fakeClock.tick(300L)
                 results.add("\nSpans exported before ending startup: ${spanExporter.exportedSpans.toList().map { it.name }}")
                 embrace.endAppStartup()
             }
             results.add("\nSpans exported after session ends: ${spanExporter.exportedSpans.toList().map { it.name }}")
-            assertTrue("Timed out waiting for the expected spans: $results", spanExporter.awaitSpanExport(7))
+            assertTrue("Timed out waiting for the expected spans: $results", spanExporter.awaitSpanExport(8))
             val sessionEndTime = harness.fakeClock.now()
             assertEquals(2, harness.fakeDeliveryModule.deliveryService.lastSentSessions.size)
             val allSpans = getSdkInitSpanFromBackgroundActivity() +
@@ -121,6 +123,7 @@ internal class TracingApiTest {
                 "completed-span",
                 "emb-startup-moment",
                 "emb-session-span",
+                "bonus-span"
             )
             expectedSpanName.forEach {
                 checkNotNull(spansMap[it]) { "$it not found: $results" }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -441,6 +441,22 @@ public final class Embrace implements EmbraceAndroidApi {
         return null;
     }
 
+    @Nullable
+    @Override
+    public EmbraceSpan startSpan(@NonNull String name) {
+        return startSpan(name, null);
+    }
+
+    @Nullable
+    @Override
+    public EmbraceSpan startSpan(@NonNull String name, @Nullable EmbraceSpan parent) {
+        if (verifyNonNullParameters("startSpan", name)) {
+            return impl.tracer.startSpan(name, parent);
+        }
+
+        return null;
+    }
+
     @Override
     public <T> T recordSpan(@NonNull String name, @NonNull Function0<? extends T> code) {
         return recordSpan(name, null, null, null, code);

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -10,11 +10,19 @@ internal class EmbraceTracer(
     private val clock: Clock,
     private val spanService: SpanService,
 ) : TracingApi {
-    override fun createSpan(name: String): EmbraceSpan? =
-        createSpan(name = name, parent = null)
+    override fun createSpan(name: String): EmbraceSpan? = createSpan(name = name, parent = null)
 
     override fun createSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? =
         spanService.createSpan(
+            name = name,
+            parent = parent,
+            internal = false
+        )
+
+    override fun startSpan(name: String): EmbraceSpan? = startSpan(name = name, parent = null)
+
+    override fun startSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? =
+        spanService.startSpan(
             name = name,
             parent = parent,
             internal = false

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -13,13 +13,10 @@ internal class InternalTracer(
     override fun startSpan(name: String, parentSpanId: String?): String? {
         val parent = validateParent(parentSpanId)
         return if (parent.isValid) {
-            embraceTracer.createSpan(
+            embraceTracer.startSpan(
                 name = name,
                 parent = parent.spanReference
-            )?.run {
-                start()
-                spanId
-            }
+            )?.spanId
         } else {
             null
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -21,6 +21,29 @@ internal interface SpanService : Initializable {
     ): EmbraceSpan?
 
     /**
+     * Create, start, and return a new [EmbraceSpan] with the given parameters
+     */
+    fun startSpan(
+        name: String,
+        parent: EmbraceSpan? = null,
+        type: EmbraceAttributes.Type = EmbraceAttributes.Type.PERFORMANCE,
+        internal: Boolean = true
+    ): EmbraceSpan? {
+        createSpan(
+            name = name,
+            parent = parent,
+            type = type,
+            internal = internal
+        )?.let { newSpan ->
+            if (newSpan.start()) {
+                return newSpan
+            }
+        }
+
+        return null
+    }
+
+    /**
      * Records a span around the execution of the given lambda. If the lambda throws an uncaught exception, it will be recorded as a
      * [ErrorCode.FAILURE]. The span will be the provided name, and the appropriate prefix will be prepended to it if [internal] is true.
      */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -29,6 +29,25 @@ internal interface TracingApi {
     ): EmbraceSpan?
 
     /**
+     * Create, start, and return a new [EmbraceSpan] with the given name that will be the root span of a new trace. Returns null if the
+     * [EmbraceSpan] cannot be created or started.
+     */
+    @BetaApi
+    fun startSpan(
+        name: String
+    ): EmbraceSpan?
+
+    /**
+     * Create, start, and return a new [EmbraceSpan] with the given name and parent. Returns null if the [EmbraceSpan] cannot be created
+     * or started, like if the parent has been started.
+     */
+    @BetaApi
+    fun startSpan(
+        name: String,
+        parent: EmbraceSpan?
+    ): EmbraceSpan?
+
+    /**
      * Execute the given block of code and record a new trace around it. If the span cannot be created, the block of code will still run and
      * return correctly. If an exception or error is thrown inside the block, the span will end at the point of the throw and the
      * [Throwable] will be rethrown.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -11,6 +11,8 @@ internal interface TracingApi {
     /**
      * Create an [EmbraceSpan] with the given name that will be the root span of a new trace. Returns null if the [EmbraceSpan] cannot
      * be created given the current conditions of the SDK or an invalid name.
+     *
+     * Note: the [EmbraceSpan] created will not be started. For a method that creates and starts the span, use [startSpan]
      */
     @BetaApi
     fun createSpan(
@@ -21,6 +23,8 @@ internal interface TracingApi {
      * Create an [EmbraceSpan] with the given name and parent. Passing in a parent that is null result in a new trace with this
      * [EmbraceSpan] as its root. Returns null if the [EmbraceSpan] cannot be created, e.g if the parent has not been started,
      * the name is invalid, or some other factor due to the current conditions of the SDK.
+     *
+     * * Note: the [EmbraceSpan] created will not be started. For a method that creates and starts the span, use [startSpan]
      */
     @BetaApi
     fun createSpan(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -30,6 +30,7 @@ internal class EmbraceSpanServiceTest {
         val uninitializedService = FakeInitModule(clock = clock).openTelemetryModule.spanService
         assertFalse(uninitializedService.initialized())
         assertNull(uninitializedService.createSpan("test-span"))
+        assertNull(uninitializedService.startSpan("test-span"))
         assertTrue(uninitializedService.recordCompletedSpan("test-span", 10, 20))
         var lambdaRan = false
         uninitializedService.recordSpan("test-span") { lambdaRan = true }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -148,6 +148,28 @@ internal class SpanServiceImplTest {
     }
 
     @Test
+    fun `start a span directly`() {
+        spanSink.flushSpans()
+        val parent = checkNotNull(spansService.startSpan(name = "test-span"))
+        val child = checkNotNull(
+            spansService.startSpan(
+                name = "child-span",
+                parent = parent,
+                type = EmbraceAttributes.Type.SESSION,
+                internal = true
+            )
+        )
+        assertTrue(child.stop())
+        val completedSpans = spanSink.flushSpans()
+        assertEquals(1, completedSpans.size)
+        with(completedSpans[0]) {
+            assertTrue(isPrivate())
+            assertFalse(isKey())
+            assertEquals(EmbraceAttributes.Type.SESSION.name, attributes[EmbraceAttributes.Type.SESSION.keyName()])
+        }
+    }
+
+    @Test
     fun `record internal completed span with all the fixings`() {
         val expectedName = "test-span"
         val expectedStartTime = clock.now()


### PR DESCRIPTION
## Goal

Expose a new public method to create and start a span at the same time

## Testing

Add all the tests at the right levels

