### PR TITLE
Change tracing API to take time in milliseconds

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -244,6 +244,7 @@ public final class io/embrace/android/embracesdk/internal/clock/Clock$DefaultImp
 
 public final class io/embrace/android/embracesdk/internal/clock/ClockKt {
 	public static final fun millisToNanos (J)J
+	public static final fun nanosToMillis (J)J
 }
 
 public class io/embrace/android/embracesdk/internal/network/http/EmbraceHttpPathOverride {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.assertions
 
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.isKey
 import io.embrace.android.embracesdk.internal.spans.isPrivate
@@ -27,8 +27,8 @@ internal fun assertEmbraceSpanData(
 ) {
     checkNotNull(span)
     with(span) {
-        assertEquals(expectedStartTimeMs.millisToNanos(), startTimeNanos)
-        assertEquals(expectedEndTimeMs.millisToNanos(), endTimeNanos)
+        assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
+        assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
         assertEquals(expectedParentId, parentSpanId)
         if (expectedTraceId != null) {
             assertEquals(expectedTraceId, traceId)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.LogType
 import io.embrace.android.embracesdk.assertions.assertLogMessageReceived
 import io.embrace.android.embracesdk.getSentLogMessages
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.recordSession
@@ -26,7 +25,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.net.SocketException
-import java.util.concurrent.TimeUnit
 
 /**
  * Validation of the internal API
@@ -291,8 +289,8 @@ internal class EmbraceInternalInterfaceTest {
                     recordSpan(name = "tz-another-span", parentSpanId = parentSpanId) { }
                     recordCompletedSpan(
                         name = "tz-old-span",
-                        startTimeNanos = (harness.fakeClock.now() - 1L).millisToNanos(),
-                        endTimeNanos = embrace.internalInterface.getSdkCurrentTime().millisToNanos(),
+                        startTimeMs = harness.fakeClock.now() - 1L,
+                        endTimeMs = embrace.internalInterface.getSdkCurrentTime(),
                     )
                     stopSpan(spanId = childSpanId, errorCode = ErrorCode.USER_ABANDON)
                     stopSpan(parentSpanId)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -484,41 +484,41 @@ public final class Embrace implements EmbraceAndroidApi {
     }
 
     @Override
-    public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable ErrorCode errorCode,
+    public boolean recordCompletedSpan(@NonNull String name, long startTimeMs, long endTimeMs, @Nullable ErrorCode errorCode,
                                        @Nullable EmbraceSpan parent, @Nullable Map<String, String> attributes,
                                        @Nullable List<EmbraceSpanEvent> events) {
         if (verifyNonNullParameters("recordCompletedSpan", name)) {
-            return impl.tracer.recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent, attributes, events);
+            return impl.tracer.recordCompletedSpan(name, startTimeMs, endTimeMs, errorCode, parent, attributes, events);
         }
 
         return false;
     }
 
     @Override
-    public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos) {
-        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, null, null, null, null);
+    public boolean recordCompletedSpan(@NonNull String name, long startTimeMs, long endTimeMs) {
+        return recordCompletedSpan(name, startTimeMs, endTimeMs, null, null, null, null);
     }
 
     @Override
-    public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable ErrorCode errorCode) {
-        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, null, null, null);
+    public boolean recordCompletedSpan(@NonNull String name, long startTimeMs, long endTimeMs, @Nullable ErrorCode errorCode) {
+        return recordCompletedSpan(name, startTimeMs, endTimeMs, errorCode, null, null, null);
     }
 
     @Override
-    public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable EmbraceSpan parent) {
-        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, null, parent, null, null);
+    public boolean recordCompletedSpan(@NonNull String name, long startTimeMs, long endTimeMs, @Nullable EmbraceSpan parent) {
+        return recordCompletedSpan(name, startTimeMs, endTimeMs, null, parent, null, null);
     }
 
     @Override
-    public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos, @Nullable ErrorCode errorCode,
+    public boolean recordCompletedSpan(@NonNull String name, long startTimeMs, long endTimeMs, @Nullable ErrorCode errorCode,
                                        @Nullable EmbraceSpan parent) {
-        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, errorCode, parent, null, null);
+        return recordCompletedSpan(name, startTimeMs, endTimeMs, errorCode, parent, null, null);
     }
 
     @Override
-    public boolean recordCompletedSpan(@NonNull String name, long startTimeNanos, long endTimeNanos,
+    public boolean recordCompletedSpan(@NonNull String name, long startTimeMs, long endTimeMs,
                                        @Nullable Map<String, String> attributes, @Nullable List<EmbraceSpanEvent> events) {
-        return recordCompletedSpan(name, startTimeNanos, endTimeNanos, null, null, attributes, events);
+        return recordCompletedSpan(name, startTimeMs, endTimeMs, null, null, attributes, events);
     }
 
     @Nullable

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -264,9 +264,9 @@ final class EmbraceImpl {
             return;
         }
 
-        final long startTime = sdkClock.now();
+        final long startTimeMs = sdkClock.now();
         internalEmbraceLogger.logDeveloper("Embrace", "Starting SDK for framework " + framework.name());
-        moduleInitBootstrapper.init(context, enableIntegrationTesting, framework, TimeUnit.MILLISECONDS.toNanos(startTime), customAppId);
+        moduleInitBootstrapper.init(context, enableIntegrationTesting, framework, startTimeMs, customAppId);
         telemetryService = moduleInitBootstrapper.getInitModule().getTelemetryService();
 
         final CoreModule coreModule = moduleInitBootstrapper.getCoreModule();
@@ -367,10 +367,10 @@ final class EmbraceImpl {
             essentialServiceModule.getConfigService().getSdkModeBehavior().getAppId() + " Version: " + BuildConfig.VERSION_NAME;
         internalEmbraceLogger.logInfo(startMsg);
 
-        final long endTime = sdkClock.now();
+        final long endTimeMs = sdkClock.now();
         started.set(true);
         Systrace.startSynchronous("startup-tracking");
-        dataCaptureServiceModule.getStartupService().setSdkStartupInfo(startTime, endTime);
+        dataCaptureServiceModule.getStartupService().setSdkStartupInfo(startTimeMs, endTimeMs);
         Systrace.endSynchronous();
 
         Systrace.startSynchronous("startup-moment");

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
@@ -4,7 +4,7 @@ package io.embrace.android.embracesdk.arch.destination
  * Represents a Log event that can be added to the current session span.
  */
 internal class LogEventData(
-    val startTimeNanos: Long,
+    val startTimeMs: Long,
     val severityNumber: Int,
     val severityText: String?,
     val message: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 internal interface SessionSpanWriter {
 
     /**
-     * Add an [EmbraceSpanEvent] with the given [name]. If [timeNanos] is null, the
+     * Add an [EmbraceSpanEvent] with the given [name]. If [spanStartTimeMs] is null, the
      * current time will be used. Optionally, the specific
      * time of the event and a set of attributes can be passed in associated with the event.
      *

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
@@ -5,6 +5,6 @@ package io.embrace.android.embracesdk.arch.destination
  */
 internal class SpanEventData(
     val spanName: String,
-    val spanStartTimeNanos: Long,
+    val spanStartTimeMs: Long,
     val attributes: Map<String, String>?
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.capture.startup
 
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.SpanService
 
 internal class StartupServiceImpl(
@@ -11,21 +10,21 @@ internal class StartupServiceImpl(
      * SDK startup time. Only set for cold start sessions.
      */
     @Volatile
-    private var sdkStartupDuration: Long? = null
+    private var sdkStartupDurationMs: Long? = null
 
     override fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long) {
-        if (sdkStartupDuration == null) {
+        if (sdkStartupDurationMs == null) {
             spanService.recordCompletedSpan(
                 name = "sdk-init",
-                startTimeNanos = startTimeMs.millisToNanos(),
-                endTimeNanos = endTimeMs.millisToNanos()
+                startTimeMs = startTimeMs,
+                endTimeMs = endTimeMs
             )
         }
-        sdkStartupDuration = endTimeMs - startTimeMs
+        sdkStartupDurationMs = endTimeMs - startTimeMs
     }
 
     override fun getSdkStartupInfo(coldStart: Boolean): Long? = when (coldStart) {
-        true -> sdkStartupDuration
+        true -> sdkStartupDurationMs
         false -> null
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.CacheableValue
 import io.embrace.android.embracesdk.internal.EventDescription
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanName
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
@@ -37,7 +36,7 @@ import java.util.concurrent.ConcurrentSkipListMap
  * time, then the event is considered late.
  */
 internal class EmbraceEventService(
-    private val startupStartTime: Long,
+    private val startupStartTimeMs: Long,
     deliveryService: DeliveryService,
     private val configService: ConfigService,
     metadataService: MetadataService,
@@ -123,7 +122,7 @@ internal class EmbraceEventService(
             STARTUP_EVENT_NAME,
             null,
             null,
-            startupStartTime
+            startupStartTimeMs
         )
     }
 
@@ -290,8 +289,8 @@ internal class EmbraceEventService(
         backgroundWorker.submit {
             spanService.recordCompletedSpan(
                 name = STARTUP_SPAN_NAME,
-                startTimeNanos = startupStartTime.millisToNanos(),
-                endTimeNanos = startupEndTimeMillis.millisToNanos(),
+                startTimeMs = startupStartTimeMs,
+                endTimeMs = startupEndTimeMillis,
                 internal = false
             )
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
@@ -38,7 +38,7 @@ internal class DataContainerModuleImpl(
     deliveryModule: DeliveryModule,
     nativeModule: NativeModule,
     sessionProperties: EmbraceSessionProperties,
-    startTime: Long
+    sdkStartTimeMs: Long
 ) : DataContainerModule {
 
     override val applicationExitInfoService: ApplicationExitInfoService by singleton {
@@ -75,7 +75,7 @@ internal class DataContainerModuleImpl(
 
     override val eventService: EventService by singleton {
         EmbraceEventService(
-            startTime,
+            sdkStartTimeMs,
             deliveryModule.deliveryService,
             essentialServiceModule.configService,
             essentialServiceModule.metadataService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -120,7 +120,7 @@ internal class ModuleInitBootstrapper(
         context: Context,
         enableIntegrationTesting: Boolean,
         appFramework: AppFramework,
-        sdkStartTimeNanos: Long,
+        sdkStartTimeMs: Long,
         customAppId: String? = null,
         configServiceProvider: Provider<ConfigService?> = { null },
         versionChecker: VersionChecker = BuildVersionChecker,
@@ -139,7 +139,7 @@ internal class ModuleInitBootstrapper(
                     val initTask = postInit(OpenTelemetryModule::class) {
                         workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit(TaskPriority.CRITICAL) {
                             Systrace.traceSynchronous("span-service-init") {
-                                openTelemetryModule.spanService.initializeService(sdkStartTimeNanos)
+                                openTelemetryModule.spanService.initializeService(sdkStartTimeMs)
                             }
                         }
                     }
@@ -358,7 +358,7 @@ internal class ModuleInitBootstrapper(
                             deliveryModule,
                             nativeModule,
                             sessionProperties,
-                            TimeUnit.NANOSECONDS.toMillis(sdkStartTimeNanos)
+                            sdkStartTimeMs
                         )
                     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Initializable.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/Initializable.kt
@@ -9,7 +9,7 @@ internal interface Initializable {
     /**
      * Explicitly initialize the service post instance creation
      */
-    fun initializeService(sdkInitStartTimeNanos: Long)
+    fun initializeService(sdkInitStartTimeMs: Long)
 
     /**
      * Returns true if this service is initialized

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
@@ -53,7 +53,8 @@ public interface InternalTracingApi {
      *
      * {
      *  "name": [String],
-     *  "timestampNanos": [Long] (optional),
+     *  "timestampMs": [Long] (optional),
+     *  "timestampNanos": [Long] (deprecated and optional),
      *  "attributes": [Map<String, String>] (optional)
      * }
      *
@@ -73,8 +74,8 @@ public interface InternalTracingApi {
      */
     public fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode? = null,
         parentSpanId: String? = null,
         attributes: Map<String, String>? = null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/clock/Clock.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/clock/Clock.kt
@@ -22,3 +22,9 @@ public fun interface Clock {
  */
 @InternalApi
 public fun Long.millisToNanos(): Long = TimeUnit.MILLISECONDS.toNanos(this)
+
+/**
+ * Turns a number that specifies a nanosecond value to milliseconds
+ */
+@InternalApi
+public fun Long.nanosToMillis(): Long = TimeUnit.NANOSECONDS.toMillis(this)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.spans
 import io.embrace.android.embracesdk.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.telemetry.TelemetryService
@@ -30,9 +31,9 @@ internal class CurrentSessionSpanImpl(
      */
     private val sessionSpan: AtomicReference<EmbraceSpan?> = AtomicReference(null)
 
-    override fun initializeService(sdkInitStartTimeNanos: Long) {
+    override fun initializeService(sdkInitStartTimeMs: Long) {
         synchronized(sessionSpan) {
-            sessionSpan.set(startSessionSpan(sdkInitStartTimeNanos))
+            sessionSpan.set(startSessionSpan(sdkInitStartTimeMs))
         }
     }
 
@@ -77,7 +78,7 @@ internal class CurrentSessionSpanImpl(
             if (appTerminationCause == null) {
                 endingSessionSpan.stop()
                 spanRepository.clearCompletedSpans()
-                sessionSpan.set(startSessionSpan(clock.now()))
+                sessionSpan.set(startSessionSpan(clock.now().nanosToMillis()))
             } else {
                 endingSessionSpan.addAttribute(
                     appTerminationCause.keyName(),
@@ -91,7 +92,7 @@ internal class CurrentSessionSpanImpl(
 
     override fun addEvent(event: SpanEventData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
-        return currentSession.addEvent(event.spanName, event.spanStartTimeNanos, event.attributes)
+        return currentSession.addEvent(event.spanName, event.spanStartTimeMs, event.attributes)
     }
 
     override fun addAttribute(attribute: SpanAttributeData): Boolean {
@@ -102,7 +103,7 @@ internal class CurrentSessionSpanImpl(
     /**
      * This method should always be used when starting a new session span
      */
-    private fun startSessionSpan(startTimeNanos: Long): EmbraceSpan {
+    private fun startSessionSpan(startTimeMs: Long): EmbraceSpan {
         traceCount.set(0)
 
         val spanBuilder = createEmbraceSpanBuilder(
@@ -111,7 +112,7 @@ internal class CurrentSessionSpanImpl(
             type = EmbraceAttributes.Type.SESSION
         )
             .setNoParent()
-            .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
+            .setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
 
         return EmbraceSpanImpl(spanBuilder, sessionSpan = true).apply {
             start()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -176,7 +176,7 @@ internal fun Span.setSequenceId(id: Long): Span {
  * Ends the given [Span], and setting the correct properties per the optional [ErrorCode] passed in. If [errorCode]
  * is not specified, it means the [Span] completed successfully, and no [ErrorCode] will be set.
  */
-internal fun Span.endSpan(errorCode: ErrorCode? = null, endTimeNanos: Long? = null): Span {
+internal fun Span.endSpan(errorCode: ErrorCode? = null, endTimeMs: Long? = null): Span {
     if (errorCode == null) {
         setStatus(StatusCode.OK)
     } else {
@@ -184,8 +184,8 @@ internal fun Span.endSpan(errorCode: ErrorCode? = null, endTimeNanos: Long? = nu
         setAttribute(errorCode.keyName(), errorCode.toString())
     }
 
-    if (endTimeNanos != null) {
-        end(endTimeNanos, TimeUnit.NANOSECONDS)
+    if (endTimeMs != null) {
+        end(endTimeMs, TimeUnit.MILLISECONDS)
     } else {
         end()
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.sdk.trace.data.EventData
@@ -57,7 +58,7 @@ internal data class EmbraceSpanData(
             eventDataList?.forEach { eventData ->
                 val event = EmbraceSpanEvent.create(
                     name = eventData.name,
-                    timestampNanos = eventData.epochNanos,
+                    timestampMs = eventData.epochNanos.nanosToMillis(),
                     attributes = eventData.attributes.asMap().entries.associate { it.key.key to it.value.toString() }
                 )
                 if (event != null) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -37,15 +37,15 @@ internal class EmbraceSpanImpl(
     override val isRecording: Boolean
         get() = startedSpan.get()?.isRecording == true
 
-    override fun start(): Boolean = start(startTimeNanos = null)
+    override fun start(): Boolean = start(startTimeMs = null)
 
-    override fun start(startTimeNanos: Long?): Boolean {
+    override fun start(startTimeMs: Long?): Boolean {
         return if (startedSpan.get() != null) {
             false
         } else {
             var successful: Boolean
-            if (startTimeNanos != null) {
-                spanBuilder.setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
+            if (startTimeMs != null) {
+                spanBuilder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
             }
             synchronized(startedSpan) {
                 startedSpan.set(spanBuilder.startSpan())
@@ -58,19 +58,19 @@ internal class EmbraceSpanImpl(
         }
     }
 
-    override fun stop(): Boolean = stop(endTimeNanos = null, errorCode = null)
+    override fun stop(): Boolean = stop(endTimeMs = null, errorCode = null)
 
-    override fun stop(endTimeNanos: Long?): Boolean = stop(endTimeNanos = endTimeNanos, errorCode = null)
+    override fun stop(endTimeMs: Long?): Boolean = stop(endTimeMs = endTimeMs, errorCode = null)
 
-    override fun stop(errorCode: ErrorCode?): Boolean = stop(endTimeNanos = null, errorCode = errorCode)
+    override fun stop(errorCode: ErrorCode?): Boolean = stop(endTimeMs = null, errorCode = errorCode)
 
-    override fun stop(endTimeNanos: Long?, errorCode: ErrorCode?): Boolean {
+    override fun stop(endTimeMs: Long?, errorCode: ErrorCode?): Boolean {
         return if (startedSpan.get()?.isRecording == false) {
             false
         } else {
             var successful: Boolean
             synchronized(startedSpan) {
-                startedSpan.get()?.endSpan(errorCode, endTimeNanos)
+                startedSpan.get()?.endSpan(errorCode, endTimeMs)
                 successful = startedSpan.get()?.isRecording == false
             }
             if (successful) {
@@ -80,17 +80,17 @@ internal class EmbraceSpanImpl(
         }
     }
 
-    override fun addEvent(name: String): Boolean = addEvent(name = name, timeNanos = null, attributes = null)
+    override fun addEvent(name: String): Boolean = addEvent(name = name, timestampMs = null, attributes = null)
 
-    override fun addEvent(name: String, timeNanos: Long?, attributes: Map<String, String>?): Boolean {
+    override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean {
         if (eventCount.get() < MAX_EVENT_COUNT && inputsValid(name, attributes)) {
             synchronized(eventCount) {
                 if (eventCount.get() < MAX_EVENT_COUNT) {
                     spanInProgress()?.let { span ->
-                        if (timeNanos != null && !attributes.isNullOrEmpty()) {
-                            span.addEvent(name, Attributes.builder().fromMap(attributes).build(), timeNanos, TimeUnit.NANOSECONDS)
-                        } else if (timeNanos != null) {
-                            span.addEvent(name, timeNanos, TimeUnit.NANOSECONDS)
+                        if (timestampMs != null && !attributes.isNullOrEmpty()) {
+                            span.addEvent(name, Attributes.builder().fromMap(attributes).build(), timestampMs, TimeUnit.MILLISECONDS)
+                        } else if (timestampMs != null) {
+                            span.addEvent(name, timestampMs, TimeUnit.MILLISECONDS)
                         } else if (!attributes.isNullOrEmpty()) {
                             span.addEvent(name, Attributes.builder().fromMap(attributes).build())
                         } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -21,7 +21,7 @@ internal class EmbraceSpanService(
     @Volatile
     private var currentDelegate: SpanService = uninitializedSdkSpansService
 
-    override fun initializeService(sdkInitStartTimeNanos: Long) {
+    override fun initializeService(sdkInitStartTimeMs: Long) {
         if (!initialized()) {
             synchronized(currentDelegate) {
                 if (!initialized()) {
@@ -30,7 +30,7 @@ internal class EmbraceSpanService(
                         currentSessionSpan = currentSessionSpan,
                         tracer = tracerSupplier(),
                     )
-                    realSpansService.initializeService(sdkInitStartTimeNanos)
+                    realSpansService.initializeService(sdkInitStartTimeMs)
                     if (realSpansService.initialized()) {
                         uninitializedSdkSpansService.triggerBufferedSpanRecording(realSpansService)
                     }
@@ -65,8 +65,8 @@ internal class EmbraceSpanService(
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean,
@@ -75,8 +75,8 @@ internal class EmbraceSpanService(
         errorCode: ErrorCode?
     ): Boolean = currentDelegate.recordCompletedSpan(
         name = name,
-        startTimeNanos = startTimeNanos,
-        endTimeNanos = endTimeNanos,
+        startTimeMs = startTimeMs,
+        endTimeMs = endTimeMs,
         parent = parent,
         type = type,
         internal = internal,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -61,33 +61,33 @@ internal class EmbraceTracer(
         code = code
     )
 
-    override fun recordCompletedSpan(name: String, startTimeNanos: Long, endTimeNanos: Long): Boolean =
+    override fun recordCompletedSpan(name: String, startTimeMs: Long, endTimeMs: Long): Boolean =
         recordCompletedSpan(
             name = name,
-            startTimeNanos = startTimeNanos,
-            endTimeNanos = endTimeNanos,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
             errorCode = null,
             parent = null,
             attributes = null,
             events = null
         )
 
-    override fun recordCompletedSpan(name: String, startTimeNanos: Long, endTimeNanos: Long, errorCode: ErrorCode?): Boolean =
+    override fun recordCompletedSpan(name: String, startTimeMs: Long, endTimeMs: Long, errorCode: ErrorCode?): Boolean =
         recordCompletedSpan(
             name = name,
-            startTimeNanos = startTimeNanos,
-            endTimeNanos = endTimeNanos,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
             errorCode = errorCode,
             parent = null,
             attributes = null,
             events = null
         )
 
-    override fun recordCompletedSpan(name: String, startTimeNanos: Long, endTimeNanos: Long, parent: EmbraceSpan?): Boolean =
+    override fun recordCompletedSpan(name: String, startTimeMs: Long, endTimeMs: Long, parent: EmbraceSpan?): Boolean =
         recordCompletedSpan(
             name = name,
-            startTimeNanos = startTimeNanos,
-            endTimeNanos = endTimeNanos,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
             errorCode = null,
             parent = parent,
             attributes = null,
@@ -96,14 +96,14 @@ internal class EmbraceTracer(
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?
     ): Boolean = recordCompletedSpan(
         name = name,
-        startTimeNanos = startTimeNanos,
-        endTimeNanos = endTimeNanos,
+        startTimeMs = startTimeMs,
+        endTimeMs = endTimeMs,
         errorCode = errorCode,
         parent = parent,
         attributes = null,
@@ -112,14 +112,14 @@ internal class EmbraceTracer(
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?
     ): Boolean = recordCompletedSpan(
         name = name,
-        startTimeNanos = startTimeNanos,
-        endTimeNanos = endTimeNanos,
+        startTimeMs = startTimeMs,
+        endTimeMs = endTimeMs,
         errorCode = null,
         parent = null,
         attributes = attributes,
@@ -128,8 +128,8 @@ internal class EmbraceTracer(
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?,
         attributes: Map<String, String>?,
@@ -137,8 +137,8 @@ internal class EmbraceTracer(
     ): Boolean =
         spanService.recordCompletedSpan(
             name = name,
-            startTimeNanos = startTimeNanos,
-            endTimeNanos = endTimeNanos,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
             parent = parent,
             internal = false,
             attributes = attributes ?: emptyMap(),
@@ -149,10 +149,10 @@ internal class EmbraceTracer(
     override fun getSpan(spanId: String): EmbraceSpan? = spanService.getSpan(spanId = spanId)
 
     /**
-     * Return the current time in nanoseconds for the clock instance used by the Embrace SDK. This should be used to obtain the time
+     * Return the current time in millis for the clock instance used by the Embrace SDK. This should be used to obtain the time
      * in used for [recordCompletedSpan] so the timestamps will be in sync with those used by the SDK when a time is implicitly recorded.
      */
-    fun getSdkCurrentTimeNanos(): Long = clock.nowInNanos()
+    fun getSdkCurrentTimeMs(): Long = clock.now()
 
     @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
     override fun isTracingAvailable(): Boolean = spanService.initialized()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -48,8 +48,8 @@ internal class InternalTracer(
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?,
         parentSpanId: String?,
         attributes: Map<String, String>?,
@@ -59,8 +59,8 @@ internal class InternalTracer(
         return if (parent.isValid) {
             embraceTracer.recordCompletedSpan(
                 name = name,
-                startTimeNanos = startTimeNanos,
-                endTimeNanos = endTimeNanos,
+                startTimeMs = startTimeMs,
+                endTimeMs = endTimeMs,
                 errorCode = errorCode,
                 parent = parent.spanReference,
                 attributes = attributes,
@@ -74,7 +74,7 @@ internal class InternalTracer(
     override fun addSpanEvent(spanId: String, name: String, time: Long?, attributes: Map<String, String>?): Boolean =
         spanRepository.getSpan(spanId = spanId)?.addEvent(
             name = name,
-            timeNanos = time,
+            timestampMs = time,
             attributes = attributes
         ) ?: false
 
@@ -86,12 +86,13 @@ internal class InternalTracer(
 
     private fun mapToEvent(map: Map<String, Any>): EmbraceSpanEvent? {
         val name = map["name"]
-        val timestampNanos = map["timestampNanos"]
+        val timestampMs = map["timestampMs"]
         val attributes = map["attributes"]
-        return if (name is String && timestampNanos is Long? && attributes is Map<*, *>?) {
+
+        return if (name is String && timestampMs is Long? && attributes is Map<*, *>?) {
             EmbraceSpanEvent.create(
                 name = name,
-                timestampNanos = timestampNanos ?: embraceTracer.getSdkCurrentTimeNanos(),
+                timestampMs = timestampMs ?: embraceTracer.getSdkCurrentTimeMs(),
                 attributes = attributes?.let { toStringMap(it) }
             )
         } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -63,8 +63,8 @@ internal interface SpanService : Initializable {
      */
     fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         parent: EmbraceSpan? = null,
         type: EmbraceAttributes.Type = EmbraceAttributes.Type.PERFORMANCE,
         internal: Boolean = true,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -18,9 +18,9 @@ internal class SpanServiceImpl(
 ) : SpanService {
     private val initialized = AtomicBoolean(false)
 
-    override fun initializeService(sdkInitStartTimeNanos: Long) {
+    override fun initializeService(sdkInitStartTimeMs: Long) {
         synchronized(initialized) {
-            currentSessionSpan.initializeService(sdkInitStartTimeNanos)
+            currentSessionSpan.initializeService(sdkInitStartTimeMs)
             initialized.set(true)
         }
     }
@@ -59,8 +59,8 @@ internal class SpanServiceImpl(
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean,
@@ -68,7 +68,7 @@ internal class SpanServiceImpl(
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?
     ): Boolean {
-        if (startTimeNanos > endTimeNanos) {
+        if (startTimeMs > endTimeMs) {
             return false
         }
 
@@ -77,11 +77,11 @@ internal class SpanServiceImpl(
         ) {
             createRootSpanBuilder(tracer = tracer, name = name, type = type, internal = internal)
                 .updateParent(parent)
-                .setStartTimestamp(startTimeNanos, TimeUnit.NANOSECONDS)
+                .setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
                 .startSpan()
                 .setAllAttributes(Attributes.builder().fromMap(attributes).build())
                 .addEvents(events)
-                .endSpan(errorCode, endTimeNanos)
+                .endSpan(errorCode, endTimeMs)
             true
         } else {
             false

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
@@ -17,7 +17,7 @@ internal class UninitializedSdkSpanService : SpanService {
     private val bufferedCallsCount = AtomicInteger(0)
     private val realSpanService: AtomicReference<SpanService?> = AtomicReference(null)
 
-    override fun initializeService(sdkInitStartTimeNanos: Long) {}
+    override fun initializeService(sdkInitStartTimeMs: Long) {}
 
     override fun initialized(): Boolean = true
 
@@ -35,8 +35,8 @@ internal class UninitializedSdkSpanService : SpanService {
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean,
@@ -46,8 +46,8 @@ internal class UninitializedSdkSpanService : SpanService {
     ): Boolean {
         return realSpanService.get()?.recordCompletedSpan(
             name = name,
-            startTimeNanos = startTimeNanos,
-            endTimeNanos = endTimeNanos,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
             parent = parent,
             type = type,
             internal = internal,
@@ -61,8 +61,8 @@ internal class UninitializedSdkSpanService : SpanService {
                 bufferedCalls.add(
                     BufferedRecordCompletedSpan(
                         name = name,
-                        startTimeNanos = startTimeNanos,
-                        endTimeNanos = endTimeNanos,
+                        startTimeMs = startTimeMs,
+                        endTimeMs = endTimeMs,
                         parent = parent,
                         type = type,
                         internal = internal,
@@ -90,8 +90,8 @@ internal class UninitializedSdkSpanService : SpanService {
                 bufferedCalls.poll()?.let {
                     delegateSpanService.recordCompletedSpan(
                         name = it.name,
-                        startTimeNanos = it.startTimeNanos,
-                        endTimeNanos = it.endTimeNanos,
+                        startTimeMs = it.startTimeMs,
+                        endTimeMs = it.endTimeMs,
                         parent = it.parent,
                         type = it.type,
                         internal = it.internal,
@@ -113,8 +113,8 @@ internal class UninitializedSdkSpanService : SpanService {
      */
     data class BufferedRecordCompletedSpan(
         val name: String,
-        val startTimeNanos: Long,
-        val endTimeNanos: Long,
+        val startTimeMs: Long,
+        val endTimeMs: Long,
         val parent: EmbraceSpan?,
         val type: EmbraceAttributes.Type,
         val internal: Boolean,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -38,7 +38,7 @@ public interface EmbraceSpan {
      * Start recording of the Span with the given start time. Returns true if this call triggered the start of the recording.
      * Returns false if the Span has already been started or has been stopped.
      */
-    public fun start(startTimeNanos: Long?): Boolean
+    public fun start(startTimeMs: Long?): Boolean
 
     /**
      * Stop the recording of the Span with no [ErrorCode], indicating a successful completion of the underlying operation. Returns true
@@ -50,7 +50,7 @@ public interface EmbraceSpan {
      * Stop the recording of the Span with no [ErrorCode], indicating a successful completion of the underlying operation. Returns true
      * if this call triggered the stopping of the recording. Returns false if the Span has not been started or if has already been stopped.
      */
-    public fun stop(endTimeNanos: Long?): Boolean
+    public fun stop(endTimeMs: Long?): Boolean
 
     /**
      * Stop the recording of the Span with an [ErrorCode], a non-null value indicating an unsuccessful completion of the underlying
@@ -59,7 +59,7 @@ public interface EmbraceSpan {
      */
     public fun stop(errorCode: ErrorCode?): Boolean
 
-    public fun stop(endTimeNanos: Long?, errorCode: ErrorCode?): Boolean
+    public fun stop(endTimeMs: Long?, errorCode: ErrorCode?): Boolean
 
     /**
      * Add an [EmbraceSpanEvent] with the given [name] at the current time. Returns false if the Event was definitely not successfully
@@ -71,14 +71,14 @@ public interface EmbraceSpan {
     ): Boolean
 
     /**
-     * Add an [EmbraceSpanEvent] with the given [name]. If [timeNanos] is null, the current time will be used. Optionally, the specific
+     * Add an [EmbraceSpanEvent] with the given [name]. If [timestampMs] is null, the current time will be used. Optionally, the specific
      * time of the event and a set of attributes can be passed in associated with the event. Returns false if the Event was definitely not
      * successfully added. Returns true if the validation at the Embrace level has passed and the call to add the Event at the
      * OpenTelemetry level was successful.
      */
     public fun addEvent(
         name: String,
-        timeNanos: Long?,
+        timestampMs: Long?,
         attributes: Map<String, String>?
     ): Boolean
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.spans
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.embrace.android.embracesdk.annotation.BetaApi
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 
 /**
  * Represents an Event in an [EmbraceSpan]
@@ -32,9 +33,9 @@ public data class EmbraceSpanEvent internal constructor(
         internal const val MAX_EVENT_NAME_LENGTH = 100
         internal const val MAX_EVENT_ATTRIBUTE_COUNT = 10
 
-        public fun create(name: String, timestampNanos: Long, attributes: Map<String, String>?): EmbraceSpanEvent? {
+        public fun create(name: String, timestampMs: Long, attributes: Map<String, String>?): EmbraceSpanEvent? {
             if (inputsValid(name, attributes)) {
-                return EmbraceSpanEvent(name = name, timestampNanos = timestampNanos, attributes = attributes ?: emptyMap())
+                return EmbraceSpanEvent(name = name, timestampNanos = timestampMs.millisToNanos(), attributes = attributes ?: emptyMap())
             }
 
             return null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -110,8 +110,8 @@ internal interface TracingApi {
     @BetaApi
     fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long
+        startTimeMs: Long,
+        endTimeMs: Long
     ): Boolean
 
     /**
@@ -122,8 +122,8 @@ internal interface TracingApi {
     @BetaApi
     fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?
     ): Boolean
 
@@ -134,8 +134,8 @@ internal interface TracingApi {
     @BetaApi
     fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         parent: EmbraceSpan?
     ): Boolean
 
@@ -147,8 +147,8 @@ internal interface TracingApi {
     @BetaApi
     fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?,
     ): Boolean
@@ -161,8 +161,8 @@ internal interface TracingApi {
     @BetaApi
     fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?
     ): Boolean
@@ -176,8 +176,8 @@ internal interface TracingApi {
     @BetaApi
     fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?,
         attributes: Map<String, String>?,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.capture.startup
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.internal.spans.isPrivate
@@ -42,8 +42,8 @@ internal class StartupServiceImplTest {
         with(currentSpans[0]) {
             assertEquals("emb-sdk-init", name)
             assertEquals(SpanId.getInvalid(), parentSpanId)
-            assertEquals(startTimeMillis.millisToNanos(), startTimeNanos)
-            assertEquals(endTimeMillis.millisToNanos(), endTimeNanos)
+            assertEquals(startTimeMillis, startTimeNanos.nanosToMillis())
+            assertEquals(endTimeMillis, endTimeNanos.nanosToMillis())
             assertEquals(
                 io.embrace.android.embracesdk.internal.spans.EmbraceAttributes.Type.PERFORMANCE.name,
                 attributes[io.embrace.android.embracesdk.internal.spans.EmbraceAttributes.Type.PERFORMANCE.keyName()]

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -22,6 +22,7 @@ import io.embrace.android.embracesdk.fakes.fakeStartupBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.gating.GatingService
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
@@ -119,7 +120,7 @@ internal class EmbraceEventServiceTest {
         spanSink = initModule.openTelemetryModule.spanSink
         currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
         spanService = initModule.openTelemetryModule.spanService
-        spanService.initializeService(fakeClock.nowInNanos())
+        spanService.initializeService(fakeClock.now())
         eventHandler = EventHandler(
             metadataService = metadataService,
             sessionIdTracker = sessionIdTracker,
@@ -426,7 +427,7 @@ internal class EmbraceEventServiceTest {
     @Test
     fun `startup logged as span if startup moment automatic end is enabled`() {
         spanService.initializeService(
-            sdkInitStartTimeNanos = 1_000_000
+            sdkInitStartTimeMs = 1L
         )
         configService.updateListeners()
         currentSessionSpan.endSession()
@@ -438,8 +439,8 @@ internal class EmbraceEventServiceTest {
         assertEquals(1, completedSpans.size)
         with(completedSpans[0]) {
             assertEquals("emb-startup-moment", name)
-            assertEquals(1_000_000L, startTimeNanos)
-            assertEquals(10_000_000L, endTimeNanos)
+            assertEquals(1L, startTimeNanos.nanosToMillis())
+            assertEquals(10L, endTimeNanos.nanosToMillis())
         }
     }
 
@@ -447,7 +448,7 @@ internal class EmbraceEventServiceTest {
     fun `startup logged as span if when startup moment manually ends`() {
         startupMomentLocalConfig = StartupMomentLocalConfig(automaticallyEnd = false)
         spanService.initializeService(
-            sdkInitStartTimeNanos = 1_000_000
+            sdkInitStartTimeMs = 1L
         )
         configService.updateListeners()
         currentSessionSpan.endSession()
@@ -466,15 +467,15 @@ internal class EmbraceEventServiceTest {
 
         with(completedSpansAgain[0]) {
             assertEquals("emb-startup-moment", name)
-            assertEquals(1_000_000L, startTimeNanos)
-            assertEquals(20_000_000L, endTimeNanos)
+            assertEquals(1L, startTimeNanos.nanosToMillis())
+            assertEquals(20L, endTimeNanos.nanosToMillis())
         }
     }
 
     @Test
     fun `startup not logged as span if startup moment is ended via a timeout`() {
         spanService.initializeService(
-            sdkInitStartTimeNanos = 1_000_000
+            sdkInitStartTimeMs = 1_000_000
         )
         configService.updateListeners()
         currentSessionSpan.endSession()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -11,7 +11,7 @@ internal class FakeCurrentSessionSpan : CurrentSessionSpan {
 
     var initializedCallCount = 0
 
-    override fun initializeService(sdkInitStartTimeNanos: Long) {
+    override fun initializeService(sdkInitStartTimeMs: Long) {
     }
 
     override fun addEvent(event: SpanEventData): Boolean {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
@@ -18,9 +18,9 @@ internal class FakeEmbraceSpan private constructor(
     override val isRecording: Boolean
         get() = started && !stopped
 
-    override fun start(): Boolean = start(startTimeNanos = null)
+    override fun start(): Boolean = start(startTimeMs = null)
 
-    override fun start(startTimeNanos: Long?): Boolean {
+    override fun start(startTimeMs: Long?): Boolean {
         if (!started) {
             spanId = IdGenerator.random().generateSpanId()
             if (parent == null) {
@@ -31,13 +31,13 @@ internal class FakeEmbraceSpan private constructor(
         return true
     }
 
-    override fun stop(): Boolean = stop(errorCode = null, endTimeNanos = null)
+    override fun stop(): Boolean = stop(errorCode = null, endTimeMs = null)
 
-    override fun stop(endTimeNanos: Long?): Boolean = stop(errorCode = null, endTimeNanos = endTimeNanos)
+    override fun stop(endTimeMs: Long?): Boolean = stop(errorCode = null, endTimeMs = endTimeMs)
 
-    override fun stop(errorCode: ErrorCode?): Boolean = stop(errorCode = errorCode, endTimeNanos = null)
+    override fun stop(errorCode: ErrorCode?): Boolean = stop(errorCode = errorCode, endTimeMs = null)
 
-    override fun stop(endTimeNanos: Long?, errorCode: ErrorCode?): Boolean {
+    override fun stop(endTimeMs: Long?, errorCode: ErrorCode?): Boolean {
         if (!stopped) {
             this.errorCode = errorCode
             stopped = true
@@ -49,7 +49,7 @@ internal class FakeEmbraceSpan private constructor(
         TODO("Not yet implemented")
     }
 
-    override fun addEvent(name: String, timeNanos: Long?, attributes: Map<String, String>?): Boolean {
+    override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean {
         TODO("Not yet implemented")
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -10,7 +10,7 @@ internal class FakeSpanService : SpanService {
 
     val createdSpans = mutableListOf<String>()
 
-    override fun initializeService(sdkInitStartTimeNanos: Long) {
+    override fun initializeService(sdkInitStartTimeMs: Long) {
     }
 
     override fun initialized(): Boolean = true
@@ -39,8 +39,8 @@ internal class FakeSpanService : SpanService {
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
@@ -53,16 +53,16 @@ internal class FakeTracingApi : TracingApi {
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long
+        startTimeMs: Long,
+        endTimeMs: Long
     ): Boolean {
         TODO("Not yet implemented")
     }
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?
     ): Boolean {
         TODO("Not yet implemented")
@@ -70,8 +70,8 @@ internal class FakeTracingApi : TracingApi {
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         parent: EmbraceSpan?
     ): Boolean {
         TODO("Not yet implemented")
@@ -79,8 +79,8 @@ internal class FakeTracingApi : TracingApi {
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?
     ): Boolean {
@@ -89,8 +89,8 @@ internal class FakeTracingApi : TracingApi {
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?
     ): Boolean {
@@ -99,8 +99,8 @@ internal class FakeTracingApi : TracingApi {
 
     override fun recordCompletedSpan(
         name: String,
-        startTimeNanos: Long,
-        endTimeNanos: Long,
+        startTimeMs: Long,
+        endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?,
         attributes: Map<String, String>?,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -18,14 +18,14 @@ internal val testSpan = EmbraceSpanData(
         checkNotNull(
             EmbraceSpanEvent.create(
                 name = "start-time",
-                timestampNanos = 1681972471807000000L,
+                timestampMs = 1681972471807L,
                 attributes = mapOf(Pair("test1", "value1"), Pair("test2", "value2"))
             )
         ),
         checkNotNull(
             EmbraceSpanEvent.create(
                 name = "end-span-event",
-                timestampNanos = 1681972471871000000L,
+                timestampMs = 1681972471871L,
                 attributes = null
             )
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -58,8 +59,8 @@ internal class CurrentSessionSpanImplTests {
             assertTrue(
                 spanService.recordCompletedSpan(
                     name = "complete$it",
-                    startTimeNanos = 100L,
-                    endTimeNanos = 200L,
+                    startTimeMs = 100L,
+                    endTimeMs = 200L,
                     internal = false
                 )
             )
@@ -92,8 +93,8 @@ internal class CurrentSessionSpanImplTests {
         assertFalse(
             spanService.recordCompletedSpan(
                 name = "failed-span",
-                startTimeNanos = 100L,
-                endTimeNanos = 200L,
+                startTimeMs = 100L,
+                endTimeMs = 200L,
                 parent = parentSpan,
                 internal = false
             )
@@ -112,8 +113,8 @@ internal class CurrentSessionSpanImplTests {
         assertTrue(
             spanService.recordCompletedSpan(
                 name = "failed-span",
-                startTimeNanos = 100L,
-                endTimeNanos = 200L,
+                startTimeMs = 100L,
+                endTimeMs = 200L,
                 parent = parentSpan,
                 internal = true
             )
@@ -186,7 +187,7 @@ internal class CurrentSessionSpanImplTests {
         // verify event was added to the span
         val testEvent = span.events.single()
         assertEquals("test-event", testEvent.name)
-        assertEquals(1000, testEvent.timestampNanos)
+        assertEquals(1000, testEvent.timestampNanos.nanosToMillis())
         assertEquals(mapOf("key" to "value"), testEvent.attributes)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -76,8 +76,8 @@ internal class EmbraceSpanImplTest {
     @Test
     fun `validate starting and stopping span with specific times`() {
         with(embraceSpan) {
-            assertTrue(start(startTimeNanos = 5L))
-            assertTrue(stop(endTimeNanos = 10L))
+            assertTrue(start(startTimeMs = 5L))
+            assertTrue(stop(endTimeMs = 10L))
             validateStoppedSpan()
         }
     }
@@ -102,12 +102,12 @@ internal class EmbraceSpanImplTest {
             assertTrue(
                 addEvent(
                     name = "second current event",
-                    timeNanos = null,
+                    timestampMs = null,
                     attributes = mapOf(Pair("key", "value"), Pair("key2", "value1"))
                 )
             )
-            assertTrue(addEvent(name = "past event", timeNanos = 1L, attributes = null))
-            assertTrue(addEvent(name = "future event", timeNanos = 2L, mapOf(Pair("key", "value"), Pair("key2", "value1"))))
+            assertTrue(addEvent(name = "past event", timestampMs = 1L, attributes = null))
+            assertTrue(addEvent(name = "future event", timestampMs = 2L, mapOf(Pair("key", "value"), Pair("key2", "value1"))))
         }
     }
 
@@ -127,11 +127,11 @@ internal class EmbraceSpanImplTest {
         with(embraceSpan) {
             assertTrue(start())
             assertFalse(addEvent(name = TOO_LONG_EVENT_NAME))
-            assertFalse(addEvent(name = TOO_LONG_EVENT_NAME, timeNanos = null, attributes = null))
-            assertFalse(addEvent(name = "yo", timeNanos = null, attributes = tooBigEventAttributes))
+            assertFalse(addEvent(name = TOO_LONG_EVENT_NAME, timestampMs = null, attributes = null))
+            assertFalse(addEvent(name = "yo", timestampMs = null, attributes = tooBigEventAttributes))
             assertTrue(addEvent(name = MAX_LENGTH_EVENT_NAME))
-            assertTrue(addEvent(name = MAX_LENGTH_EVENT_NAME, timeNanos = null, attributes = null))
-            assertTrue(addEvent(name = "yo", timeNanos = null, attributes = maxSizeEventAttributes))
+            assertTrue(addEvent(name = MAX_LENGTH_EVENT_NAME, timestampMs = null, attributes = null))
+            assertTrue(addEvent(name = "yo", timestampMs = null, attributes = maxSizeEventAttributes))
             repeat(EmbraceSpanImpl.MAX_EVENT_COUNT - 4) {
                 assertTrue(addEvent(name = "event $it"))
             }
@@ -145,7 +145,7 @@ internal class EmbraceSpanImplTest {
             assertTrue(
                 addEvent(
                     name = "yo",
-                    timeNanos = null,
+                    timestampMs = null,
                     attributes = eventAttributesAMap
                 )
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -55,22 +55,22 @@ internal class EmbraceSpanServiceTest {
     fun `record internal completed span recording with all the fixings`() {
         spanSink.flushSpans()
         val expectedName = "test-span"
-        val expectedStartTime = clock.now()
-        val expectedEndTime = expectedStartTime + 100L
+        val expectedStartTimeMs = clock.now()
+        val expectedEndTimeMs = expectedStartTimeMs + 100L
         val expectedType = EmbraceAttributes.Type.PERFORMANCE
         val expectedAttributes = mapOf(
             Pair("attribute1", "value1"),
             Pair("attribute2", "value2")
         )
         val expectedEvents = listOf(
-            EmbraceSpanEvent(name = "event1", timestampNanos = 0L, attributes = expectedAttributes),
-            EmbraceSpanEvent(name = "event2", timestampNanos = 5L, attributes = expectedAttributes)
+            EmbraceSpanEvent(name = "event1", timestampNanos = 1_000_000L, expectedAttributes),
+            EmbraceSpanEvent(name = "event2", timestampNanos = 5_000_000L, expectedAttributes),
         )
 
         spanService.recordCompletedSpan(
             name = expectedName,
-            startTimeNanos = expectedStartTime,
-            endTimeNanos = expectedEndTime,
+            startTimeMs = expectedStartTimeMs,
+            endTimeMs = expectedEndTimeMs,
             type = expectedType,
             attributes = expectedAttributes,
             events = expectedEvents
@@ -83,8 +83,8 @@ internal class EmbraceSpanServiceTest {
 
         with(span) {
             assertEquals(name, name)
-            assertEquals(expectedStartTime, startTimeNanos)
-            assertEquals(expectedEndTime, endTimeNanos)
+            assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
+            assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
             assertEquals(expectedType.name, attributes[EmbraceAttributes.Type.PERFORMANCE.keyName()])
             expectedAttributes.forEach {
                 assertEquals(it.value, attributes[it.key])
@@ -99,9 +99,9 @@ internal class EmbraceSpanServiceTest {
         val parent = checkNotNull(spanService.createSpan("test-span"))
         assertTrue(parent.start())
         val child = checkNotNull(spanService.createSpan(name = "child-span", parent = parent))
-        assertTrue(child.start(startTimeNanos = (clock.now() - 10).millisToNanos()))
+        assertTrue(child.start(startTimeMs = clock.now() - 10))
         assertTrue(child.stop())
-        assertTrue(parent.stop(endTimeNanos = (clock.now() + 50).millisToNanos()))
+        assertTrue(parent.stop(endTimeMs = clock.now() + 50))
         assertTrue(parent.traceId == child.traceId)
         assertTrue(parent.spanId == checkNotNull(child.parent).spanId)
     }
@@ -110,13 +110,13 @@ internal class EmbraceSpanServiceTest {
     fun `can record completed span after init`() {
         spanSink.flushSpans()
         val expectedName = "test-span"
-        val expectedStartTime = clock.now()
-        val expectedEndTime = expectedStartTime + 100L
+        val expectedStartTimeMs = clock.now()
+        val expectedEndTimeMs = expectedStartTimeMs + 100L
         assertTrue(
             spanService.recordCompletedSpan(
                 name = expectedName,
-                startTimeNanos = expectedStartTime,
-                endTimeNanos = expectedEndTime
+                startTimeMs = expectedStartTimeMs,
+                endTimeMs = expectedEndTimeMs
             )
         )
 
@@ -127,16 +127,16 @@ internal class EmbraceSpanServiceTest {
     fun `can record completed child span after init`() {
         spanSink.flushSpans()
         val expectedName = "child-span"
-        val expectedStartTime = clock.now()
-        val expectedEndTime = expectedStartTime + 100L
+        val expectedStartTimeMs = clock.now()
+        val expectedEndTimeMs = expectedStartTimeMs + 100L
         val parentSpan = checkNotNull(spanService.createSpan(name = "test-span"))
         assertTrue(parentSpan.start())
         assertTrue(
             spanService.recordCompletedSpan(
                 name = expectedName,
                 parent = parentSpan,
-                startTimeNanos = expectedStartTime,
-                endTimeNanos = expectedEndTime
+                startTimeMs = expectedStartTimeMs,
+                endTimeMs = expectedEndTimeMs
             )
         )
         assertTrue(parentSpan.stop())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -108,7 +108,7 @@ internal class PayloadFactoryBaTest {
         // Prevent background thread from overwriting deliveryService.lastSavedBackgroundActivity
         blockingExecutorService = BlockingScheduledExecutorService(blockingMode = true)
         service = createService()
-        val now = clock.nowInNanos()
+        val now = clock.now()
         spanService.initializeService(now)
         val msg = service.endBackgroundActivityWithCrash(initial, now, "crashId")
 
@@ -120,7 +120,7 @@ internal class PayloadFactoryBaTest {
     @Test
     fun `foregrounding will flush the current completed spans`() {
         service = createService()
-        spanService.initializeService(clock.nowInNanos())
+        spanService.initializeService(clock.now())
         val msg = service.endBackgroundActivityWithState(initial, clock.now())
 
         // there should be 1 completed span: the session span
@@ -131,7 +131,7 @@ internal class PayloadFactoryBaTest {
     @Test
     fun `sending background activity will flush the current completed spans`() {
         service = createService()
-        spanService.initializeService(clock.nowInNanos())
+        spanService.initializeService(clock.now())
         clock.tick(1000L)
         val msg = service.endBackgroundActivityWithState(initial, clock.now())
 


### PR DESCRIPTION
## Goal

Changing the public Embrace API to use milliseconds when specifying times to be more inline with Android developer expectations. Make every time-based parameter specify the unit in the name. Serialized forms stay in milliseconds to comply with OTel and not change server expectations.

The work to detect if a given timestamp is in nanoseconds and then auto converting to millis to ensure current usage don't fail will be done in a subsequent PR.

## Testing

Modified existing tests