### PR TITLE
Ensure session fully written before using it

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService.Companion.getFileNameForSession
 import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryCacheManager.Companion.PENDING_API_CALLS_FILE_NAME
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -21,11 +22,6 @@ internal class EmbraceDeliveryCacheManager(
 ) : Closeable, DeliveryCacheManager {
 
     companion object {
-        /**
-         * File names for all cached sessions start with this prefix
-         */
-        const val SESSION_FILE_PREFIX = "last_session"
-
         /**
          * File name to cache JVM crash information
          */
@@ -200,7 +196,7 @@ internal class EmbraceDeliveryCacheManager(
 
     private fun deleteOldestSessions() {
         cachedSessions.values
-            .sortedBy { it.timestamp }
+            .sortedBy { it.timestampMs }
             .take(cachedSessions.size - MAX_SESSIONS_CACHED + 1)
             .forEach { deleteSession(it.sessionId) }
     }
@@ -248,8 +244,8 @@ internal class EmbraceDeliveryCacheManager(
 
     data class CachedSession(
         val sessionId: String,
-        val timestamp: Long?
+        val timestampMs: Long
     ) {
-        val filename = "$SESSION_FILE_PREFIX.$timestamp.$sessionId.json"
+        val filename = getFileNameForSession(sessionId, timestampMs)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageService.kt
@@ -43,7 +43,7 @@ internal interface StorageService {
     /**
      * Returns a list of files from the files and cache directories that match the [filter].
      */
-    fun listFiles(filter: FilenameFilter): List<File>
+    fun listFiles(filter: FilenameFilter = FilenameFilter { _, _ -> true }): List<File>
 
     /**
      * Logs storage telemetry such as the currently used size.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -4,14 +4,18 @@ import io.embrace.android.embracesdk.comms.api.ApiRequest
 import io.embrace.android.embracesdk.comms.api.EmbraceUrl
 import io.embrace.android.embracesdk.comms.delivery.CacheService
 import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService
-import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryCacheManager
-import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryCacheManager.Companion.SESSION_FILE_PREFIX
+import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService.Companion.EMBRACE_PREFIX
+import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService.Companion.NEW_COPY_SUFFIX
+import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService.Companion.OLD_COPY_SUFFIX
+import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService.Companion.TEMP_COPY_SUFFIX
+import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService.Companion.getFileNameForSession
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
 import io.embrace.android.embracesdk.fakes.FakeLoggerAction
 import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fixtures.testSessionMessage
+import io.embrace.android.embracesdk.fixtures.testSessionMessage2
 import io.embrace.android.embracesdk.fixtures.testSessionMessageOneMinuteLater
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -223,18 +227,77 @@ internal class EmbraceCacheServiceTest {
     }
 
     @Test
-    fun `test listFilenamesByPrefix`() {
-        val myBytes = "{ \"payload\": \"test_payload\"}".toByteArray()
-        service.cacheBytes(CUSTOM_OBJECT_1_FILE_NAME, myBytes)
-        service.cacheBytes(CUSTOM_OBJECT_2_FILE_NAME, myBytes)
-        service.cacheBytes(CUSTOM_OBJECT_3_FILE_NAME, myBytes)
-        service.cacheBytes("not-match.json", myBytes)
+    fun `only proper session file IDs returned when normalizeCacheAndGetSessionFileIds is called`() {
+        val session1 = testSessionMessage
+        val session2 = testSessionMessage2
+        val session1FileName = getFileNameForSession(session1.session.sessionId, session1.session.startTime)
+        val session2FileName = getFileNameForSession(session2.session.sessionId, session2.session.startTime)
+        service.writeSession(session1FileName, session1)
+        service.writeSession(session2FileName, session2)
+        service.cacheBytes("not-match.json", testPayloadBytes)
 
         val filenames = service.normalizeCacheAndGetSessionFileIds()
-        assertEquals(3, filenames.size)
-        assertTrue(filenames.contains("last_session_1.json"))
-        assertTrue(filenames.contains("last_session_2.json"))
-        assertTrue(filenames.contains("last_session_3.json"))
+        assertEquals(3, storageManager.listFiles().size)
+        assertEquals(2, filenames.size)
+        assertTrue(filenames.contains(session1FileName))
+        assertTrue(filenames.contains(session1FileName))
+    }
+
+    @Test
+    fun `temp files removed during cache normalization`() {
+        val session1 = testSessionMessage
+        val session2 = testSessionMessage2
+        val session1FileName = getFileNameForSession(session1.session.sessionId, session1.session.startTime)
+        val session2FileName = getFileNameForSession(session2.session.sessionId, session2.session.startTime)
+        val badSessionFileName = getFileNameForSession("badId", System.currentTimeMillis())
+        service.writeSession(session1FileName, session1)
+        service.writeSession(session2FileName + OLD_COPY_SUFFIX, session2)
+        service.cacheBytes(badSessionFileName + TEMP_COPY_SUFFIX, testPayloadBytes)
+        assertEquals(3, storageManager.listFiles().size)
+
+        val filenames = service.normalizeCacheAndGetSessionFileIds()
+        assertEquals(1, storageManager.listFiles().size)
+        assertEquals(1, filenames.size)
+        assertTrue(filenames.contains(session1FileName))
+    }
+
+    @Test
+    fun `new version of session file replaces existing one during cache normalization`() {
+        val session = testSessionMessage
+        val newSession = testSessionMessageOneMinuteLater
+        val sessionFileName = getFileNameForSession(session.session.sessionId, session.session.startTime)
+        service.writeSession(sessionFileName, session)
+        service.writeSession(sessionFileName + NEW_COPY_SUFFIX, newSession)
+
+        val rawFilenames = storageManager.listFiles().map { it.name }
+        assertEquals(2, rawFilenames.size)
+        assertTrue(rawFilenames.contains(EMBRACE_PREFIX + sessionFileName))
+        assertTrue(rawFilenames.contains(EMBRACE_PREFIX + sessionFileName + NEW_COPY_SUFFIX))
+        assertEquals(session, service.loadObject(sessionFileName, SessionMessage::class.java))
+
+        val sessionFilenames = service.normalizeCacheAndGetSessionFileIds()
+        assertEquals(1, storageManager.listFiles().size)
+        assertEquals(1, sessionFilenames.size)
+        assertTrue(sessionFilenames.contains(sessionFileName))
+        assertEquals(newSession, service.loadObject(sessionFileName, SessionMessage::class.java))
+    }
+
+    @Test
+    fun `new version of session file swapped in during cache normalization if proper session file is missing`() {
+        val session = testSessionMessage
+        val sessionFileName = getFileNameForSession(session.session.sessionId, session.session.startTime)
+        service.writeSession(sessionFileName + NEW_COPY_SUFFIX, session)
+        service.writeSession(sessionFileName + OLD_COPY_SUFFIX, session)
+
+        val rawFilenames = storageManager.listFiles().map { it.name }
+        assertEquals(2, rawFilenames.size)
+        assertTrue(rawFilenames.contains(EMBRACE_PREFIX + sessionFileName + NEW_COPY_SUFFIX))
+        assertTrue(rawFilenames.contains(EMBRACE_PREFIX + sessionFileName + OLD_COPY_SUFFIX))
+
+        val sessionFilenames = service.normalizeCacheAndGetSessionFileIds()
+        assertEquals(1, storageManager.listFiles().size)
+        assertEquals(1, sessionFilenames.size)
+        assertTrue(sessionFilenames.contains(sessionFileName))
     }
 
     @Test
@@ -283,10 +346,10 @@ internal class EmbraceCacheServiceTest {
     @Test
     fun `session replacement does not create duplicate files`() {
         val original = testSessionMessage
-        val filename = EmbraceDeliveryCacheManager.CachedSession(
+        val filename = getFileNameForSession(
             sessionId = original.session.sessionId,
-            timestamp = original.session.startTime
-        ).filename
+            timestampMs = original.session.startTime
+        )
         val replacement = testSessionMessageOneMinuteLater
 
         service.writeSession(filename, original)
@@ -305,8 +368,10 @@ internal class EmbraceCacheServiceTest {
         val errors = loggerAction.msgQueue.filter { it.severity == InternalStaticEmbraceLogger.Severity.ERROR }
         assertEquals("The following errors were logged: $errors", 0, errors.size)
     }
-}
 
-internal const val CUSTOM_OBJECT_1_FILE_NAME = "${SESSION_FILE_PREFIX}_1.json"
-internal const val CUSTOM_OBJECT_2_FILE_NAME = "${SESSION_FILE_PREFIX}_2.json"
-internal const val CUSTOM_OBJECT_3_FILE_NAME = "${SESSION_FILE_PREFIX}_3.json"
+    companion object {
+        private const val CUSTOM_OBJECT_1_FILE_NAME = "custom_object_1.json"
+        private const val TEST_PAYLOAD = "this is payload"
+        private val testPayloadBytes = TEST_PAYLOAD.toByteArray()
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -147,15 +147,15 @@ internal class EmbraceDeliveryCacheManagerTest {
     @Test
     fun `read cached sessions`() {
         cacheService.writeSession(
-            getCachedSessionName("session1", clockInit - 300000),
+            EmbraceCacheService.getFileNameForSession("session1", clockInit - 300000),
             testSessionMessage.copy(session = testSessionMessage.session.copy(sessionId = "session1", startTime = clockInit - 300000))
         )
         cacheService.writeSession(
-            getCachedSessionName("session2", clockInit - 360000),
+            EmbraceCacheService.getFileNameForSession("session2", clockInit - 360000),
             testSessionMessage.copy(session = testSessionMessage.session.copy(sessionId = "session2", startTime = clockInit - 360000))
         )
         cacheService.writeSession(
-            getCachedSessionName("session3", clockInit - 420000),
+            EmbraceCacheService.getFileNameForSession("session3", clockInit - 420000),
             testSessionMessage.copy(session = testSessionMessage.session.copy(sessionId = "session3", startTime = clockInit - 420000))
         )
         assertEquals(
@@ -349,9 +349,5 @@ internal class EmbraceDeliveryCacheManagerTest {
             startTime = fakeClock.now()
         )
         return SessionMessage(session)
-    }
-
-    private fun getCachedSessionName(sessionId: String, timestamp: Long): String {
-        return EmbraceDeliveryCacheManager.CachedSession(sessionId, timestamp).filename
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -7,14 +7,16 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 internal fun fakeSession(
     sessionId: String = "fakeSessionId",
     startMs: Long = 160000000000L,
+    number: Int = 1,
+    properties: Map<String, String> = mapOf()
 ): Session = Session(
     sessionId = sessionId,
     startTime = startMs,
-    number = 1,
+    number = number,
     appState = APPLICATION_STATE_FOREGROUND,
     isColdStart = true,
     startType = Session.LifeEventType.STATE,
-    properties = mapOf(),
+    properties = properties,
     messageType = Session.MESSAGE_TYPE_END
 )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SessionTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SessionTestFixtures.kt
@@ -1,26 +1,29 @@
 package io.embrace.android.embracesdk.fixtures
 
-import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal val testSessionMessage = SessionMessage(
-    session = Session(
-        sessionId = "fakefakefakefakeId",
-        startTime = 1681972471807L,
-        number = 1,
-        appState = Session.APPLICATION_STATE_FOREGROUND,
-        isColdStart = true,
-        startType = Session.LifeEventType.BKGND_STATE,
-        properties = mapOf("nah" to "nah nah"),
-        messageType = Session.MESSAGE_TYPE_END
+    session = fakeSession(
+        sessionId = "80DCEC19B24B434599B04C237970B785",
+        startMs = 1681972471807L,
+        properties = mapOf("nah" to "nah nah")
     )
 )
 
 internal val testSessionMessageOneMinuteLater =
     testSessionMessage.copy(
         session = testSessionMessage.session.copy(
-            startTime = 1681972531807L,
-            number = 2,
+            startTime = testSessionMessage.session.startTime + 60000L,
             properties = mapOf("nah" to "nah nah", "no" to "no no no no"),
         )
     )
+
+internal val testSessionMessage2 = SessionMessage(
+    session = fakeSession(
+        sessionId = "03FC033631F346C48AF6E3D5B56F6AA3",
+        startMs = testSessionMessageOneMinuteLater.session.startTime + 300000L,
+        number = testSessionMessageOneMinuteLater.session.number + 1,
+        properties = mapOf("bur" to "boo bur")
+    )
+)


### PR DESCRIPTION
## Goal

Always write a temp file and verify that it's fully written before swapping it with an existing files. 

Also fixed a bug with temp file cleanup not happening properly.

## Testing

Fully test the temp file cleanup and renaming based on all the failure scenarios

