### PR TITLE
Add detection and fallback to nanos of inappropriate times in millis

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -242,11 +242,6 @@ public final class io/embrace/android/embracesdk/internal/clock/Clock$DefaultImp
 	public static fun nowInNanos (Lio/embrace/android/embracesdk/internal/clock/Clock;)J
 }
 
-public final class io/embrace/android/embracesdk/internal/clock/ClockKt {
-	public static final fun millisToNanos (J)J
-	public static final fun nanosToMillis (J)J
-}
-
 public class io/embrace/android/embracesdk/internal/network/http/EmbraceHttpPathOverride {
 	protected static final field PATH_OVERRIDE Ljava/lang/String;
 	public fun <init> ()V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
@@ -32,7 +32,7 @@ public interface InternalTracingApi {
     public fun addSpanEvent(
         spanId: String,
         name: String,
-        time: Long? = null,
+        timestampMs: Long? = null,
         attributes: Map<String, String>? = null
     ): Boolean
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/clock/Clock.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/clock/Clock.kt
@@ -20,11 +20,25 @@ public fun interface Clock {
 /**
  * Turns a number that specifies a millisecond value to nanoseconds
  */
-@InternalApi
-public fun Long.millisToNanos(): Long = TimeUnit.MILLISECONDS.toNanos(this)
+internal fun Long.millisToNanos(): Long = TimeUnit.MILLISECONDS.toNanos(this)
 
 /**
  * Turns a number that specifies a nanosecond value to milliseconds
  */
-@InternalApi
-public fun Long.nanosToMillis(): Long = TimeUnit.NANOSECONDS.toMillis(this)
+internal fun Long.nanosToMillis(): Long = TimeUnit.NANOSECONDS.toMillis(this)
+
+/**
+ * Any epoch timestamp that we detect to be unreasonable to be interpreted as milliseconds, we assume it's an unintended use of nanoseconds
+ * based on an old API version or assumption from OpenTelemetry conventions
+ */
+internal fun Long.normalizeTimestampAsMillis(): Long =
+    if (this < MAX_MS_CUTOFF) {
+        this
+    } else {
+        this.nanosToMillis()
+    }
+
+/**
+ * Equivalent to the epoch time of January 1, 5000 12:00:00 AM GMT
+ */
+internal const val MAX_MS_CUTOFF = 95_617_584_000_000L

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent.Companion.inputsValid
@@ -88,9 +89,14 @@ internal class EmbraceSpanImpl(
                 if (eventCount.get() < MAX_EVENT_COUNT) {
                     spanInProgress()?.let { span ->
                         if (timestampMs != null && !attributes.isNullOrEmpty()) {
-                            span.addEvent(name, Attributes.builder().fromMap(attributes).build(), timestampMs, TimeUnit.MILLISECONDS)
+                            span.addEvent(
+                                name,
+                                Attributes.builder().fromMap(attributes).build(),
+                                timestampMs.normalizeTimestampAsMillis(),
+                                TimeUnit.MILLISECONDS
+                            )
                         } else if (timestampMs != null) {
-                            span.addEvent(name, timestampMs, TimeUnit.MILLISECONDS)
+                            span.addEvent(name, timestampMs.normalizeTimestampAsMillis(), TimeUnit.MILLISECONDS)
                         } else if (!attributes.isNullOrEmpty()) {
                             span.addEvent(name, Attributes.builder().fromMap(attributes).build())
                         } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -137,8 +138,8 @@ internal class EmbraceTracer(
     ): Boolean =
         spanService.recordCompletedSpan(
             name = name,
-            startTimeMs = startTimeMs,
-            endTimeMs = endTimeMs,
+            startTimeMs = startTimeMs.normalizeTimestampAsMillis(),
+            endTimeMs = endTimeMs.normalizeTimestampAsMillis(),
             parent = parent,
             internal = false,
             attributes = attributes ?: emptyMap(),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.InternalTracingApi
+import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -71,10 +72,10 @@ internal class InternalTracer(
         }
     }
 
-    override fun addSpanEvent(spanId: String, name: String, time: Long?, attributes: Map<String, String>?): Boolean =
+    override fun addSpanEvent(spanId: String, name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean =
         spanRepository.getSpan(spanId = spanId)?.addEvent(
             name = name,
-            timestampMs = time,
+            timestampMs = timestampMs?.normalizeTimestampAsMillis(),
             attributes = attributes
         ) ?: false
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -26,7 +26,7 @@ internal class StartupServiceImplTest {
         val initModule = FakeInitModule(clock = clock)
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
-        spanService.initializeService(clock.nowInNanos())
+        spanService.initializeService(clock.now())
         startupService = StartupServiceImpl(spanService)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeClock.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeClock.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 
 internal class FakeClock(
     @Volatile
-    private var currentTime: Long = 0
+    private var currentTime: Long = DEFAULT_FAKE_CURRENT_TIME
 ) : Clock {
 
     fun setCurrentTime(currentTime: Long) {
@@ -19,4 +19,8 @@ internal class FakeClock(
     fun tickSecond() = tick(1000)
 
     override fun now(): Long = currentTime
+
+    companion object {
+        const val DEFAULT_FAKE_CURRENT_TIME = 1692201601000L
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/clock/ClockTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/clock/ClockTest.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.internal.clock
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+internal class ClockTest {
+    @Test
+    fun `test timestamp fallback conversion`() {
+        // We need to fix this before the year 5000. I will be dead by then so it'll be someone else's problem.
+        val systemCurrentTimeMs = System.currentTimeMillis()
+        assertEquals(systemCurrentTimeMs, systemCurrentTimeMs.normalizeTimestampAsMillis())
+        assertEquals(JAN_1_2025_MS, JAN_1_2025_MS.normalizeTimestampAsMillis())
+        assertEquals(BEFORE_CUTOFF, BEFORE_CUTOFF.normalizeTimestampAsMillis())
+        assertNotEquals(MAX_MS_CUTOFF, MAX_MS_CUTOFF.normalizeTimestampAsMillis())
+    }
+
+    companion object {
+        private const val JAN_1_2025_MS = 1_735_689_600_000L
+        private const val BEFORE_CUTOFF = MAX_MS_CUTOFF - 1L
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -42,7 +42,7 @@ internal class SpanServiceImplTest {
             currentSessionSpan = currentSessionSpan,
             tracer = initModule.openTelemetryModule.tracer
         )
-        spansService.initializeService(clock.nowInNanos())
+        spansService.initializeService(clock.now())
     }
 
     @Test


### PR DESCRIPTION
## Goal

We are changing the API to take in millisecond, but because the method signature hasn't changed, just how we are naming the parameter and how interpret it, there would be no compile time failure to warn folks they are passing in a time in nanos rather than millis.

For now, we'll work around this by detecting that a timestamp is way too big to be a reasonable time in millis in real life (until the year 5000), and assume its' a nanos time and convert it to millis. Once we detect that this isn't done anymore, we can remove this workaround.

## Testing

Added tests at all layers to verify this