### PR TITLE
[POC] Synchronise access when reading/writing files to avoid corrupting payloads

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
@@ -85,4 +85,6 @@ internal interface CacheService {
      * Loads the old format of pending API calls.
      */
     fun loadOldPendingApiCalls(name: String): List<PendingApiCall>?
+
+    fun replaceSession(name: String, transformer: (SessionMessage) -> SessionMessage)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 internal interface DeliveryCacheManager {
     fun saveSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun loadSession(sessionId: String): SessionMessage?
+    fun replaceSession(sessionId: String, mutator: (SessionMessage) -> SessionMessage)
     fun loadSessionAsAction(sessionId: String): SerializationAction?
     fun deleteSession(sessionId: String)
     fun getAllCachedSessionIds(): List<String>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -11,6 +11,9 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.lang.RuntimeException
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 /**
  * Handles the reading and writing of objects from the app's cache.
@@ -21,24 +24,35 @@ internal class EmbraceCacheService(
     private val logger: InternalEmbraceLogger
 ) : CacheService {
 
+    /**
+     * Holds read-write locks for each filename.
+     *
+     * If a file is being written then nothing else should read/write it. Otherwise, it's safe
+     * to read a file using multiple threads at the same time.
+     */
+    private val fileLocks = mutableMapOf<String, ReentrantReadWriteLock>()
+
     override fun cacheBytes(name: String, bytes: ByteArray?) {
-        logger.logDeveloper(TAG, "Attempting to write bytes to $name")
-        if (bytes != null) {
-            val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
-            try {
-                if (name == "testfile-truncate") {
-                    file.writeHalfTheBytes(bytes)
-                } else if (name == "testfile-pause") {
-                    file.writeBytesWithPause(bytes)
-                }  else {
-                    file.writeBytes(bytes)
+        findLock(name).write {
+            logger.logDeveloper(TAG, "Attempting to write bytes to $name")
+            if (bytes != null) {
+                val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
+                try {
+                    if (name == "testfile-truncate") {
+                        file.writeHalfTheBytes(bytes)
+                    } else if (name == "testfile-pause") {
+                        file.writeBytesWithPause(bytes)
+                    } else {
+                        file.writeBytes(bytes)
+                    }
+                    logger.logDeveloper(TAG, "Bytes cached")
+                } catch (ex: Exception) {
+                    logger.logWarning("Failed to store cache object " + file.path, ex)
+                    deleteFile(name)
                 }
-                logger.logDeveloper(TAG, "Bytes cached")
-            } catch (ex: Exception) {
-                logger.logWarning("Failed to store cache object " + file.path, ex)
+            } else {
+                logger.logWarning("No bytes to save to file $name")
             }
-        } else {
-            logger.logWarning("No bytes to save to file $name")
         }
     }
 
@@ -56,27 +70,31 @@ internal class EmbraceCacheService(
     }
 
     override fun loadBytes(name: String): ByteArray? {
-        logger.logDeveloper(TAG, "Attempting to read bytes from $name")
-        val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
-        try {
-            return file.readBytes()
-        } catch (ex: FileNotFoundException) {
-            logger.logWarning("Cache file cannot be found " + file.path)
-        } catch (ex: Exception) {
-            logger.logWarning("Failed to read cache object " + file.path, ex)
+        findLock(name).read {
+            logger.logDeveloper(TAG, "Attempting to read bytes from $name")
+            val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
+            try {
+                return file.readBytes()
+            } catch (ex: FileNotFoundException) {
+                logger.logWarning("Cache file cannot be found " + file.path)
+            } catch (ex: Exception) {
+                logger.logWarning("Failed to read cache object " + file.path, ex)
+            }
+            return null
         }
-        return null
     }
 
     override fun cachePayload(name: String, action: SerializationAction) {
-        logger.logDeveloper(TAG, "Attempting to write bytes to $name")
-        val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
-        try {
-            file.outputStream().buffered().use(action)
-            logger.logDeveloper(TAG, "Bytes cached")
-        } catch (ex: Exception) {
-            runCatching { file.delete() }
-            logger.logWarning("Failed to store cache object " + file.path, ex)
+        findLock(name).write {
+            logger.logDeveloper(TAG, "Attempting to write bytes to $name")
+            val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
+            try {
+                file.outputStream().buffered().use(action)
+                logger.logDeveloper(TAG, "Bytes cached")
+            } catch (ex: Exception) {
+                logger.logWarning("Failed to store cache object " + file.path, ex)
+                deleteFile(name)
+            }
         }
     }
 
@@ -89,19 +107,21 @@ internal class EmbraceCacheService(
      * before 6.3.0 didn't compress the data.
      */
     override fun loadPayload(name: String): SerializationAction {
-        logger.logDeveloper(TAG, "Attempting to read bytes from $name")
         return { stream ->
-            val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
-            try {
-                ConditionalGzipOutputStream(stream).use {
-                    file.inputStream().buffered().use { input ->
-                        input.copyTo(it)
+            logger.logDeveloper(TAG, "Attempting to read bytes from $name")
+            findLock(name).read {
+                val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
+                try {
+                    ConditionalGzipOutputStream(stream).use {
+                        file.inputStream().buffered().use { input ->
+                            input.copyTo(it)
+                        }
                     }
+                } catch (ex: FileNotFoundException) {
+                    logger.logWarning("Cache file cannot be found " + file.path)
+                } catch (ex: Exception) {
+                    logger.logWarning("Failed to read cache object " + file.path, ex)
                 }
-            } catch (ex: FileNotFoundException) {
-                logger.logWarning("Cache file cannot be found " + file.path)
-            } catch (ex: Exception) {
-                logger.logWarning("Failed to read cache object " + file.path, ex)
             }
         }
     }
@@ -118,67 +138,103 @@ internal class EmbraceCacheService(
      * @param <T>    the type of the object to write
      */
     override fun <T> cacheObject(name: String, objectToCache: T, clazz: Class<T>) {
-        logger.logDeveloper(TAG, "Attempting to cache object: $name")
-        val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
-        try {
-            serializer.toJson(objectToCache, clazz, file.outputStream())
-        } catch (ex: Exception) {
-            logger.logDebug("Failed to store cache object " + file.path, ex)
+        findLock(name).write {
+            logger.logDeveloper(TAG, "Attempting to cache object: $name")
+            val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
+            try {
+                serializer.toJson(objectToCache, clazz, file.outputStream())
+            } catch (ex: Exception) {
+                logger.logDebug("Failed to store cache object " + file.path, ex)
+                deleteFile(name)
+            }
         }
     }
 
     override fun <T> loadObject(name: String, clazz: Class<T>): T? {
-        val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
-        try {
-            return serializer.fromJson(file.inputStream(), clazz)
-        } catch (ex: FileNotFoundException) {
-            logger.logDebug("Cache file cannot be found " + file.path)
-        } catch (ex: Exception) {
-            logger.logDebug("Failed to read cache object " + file.path, ex)
+        findLock(name).read {
+            val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
+            try {
+                return serializer.fromJson(file.inputStream(), clazz)
+            } catch (ex: FileNotFoundException) {
+                logger.logDebug("Cache file cannot be found " + file.path)
+            } catch (ex: Exception) {
+                logger.logDebug("Failed to read cache object " + file.path, ex)
+            }
+            return null
         }
-        return null
     }
 
     override fun deleteFile(name: String): Boolean {
-        logger.logDeveloper("EmbraceCacheService", "Attempting to delete file from cache: $name")
-        val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
-        try {
-            return file.delete()
-        } catch (ex: Exception) {
-            logger.logDebug("Failed to delete cache object " + file.path)
+        val success = findLock(name).write {
+            logger.logDeveloper(
+                "EmbraceCacheService",
+                "Attempting to delete file from cache: $name"
+            )
+            val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
+            try {
+                file.delete()
+            } catch (ex: Exception) {
+                logger.logDebug("Failed to delete cache object " + file.path)
+            }
+            false
         }
-        return false
+
+        // allow lock object to be garbage collected
+        fileLocks.remove(name)
+        return success
     }
 
-    override fun listFilenamesByPrefix(prefix: String): List<String> {
+    override fun listFilenamesByPrefix(prefix: String): List<String> { // TODO: locking?
         return storageService.listFiles { _, name ->
             name.startsWith(EMBRACE_PREFIX + prefix)
         }.map { file -> file.name.substring(EMBRACE_PREFIX.length) }
     }
 
     override fun writeSession(name: String, sessionMessage: SessionMessage) {
-        try {
-            logger.logDeveloper(TAG, "Attempting to write bytes to $name")
-            val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
-            serializer.toJson(sessionMessage, SessionMessage::class.java, file.outputStream())
-            logger.logDeveloper(TAG, "Bytes cached")
-        } catch (ex: Throwable) {
-            logger.logWarning("Failed to write session with buffered writer", ex)
+        findLock(name).write {
+            try {
+                logger.logDeveloper(TAG, "Attempting to write bytes to $name")
+                val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
+                serializer.toJson(sessionMessage, SessionMessage::class.java, file.outputStream())
+                logger.logDeveloper(TAG, "Bytes cached")
+            } catch (ex: Throwable) {
+                logger.logWarning("Failed to write session with buffered writer", ex)
+                deleteFile(name)
+            }
         }
     }
 
     override fun loadOldPendingApiCalls(name: String): List<PendingApiCall>? {
-        val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
-        try {
-            val type = Types.newParameterizedType(List::class.java, PendingApiCall::class.java)
-            return serializer.fromJson(file.inputStream(), type) as List<PendingApiCall>? ?: emptyList()
-        } catch (ex: FileNotFoundException) {
-            logger.logDebug("Cache file cannot be found " + file.path)
-        } catch (ex: Exception) {
-            logger.logDebug("Failed to read cache object " + file.path, ex)
+        findLock(name).read {
+            val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
+            try {
+                val type = Types.newParameterizedType(List::class.java, PendingApiCall::class.java)
+                return serializer.fromJson(file.inputStream(), type) as List<PendingApiCall>?
+                    ?: emptyList()
+            } catch (ex: FileNotFoundException) {
+                logger.logDebug("Cache file cannot be found " + file.path)
+            } catch (ex: Exception) {
+                logger.logDebug("Failed to read cache object " + file.path, ex)
+            }
+            return null
         }
-        return null
     }
+
+    override fun replaceSession(name: String, transformer: (SessionMessage) -> SessionMessage) {
+        findLock(name).write {
+            try {
+                val sessionMessage = loadObject(name, SessionMessage::class.java) ?: return@write
+                val newMessage = transformer(sessionMessage)
+                cacheObject(name, newMessage, SessionMessage::class.java)
+            } catch (ex: Exception) {
+                logger.logDebug("Failed to replace session object ", ex)
+                deleteFile(name)
+            }
+        }
+    }
+
+    private fun findLock(name: String) =
+        fileLocks.getOrPut(name, ::ReentrantReadWriteLock)
 
     companion object {
         private const val EMBRACE_PREFIX = "emb_"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -198,6 +198,11 @@ internal class EmbraceDeliveryCacheManager(
         }
     }
 
+    override fun replaceSession(sessionId: String, mutator: (SessionMessage) -> SessionMessage) {
+        val filename = cachedSessions[sessionId]?.filename ?: return
+        cacheService.replaceSession(filename, mutator)
+    }
+
     /**
      * Loads the old version of the [PENDING_API_CALLS_FILE_NAME] file where
      * it was storing a list of [PendingApiCall] instead of [PendingApiCalls]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -117,18 +117,8 @@ internal class EmbraceDeliveryService(
     }
 
     private fun addCrashDataToCachedSession(nativeCrashData: NativeCrashData) {
-        cacheManager.loadSession(nativeCrashData.sessionId)
-            ?.also { sessionMessage ->
-                // Create a new session message with the specified crash id
-                val newSessionMessage =
-                    attachCrashToSession(nativeCrashData, sessionMessage)
-                // Replace the cached file for the corresponding session
-                cacheManager.saveSession(newSessionMessage, SessionSnapshotType.NORMAL_END)
-            } ?: run {
-            logger.logError(
-                "Could not find session with id ${nativeCrashData.sessionId} to " +
-                    "add native crash"
-            )
+        cacheManager.replaceSession(nativeCrashData.sessionId) { sessionMessage ->
+            attachCrashToSession(nativeCrashData, sessionMessage)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -74,9 +74,7 @@ internal class EmbraceCacheServiceTest {
         service.cacheBytes(CUSTOM_OBJECT_1_FILE_NAME, myBytes)
 
         val loadedBytes = service.loadBytes(CUSTOM_OBJECT_1_FILE_NAME)
-        assertNotNull(loadedBytes)
-        assertArrayEquals("locked file".toByteArray(), loadedBytes)
-        cacheFile.delete()
+        assertNull(loadedBytes)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FileSaveTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FileSaveTests.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import java.nio.charset.StandardCharsets
@@ -57,7 +57,6 @@ internal class FileSaveTests {
             numbersBytes,
             loadedObject
         )
-
     }
 
     @Test
@@ -68,7 +67,7 @@ internal class FileSaveTests {
         val loadedObject = service.loadBytes(filename)
 
         // Failure - whatever gets written is read
-        assertEquals("", loadedObject?.toString(Charsets.UTF_8))
+        assertNull(loadedObject?.toString(Charsets.UTF_8))
     }
 
     @Test
@@ -121,11 +120,7 @@ internal class FileSaveTests {
         val loadedObject = service.loadBytes(filename)
 
         // Failed: what was written already is read
-        assertArrayEquals(
-            "error! actual: ${loadedObject?.toString(StandardCharsets.UTF_8)}\n expected: $lettersString",
-            lettersBytes,
-            loadedObject
-        )
+        assertNull(loadedObject)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/TestCacheService.kt
@@ -63,4 +63,7 @@ internal class TestCacheService : CacheService {
             it.write(cache[name])
         }
     }
+
+    override fun replaceSession(name: String, transformer: (SessionMessage) -> SessionMessage) {
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
@@ -45,4 +45,8 @@ internal class FakeCacheService : CacheService {
     override fun loadPayload(name: String): SerializationAction {
         TODO("Not yet implemented")
     }
+
+    override fun replaceSession(name: String, transformer: (SessionMessage) -> SessionMessage) {
+        TODO("Not yet implemented")
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -79,6 +79,10 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
         TODO("Not yet implemented")
     }
 
+    override fun replaceSession(sessionId: String, mutator: (SessionMessage) -> SessionMessage) {
+        TODO("Not yet implemented")
+    }
+
     fun addCachedSessions(vararg sessionMessages: SessionMessage) {
         cachedSessions.addAll(sessionMessages)
     }


### PR DESCRIPTION
## Goal

Previously there was not any synchronisation when reading/writing files which in some cases could lead to corrupted payloads being sent. This changeset demonstrates a POC that avoids all scenarios where payloads could be accessed concurrently.

My approach is to add a `ReadWriteLock` in the `CacheService`. A lock is allocated for each filename as this should always be unique & allows high throughput of other files. I chose `ReadWriteLock` as a further optimization - when a write is happening only one thread can hold a lock, but multiple threads are allowed to hold a read lock.

I have not written unit tests or extensively tested the behavior but will do so once everyone is happy with this approach. I was able to make the failing test cases pass from #470.
