### PR TITLE
Add skeleton for creating new payload

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/EnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/EnvelopeSource.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.capture.envelope
+
+import io.embrace.android.embracesdk.internal.payload.Envelope
+
+internal fun interface EnvelopeSource<T> {
+    fun getEnvelope(): Envelope<T>
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSource.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.capture.envelope
+
+import io.embrace.android.embracesdk.capture.envelope.session.SessionPayloadSource
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.session.SessionPayload
+
+internal class SessionEnvelopeSource(
+    private val sessionPayloadSource: SessionPayloadSource
+) : EnvelopeSource<SessionPayload> {
+
+    override fun getEnvelope(): Envelope<SessionPayload> {
+        sessionPayloadSource.getSessionPayload()
+        throw NotImplementedError("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSource.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.capture.envelope.resource
+
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+
+/**
+ * Creates a [EnvelopeResource] object.
+ */
+internal fun interface EnvelopeResourceSource {
+    fun getEnvelopeResource(): EnvelopeResource
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.capture.envelope.resource
+
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+
+internal class EnvelopeResourceSourceImpl : EnvelopeResourceSource {
+    override fun getEnvelopeResource(): EnvelopeResource {
+        throw NotImplementedError("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSource.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.capture.envelope.session
+
+import io.embrace.android.embracesdk.internal.session.SessionPayload
+
+/**
+ * Creates a [SessionPayload] object.
+ */
+internal fun interface SessionPayloadSource {
+    fun getSessionPayload(): SessionPayload
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.capture.envelope.session
+
+import io.embrace.android.embracesdk.internal.session.SessionPayload
+
+internal class SessionPayloadSourceImpl : SessionPayloadSource {
+
+    override fun getSessionPayload(): SessionPayload {
+        throw NotImplementedError("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSourceTest.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.capture.envelope
+
+import io.embrace.android.embracesdk.capture.envelope.session.SessionPayloadSourceImpl
+import org.junit.Test
+
+internal class SessionEnvelopeSourceTest {
+
+    @Test(expected = NotImplementedError::class)
+    fun getEnvelope() {
+        SessionEnvelopeSource(SessionPayloadSourceImpl()).getEnvelope()
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.embracesdk.capture.envelope.resource
+
+import org.junit.Test
+
+internal class EnvelopeResourceSourceImplTest {
+
+    @Test(expected = NotImplementedError::class)
+    fun `test source`() {
+        EnvelopeResourceSourceImpl().getEnvelopeResource()
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.embracesdk.capture.envelope.session
+
+import org.junit.Test
+
+internal class SessionPayloadSourceImplTest {
+
+    @Test(expected = NotImplementedError::class)
+    fun getSessionPayload() {
+        SessionPayloadSourceImpl().getSessionPayload()
+    }
+}


### PR DESCRIPTION
## Goal

Adds skeleton classes that will capture data in the new `Envelope` classes. This will eventually be used to construct a new payload, but right now is only touched in tests.
