### PR TITLE
Pre-requisite changes for migrating breadcrumbs to OTel

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/CleanSessionBoundaryTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/CleanSessionBoundaryTest.kt
@@ -29,19 +29,15 @@ internal class CleanSessionBoundaryTest {
     fun `session messages have a clean boundary`() {
         with(testRule) {
             val message = harness.recordSession {
-                embrace.addBreadcrumb("Hello, World!")
                 embrace.addSessionProperty("foo", "bar", false)
             }
             checkNotNull(message)
 
             // validate info added to first session
-            val crumbs = checkNotNull(message.breadcrumbs?.customBreadcrumbs)
-            assertEquals("Hello, World!", crumbs.single().message)
             assertEquals(mapOf("foo" to "bar"), message.session.properties)
 
             // confirm info not added to next session
             val nextMessage = checkNotNull(harness.recordSession())
-            assertEquals(0, nextMessage.breadcrumbs?.customBreadcrumbs?.size)
             assertEquals(emptyMap<String, String>(), nextMessage.session.properties)
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
@@ -1,0 +1,142 @@
+package io.embrace.android.embracesdk.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.FakeDeliveryService
+import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.IntegrationTestRule.*
+import io.embrace.android.embracesdk.IntegrationTestRule.Harness
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
+import io.embrace.android.embracesdk.gating.EmbraceGatingService
+import io.embrace.android.embracesdk.gating.GatingService
+import io.embrace.android.embracesdk.gating.SessionGatingKeys
+import io.embrace.android.embracesdk.getSentSessionMessages
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.recordSession
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.android.embracesdk.verifySessionHappened
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Asserts that OTel parts of sessions are gated.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class OtelSessionGatingTest {
+
+    private var gatingConfig = SessionRemoteConfig(
+        fullSessionEvents = setOf(),
+        sessionComponents = setOf()
+    )
+
+    private val gatingService = EmbraceGatingService(
+        FakeConfigService(
+            sessionBehavior = fakeSessionBehavior {
+                RemoteConfig(sessionConfig = gatingConfig)
+            }
+        )
+    )
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule(
+        harnessSupplier = {
+            Harness(
+                fakeDeliveryModule = FakeDeliveryModule(
+                    deliveryService = GatedDeliveryService(gatingService)
+                )
+            )
+        }
+    )
+
+    @Before
+    fun setUp() {
+        assertTrue(testRule.harness.getSentSessionMessages().isEmpty())
+    }
+
+    @Test
+    fun `session sent in full without gating`() {
+        gatingConfig = SessionRemoteConfig()
+
+        with(testRule) {
+            simulateSession()
+            val payload = harness.getSentSessionMessages().single()
+            verifySessionHappened(payload)
+            assertSessionGating(payload, gated = false)
+        }
+    }
+
+    @Test
+    fun `session gated`() {
+        gatingConfig = SessionRemoteConfig(
+            sessionComponents = emptySet(),
+            fullSessionEvents = setOf(
+                SessionGatingKeys.FULL_SESSION_CRASHES,
+                SessionGatingKeys.FULL_SESSION_ERROR_LOGS
+            )
+        )
+
+        with(testRule) {
+            simulateSession()
+            val payload = harness.getSentSessionMessages().single()
+            verifySessionHappened(payload)
+            assertSessionGating(payload, gated = true)
+        }
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun assertSessionGating(
+        payload: SessionMessage,
+        gated: Boolean
+    ) {
+        val sessionSpan = payload.findSessionSpan()
+        assertNotNull(sessionSpan)
+    }
+
+    private fun IntegrationTestRule.simulateSession(action: () -> Unit = {}) {
+        harness.recordSession {
+            embrace.addBreadcrumb("Hello, world!")
+            harness.fakeClock.tick(10000) // enough to trigger new session
+            action()
+        }
+    }
+
+    private fun SessionMessage.findSessionSpan(): EmbraceSpanData =
+        checkNotNull(findSpan("emb-session-span")) {
+            "Session span not found"
+        }
+
+    private fun SessionMessage.findSpan(name: String): EmbraceSpanData? =
+        spans?.singleOrNull { it.name == name }
+
+    private fun EmbraceSpanData.findEvent(name: String): EmbraceSpanEvent? =
+        events.singleOrNull { it.name == name }
+
+    /**
+     * Wraps a fake delivery service around the [GatingService] so we can assert against
+     * gating behavior.
+     */
+    private class GatedDeliveryService(
+        private val gatingService: GatingService,
+    ) : FakeDeliveryService() {
+
+        override fun sendSession(
+            sessionMessage: SessionMessage,
+            snapshotType: SessionSnapshotType
+        ) = super.sendSession(
+            gatingService.gateSessionMessage(sessionMessage),
+            snapshotType
+        )
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
@@ -40,13 +40,13 @@ internal class PeriodicSessionCacheTest {
 
             harness.recordSession {
                 executor.runCurrentlyBlocked()
-                embrace.addBreadcrumb("Test")
+                embrace.addSessionProperty("Test", "Test", true)
 
                 var endMessage = checkNotNull(harness.getLastSavedSessionMessage())
                 assertEquals("en", endMessage.session.messageType)
                 assertEquals(false, endMessage.session.isEndedCleanly)
                 assertEquals(true, endMessage.session.isReceivedTermination)
-                assertEquals(0, endMessage.breadcrumbs?.customBreadcrumbs?.size)
+                assertEquals(0, endMessage.session.properties?.size)
 
                 // trigger another periodic cache
                 executor.moveForwardAndRunBlocked(2000)
@@ -54,14 +54,14 @@ internal class PeriodicSessionCacheTest {
                 assertEquals("en", endMessage.session.messageType)
                 assertEquals(false, endMessage.session.isEndedCleanly)
                 assertEquals(true, endMessage.session.isReceivedTermination)
-                assertEquals("Test", endMessage.breadcrumbs?.customBreadcrumbs?.single()?.message)
+                assertEquals("Test", checkNotNull(endMessage.session.properties)["Test"])
             }
 
             val endMessage = checkNotNull(harness.getLastSentSessionMessage())
             assertEquals("en", endMessage.session.messageType)
             assertEquals(true, endMessage.session.isEndedCleanly)
             assertNull(endMessage.session.isReceivedTermination)
-            assertEquals("Test", endMessage.breadcrumbs?.customBreadcrumbs?.single()?.message)
+            assertEquals("Test", checkNotNull(endMessage.session.properties)["Test"])
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
@@ -45,14 +45,11 @@ internal class StatefulSessionTest {
             verifySessionHappened(first)
             assertEquals(LifeEventType.STATE, first.session.startType)
             assertEquals(LifeEventType.STATE, first.session.endType)
-            val crumb = checkNotNull(first.breadcrumbs?.customBreadcrumbs?.single())
-            assertEquals("Hello, World!", crumb.message)
 
             // verify second session
             val second = messages[1]
             verifySessionHappened(second)
             assertNotEquals(first.session.sessionId, second.session.sessionId)
-            assertEquals(true, second.breadcrumbs?.customBreadcrumbs?.isEmpty())
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizerFacade.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizerFacade.kt
@@ -19,12 +19,14 @@ internal class SessionSanitizerFacade(
         val sanitizedPerformanceInfo = PerformanceInfoSanitizer(sessionMessage.performanceInfo, components).sanitize()
         val sanitizedBreadcrumbs =
             BreadcrumbsSanitizer(sessionMessage.breadcrumbs, components).sanitize()
+        val sanitizedSpans = SpanSanitizer(sessionMessage.spans, components).sanitize()
 
         return sessionMessage.copy(
             session = sanitizedSession,
             userInfo = sanitizedUserInfo,
             performanceInfo = sanitizedPerformanceInfo,
-            breadcrumbs = sanitizedBreadcrumbs
+            breadcrumbs = sanitizedBreadcrumbs,
+            spans = sanitizedSpans
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
@@ -1,0 +1,47 @@
+package io.embrace.android.embracesdk.gating
+
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+
+internal class SpanSanitizer(
+    private val spans: List<EmbraceSpanData>?,
+    @Suppress("UnusedPrivateProperty") private val enabledComponents: Set<String>
+) : Sanitizable<List<EmbraceSpanData>> {
+
+    override fun sanitize(): List<EmbraceSpanData>? {
+        if (spans == null) {
+            return null
+        }
+
+        val sanitizedSpans = spans.filter(::sanitizeSpans).toMutableList()
+        val sessionSpan =
+            sanitizedSpans.singleOrNull { it.name == "emb-session-span" } ?: return spans
+        sanitizedSpans.remove(sessionSpan)
+
+        val sanitizedEvents = sessionSpan.events.filter(::sanitizeEvents)
+
+        val sanitizedSessionSpan = EmbraceSpanData(
+            sessionSpan.traceId,
+            sessionSpan.spanId,
+            sessionSpan.parentSpanId,
+            sessionSpan.name,
+            sessionSpan.startTimeNanos,
+            sessionSpan.endTimeNanos,
+            sessionSpan.status,
+            sanitizedEvents,
+            sessionSpan.attributes
+        )
+        sanitizedSpans.add(sanitizedSessionSpan)
+        return sanitizedSpans
+    }
+
+    @Suppress("UNUSED_PARAMETER", "FunctionOnlyReturningConstant")
+    private fun sanitizeSpans(span: EmbraceSpanData): Boolean {
+        return true
+    }
+
+    @Suppress("UNUSED_PARAMETER", "FunctionOnlyReturningConstant")
+    private fun sanitizeEvents(event: EmbraceSpanEvent): Boolean {
+        return true
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
@@ -3,13 +3,13 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.payload.AppInfo
 import io.embrace.android.embracesdk.payload.Breadcrumbs
-import io.embrace.android.embracesdk.payload.CustomBreadcrumb
 import io.embrace.android.embracesdk.payload.DeviceInfo
 import io.embrace.android.embracesdk.payload.DiskUsage
 import io.embrace.android.embracesdk.payload.PerformanceInfo
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.UserInfo
+import io.embrace.android.embracesdk.payload.ViewBreadcrumb
 import io.opentelemetry.api.trace.StatusCode
 
 internal fun fakeBackgroundActivityMessage(): SessionMessage {
@@ -18,7 +18,7 @@ internal fun fakeBackgroundActivityMessage(): SessionMessage {
     val appInfo = AppInfo("fake-app-id")
     val deviceInfo = DeviceInfo("fake-manufacturer")
     val breadcrumbs = Breadcrumbs(
-        customBreadcrumbs = listOf(CustomBreadcrumb("fake-breadcrumb", 1))
+        viewBreadcrumbs = listOf(ViewBreadcrumb("fake-view", 1))
     )
     val spans = listOf(EmbraceSpanData("fake-span-id", "", "", "", 0, 0, StatusCode.OK))
     val perfInfo = PerformanceInfo(DiskUsage(1, 2))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
  * A [DeliveryService] that records the last parameters used to invoke each method, and for the ones that need it, count the number of
  * invocations. Please add additional tracking functionality as tests require them.
  */
-internal class FakeDeliveryService : DeliveryService {
+internal open class FakeDeliveryService : DeliveryService {
     var lastSentNetworkCall: NetworkEvent? = null
     var lastSentCrash: EventMessage? = null
     var lastSentEvent: EventMessage? = null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
@@ -1,12 +1,20 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.arch.destination.SpanEventData
+import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.sdk.trace.IdGenerator
 
-internal class FakeEmbraceSpan private constructor(
-    override val parent: EmbraceSpan?
+internal class FakeEmbraceSpan(
+    override val parent: EmbraceSpan?,
+    val name: String? = null,
+    val type: EmbraceAttributes.Type = EmbraceAttributes.Type.PERFORMANCE,
+    val internal: Boolean = true
 ) : EmbraceSpan {
+
+    val attributes = mutableMapOf<String, String>()
+    val events = mutableListOf<SpanEventData>()
 
     private var started = false
     private var stopped = false
@@ -46,15 +54,18 @@ internal class FakeEmbraceSpan private constructor(
     }
 
     override fun addEvent(name: String): Boolean {
-        TODO("Not yet implemented")
+        events.add(SpanEventData(name, 0, null))
+        return true
     }
 
     override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean {
-        TODO("Not yet implemented")
+        events.add(SpanEventData(name, checkNotNull(timestampMs), attributes))
+        return true
     }
 
     override fun addAttribute(key: String, value: String): Boolean {
-        TODO("Not yet implemented")
+        attributes[key] = value
+        return true
     }
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 
 internal class FakeSpanService : SpanService {
 
-    val createdSpans = mutableListOf<String>()
+    val createdSpans = mutableListOf<FakeEmbraceSpan>()
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
     }
@@ -20,9 +20,8 @@ internal class FakeSpanService : SpanService {
         parent: EmbraceSpan?,
         type: EmbraceAttributes.Type,
         internal: Boolean
-    ): EmbraceSpan? {
-        createdSpans.add(name)
-        return null
+    ): EmbraceSpan = FakeEmbraceSpan(null, name, type, internal).apply {
+        createdSpans.add(this)
     }
 
     override fun <T> recordSpan(


### PR DESCRIPTION
## Goal

Makes some pre-requisite changes for migrating breadcrumbs to OTel. This changeset adds code to support gating of OTel features in sessions & an integration test to assert it works. This will assert on actual OTel spans in #406. It also alters some test assertions that will be obsolete.

