### PR TITLE
Add AEI data source

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSource.kt
@@ -1,0 +1,5 @@
+package io.embrace.android.embracesdk.capture.aei
+
+import io.embrace.android.embracesdk.arch.datasource.LogDataSource
+
+internal interface AeiDataSource : LogDataSource

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -1,0 +1,316 @@
+package io.embrace.android.embracesdk.capture.aei
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.os.Build.VERSION_CODES
+import androidx.annotation.RequiresApi
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.arch.datasource.LogDataSourceImpl
+import io.embrace.android.embracesdk.arch.destination.LogEventData
+import io.embrace.android.embracesdk.arch.destination.LogEventMapper
+import io.embrace.android.embracesdk.arch.destination.LogWriter
+import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.capture.user.UserService
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.config.behavior.AppExitInfoBehavior
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.internal.utils.toNonNullMap
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logInfoWithException
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logWarningWithException
+import io.embrace.android.embracesdk.payload.AppExitInfoData
+import io.embrace.android.embracesdk.payload.BlobMessage
+import io.embrace.android.embracesdk.payload.BlobSession
+import io.embrace.android.embracesdk.prefs.PreferencesService
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.worker.BackgroundWorker
+import java.io.IOException
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicBoolean
+
+@RequiresApi(VERSION_CODES.R)
+internal class AeiDataSourceImpl(
+    private val backgroundWorker: BackgroundWorker,
+    private val configService: ConfigService,
+    private val activityManager: ActivityManager?,
+    private val preferencesService: PreferencesService,
+    private val metadataService: MetadataService,
+    private val sessionIdTracker: SessionIdTracker,
+    private val userService: UserService,
+    logWriter: LogWriter,
+    private val buildVersionChecker: VersionChecker = BuildVersionChecker,
+) : AeiDataSource, LogEventMapper<BlobMessage>, LogDataSourceImpl(
+    logWriter,
+    limitStrategy = UpToLimitStrategy({ SDK_AEI_SEND_LIMIT })
+) {
+
+    companion object {
+        private const val TYPE_NAME = "system.exit"
+        private const val LOG_NAME = "aei-record"
+        private const val SDK_AEI_SEND_LIMIT = 32
+    }
+
+    @Volatile
+    private var backgroundExecution: Future<*>? = null
+    private val sessionApplicationExitInfoData: MutableList<AppExitInfoData> = mutableListOf()
+    private val isSessionApplicationExitInfoDataReady = AtomicBoolean(false)
+
+    override fun enableDataCapture() {
+        if (backgroundExecution != null) {
+            return
+        }
+        backgroundExecution = backgroundWorker.submit {
+            try {
+                processApplicationExitInfo()
+            } catch (exc: Throwable) {
+                logWarningWithException(
+                    "AEI - Failed to process AEIs due to unexpected error",
+                    exc,
+                    true
+                )
+            }
+        }
+    }
+
+    override fun disableDataCapture() {
+        try {
+            backgroundExecution?.cancel(true)
+            backgroundExecution = null
+        } catch (t: Throwable) {
+            logWarningWithException(
+                "AEI - Failed to disable EmbraceApplicationExitInfoService work",
+                t
+            )
+        }
+    }
+
+    private fun processApplicationExitInfo() {
+        val historicalProcessExitReasons = getHistoricalProcessExitReasons()
+        val unsentExitReasons = getUnsentExitReasons(historicalProcessExitReasons)
+
+        unsentExitReasons.forEach {
+            sessionApplicationExitInfoData.add(buildSessionAppExitInfoData(it, null, null))
+        }
+
+        isSessionApplicationExitInfoDataReady.set(true)
+        processApplicationExitInfoBlobs(unsentExitReasons)
+    }
+
+    private fun processApplicationExitInfoBlobs(unsentExitReasons: List<ApplicationExitInfo>) {
+        unsentExitReasons.forEach { aei: ApplicationExitInfo ->
+            val traceResult = collectExitInfoTrace(aei)
+            if (traceResult != null) {
+                val payload = buildSessionAppExitInfoData(
+                    aei,
+                    getTrace(traceResult),
+                    getTraceStatus(traceResult)
+                )
+                sendApplicationExitInfoWithTraces(listOf(payload))
+            }
+        }
+    }
+
+    private fun getHistoricalProcessExitReasons(): List<ApplicationExitInfo> {
+        // A process ID that used to belong to this package but died later;
+        // a value of 0 means to ignore this parameter and return all matching records.
+        val pid = 0
+
+        // number of results to be returned; a value of 0 means to ignore this parameter and return
+        // all matching records with a maximum of 16 entries
+        val maxNum = configService.appExitInfoBehavior.appExitInfoMaxNum()
+
+        var historicalProcessExitReasons: List<ApplicationExitInfo> =
+            activityManager?.getHistoricalProcessExitReasons(null, pid, maxNum)
+                ?: return emptyList()
+
+        if (historicalProcessExitReasons.size > SDK_AEI_SEND_LIMIT) {
+            logInfoWithException("AEI - size greater than $SDK_AEI_SEND_LIMIT")
+            historicalProcessExitReasons = historicalProcessExitReasons.take(SDK_AEI_SEND_LIMIT)
+        }
+
+        return historicalProcessExitReasons
+    }
+
+    private fun getUnsentExitReasons(historicalProcessExitReasons: List<ApplicationExitInfo>): List<ApplicationExitInfo> {
+        // Generates the set of current aei captured
+        val allAeiHashCodes = historicalProcessExitReasons.map(::generateUniqueHash).toSet()
+
+        // Get hash codes that were previously delivered
+        val deliveredHashCodes = preferencesService.applicationExitInfoHistory ?: emptySet()
+
+        // Subtracts aei hashcodes of already sent information to get new entries
+        val unsentHashCodes = allAeiHashCodes.subtract(deliveredHashCodes)
+
+        // Updates preferences with the new set of hashcodes
+        preferencesService.applicationExitInfoHistory = allAeiHashCodes
+
+        // Get AEI objects that were not sent
+        val unsentAeiObjects = historicalProcessExitReasons.filter {
+            unsentHashCodes.contains(generateUniqueHash(it))
+        }
+
+        return unsentAeiObjects
+    }
+
+    private fun buildSessionAppExitInfoData(
+        appExitInfo: ApplicationExitInfo,
+        trace: String?,
+        traceStatus: String?
+    ): AppExitInfoData {
+        val sessionId = String(appExitInfo.processStateSummary ?: ByteArray(0))
+
+        return AppExitInfoData(
+            sessionId = sessionId,
+            sessionIdError = getSessionIdValidationError(sessionId),
+            importance = appExitInfo.importance,
+            pss = appExitInfo.pss,
+            reason = appExitInfo.reason,
+            rss = appExitInfo.rss,
+            status = appExitInfo.status,
+            timestamp = appExitInfo.timestamp,
+            trace = trace,
+            description = appExitInfo.description,
+            traceStatus = traceStatus
+        )
+    }
+
+    private fun getTrace(traceResult: AppExitInfoBehavior.CollectTracesResult): String? =
+        when (traceResult) {
+            is AppExitInfoBehavior.CollectTracesResult.Success -> traceResult.result
+            is AppExitInfoBehavior.CollectTracesResult.TooLarge -> traceResult.result
+            else -> null
+        }
+
+    private fun getTraceStatus(traceResult: AppExitInfoBehavior.CollectTracesResult): String? =
+        when (traceResult) {
+            is AppExitInfoBehavior.CollectTracesResult.Success -> null
+            is AppExitInfoBehavior.CollectTracesResult.TooLarge -> "Trace was too large, sending truncated trace"
+            else -> traceResult.result
+        }
+
+    private fun sendApplicationExitInfoWithTraces(appExitInfoWithTraces: List<AppExitInfoData>) {
+        appExitInfoWithTraces.forEach { data ->
+            alterSessionSpan(
+                inputValidation = { true },
+                captureAction = {
+                    val blob = BlobMessage(
+                        metadataService.getAppInfo(),
+                        listOf(data),
+                        metadataService.getDeviceInfo(),
+                        BlobSession(sessionIdTracker.getActiveSessionId()),
+                        userService.getUserInfo()
+                    )
+                    addLog(blob, ::toLogEventData)
+                }
+            )
+        }
+    }
+
+    override fun toLogEventData(obj: BlobMessage): LogEventData {
+        val message: AppExitInfoData = obj.applicationExits.single()
+        val attrs = mapOf(
+            "session-id" to message.sessionId,
+            "session-id-error" to message.sessionIdError,
+            "process-importance" to message.importance.toString(),
+            "pss" to message.pss.toString(),
+            "rs" to message.reason.toString(),
+            "rss" to message.rss.toString(),
+            "exit-status" to message.status.toString(),
+            "timestamp" to message.timestamp.toString(),
+            "blob" to message.trace,
+            "description" to message.description,
+            "trace-status" to message.traceStatus
+        )
+        return LogEventData(
+            TYPE_NAME,
+            severity = Severity.INFO,
+            message = LOG_NAME,
+            attributes = attrs.toNonNullMap()
+        )
+    }
+
+    private fun collectExitInfoTrace(appExitInfo: ApplicationExitInfo): AppExitInfoBehavior.CollectTracesResult? {
+        try {
+            val trace = readTraceAsString(appExitInfo)
+
+            if (trace == null) {
+                logDebug("AEI - No info trace collected")
+                return null
+            }
+
+            val traceMaxLimit = configService.appExitInfoBehavior.getTraceMaxLimit()
+            if (trace.length > traceMaxLimit) {
+                logInfoWithException("AEI - Blob size was reduced. Current size is ${trace.length} and the limit is $traceMaxLimit")
+                return AppExitInfoBehavior.CollectTracesResult.TooLarge(trace.take(traceMaxLimit))
+            }
+
+            return AppExitInfoBehavior.CollectTracesResult.Success(trace)
+        } catch (e: IOException) {
+            logWarningWithException("AEI - IOException: ${e.message}", e, true)
+            return AppExitInfoBehavior.CollectTracesResult.TraceException(("ioexception: ${e.message}"))
+        } catch (e: OutOfMemoryError) {
+            logWarningWithException("AEI - Out of Memory: ${e.message}", e, true)
+            return AppExitInfoBehavior.CollectTracesResult.TraceException(("oom: ${e.message}"))
+        } catch (tr: Throwable) {
+            logWarningWithException("AEI - An error occurred: ${tr.message}", tr, true)
+            return AppExitInfoBehavior.CollectTracesResult.TraceException(("error: ${tr.message}"))
+        }
+    }
+
+    private fun readTraceAsString(appExitInfo: ApplicationExitInfo): String? {
+        if (appExitInfo.isNdkProtobufFile()) {
+            val bytes = appExitInfo.traceInputStream?.readBytes()
+
+            if (bytes == null) {
+                logDebug("AEI - No info trace collected")
+                return null
+            }
+            return bytesToUTF8String(bytes)
+        } else {
+            return appExitInfo.traceInputStream?.bufferedReader()?.readText()
+        }
+    }
+
+    /**
+     * NDK protobuf files are only available on Android 12 and above for AEI with
+     * the REASON_CRASH_NATIVE reason.
+     */
+    private fun ApplicationExitInfo.isNdkProtobufFile(): Boolean {
+        return buildVersionChecker.isAtLeast(VERSION_CODES.S) && reason == ApplicationExitInfo.REASON_CRASH_NATIVE
+    }
+
+    /**
+     * Converts a byte array to a UTF-8 string, escaping non-encodable bytes as
+     * 2-byte UTF-8 sequences, which will later be converted into unicode by JSON marshalling.
+     * This allows us to send arbitrary binary data from the NDK
+     * protobuf file without needing to encode it as Base64 (which compresses poorly).
+     */
+    private fun bytesToUTF8String(bytes: ByteArray): String {
+        val encoded = ByteArray(bytes.size * 2)
+        var i = 0
+        for (b in bytes) {
+            val u = b.toInt() and 0xFF
+            if (u < 128) {
+                encoded[i++] = u.toByte()
+                continue
+            }
+            encoded[i++] = (0xC0 or (u shr 6)).toByte()
+            encoded[i++] = (0x80 or (u and 0x3F)).toByte()
+        }
+        return String(encoded.copyOf(i), Charsets.UTF_8)
+    }
+
+    private fun getSessionIdValidationError(sid: String): String {
+        return if (sid.isEmpty() || sid.matches(Regex("^[0-9a-fA-F]{32}\$"))) {
+            ""
+        } else {
+            "invalid session ID: $sid"
+        }
+    }
+
+    private fun generateUniqueHash(appExitInfo: ApplicationExitInfo): String {
+        return "${appExitInfo.timestamp}_${appExitInfo.pid}"
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
@@ -1,0 +1,364 @@
+package io.embrace.android.embracesdk.capture.aei
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import com.google.common.util.concurrent.MoreExecutors
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.config.remote.AppExitInfoConfig
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeLogWriter
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
+import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.worker.BackgroundWorker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+private const val TIMESTAMP = 15000000000L
+private const val PID = 6952
+private const val IMPORTANCE = 125
+private const val PSS = 1509123409L
+private const val RSS = 1123409L
+private const val REASON = 4
+private const val STATUS = 1
+private const val DESCRIPTION = "testDescription"
+private const val TRACE = "testInputStream"
+private const val SESSION_ID = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+
+internal class AeiDataSourceImplTest {
+
+    private lateinit var applicationExitInfoService: AeiDataSourceImpl
+    private lateinit var logWriter: FakeLogWriter
+
+    private val worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
+
+    private var appExitInfoConfig = AppExitInfoConfig(pctAeiCaptureEnabled = 100.0f)
+    private val configService = FakeConfigService(
+        appExitInfoBehavior = fakeAppExitInfoBehavior {
+            RemoteConfig(appExitInfoConfig = appExitInfoConfig)
+        }
+    )
+
+    private val preferenceService = FakePreferenceService()
+    private val metadataService = FakeMetadataService()
+    private val sessionIdTracker = FakeSessionIdTracker()
+    private val userService = FakeUserService()
+
+    private val mockActivityManager: ActivityManager = mockk {
+        every { getHistoricalProcessExitReasons(any(), any(), any()) } returns emptyList()
+    }
+
+    private val mockAppExitInfo = mockk<ApplicationExitInfo>(relaxed = true) {
+        every { timestamp } returns TIMESTAMP
+        every { pid } returns PID
+        every { processStateSummary } returns SESSION_ID.toByteArray()
+        every { importance } returns IMPORTANCE
+        every { pss } returns PSS
+        every { reason } returns REASON
+        every { rss } returns RSS
+        every { status } returns STATUS
+        every { description } returns DESCRIPTION
+        every { traceInputStream } returns TRACE.byteInputStream()
+    }
+
+    companion object {
+        @AfterClass
+        @JvmStatic
+        fun afterClass() {
+            unmockkAll()
+        }
+    }
+
+    private fun startApplicationExitInfoService() {
+        logWriter = FakeLogWriter()
+        applicationExitInfoService = AeiDataSourceImpl(
+            worker,
+            configService,
+            mockActivityManager,
+            preferenceService,
+            metadataService,
+            sessionIdTracker,
+            userService,
+            logWriter
+        ).apply(AeiDataSourceImpl::enableDataCapture)
+    }
+
+    @Test
+    fun `AEI data capture happy path`() {
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns listOf(mockAppExitInfo)
+
+        startApplicationExitInfoService()
+
+        // when getCapturedData is called
+        val attrs = getAeiLogAttrs()
+        assertEquals(TIMESTAMP.toString(), attrs["timestamp"])
+        assertEquals(SESSION_ID, attrs["session-id"])
+        assertEquals(IMPORTANCE.toString(), attrs["process-importance"])
+        assertEquals(PSS.toString(), attrs["pss"])
+        assertEquals(RSS.toString(), attrs["rss"])
+        assertEquals(STATUS.toString(), attrs["exit-status"])
+        assertEquals(DESCRIPTION, attrs["description"])
+        assertEquals(TRACE, attrs["blob"])
+        assertEquals("", attrs["session-id-error"])
+        assertNull(attrs["trace-status"])
+    }
+
+    @Test
+    fun `getCapturedData should return an empty list when getHistoricalProcessExitInfo returns an empty list`() {
+        // given getHistoricalProcessExitReasons returns an empty list
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns emptyList()
+        startApplicationExitInfoService()
+
+        // no logs delivered
+        assertTrue(logWriter.logEvents.isEmpty())
+    }
+
+    @Test
+    fun `getHistoricalProcessExitInfo should truncate to 32 entries`() {
+        // given getHistoricalProcessExitReasons returns more than 32 entries
+        val appExitInfoListWithMoreThan32Entries = mutableListOf<ApplicationExitInfo>()
+        repeat(33) {
+            appExitInfoListWithMoreThan32Entries.add(mockAppExitInfo)
+        }
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns appExitInfoListWithMoreThan32Entries
+
+        startApplicationExitInfoService()
+
+        // then captured data should only have 32 entries
+        assertEquals(32, logWriter.logEvents.size)
+    }
+
+    @Test
+    fun `getUnsentExitReasons should not return AEI that have already been sent`() {
+        // given getHistoricalProcessExitReasons returns 3 entries, but there are 2 that have already been sent
+        val appExitInfo1 = mockk<ApplicationExitInfo>(relaxed = true) {
+            every { timestamp } returns 1L
+            every { pid } returns STATUS
+        }
+        val appExitInfo2 = mockk<ApplicationExitInfo>(relaxed = true) {
+            every { timestamp } returns 2L
+            every { pid } returns 2
+        }
+        val appExitInfo3 = mockk<ApplicationExitInfo>(relaxed = true) {
+            every { timestamp } returns 3L
+            every { pid } returns 3
+        }
+
+        val appExitInfo1Hash = "${appExitInfo1.timestamp}_${appExitInfo1.pid}"
+        val appExitInfo2Hash = "${appExitInfo2.timestamp}_${appExitInfo2.pid}"
+
+        every { mockActivityManager.getHistoricalProcessExitReasons(any(), any(), any()) } returns
+            listOf(appExitInfo1, appExitInfo2, appExitInfo3)
+
+        preferenceService.applicationExitInfoHistory = setOf(
+            appExitInfo1Hash,
+            appExitInfo2Hash
+        )
+
+        startApplicationExitInfoService()
+
+        // when AEI is delivered
+        val attrs = getAeiLogAttrs()
+
+        // then captured data should only have applicationExitInfo3
+        assertEquals("3", attrs["timestamp"])
+    }
+
+    @Test
+    fun `invalid session id should show up in ApplicationExitInfoData sessionIdError`() {
+        // given an AEI with an invalid session ID
+        val invalidSessionId = "_ 1NV@lid"
+        every { mockAppExitInfo.processStateSummary } returns invalidSessionId.toByteArray()
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns listOf(mockAppExitInfo)
+        startApplicationExitInfoService()
+
+        // when AEI is delivered
+        val attrs = getAeiLogAttrs()
+
+        // then the invalid session ID message should be added to the sessionIdError
+        assertEquals("invalid session ID: $invalidSessionId", attrs["session-id-error"])
+        assertEquals(invalidSessionId, attrs["session-id"])
+    }
+
+    @Test
+    fun `null traces won't be sent to the blob endpoint`() {
+        // given an application exit info with a null trace
+        every { mockAppExitInfo.traceInputStream } returns null
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns listOf(mockAppExitInfo)
+
+        // when the service is started
+        startApplicationExitInfoService()
+
+        // then no logs should be sent
+        assertTrue(logWriter.logEvents.isEmpty())
+    }
+
+    @Test
+    fun `OOM while reading trace`() {
+        // given an OOM happens when reading a trace
+        every { mockAppExitInfo.traceInputStream } throws OutOfMemoryError("Ouch")
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns listOf(mockAppExitInfo)
+
+        // when the service is started
+        startApplicationExitInfoService()
+
+        // then a null trace should be sent
+        val attrs = getAeiLogAttrs()
+        assertNull("", attrs["blob"])
+        assertEquals("oom: Ouch", attrs["trace-status"])
+    }
+
+    @Test
+    fun `IOException while reading trace`() {
+        // given an IO exception happens when reading a trace
+        every { mockAppExitInfo.traceInputStream } throws IOException("Ouch")
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns listOf(mockAppExitInfo)
+
+        // when the service is started
+        startApplicationExitInfoService()
+
+        // then a null trace should be sent
+        val attrs = getAeiLogAttrs()
+        assertNull(attrs["blob"])
+        assertEquals("ioexception: Ouch", attrs["trace-status"])
+    }
+
+    @Test
+    fun `other error while reading trace`() {
+        val errorMessage = "Please turn your computer screen back on."
+        // given an IO exception happens when reading a trace
+        every { mockAppExitInfo.traceInputStream } throws IllegalMonitorStateException(errorMessage)
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns listOf(mockAppExitInfo)
+
+        // when the service is started
+        startApplicationExitInfoService()
+
+        // then a null trace should be sent
+        val attrs = getAeiLogAttrs()
+        assertNull(attrs["blob"])
+        assertEquals("error: $errorMessage", attrs["trace-status"])
+    }
+
+    @Test
+    fun `Truncate trace if it exceeds limit`() {
+        // given a trace that exceeds the limit
+        every { mockAppExitInfo.traceInputStream } returns "a".repeat(500).byteInputStream()
+
+        appExitInfoConfig =
+            AppExitInfoConfig(pctAeiCaptureEnabled = 100.0f, appExitInfoTracesLimit = 100)
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns listOf(mockAppExitInfo)
+
+        // when the service is started
+        startApplicationExitInfoService()
+
+        // then a truncated trace should be sent
+        val attrs = getAeiLogAttrs()
+        assertEquals("a".repeat(100), attrs["blob"])
+    }
+
+    @Test
+    fun testActivityManagerException() {
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } throws NullPointerException()
+
+        // when the service is started
+        startApplicationExitInfoService()
+
+        // no logs were sent
+        assertTrue(logWriter.logEvents.isEmpty())
+    }
+
+    @Test
+    fun `one object sent per payload`() {
+        val entries = (0..32).map { mockAppExitInfo }
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any()
+            )
+        } returns entries
+
+        startApplicationExitInfoService()
+
+        // each AEI object with a trace should be sent in a separate payload
+        assertEquals(32, logWriter.logEvents.size)
+    }
+
+    private fun getAeiLogAttrs(): Map<String, String> {
+        val logEventData = logWriter.logEvents.single()
+        assertEquals("aei-record", logEventData.message)
+        assertEquals(Severity.INFO, logEventData.severity)
+        assertEquals("system.exit", logEventData.attributes["emb.type"])
+        return logEventData.attributes
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAeiDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAeiDataSource.kt
@@ -1,0 +1,27 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.arch.destination.LogWriter
+import io.embrace.android.embracesdk.capture.aei.AeiDataSource
+import io.embrace.android.embracesdk.payload.AppExitInfoData
+
+internal class FakeAeiDataSource : AeiDataSource {
+
+    var data: List<AppExitInfoData> =
+        listOf(AppExitInfoData(null, null, null, null, null, null, null, null, null, null, null))
+
+    override fun alterSessionSpan(
+        inputValidation: () -> Boolean,
+        captureAction: LogWriter.() -> Unit
+    ): Boolean {
+        return false
+    }
+
+    override fun enableDataCapture() {
+    }
+
+    override fun disableDataCapture() {
+    }
+
+    override fun resetDataCaptureLimits() {
+    }
+}


### PR DESCRIPTION
## Goal

Implements the capture of AEI via the `DataSource` interface which allows them to be sent as OTel logs. It's important to note this does _not_ alter any payloads yet. The existing `ApplicationExitInfoService` will continue to add directly to the payload.

A future PR will contain the changeset for enabling the new data capture mechanism. This uncouples work & allows us to merge more without blocking changes.

## Testing

Added unit test coverage.

