### PR TITLE
Add extra functions to `DataSource` interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
-import io.embrace.android.embracesdk.spans.TracingApi
+import io.embrace.android.embracesdk.internal.spans.SpanService
 
 /**
  * Defines a 'data source'. This should be responsible for capturing a specific type
@@ -16,17 +16,21 @@ import io.embrace.android.embracesdk.spans.TracingApi
 internal interface DataSource<T> {
 
     /**
-     * The DataSource should call this function when it wants to capture data
-     * and send it to the destination.
+     * The DataSource should call this function when it wants to capture a [EmbraceSpanEvent] or
+     * [EmbraceSpanAttribute] and send it to the destination. This function is only intended
+     * for one-time use - if you want to record a span, please use [startSpan] and [stopSpan].
      *
-     * The [inputValidation] parameter returns true if the user inputs are valid. (e.g. an empty
-     * string is not valid for a breadcrumb message).
+     * The [inputValidation] parameter should return true if the user inputs are valid.
+     * (e.g. an empty string is not valid for a breadcrumb message).
      *
      * The [captureAction] parameter is a lambda that captures the data and sends it to the
      * destination. It will be called only if [inputValidation] returns true & no data capture
      * limits have been exceeded.
+     *
+     * This function returns true if data was successfully captured & false if not.
+     * This is assumed to be the case if [captureAction] completed without throwing.
      */
-    fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit)
+    fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean
 
     /**
      * Enables data capture. This should include registering any listeners, and resetting
@@ -51,20 +55,55 @@ internal interface DataSource<T> {
 }
 
 /**
+ * A [DataSource] that adds or alters a new span on the [SpansService]
+ */
+internal interface SpanDataSource : DataSource<SpanService> {
+
+    /**
+     * The DataSource should call this function when it wants to start an [EmbraceSpan].
+     * If you want to add an event or attribute, please use [captureData] instead.
+     *
+     * The [inputValidation] parameter should return true if the user inputs are valid.
+     * (e.g. an empty string is not valid for a breadcrumb message).
+     *
+     * The [captureAction] parameter is a lambda that captures the data and sends it to the
+     * destination. It will be called only if [inputValidation] returns true & no data capture
+     * limits have been exceeded.
+     *
+     * This function returns true if data was successfully captured & false if not.
+     * This is assumed to be the case if [captureAction] completed without throwing.
+     */
+    fun startSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
+
+    /**
+     * The DataSource should call this function when it wants to stop an existing [EmbraceSpan].
+     * If you want to add an event or attribute, please use [captureData] instead.
+     *
+     * The [inputValidation] parameter should return true if the user inputs are valid.
+     * (e.g. an empty string is not valid for a breadcrumb message).
+     *
+     * The [captureAction] parameter is a lambda that captures the data and sends it to the
+     * destination. It will be called only if [inputValidation] returns true & no data capture
+     * limits have been exceeded.
+     *
+     * This function returns true if data was successfully captured & false if not.
+     * This is assumed to be the case if [captureAction] completed without throwing.
+     */
+    fun stopSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
+}
+
+/**
  * A [DataSource] that adds either a [EmbraceSpanEvent] or [EmbraceSpanAttribute]
  * to the current session span.
  */
 internal typealias EventDataSource = DataSource<SessionSpanWriter>
-
-/**
- * A [DataSource] that adds or alters a new span on the [SpansService]
- */
-internal typealias SpanDataSource = DataSource<TracingApi>
+internal typealias EventDataSourceImpl = DataSourceImpl<SessionSpanWriter>
 
 /**
  * A [DataSource] that adds a new log to the log service.
  */
 internal typealias LogDataSource = DataSource<LogService>
+internal typealias LogDataSourceImpl = DataSourceImpl<LogService>
 
 /**
  * Placeholder type for the log service.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionSpanWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionSpanWriter.kt
@@ -28,8 +28,8 @@ internal interface SessionSpanWriter {
  * Represents a span event that can be added to the current session span.
  */
 internal class SpanEventData(
-    val name: String,
-    val timeNanos: Long,
+    val spanName: String,
+    val spanStartTimeNanos: Long,
     val attributes: Map<String, String>?
 )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanDataSourceImpl.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.arch.limits.LimitStrategy
