### PR TITLE
Update proguard config to fix R8 warnings introduced by using OTel logs SDK

### DIFF
--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -12,5 +12,6 @@
 -keep class java9.** { *; }
 -dontwarn java9.**
 
-## OTel
+## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations


### PR DESCRIPTION
## Goal

Running proguard on the test suite app caused some warnings that this fixed. Not sure if this is the best way to fix this, but the immutable annotation doesn't seem to be that important for this usage, but I'm open to better ideas. Simply keeping that doesn't seem to work