### PR TITLE
Add internal error payload models

### DIFF
--- a/embrace-android-sdk/config/detekt/baseline.xml
+++ b/embrace-android-sdk/config/detekt/baseline.xml
@@ -2,9 +2,11 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>DataClassContainsFunctions:ExceptionError.kt$ExceptionError$fun addException(ex: Throwable?, appState: String?, clock: Clock)</ID>
-    <ID>DataClassContainsFunctions:ExceptionError.kt$ExceptionError$private fun getExceptionInfo(ex: Throwable?): List&lt;ExceptionInfo&gt;</ID>
-    <ID>DataClassShouldBeImmutable:ExceptionError.kt$ExceptionError$@Json(name = "c") var occurrences = 0</ID>
-    <ID>DataClassShouldBeImmutable:ExceptionError.kt$ExceptionError$@Json(name = "rep") var exceptionErrors = mutableListOf&lt;ExceptionErrorInfo&gt;()</ID>
+    <ID>ArgumentListWrapping:LegacyExceptionInfoTest.kt$LegacyExceptionInfoTest$( "io.embrace.android.embracesdk.LegacyExceptionInfoTest.testOfThrowable(LegacyExceptionInfoTest.kt:45)", info.lines.first())</ID>
+    <ID>ArgumentListWrapping:LegacyExceptionInfoTest.kt$LegacyExceptionInfoTest$("io.embrace.android.embracesdk.LegacyExceptionInfoTest.testOfThrowable(LegacyExceptionInfoTest.kt:45)", info.lines.first())</ID>
+    <ID>DataClassContainsFunctions:LegacyExceptionError.kt$LegacyExceptionError$fun addException(ex: Throwable?, appState: String?, clock: Clock)</ID>
+    <ID>DataClassContainsFunctions:LegacyExceptionError.kt$LegacyExceptionError$private fun getExceptionInfo(ex: Throwable?): List&lt;LegacyExceptionInfo&gt;</ID>
+    <ID>DataClassShouldBeImmutable:LegacyExceptionError.kt$LegacyExceptionError$@Json(name = "c") var occurrences = 0</ID>
+    <ID>DataClassShouldBeImmutable:LegacyExceptionError.kt$LegacyExceptionError$@Json(name = "rep") var exceptionErrors = mutableListOf&lt;LegacyExceptionErrorInfo&gt;()</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.assertions
 
-import io.embrace.android.embracesdk.payload.ExceptionError
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.IntegrationTestRule
 import org.junit.Assert.assertTrue
 
