### PR TITLE
Pass in missing activity manager

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -283,7 +283,7 @@ internal class EssentialServiceModuleImpl(
     }
 
     override val sessionIdTracker: SessionIdTracker by singleton {
-        SessionIdTrackerImpl()
+        SessionIdTrackerImpl(systemServiceModule.activityManager)
     }
 }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 
 internal class SessionIdTrackerImpl(
-    private val activityManager: ActivityManager? = null
+    private val activityManager: ActivityManager?
 ) : SessionIdTracker {
 
     @Volatile

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImplTest.kt
@@ -13,7 +13,7 @@ internal class SessionIdTrackerImplTest {
 
     @Before
     fun setUp() {
-        tracker = SessionIdTrackerImpl()
+        tracker = SessionIdTrackerImpl(null)
         ndkService = FakeNdkService()
     }
 


### PR DESCRIPTION
## Goal

Passes in a missing activity manager parameter. This is required by the `SessionIdTracker` to persist the session ID for AEI but `null` seems to have been passed in a recent refactor unintentionally. The `ActivityManager` returned by `SystemServiceModule` can legitimately be null in rare circumstances so I've kept the type nullable.
