### PR TITLE
Allow a specific start time to be used with startSpan

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -82,6 +82,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun startMoment (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public fun startSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public fun startSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
+	public fun startSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/lang/Long;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public fun startView (Ljava/lang/String;)Z
 	public fun trackWebViewPerformance (Ljava/lang/String;Landroid/webkit/ConsoleMessage;)V
 	public fun trackWebViewPerformance (Ljava/lang/String;Ljava/lang/String;)V
@@ -221,7 +222,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/InternalT
 	public abstract fun addSpanEvent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/Map;)Z
 	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)Z
 	public abstract fun recordSpan (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public abstract fun startSpan (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun startSpan (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Ljava/lang/String;
 	public abstract fun stopSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/ErrorCode;)Z
 }
 
@@ -229,7 +230,7 @@ public final class io/embrace/android/embracesdk/internal/InternalTracingApi$Def
 	public static synthetic fun addSpanEvent$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/util/Map;ILjava/lang/Object;)Z
 	public static synthetic fun recordCompletedSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Z
 	public static synthetic fun recordSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun startSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun startSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Ljava/lang/String;
 	public static synthetic fun stopSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/ErrorCode;ILjava/lang/Object;)Z
 }
 

--- a/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
+++ b/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
@@ -270,6 +270,12 @@ public class NullParametersTest {
     }
 
     @Test