+import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+/**
+ * Base class for data sources.
+ */
+internal abstract class SpanDataSourceImpl(
+    destination: SpanService,
+    limitStrategy: LimitStrategy,
+    logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : SpanDataSource, DataSourceImpl<SpanService>(
+    destination,
+    limitStrategy,
+    logger
+) {
+
+    override fun startSpan(
+        inputValidation: () -> Boolean,
+        captureAction: SpanService.() -> Unit
+    ): Boolean = captureDataImpl(inputValidation, captureAction)
+
+    override fun stopSpan(
+        inputValidation: () -> Boolean,
+        captureAction: SpanService.() -> Unit
+    ): Boolean = captureDataImpl(inputValidation, captureAction, false)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -91,7 +91,7 @@ internal class CurrentSessionSpanImpl(
 
     override fun addEvent(event: SpanEventData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
-        return currentSession.addEvent(event.name, event.timeNanos, event.attributes)
+        return currentSession.addEvent(event.spanName, event.spanStartTimeNanos, event.attributes)
     }
 
     override fun addAttribute(attribute: SpanAttributeData): Boolean {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -5,6 +5,8 @@ import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class DataSourceImplTest {
@@ -13,9 +15,10 @@ internal class DataSourceImplTest {
     fun `capture data successfully`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        source.captureData(inputValidation = { true }) {
+        val success = source.captureData(inputValidation = { true }) {
             initialized()
         }
+        assertTrue(success)
         assertEquals(1, dst.initializedCallCount)
     }
 
@@ -23,9 +26,10 @@ internal class DataSourceImplTest {
     fun `capture data threw exception`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        source.captureData(inputValidation = { true }) {
+        val success = source.captureData(inputValidation = { true }) {
             error("Whoops!")
         }
+        assertFalse(success)
         assertEquals(0, dst.initializedCallCount)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
@@ -1,0 +1,168 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.arch.limits.LimitStrategy
+import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
+import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.fakes.FakeSpanService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class SpanDataSourceImplTest {
+
+    @Test
+    fun `capture data successfully`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst)
+        val success = source.captureData(inputValidation = { true }) {
+            createSpan("test")
+        }
+        assertTrue(success)
+        assertEquals(1, dst.createdSpans.size)
+    }
+
+    @Test
+    fun `capture data threw exception`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst)
+        val success = source.captureData(inputValidation = { true }) {
+            error("Whoops!")
+        }
+        assertFalse(success)
+        assertEquals(0, dst.createdSpans.size)
+    }
+
+    @Test
+    fun `capture data respects limits`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.captureData(inputValidation = { true }) {
+                count++
+            }
+        }
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun `capture data respects validation`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.captureData(inputValidation = { false }) {
+                count++
+            }
+        }
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun `start span succeeds`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst)
+        val success = source.startSpan(inputValidation = { true }) {
+            createSpan("test")
+        }
+        assertTrue(success)
+        assertEquals(1, dst.createdSpans.size)
+    }
+
+    @Test
+    fun `start span data threw exception`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst)
+        val success = source.startSpan(inputValidation = { true }) {
+            error("Whoops!")
+        }
+        assertFalse(success)
+        assertEquals(0, dst.createdSpans.size)
+    }
+
+    @Test
+    fun `start span respects limits`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.startSpan(inputValidation = { true }) {
+                count++
+            }
+        }
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun `start span respects validation`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.startSpan(inputValidation = { false }) {
+                count++
+            }
+        }
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun `stop span succeeeds`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst)
+        val success = source.stopSpan(inputValidation = { true }) {
+            createSpan("test")
+        }
+        assertTrue(success)
+        assertEquals(1, dst.createdSpans.size)
+    }
+
+    @Test
+    fun `stop span data threw exception`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst)
+        val success = source.stopSpan(inputValidation = { true }) {
+            error("Whoops!")
+        }
+        assertFalse(success)
+        assertEquals(0, dst.createdSpans.size)
+    }
+
+    @Test
+    fun `stop span does not increment limits`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.stopSpan(inputValidation = { true }) {
+                count++
+            }
+        }
+        assertEquals(4, count)
+    }
+
+    @Test
+    fun `stop span respects validation`() {
+        val dst = FakeSpanService()
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+
+        var count = 0
+        repeat(4) {
+            source.stopSpan(inputValidation = { false }) {
+                count++
+            }
+        }
+        assertEquals(0, count)
+    }
+
+    private class FakeDataSourceImpl(
+        dst: FakeSpanService,
+        limitStrategy: LimitStrategy = NoopLimitStrategy
+    ) : SpanDataSourceImpl(dst, limitStrategy)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -18,8 +18,7 @@ internal class FakeDataSource(
     override fun captureData(
         inputValidation: () -> Boolean,
         captureAction: SessionSpanWriter.() -> Unit
-    ) {
-    }
+    ): Boolean = true
 
     override fun enableDataCapture() {
         ctx.registerComponentCallbacks(this)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -8,6 +8,8 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 
 internal class FakeSpanService : SpanService {
 
+    val createdSpans = mutableListOf<String>()
+
     override fun initializeService(sdkInitStartTimeNanos: Long) {
     }
 
@@ -19,6 +21,7 @@ internal class FakeSpanService : SpanService {
         type: EmbraceAttributes.Type,
         internal: Boolean
     ): EmbraceSpan? {
+        createdSpans.add(name)
         return null
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
@@ -1,0 +1,113 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.spans.TracingApi
+
+internal class FakeTracingApi : TracingApi {
+
+    val createdSpans = mutableListOf<String>()
+
+    override fun createSpan(name: String): EmbraceSpan? {
+        createdSpans.add(name)
+        return null
+    }
+
+    override fun createSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T> recordSpan(name: String, code: () -> T): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T> recordSpan(name: String, parent: EmbraceSpan?, code: () -> T): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T> recordSpan(
+        name: String,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?,
+        code: () -> T
+    ): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T> recordSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?,
+        code: () -> T
+    ): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeNanos: Long,
+        endTimeNanos: Long
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeNanos: Long,
+        endTimeNanos: Long,
+        errorCode: ErrorCode?
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeNanos: Long,
+        endTimeNanos: Long,
+        parent: EmbraceSpan?
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeNanos: Long,
+        endTimeNanos: Long,
+        errorCode: ErrorCode?,
+        parent: EmbraceSpan?
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeNanos: Long,
+        endTimeNanos: Long,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeNanos: Long,
+        endTimeNanos: Long,
+        errorCode: ErrorCode?,
+        parent: EmbraceSpan?,
+        attributes: Map<String, String>?,
+        events: List<EmbraceSpanEvent>?
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSpan(spanId: String): EmbraceSpan? {
+        TODO("Not yet implemented")
+    }
+
+    override fun isTracingAvailable(): Boolean {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
## Goal

Adds extra functions to the `DataSource` interface that provide a way to start/stop spans. This is used in #439 but separated out for better reviewability.

## Testing

Added unit test coverage.