### PR TITLE
Refactor log service implementation

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.arch.destination
 
-import io.opentelemetry.api.logs.Severity
+import io.embrace.android.embracesdk.Severity
 
 /**
  * Represents a Log event that can be added to the current session span.
@@ -8,7 +8,6 @@ import io.opentelemetry.api.logs.Severity
 internal class LogEventData(
     val startTimeMs: Long,
     val severity: Severity,
-    val severityText: String?,
     val message: String,
     val attributes: Map<String, String>?
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -2,22 +2,30 @@ package io.embrace.android.embracesdk.arch.destination
 
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Logger
+import io.opentelemetry.api.logs.Severity
 import java.util.concurrent.TimeUnit
 
 internal class LogWriterImpl(private val logger: Logger) : LogWriter {
 
     override fun <T> addLog(log: T, mapper: T.() -> LogEventData) {
         val logEventData = log.mapper()
+
+        // placeholder implementation: copied from PR #460
         val builder = logger.logRecordBuilder()
             .setBody(logEventData.message)
-            .setSeverity(logEventData.severity)
-            .setSeverityText(logEventData.severityText)
+            .setSeverity(logEventData.severity.toOtelSeverity())
+            .setSeverityText(logEventData.severity.name)
             .setTimestamp(logEventData.startTimeMs, TimeUnit.MILLISECONDS)
 
         logEventData.attributes?.forEach {
             builder.setAttribute(AttributeKey.stringKey(it.key), it.value)
         }
-
         builder.emit()
+    }
+
+    private fun io.embrace.android.embracesdk.Severity.toOtelSeverity(): Severity = when (this) {
+        io.embrace.android.embracesdk.Severity.INFO -> Severity.INFO
+        io.embrace.android.embracesdk.Severity.WARNING -> Severity.WARN
+        io.embrace.android.embracesdk.Severity.ERROR -> Severity.ERROR
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -125,12 +125,10 @@ internal class EmbraceLogService(
             metadataService.getAppState()?.let { attributes.setAppState(it) }
             attributes.setLogId(Uuid.getEmbUuid())
 
-            val otelSeverity = mapSeverity(severity)
             val logEventData = LogEventData(
                 startTimeMs = clock.nowInNanos(),
                 message = trimToMaxLength(message),
-                severity = otelSeverity,
-                severityText = otelSeverity.name,
+                severity = severity,
                 attributes = attributes.toMap()
             )
 
@@ -158,14 +156,6 @@ internal class EmbraceLogService(
             message.substring(0, allowedLength) + endChars
         } else {
             message
-        }
-    }
-
-    private fun mapSeverity(embraceSeverity: Severity): io.opentelemetry.api.logs.Severity {
-        return when (embraceSeverity) {
-            Severity.INFO -> io.opentelemetry.api.logs.Severity.INFO
-            Severity.WARNING -> io.opentelemetry.api.logs.Severity.WARN
-            Severity.ERROR -> io.opentelemetry.api.logs.Severity.ERROR
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/MapExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/MapExtensions.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.utils
+
+/**
+ * Returns a new map that does not contain any null values. This
+ * performs the necessary casts to ensure Kotlin's type system is happy.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun <K, V> Map<K, V?>.toNonNullMap(): Map<K, V> {
+    return filter { it.value != null } as Map<K, V>
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.arch.destination.LogEventData
 import io.embrace.android.embracesdk.arch.destination.LogWriter
 
-internal class FakeOpenTelemetryLogWriter : LogWriter {
+internal class FakeLogWriter : LogWriter {
 
     val logEvents = mutableListOf<LogEventData>()
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -8,8 +8,8 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogWriter
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeLogMessageBehavior
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicLong
 internal class EmbraceLogServiceTest {
 
     companion object {
-        private lateinit var logWriter: FakeOpenTelemetryLogWriter
+        private lateinit var logWriter: FakeLogWriter
         private lateinit var metadataService: FakeMetadataService
         private lateinit var configService: ConfigService
         private lateinit var sessionIdTracker: FakeSessionIdTracker
@@ -54,7 +54,7 @@ internal class EmbraceLogServiceTest {
 
     @Before
     fun setUp() {
-        logWriter = FakeOpenTelemetryLogWriter()
+        logWriter = FakeLogWriter()
         sessionIdTracker.setActiveSessionId("session-123", true)
         cfg = RemoteConfig()
         configService = FakeConfigService(
@@ -84,8 +84,7 @@ internal class EmbraceLogServiceTest {
         val first = logs[0]
         assertEquals("Hello world", first.message)
         assertNotEquals(0, first.startTimeMs)
-        assertEquals(io.opentelemetry.api.logs.Severity.INFO, first.severity)
-        assertEquals(io.opentelemetry.api.logs.Severity.INFO.name, first.severityText)
+        assertEquals(Severity.INFO, first.severity)
         assertEquals("bar", first.attributes?.get("foo"))
         assertNotNull(first.attributes?.get("emb.log_id"))
         assertEquals("session-123", first.attributes?.get("emb.session_id"))
@@ -94,8 +93,7 @@ internal class EmbraceLogServiceTest {
         val second = logs[1]
         assertEquals("Warning world", second.message)
         assertNotEquals(0, second.startTimeMs)
-        assertEquals(io.opentelemetry.api.logs.Severity.WARN, second.severity)
-        assertEquals(io.opentelemetry.api.logs.Severity.WARN.name, second.severityText)
+        assertEquals(Severity.WARNING, second.severity)
         assertNotNull(second.attributes?.get("emb.log_id"))
         assertEquals("session-123", second.attributes?.get("emb.session_id"))
         assertNull(second.attributes?.get("emb.exception_type"))
@@ -103,8 +101,7 @@ internal class EmbraceLogServiceTest {
         val third = logs[2]
         assertEquals("Hello errors", third.message)
         assertNotEquals(0, third.startTimeMs)
-        assertEquals(io.opentelemetry.api.logs.Severity.ERROR, third.severity)
-        assertEquals(io.opentelemetry.api.logs.Severity.ERROR.name, third.severityText)
+        assertEquals(Severity.ERROR, third.severity)
         assertNotNull(third.attributes?.get("emb.log_id"))
         assertEquals("session-123", third.attributes?.get("emb.session_id"))
         assertNull(third.attributes?.get("emb.exception_type"))
@@ -130,8 +127,7 @@ internal class EmbraceLogServiceTest {
 
         val log = logWriter.logEvents.single()
         assertEquals("Hello world", log.message)
-        assertEquals(io.opentelemetry.api.logs.Severity.WARN, log.severity)
-        assertEquals(io.opentelemetry.api.logs.Severity.WARN.name, log.severityText)
+        assertEquals(Severity.WARNING, log.severity)
         assertEquals("NullPointerException", log.attributes?.get("emb.exception_name"))
         assertEquals("exception message", log.attributes?.get("emb.exception_message"))
         assertNotNull(log.attributes?.get("emb.log_id"))
@@ -147,8 +143,7 @@ internal class EmbraceLogServiceTest {
 
         val log = logWriter.logEvents.single()
         assertEquals("Hello world", log.message)
-        assertEquals(io.opentelemetry.api.logs.Severity.INFO, log.severity)
-        assertEquals(io.opentelemetry.api.logs.Severity.INFO.name, log.severityText)
+        assertEquals(Severity.INFO, log.severity)
         assertNotNull(log.attributes?.get("emb.log_id"))
         assertEquals("session-123", log.attributes?.get("emb.session_id"))
     }


### PR DESCRIPTION
## Goal

This contains a couple of refactors I made while building #441:

1. Map Embrace's `Severity` enum onto OTel's enum to simplify how we capture logs
2. Added a fake implementation of `LogWriter` that will be used for tests
3. Added a utility function to remove nulls from maps

## Testing

Added unit test coverage