+    public void testStartSpanWithParentAndStartTime() {
+        assertNull(embrace.startSpan(null, null, null));
+        assertError("startSpan");
+    }
+
+    @Test
     public void testRecordSpan() {
         assertTrue(embrace.recordSpan(null, () -> true));
         assertError("recordSpan");

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -444,14 +444,20 @@ public final class Embrace implements EmbraceAndroidApi {
     @Nullable
     @Override
     public EmbraceSpan startSpan(@NonNull String name) {
-        return startSpan(name, null);
+        return startSpan(name, null, null);
     }
 
     @Nullable
     @Override
     public EmbraceSpan startSpan(@NonNull String name, @Nullable EmbraceSpan parent) {
+        return startSpan(name, parent, null);
+    }
+
+    @Nullable
+    @Override
+    public EmbraceSpan startSpan(@NonNull String name, @Nullable EmbraceSpan parent, @Nullable Long startTimeMs) {
         if (verifyNonNullParameters("startSpan", name)) {
-            return impl.tracer.startSpan(name, parent);
+            return impl.tracer.startSpan(name, parent, startTimeMs);
         }
 
         return null;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
@@ -14,7 +14,8 @@ public interface InternalTracingApi {
      */
     public fun startSpan(
         name: String,
-        parentSpanId: String? = null
+        parentSpanId: String? = null,
+        startTimeMs: Long? = null
     ): String?
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -23,9 +23,17 @@ internal class EmbraceTracer(
     override fun startSpan(name: String): EmbraceSpan? = startSpan(name = name, parent = null)
 
     override fun startSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? =
+        startSpan(
+            name = name,
+            parent = parent,
+            startTimeMs = null
+        )
+
+    override fun startSpan(name: String, parent: EmbraceSpan?, startTimeMs: Long?): EmbraceSpan? =
         spanService.startSpan(
             name = name,
             parent = parent,
+            startTimeMs = startTimeMs,
             internal = false
         )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -12,12 +12,13 @@ internal class InternalTracer(
     private val embraceTracer: EmbraceTracer,
 ) : InternalTracingApi {
 
-    override fun startSpan(name: String, parentSpanId: String?): String? {
+    override fun startSpan(name: String, parentSpanId: String?, startTimeMs: Long?): String? {
         val parent = validateParent(parentSpanId)
         return if (parent.isValid) {
             embraceTracer.startSpan(
                 name = name,
-                parent = parent.spanReference
+                parent = parent.spanReference,
+                startTimeMs = startTimeMs
             )?.spanId
         } else {
             null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -26,6 +26,7 @@ internal interface SpanService : Initializable {
     fun startSpan(
         name: String,
         parent: EmbraceSpan? = null,
+        startTimeMs: Long? = null,
         type: EmbraceAttributes.Type = EmbraceAttributes.Type.PERFORMANCE,
         internal: Boolean = true
     ): EmbraceSpan? {
@@ -35,7 +36,7 @@ internal interface SpanService : Initializable {
             type = type,
             internal = internal
         )?.let { newSpan ->
-            if (newSpan.start()) {
+            if (newSpan.start(startTimeMs)) {
                 return newSpan
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -52,6 +52,17 @@ internal interface TracingApi {
     ): EmbraceSpan?
 
     /**
+     * Create, start, and return a new [EmbraceSpan] with the given name, parent, and start time. Returns null if the [EmbraceSpan] cannot
+     * be created or started, like if the parent has been started.
+     */
+    @BetaApi
+    fun startSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        startTimeMs: Long?
+    ): EmbraceSpan?
+
+    /**
      * Execute the given block of code and record a new trace around it. If the span cannot be created, the block of code will still run and
      * return correctly. If an exception or error is thrown inside the block, the span will end at the point of the throw and the
      * [Throwable] will be rethrown.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
@@ -24,6 +24,10 @@ internal class FakeTracingApi : TracingApi {
         TODO("Not yet implemented")
     }
 
+    override fun startSpan(name: String, parent: EmbraceSpan?, startTimeMs: Long?): EmbraceSpan? {
+        TODO("Not yet implemented")
+    }
+
     override fun <T> recordSpan(name: String, code: () -> T): T {
         TODO("Not yet implemented")
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -43,6 +43,7 @@ internal class EmbraceSpanServiceTest {
     fun `service works once initialized`() {
         assertTrue(spanService.initialized())
         assertNotNull(spanService.createSpan("test-span"))
+        assertNotNull(spanService.startSpan("test-span"))
         assertTrue(spanService.recordCompletedSpan("test-span", 10, 20))
         var lambdaRan = false
         spanService.recordSpan("test-span") { lambdaRan = true }
@@ -100,6 +101,9 @@ internal class EmbraceSpanServiceTest {
         assertTrue(parent.start())
         val child = checkNotNull(spanService.createSpan(name = "child-span", parent = parent))
         assertTrue(child.start(startTimeMs = clock.now() - 10))
+        val grandchild =
+            checkNotNull(spanService.startSpan(name = "grand-child-span", parent = child, startTimeMs = clock.now() + 1L))
+        assertTrue(grandchild.stop())
         assertTrue(child.stop())
         assertTrue(parent.stop(endTimeMs = clock.now() + 50))
         assertTrue(parent.traceId == child.traceId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -74,10 +74,15 @@ internal class EmbraceTracerTest {
     fun `start a span directly`() {
         spanSink.flushSpans()
         val parent = checkNotNull(embraceTracer.startSpan(name = "test-span"))
-        val child = checkNotNull(embraceTracer.startSpan(name = "child-span", parent))
+        clock.tick(20L)
+        val childStartTimeMs = clock.now() - 10L
+        val child =
+            checkNotNull(embraceTracer.startSpan(name = "child-span", parent = parent, startTimeMs = childStartTimeMs))
         assertTrue(parent.stop())
         assertTrue(child.stop())
-        assertEquals(2, spanSink.flushSpans().size)
+        val spans = spanSink.flushSpans()
+        assertEquals(2, spans.size)
+        assertEquals(childStartTimeMs, spans[1].startTimeNanos.nanosToMillis())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -161,14 +161,18 @@ internal class SpanServiceImplTest {
     fun `start a span directly`() {
         spanSink.flushSpans()
         val parent = checkNotNull(spansService.startSpan(name = "test-span"))
+        val childStartTimeMs = clock.now() + 10L
         val child = checkNotNull(
             spansService.startSpan(
                 name = "child-span",
                 parent = parent,
+                startTimeMs = childStartTimeMs,
                 type = EmbraceAttributes.Type.SESSION,
                 internal = true
             )
         )
+        clock.tick(40L)
+        val childSpanEndTimeMs = clock.now()
         assertTrue(child.stop())
         val completedSpans = spanSink.flushSpans()
         assertEquals(1, completedSpans.size)
@@ -176,6 +180,8 @@ internal class SpanServiceImplTest {
             assertTrue(isPrivate())
             assertFalse(isKey())
             assertEquals(EmbraceAttributes.Type.SESSION.name, attributes[EmbraceAttributes.Type.SESSION.keyName()])
+            assertEquals(childStartTimeMs, startTimeNanos.nanosToMillis())
+            assertEquals(childSpanEndTimeMs, endTimeNanos.nanosToMillis())
         }
     }
 


### PR DESCRIPTION
## Goal

Add the ability to specify a start time that was added to EmbraceSpan.start() to startSpan()

## Testing

Added appropriate component tests and also to the integration test

