### PR TITLE
Convert LogsApi to kotlin.

### DIFF
--- a/embrace-android-sdk/lint-baseline.xml
+++ b/embrace-android-sdk/lint-baseline.xml
@@ -268,10 +268,10 @@
     <issue
         id="EmbracePublicApiPackageRule"
         message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
-        errorLine1="interface LogsApi {"
+        errorLine1="internal interface LogsApi {"
         errorLine2="          ~~~~~~~">
         <location
-            file="src/main/java/io/embrace/android/embracesdk/LogsApi.java"
+            file="src/main/java/io/embrace/android/embracesdk/LogsApi.kt"
             line="11"
             column="11"/>
     </issue>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -311,7 +311,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public void logMessage(@NonNull String message,
                            @NonNull Severity severity,
-                           @Nullable Map<String, Object> properties) {
+                           @Nullable Map<String, ?> properties) {
         if (verifyNonNullParameters("logMessage", message, severity)) {
             impl.logMessage(message, severity, properties);
         }
@@ -334,7 +334,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public void logException(@NonNull Throwable throwable,
                              @NonNull Severity severity,
-                             @Nullable Map<String, Object> properties) {
+                             @Nullable Map<String, ?> properties) {
         if (verifyNonNullParameters("logException", throwable, severity)) {
             logException(throwable, severity, properties, null);
         }
@@ -343,7 +343,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public void logException(@NonNull Throwable throwable,
                              @NonNull Severity severity,
-                             @Nullable Map<String, Object> properties,
+                             @Nullable Map<String, ?> properties,
                              @Nullable String message) {
         if (verifyNonNullParameters("logException", throwable, severity)) {
             impl.logException(throwable, severity, properties, message);
@@ -367,7 +367,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements,
                                     @NonNull Severity severity,
-                                    @Nullable Map<String, Object> properties) {
+                                    @Nullable Map<String, ?> properties) {
         if (verifyNonNullParameters("logCustomStacktrace", (Object) stacktraceElements, severity)) {
             logCustomStacktrace(stacktraceElements, severity, properties, null);
         }
@@ -376,7 +376,7 @@ public final class Embrace implements EmbraceAndroidApi {
     @Override
     public void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements,
                                     @NonNull Severity severity,
-                                    @Nullable Map<String, Object> properties,
+                                    @Nullable Map<String, ?> properties,
                                     @Nullable String message) {
         if (verifyNonNullParameters("logCustomStacktrace", (Object) stacktraceElements, severity)) {
             impl.logCustomStacktrace(stacktraceElements, severity, properties, message);

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -783,7 +783,7 @@ final class EmbraceImpl {
 
     void logMessage(@NonNull String message,
                     @NonNull Severity severity,
-                    @Nullable Map<String, Object> properties) {
+                    @Nullable Map<String, ?> properties) {
         logMessage(
             EventType.Companion.fromSeverity(severity),
             message,
@@ -798,7 +798,7 @@ final class EmbraceImpl {
 
     void logException(@NonNull Throwable throwable,
                       @NonNull Severity severity,
-                      @Nullable Map<String, Object> properties,
+                      @Nullable Map<String, ?> properties,
                       @Nullable String message) {
         String exceptionMessage = throwable.getMessage() != null ? throwable.getMessage() : "";
         logMessage(
@@ -816,7 +816,7 @@ final class EmbraceImpl {
 
     void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements,
                              @NonNull Severity severity,
-                             @Nullable Map<String, Object> properties,
+                             @Nullable Map<String, ?> properties,
                              @Nullable String message) {
         logMessage(
             EventType.Companion.fromSeverity(severity),
@@ -834,7 +834,7 @@ final class EmbraceImpl {
     void logMessage(
         @NonNull EventType type,
         @NonNull String message,
-        @Nullable Map<String, Object> properties,
+        @Nullable Map<String, ?> properties,
         @Nullable StackTraceElement[] stackTraceElements,
         @Nullable String customStackTrace,
         @NonNull LogExceptionType logExceptionType,
@@ -855,7 +855,7 @@ final class EmbraceImpl {
     void logMessage(
         @NonNull EventType type,
         @NonNull String message,
-        @Nullable Map<String, Object> properties,
+        @Nullable Map<String, ?> properties,
         @Nullable StackTraceElement[] stackTraceElements,
         @Nullable String customStackTrace,
         @NonNull LogExceptionType logExceptionType,
@@ -1221,7 +1221,7 @@ final class EmbraceImpl {
     }
 
     @Nullable
-    private Map<String, Object> normalizeProperties(@Nullable Map<String, Object> properties) {
+    private Map<String, Object> normalizeProperties(@Nullable Map<String, ?> properties) {
         Map<String, Object> normalizedProperties = new HashMap<>();
         if (properties != null) {
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LogsApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LogsApi.kt
@@ -1,15 +1,9 @@
-package io.embrace.android.embracesdk;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import java.util.Map;
+package io.embrace.android.embracesdk
 
 /**
  * The public API that is used to send log messages.
  */
-interface LogsApi {
-
+internal interface LogsApi {
     /**
      * Remotely logs a message at the given severity level. These log messages will appear as part of the session
      * timeline, and can be used to describe what was happening at a particular time within the app.
@@ -17,8 +11,10 @@ interface LogsApi {
      * @param message  the message to remotely log
      * @param severity the severity level of the log message
      */
-    void logMessage(@NonNull String message,
-                    @NonNull Severity severity);
+    fun logMessage(
+        message: String,
+        severity: Severity,
+    )
 
     /**
      * Remotely logs a message at the given severity level. These log messages will appear as part of the session
@@ -28,9 +24,11 @@ interface LogsApi {
      * @param severity   the severity level of the log message
      * @param properties the properties to attach to the log message
      */
-    void logMessage(@NonNull String message,
-                    @NonNull Severity severity,
-                    @Nullable Map<String, Object> properties);
+    fun logMessage(
+        message: String,
+        severity: Severity,
+        properties: Map<String, Any>?,
+    )
 
     /**
      * Remotely logs a message at INFO level. These log messages will appear as part of the session
@@ -38,7 +36,7 @@ interface LogsApi {
      *
      * @param message the message to remotely log
      */
-    void logInfo(@NonNull String message);
+    fun logInfo(message: String)
 
     /**
      * Remotely logs a message at WARN level. These log messages will appear as part of the session
@@ -46,7 +44,7 @@ interface LogsApi {
      *
      * @param message the message to remotely log
      */
-    void logWarning(@NonNull String message);
+    fun logWarning(message: String)
 
     /**
      * Remotely logs a message at ERROR level. These log messages will appear as part of the session
@@ -54,7 +52,7 @@ interface LogsApi {
      *
      * @param message the message to remotely log
      */
-    void logError(@NonNull String message);
+    fun logError(message: String)
 
     /**
      * Remotely logs a Throwable/Exception at ERROR level. These log messages and stacktraces
@@ -63,7 +61,7 @@ interface LogsApi {
      *
      * @param throwable the throwable to remotely log
      */
-    void logException(@NonNull Throwable throwable);
+    fun logException(throwable: Throwable)
 
     /**
      * Remotely logs a Throwable/Exception at given severity level. These log messages and stacktraces
@@ -73,8 +71,10 @@ interface LogsApi {
      * @param throwable the throwable to remotely log
      * @param severity  the severity level of the log message
      */
-    void logException(@NonNull Throwable throwable,
-                      @NonNull Severity severity);
+    fun logException(
+        throwable: Throwable,
+        severity: Severity,
+    )
 
     /**
      * Remotely logs a Throwable/Exception at given severity level. These log messages and stacktraces
@@ -85,9 +85,11 @@ interface LogsApi {
      * @param severity   the severity level of the log message
      * @param properties custom key-value pairs to include with the log message
      */
-    void logException(@NonNull Throwable throwable,
-                      @NonNull Severity severity,
-                      @Nullable Map<String, Object> properties);
+    fun logException(
+        throwable: Throwable,
+        severity: Severity,
+        properties: Map<String, Any>?,
+    )
 
     /**
      * Remotely logs a Throwable/Exception at given severity level. These log messages and stacktraces
@@ -99,10 +101,12 @@ interface LogsApi {
      * @param properties      custom key-value pairs to include with the log message
      * @param message         the message to remotely log instead of the throwable message
      */
-    void logException(@NonNull Throwable throwable,
-                      @NonNull Severity severity,
-                      @Nullable Map<String, Object> properties,
-                      @Nullable String message);
+    fun logException(
+        throwable: Throwable,
+        severity: Severity,
+        properties: Map<String, Any>?,
+        message: String?,
+    )
 
     /**
      * Remotely logs a custom stacktrace at ERROR level. These log messages and stacktraces
@@ -111,7 +115,7 @@ interface LogsApi {
      *
      * @param stacktraceElements the stacktrace to remotely log
      */
-    void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements);
+    fun logCustomStacktrace(stacktraceElements: Array<StackTraceElement?>)
 
     /**
      * Remotely logs a custom stacktrace at given severity level. These log messages and stacktraces
@@ -121,8 +125,10 @@ interface LogsApi {
      * @param stacktraceElements the stacktrace to remotely log
      * @param severity           the severity level of the log message
      */
-    void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements,
-                             @NonNull Severity severity);
+    fun logCustomStacktrace(
+        stacktraceElements: Array<StackTraceElement?>,
+        severity: Severity,
+    )
 
     /**
      * Remotely logs a custom stacktrace at given severity level. These log messages and stacktraces
@@ -133,9 +139,11 @@ interface LogsApi {
      * @param severity           the severity level of the log message
      * @param properties         custom key-value pairs to include with the log message
      */
-    void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements,
-                             @NonNull Severity severity,
-                             @Nullable Map<String, Object> properties);
+    fun logCustomStacktrace(
+        stacktraceElements: Array<StackTraceElement?>,
+        severity: Severity,
+        properties: Map<String, Any>?,
+    )
 
     /**
      * Remotely logs a custom stacktrace at given severity level. These log messages and stacktraces
@@ -147,10 +155,12 @@ interface LogsApi {
      * @param properties         custom key-value pairs to include with the log message
      * @param message            the message to remotely log instead of the throwable message
      */
-    void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements,
-                             @NonNull Severity severity,
-                             @Nullable Map<String, Object> properties,
-                             @Nullable String message);
+    fun logCustomStacktrace(
+        stacktraceElements: Array<StackTraceElement?>,
+        severity: Severity,
+        properties: Map<String, Any>?,
+        message: String?,
+    )
 
     /**
      * Saves captured push notification information into session payload
@@ -164,12 +174,14 @@ interface LogsApi {
      * @param isNotification           if it is a notification message.
      * @param hasData                  if the message contains payload data.
      */
-    void logPushNotification(@Nullable String title,
-                             @Nullable String body,
-                             @Nullable String topic,
-                             @Nullable String id,
-                             @Nullable Integer notificationPriority,
-                             @NonNull Integer messageDeliveredPriority,
-                             @NonNull Boolean isNotification,
-                             @NonNull Boolean hasData);
+    fun logPushNotification(
+        title: String?,
+        body: String?,
+        topic: String?,
+        id: String?,
+        notificationPriority: Int?,
+        messageDeliveredPriority: Int?,
+        isNotification: Boolean?,
+        hasData: Boolean?,
+    )
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LogsApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LogsApi.kt
@@ -115,7 +115,7 @@ internal interface LogsApi {
      *
      * @param stacktraceElements the stacktrace to remotely log
      */
-    fun logCustomStacktrace(stacktraceElements: Array<StackTraceElement?>)
+    fun logCustomStacktrace(stacktraceElements: Array<StackTraceElement>)
 
     /**
      * Remotely logs a custom stacktrace at given severity level. These log messages and stacktraces
@@ -126,7 +126,7 @@ internal interface LogsApi {
      * @param severity           the severity level of the log message
      */
     fun logCustomStacktrace(
-        stacktraceElements: Array<StackTraceElement?>,
+        stacktraceElements: Array<StackTraceElement>,
         severity: Severity,
     )
 
@@ -140,7 +140,7 @@ internal interface LogsApi {
      * @param properties         custom key-value pairs to include with the log message
      */
     fun logCustomStacktrace(
-        stacktraceElements: Array<StackTraceElement?>,
+        stacktraceElements: Array<StackTraceElement>,
         severity: Severity,
         properties: Map<String, Any>?,
     )
@@ -156,7 +156,7 @@ internal interface LogsApi {
      * @param message            the message to remotely log instead of the throwable message
      */
     fun logCustomStacktrace(
-        stacktraceElements: Array<StackTraceElement?>,
+        stacktraceElements: Array<StackTraceElement>,
         severity: Severity,
         properties: Map<String, Any>?,
         message: String?,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
@@ -58,7 +58,7 @@ internal class EmbraceInternalInterfaceImplTest {
             embraceImpl.logMessage(
                 EventType.INFO_LOG,
                 "",
-                emptyMap(),
+                emptyMap<String, String>(),
                 null,
                 null,
                 LogExceptionType.NONE,
@@ -75,7 +75,7 @@ internal class EmbraceInternalInterfaceImplTest {
             embraceImpl.logMessage(
                 EventType.WARNING_LOG,
                 "",
-                emptyMap(),
+                emptyMap<String, String>(),
                 null,
                 null,
                 LogExceptionType.NONE,
@@ -92,7 +92,7 @@ internal class EmbraceInternalInterfaceImplTest {
             embraceImpl.logMessage(
                 EventType.ERROR_LOG,
                 "",
-                emptyMap(),
+                emptyMap<String, String>(),
                 null,
                 null,
                 LogExceptionType.NONE,
@@ -111,7 +111,7 @@ internal class EmbraceInternalInterfaceImplTest {
             embraceImpl.logMessage(
                 EventType.ERROR_LOG,
                 "handled exception",
-                emptyMap(),
+                emptyMap<String, String>(),
                 exception.stackTrace,
                 null,
                 LogExceptionType.NONE,


### PR DESCRIPTION
## Goal

- Convert LogsApi to kotlin

## Testing

- Relied on existing unit tests. 

NOTE: Please review the last 3 params of `logPushNotification`. I had to make them nullable because if I make them non-nullable the implementation needs to be updated to primitive types on those 3 params and we would be changing the API. 