@@ -8,7 +8,7 @@ import org.junit.Assert.assertTrue
  * Return true if at least one exception matching the expected time, exception type, and error message is found in the internal errors
  */
 internal fun assertInternalErrorLogged(
-    exceptionError: ExceptionError?,
+    exceptionError: LegacyExceptionError?,
     exceptionClassName: String,
     errorMessage: String,
     errorTimeMs: Long = IntegrationTestRule.DEFAULT_SDK_START_TIME_MS

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/ExceptionErrorInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/ExceptionErrorInfo.kt
@@ -1,0 +1,42 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ *
+ *
+ * @param timestamp The timestamp in milliseconds of when an error happened. Previous name: s.e.rep.ts
+ * @param appState The app state at the time of the error (foreground/background). Previous name: s.e.rep.s
+ * @param exceptions A list of exceptions. Previous name: s.e.rep.ex
+ */
+@JsonClass(generateAdapter = true)
+internal data class ExceptionErrorInfo(
+
+    /* The timestamp in milliseconds of when an error happened. Previous name: s.e.rep.ts */
+    @Json(name = "timestamp")
+    val timestamp: Long? = null,
+
+    /* The app state at the time of the error (foreground/background). Previous name: s.e.rep.s */
+    @Json(name = "app_state")
+    val appState: AppState? = null,
+
+    /* A list of exceptions. Previous name: s.e.rep.ex */
+    @Json(name = "exceptions")
+    val exceptions: List<ExceptionInfo>? = null
+
+) {
+
+    /**
+     * The app state at the time of the error (foreground/background). Previous name: s.e.rep.s
+     *
+     * Values: ACTIVE,BACKGROUND
+     */
+    internal enum class AppState(val value: String) {
+        @Json(name = "active")
+        ACTIVE("active"),
+
+        @Json(name = "background")
+        BACKGROUND("background")
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/ExceptionInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/ExceptionInfo.kt
@@ -1,0 +1,28 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Describes a Java exception.
+ *
+ * @param name The name of the class causing an error. Previous name: s.e.rep.ex.n
+ * @param message The error message, if any. Previous name: s.e.rep.ex.m
+ * @param stacktrace String representation of each line in the stack trace. Previous name: s.e.rep.ex.tt
+ */
+@JsonClass(generateAdapter = true)
+internal data class ExceptionInfo(
+
+    /* The name of the class causing an error. Previous name: s.e.rep.ex.n */
+    @Json(name = "name")
+    val name: String? = null,
+
+    /* The error message, if any. Previous name: s.e.rep.ex.m */
+    @Json(name = "message")
+    val message: String? = null,
+
+    /* String representation of each line in the stack trace. Previous name: s.e.rep.ex.tt */
+    @Json(name = "stacktrace")
+    val stacktrace: List<String>? = null
+
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/InternalError.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/InternalError.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Describes an Exception Error with a count of occurrences and a list of exceptions (causes).
+ *
+ * @param count The number of internal error that occurred within Embrace. Previous name: s.e.c
+ * @param errors A list of causes of the internal error. Previous name: s.e.rep
+ */
+@JsonClass(generateAdapter = true)
+internal data class InternalError(
+
+    /* The number of internal error that occurred within Embrace. Previous name: s.e.c */
+    @Json(name = "count")
+    val count: Int? = null,
+
+    /* A list of causes of the internal error. Previous name: s.e.rep */
+    @Json(name = "errors")
+    val errors: List<ExceptionErrorInfo>? = null
+
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SessionPayload.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SessionPayload.kt
@@ -5,6 +5,10 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 internal data class SessionPayload(
+
+    @Json(name = "internal_error")
+    val internalError: InternalError? = null,
+
     /**
      * A map of symbols that are associated with the session.
      * We use this to associate the symbolication files that have been uploaded with UUIDs with the stacktrace module names,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
-import io.embrace.android.embracesdk.payload.ExceptionError
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import java.net.BindException
 import java.net.ConnectException
@@ -26,9 +26,9 @@ internal class EmbraceInternalErrorService(
     private val logStrictMode: Boolean
 ) : InternalErrorService {
     private var configService: ConfigService? = null
-    private var err: ExceptionError? = null
+    private var err: LegacyExceptionError? = null
 
-    override val currentExceptionError: ExceptionError?
+    override val currentExceptionError: LegacyExceptionError?
         get() = err
 
     // ignore network-related exceptions since they are expected
@@ -104,7 +104,7 @@ internal class EmbraceInternalErrorService(
             return
         }
         if (err == null) {
-            err = ExceptionError(logStrictMode)
+            err = LegacyExceptionError(logStrictMode)
         }
 
         // if the config service has not been set yet, capture the exception

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorService.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.logging
 
 import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.payload.ExceptionError
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
 
 internal interface InternalErrorService {
     fun setConfigService(configService: ConfigService?)
     fun handleInternalError(throwable: Throwable)
     fun resetExceptionErrorObject()
-    val currentExceptionError: ExceptionError?
+    val currentExceptionError: LegacyExceptionError?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Crash.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Crash.kt
@@ -10,7 +10,7 @@ internal data class Crash(
     val crashId: String,
 
     @Json(name = "ex")
-    val exceptions: List<ExceptionInfo>? = null,
+    val exceptions: List<LegacyExceptionInfo>? = null,
 
     @Json(name = "rep_js")
     val jsExceptions: List<String>? = null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/LegacyExceptionErrorInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/LegacyExceptionErrorInfo.kt
@@ -2,13 +2,14 @@ package io.embrace.android.embracesdk.payload
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import io.embrace.android.embracesdk.internal.payload.ExceptionErrorInfo
 
 /**
  * Describes a particular Exception error. Where an exception error has a cause, there will be an
  * {@link ExceptionErrorInfo} for each nested cause.
  */
 @JsonClass(generateAdapter = true)
-internal data class ExceptionErrorInfo(
+internal data class LegacyExceptionErrorInfo(
 
     /**
      * Timestamp when exception error happened.
@@ -23,6 +24,18 @@ internal data class ExceptionErrorInfo(
     /**
      * A list of exceptions.
      */
-    @Json(name = "ex") val exceptions: List<ExceptionInfo>? = null
+    @Json(name = "ex") val exceptions: List<LegacyExceptionInfo>? = null
 
-)
+) {
+    fun toNewPayload(): ExceptionErrorInfo {
+        val mappedState = when (state) {
+            "background" -> ExceptionErrorInfo.AppState.BACKGROUND
+            else -> ExceptionErrorInfo.AppState.ACTIVE
+        }
+        return ExceptionErrorInfo(
+            timestamp,
+            mappedState,
+            exceptions?.map(LegacyExceptionInfo::toNewPayload)
+        )
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/LegacyExceptionInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/LegacyExceptionInfo.kt
@@ -5,10 +5,10 @@ import com.squareup.moshi.JsonClass
 
 /**
  * Describes a particular Java exception. Where an exception has a cause, there will be an
- * [ExceptionInfo] for each nested cause.
+ * [LegacyExceptionInfo] for each nested cause.
  */
 @JsonClass(generateAdapter = true)
-internal class ExceptionInfo internal constructor(
+internal class LegacyExceptionInfo internal constructor(
 
     /**
      * The name of the class throwing the exception.
@@ -35,6 +35,10 @@ internal class ExceptionInfo internal constructor(
     @Json(name = "length")
     val originalLength: Int? = lines.size.takeIf { it > STACK_FRAME_LIMIT }
 
+    fun toNewPayload(): io.embrace.android.embracesdk.internal.payload.ExceptionInfo {
+        return io.embrace.android.embracesdk.internal.payload.ExceptionInfo(name, message, lines)
+    }
+
     companion object {
 
         /**
@@ -43,18 +47,18 @@ internal class ExceptionInfo internal constructor(
         private const val STACK_FRAME_LIMIT = 200
 
         /**
-         * Creates a [ExceptionInfo] from a [Throwable], using the classname as the name,
+         * Creates a [LegacyExceptionInfo] from a [Throwable], using the classname as the name,
          * the exception message as the message, and each stacktrace element as each line.
          *
          * @param throwable the exception
          * @return the stacktrace instance
          */
         @JvmStatic
-        fun ofThrowable(throwable: Throwable): ExceptionInfo {
+        fun ofThrowable(throwable: Throwable): LegacyExceptionInfo {
             val name = throwable.javaClass.name
             val message = throwable.message ?: ""
             val lines = throwable.stackTrace.map(StackTraceElement::toString)
-            return ExceptionInfo(name, message, lines)
+            return LegacyExceptionInfo(name, message, lines)
         }
     }
 
@@ -62,7 +66,7 @@ internal class ExceptionInfo internal constructor(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as ExceptionInfo
+        other as LegacyExceptionInfo
 
         if (name != other.name) return false
         if (message != other.message) return false

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
@@ -85,7 +85,7 @@ internal data class Session @JvmOverloads internal constructor(
     val errorLogsAttemptedToSend: Int? = null,
 
     @Json(name = "e")
-    val exceptionError: ExceptionError? = null,
+    val exceptionError: LegacyExceptionError? = null,
 
     @Json(name = "ri")
     val crashReportId: String? = null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Crash
-import io.embrace.android.embracesdk.payload.ExceptionInfo
 import io.embrace.android.embracesdk.payload.JsException
+import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
 import io.embrace.android.embracesdk.payload.ThreadInfo
 
 internal object CrashFactory {
@@ -39,14 +39,14 @@ internal object CrashFactory {
 
     /**
      * @param ex the throwable to parse
-     * @return a list of [ExceptionInfo] elements of the throwable.
+     * @return a list of [LegacyExceptionInfo] elements of the throwable.
      */
     @JvmStatic
-    private fun exceptionInfo(ex: Throwable?): List<ExceptionInfo> {
-        val result = mutableListOf<ExceptionInfo>()
+    private fun exceptionInfo(ex: Throwable?): List<LegacyExceptionInfo> {
+        val result = mutableListOf<LegacyExceptionInfo>()
         var throwable: Throwable? = ex
         while (throwable != null && throwable != throwable.cause) {
-            val exceptionInfo = ExceptionInfo.ofThrowable(throwable)
+            val exceptionInfo = LegacyExceptionInfo.ofThrowable(throwable)
             result.add(0, exceptionInfo)
             throwable = throwable.cause
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
@@ -18,8 +18,8 @@ import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarker
 import io.embrace.android.embracesdk.payload.Crash
-import io.embrace.android.embracesdk.payload.ExceptionInfo
 import io.embrace.android.embracesdk.payload.JsException
+import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import io.embrace.android.embracesdk.payload.extensions.CrashFactory
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
@@ -183,7 +183,7 @@ internal class EmbraceCrashServiceTest {
         val crash = Crash(
             "123",
             listOf(
-                ExceptionInfo(
+                LegacyExceptionInfo(
                     "java.lang.RuntimeException",
                     "ExceptionMessage",
                     listOf("stacktrace.line")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LegacyExceptionInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LegacyExceptionInfoTest.kt
@@ -1,15 +1,15 @@
 package io.embrace.android.embracesdk
 
 import com.squareup.moshi.JsonDataException
-import io.embrace.android.embracesdk.payload.ExceptionInfo
+import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
-internal class ExceptionInfoTest {
+internal class LegacyExceptionInfoTest {
 
-    private val info = ExceptionInfo(
+    private val info = LegacyExceptionInfo(
         "java.lang.IllegalStateException",
         "Whoops!",
         listOf(
@@ -25,7 +25,7 @@ internal class ExceptionInfoTest {
 
     @Test
     fun testExceptionInfoDeserialization() {
-        val obj = deserializeJsonFromResource<ExceptionInfo>("exception_info_expected.json")
+        val obj = deserializeJsonFromResource<LegacyExceptionInfo>("exception_info_expected.json")
         assertEquals("java.lang.IllegalStateException", obj.name)
         assertEquals("Whoops!", obj.message)
         assertEquals("java.base/java.lang.Thread.getStackTrace(Thread.java:1602)", obj.lines[0])
@@ -37,17 +37,20 @@ internal class ExceptionInfoTest {
 
     @Test(expected = JsonDataException::class)
     fun testExceptionInfoEmptyObject() {
-        deserializeEmptyJsonString<ExceptionInfo>()
+        deserializeEmptyJsonString<LegacyExceptionInfo>()
     }
 
     @Test
     fun testOfThrowable() {
         val throwable = object : Throwable("UhOh.") {}
-        val info = ExceptionInfo.ofThrowable(throwable)
+        val info = LegacyExceptionInfo.ofThrowable(throwable)
         assertNotNull(info)
         assertEquals("UhOh.", info.message)
-        assertEquals("io.embrace.android.embracesdk.ExceptionInfoTest\$testOfThrowable\$throwable\$1", info.name)
-        assertEquals("io.embrace.android.embracesdk.ExceptionInfoTest.testOfThrowable(ExceptionInfoTest.kt:45)", info.lines.first())
+        assertEquals("io.embrace.android.embracesdk.LegacyExceptionInfoTest\$testOfThrowable\$throwable\$1", info.name)
+        assertEquals(
+            "io.embrace.android.embracesdk.LegacyExceptionInfoTest.testOfThrowable(LegacyExceptionInfoTest.kt:45)",
+            info.lines.first()
+        )
         assertNull(info.originalLength)
     }
 
@@ -55,7 +58,7 @@ internal class ExceptionInfoTest {
     fun testMaxStacktraceLimit() {
         val limit = 200
         val len = limit + 100
-        val obj = ExceptionInfo(
+        val obj = LegacyExceptionInfo(
             "java.lang.IllegalStateException",
             "Whoops!",
             (0 until len).map { "line $it" }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LegacyLegacyExceptionErrorInfoTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LegacyLegacyExceptionErrorInfoTest.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.payload.ExceptionErrorInfo
-import io.embrace.android.embracesdk.payload.ExceptionInfo
+import io.embrace.android.embracesdk.payload.LegacyExceptionErrorInfo
+import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-internal class ExceptionErrorInfoTest {
+internal class LegacyLegacyExceptionErrorInfoTest {
 
-    private val info = ExceptionInfo(
+    private val info = LegacyExceptionInfo(
         "java.lang.IllegalStateException",
         "Whoops!",
         listOf(
@@ -18,7 +18,7 @@ internal class ExceptionErrorInfoTest {
 
     @Test
     fun testExceptionErrorInfoSerialization() {
-        val exceptionErrorInfo = ExceptionErrorInfo(
+        val exceptionErrorInfo = LegacyExceptionErrorInfo(
             0,
             "STATE",
             listOf(
@@ -30,7 +30,7 @@ internal class ExceptionErrorInfoTest {
 
     @Test
     fun testExceptionErrorInfoDeserialization() {
-        val obj = deserializeJsonFromResource<ExceptionErrorInfo>("exception_error_info_expected.json")
+        val obj = deserializeJsonFromResource<LegacyExceptionErrorInfo>("exception_error_info_expected.json")
         assertEquals(0L, obj.timestamp)
         assertEquals("STATE", obj.state)
         val exceptionInfo = obj.exceptions?.get(0)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import com.squareup.moshi.JsonDataException
 import io.embrace.android.embracesdk.payload.BetaFeatures
-import io.embrace.android.embracesdk.payload.ExceptionError
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.payload.Orientation
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
@@ -41,7 +41,7 @@ internal class SessionTest {
         startupThreshold = 5000,
         sdkStartupDuration = 109,
         unhandledExceptions = 1,
-        exceptionError = ExceptionError(false),
+        exceptionError = LegacyExceptionError(false),
         orientations = listOf(Orientation(1, 16092342200)),
         properties = mapOf("fake-key" to "fake-value"),
         symbols = mapOf("fake-native-key" to "fake-native-value"),
@@ -92,7 +92,7 @@ internal class SessionTest {
             assertEquals(5000L, startupThreshold)
             assertEquals(109L, sdkStartupDuration)
             assertEquals(1, unhandledExceptions)
-            assertEquals(ExceptionError(false), exceptionError)
+            assertEquals(LegacyExceptionError(false), exceptionError)
             assertEquals(listOf(Orientation(1, 16092342200)), orientations)
             assertEquals(mapOf("fake-key" to "fake-value"), properties)
             assertEquals(mapOf("fake-native-key" to "fake-native-value"), symbols)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalErrorService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalErrorService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalErrorService
-import io.embrace.android.embracesdk.payload.ExceptionError
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
 
 internal class FakeInternalErrorService : InternalErrorService {
 
@@ -22,5 +22,5 @@ internal class FakeInternalErrorService : InternalErrorService {
         resetCallCount++
     }
 
-    override var currentExceptionError: ExceptionError? = null
+    override var currentExceptionError: LegacyExceptionError? = null
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/payload/MapInternalErrorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/payload/MapInternalErrorTest.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import io.embrace.android.embracesdk.internal.payload.ExceptionErrorInfo.AppState
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
+import io.embrace.android.embracesdk.payload.LegacyExceptionErrorInfo
+import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class MapInternalErrorTest {
+
+    @Test
+    fun `convert to model`() {
+        val input = LegacyExceptionError()
+        input.occurrences = 1
+        input.exceptionErrors.add(
+            LegacyExceptionErrorInfo(
+                timestamp = 0,
+                state = "foreground",
+                exceptions = listOf(
+                    LegacyExceptionInfo(
+                        name = "name",
+                        message = "message",
+                        lines = listOf("line1", "line2")
+                    )
+                )
+            )
+        )
+
+        // validate transform
+        val output = input.toNewPayload()
+        assertEquals(1, output.count)
+
+        val error = checkNotNull(output.errors).single()
+        assertEquals(0L, error.timestamp)
+        assertEquals(AppState.ACTIVE, error.appState)
+
+        val exception = checkNotNull(error.exceptions).single()
+        assertEquals("name", exception.name)
+        assertEquals("message", exception.message)
+        assertEquals(listOf("line1", "line2"), exception.stacktrace)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
@@ -27,7 +27,7 @@ internal class BackgroundActivityTest {
         infoLogsAttemptedToSend = 1,
         warnLogsAttemptedToSend = 2,
         errorLogsAttemptedToSend = 3,
-        exceptionError = ExceptionError(false),
+        exceptionError = LegacyExceptionError(false),
         crashReportId = "fake-crash-id",
         endType = Session.LifeEventType.BKGND_STATE,
         startType = Session.LifeEventType.BKGND_STATE,
@@ -65,7 +65,7 @@ internal class BackgroundActivityTest {
             assertEquals(Session.LifeEventType.BKGND_STATE, endType)
             assertEquals(Session.LifeEventType.BKGND_STATE, startType)
             assertEquals(1, unhandledExceptions)
-            assertEquals(ExceptionError(false), exceptionError)
+            assertEquals(LegacyExceptionError(false), exceptionError)
             assertEquals(mapOf("fake-key" to "fake-value"), properties)
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/LegacyExceptionErrorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/LegacyExceptionErrorTest.kt
@@ -9,10 +9,10 @@ import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
 import org.junit.Test
 
-internal class ExceptionErrorTest {
+internal class LegacyExceptionErrorTest {
 
     companion object {
-        private lateinit var exceptionError: ExceptionError
+        private lateinit var exceptionError: LegacyExceptionError
         private lateinit var clock: FakeClock
 
         @BeforeClass
@@ -30,15 +30,15 @@ internal class ExceptionErrorTest {
 
     @Test
     fun `serialize then deserialize default object`() {
-        val obj = ExceptionError(false)
+        val obj = LegacyExceptionError(false)
         assertJsonMatchesGoldenFile("exception_error_expected.json", obj)
-        val other = deserializeJsonFromResource<ExceptionError>("exception_error_expected.json")
+        val other = deserializeJsonFromResource<LegacyExceptionError>("exception_error_expected.json")
         assertEquals(obj, other)
     }
 
     @Test
     fun `test addException with strict mode disabled has a limit of 5 exceptions`() {
-        exceptionError = ExceptionError(false)
+        exceptionError = LegacyExceptionError(false)
         val throwable = Throwable("exceptions")
         exceptionError.addException(throwable, "state", clock)
         exceptionError.addException(throwable, "state", clock)
@@ -53,7 +53,7 @@ internal class ExceptionErrorTest {
 
     @Test
     fun `test addException with strict mode enabled has a limit of 50 exceptions`() {
-        exceptionError = ExceptionError(true)
+        exceptionError = LegacyExceptionError(true)
         val throwable = Throwable("exceptions")
 
         repeat(50) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadMessageCollatorTest.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.payload.ExceptionError
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -50,7 +50,7 @@ internal class PayloadMessageCollatorTest {
             preferencesService = FakePreferenceService(),
             eventService = FakeEventService(),
             logMessageService = FakeLogMessageService(),
-            internalErrorService = FakeInternalErrorService().apply { currentExceptionError = ExceptionError() },
+            internalErrorService = FakeInternalErrorService().apply { currentExceptionError = LegacyExceptionError() },
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),


### PR DESCRIPTION
## Goal

Adds model classes for the new internal error payload. This is mostly generated via OpenAPI but tweaked manually for style reasons.

## Testing

Added unit test to confirm new model can be constructed from old one.

