### PR TITLE
Add method to notify CodePush update into RN internal interface.

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -145,6 +145,7 @@ public abstract interface class io/embrace/android/embracesdk/ReactNativeInterna
 	public abstract fun logRnView (Ljava/lang/String;)V
 	public abstract fun logUnhandledJsException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setJavaScriptBundleUrl (Landroid/content/Context;Ljava/lang/String;)V
+	public abstract fun setJavaScriptBundleUrlFromCodePush (Landroid/content/Context;Ljava/lang/String;Z)V
 	public abstract fun setJavaScriptPatchNumber (Ljava/lang/String;)V
 	public abstract fun setReactNativeSdkVersion (Ljava/lang/String;)V
 	public abstract fun setReactNativeVersionNumber (Ljava/lang/String;)V

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -145,7 +145,7 @@ public abstract interface class io/embrace/android/embracesdk/ReactNativeInterna
 	public abstract fun logRnView (Ljava/lang/String;)V
 	public abstract fun logUnhandledJsException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setJavaScriptBundleUrl (Landroid/content/Context;Ljava/lang/String;)V
-	public abstract fun setJavaScriptBundleUrlFromCodePush (Landroid/content/Context;Ljava/lang/String;Z)V
+	public abstract fun setJavaScriptBundleUrlForCodePush (Landroid/content/Context;Ljava/lang/String;Z)V
 	public abstract fun setJavaScriptPatchNumber (Ljava/lang/String;)V
 	public abstract fun setReactNativeSdkVersion (Ljava/lang/String;)V
 	public abstract fun setReactNativeVersionNumber (Ljava/lang/String;)V

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -144,8 +144,8 @@ public abstract interface class io/embrace/android/embracesdk/ReactNativeInterna
 	public abstract fun logRnAction (Ljava/lang/String;JJLjava/util/Map;ILjava/lang/String;)V
 	public abstract fun logRnView (Ljava/lang/String;)V
 	public abstract fun logUnhandledJsException (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setCacheableJavaScriptBundleUrl (Landroid/content/Context;Ljava/lang/String;Z)V
 	public abstract fun setJavaScriptBundleUrl (Landroid/content/Context;Ljava/lang/String;)V
-	public abstract fun setJavaScriptBundleUrlForCodePush (Landroid/content/Context;Ljava/lang/String;Z)V
 	public abstract fun setJavaScriptPatchNumber (Ljava/lang/String;)V
 	public abstract fun setReactNativeSdkVersion (Ljava/lang/String;)V
 	public abstract fun setReactNativeVersionNumber (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
@@ -33,7 +33,7 @@ public interface ReactNativeInternalInterface : EmbraceInternalInterface {
 
     public fun setJavaScriptBundleUrl(context: Context, url: String)
 
-    public fun setJavaScriptBundleUrlForCodePush(context: Context, url: String, didUpdate: Boolean)
+    public fun setCacheableJavaScriptBundleUrl(context: Context, url: String, didUpdate: Boolean)
 
     /**
      * Logs a React Native Redux Action - this is not intended for public use.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
@@ -33,6 +33,8 @@ public interface ReactNativeInternalInterface : EmbraceInternalInterface {
 
     public fun setJavaScriptBundleUrl(context: Context, url: String)
 
+    public fun setJavaScriptBundleUrlForCodePush(context: Context, url: String, didUpdate: Boolean)
+
     /**
      * Logs a React Native Redux Action - this is not intended for public use.
      */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
@@ -31,8 +31,21 @@ public interface ReactNativeInternalInterface : EmbraceInternalInterface {
 
     public fun setReactNativeVersionNumber(version: String?)
 
+    /**
+     * Sets the React Native Bundle URL.
+     * @param context the context
+     * @param url the JavaScript bundle URL
+     */
     public fun setJavaScriptBundleUrl(context: Context, url: String)
 
+    /**
+     * Sets the React Native Bundle URL, indicating if the bundle was updated or not.
+     * If it was updated, the bundle ID will be recomputed.
+     * If not, the bundle ID will be retrieved from cache.
+     * @param context the context
+     * @param url the JavaScript bundle URL
+     * @param didUpdate if the bundle was updated
+     */
     public fun setCacheableJavaScriptBundleUrl(context: Context, url: String, didUpdate: Boolean)
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
@@ -96,18 +96,11 @@ internal class ReactNativeInternalInterfaceImpl(
     }
 
     override fun setJavaScriptBundleUrl(context: Context, url: String) {
-        if (embrace.isStarted) {
-            if (framework != AppFramework.REACT_NATIVE) {
-                logger.logError(
-                    "Failed to set Java Script bundle ID URL. Current framework: " +
-                        framework.name + " is not React Native."
-                )
-                return
-            }
-            metadataService.setReactNativeBundleId(context, url)
-        } else {
-            logger.logSDKNotInitialized("set JavaScript bundle URL")
-        }
+        setJavaScriptBundleUrl(context, url, null)
+    }
+
+    override fun setJavaScriptBundleUrlForCodePush(context: Context, url: String, didUpdate: Boolean) {
+        setJavaScriptBundleUrl(context, url, didUpdate)
     }
 
     override fun logRnAction(
@@ -123,5 +116,20 @@ internal class ReactNativeInternalInterfaceImpl(
 
     override fun logRnView(screen: String) {
         embrace.logRnView(screen)
+    }
+
+    private fun setJavaScriptBundleUrl(context: Context, url: String, didUpdate: Boolean? = null) {
+        if (embrace.isStarted) {
+            if (framework != AppFramework.REACT_NATIVE) {
+                logger.logError(
+                    "Failed to set Java Script bundle ID URL. Current framework: " +
+                        framework.name + " is not React Native."
+                )
+                return
+            }
+            metadataService.setReactNativeBundleId(context, url, didUpdate)
+        } else {
+            logger.logSDKNotInitialized("set JavaScript bundle URL")
+        }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
@@ -99,7 +99,7 @@ internal class ReactNativeInternalInterfaceImpl(
         setJavaScriptBundleUrl(context, url, null)
     }
 
-    override fun setJavaScriptBundleUrlForCodePush(context: Context, url: String, didUpdate: Boolean) {
+    override fun setCacheableJavaScriptBundleUrl(context: Context, url: String, didUpdate: Boolean) {
         setJavaScriptBundleUrl(context, url, didUpdate)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
@@ -112,8 +112,11 @@ internal interface MetadataService {
 
     /**
      * Sets React Native Bundle ID from a custom JavaScript Bundle URL.
+     * @param context the context
+     * @param jsBundleUrl the JavaScript bundle URL
+     * @param didCodePushBundleUpdate if the bundle was updated and we need to recompute the bundleId
      */
-    fun setReactNativeBundleId(context: Context, jsBundleUrl: String?)
+    fun setReactNativeBundleId(context: Context, jsBundleUrl: String?, didCodePushBundleUpdate: Boolean? = null)
 
     /**
      * Sets the Embrace Flutter SDK version

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
@@ -114,9 +114,9 @@ internal interface MetadataService {
      * Sets React Native Bundle ID from a custom JavaScript Bundle URL.
      * @param context the context
      * @param jsBundleUrl the JavaScript bundle URL
-     * @param didCodePushBundleUpdate if the bundle was updated and we need to recompute the bundleId
+     * @param forceUpdate if the bundle was updated and we need to recompute the bundleId
      */
-    fun setReactNativeBundleId(context: Context, jsBundleUrl: String?, didCodePushBundleUpdate: Boolean? = null)
+    fun setReactNativeBundleId(context: Context, jsBundleUrl: String?, forceUpdate: Boolean? = null)
 
     /**
      * Sets the Embrace Flutter SDK version

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -265,6 +265,10 @@ internal class EmbracePreferencesService(
         get() = prefs.getStringPreference(JAVA_SCRIPT_BUNDLE_URL_KEY)
         set(value) = prefs.setStringPreference(JAVA_SCRIPT_BUNDLE_URL_KEY, value)
 
+    override var codePushJsBundleId: String?
+        get() = prefs.getStringPreference(JAVA_SCRIPT_BUNDLE_ID_KEY)
+        set(value) = prefs.setStringPreference(JAVA_SCRIPT_BUNDLE_ID_KEY, value)
+
     override var rnSdkVersion: String?
         get() = prefs.getStringPreference(REACT_NATIVE_SDK_VERSION_KEY)
         set(value) = prefs.setStringPreference(REACT_NATIVE_SDK_VERSION_KEY, value)
@@ -372,6 +376,7 @@ internal class EmbracePreferencesService(
         private const val LAST_CRASH_NUMBER_KEY = "io.embrace.crashnumber"
         private const val LAST_NATIVE_CRASH_NUMBER_KEY = "io.embrace.nativecrashnumber"
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"
+        private const val JAVA_SCRIPT_BUNDLE_ID_KEY = "io.embrace.jsbundle.id"
         private const val JAVA_SCRIPT_PATCH_NUMBER_KEY = "io.embrace.javascript.patch"
         private const val REACT_NATIVE_VERSION_KEY = "io.embrace.reactnative.version"
         private const val REACT_NATIVE_SDK_VERSION_KEY = "io.embrace.reactnative.sdk.version"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -265,7 +265,7 @@ internal class EmbracePreferencesService(
         get() = prefs.getStringPreference(JAVA_SCRIPT_BUNDLE_URL_KEY)
         set(value) = prefs.setStringPreference(JAVA_SCRIPT_BUNDLE_URL_KEY, value)
 
-    override var codePushJsBundleId: String?
+    override var javaScriptBundleId: String?
         get() = prefs.getStringPreference(JAVA_SCRIPT_BUNDLE_ID_KEY)
         set(value) = prefs.setStringPreference(JAVA_SCRIPT_BUNDLE_ID_KEY, value)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
@@ -117,9 +117,9 @@ internal interface PreferencesService {
     var javaScriptBundleURL: String?
 
     /**
-     * Last Code Push javaScript bundle ID.
+     * Last javaScript bundle ID.
      */
-    var codePushJsBundleId: String?
+    var javaScriptBundleId: String?
 
     /**
      * Embrace sdk version.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/PreferencesService.kt
@@ -117,6 +117,11 @@ internal interface PreferencesService {
     var javaScriptBundleURL: String?
 
     /**
+     * Last Code Push javaScript bundle ID.
+     */
+    var codePushJsBundleId: String?
+
+    /**
      * Embrace sdk version.
      */
     var rnSdkVersion: String?

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
@@ -174,7 +174,7 @@ internal class ReactNativeInternalInterfaceImplTest {
         impl.setCacheableJavaScriptBundleUrl(context, "index.android.bundle", true)
         // Test that the metadata service was called with the correct parameters
         assertEquals("index.android.bundle", metadataService.fakeReactNativeBundleId)
-        assertEquals(true, metadataService.didCodePushBundleUpdate)
+        assertEquals(true, metadataService.forceUpdate)
     }
 
     @Test
@@ -193,7 +193,7 @@ internal class ReactNativeInternalInterfaceImplTest {
         impl.setJavaScriptBundleUrl(context, "index.android.bundle")
         // Test that the metadata service was called with the correct parameters
         assertEquals("index.android.bundle", metadataService.fakeReactNativeBundleId)
-        assertEquals(null, metadataService.didCodePushBundleUpdate)
+        assertEquals(null, metadataService.forceUpdate)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
@@ -159,7 +159,7 @@ internal class ReactNativeInternalInterfaceImplTest {
     }
 
     @Test
-    fun testSetJavaScriptBundleURLForCodePush() {
+    fun testSetCacheableJavaScriptBundleUrl() {
         impl = ReactNativeInternalInterfaceImpl(
             embrace,
             mockk(),
@@ -171,7 +171,7 @@ internal class ReactNativeInternalInterfaceImplTest {
         )
 
         every { embrace.isStarted } returns true
-        impl.setJavaScriptBundleUrlForCodePush(context, "index.android.bundle", true)
+        impl.setCacheableJavaScriptBundleUrl(context, "index.android.bundle", true)
         // Test that the metadata service was called with the correct parameters
         assertEquals("index.android.bundle", metadataService.fakeReactNativeBundleId)
         assertEquals(true, metadataService.didCodePushBundleUpdate)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
@@ -159,6 +159,44 @@ internal class ReactNativeInternalInterfaceImplTest {
     }
 
     @Test
+    fun testSetJavaScriptBundleURLForCodePush() {
+        impl = ReactNativeInternalInterfaceImpl(
+            embrace,
+            mockk(),
+            REACT_NATIVE,
+            preferencesService,
+            crashService,
+            metadataService,
+            logger
+        )
+
+        every { embrace.isStarted } returns true
+        impl.setJavaScriptBundleUrlForCodePush(context, "index.android.bundle", true)
+        // Test that the metadata service was called with the correct parameters
+        assertEquals("index.android.bundle", metadataService.fakeReactNativeBundleId)
+        assertEquals(true, metadataService.didCodePushBundleUpdate)
+    }
+
+    @Test
+    fun testSetJavaScriptBundleURLForOtherOTAs() {
+        impl = ReactNativeInternalInterfaceImpl(
+            embrace,
+            mockk(),
+            REACT_NATIVE,
+            preferencesService,
+            crashService,
+            metadataService,
+            logger
+        )
+
+        every { embrace.isStarted } returns true
+        impl.setJavaScriptBundleUrl(context, "index.android.bundle")
+        // Test that the metadata service was called with the correct parameters
+        assertEquals("index.android.bundle", metadataService.fakeReactNativeBundleId)
+        assertEquals(null, metadataService.didCodePushBundleUpdate)
+    }
+
+    @Test
     fun testLogUnhandledJsException() {
         every { embrace.isStarted } returns true
         impl.logUnhandledJsException("name", "message", "type", "stack")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
@@ -105,6 +105,15 @@ internal class EmbraceMetadataReactNativeTest {
     }
 
     @Test
+    fun `test React Native bundle ID from preference if jsBundleIdUrl is a new value`() {
+        preferencesService.javaScriptBundleURL = "oldJavaScriptBundleURL"
+        val metadataService = getMetadataService()
+
+        metadataService.setReactNativeBundleId(context, "newJavaScriptBundleURL")
+        assertEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
+    }
+
+    @Test
     fun `test React Native bundle ID url as Asset`() {
         val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
         val inputStream = FileInputStream(bundleIdFile)
@@ -115,13 +124,67 @@ internal class EmbraceMetadataReactNativeTest {
 
         val metadataService = getMetadataService()
         metadataService.setReactNativeBundleId(context, "assets://index.android.bundle")
-        // get the react native Bundle ID once to call the lazy property
-        metadataService.getReactNativeBundleId()
 
         verify(exactly = 1) { assetManager.open(eq("index.android.bundle")) }
 
         assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
         assertEquals("D41D8CD98F00B204E9800998ECF8427E", metadataService.getReactNativeBundleId())
+    }
+
+    @Test
+    fun `test React Native bundle ID url as Asset with CodePush didUpdate param in true`() {
+        val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
+        val inputStream = FileInputStream(bundleIdFile)
+        preferencesService.javaScriptBundleURL = null
+        preferencesService.codePushJsBundleId = null
+
+        every { context.assets } returns assetManager
+        every { assetManager.open(any()) } returns inputStream
+
+        val metadataService = getMetadataService()
+        metadataService.setReactNativeBundleId(context, "assets://index.android.bundle", true)
+
+        verify(exactly = 1) { assetManager.open(eq("index.android.bundle")) }
+
+        assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
+        assertEquals("D41D8CD98F00B204E9800998ECF8427E", metadataService.getReactNativeBundleId())
+        assertEquals("D41D8CD98F00B204E9800998ECF8427E", preferencesService.codePushJsBundleId)
+    }
+
+    @Test
+    fun `test React Native bundle ID url as Asset with CodePush didUpdate param in false`() {
+        val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
+        val inputStream = FileInputStream(bundleIdFile)
+        preferencesService.javaScriptBundleURL = "assets://index.android.bundle"
+        preferencesService.codePushJsBundleId = "persistedBundleId"
+
+        every { context.assets } returns assetManager
+        every { assetManager.open(any()) } returns inputStream
+
+        val metadataService = getMetadataService()
+        metadataService.setReactNativeBundleId(context, "assets://index.android.bundle", false)
+
+        assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
+        assertEquals("persistedBundleId", metadataService.getReactNativeBundleId())
+        assertEquals("persistedBundleId", preferencesService.codePushJsBundleId)
+    }
+
+    @Test
+    fun `test React Native bundle ID url as Asset with CodePush didUpdate param being null`() {
+        val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
+        val inputStream = FileInputStream(bundleIdFile)
+        preferencesService.javaScriptBundleURL = null
+        preferencesService.codePushJsBundleId = null
+
+        every { context.assets } returns assetManager
+        every { assetManager.open(any()) } returns inputStream
+
+        val metadataService = getMetadataService()
+        metadataService.setReactNativeBundleId(context, "assets://index.android.bundle", null)
+
+        assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
+        assertEquals("D41D8CD98F00B204E9800998ECF8427E", metadataService.getReactNativeBundleId())
+        assertEquals(null, preferencesService.codePushJsBundleId)
     }
 
     @Test
@@ -132,9 +195,6 @@ internal class EmbraceMetadataReactNativeTest {
             context,
             bundleIdFile.absolutePath
         )
-        // get the react native Bundle ID once to call the lazy property
-        metadataService.getReactNativeBundleId()
-
         assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
         assertEquals("D41D8CD98F00B204E9800998ECF8427E", metadataService.getReactNativeBundleId())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
@@ -132,11 +132,11 @@ internal class EmbraceMetadataReactNativeTest {
     }
 
     @Test
-    fun `test React Native bundle ID url as Asset with CodePush didUpdate param in true`() {
+    fun `test React Native bundle ID url as Asset with forceUpdate param in true`() {
         val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
         val inputStream = FileInputStream(bundleIdFile)
         preferencesService.javaScriptBundleURL = null
-        preferencesService.codePushJsBundleId = null
+        preferencesService.javaScriptBundleId = null
 
         every { context.assets } returns assetManager
         every { assetManager.open(any()) } returns inputStream
@@ -148,15 +148,15 @@ internal class EmbraceMetadataReactNativeTest {
 
         assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
         assertEquals("D41D8CD98F00B204E9800998ECF8427E", metadataService.getReactNativeBundleId())
-        assertEquals("D41D8CD98F00B204E9800998ECF8427E", preferencesService.codePushJsBundleId)
+        assertEquals("D41D8CD98F00B204E9800998ECF8427E", preferencesService.javaScriptBundleId)
     }
 
     @Test
-    fun `test React Native bundle ID url as Asset with CodePush didUpdate param in false`() {
+    fun `test React Native bundle ID url as Asset with forceUpdate param in false`() {
         val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
         val inputStream = FileInputStream(bundleIdFile)
         preferencesService.javaScriptBundleURL = "assets://index.android.bundle"
-        preferencesService.codePushJsBundleId = "persistedBundleId"
+        preferencesService.javaScriptBundleId = "persistedBundleId"
 
         every { context.assets } returns assetManager
         every { assetManager.open(any()) } returns inputStream
@@ -166,15 +166,15 @@ internal class EmbraceMetadataReactNativeTest {
 
         assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
         assertEquals("persistedBundleId", metadataService.getReactNativeBundleId())
-        assertEquals("persistedBundleId", preferencesService.codePushJsBundleId)
+        assertEquals("persistedBundleId", preferencesService.javaScriptBundleId)
     }
 
     @Test
-    fun `test React Native bundle ID url as Asset with CodePush didUpdate param being null`() {
+    fun `test React Native bundle ID url as Asset with forceUpdate param being null`() {
         val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
         val inputStream = FileInputStream(bundleIdFile)
         preferencesService.javaScriptBundleURL = null
-        preferencesService.codePushJsBundleId = null
+        preferencesService.javaScriptBundleId = null
 
         every { context.assets } returns assetManager
         every { assetManager.open(any()) } returns inputStream
@@ -184,7 +184,7 @@ internal class EmbraceMetadataReactNativeTest {
 
         assertNotEquals(buildInfo.buildId, metadataService.getReactNativeBundleId())
         assertEquals("D41D8CD98F00B204E9800998ECF8427E", metadataService.getReactNativeBundleId())
-        assertEquals(null, preferencesService.codePushJsBundleId)
+        assertEquals(null, preferencesService.javaScriptBundleId)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -217,6 +217,8 @@ internal class EmbraceMetadataServiceTest {
         every { preferencesService.unityBuildIdNumber }.returns(null)
         every { preferencesService.rnSdkVersion }.returns(null)
         every { preferencesService.javaScriptPatchNumber }.returns(null)
+        every { preferencesService.javaScriptBundleURL }.returns(null)
+        every { preferencesService.codePushJsBundleId }.returns(null)
         every { MetadataUtils.appEnvironment(any()) }.returns("UNKNOWN")
 
         val metadataService = getReactNativeMetadataService()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -218,7 +218,7 @@ internal class EmbraceMetadataServiceTest {
         every { preferencesService.rnSdkVersion }.returns(null)
         every { preferencesService.javaScriptPatchNumber }.returns(null)
         every { preferencesService.javaScriptBundleURL }.returns(null)
-        every { preferencesService.codePushJsBundleId }.returns(null)
+        every { preferencesService.javaScriptBundleId }.returns(null)
         every { MetadataUtils.appEnvironment(any()) }.returns("UNKNOWN")
 
         val metadataService = getReactNativeMetadataService()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -44,6 +44,7 @@ internal class FakeMetadataService(sessionId: String? = null) : MetadataService 
     var fakeAppId: String = "o0o0o"
     var fakeDeviceId: String = "07D85B44E4E245F4A30E559BFC0D07FF"
     var fakeReactNativeBundleId: String? = "fakeReactNativeBundleId"
+    var didCodePushBundleUpdate: Boolean? = null
     var fakeFlutterSdkVersion: String? = "fakeFlutterSdkVersion"
     var fakeDartVersion: String? = "fakeDartVersion"
     var fakeRnSdkVersion: String? = "fakeRnSdkVersion"
@@ -96,8 +97,9 @@ internal class FakeMetadataService(sessionId: String? = null) : MetadataService 
 
     override fun getAppState(): String = appState
 
-    override fun setReactNativeBundleId(context: Context, jsBundleUrl: String?) {
+    override fun setReactNativeBundleId(context: Context, jsBundleUrl: String?, didCodePushBundleUpdate: Boolean?) {
         fakeReactNativeBundleId = jsBundleUrl
+        this.didCodePushBundleUpdate = didCodePushBundleUpdate
     }
 
     override fun setEmbraceFlutterSdkVersion(version: String?) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -44,7 +44,7 @@ internal class FakeMetadataService(sessionId: String? = null) : MetadataService 
     var fakeAppId: String = "o0o0o"
     var fakeDeviceId: String = "07D85B44E4E245F4A30E559BFC0D07FF"
     var fakeReactNativeBundleId: String? = "fakeReactNativeBundleId"
-    var didCodePushBundleUpdate: Boolean? = null
+    var forceUpdate: Boolean? = null
     var fakeFlutterSdkVersion: String? = "fakeFlutterSdkVersion"
     var fakeDartVersion: String? = "fakeDartVersion"
     var fakeRnSdkVersion: String? = "fakeRnSdkVersion"
@@ -97,9 +97,9 @@ internal class FakeMetadataService(sessionId: String? = null) : MetadataService 
 
     override fun getAppState(): String = appState
 
-    override fun setReactNativeBundleId(context: Context, jsBundleUrl: String?, didCodePushBundleUpdate: Boolean?) {
+    override fun setReactNativeBundleId(context: Context, jsBundleUrl: String?, forceUpdate: Boolean?) {
         fakeReactNativeBundleId = jsBundleUrl
-        this.didCodePushBundleUpdate = didCodePushBundleUpdate
+        this.forceUpdate = forceUpdate
     }
 
     override fun setEmbraceFlutterSdkVersion(version: String?) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -27,6 +27,7 @@ internal class FakePreferenceService(
     override var backgroundActivityEnabled: Boolean = false,
     override var dartSdkVersion: String? = null,
     override var javaScriptBundleURL: String? = null,
+    override var codePushJsBundleId: String? = null,
     override var rnSdkVersion: String? = null,
     override var javaScriptPatchNumber: String? = null,
     override var embraceFlutterSdkVersion: String? = null,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -27,7 +27,7 @@ internal class FakePreferenceService(
     override var backgroundActivityEnabled: Boolean = false,
     override var dartSdkVersion: String? = null,
     override var javaScriptBundleURL: String? = null,
-    override var codePushJsBundleId: String? = null,
+    override var javaScriptBundleId: String? = null,
     override var rnSdkVersion: String? = null,
     override var javaScriptPatchNumber: String? = null,
     override var embraceFlutterSdkVersion: String? = null,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
@@ -248,12 +248,12 @@ internal class EmbracePreferencesServiceTest {
     }
 
     @Test
-    fun `test code push JS bundle id is saved`() {
-        assertNull(service.codePushJsBundleId)
+    fun `test java script bundle id is saved`() {
+        assertNull(service.javaScriptBundleId)
 
         val id = "0d48510589c0426b43f01a5fa060a333"
-        service.codePushJsBundleId = id
-        assertEquals(id, service.codePushJsBundleId)
+        service.javaScriptBundleId = id
+        assertEquals(id, service.javaScriptBundleId)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesServiceTest.kt
@@ -248,6 +248,15 @@ internal class EmbracePreferencesServiceTest {
     }
 
     @Test
+    fun `test code push JS bundle id is saved`() {
+        assertNull(service.codePushJsBundleId)
+
+        val id = "0d48510589c0426b43f01a5fa060a333"
+        service.codePushJsBundleId = id
+        assertEquals(id, service.codePushJsBundleId)
+    }
+
+    @Test
     fun `test java script patch number is saved`() {
         assertNull(service.javaScriptPatchNumber)
 


### PR DESCRIPTION
## Goal

- From RN side we have a way to know if CodePush has recently updated the bundle.
- In this PR I added a method to differentiate CodePush from other OTAs. 
- If a customer is using CodePush, RN SDK will call `setJavaScriptBundleUrlForCodePush` passing also a boolean indicating if this is the first run for that bundle and we need to update the `bundleId`.
- If a customer is using other OTA like Expo, RN SDK will call `setJavaScriptBundleUrl` and the bundleId will need to be calculated each time this method is called with a new bundleUrl, because if it's the same as the persisted one, the bundleId was calculated at startup. 
- At startup, we calculate the bundleId if it's not persisted and if the bundleURL is not persisted either, we use buildInfo.buildId as the default value. 

## Testing

Added unit tests.

## Release Notes

- Optimized Bundle Id calculation for RN Apps using CodePush.

