### PR TITLE
Tweak data source implementation

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSource.kt
@@ -29,7 +29,7 @@ internal interface DataSource<T> {
      * This function returns true if data was successfully captured & false if not.
      * This is assumed to be the case if [captureAction] completed without throwing.
      */
-    fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean
+    fun alterSessionSpan(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean
 
     /**
      * Enables data capture. This should include registering any listeners, and resetting

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
@@ -25,9 +25,10 @@ internal abstract class DataSourceImpl<T>(
         limitStrategy.resetDataCaptureLimits()
     }
 
-    override fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean {
-        return captureDataImpl(inputValidation, captureAction)
-    }
+    override fun alterSessionSpan(
+        inputValidation: () -> Boolean,
+        captureAction: T.() -> Unit
+    ): Boolean = captureDataImpl(inputValidation, captureAction, true)
 
     protected fun captureDataImpl(
         inputValidation: () -> Boolean,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.arch.datasource
 
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
+import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
@@ -10,8 +11,11 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 internal interface SpanDataSource : DataSource<SpanService> {
 
     /**
-     * The DataSource should call this function when it wants to start an [EmbraceSpan].
-     * If you want to add an event or attribute, please use [captureData] instead.
+     * The DataSource should call this function when it wants to start, stop, or mutate
+     * an [EmbraceSpan]. [alterSessionSpan] should only be used for adding to the session span.
+     *
+     * The [countsTowardsLimits] parameter should be true if the [captureAction] will add data
+     * that should count towards the limits.
      *
      * The [inputValidation] parameter should return true if the user inputs are valid.
      * (e.g. an empty string is not valid for a breadcrumb message).
@@ -23,29 +27,18 @@ internal interface SpanDataSource : DataSource<SpanService> {
      * This function returns true if data was successfully captured & false if not.
      * This is assumed to be the case if [captureAction] completed without throwing.
      */
-    fun startSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
-
-    /**
-     * The DataSource should call this function when it wants to stop an existing [EmbraceSpan].
-     * If you want to add an event or attribute, please use [captureData] instead.
-     *
-     * The [inputValidation] parameter should return true if the user inputs are valid.
-     * (e.g. an empty string is not valid for a breadcrumb message).
-     *
-     * The [captureAction] parameter is a lambda that captures the data and sends it to the
-     * destination. It will be called only if [inputValidation] returns true & no data capture
-     * limits have been exceeded.
-     *
-     * This function returns true if data was successfully captured & false if not.
-     * This is assumed to be the case if [captureAction] completed without throwing.
-     */
-    fun stopSpan(inputValidation: () -> Boolean, captureAction: SpanService.() -> Unit): Boolean
+    fun captureSpanData(
+        countsTowardsLimits: Boolean,
+        inputValidation: () -> Boolean,
+        captureAction: SpanService.() -> Unit
+    ): Boolean
 }
 
 /**
  * Starts a span using the given [SpanEventData].
  */
-internal fun SpanService.startSpan(data: SpanEventData): EmbraceSpan? {
+internal fun <T> SpanService.startSpanCapture(obj: T, mapper: T.() -> StartSpanData): EmbraceSpan? {
+    val data = obj.mapper()
     return createSpan(data.spanName)?.apply {
         data.attributes?.forEach {
             addAttribute(it.key, it.value)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSourceImpl.kt
@@ -18,13 +18,9 @@ internal abstract class SpanDataSourceImpl(
     logger
 ) {
 
-    override fun startSpan(
+    override fun captureSpanData(
+        countsTowardsLimits: Boolean,
         inputValidation: () -> Boolean,
         captureAction: SpanService.() -> Unit
-    ): Boolean = captureDataImpl(inputValidation, captureAction)
-
-    override fun stopSpan(
-        inputValidation: () -> Boolean,
-        captureAction: SpanService.() -> Unit
-    ): Boolean = captureDataImpl(inputValidation, captureAction, false)
+    ): Boolean = captureDataImpl(inputValidation, captureAction, countsTowardsLimits)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
@@ -12,9 +12,12 @@ internal interface SessionSpanWriter {
      * current time will be used. Optionally, the specific
      * time of the event and a set of attributes can be passed in associated with the event.
      *
+     * Callers should pass the object & a function reference that converts the object
+     * to a [SpanEventData] object.
+     *
      * Returns true if the event was added, otherwise false.
      */
-    fun addEvent(event: SpanEventData): Boolean
+    fun <T> addEvent(obj: T, mapper: T.() -> SpanEventData): Boolean
 
     /**
      * Add the given key-value pair as an Attribute to the Event.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventMapper.kt
@@ -4,5 +4,5 @@ package io.embrace.android.embracesdk.arch.destination
  * Converts an object of type T to a [SpanEventData]
  */
 internal fun interface SpanEventMapper<T> {
-    fun T.toSpanEventData(): SpanEventData
+    fun toSpanEventData(obj: T): SpanEventData
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.arch.destination
+
+/**
+ * Holds the information required to start a span.
+ */
+internal class StartSpanData(
+    val spanName: String,
+    val spanStartTimeMs: Long,
+    val attributes: Map<String, String>?
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanMapper.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.arch.destination
+
+/**
+ * Converts an object of type T to a [StartSpanData]
+ */
+internal fun interface StartSpanMapper<T> {
+    fun toStartSpanData(obj: T): StartSpanData
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -23,6 +23,8 @@ internal interface DataSourceModule {
 
 internal class DataSourceModuleImpl(
     essentialServiceModule: EssentialServiceModule,
+    @Suppress("UNUSED_PARAMETER") initModule: InitModule,
+    @Suppress("UNUSED_PARAMETER") otelModule: OpenTelemetryModule
 ) : DataSourceModule {
     private val values: MutableList<DataSourceState> = mutableListOf()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -371,7 +371,11 @@ internal class ModuleInitBootstrapper(
                     }
 
                     dataSourceModule = init(DataSourceModule::class) {
-                        dataSourceModuleSupplier(essentialServiceModule)
+                        dataSourceModuleSupplier(
+                            essentialServiceModule,
+                            initModule,
+                            openTelemetryModule
+                        )
                     }
 
                     sessionModule = init(SessionModule::class) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -90,8 +90,9 @@ internal class CurrentSessionSpanImpl(
         }
     }
 
-    override fun addEvent(event: SpanEventData): Boolean {
+    override fun <T> addEvent(obj: T, mapper: T.() -> SpanEventData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
+        val event = obj.mapper()
         return currentSession.addEvent(event.spanName, event.spanStartTimeMs, event.attributes)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -184,6 +184,8 @@ internal typealias DataContainerModuleSupplier = (
 
 internal typealias DataSourceModuleSupplier = (
     essentialServiceModule: EssentialServiceModule,
+    initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule
 ) -> DataSourceModule
 
 /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -16,7 +16,7 @@ internal class DataSourceImplTest {
     fun `capture data successfully`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        val success = source.captureData(inputValidation = { true }) {
+        val success = source.alterSessionSpan(inputValidation = { true }) {
             initialized()
         }
         assertTrue(success)
@@ -27,7 +27,7 @@ internal class DataSourceImplTest {
     fun `capture data threw exception`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        val success = source.captureData(inputValidation = { true }) {
+        val success = source.alterSessionSpan(inputValidation = { true }) {
             error("Whoops!")
         }
         assertFalse(success)
@@ -41,7 +41,7 @@ internal class DataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.captureData(inputValidation = { true }) {
+            source.alterSessionSpan(inputValidation = { true }) {
                 count++
             }
         }
@@ -55,7 +55,7 @@ internal class DataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.captureData(inputValidation = { false }) {
+            source.alterSessionSpan(inputValidation = { false }) {
                 count++
             }
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
@@ -16,7 +16,7 @@ internal class SpanDataSourceImplTest {
     fun `capture data successfully`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.captureData(inputValidation = { true }) {
+        val success = source.alterSessionSpan(inputValidation = { true }) {
             createSpan("test")
         }
         assertTrue(success)
@@ -27,7 +27,7 @@ internal class SpanDataSourceImplTest {
     fun `capture data threw exception`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.captureData(inputValidation = { true }) {
+        val success = source.alterSessionSpan(inputValidation = { true }) {
             error("Whoops!")
         }
         assertFalse(success)
@@ -41,7 +41,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.captureData(inputValidation = { true }) {
+            source.alterSessionSpan(inputValidation = { true }) {
                 count++
             }
         }
@@ -55,7 +55,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.captureData(inputValidation = { false }) {
+            source.alterSessionSpan(inputValidation = { false }) {
                 count++
             }
         }
@@ -66,7 +66,7 @@ internal class SpanDataSourceImplTest {
     fun `start span succeeds`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.startSpan(inputValidation = { true }) {
+        val success = source.captureSpanData(true, inputValidation = { true }) {
             createSpan("test")
         }
         assertTrue(success)
@@ -77,7 +77,7 @@ internal class SpanDataSourceImplTest {
     fun `start span data threw exception`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.startSpan(inputValidation = { true }) {
+        val success = source.captureSpanData(true, inputValidation = { true }) {
             error("Whoops!")
         }
         assertFalse(success)
@@ -91,7 +91,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.startSpan(inputValidation = { true }) {
+            source.captureSpanData(true, inputValidation = { true }) {
                 count++
             }
         }
@@ -105,7 +105,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.startSpan(inputValidation = { false }) {
+            source.captureSpanData(true, inputValidation = { false }) {
                 count++
             }
         }
@@ -116,7 +116,7 @@ internal class SpanDataSourceImplTest {
     fun `stop span succeeeds`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.stopSpan(inputValidation = { true }) {
+        val success = source.captureSpanData(false, inputValidation = { true }) {
             createSpan("test")
         }
         assertTrue(success)
@@ -127,7 +127,7 @@ internal class SpanDataSourceImplTest {
     fun `stop span data threw exception`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.stopSpan(inputValidation = { true }) {
+        val success = source.captureSpanData(false, inputValidation = { true }) {
             error("Whoops!")
         }
         assertFalse(success)
@@ -141,7 +141,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.stopSpan(inputValidation = { true }) {
+            source.captureSpanData(false, inputValidation = { true }) {
                 count++
             }
         }
@@ -155,7 +155,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.stopSpan(inputValidation = { false }) {
+            source.captureSpanData(false, inputValidation = { false }) {
                 count++
             }
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.arch
 
-import io.embrace.android.embracesdk.arch.datasource.startSpan
-import io.embrace.android.embracesdk.arch.destination.SpanEventData
+import io.embrace.android.embracesdk.arch.datasource.startSpanCapture
+import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanServiceImpl
@@ -19,8 +19,13 @@ internal class SpanDataSourceKtTest {
         )
         service.initializeService(1500000000000)
 
-        val data = SpanEventData("spanName", 1500000000000, mapOf("key" to "value"))
-        val span = service.startSpan(data)
+        val span = service.startSpanCapture("") {
+            StartSpanData(
+                "spanName",
+                1500000000000,
+                mapOf("key" to "value")
+            )
+        }
         checkNotNull(span)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -10,15 +10,19 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 internal class FakeCurrentSessionSpan : CurrentSessionSpan {
 
     var initializedCallCount = 0
+    var addedEvents = mutableListOf<SpanEventData>()
+    var addedAttributes = mutableListOf<SpanAttributeData>()
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
     }
 
-    override fun addEvent(event: SpanEventData): Boolean {
+    override fun <T> addEvent(obj: T, mapper: T.() -> SpanEventData): Boolean {
+        addedEvents.add(obj.mapper())
         return true
     }
 
     override fun addAttribute(attribute: SpanAttributeData): Boolean {
+        addedAttributes.add(attribute)
         return true
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -15,7 +15,7 @@ internal class FakeDataSource(
     var disableDataCaptureCount = 0
     var resetCount = 0
 
-    override fun captureData(
+    override fun alterSessionSpan(
         inputValidation: () -> Boolean,
         captureAction: SessionSpanWriter.() -> Unit
     ): Boolean = true
@@ -35,7 +35,7 @@ internal class FakeDataSource(
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
-        captureData(inputValidation = { true }) {
+        alterSessionSpan(inputValidation = { true }) {
             addAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -1,0 +1,39 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.arch.destination.LogWriter
+import io.embrace.android.embracesdk.injection.OpenTelemetryModule
+import io.embrace.android.embracesdk.internal.logs.LogSink
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
+import io.embrace.android.embracesdk.internal.spans.InternalTracer
+import io.embrace.android.embracesdk.internal.spans.SpanRepository
+import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.opentelemetry.OpenTelemetryConfiguration
+import io.opentelemetry.api.logs.Logger
+import io.opentelemetry.api.trace.Tracer
+
+internal class FakeOpenTelemetryModule(
+    override val currentSessionSpan: CurrentSessionSpan = FakeCurrentSessionSpan()
+) : OpenTelemetryModule {
+    override val openTelemetryConfiguration: OpenTelemetryConfiguration
+        get() = TODO()
+    override val spanRepository: SpanRepository
+        get() = TODO()
+    override val spanSink: SpanSink
+        get() = TODO()
+    override val tracer: Tracer
+        get() = TODO()
+    override val spanService: SpanService
+        get() = TODO()
+    override val embraceTracer: EmbraceTracer
+        get() = TODO()
+    override val internalTracer: InternalTracer
+        get() = TODO()
+    override val logWriter: LogWriter
+        get() = TODO()
+    override val logger: Logger
+        get() = TODO()
+    override val logSink: LogSink
+        get() = TODO()
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -1,6 +1,9 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -8,7 +11,12 @@ internal class DataSourceModuleImplTest {
 
     @Test
     fun `test default behavior`() {
-        val module = DataSourceModuleImpl(FakeEssentialServiceModule())
+        val module = DataSourceModuleImpl(
+            FakeEssentialServiceModule(),
+            FakeInitModule(),
+            FakeOpenTelemetryModule()
+        )
         assertNotNull(module.getDataSources())
+        assertEquals(0, module.getDataSources().size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -180,7 +180,9 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add event forwarded to span`() {
-        currentSessionSpan.addEvent(SpanEventData("test-event", 1000L, mapOf("key" to "value")))
+        currentSessionSpan.addEvent("test-event") {
+            SpanEventData(this, 1000L, mapOf("key" to "value"))
+        }
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session-span", span.name)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCustomerLogModule
@@ -26,11 +27,13 @@ internal class SessionModuleImplTest {
     private val workerThreadModule = FakeWorkerThreadModule(fakeInitModule, WorkerName.BACKGROUND_REGISTRATION)
 
     private val configService = FakeConfigService()
+    private val initModule = FakeInitModule()
+    private val otelModule = FakeOpenTelemetryModule()
 
     @Test
     fun testDefaultImplementations() {
         val essentialServiceModule = FakeEssentialServiceModule(configService = configService)
-        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule)
+        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule, initModule, otelModule)
         val module = SessionModuleImpl(
             fakeInitModule,
             fakeInitModule.openTelemetryModule,
@@ -58,7 +61,7 @@ internal class SessionModuleImplTest {
     @Test
     fun testEnabledBehaviors() {
         val essentialServiceModule = createEnabledBehavior()
-        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule)
+        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule, initModule, otelModule)
 
         val module = SessionModuleImpl(
             fakeInitModule,


### PR DESCRIPTION
## Goal

Makes several tweaks to the [DataSource] implementation to support capturing data. This addresses review comments that were made in #439 and #406 and is separated out to keep the changeset small. Changes include:

- Implementation of a fake for `OpenTelemetryModule`
- Altered interface for adding an event to the session span
- Renamed interfaces/functions to better reflect what they do
- Miscellaneous updates to test code

