### PR TITLE
Harden NDK json serialization

### DIFF
--- a/embrace-android-sdk/src/main/cpp/base_64_encoder.c
+++ b/embrace-android-sdk/src/main/cpp/base_64_encoder.c
@@ -22,19 +22,21 @@ size_t b64_encoded_size(size_t inlen)
     return ret;
 }
 
-char *b64_encode(const char *in, size_t len)
-{
-    char   *out;
-    size_t  elen;
-    size_t  i;
-    size_t  j;
-    size_t  v;
+char *b64_encode(const char *in, size_t len) {
+    char *out;
+    size_t elen;
+    size_t i;
+    size_t j;
+    size_t v;
 
     if (in == NULL || len == 0)
         return NULL;
 
     elen = b64_encoded_size(len);
-    out  = malloc(elen+1);
+    out = malloc(elen + 1);
+    if (out == NULL) {
+        return NULL;
+    }
     out[elen] = '\0';
 
     for (i=0, j=0; i<len; i+=3, j+=4) {

--- a/embrace-android-sdk/src/main/cpp/file_writer.c
+++ b/embrace-android-sdk/src/main/cpp/file_writer.c
@@ -60,19 +60,28 @@ static const char *kErrContext = "c";
 static const char *kDefaultNULLFallbackString = "";
 static const char *kCurrentPayloadVersion = "1";
 
+#define RETURN_ON_JSON_FAILURE(func) \
+if ((func) != JSONSuccess) { \
+    return false; \
+}
 
-void emb_add_metadata_to_json(const emb_crash *crash, JSON_Object *root_object);
+bool emb_add_metadata_to_json(const emb_crash *crash, JSON_Object *root_object);
 
-void emb_add_basic_info_to_json(const emb_crash *crash, JSON_Object *root_object);
+bool emb_add_basic_info_to_json(const emb_crash *crash, JSON_Object *root_object);
 
-void emb_add_exc_info_to_json(const emb_crash *crash, JSON_Object *crash_object,
+bool emb_add_exc_info_to_json(const emb_crash *crash, JSON_Object *crash_object,
                               const emb_exception *exception);
 
-void emb_add_frame_dbg_to_json(JSON_Object *frame_object, emb_sframe *frame);
+bool emb_add_frame_dbg_to_json(JSON_Object *frame_object, emb_sframe *frame);
 
-void emb_add_frame_info_to_json(JSON_Object *frame_object, emb_sframe *frame);
+bool emb_add_frame_info_to_json(JSON_Object *frame_object, emb_sframe *frame);
 
-void emb_add_exc_to_json(const emb_exception *exception, JSON_Array *frames_object);
+bool emb_add_exc_to_json(const emb_exception *exception, JSON_Array *frames_object);
+
+bool emb_add_b64_value_to_json(JSON_Object *root_object, const JSON_Value *crash_value);
+
+bool emb_build_crash_json_tree(emb_crash *crash, JSON_Object *root_object,
+                               JSON_Object *crash_object);
 
 bool emb_write_crash_to_file(emb_env *env) {
     int fd = open(env->report_path, O_WRONLY | O_CREAT, 0644);
@@ -137,14 +146,16 @@ emb_error *emb_read_errors_from_file(const char *path) {
         ssize_t len = read(fd, wp++, error_size);
 
         if (len == -1) { // log the error code for more debug info.
-            EMB_LOGERROR("Encountered error reading emb_error struct. %d: %s", errno, strerror(errno));
+            EMB_LOGERROR("Encountered error reading emb_error struct. %d: %s", errno,
+                         strerror(errno));
         }
         if (len == 0) {
             break;
         }
         if (len != error_size) {
-            EMB_LOGERROR("exiting native crash error file read because we read %d instead of %d after %d errors",
-                         (int) len, (int) error_size, count);
+            EMB_LOGERROR(
+                    "exiting native crash error file read because we read %d instead of %d after %d errors",
+                    (int) len, (int) error_size, count);
             free(errors);
             close(fd);
             return NULL;
@@ -158,147 +169,230 @@ emb_error *emb_read_errors_from_file(const char *path) {
 }
 
 char *emb_crash_to_json(emb_crash *crash) {
+    if (crash == NULL) {
+        return NULL;
+    }
     EMB_LOGDEV("Starting serialization of emb_crash struct to JSON string.");
-    JSON_Value *root_value = json_value_init_object();
-    JSON_Object *root_object = json_value_get_object(root_value);
+    JSON_Value *root_value = NULL;
+    JSON_Object *root_object = NULL;
+    JSON_Value *crash_value = NULL;
+    JSON_Object *crash_object = NULL;
     char *serialized_string = NULL;
 
-    emb_add_metadata_to_json(crash, root_object);
-    emb_add_basic_info_to_json(crash, root_object);
+    // initialize JSON objects.
+    root_value = json_value_init_object();
+    if (root_value == NULL) {
+        goto Exit;
+    }
+    root_object = json_value_get_object(root_value);
+    if (root_object == NULL) {
+        goto Exit;
+    }
+    crash_value = json_value_init_object();
+    if (crash_value == NULL) {
+        goto Exit;
+    }
+    crash_object = json_value_get_object(crash_value);
+    if (crash_object == NULL) {
+        goto Exit;
+    }
 
-    // crash data
-    EMB_LOGDEV("Serializing crash data.");
-    JSON_Value *crash_value = json_value_init_object();
-    JSON_Object *crash_object = json_value_get_object(crash_value);
+    // start adding metadata/basic info to tree
+    if (!emb_add_metadata_to_json(crash, root_object)) {
+        goto Exit;
+    }
+    if (!emb_add_basic_info_to_json(crash, root_object)) {
+        goto Exit;
+    }
 
-    json_object_set_number(root_object, kUnwinderErrorCode, crash->unwinder_error);
+    // add crash data to tree
+    if (!emb_build_crash_json_tree(crash, root_object, crash_object)) {
+        goto Exit;
+    }
 
-    emb_exception *exception = &crash->capture;
-    emb_add_exc_info_to_json(crash, crash_object, exception);
+    if (!emb_add_b64_value_to_json(root_object, crash_value)) {
+        goto Exit;
+    }
 
-    JSON_Value *frames_value = json_value_init_array();
-    JSON_Array *frames_object = json_value_get_array(frames_value);
-    emb_add_exc_to_json(exception, frames_object);
-
-    json_object_set_value(crash_object, kFramesKey, frames_value);
-
-    EMB_LOGDEV("Converting tree to JSON string.");
-    char *serialized_crash = json_serialize_to_string_pretty(crash_value);
-
-    EMB_LOGDEV("Starting Base64 encoding.");
-    char *base64_crash = b64_encode(serialized_crash, strlen(serialized_crash));
-    json_free_serialized_string(serialized_crash);
-
-    EMB_LOGDEV("Altering JSON tree root.");
-    json_object_set_string(root_object, kCrashKey, base64_crash);
-    free(base64_crash);
-
-    // final result
+    // serialize final result & return as string
     EMB_LOGDEV("Serializing final JSON string");
-    serialized_string = json_serialize_to_string_pretty(root_value);
-//    json_free_serialized_string(serialized_string);
-    json_value_free(root_value);
-    json_value_free(crash_value);
+    serialized_string = json_serialize_to_string(root_value);
+
+    Exit:
+    if (root_value != NULL) {
+        json_value_free(root_value);
+    }
+    if (crash_value != NULL) {
+        json_value_free(crash_value);
+    }
     return serialized_string;
 }
 
-void emb_add_metadata_to_json(const emb_crash *crash, JSON_Object *root_object) {
+bool emb_add_metadata_to_json(const emb_crash *crash, JSON_Object *root_object) {
     JSON_Value *meta_value = json_parse_string(crash->meta_data);
+    bool success = false;
 
     if (meta_value != NULL) {
-        EMB_LOGDEV("Successfully parsed crash JSON metadata");
-        json_object_set_value(root_object, kDeviceMetaKey, meta_value);
-    } else {
-        EMB_LOGERROR("Could not JSON decode metadata: %s", crash->meta_data);
+        success = json_object_set_value(root_object, kDeviceMetaKey, meta_value) == JSONSuccess;
     }
+    return success;
 }
 
-void emb_add_basic_info_to_json(const emb_crash *crash, JSON_Object *root_object) {
+bool emb_add_basic_info_to_json(const emb_crash *crash, JSON_Object *root_object) {
     EMB_LOGDEV("Serializing IDs + payload version.");
-    json_object_set_string(root_object, kReportIDKey, crash->report_id);
-    json_object_set_string(root_object, kVersionKey, kCurrentPayloadVersion);
-    json_object_set_number(root_object, kCrashTSKey, crash->crash_ts);
-    json_object_set_string(root_object, kSessionIDKey, crash->session_id);
-    json_object_set_string(root_object, kAppStateKey, crash->app_state);
+    RETURN_ON_JSON_FAILURE(json_object_set_string(root_object, kReportIDKey, crash->report_id));
+    RETURN_ON_JSON_FAILURE(json_object_set_string(root_object, kVersionKey, kCurrentPayloadVersion));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(root_object, kCrashTSKey, crash->crash_ts));
+    RETURN_ON_JSON_FAILURE(json_object_set_string(root_object, kSessionIDKey, crash->session_id));
+    RETURN_ON_JSON_FAILURE(json_object_set_string(root_object, kAppStateKey, crash->app_state));
+    return true;
 }
 
-void emb_add_exc_info_to_json(const emb_crash *crash, JSON_Object *crash_object,
+bool emb_add_exc_info_to_json(const emb_crash *crash, JSON_Object *crash_object,
                               const emb_exception *exception) {// exception name
     if (strlen(exception->name) == 0) {
         EMB_LOGDEV("Defaulting to NULL exception name.");
-        json_object_set_string(crash_object, kExceptionNameKey, kDefaultNULLFallbackString);
+        RETURN_ON_JSON_FAILURE(json_object_set_string(crash_object, kExceptionNameKey, kDefaultNULLFallbackString));
     } else {
         EMB_LOGDEV("Serializing exception name %s", exception->name);
-        json_object_set_string(crash_object, kExceptionNameKey, exception->name);
+        RETURN_ON_JSON_FAILURE(json_object_set_string(crash_object, kExceptionNameKey, exception->name));
     }
     // exception message
     if (strlen(exception->message) == 0) {
         EMB_LOGDEV("Defaulting to NULL exception message.");
-        json_object_set_string(crash_object, kExceptionMsgKey, kDefaultNULLFallbackString);
+        RETURN_ON_JSON_FAILURE(json_object_set_string(crash_object, kExceptionMsgKey, kDefaultNULLFallbackString));
     } else {
         EMB_LOGDEV("Serializing exception message %s", exception->message);
-        json_object_set_string(crash_object, kExceptionMsgKey, exception->message);
+        RETURN_ON_JSON_FAILURE(json_object_set_string(crash_object, kExceptionMsgKey, exception->message));
     }
 
     EMB_LOGDEV("Serializing signal information. sig_code=%d, sig_errno=%d, sig_no=%d",
                crash->sig_code, crash->sig_errno, crash->sig_no);
-    json_object_set_number(crash_object, kExceptionCodeKey, crash->sig_code);
-    json_object_set_number(crash_object, kExceptionErrnoKey, crash->sig_errno);
-    json_object_set_number(crash_object, kExceptionSignoKey, crash->sig_no);
-    json_object_set_number(crash_object, kExceptionFaultAddr, crash->fault_addr);
+
+    RETURN_ON_JSON_FAILURE(json_object_set_number(crash_object, kExceptionCodeKey, crash->sig_code));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(crash_object, kExceptionErrnoKey, crash->sig_errno));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(crash_object, kExceptionSignoKey, crash->sig_no));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(crash_object, kExceptionFaultAddr, crash->fault_addr));
+    return true;
 }
 
-void emb_add_exc_to_json(const emb_exception *exception, JSON_Array *frames_object) {
+bool emb_add_exc_to_json(const emb_exception *exception, JSON_Array *frames_object) {
     EMB_LOGDEV("About to serialize %d stack frames.", (int) exception->num_sframes);
 
     for (int i = 0; i < exception->num_sframes; ++i) {
         JSON_Value *frame_value = json_value_init_object();
+        if (frame_value == NULL) {
+            return false;
+        }
         JSON_Object *frame_object = json_value_get_object(frame_value);
+        if (frame_object == NULL) {
+            return false;
+        }
 
         emb_sframe frame = exception->stacktrace[i];
-        emb_add_frame_info_to_json(frame_object, &frame);
+        if (!emb_add_frame_info_to_json(frame_object, &frame)) {
+            return false;
+        }
 
         // extra debug info
-        emb_add_frame_dbg_to_json(frame_object, &frame);
-
-        json_array_append_value(frames_object, frame_value);
+        if (!emb_add_frame_dbg_to_json(frame_object, &frame)) {
+            return false;
+        };
+        RETURN_ON_JSON_FAILURE(json_array_append_value(frames_object, frame_value));
     }
     EMB_LOGDEV("Finished serializing stackframes.");
+    return true;
 }
 
-void emb_add_frame_info_to_json(JSON_Object *frame_object, emb_sframe *frame) {// module name
-    if (strlen((*frame).filename) == 0) {
-        json_object_set_string(frame_object, kFilenameKey, kDefaultNULLFallbackString);
+bool emb_add_frame_info_to_json(JSON_Object *frame_object, emb_sframe *frame) {// module name
+    if (strlen(frame->filename) == 0) {
+        RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kFilenameKey, kDefaultNULLFallbackString));
     } else {
-        json_object_set_string(frame_object, kFilenameKey, (*frame).filename);
+        RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kFilenameKey, frame->filename));
     }
     // symbol name
-    if (strlen((*frame).method) == 0) {
-        json_object_set_string(frame_object, kMethodKey, kDefaultNULLFallbackString);
+    if (strlen(frame->method) == 0) {
+        RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kMethodKey, kDefaultNULLFallbackString));
     } else {
-        json_object_set_string(frame_object, kMethodKey, (*frame).method);
+        RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kMethodKey, frame->method));
     }
     // TODO: lu vs u?
-    json_object_set_number(frame_object, kFrameAddrKey, (*frame).frame_addr);
-    json_object_set_number(frame_object, kOffsetAddrKey, (*frame).offset_addr);
-    json_object_set_number(frame_object, kModuleAddrKey, (*frame).module_addr);
-    json_object_set_number(frame_object, kLineNumKey, (*frame).line_num);
-    json_object_set_string(frame_object, kBuildIdKey, (*frame).build_id);
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kFrameAddrKey, frame->frame_addr));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kOffsetAddrKey, frame->offset_addr));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kModuleAddrKey, frame->module_addr));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kLineNumKey, frame->line_num));
+    RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kBuildIdKey, frame->build_id));
+    return true;
 }
 
