### PR TITLE
Additional tweaks to data source implementation

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
@@ -15,7 +15,7 @@ internal class DataSourceState(
      * that extends [DataSource] for orchestration. This helps enforce testability
      * by making it impossible to register data capture without defining a testable interface.
      */
-    factory: Provider<DataSource<*>>,
+    factory: Provider<DataSource<*>?>,
 
     /**
      * Predicate that determines if the service should be enabled or not, via a config value.
@@ -48,7 +48,7 @@ internal class DataSourceState(
     fun onSessionTypeChange(sessionType: SessionType?) {
         this.currentSessionType = sessionType
         updateDataSource()
-        enabledDataSource.resetDataCaptureLimits()
+        enabledDataSource?.resetDataCaptureLimits()
     }
 
     /**
@@ -63,7 +63,7 @@ internal class DataSourceState(
             currentSessionType != null && currentSessionType != disabledSessionType && configGate()
 
         if (enabled && dataSource == null) {
-            dataSource = enabledDataSource.apply {
+            dataSource = enabledDataSource?.apply {
                 enableDataCapture()
             }
         } else if (!enabled && dataSource != null) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventMapper.kt
@@ -4,5 +4,5 @@ package io.embrace.android.embracesdk.arch.destination
  * Converts an object of type T to a [LogEventData]
  */
 internal fun interface LogEventMapper<T> {
-    fun T.toLogEventData(): LogEventData
+    fun toLogEventData(obj: T): LogEventData
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriter.kt
@@ -4,5 +4,5 @@ package io.embrace.android.embracesdk.arch.destination
  * Declares functions for writing a [LogEventData] to the current session span.
  */
 internal interface LogWriter {
-    fun addLog(log: LogEventData)
+    fun <T> addLog(log: T, mapper: T.() -> LogEventData)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.arch.destination
 
 internal class LogWriterImpl : LogWriter {
 
-    override fun addLog(log: LogEventData) {
+    override fun <T> addLog(log: T, mapper: T.() -> LogEventData) {
         // no-op
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanAttributeMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanAttributeMapper.kt
@@ -4,5 +4,5 @@ package io.embrace.android.embracesdk.arch.destination
  * Converts an object of type T to a [SpanAttributeData]
  */
 internal fun interface SpanAttributeMapper<T> {
-    fun T.toSpanAttributeData(): SpanAttributeData
+    fun toSpanAttributeData(obj: T): SpanAttributeData
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -24,8 +25,12 @@ internal interface DataSourceModule {
 internal class DataSourceModuleImpl(
     essentialServiceModule: EssentialServiceModule,
     @Suppress("UNUSED_PARAMETER") initModule: InitModule,
-    @Suppress("UNUSED_PARAMETER") otelModule: OpenTelemetryModule
+    @Suppress("UNUSED_PARAMETER") otelModule: OpenTelemetryModule,
+    @Suppress("UNUSED_PARAMETER") systemServiceModule: SystemServiceModule,
+    @Suppress("UNUSED_PARAMETER") androidServicesModule: AndroidServicesModule,
+    @Suppress("UNUSED_PARAMETER") workerThreadModule: WorkerThreadModule,
 ) : DataSourceModule {
+
     private val values: MutableList<DataSourceState> = mutableListOf()
 
     /* Implementation details */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -374,7 +374,10 @@ internal class ModuleInitBootstrapper(
                         dataSourceModuleSupplier(
                             essentialServiceModule,
                             initModule,
-                            openTelemetryModule
+                            openTelemetryModule,
+                            systemServiceModule,
+                            androidServicesModule,
+                            workerThreadModule
                         )
                     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -185,7 +185,10 @@ internal typealias DataContainerModuleSupplier = (
 internal typealias DataSourceModuleSupplier = (
     essentialServiceModule: EssentialServiceModule,
     initModule: InitModule,
-    openTelemetryModule: OpenTelemetryModule
+    openTelemetryModule: OpenTelemetryModule,
+    systemServiceModule: SystemServiceModule,
+    androidServicesModule: AndroidServicesModule,
+    workerThreadModule: WorkerThreadModule,
 ) -> DataSourceModule
 
 /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -1,8 +1,12 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
+import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
+import io.embrace.android.embracesdk.worker.WorkerName
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -14,7 +18,10 @@ internal class DataSourceModuleImplTest {
         val module = DataSourceModuleImpl(
             FakeEssentialServiceModule(),
             FakeInitModule(),
-            FakeOpenTelemetryModule()
+            FakeOpenTelemetryModule(),
+            FakeSystemServiceModule(),
+            FakeAndroidServicesModule(),
+            FakeWorkerThreadModule(FakeInitModule(), WorkerName.BACKGROUND_REGISTRATION)
         )
         assertNotNull(module.getDataSources())
         assertEquals(0, module.getDataSources().size)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSdkObservabilityModule
+import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.injection.DataSourceModuleImpl
 import io.embrace.android.embracesdk.injection.SessionModuleImpl
@@ -29,11 +30,20 @@ internal class SessionModuleImplTest {
     private val configService = FakeConfigService()
     private val initModule = FakeInitModule()
     private val otelModule = FakeOpenTelemetryModule()
+    private val systemServiceModule = FakeSystemServiceModule()
+    private val androidServicesModule = FakeAndroidServicesModule()
 
     @Test
     fun testDefaultImplementations() {
         val essentialServiceModule = FakeEssentialServiceModule(configService = configService)
-        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule, initModule, otelModule)
+        val dataSourceModule = DataSourceModuleImpl(
+            essentialServiceModule,
+            initModule,
+            otelModule,
+            systemServiceModule,
+            androidServicesModule,
+            workerThreadModule
+        )
         val module = SessionModuleImpl(
             fakeInitModule,
             fakeInitModule.openTelemetryModule,
@@ -61,7 +71,14 @@ internal class SessionModuleImplTest {
     @Test
     fun testEnabledBehaviors() {
         val essentialServiceModule = createEnabledBehavior()
-        val dataSourceModule = DataSourceModuleImpl(essentialServiceModule, initModule, otelModule)
+        val dataSourceModule = DataSourceModuleImpl(
+            essentialServiceModule,
+            initModule,
+            otelModule,
+            systemServiceModule,
+            androidServicesModule,
+            workerThreadModule
+        )
 
         val module = SessionModuleImpl(
             fakeInitModule,


### PR DESCRIPTION
## Goal

A few additional tweaks to our data source implementation that have been separated out from the prototyping. These include:

- Making `DataSource` nullable in the module, as AEI capture is not supported on lower API versions & therefore nothing is returned
- Tweak Log/SpanAttribute mappers to match `SpanEventMapper` signature change that was delivered in separate PR
- Added params to `DataSourceModule` that will be used by AEI data source

## Testing

Updated test coverage where applicable.