### PR TITLE
Fix issue with OkHttp3

### DIFF
--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
@@ -66,7 +66,7 @@ public class EmbraceOkHttp3NetworkInterceptor internal constructor(
 
         if (contentLength == null) {
             // If we get the body for a server-sent events stream, then we will wait forever
-            contentLength = getContentLengthFromBody(networkResponse, networkResponse.header(CONTENT_TYPE_HEADER_NAME))
+            contentLength = getContentLengthFromBody(networkResponse, networkResponse.header(CONTENT_TYPE_HEADER_NAME, null))
         }
 
         if (contentLength == null) {
@@ -80,7 +80,7 @@ public class EmbraceOkHttp3NetworkInterceptor internal constructor(
 
         // If we need to capture the network response body,
         if (shouldCaptureNetworkData) {
-            if (ENCODING_GZIP.equals(networkResponse.header(CONTENT_ENCODING_HEADER_NAME), ignoreCase = true) &&
+            if (ENCODING_GZIP.equals(networkResponse.header(CONTENT_ENCODING_HEADER_NAME, null), ignoreCase = true) &&
                 networkResponse.promisesBody()
             ) {
                 val body = networkResponse.body
@@ -90,7 +90,7 @@ public class EmbraceOkHttp3NetworkInterceptor internal constructor(
                         .removeAll(CONTENT_LENGTH_HEADER_NAME)
                         .build()
                     val realResponseBody = RealResponseBody(
-                        networkResponse.header(CONTENT_TYPE_HEADER_NAME),
+                        networkResponse.header(CONTENT_TYPE_HEADER_NAME, null),
                         -1L,
                         GzipSource(body.source()).buffer()
                     )
@@ -123,7 +123,7 @@ public class EmbraceOkHttp3NetworkInterceptor internal constructor(
 
     private fun getContentLengthFromHeader(networkResponse: Response): Long? {
         var contentLength: Long? = null
-        val contentLengthHeaderValue = networkResponse.header(CONTENT_LENGTH_HEADER_NAME)
+        val contentLengthHeaderValue = networkResponse.header(CONTENT_LENGTH_HEADER_NAME, null)
         if (contentLengthHeaderValue != null) {
             try {
                 contentLength = contentLengthHeaderValue.toLong()


### PR DESCRIPTION
## Goal

- When using Embrace SDK 6+ with OkHttp3 there was a `NoSuchMethod` exception being thrown because from OkHttp v3 to v4 the `Response` class was converted to kotlin and we were calling the `header` method without passing a default param, but in Java (version 3) that param is mandatory. 

## Testing

Tested manually. 

## Release Notes

- Fixed a compatibility issue with OkHttp3. 

