### PR TITLE
Add a LogEventData class for holding info

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.arch.destination
+
+/**
+ * Represents a Log event that can be added to the current session span.
+ */
+internal class LogEventData(
+    val startTimeNanos: Long,
+    val severityNumber: Int,
+    val severityText: String?,
+    val message: String,
+    val attributes: Map<String, String>?
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventMapper.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.arch.destination
+
+/**
+ * Converts an object of type T to a [LogEventData]
+ */
+internal fun interface LogEventMapper<T> {
+    fun T.toLogEventData(): LogEventData
+}


### PR DESCRIPTION
## Goal

Adds a `LogEventData` class that holds info. This follows the same pattern as `SpanEventData` and `SpanAttributeData` & will be used to hold data before it is put into an OTel store.

