### PR TITLE
Allow a custom span stop time to be specified when stopping a span

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -337,6 +337,8 @@ public abstract interface class io/embrace/android/embracesdk/spans/EmbraceSpan 
 	public abstract fun start (Ljava/lang/Long;)Z
 	public abstract fun stop ()Z
 	public abstract fun stop (Lio/embrace/android/embracesdk/spans/ErrorCode;)Z
+	public abstract fun stop (Ljava/lang/Long;)Z
+	public abstract fun stop (Ljava/lang/Long;Lio/embrace/android/embracesdk/spans/ErrorCode;)Z
 }
 
 public final class io/embrace/android/embracesdk/spans/EmbraceSpanEvent {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -58,15 +58,19 @@ internal class EmbraceSpanImpl(
         }
     }
 
-    override fun stop(): Boolean = stop(errorCode = null)
+    override fun stop(): Boolean = stop(endTimeNanos = null, errorCode = null)
 
-    override fun stop(errorCode: ErrorCode?): Boolean {
+    override fun stop(endTimeNanos: Long?): Boolean = stop(endTimeNanos = endTimeNanos, errorCode = null)
+
+    override fun stop(errorCode: ErrorCode?): Boolean = stop(endTimeNanos = null, errorCode = errorCode)
+
+    override fun stop(endTimeNanos: Long?, errorCode: ErrorCode?): Boolean {
         return if (startedSpan.get()?.isRecording == false) {
             false
         } else {
             var successful: Boolean
             synchronized(startedSpan) {
-                startedSpan.get()?.endSpan(errorCode)
+                startedSpan.get()?.endSpan(errorCode, endTimeNanos)
                 successful = startedSpan.get()?.isRecording == false
             }
             if (successful) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -47,11 +47,19 @@ public interface EmbraceSpan {
     public fun stop(): Boolean
 
     /**
+     * Stop the recording of the Span with no [ErrorCode], indicating a successful completion of the underlying operation. Returns true
+     * if this call triggered the stopping of the recording. Returns false if the Span has not been started or if has already been stopped.
+     */
+    public fun stop(endTimeNanos: Long?): Boolean
+
+    /**
      * Stop the recording of the Span with an [ErrorCode], a non-null value indicating an unsuccessful completion of the underlying
      * operation with the given reason. Returns true if this call triggered the stopping of the recording. Returns false if the Span has
      * not been started or if has already been stopped.
      */
     public fun stop(errorCode: ErrorCode?): Boolean
+
+    public fun stop(endTimeNanos: Long?, errorCode: ErrorCode?): Boolean
 
     /**
      * Add an [EmbraceSpanEvent] with the given [name] at the current time. Returns false if the Event was definitely not successfully

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
@@ -31,12 +31,13 @@ internal class FakeEmbraceSpan private constructor(
         return true
     }
 
-    override fun stop(): Boolean {
-        stop(errorCode = null)
-        return true
-    }
+    override fun stop(): Boolean = stop(errorCode = null, endTimeNanos = null)
 
-    override fun stop(errorCode: ErrorCode?): Boolean {
+    override fun stop(endTimeNanos: Long?): Boolean = stop(errorCode = null, endTimeNanos = endTimeNanos)
+
+    override fun stop(errorCode: ErrorCode?): Boolean = stop(errorCode = errorCode, endTimeNanos = null)
+
+    override fun stop(endTimeNanos: Long?, errorCode: ErrorCode?): Boolean {
         if (!stopped) {
             this.errorCode = errorCode
             stopped = true

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -74,10 +74,10 @@ internal class EmbraceSpanImplTest {
     }
 
     @Test
-    fun `validate starting span with specific time `() {
+    fun `validate starting and stopping span with specific times`() {
         with(embraceSpan) {
             assertTrue(start(startTimeNanos = 5L))
-            assertTrue(stop())
+            assertTrue(stop(endTimeNanos = 10L))
             validateStoppedSpan()
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -98,8 +98,10 @@ internal class EmbraceSpanServiceTest {
         spanSink.flushSpans()
         val parent = checkNotNull(spanService.createSpan("test-span"))
         assertTrue(parent.start())
-        val child = checkNotNull(spanService.createSpan(name = "test-span", parent = parent))
-        assertTrue(child.start(startTimeNanos = (clock.now() + 10).millisToNanos()))
+        val child = checkNotNull(spanService.createSpan(name = "child-span", parent = parent))
+        assertTrue(child.start(startTimeNanos = (clock.now() - 10).millisToNanos()))
+        assertTrue(child.stop())
+        assertTrue(parent.stop(endTimeNanos = (clock.now() + 50).millisToNanos()))
         assertTrue(parent.traceId == child.traceId)
         assertTrue(parent.spanId == checkNotNull(child.parent).spanId)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -44,13 +44,13 @@ internal class EmbraceTracerTest {
     }
 
     @Test
-    fun `start EmbraceSpan with a specific timestamp`() {
+    fun `start and stop EmbraceSpan with specific timestamps`() {
         val embraceSpan = checkNotNull(embraceTracer.createSpan(name = "test-span"))
         assertNotNull(embraceSpan)
         val expectedStartTime = (clock.now() - 1L).millisToNanos()
-        val expectedEndTime = clock.nowInNanos()
-        assertTrue(embraceSpan.start(startTimeNanos = (clock.now() - 1L).millisToNanos()))
-        assertTrue(embraceSpan.stop())
+        val expectedEndTime = (clock.now() + 2L).millisToNanos()
+        assertTrue(embraceSpan.start(startTimeNanos = expectedStartTime))
+        assertTrue(embraceSpan.stop(endTimeNanos = expectedEndTime))
         with(verifyPublicSpan("test-span")) {
             assertEquals(expectedStartTime, startTimeNanos)
             assertEquals(expectedEndTime, endTimeNanos)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -62,11 +62,11 @@ internal class SpanServiceImplTest {
     }
 
     @Test
-    fun `create trace with custom start time`() {
+    fun `create trace with custom start and end times`() {
         val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertNull(embraceSpan.parent)
         assertTrue(embraceSpan.start((clock.now() - 1).millisToNanos()))
-        assertTrue(embraceSpan.stop())
+        assertTrue(embraceSpan.stop((clock.now() + 10).millisToNanos()))
         verifyAndReturnSoleCompletedSpan("emb-test-span")
     }
 


### PR DESCRIPTION
## Goal

Allow a custom time to be specified when stopping an `EmbraceSpan`

## Testing

Tests added in the appropriate layers. This one adds an integration test as well for both the start/stop cases.