### PR TITLE
Move pass through method function implementations of spans API to interface

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -339,6 +339,7 @@ public abstract interface class io/embrace/android/embracesdk/spans/EmbraceSpan 
 }
 
 public final class io/embrace/android/embracesdk/spans/EmbraceSpan$DefaultImpls {
+	public static fun addEvent (Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/lang/String;)Z
 	public static fun start (Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
 	public static fun stop (Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
 	public static fun stop (Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/ErrorCode;)Z

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -73,8 +73,6 @@ internal class EmbraceSpanImpl(
         }
     }
 
-    override fun addEvent(name: String): Boolean = addEvent(name = name, timestampMs = null, attributes = null)
-
     override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean {
         if (eventCount.get() < MAX_EVENT_COUNT && inputsValid(name, attributes)) {
             synchronized(eventCount) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -11,22 +11,11 @@ internal class EmbraceTracer(
     private val clock: Clock,
     private val spanService: SpanService,
 ) : TracingApi {
-    override fun createSpan(name: String): EmbraceSpan? = createSpan(name = name, parent = null)
-
     override fun createSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? =
         spanService.createSpan(
             name = name,
             parent = parent,
             internal = false
-        )
-
-    override fun startSpan(name: String): EmbraceSpan? = startSpan(name = name, parent = null)
-
-    override fun startSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? =
-        startSpan(
-            name = name,
-            parent = parent,
-            startTimeMs = null
         )
 
     override fun startSpan(name: String, parent: EmbraceSpan?, startTimeMs: Long?): EmbraceSpan? =
@@ -36,24 +25,6 @@ internal class EmbraceTracer(
             startTimeMs = startTimeMs,
             internal = false
         )
-
-    override fun <T> recordSpan(
-        name: String,
-        code: () -> T
-    ): T = recordSpan(name = name, parent = null, attributes = null, events = null, code = code)
-
-    override fun <T> recordSpan(
-        name: String,
-        parent: EmbraceSpan?,
-        code: () -> T
-    ): T = recordSpan(name = name, parent = parent, attributes = null, events = null, code = code)
-
-    override fun <T> recordSpan(
-        name: String,
-        attributes: Map<String, String>?,
-        events: List<EmbraceSpanEvent>?,
-        code: () -> T
-    ): T = recordSpan(name = name, parent = null, attributes = attributes, events = events, code = code)
 
     override fun <T> recordSpan(
         name: String,
@@ -70,71 +41,6 @@ internal class EmbraceTracer(
         code = code
     )
 
-    override fun recordCompletedSpan(name: String, startTimeMs: Long, endTimeMs: Long): Boolean =
-        recordCompletedSpan(
-            name = name,
-            startTimeMs = startTimeMs,
-            endTimeMs = endTimeMs,
-            errorCode = null,
-            parent = null,
-            attributes = null,
-            events = null
-        )
-
-    override fun recordCompletedSpan(name: String, startTimeMs: Long, endTimeMs: Long, errorCode: ErrorCode?): Boolean =
-        recordCompletedSpan(
-            name = name,
-            startTimeMs = startTimeMs,
-            endTimeMs = endTimeMs,
-            errorCode = errorCode,
-            parent = null,
-            attributes = null,
-            events = null
-        )
-
-    override fun recordCompletedSpan(name: String, startTimeMs: Long, endTimeMs: Long, parent: EmbraceSpan?): Boolean =
-        recordCompletedSpan(
-            name = name,
-            startTimeMs = startTimeMs,
-            endTimeMs = endTimeMs,
-            errorCode = null,
-            parent = parent,
-            attributes = null,
-            events = null
-        )
-
-    override fun recordCompletedSpan(
-        name: String,
-        startTimeMs: Long,
-        endTimeMs: Long,
-        errorCode: ErrorCode?,
-        parent: EmbraceSpan?
-    ): Boolean = recordCompletedSpan(
-        name = name,
-        startTimeMs = startTimeMs,
-        endTimeMs = endTimeMs,
-        errorCode = errorCode,
-        parent = parent,
-        attributes = null,
-        events = null
-    )
-
-    override fun recordCompletedSpan(
-        name: String,
-        startTimeMs: Long,
-        endTimeMs: Long,
-        attributes: Map<String, String>?,
-        events: List<EmbraceSpanEvent>?
-    ): Boolean = recordCompletedSpan(
-        name = name,
-        startTimeMs = startTimeMs,
-        endTimeMs = endTimeMs,
-        errorCode = null,
-        parent = null,
-        attributes = attributes,
-        events = events
-    )
-
     override fun recordCompletedSpan(
         name: String,
         startTimeMs: Long,
@@ -143,17 +49,16 @@ internal class EmbraceTracer(
         parent: EmbraceSpan?,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?
-    ): Boolean =
-        spanService.recordCompletedSpan(
-            name = name,
-            startTimeMs = startTimeMs.normalizeTimestampAsMillis(),
-            endTimeMs = endTimeMs.normalizeTimestampAsMillis(),
-            parent = parent,
-            internal = false,
-            attributes = attributes ?: emptyMap(),
-            events = events ?: emptyList(),
-            errorCode = errorCode
-        )
+    ): Boolean = spanService.recordCompletedSpan(
+        name = name,
+        startTimeMs = startTimeMs.normalizeTimestampAsMillis(),
+        endTimeMs = endTimeMs.normalizeTimestampAsMillis(),
+        parent = parent,
+        internal = false,
+        attributes = attributes ?: emptyMap(),
+        events = events ?: emptyList(),
+        errorCode = errorCode
+    )
 
     override fun getSpan(spanId: String): EmbraceSpan? = spanService.getSpan(spanId = spanId)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -73,7 +73,7 @@ public interface EmbraceSpan {
      */
     public fun addEvent(
         name: String
-    ): Boolean
+    ): Boolean = addEvent(name = name, timestampMs = null, attributes = null)
 
     /**
      * Add an [EmbraceSpanEvent] with the given [name]. If [timestampMs] is null, the current time will be used. Optionally, the specific

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -17,7 +17,7 @@ internal interface TracingApi {
     @BetaApi
     fun createSpan(
         name: String
-    ): EmbraceSpan?
+    ): EmbraceSpan? = createSpan(name = name, parent = null)
 
     /**
      * Create an [EmbraceSpan] with the given name and parent. Passing in a parent that is null result in a new trace with this
@@ -39,7 +39,7 @@ internal interface TracingApi {
     @BetaApi
     fun startSpan(
         name: String
-    ): EmbraceSpan?
+    ): EmbraceSpan? = startSpan(name = name, parent = null)
 
     /**
      * Create, start, and return a new [EmbraceSpan] with the given name and parent. Returns null if the [EmbraceSpan] cannot be created
@@ -49,7 +49,11 @@ internal interface TracingApi {
     fun startSpan(
         name: String,
         parent: EmbraceSpan?
-    ): EmbraceSpan?
+    ): EmbraceSpan? = startSpan(
+        name = name,
+        parent = parent,
+        startTimeMs = null
+    )
 
     /**
      * Create, start, and return a new [EmbraceSpan] with the given name, parent, and start time. Returns null if the [EmbraceSpan] cannot
@@ -71,7 +75,7 @@ internal interface TracingApi {
     fun <T> recordSpan(
         name: String,
         code: () -> T
-    ): T
+    ): T = recordSpan(name = name, parent = null, attributes = null, events = null, code = code)
 
     /**
      * Execute the given block of code and record a new span around it with the given parent. Passing in a parent that is null will result
@@ -84,7 +88,7 @@ internal interface TracingApi {
         name: String,
         parent: EmbraceSpan?,
         code: () -> T
-    ): T
+    ): T = recordSpan(name = name, parent = parent, attributes = null, events = null, code = code)
 
     /**
      * Execute the given block of code and record a new trace around it with optional attributes and list of [EmbraceSpanEvent]. If the span
@@ -97,7 +101,7 @@ internal interface TracingApi {
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?,
         code: () -> T
-    ): T
+    ): T = recordSpan(name = name, parent = null, attributes = attributes, events = events, code = code)
 
     /**
      * Execute the given block of code and record a new span around it with the given parent with optional attributes and list
@@ -123,7 +127,16 @@ internal interface TracingApi {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long
-    ): Boolean
+    ): Boolean =
+        recordCompletedSpan(
+            name = name,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
+            errorCode = null,
+            parent = null,
+            attributes = null,
+            events = null
+        )
 
     /**
      * Record a span with the given name, error code, as well as start and end times, which will be the root span of a new trace. A
@@ -136,7 +149,16 @@ internal interface TracingApi {
         startTimeMs: Long,
         endTimeMs: Long,
         errorCode: ErrorCode?
-    ): Boolean
+    ): Boolean =
+        recordCompletedSpan(
+            name = name,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
+            errorCode = errorCode,
+            parent = null,
+            attributes = null,
+            events = null
+        )
 
     /**
      * Record a span with the given name, parent, as well as start and end times. Passing in a parent that is null will result
@@ -148,7 +170,16 @@ internal interface TracingApi {
         startTimeMs: Long,
         endTimeMs: Long,
         parent: EmbraceSpan?
-    ): Boolean
+    ): Boolean =
+        recordCompletedSpan(
+            name = name,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
+            errorCode = null,
+            parent = parent,
+            attributes = null,
+            events = null
+        )
 
     /**
      * Record a span with the given name, parent, error code, as well as start and end times. Passing in a parent that is null will result
@@ -162,7 +193,15 @@ internal interface TracingApi {
         endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?,
-    ): Boolean
+    ): Boolean = recordCompletedSpan(
+        name = name,
+        startTimeMs = startTimeMs,
+        endTimeMs = endTimeMs,
+        errorCode = errorCode,
+        parent = parent,
+        attributes = null,
+        events = null
+    )
 
     /**
      * Record a span with the given name as well as start and end times, which will be the root span of a new trace. You can also pass in
@@ -176,7 +215,15 @@ internal interface TracingApi {
         endTimeMs: Long,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?
-    ): Boolean
+    ): Boolean = recordCompletedSpan(
+        name = name,
+        startTimeMs = startTimeMs,
+        endTimeMs = endTimeMs,
+        errorCode = null,
+        parent = null,
+        attributes = attributes,
+        events = events
+    )
 
     /**
      * Record a span with the given name, error code, parent, as well as start and end times. Passing in a parent that is null will result

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
@@ -9,39 +9,12 @@ internal class FakeTracingApi : TracingApi {
 
     val createdSpans = mutableListOf<String>()
 
-    override fun createSpan(name: String): EmbraceSpan? = createSpan(name = name, parent = null)
-
     override fun createSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? {
         createdSpans.add(name)
         return null
     }
 
-    override fun startSpan(name: String): EmbraceSpan? {
-        TODO("Not yet implemented")
-    }
-
-    override fun startSpan(name: String, parent: EmbraceSpan?): EmbraceSpan? {
-        TODO("Not yet implemented")
-    }
-
     override fun startSpan(name: String, parent: EmbraceSpan?, startTimeMs: Long?): EmbraceSpan? {
-        TODO("Not yet implemented")
-    }
-
-    override fun <T> recordSpan(name: String, code: () -> T): T {
-        TODO("Not yet implemented")
-    }
-
-    override fun <T> recordSpan(name: String, parent: EmbraceSpan?, code: () -> T): T {
-        TODO("Not yet implemented")
-    }
-
-    override fun <T> recordSpan(
-        name: String,
-        attributes: Map<String, String>?,
-        events: List<EmbraceSpanEvent>?,
-        code: () -> T
-    ): T {
         TODO("Not yet implemented")
     }
 
@@ -52,52 +25,6 @@ internal class FakeTracingApi : TracingApi {
         events: List<EmbraceSpanEvent>?,
         code: () -> T
     ): T {
-        TODO("Not yet implemented")
-    }
-
-    override fun recordCompletedSpan(
-        name: String,
-        startTimeMs: Long,
-        endTimeMs: Long
-    ): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override fun recordCompletedSpan(
-        name: String,
-        startTimeMs: Long,
-        endTimeMs: Long,
-        errorCode: ErrorCode?
-    ): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override fun recordCompletedSpan(
-        name: String,
-        startTimeMs: Long,
-        endTimeMs: Long,
-        parent: EmbraceSpan?
-    ): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override fun recordCompletedSpan(
-        name: String,
-        startTimeMs: Long,
-        endTimeMs: Long,
-        errorCode: ErrorCode?,
-        parent: EmbraceSpan?
-    ): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override fun recordCompletedSpan(
-        name: String,
-        startTimeMs: Long,
-        endTimeMs: Long,
-        attributes: Map<String, String>?,
-        events: List<EmbraceSpanEvent>?
-    ): Boolean {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
## Goal

Put the method overloads that just call the main method into the interface of the public and internal tracing APIs. 

## Testing

Verified by existing tests
