### PR TITLE
Set the window callback on the mock activity so callback is never null when the activity is created

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/internal/MockActivity.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/internal/MockActivity.kt
@@ -13,6 +13,12 @@ import androidx.appcompat.app.AppCompatActivity
 public class MockActivity(private val context: EmbraceContext) : AppCompatActivity() {
     private val fragmentManager = MockFragmentManager(this)
     private val mockView = MockView(context)
+    private val mockWindow = MockWindow(context, mockView)
+
+    init {
+        mockWindow.callback = this
+    }
+
     public fun setContext(context: Context) {
         this.attachBaseContext(context)
     }
@@ -27,6 +33,6 @@ public class MockActivity(private val context: EmbraceContext) : AppCompatActivi
     }
 
     override fun getWindow(): Window {
-        return MockWindow(context, mockView)
+        return mockWindow
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -188,6 +188,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     override val startupTracker: StartupTracker by singleton {
         StartupTracker(
             appStartupTraceEmitter = appStartupTraceEmitter,
+            logger = coreModule.logger,
             versionChecker = versionChecker,
         )
     }


### PR DESCRIPTION
## Goal

The functional tests' mocks are missing the window callback, so the startup code fails. Fixed the mocks as well as deal with the case where the window callback is null, which should not happen, but just in case.....

## Testing

Functional tests pass