### PR TITLE
Allow spans to start with a different start time than now

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -334,6 +334,7 @@ public abstract interface class io/embrace/android/embracesdk/spans/EmbraceSpan 
 	public abstract fun getTraceId ()Ljava/lang/String;
 	public abstract fun isRecording ()Z
 	public abstract fun start ()Z
+	public abstract fun start (Ljava/lang/Long;)Z
 	public abstract fun stop ()Z
 	public abstract fun stop (Lio/embrace/android/embracesdk/spans/ErrorCode;)Z
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -37,11 +37,16 @@ internal class EmbraceSpanImpl(
     override val isRecording: Boolean
         get() = startedSpan.get()?.isRecording == true
 
-    override fun start(): Boolean {
+    override fun start(): Boolean = start(startTimeNanos = null)
+
+    override fun start(startTimeNanos: Long?): Boolean {
         return if (startedSpan.get() != null) {
             false
         } else {
             var successful: Boolean
+            if (startTimeNanos != null) {
+                spanBuilder.setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
+            }
             synchronized(startedSpan) {
                 startedSpan.set(spanBuilder.startSpan())
                 successful = startedSpan.get() != null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -35,6 +35,12 @@ public interface EmbraceSpan {
     public fun start(): Boolean
 
     /**
+     * Start recording of the Span with the given start time. Returns true if this call triggered the start of the recording.
+     * Returns false if the Span has already been started or has been stopped.
+     */
+    public fun start(startTimeNanos: Long?): Boolean
+
+    /**
      * Stop the recording of the Span with no [ErrorCode], indicating a successful completion of the underlying operation. Returns true
      * if this call triggered the stopping of the recording. Returns false if the Span has not been started or if has already been stopped.
      */

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
@@ -18,7 +18,9 @@ internal class FakeEmbraceSpan private constructor(
     override val isRecording: Boolean
         get() = started && !stopped
 
-    override fun start(): Boolean {
+    override fun start(): Boolean = start(startTimeNanos = null)
+
+    override fun start(startTimeNanos: Long?): Boolean {
         if (!started) {
             spanId = IdGenerator.random().generateSpanId()
             if (parent == null) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
@@ -9,20 +9,18 @@ internal class FakeTracingApi : TracingApi {
 
     val createdSpans = mutableListOf<String>()
 
+    override fun createSpan(name: String): EmbraceSpan? = createSpan(name = name, parent = null)
+
+    override fun createSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? {
+        createdSpans.add(name)
+        return null
+    }
+
     override fun startSpan(name: String): EmbraceSpan? {
         TODO("Not yet implemented")
     }
 
     override fun startSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? {
-        TODO("Not yet implemented")
-    }
-
-    override fun createSpan(name: String): EmbraceSpan? {
-        createdSpans.add(name)
-        return null
-    }
-
-    override fun createSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? {
         TODO("Not yet implemented")
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -69,14 +69,16 @@ internal class EmbraceSpanImplTest {
         with(embraceSpan) {
             assertTrue(start())
             assertTrue(stop())
-            assertFalse(stop())
-            assertNotNull(traceId)
-            assertNotNull(spanId)
-            assertFalse(isRecording)
-            assertFalse(addEvent("eventName"))
-            assertFalse(addAttribute("first", "value"))
-            assertEquals(0, spanRepository.getActiveSpans().size)
-            assertEquals(1, spanRepository.getCompletedSpans().size)
+            validateStoppedSpan()
+        }
+    }
+
+    @Test
+    fun `validate starting span with specific time `() {
+        with(embraceSpan) {
+            assertTrue(start(startTimeNanos = 5L))
+            assertTrue(stop())
+            validateStoppedSpan()
         }
     }
 
@@ -166,5 +168,16 @@ internal class EmbraceSpanImplTest {
             }
             assertFalse(addAttribute(key = "failedKey", value = "value"))
         }
+    }
+
+    private fun EmbraceSpanImpl.validateStoppedSpan() {
+        assertFalse(stop())
+        assertNotNull(traceId)
+        assertNotNull(spanId)
+        assertFalse(isRecording)
+        assertFalse(addEvent("eventName"))
+        assertFalse(addAttribute("first", "value"))
+        assertEquals(0, spanRepository.getActiveSpans().size)
+        assertEquals(1, spanRepository.getCompletedSpans().size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -2,9 +2,11 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -40,6 +42,7 @@ internal class EmbraceSpanServiceTest {
     @Test
     fun `service works once initialized`() {
         assertTrue(spanService.initialized())
+        assertNotNull(spanService.createSpan("test-span"))
         assertTrue(spanService.recordCompletedSpan("test-span", 10, 20))
         var lambdaRan = false
         spanService.recordSpan("test-span") { lambdaRan = true }
@@ -96,7 +99,7 @@ internal class EmbraceSpanServiceTest {
         val parent = checkNotNull(spanService.createSpan("test-span"))
         assertTrue(parent.start())
         val child = checkNotNull(spanService.createSpan(name = "test-span", parent = parent))
-        assertTrue(child.start())
+        assertTrue(child.start(startTimeNanos = (clock.now() + 10).millisToNanos()))
         assertTrue(parent.traceId == child.traceId)
         assertTrue(parent.spanId == checkNotNull(child.parent).spanId)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.spans
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_SPAN_NAME
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
@@ -40,6 +41,20 @@ internal class EmbraceTracerTest {
         assertTrue(embraceSpan.start())
         assertTrue(embraceSpan.stop())
         verifyPublicSpan("test-span")
+    }
+
+    @Test
+    fun `start EmbraceSpan with a specific timestamp`() {
+        val embraceSpan = checkNotNull(embraceTracer.createSpan(name = "test-span"))
+        assertNotNull(embraceSpan)
+        val expectedStartTime = (clock.now() - 1L).millisToNanos()
+        val expectedEndTime = clock.nowInNanos()
+        assertTrue(embraceSpan.start(startTimeNanos = (clock.now() - 1L).millisToNanos()))
+        assertTrue(embraceSpan.stop())
+        with(verifyPublicSpan("test-span")) {
+            assertEquals(expectedStartTime, startTimeNanos)
+            assertEquals(expectedEndTime, endTimeNanos)
+        }
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fixtures.maxSizeAttributes
 import io.embrace.android.embracesdk.fixtures.maxSizeEvents
 import io.embrace.android.embracesdk.fixtures.tooBigAttributes
 import io.embrace.android.embracesdk.fixtures.tooBigEvents
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
@@ -58,6 +59,15 @@ internal class SpanServiceImplTest {
             )
             assertTrue(isKey())
         }
+    }
+
+    @Test
+    fun `create trace with custom start time`() {
+        val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
+        assertNull(embraceSpan.parent)
+        assertTrue(embraceSpan.start((clock.now() - 1).millisToNanos()))
+        assertTrue(embraceSpan.stop())
+        verifyAndReturnSoleCompletedSpan("emb-test-span")
     }
 
     @Test


### PR DESCRIPTION
## Goal

Allow the `start` method to specify an optional timestamp in which the span to be recorded will start

## Testing

At tests at all appropriate levels. Because `EmbraceSpan` doesn't expose an start time, we will validate the timing only in the tests that actually log a span into a sink

