### PR TITLE
Allow capturing metadata in new envelope

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/metadata/EnvelopeMetadataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/metadata/EnvelopeMetadataSource.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.capture.envelope.metadata
+
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+
+/**
+ * Creates a [EnvelopeMetadata] object for Embrace API requests.
+ */
+internal fun interface EnvelopeMetadataSource {
+    fun getEnvelopeMetadata(): EnvelopeMetadata
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/metadata/EnvelopeMetadataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/metadata/EnvelopeMetadataSourceImpl.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.embracesdk.capture.envelope.metadata
+
+import io.embrace.android.embracesdk.capture.user.UserService
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import java.util.Locale
+import java.util.TimeZone
+
+internal class EnvelopeMetadataSourceImpl(
+    private val userService: UserService,
+) : EnvelopeMetadataSource {
+
+    override fun getEnvelopeMetadata(): EnvelopeMetadata {
+        val userInfo = userService.getUserInfo()
+
+        return EnvelopeMetadata(
+            userId = userInfo.userId,
+            email = userInfo.email,
+            username = userInfo.username,
+            personas = userInfo.personas ?: emptySet(),
+            timezoneDescription = TimeZone.getDefault().id,
+            locale = Locale.getDefault().language + "_" + Locale.getDefault().country
+        )
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/metadata/EnvelopeMetadataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/metadata/EnvelopeMetadataSourceImplTest.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.capture.envelope.metadata
+
+import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.payload.UserInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+internal class EnvelopeMetadataSourceImplTest {
+
+    @Test
+    fun getEnvelopeMetadata() {
+        val userService = FakeUserService().apply {
+            obj = UserInfo(
+                userId = "userId",
+                email = "email",
+                username = "username",
+                personas = setOf("persona1", "persona2")
+            )
+        }
+        val source = EnvelopeMetadataSourceImpl(userService)
+        val metadata = source.getEnvelopeMetadata()
+        assertEquals("userId", metadata.userId)
+        assertEquals("email", metadata.email)
+        assertEquals("username", metadata.username)
+        assertEquals(setOf("persona1", "persona2"), metadata.personas)
+        assertNotNull(metadata.timezoneDescription)
+        assertNotNull(metadata.locale)
+    }
+}


### PR DESCRIPTION
## Goal

Adds the ability to capture mutable data in the new `EnvelopeMetadata` class. This will eventually be used to construct a new payload, but right now is only touched in tests.

I have added an interface + implementation as this will make it easier to add fakes for our integration testing. We can follow a similar approach with `EnvelopeResource`. I have inlined functions for timezone/locale that were previously in `MetadataUtils` (as we want to get rid of that class ultimately)

## Testing

Added unit test coverage.
