### PR TITLE
Add custom breadcrumb data source

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -32,7 +32,7 @@ internal class EmbraceBreadcrumbService(
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : BreadcrumbService, ActivityLifecycleListener, MemoryCleanerListener {
 
-    private val customBreadcrumbDataSource = CustomBreadcrumbDataSource(configService)
+    private val customBreadcrumbDataSource = LegacyCustomBreadcrumbDataSource(configService)
     private val webViewBreadcrumbDataSource = WebViewBreadcrumbDataSource(configService)
     private val rnBreadcrumbDataSource = RnBreadcrumbDataSource(configService)
     private val tapBreadcrumbDataSource = TapBreadcrumbDataSource(configService)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/LegacyCustomBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/LegacyCustomBreadcrumbDataSource.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import android.text.TextUtils
+import io.embrace.android.embracesdk.arch.DataCaptureService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.CustomBreadcrumb
+
+/**
+ * Captures custom breadcrumbs.
+ */
+internal class LegacyCustomBreadcrumbDataSource(
+    private val configService: ConfigService,
+    private val store: BreadcrumbDataStore<CustomBreadcrumb> = BreadcrumbDataStore {
+        configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
+    },
+    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+) : DataCaptureService<List<CustomBreadcrumb>> by store {
+
+    fun logCustom(message: String, timestamp: Long) {
+        if (TextUtils.isEmpty(message)) {
+            logger.logWarning("Breadcrumb message must not be blank")
+            return
+        }
+        try {
+            store.tryAddBreadcrumb(CustomBreadcrumb(message, timestamp))
+        } catch (ex: Exception) {
+            logger.logError("Failed to log custom breadcrumb with message $message", ex)
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -1,0 +1,53 @@
+package io.embrace.android.embracesdk.capture.crumbs
+
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class CustomBreadcrumbDataSourceTest {
+
+    private lateinit var source: CustomBreadcrumbDataSource
+    private lateinit var writer: FakeCurrentSessionSpan
+
+    @Before
+    fun setUp() {
+        writer = FakeCurrentSessionSpan()
+        source = CustomBreadcrumbDataSource(
+            FakeConfigService(),
+            writer
+        )
+    }
+
+    @Test
+    fun `add invalid breadcrumb`() {
+        source.logCustom("", 0)
+        assertEquals(0, writer.addedEvents.size)
+    }
+
+    @Test
+    fun `add breadcrumb`() {
+        source.logCustom("Hello, world!", 15000000000)
+        with(writer.addedEvents.single()) {
+            assertEquals("custom-breadcrumb", spanName)
+            assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
+            assertEquals(
+                mapOf(
+                    "emb.type" to "system.breadcrumb",
+                    "message" to "Hello, world!"
+                ),
+                attributes
+            )
+        }
+    }
+
+    @Test
+    fun `limit not exceeded`() {
+        repeat(150) { k ->
+            source.logCustom("Crumb #$k", 15000000000)
+        }
+        assertEquals(100, writer.addedEvents.size)
+    }
+}


### PR DESCRIPTION
## Goal

Implements the capture of custom breadcrumbs via the `DataSource` interface which allows them to be sent as OTel data types in the session payload. It's important to note this does _not_ alter the session payload yet. The `LegacyCustomBreadcrumbDataSource` will continue to add directly to the payload.

#488  contains the changeset for enabling the new data capture mechanism. This uncouples work & allows us to merge more without blocking changes.

## Testing

Added a unit test.