-void emb_add_frame_dbg_to_json(JSON_Object *frame_object, emb_sframe *frame) {
-    json_object_set_string(frame_object, kFullNameKey, (*frame).full_name);
-    json_object_set_string(frame_object, kFunctionNameKey, (*frame).function_name);
-    json_object_set_number(frame_object, kRelPcKey, (unsigned long) (*frame).rel_pc);
-    json_object_set_number(frame_object, kPcKey, (unsigned long) (*frame).pc);
-    json_object_set_number(frame_object, kSpKey, (unsigned long) (*frame).sp);
-    json_object_set_number(frame_object, kLrKey, (unsigned long) (*frame).lr);
-    json_object_set_number(frame_object, kStartKey, (unsigned long) (*frame).start);
-    json_object_set_number(frame_object, kEndKey, (unsigned long) (*frame).end);
-    json_object_set_number(frame_object, kOffsetKey, (unsigned long) (*frame).offset);
-    json_object_set_number(frame_object, kFunctionOffsetKey,(unsigned long) (*frame).function_offset);
-    json_object_set_number(frame_object, kFlagsKey, (*frame).flags);
-    json_object_set_number(frame_object, kElfFileNotReadableKey, (*frame).elf_file_not_readable);
+bool emb_add_frame_dbg_to_json(JSON_Object *frame_object, emb_sframe *frame) {
+    RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kFullNameKey, frame->full_name));
+    RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kFunctionNameKey, frame->function_name));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kRelPcKey, (unsigned long) frame->rel_pc));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kPcKey, (unsigned long) frame->pc));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kSpKey, (unsigned long) frame->sp));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kLrKey, (unsigned long) frame->lr));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kStartKey, (unsigned long) frame->start));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kEndKey, (unsigned long) frame->end));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kOffsetKey, (unsigned long) frame->offset));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kFunctionOffsetKey,
+                                                  (unsigned long) frame->function_offset));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kFlagsKey, frame->flags));
+    RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kElfFileNotReadableKey,
+                                                  frame->elf_file_not_readable));
+    return true;
+}
+
+bool emb_build_crash_json_tree(emb_crash *crash, JSON_Object *root_object,
+                               JSON_Object *crash_object) {
+    if (crash_object == NULL) {
+        return false;
+    }
+    RETURN_ON_JSON_FAILURE(json_object_set_number(root_object, kUnwinderErrorCode, crash->unwinder_error));
+
+    emb_exception *exception = &crash->capture;
+    if (!emb_add_exc_info_to_json(crash, crash_object, exception)) {
+        return false;
+    }
+
+    JSON_Value *frames_value = json_value_init_array();
+    if (frames_value == NULL) {
+        return false;
+    }
+    JSON_Array *frames_object = json_value_get_array(frames_value);
+    if (frames_object == NULL) {
+        return false;
+    }
+    if (!emb_add_exc_to_json(exception, frames_object)) {
+        return false;
+    }
+    if (json_object_set_value(crash_object, kFramesKey, frames_value) != JSONSuccess) {
+        return false;
+    }
+    return true;
+}
+
+bool emb_add_b64_value_to_json(JSON_Object *root_object, const JSON_Value *crash_value) {
+    EMB_LOGDEV("Converting tree to JSON string.");
+    char *serialized_crash = json_serialize_to_string_pretty(crash_value);
+    if (serialized_crash == NULL) {
+        return false;
+    }
+
+    EMB_LOGDEV("Starting Base64 encoding.");
+    char *base64_crash = b64_encode(serialized_crash, strlen(serialized_crash));
+
+    if (base64_crash == NULL) {
+        return false;
+    }
+    json_free_serialized_string(serialized_crash);
+
+    EMB_LOGDEV("Altering JSON tree root.");
+    if (json_object_set_string(root_object, kCrashKey, base64_crash) != JSONSuccess) {
+        return false;
+    }
+    free(base64_crash);
+    return true;
 }
 
 char *emb_errors_to_json(emb_error *errors) {
@@ -308,7 +402,13 @@ char *emb_errors_to_json(emb_error *errors) {
     int count = 0;
 
     JSON_Value *errors_value = json_value_init_array();
+    if (errors_value == NULL) {
+        return NULL;
+    }
     JSON_Array *errors_object = json_value_get_array(errors_value);
+    if (errors_object == NULL) {
+        return NULL;
+    }
 
     while (count < EMB_MAX_ERRORS) {
         // errors is calloc'd so we know that once we hit a value with zero, we are done.
@@ -317,12 +417,24 @@ char *emb_errors_to_json(emb_error *errors) {
         }
 
         JSON_Value *error_value = json_value_init_object();
+        if (error_value == NULL) {
+            return NULL;
+        }
         JSON_Object *error_object = json_value_get_object(error_value);
+        if (error_object == NULL) {
+            return NULL;
+        }
 
-        json_object_set_number(error_object, kErrNum, cur_error->num);
-        json_object_set_number(error_object, kErrContext, cur_error->context);
+        if (json_object_set_number(error_object, kErrNum, cur_error->num) != JSONSuccess) {
+            return NULL;
+        }
+        if (json_object_set_number(error_object, kErrContext, cur_error->context) != JSONSuccess) {
+            return NULL;
+        }
 
-        json_array_append_value(errors_object, error_value);
+        if (json_array_append_value(errors_object, error_value) != JSONSuccess) {
+            return NULL;
+        }
 
         cur_error++;
         count++;


### PR DESCRIPTION
## Goal

Hardens the NDK JSON serialization by checking for `NULL` when dynamically allocation memory & checking the `Json_Status` return code when altering the JSON tree. If any of those return `false` then we should return `NULL` from the function & free the JSON tree (which frees anything that was added to the tree).

In rare scenarios where the system is under a lot of memory pressure our calls to `calloc` can fail. We were not checking this appropriately which could lead to a segfault at various points within this function.

Additionally we seemed to be pretty printing the JSON - I've switched this to compact as this usually saves around ~25% memory usage.

## Testing

Regression tested via NDK app & confirmed crash reports are still displayed in dashboard.

