### PR TITLE
Add activity listener that consumes lifecycle events and feeds AppStartupTraceEmitter

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -1,0 +1,304 @@
+package io.embrace.android.embracesdk.capture.startup
+
+import android.os.Build.VERSION_CODES
+import android.os.Process
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.worker.BackgroundWorker
+import io.opentelemetry.sdk.common.Clock
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Records startup traces based on the data that it is provided. It adjusts what it logs based on what data has been provided and
+ * and which Android version the app is running.
+ */
+internal class AppStartupTraceEmitter(
+    private val clock: Clock,
+    private val startupServiceProvider: Provider<StartupService?>,
+    private val spanService: SpanService,
+    private val backgroundWorker: BackgroundWorker,
+    private val versionChecker: VersionChecker,
+    private val logger: InternalEmbraceLogger
+) {
+    private val processCreateRequestedMs: Long?
+    private val processCreatedMs: Long?
+
+    init {
+        val timestampAtDeviceStart = nowMs() - clock.nanoTime().nanosToMillis()
+        processCreateRequestedMs = if (versionChecker.isAtLeast(VERSION_CODES.N)) {
+            timestampAtDeviceStart + Process.getStartElapsedRealtime()
+        } else {
+            null
+        }
+        processCreatedMs = if (versionChecker.isAtLeast(VERSION_CODES.TIRAMISU)) {
+            timestampAtDeviceStart + Process.getStartRequestedElapsedRealtime()
+        } else {
+            null
+        }
+    }
+
+    @Volatile
+    private var applicationInitStartMs: Long? = null
+
+    @Volatile
+    private var applicationInitEndMs: Long? = null
+
+    @Volatile
+    private var startupActivityInitStartMs: Long? = null
+
+    @Volatile
+    private var startupActivityInitEndMs: Long? = null
+
+    @Volatile
+    private var startupActivityResumedMs: Long? = null
+
+    @Volatile
+    private var firstFrameRenderedMs: Long? = null
+
+    private val startupRecorded = AtomicBoolean(false)
+    private val endWithFrameDraw: Boolean = versionChecker.isAtLeast(VERSION_CODES.Q)
+
+    fun applicationInitStart(timestampMs: Long? = null) {
+        applicationInitStartMs = timestampMs ?: nowMs()
+    }
+
+    fun applicationInitEnd(timestampMs: Long? = null) {
+        applicationInitEndMs = timestampMs ?: nowMs()
+    }
+
+    fun startupActivityInitStart(timestampMs: Long? = null) {
+        if (startupActivityInitStartMs == null) {
+            startupActivityInitStartMs = timestampMs ?: nowMs()
+        }
+    }
+
+    fun startupActivityInitEnd(timestampMs: Long? = null) {
+        startupActivityInitEndMs = timestampMs ?: nowMs()
+    }
+
+    fun startupActivityResumed(timestampMs: Long? = null) {
+        startupActivityResumedMs = timestampMs ?: nowMs()
+        if (!endWithFrameDraw) {
+            dataCollectionComplete()
+        }
+    }
+
+    fun firstFrameRendered(timestampMs: Long? = null) {
+        firstFrameRenderedMs = timestampMs ?: nowMs()
+        if (endWithFrameDraw) {
+            dataCollectionComplete()
+        }
+    }
+
+    private fun dataCollectionComplete() {
+        if (!startupRecorded.get()) {
+            synchronized(startupRecorded) {
+                if (!startupRecorded.get()) {
+                    backgroundWorker.submit {
+                        recordStartup()
+                        if (!startupRecorded.get()) {
+                            logger.logWarning("App startup trace recording attempted but did not succeed")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun recordStartup() {
+        val startupService = startupServiceProvider() ?: return
+        val sdkInitStartMs = startupService.getSdkInitStartMs()
+        val sdkInitEndMs = startupService.getSdkInitEndMs()
+        val sdkStartupDuration = duration(sdkInitStartMs, sdkInitEndMs)
+        val processStartTimeMs: Long? =
+            if (versionChecker.isAtLeast(VERSION_CODES.N)) {
+                processCreatedMs
+            } else {
+                applicationInitStartMs ?: sdkInitStartMs
+            }
+
+        val traceEndTimeMs: Long? =
+            if (versionChecker.isAtLeast(VERSION_CODES.Q)) {
+                firstFrameRenderedMs
+            } else {
+                startupActivityResumedMs
+            }
+
+        if (processStartTimeMs != null && traceEndTimeMs != null) {
+            val gap = applicationActivityCreationGap() ?: duration(sdkInitEndMs, startupActivityInitStartMs)
+            if (gap != null) {
+                if (!spanService.initialized()) {
+                    logger.logWarning("Startup trace not recorded because the spans service is not initialized")
+                } else if (gap <= SDK_AND_ACTIVITY_INIT_GAP) {
+                    recordColdTtid(
+                        traceStartTimeMs = processStartTimeMs,
+                        applicationInitEndMs = applicationInitEndMs,
+                        sdkInitStartMs = sdkInitStartMs,
+                        sdkInitEndMs = sdkInitEndMs,
+                        activityInitStartMs = startupActivityInitStartMs,
+                        activityInitEndMs = startupActivityInitEndMs,
+                        traceEndTimeMs = traceEndTimeMs,
+                        processCreateDelay = processCreateDelay(),
+                    )
+                } else {
+                    startupActivityInitStartMs?.let { startTime ->
+                        recordWarmTtid(
+                            traceStartTimeMs = startTime,
+                            activityInitEndMs = startupActivityInitEndMs,
+                            traceEndTimeMs = traceEndTimeMs,
+                            processCreateDelay = processCreateDelay(),
+                            processToActivityCreateGap = gap,
+                            sdkStartupDuration = sdkStartupDuration
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "ComplexMethod")
+    private fun recordColdTtid(
+        traceStartTimeMs: Long,
+        applicationInitEndMs: Long?,
+        sdkInitStartMs: Long?,
+        sdkInitEndMs: Long?,
+        activityInitStartMs: Long?,
+        activityInitEndMs: Long?,
+        traceEndTimeMs: Long,
+        processCreateDelay: Long?,
+    ) {
+        if (!startupRecorded.get()) {
+            spanService.startSpan(
+                name = "cold-time-to-initial-display",
+                startTimeMs = traceStartTimeMs,
+            )?.run {
+                processCreateDelay?.let { delay ->
+                    addAttribute("process-create-delay-ms".toEmbraceAttributeName(), delay.toString())
+                }
+                if (stop(endTimeMs = traceEndTimeMs)) {
+                    startupRecorded.set(true)
+                }
+
+                if (applicationInitEndMs != null) {
+                    spanService.recordCompletedSpan(
+                        name = "process-init",
+                        parent = this,
+                        startTimeMs = traceStartTimeMs,
+                        endTimeMs = applicationInitEndMs,
+                    )
+                }
+                if (sdkInitStartMs != null && sdkInitEndMs != null) {
+                    spanService.recordCompletedSpan(
+                        name = "embrace-init",
+                        parent = this,
+                        startTimeMs = sdkInitStartMs,
+                        endTimeMs = sdkInitEndMs,
+                    )
+                }
+                val lastEventBeforeActivityInit = applicationInitEndMs ?: sdkInitEndMs
+                if (lastEventBeforeActivityInit != null && activityInitStartMs != null) {
+                    spanService.recordCompletedSpan(
+                        name = "activity-init-gap",
+                        parent = this,
+                        startTimeMs = lastEventBeforeActivityInit,
+                        endTimeMs = activityInitStartMs,
+                    )
+                }
+                if (activityInitStartMs != null && activityInitEndMs != null) {
+                    spanService.recordCompletedSpan(
+                        name = "activity-create",
+                        parent = this,
+                        startTimeMs = activityInitStartMs,
+                        endTimeMs = activityInitEndMs,
+                    )
+                }
+                if (activityInitEndMs != null) {
+                    val uiLoadSpanName = if (endWithFrameDraw) {
+                        "first-frame-render"
+                    } else {
+                        "activity-resume"
+                    }
+                    spanService.recordCompletedSpan(
+                        name = uiLoadSpanName,
+                        parent = this,
+                        startTimeMs = activityInitEndMs,
+                        endTimeMs = traceEndTimeMs,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun recordWarmTtid(
+        traceStartTimeMs: Long,
+        activityInitEndMs: Long?,
+        traceEndTimeMs: Long,
+        processCreateDelay: Long?,
+        processToActivityCreateGap: Long?,
+        sdkStartupDuration: Long?,
+    ) {
+        if (!startupRecorded.get()) {
+            spanService.startSpan(
+                name = "warm-time-to-initial-display",
+                startTimeMs = traceStartTimeMs,
+            )?.run {
+                processCreateDelay?.let { delay ->
+                    addAttribute("process-create-delay-ms".toEmbraceAttributeName(), delay.toString())
+                }
+                processToActivityCreateGap?.let { gap ->
+                    addAttribute("activity-init-gap-ms".toEmbraceAttributeName(), gap.toString())
+                }
+                sdkStartupDuration?.let { duration ->
+                    addAttribute("embrace-init-duration-ms".toEmbraceAttributeName(), duration.toString())
+                }
+                if (stop(endTimeMs = traceEndTimeMs)) {
+                    startupRecorded.set(true)
+                }
+                if (activityInitEndMs != null) {
+                    spanService.recordCompletedSpan(
+                        name = "activity-create",
+                        parent = this,
+                        startTimeMs = traceStartTimeMs,
+                        endTimeMs = activityInitEndMs,
+                    )
+                    val uiLoadSpanName = if (endWithFrameDraw) {
+                        "first-frame-render"
+                    } else {
+                        "activity-resume"
+                    }
+                    spanService.recordCompletedSpan(
+                        name = uiLoadSpanName,
+                        parent = this,
+                        startTimeMs = activityInitEndMs,
+                        endTimeMs = traceEndTimeMs,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun processCreateDelay(): Long? = duration(processCreateRequestedMs, processCreatedMs)
+
+    private fun applicationActivityCreationGap(): Long? = duration(applicationInitEndMs, startupActivityInitStartMs)
+
+    private fun nowMs(): Long = clock.now().nanosToMillis()
+
+    companion object {
+        /**
+         * The gap between the end of the Embrace SDK initialization to when the first activity loaded after startup happens.
+         * If this gap is greater than 1 minute, it's likely that the app process was not created because the user tapped on the app icon,
+         * so we track this app launch as a warm start.
+         */
+        const val SDK_AND_ACTIVITY_INIT_GAP = 60000L
+
+        fun duration(start: Long?, end: Long?): Long? = if (start != null && end != null) {
+            end - start
+        } else {
+            null
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -20,6 +20,7 @@ internal class AppStartupTraceEmitter(
     private val clock: Clock,
     private val startupServiceProvider: Provider<StartupService?>,
     private val spanService: SpanService,
+    @Suppress("UnusedPrivateMember")
     private val backgroundWorker: BackgroundWorker,
     private val versionChecker: VersionChecker,
     private val logger: InternalEmbraceLogger

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -98,11 +98,9 @@ internal class AppStartupTraceEmitter(
         if (!startupRecorded.get()) {
             synchronized(startupRecorded) {
                 if (!startupRecorded.get()) {
-                    backgroundWorker.submit {
-                        recordStartup()
-                        if (!startupRecorded.get()) {
-                            logger.logWarning("App startup trace recording attempted but did not succeed")
-                        }
+                    recordStartup()
+                    if (!startupRecorded.get()) {
+                        logger.logWarning("App startup trace recording attempted but did not succeed")
                     }
                 }
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -20,7 +20,6 @@ internal class AppStartupTraceEmitter(
     private val clock: Clock,
     private val startupServiceProvider: Provider<StartupService?>,
     private val spanService: SpanService,
-    @Suppress("UnusedPrivateMember")
     private val backgroundWorker: BackgroundWorker,
     private val versionChecker: VersionChecker,
     private val logger: InternalEmbraceLogger
@@ -99,9 +98,11 @@ internal class AppStartupTraceEmitter(
         if (!startupRecorded.get()) {
             synchronized(startupRecorded) {
                 if (!startupRecorded.get()) {
-                    recordStartup()
-                    if (!startupRecorded.get()) {
-                        logger.logWarning("App startup trace recording attempted but did not succeed")
+                    backgroundWorker.submit {
+                        recordStartup()
+                        if (!startupRecorded.get()) {
+                            logger.logWarning("App startup trace recording attempted but did not succeed")
+                        }
                     }
                 }
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupService.kt
@@ -11,7 +11,17 @@ internal interface StartupService {
     fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long)
 
     /**
-     * Returns the SDK startup info. This is called when the session ends.
+     * Returns the SDK startup duration. This is called when the session ends.
      */
-    fun getSdkStartupInfo(coldStart: Boolean): Long?
+    fun getSdkStartupDuration(coldStart: Boolean): Long?
+
+    /**
+     * The epoch time in milliseconds of when the SDK startup began
+     */
+    fun getSdkInitStartMs(): Long?
+
+    /**
+     * The epoch time in milliseconds of when the SDK startup finished
+     */
+    fun getSdkInitEndMs(): Long?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.worker.BackgroundWorker
 
 internal class StartupServiceImpl(
     private val spanService: SpanService,
+    @Suppress("UnusedPrivateMember")
     private val backgroundWorker: BackgroundWorker
 ) : StartupService {
 
@@ -22,13 +23,11 @@ internal class StartupServiceImpl(
 
     override fun setSdkStartupInfo(startTimeMs: Long, endTimeMs: Long) {
         if (sdkStartupDurationMs == null) {
-            backgroundWorker.submit {
-                spanService.recordCompletedSpan(
-                    name = "sdk-init",
-                    startTimeMs = startTimeMs,
-                    endTimeMs = endTimeMs
-                )
-            }
+            spanService.recordCompletedSpan(
+                name = "sdk-init",
+                startTimeMs = startTimeMs,
+                endTimeMs = endTimeMs
+            )
         }
         sdkInitStartMs = startTimeMs
         sdkInitEndMs = endTimeMs

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupTracker.kt
@@ -1,0 +1,165 @@
+package io.embrace.android.embracesdk.capture.startup
+
+import android.app.Activity
+import android.app.Application
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.Window
+import io.embrace.android.embracesdk.annotation.StartupActivity
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+
+/**
+ * Component that captures various timestamps throughout the startup process and uses that information to log spans that approximates to
+ * the canonical cold and warm "Time to First Display" metric.
+ *
+ * In the abstract, we want to be as close as possible to approximate the duration between the start of the app process, to when the first
+ * frame is completely rendered in the first useful activity. Because of the different capabilities of each Android version, we are
+ * measuring slightly different events during startup, so there will be several flavors the startup trace depending on which version of
+ * Android the app is currently running on.
+ *
+ * For app process start time:
+ *
+ * - Android 13 onwards, it is determined by when the app process is requested to be specialized, which could be some time after the
+ *   the zygote process is created, depending on, perhaps among other things, the manufacturer of the device. If this value is used,
+ *   it value will be captured in an attribute on the root span of the trace.
+ *
+ * - Android 7.0 to 12 (inclusive), it is determined by when the app process is created. Some OEMs on some versions of Android are known to
+ *   pre-created a bunch of zygotes in order to speed up start time, to mixed success. The fact that Pixel devices don't do this should
+ *   tell you how effectively that strategy overall is.
+ *
+ * - Older Android version that are supported, we use the SDK startup time (for now).
+ *
+ * For approximating the first frame being completely drawn:
+ *
+ * - Android 10 onwards, we use a [ViewTreeObserver.OnDrawListener] callback to detect that the first frame from the first activity load
+ *   has been fully rendered and queued for display.
+ *
+ * - Older Android versions that are supported, we just use when the first Activity was resumed.
+ *
+ * Note that this implementation has benefited from the work of Pierre-Yves Ricau and his blog post about Android application launch time
+ * that can be found here: https://blog.p-y.wtf/tracking-android-app-launch-in-production. PY's code was adapted and tweaked for use here.
+ */
+internal class StartupTracker(
+    private val appStartupTraceEmitter: AppStartupTraceEmitter,
+    private val versionChecker: VersionChecker,
+) : Application.ActivityLifecycleCallbacks {
+    private var isFirstDraw = false
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (activity.observeForStartup()) {
+            appStartupTraceEmitter.startupActivityInitStart()
+            if (versionChecker.isAtLeast(Build.VERSION_CODES.Q)) {
+                if (!isFirstDraw) {
+                    val window = activity.window
+                    window.onDecorViewReady {
+                        val decorView = window.decorView
+                        decorView.onNextDraw {
+                            if (!isFirstDraw) {
+                                isFirstDraw = true
+                                val callback = { appStartupTraceEmitter.firstFrameRendered() }
+                                decorView.viewTreeObserver.registerFrameCommitCallback(callback)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (activity.observeForStartup()) {
+            appStartupTraceEmitter.startupActivityInitStart()
+        }
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        if (activity.observeForStartup()) {
+            appStartupTraceEmitter.startupActivityInitEnd()
+        }
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        if (activity.observeForStartup()) {
+            appStartupTraceEmitter.startupActivityResumed()
+        }
+    }
+
+    override fun onActivityPaused(activity: Activity) {}
+
+    override fun onActivityStopped(activity: Activity) {}
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+    override fun onActivityDestroyed(activity: Activity) {}
+
+    companion object {
+        private class PyNextDrawListener(
+            val view: View,
+            val onDrawCallback: () -> Unit
+        ) : ViewTreeObserver.OnDrawListener {
+            val handler = Handler(Looper.getMainLooper())
+            var invoked = false
+
+            override fun onDraw() {
+                if (!invoked) {
+                    invoked = true
+                    onDrawCallback()
+                    handler.post {
+                        if (view.viewTreeObserver.isAlive) {
+                            view.viewTreeObserver.removeOnDrawListener(this)
+                        }
+                    }
+                }
+            }
+        }
+
+        private class PyWindowDelegateCallback(
+            private val delegate: Window.Callback
+        ) : Window.Callback by delegate {
+
+            val onContentChangedCallbacks = mutableListOf<() -> Boolean>()
+
+            override fun onContentChanged() {
+                onContentChangedCallbacks.removeAll { callback ->
+                    !callback()
+                }
+                delegate.onContentChanged()
+            }
+        }
+
+        fun Activity.observeForStartup(): Boolean = !javaClass.isAnnotationPresent(StartupActivity::class.java)
+
+        fun View.onNextDraw(onDrawCallback: () -> Unit) {
+            viewTreeObserver.addOnDrawListener(
+                PyNextDrawListener(this, onDrawCallback)
+            )
+        }
+
+        fun Window.onDecorViewReady(callback: () -> Unit) {
+            if (peekDecorView() == null) {
+                onContentChanged {
+                    callback()
+                    return@onContentChanged false
+                }
+            } else {
+                callback()
+            }
+        }
+
+        private fun Window.onContentChanged(onDrawCallbackInvocation: () -> Boolean) {
+            val currentCallback = callback
+            val callback = if (currentCallback is PyWindowDelegateCallback) {
+                currentCallback
+            } else {
+                val newCallback = PyWindowDelegateCallback(currentCallback)
+                callback = newCallback
+                newCallback
+            }
+            callback.onContentChangedCallbacks += onDrawCallbackInvocation
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -162,6 +162,9 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     }
 
     override val startupService: StartupService by singleton {
-        StartupServiceImpl(openTelemetryModule.spanService)
+        StartupServiceImpl(
+            spanService = openTelemetryModule.spanService,
+            backgroundWorker = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
+        )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
@@ -49,8 +49,10 @@ internal class OpenTelemetrySdk(
         sdk.getTracer(configuration.serviceName, configuration.serviceVersion)
     }
 
-    private val logger = Systrace.traceSynchronous("otel-logger-init") {
-        sdk.logsBridge.loggerBuilder(configuration.serviceName).build()
+    private val logger by lazy {
+        Systrace.traceSynchronous("otel-logger-init") {
+            sdk.logsBridge.loggerBuilder(configuration.serviceName).build()
+        }
     }
 
     fun getOpenTelemetryTracer(): Tracer = tracer

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -90,7 +90,7 @@ internal class PayloadMessageCollator(
             terminationTime = terminationTime,
             isReceivedTermination = receivedTermination,
             endTime = endTimeVal,
-            sdkStartupDuration = startupService.getSdkStartupInfo(initial.isColdStart),
+            sdkStartupDuration = startupService.getSdkStartupDuration(initial.isColdStart),
             startupDuration = startupInfo?.duration,
             startupThreshold = startupInfo?.threshold,
             betaFeatures = betaFeatures,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitterTest.kt
@@ -1,0 +1,383 @@
+package io.embrace.android.embracesdk.capture.startup
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeLoggerAction
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.worker.BackgroundWorker
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+internal class AppStartupTraceEmitterTest {
+    private var startupService: StartupService? = null
+    private lateinit var clock: FakeClock
+    private lateinit var spanSink: SpanSink
+    private lateinit var spanService: SpanService
+    private lateinit var loggerAction: FakeLoggerAction
+    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var backgroundWorker: BackgroundWorker
+    private lateinit var appStartupTraceEmitter: AppStartupTraceEmitter
+
+    @Before
+    fun setUp() {
+        clock = FakeClock()
+        val initModule = FakeInitModule(clock = clock)
+        backgroundWorker = BackgroundWorker(BlockableExecutorService())
+        spanSink = initModule.openTelemetryModule.spanSink
+        spanService = initModule.openTelemetryModule.spanService
+        spanService.initializeService(clock.now())
+        startupService = StartupServiceImpl(
+            spanService,
+            backgroundWorker
+        )
+        clock.tick(100L)
+        loggerAction = FakeLoggerAction()
+        logger = InternalEmbraceLogger().apply { addLoggerAction(loggerAction) }
+        appStartupTraceEmitter = AppStartupTraceEmitter(
+            clock = initModule.openTelemetryClock,
+            startupServiceProvider = { startupService },
+            spanService = spanService,
+            backgroundWorker = backgroundWorker,
+            versionChecker = BuildVersionChecker,
+            logger = logger
+        )
+        loggerAction.msgQueue.clear()
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `no crashes if startup service not available in T`() {
+        startupService = null
+        appStartupTraceEmitter.firstFrameRendered()
+        assertEquals(1, loggerAction.msgQueue.size)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify cold start trace with every event triggered in T`() {
+        clock.tick(100L)
+        appStartupTraceEmitter.applicationInitStart()
+        val sdkInitStart = clock.now()
+        clock.tick(30L)
+        val sdkInitEnd = clock.now()
+        clock.tick(400L)
+        appStartupTraceEmitter.applicationInitEnd()
+        val applicationInitEnd = clock.now()
+        clock.tick(50L)
+        checkNotNull(startupService).setSdkStartupInfo(sdkInitStart, sdkInitEnd)
+        appStartupTraceEmitter.startupActivityInitStart()
+        val startupActivityStart = clock.now()
+        clock.tick(180L)
+        appStartupTraceEmitter.startupActivityInitEnd()
+        val startupActivityEnd = clock.now()
+        clock.tick(15L)
+        appStartupTraceEmitter.startupActivityResumed()
+        clock.tick(199L)
+        appStartupTraceEmitter.firstFrameRendered()
+        val traceEnd = clock.now()
+
+        assertEquals(7, spanSink.completedSpans().size)
+        val spanMap = spanSink.completedSpans().associateBy { it.name }
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
+        val processInit = checkNotNull(spanMap["emb-process-init"])
+        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
+        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
+        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
+        val firstRender = checkNotNull(spanMap["emb-first-frame-render"])
+
+        with(trace) {
+            assertEquals(FakeClock.DEFAULT_FAKE_CURRENT_TIME, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+        with(processInit) {
+            assertEquals(FakeClock.DEFAULT_FAKE_CURRENT_TIME, startTimeNanos.nanosToMillis())
+            assertEquals(applicationInitEnd, endTimeNanos.nanosToMillis())
+        }
+        with(embraceInit) {
+            assertEquals(sdkInitStart, startTimeNanos.nanosToMillis())
+            assertEquals(sdkInitEnd, endTimeNanos.nanosToMillis())
+        }
+        with(activityInitDelay) {
+            assertEquals(applicationInitEnd, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityStart, endTimeNanos.nanosToMillis())
+        }
+        with(activityCreate) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityEnd, endTimeNanos.nanosToMillis())
+        }
+        with(firstRender) {
+            assertEquals(startupActivityEnd, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+
+        assertEquals(0, loggerAction.msgQueue.size)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify cold start trace without application init start and end triggered in T`() {
+        clock.tick(100L)
+        val sdkInitStart = clock.now()
+        clock.tick(30L)
+        val sdkInitEnd = clock.now()
+        clock.tick(400L)
+        checkNotNull(startupService).setSdkStartupInfo(sdkInitStart, sdkInitEnd)
+        appStartupTraceEmitter.startupActivityInitStart()
+        val startupActivityStart = clock.now()
+        clock.tick(180L)
+        appStartupTraceEmitter.startupActivityInitEnd()
+        val startupActivityEnd = clock.now()
+        clock.tick(15L)
+        appStartupTraceEmitter.startupActivityResumed()
+        clock.tick(199L)
+        appStartupTraceEmitter.firstFrameRendered()
+        val traceEnd = clock.now()
+
+        assertEquals(6, spanSink.completedSpans().size)
+        val spanMap = spanSink.completedSpans().associateBy { it.name }
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
+        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
+        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
+        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
+        val firstRender = checkNotNull(spanMap["emb-first-frame-render"])
+
+        with(trace) {
+            assertEquals(FakeClock.DEFAULT_FAKE_CURRENT_TIME, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+        with(embraceInit) {
+            assertEquals(sdkInitStart, startTimeNanos.nanosToMillis())
+            assertEquals(sdkInitEnd, endTimeNanos.nanosToMillis())
+        }
+        with(activityInitDelay) {
+            assertEquals(sdkInitEnd, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityStart, endTimeNanos.nanosToMillis())
+        }
+        with(activityCreate) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityEnd, endTimeNanos.nanosToMillis())
+        }
+        with(firstRender) {
+            assertEquals(startupActivityEnd, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+
+        assertEquals(0, loggerAction.msgQueue.size)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify warm start trace without application init start and end triggered in T`() {
+        clock.tick(100L)
+        val sdkInitStart = clock.now()
+        clock.tick(30L)
+        val sdkInitEnd = clock.now()
+        checkNotNull(startupService).setSdkStartupInfo(sdkInitStart, sdkInitEnd)
+        clock.tick(60001L)
+        appStartupTraceEmitter.startupActivityInitStart()
+        val startupActivityStart = clock.now()
+        clock.tick(180L)
+        appStartupTraceEmitter.startupActivityInitEnd()
+        val startupActivityEnd = clock.now()
+        clock.tick(15L)
+        appStartupTraceEmitter.startupActivityResumed()
+        clock.tick(199L)
+        appStartupTraceEmitter.firstFrameRendered()
+        val traceEnd = clock.now()
+
+        assertEquals(4, spanSink.completedSpans().size)
+        val spanMap = spanSink.completedSpans().associateBy { it.name }
+        val trace = checkNotNull(spanMap["emb-warm-time-to-initial-display"])
+        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
+        val firstRender = checkNotNull(spanMap["emb-first-frame-render"])
+
+        with(trace) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+            assertEquals("60001", attributes["emb.activity-init-gap-ms"])
+            assertEquals("30", attributes["emb.embrace-init-duration-ms"])
+        }
+        with(activityCreate) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityEnd, endTimeNanos.nanosToMillis())
+        }
+        with(firstRender) {
+            assertEquals(startupActivityEnd, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+
+        assertEquals(0, loggerAction.msgQueue.size)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `no crashes if startup service not available in L`() {
+        startupService = null
+        appStartupTraceEmitter.startupActivityResumed()
+        assertEquals(1, loggerAction.msgQueue.size)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify cold start trace with every event triggered in L`() {
+        clock.tick(100L)
+        appStartupTraceEmitter.applicationInitStart()
+        val applicationInitStart = clock.now()
+        clock.tick(10L)
+        val sdkInitStart = clock.now()
+        clock.tick(30L)
+        val sdkInitEnd = clock.now()
+        clock.tick(400L)
+        appStartupTraceEmitter.applicationInitEnd()
+        val applicationInitEnd = clock.now()
+        clock.tick(50L)
+        checkNotNull(startupService).setSdkStartupInfo(sdkInitStart, sdkInitEnd)
+        appStartupTraceEmitter.startupActivityInitStart()
+        val startupActivityStart = clock.now()
+        clock.tick(180L)
+        appStartupTraceEmitter.startupActivityInitEnd()
+        val startupActivityEnd = clock.now()
+        clock.tick(15L)
+        appStartupTraceEmitter.startupActivityResumed()
+        val traceEnd = clock.now()
+
+        assertEquals(7, spanSink.completedSpans().size)
+        val spanMap = spanSink.completedSpans().associateBy { it.name }
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
+        val processInit = checkNotNull(spanMap["emb-process-init"])
+        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
+        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
+        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
+        val activityResume = checkNotNull(spanMap["emb-activity-resume"])
+
+        with(trace) {
+            assertEquals(applicationInitStart, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+        with(processInit) {
+            assertEquals(applicationInitStart, startTimeNanos.nanosToMillis())
+            assertEquals(applicationInitEnd, endTimeNanos.nanosToMillis())
+        }
+        with(embraceInit) {
+            assertEquals(sdkInitStart, startTimeNanos.nanosToMillis())
+            assertEquals(sdkInitEnd, endTimeNanos.nanosToMillis())
+        }
+        with(activityInitDelay) {
+            assertEquals(applicationInitEnd, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityStart, endTimeNanos.nanosToMillis())
+        }
+        with(activityCreate) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityEnd, endTimeNanos.nanosToMillis())
+        }
+        with(activityResume) {
+            assertEquals(startupActivityEnd, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+
+        assertEquals(0, loggerAction.msgQueue.size)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify cold start trace without application init start and end triggered in L`() {
+        clock.tick(100L)
+        val sdkInitStart = clock.now()
+        clock.tick(30L)
+        val sdkInitEnd = clock.now()
+        clock.tick(400L)
+        checkNotNull(startupService).setSdkStartupInfo(sdkInitStart, sdkInitEnd)
+        appStartupTraceEmitter.startupActivityInitStart()
+        val startupActivityStart = clock.now()
+        clock.tick(180L)
+        appStartupTraceEmitter.startupActivityInitEnd()
+        val startupActivityEnd = clock.now()
+        clock.tick(15L)
+        appStartupTraceEmitter.startupActivityResumed()
+        val traceEnd = clock.now()
+
+        assertEquals(6, spanSink.completedSpans().size)
+        val spanMap = spanSink.completedSpans().associateBy { it.name }
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
+        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
+        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
+        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
+        val activityResume = checkNotNull(spanMap["emb-activity-resume"])
+
+        with(trace) {
+            assertEquals(sdkInitStart, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+        with(embraceInit) {
+            assertEquals(sdkInitStart, startTimeNanos.nanosToMillis())
+            assertEquals(sdkInitEnd, endTimeNanos.nanosToMillis())
+        }
+        with(activityInitDelay) {
+            assertEquals(sdkInitEnd, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityStart, endTimeNanos.nanosToMillis())
+        }
+        with(activityCreate) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityEnd, endTimeNanos.nanosToMillis())
+        }
+        with(activityResume) {
+            assertEquals(startupActivityEnd, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+
+        assertEquals(0, loggerAction.msgQueue.size)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify warm start trace without application init start and end triggered in L`() {
+        clock.tick(100L)
+        val sdkInitStart = clock.now()
+        clock.tick(30L)
+        val sdkInitEnd = clock.now()
+        checkNotNull(startupService).setSdkStartupInfo(sdkInitStart, sdkInitEnd)
+        clock.tick(60001L)
+        appStartupTraceEmitter.startupActivityInitStart()
+        val startupActivityStart = clock.now()
+        clock.tick(180L)
+        appStartupTraceEmitter.startupActivityInitEnd()
+        val startupActivityEnd = clock.now()
+        clock.tick(15L)
+        appStartupTraceEmitter.startupActivityResumed()
+        val traceEnd = clock.now()
+
+        assertEquals(4, spanSink.completedSpans().size)
+        val spanMap = spanSink.completedSpans().associateBy { it.name }
+        val trace = checkNotNull(spanMap["emb-warm-time-to-initial-display"])
+        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
+        val activityResume = checkNotNull(spanMap["emb-activity-resume"])
+
+        with(trace) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+            assertEquals("60001", attributes["emb.activity-init-gap-ms"])
+            assertEquals("30", attributes["emb.embrace-init-duration-ms"])
+        }
+        with(activityCreate) {
+            assertEquals(startupActivityStart, startTimeNanos.nanosToMillis())
+            assertEquals(startupActivityEnd, endTimeNanos.nanosToMillis())
+        }
+        with(activityResume) {
+            assertEquals(startupActivityEnd, startTimeNanos.nanosToMillis())
+            assertEquals(traceEnd, endTimeNanos.nanosToMillis())
+        }
+
+        assertEquals(0, loggerAction.msgQueue.size)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -1,14 +1,17 @@
 package io.embrace.android.embracesdk.capture.startup
 
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.internal.spans.isPrivate
+import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -19,15 +22,17 @@ internal class StartupServiceImplTest {
     private lateinit var spanService: SpanService
     private lateinit var startupService: StartupService
     private lateinit var clock: FakeClock
+    private lateinit var backgroundWorker: BackgroundWorker
 
     @Before
     fun setUp() {
         clock = FakeClock(10000000)
         val initModule = FakeInitModule(clock = clock)
+        backgroundWorker = BackgroundWorker(BlockableExecutorService())
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
         spanService.initializeService(clock.now())
-        startupService = StartupServiceImpl(spanService)
+        startupService = StartupServiceImpl(spanService, backgroundWorker)
     }
 
     @Test
@@ -68,5 +73,14 @@ internal class StartupServiceImplTest {
         startupService.setSdkStartupInfo(10, 20)
         spanService.initializeService(10)
         assertEquals(1, spanSink.completedSpans().size)
+    }
+
+    @Test
+    fun `startup info available right after setting on the service`() {
+        startupService.setSdkStartupInfo(1111L, 3222L)
+        assertEquals(1111L, startupService.getSdkInitStartMs())
+        assertEquals(3222L, startupService.getSdkInitEndMs())
+        assertEquals(2111L, startupService.getSdkStartupDuration(true))
+        assertNull(startupService.getSdkStartupDuration(false))
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
@@ -10,7 +10,15 @@ internal class FakeStartupService : StartupService {
         sdkStartupDuration = endTimeMs - startTimeMs
     }
 
-    override fun getSdkStartupInfo(coldStart: Boolean): Long? {
+    override fun getSdkStartupDuration(coldStart: Boolean): Long? {
         return sdkStartupDuration
+    }
+
+    override fun getSdkInitStartMs(): Long? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSdkInitEndMs(): Long? {
+        TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Goal

Add an activity lifecycle callback handler funnel application lifecycle events to the `AppStartupTraceEmitter`. The implementation to observe the frame render event is based on PY's blog post here: https://blog.p-y.wtf/tracking-android-app-launch-in-production

Almost all of the complexity is in that code, and while I don't have automation yet, I have tested this manually in API 21 and 34, and many in between. That said, this is the part that needs the most scrutiny to determine whether this is viable to introduce now

## Testing

Manual testing done
