### PR TITLE
Add emb-type as mandatory attribute for spans, events, and logs

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
@@ -40,7 +40,7 @@ internal interface SpanDataSource : DataSource<SpanService> {
 internal fun <T> SpanService.startSpanCapture(obj: T, mapper: T.() -> StartSpanData): EmbraceSpan? {
     val data = obj.mapper()
     return createSpan(data.spanName)?.apply {
-        data.attributes?.forEach {
+        data.attributes.forEach {
             addAttribute(it.key, it.value)
         }
         start()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
@@ -4,10 +4,19 @@ import io.embrace.android.embracesdk.Severity
 
 /**
  * Represents a Log event that can be added to the current session span.
+ *
+ *
+ * @param embType the type of the span. Used to differentiate data from different sources
+ * by the backend.
+ * @param severity the severity of the log
+ * @param message the message of the log
+ * @param attributes the attributes of the span. emb-type is automatically added to these.
  */
 internal class LogEventData(
-    val startTimeMs: Long,
+    embType: String,
     val severity: Severity,
     val message: String,
-    val attributes: Map<String, String>?
-)
+    attributes: Map<String, String>? = null
+) {
+    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType))
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.arch.destination
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.logs.Severity
-import java.util.concurrent.TimeUnit
 
 internal class LogWriterImpl(private val logger: Logger) : LogWriter {
 
@@ -15,9 +14,8 @@ internal class LogWriterImpl(private val logger: Logger) : LogWriter {
             .setBody(logEventData.message)
             .setSeverity(logEventData.severity.toOtelSeverity())
             .setSeverityText(logEventData.severity.name)
-            .setTimestamp(logEventData.startTimeMs, TimeUnit.MILLISECONDS)
 
-        logEventData.attributes?.forEach {
+        logEventData.attributes.forEach {
             builder.setAttribute(AttributeKey.stringKey(it.key), it.value)
         }
         builder.emit()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
@@ -2,9 +2,18 @@ package io.embrace.android.embracesdk.arch.destination
 
 /**
  * Represents a span event that can be added to the current session span.
+ *
+ * @param embType the type of the event. Used to differentiate data from different sources
+ * by the backend.
+ * @param spanName the name of the span event.
+ * @param spanStartTimeMs the start time of the span event in milliseconds.
+ * @param attributes the attributes of the span event. emb-type is automatically added to these.
  */
 internal class SpanEventData(
+    embType: String,
     val spanName: String,
     val spanStartTimeMs: Long,
-    val attributes: Map<String, String>?
-)
+    attributes: Map<String, String>? = null
+) {
+    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType))
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
@@ -2,9 +2,18 @@ package io.embrace.android.embracesdk.arch.destination
 
 /**
  * Holds the information required to start a span.
+ *
+ * @param embType the type of the span. Used to differentiate data from different sources
+ * by the backend.
+ * @param spanName the name of the span.
+ * @param spanStartTimeMs the start time of the span event in milliseconds.
+ * @param attributes the attributes of the span. emb-type is automatically added to these.
  */
 internal class StartSpanData(
+    embType: String,
     val spanName: String,
     val spanStartTimeMs: Long,
-    val attributes: Map<String, String>?
-)
+    attributes: Map<String, String>? = null
+) {
+    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType))
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -126,7 +126,7 @@ internal class EmbraceLogService(
             attributes.setLogId(Uuid.getEmbUuid())
 
             val logEventData = LogEventData(
-                startTimeMs = clock.nowInNanos(),
+                "emb-log",
                 message = trimToMaxLength(message),
                 severity = severity,
                 attributes = attributes.toMap()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanServiceImpl
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class SpanDataSourceKtTest {
@@ -19,13 +20,16 @@ internal class SpanDataSourceKtTest {
         )
         service.initializeService(1500000000000)
 
-        val span = service.startSpanCapture("") {
-            StartSpanData(
-                "spanName",
-                1500000000000,
-                mapOf("key" to "value")
-            )
-        }
+        val data = StartSpanData(
+            "my-type",
+            "spanName",
+            1500000000000,
+            mapOf("key" to "value")
+        )
+        assertEquals("my-type", data.attributes["emb.type"])
+        assertEquals("value", data.attributes["key"])
+
+        val span = service.startSpanCapture("") { data }
         checkNotNull(span)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
@@ -48,12 +48,12 @@ internal class FakeEmbraceSpan(
     }
 
     override fun addEvent(name: String): Boolean {
-        events.add(SpanEventData(name, 0, null))
+        events.add(SpanEventData(TYPE_VALUE, name, 0, null))
         return true
     }
 
     override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean {
-        events.add(SpanEventData(name, checkNotNull(timestampMs), attributes))
+        events.add(SpanEventData(TYPE_VALUE, name, checkNotNull(timestampMs), attributes))
         return true
     }
 
@@ -63,6 +63,7 @@ internal class FakeEmbraceSpan(
     }
 
     companion object {
+        private const val TYPE_VALUE = "emb-fake-span"
         fun notStarted(parent: EmbraceSpan? = null): FakeEmbraceSpan = FakeEmbraceSpan(parent)
 
         fun started(parent: EmbraceSpan? = null): FakeEmbraceSpan {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.Assert
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -83,28 +82,26 @@ internal class EmbraceLogServiceTest {
         assertEquals(3, logs.size)
         val first = logs[0]
         assertEquals("Hello world", first.message)
-        assertNotEquals(0, first.startTimeMs)
         assertEquals(Severity.INFO, first.severity)
-        assertEquals("bar", first.attributes?.get("foo"))
-        assertNotNull(first.attributes?.get("emb.log_id"))
-        assertEquals("session-123", first.attributes?.get("emb.session_id"))
-        assertNull(first.attributes?.get("emb.exception_type"))
+        assertEquals("bar", first.attributes["foo"])
+        assertNotNull(first.attributes["emb.log_id"])
+        assertEquals("session-123", first.attributes["emb.session_id"])
+        assertNull(first.attributes["emb.exception_type"])
 
         val second = logs[1]
         assertEquals("Warning world", second.message)
-        assertNotEquals(0, second.startTimeMs)
         assertEquals(Severity.WARNING, second.severity)
-        assertNotNull(second.attributes?.get("emb.log_id"))
-        assertEquals("session-123", second.attributes?.get("emb.session_id"))
-        assertNull(second.attributes?.get("emb.exception_type"))
+        assertNotNull(second.attributes["emb.log_id"])
+        assertEquals("session-123", second.attributes["emb.session_id"])
+        assertNull(second.attributes["emb.exception_type"])
 
         val third = logs[2]
         assertEquals("Hello errors", third.message)
-        assertNotEquals(0, third.startTimeMs)
         assertEquals(Severity.ERROR, third.severity)
-        assertNotNull(third.attributes?.get("emb.log_id"))
-        assertEquals("session-123", third.attributes?.get("emb.session_id"))
-        assertNull(third.attributes?.get("emb.exception_type"))
+        assertNotNull(third.attributes["emb.log_id"])
+        assertEquals("session-123", third.attributes["emb.session_id"])
+        assertNull(third.attributes["emb.exception_type"])
+        assertEquals("emb-log", third.attributes["emb.type"])
     }
 
     @Test
@@ -128,11 +125,12 @@ internal class EmbraceLogServiceTest {
         val log = logWriter.logEvents.single()
         assertEquals("Hello world", log.message)
         assertEquals(Severity.WARNING, log.severity)
-        assertEquals("NullPointerException", log.attributes?.get("emb.exception_name"))
-        assertEquals("exception message", log.attributes?.get("emb.exception_message"))
-        assertNotNull(log.attributes?.get("emb.log_id"))
-        assertEquals("session-123", log.attributes?.get("emb.session_id"))
-        assertEquals("none", log.attributes?.get("emb.exception_type"))
+        assertEquals("NullPointerException", log.attributes["emb.exception_name"])
+        assertEquals("exception message", log.attributes["emb.exception_message"])
+        assertNotNull(log.attributes["emb.log_id"])
+        assertEquals("session-123", log.attributes["emb.session_id"])
+        assertEquals("none", log.attributes["emb.exception_type"])
+        assertEquals("emb-log", log.attributes["emb.type"])
     }
 
     @Test
@@ -144,8 +142,8 @@ internal class EmbraceLogServiceTest {
         val log = logWriter.logEvents.single()
         assertEquals("Hello world", log.message)
         assertEquals(Severity.INFO, log.severity)
-        assertNotNull(log.attributes?.get("emb.log_id"))
-        assertEquals("session-123", log.attributes?.get("emb.session_id"))
+        assertNotNull(log.attributes["emb.log_id"])
+        assertEquals("session-123", log.attributes["emb.session_id"])
     }
 
     @Test
@@ -237,7 +235,7 @@ internal class EmbraceLogServiceTest {
         val log = logWriter.logEvents.single()
         assertEquals("Unity".repeat(1000), log.message) // log limit higher on unity
         // TBD: Assert stacktrace
-        assertEquals(LogExceptionType.HANDLED.value, log.attributes?.get("emb.exception_type"))
+        assertEquals(LogExceptionType.HANDLED.value, log.attributes["emb.exception_type"])
         // TBD: Assert unhandled exceptions
         // assertEquals(0, logMessageService.getUnhandledExceptionsSent())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -181,7 +181,7 @@ internal class CurrentSessionSpanImplTests {
     @Test
     fun `add event forwarded to span`() {
         currentSessionSpan.addEvent("test-event") {
-            SpanEventData(this, 1000L, mapOf("key" to "value"))
+            SpanEventData("my-type", this, 1000L, mapOf("key" to "value"))
         }
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session", span.name)
@@ -190,7 +190,7 @@ internal class CurrentSessionSpanImplTests {
         val testEvent = span.events.single()
         assertEquals("test-event", testEvent.name)
         assertEquals(1000, testEvent.timestampNanos.nanosToMillis())
-        assertEquals(mapOf("key" to "value"), testEvent.attributes)
+        assertEquals(mapOf("emb.type" to "my-type", "key" to "value"), testEvent.attributes)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Enforces that `emb-type` must be specified when creating a span, event, or a log in a `DataSource` implementation. This was requested by the backend to make it easier to distinguish between data types.

## Testing

Added unit test coverage.

