### PR TITLE
Tweak data capture functions

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSource.kt
@@ -2,14 +2,13 @@ package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
-import io.embrace.android.embracesdk.internal.spans.SpanService
 
 /**
  * Defines a 'data source'. This should be responsible for capturing a specific type
  * of data that will be sent to Embrace.
  *
  * @param T The type of the destination that the data will be sent to. This could be
- * either a [CurrentSessionSpan], [EmbraceTracer], or [LogService].
+ * either a [CurrentSessionSpan], [EmbraceTracer], or [LogWriter].
  *
  * See [EventDataSource], [SpanDataSource], and [LogDataSource] for more information.
  */
@@ -55,44 +54,6 @@ internal interface DataSource<T> {
 }
 
 /**
- * A [DataSource] that adds or alters a new span on the [SpansService]
- */
-internal interface SpanDataSource : DataSource<SpanService> {
-
-    /**
-     * The DataSource should call this function when it wants to start an [EmbraceSpan].
-     * If you want to add an event or attribute, please use [captureData] instead.
-     *
-     * The [inputValidation] parameter should return true if the user inputs are valid.
-     * (e.g. an empty string is not valid for a breadcrumb message).
-     *
-     * The [captureAction] parameter is a lambda that captures the data and sends it to the
-     * destination. It will be called only if [inputValidation] returns true & no data capture
-     * limits have been exceeded.
-     *
-     * This function returns true if data was successfully captured & false if not.
-     * This is assumed to be the case if [captureAction] completed without throwing.
-     */
-    fun startSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
-
-    /**
-     * The DataSource should call this function when it wants to stop an existing [EmbraceSpan].
-     * If you want to add an event or attribute, please use [captureData] instead.
-     *
-     * The [inputValidation] parameter should return true if the user inputs are valid.
-     * (e.g. an empty string is not valid for a breadcrumb message).
-     *
-     * The [captureAction] parameter is a lambda that captures the data and sends it to the
-     * destination. It will be called only if [inputValidation] returns true & no data capture
-     * limits have been exceeded.
-     *
-     * This function returns true if data was successfully captured & false if not.
-     * This is assumed to be the case if [captureAction] completed without throwing.
-     */
-    fun stopSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
-}
-
-/**
  * A [DataSource] that adds either a [EmbraceSpanEvent] or [EmbraceSpanAttribute]
  * to the current session span.
  */
@@ -102,10 +63,10 @@ internal typealias EventDataSourceImpl = DataSourceImpl<SessionSpanWriter>
 /**
  * A [DataSource] that adds a new log to the log service.
  */
-internal typealias LogDataSource = DataSource<LogService>
-internal typealias LogDataSourceImpl = DataSourceImpl<LogService>
+internal typealias LogDataSource = DataSource<LogWriter>
+internal typealias LogDataSourceImpl = DataSourceImpl<LogWriter>
 
 /**
  * Placeholder type for the log service.
  */
-internal interface LogService
+internal interface LogWriter

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataSourceImpl.kt
@@ -51,3 +51,9 @@ internal abstract class DataSourceImpl<T>(
         }
     }
 }
+
+/**
+ * Syntactic sugar for when no input validation is required. Developers must explicitly state
+ * this is the case.
+ */
+internal val NoInputValidation = { true }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SpanDataSource.kt
@@ -1,0 +1,54 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+
+/**
+ * A [DataSource] that adds or alters a new span on the [SpansService]
+ */
+internal interface SpanDataSource : DataSource<SpanService> {
+
+    /**
+     * The DataSource should call this function when it wants to start an [EmbraceSpan].
+     * If you want to add an event or attribute, please use [captureData] instead.
+     *
+     * The [inputValidation] parameter should return true if the user inputs are valid.
+     * (e.g. an empty string is not valid for a breadcrumb message).
+     *
+     * The [captureAction] parameter is a lambda that captures the data and sends it to the
+     * destination. It will be called only if [inputValidation] returns true & no data capture
+     * limits have been exceeded.
+     *
+     * This function returns true if data was successfully captured & false if not.
+     * This is assumed to be the case if [captureAction] completed without throwing.
+     */
+    fun startSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
+
+    /**
+     * The DataSource should call this function when it wants to stop an existing [EmbraceSpan].
+     * If you want to add an event or attribute, please use [captureData] instead.
+     *
+     * The [inputValidation] parameter should return true if the user inputs are valid.
+     * (e.g. an empty string is not valid for a breadcrumb message).
+     *
+     * The [captureAction] parameter is a lambda that captures the data and sends it to the
+     * destination. It will be called only if [inputValidation] returns true & no data capture
+     * limits have been exceeded.
+     *
+     * This function returns true if data was successfully captured & false if not.
+     * This is assumed to be the case if [captureAction] completed without throwing.
+     */
+    fun stopSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
+}
+
+/**
+ * Starts a span using the given [SpanEventData].
+ */
+internal fun SpanService.startSpan(data: SpanEventData): EmbraceSpan? {
+    return createSpan(data.spanName)?.apply {
+        data.attributes?.forEach {
+            addAttribute(it.key, it.value)
+        }
+        start()
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.spans.SpanServiceImpl
+import org.junit.Test
+
+internal class SpanDataSourceKtTest {
+
+    @Test
+    fun `start span`() {
+        val initModule = FakeInitModule(FakeClock())
+        val service = SpanServiceImpl(
+            spanRepository = initModule.openTelemetryModule.spanRepository,
+            currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
+            tracer = initModule.openTelemetryModule.tracer
+        )
+        service.initializeService(1500000000000)
+
+        val data = SpanEventData("spanName", 1500000000000, mapOf("key" to "value"))
+        val span = service.startSpan(data)
+        checkNotNull(span)
+    }
+}


### PR DESCRIPTION
## Goal

Makes a couple of tweaks to functions within the internal data capture services:

- Extracts `SpanDataSource` to separate source file
- Renames `LogService` to `LogWriter`
- Adds a utility function for converting `EmbraceSpanData` to a `EmbraceSpan`
