### PR TITLE
Don't create the OTel logger unless it's used

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
@@ -49,8 +49,10 @@ internal class OpenTelemetrySdk(
         sdk.getTracer(configuration.serviceName, configuration.serviceVersion)
     }
 
-    private val logger = Systrace.traceSynchronous("otel-logger-init") {
-        sdk.logsBridge.loggerBuilder(configuration.serviceName).build()
+    private val logger by lazy {
+        Systrace.traceSynchronous("otel-logger-init") {
+            sdk.logsBridge.loggerBuilder(configuration.serviceName).build()
+        }
     }
 
     fun getOpenTelemetryTracer(): Tracer = tracer


### PR DESCRIPTION
## Goal

We were initializing the OTel logger even though it's not used in production. Make the init happen lazily so that won't be called until first accessed, which wouldn't happen yet.