### PR TITLE
Extract emb.type to separate source file

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.arch.destination
 
 import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.arch.schema.TelemetryType
 
 /**
  * Represents a Log event that can be added to the current session span.
@@ -13,10 +14,10 @@ import io.embrace.android.embracesdk.Severity
  * @param attributes the attributes of the span. emb-type is automatically added to these.
  */
 internal class LogEventData(
-    embType: String,
+    embType: TelemetryType,
     val severity: Severity,
     val message: String,
     attributes: Map<String, String>? = null
 ) {
-    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType))
+    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType.description))
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.arch.destination
 
+import io.embrace.android.embracesdk.arch.schema.TelemetryType
+
 /**
  * Represents a span event that can be added to the current session span.
  *
@@ -10,10 +12,10 @@ package io.embrace.android.embracesdk.arch.destination
  * @param attributes the attributes of the span event. emb-type is automatically added to these.
  */
 internal class SpanEventData(
-    embType: String,
+    embType: TelemetryType,
     val spanName: String,
     val spanStartTimeMs: Long,
     attributes: Map<String, String>? = null
 ) {
-    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType))
+    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType.description))
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.arch.destination
 
+import io.embrace.android.embracesdk.arch.schema.TelemetryType
+
 /**
  * Holds the information required to start a span.
  *
@@ -10,10 +12,10 @@ package io.embrace.android.embracesdk.arch.destination
  * @param attributes the attributes of the span. emb-type is automatically added to these.
  */
 internal class StartSpanData(
-    embType: String,
+    embType: TelemetryType,
     val spanName: String,
     val spanStartTimeMs: Long,
     attributes: Map<String, String>? = null
 ) {
-    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType))
+    val attributes = (attributes ?: emptyMap()).plus(Pair("emb.type", embType.description))
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.arch.schema
+
+internal sealed class EmbType {
+
+    /**
+     * Keys that track how fast a time interval is. Only applies to spans.
+     */
+    internal sealed class Performance : TelemetryType
+
+    /**
+     * Keys that track a point in time & is visual in nature. Applies to spans, logs, and span events.
+     */
+    internal sealed class Ux(subtype: String) : TelemetryType {
+        internal object View : Ux("view")
+
+        override val description = "ux.$subtype"
+    }
+
+    /**
+     * Keys that track a point in time that is not visual in nature. Applies to spans, logs, and span events.
+     */
+    internal sealed class System(subtype: String) : TelemetryType {
+        internal object Breadcrumb : System("breadcrumb")
+        internal object Log : System("log")
+        internal object Exit : System("exit")
+
+        override val description = "system.$subtype"
+    }
+}
+
+/**
+ * Represents a telemetry type (emb.type). For example, "ux.view" is a type that represents
+ * a visual event around a UI element. ux is the type, and view is the subtype. This tells the
+ * backend that it can assume the data in the event follows a particular schema.
+ */
+internal interface TelemetryType {
+    val description: String
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.arch.destination.LogEventData
 import io.embrace.android.embracesdk.arch.destination.LogEventMapper
 import io.embrace.android.embracesdk.arch.destination.LogWriter
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.config.ConfigService
@@ -47,7 +48,6 @@ internal class AeiDataSourceImpl(
 ) {
 
     companion object {
-        private const val TYPE_NAME = "system.exit"
         private const val LOG_NAME = "aei-record"
         private const val SDK_AEI_SEND_LIMIT = 32
     }
@@ -224,7 +224,7 @@ internal class AeiDataSourceImpl(
             "trace-status" to message.traceStatus
         )
         return LogEventData(
-            TYPE_NAME,
+            EmbType.System.Exit,
             severity = Severity.INFO,
             message = LOG_NAME,
             attributes = attrs.toNonNullMap()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.destination.SpanEventMapper
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.payload.CustomBreadcrumb
@@ -22,7 +23,6 @@ internal class CustomBreadcrumbDataSource(
     SpanEventMapper<CustomBreadcrumb> {
 
     companion object {
-        internal const val TYPE_NAME = "system.breadcrumb"
         internal const val EVENT_NAME = "custom-breadcrumb"
         internal const val ATTR_KEY_MESSAGE = "message"
     }
@@ -40,7 +40,7 @@ internal class CustomBreadcrumbDataSource(
     }
 
     override fun toSpanEventData(obj: CustomBreadcrumb) = SpanEventData(
-        TYPE_NAME,
+        EmbType.System.Breadcrumb,
         EVENT_NAME,
         obj.timestamp.millisToNanos(),
         mapOf("message" to (obj.message ?: ""))

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSource.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.arch.datasource.startSpanCapture
 import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.arch.destination.StartSpanMapper
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.SpanService
@@ -26,7 +27,6 @@ internal class FragmentBreadcrumbDataSource(
     StartSpanMapper<FragmentBreadcrumb> {
 
     companion object {
-        internal const val TYPE_NAME = "ux.view"
         internal const val SPAN_NAME = "screen-view"
     }
 
@@ -74,7 +74,7 @@ internal class FragmentBreadcrumbDataSource(
 
     override fun toStartSpanData(obj: FragmentBreadcrumb): StartSpanData = with(obj) {
         StartSpanData(
-            embType = TYPE_NAME,
+            embType = EmbType.Ux.View,
             spanName = SPAN_NAME,
             spanStartTimeMs = start,
             attributes = mapOf("view.name" to name)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.arch.destination.LogEventData
 import io.embrace.android.embracesdk.arch.destination.LogWriter
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.behavior.LogMessageBehavior
@@ -128,7 +129,7 @@ internal class EmbraceLogService(
             attributes.setLogId(Uuid.getEmbUuid())
 
             val logEventData = LogEventData(
-                "emb-log",
+                EmbType.System.Log,
                 message = trimToMaxLength(message),
                 severity = severity,
                 attributes = attributes.toMap()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.arch.datasource.startSpanCapture
 import io.embrace.android.embracesdk.arch.destination.StartSpanData
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanServiceImpl
@@ -21,12 +22,12 @@ internal class SpanDataSourceKtTest {
         service.initializeService(1500000000000)
 
         val data = StartSpanData(
-            "my-type",
+            EmbType.Ux.View,
             "spanName",
             1500000000000,
             mapOf("key" to "value")
         )
-        assertEquals("my-type", data.attributes["emb.type"])
+        assertEquals("ux.view", data.attributes["emb.type"])
         assertEquals("value", data.attributes["key"])
 
         val span = service.startSpanCapture("") { data }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbraceSpan.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.spans.EmbraceAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -48,12 +49,12 @@ internal class FakeEmbraceSpan(
     }
 
     override fun addEvent(name: String): Boolean {
-        events.add(SpanEventData(TYPE_VALUE, name, 0, null))
+        events.add(SpanEventData(EmbType.System.Log, name, 0, null))
         return true
     }
 
     override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean {
-        events.add(SpanEventData(TYPE_VALUE, name, checkNotNull(timestampMs), attributes))
+        events.add(SpanEventData(EmbType.System.Log, name, checkNotNull(timestampMs), attributes))
         return true
     }
 
@@ -63,7 +64,6 @@ internal class FakeEmbraceSpan(
     }
 
     companion object {
-        private const val TYPE_VALUE = "emb-fake-span"
         fun notStarted(parent: EmbraceSpan? = null): FakeEmbraceSpan = FakeEmbraceSpan(parent)
 
         fun started(parent: EmbraceSpan? = null): FakeEmbraceSpan {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -103,7 +103,7 @@ internal class EmbraceLogServiceTest {
         assertNotNull(third.attributes["emb.log_id"])
         assertEquals("session-123", third.attributes["emb.session_id"])
         assertNull(third.attributes["emb.exception_type"])
-        assertEquals("emb-log", third.attributes["emb.type"])
+        assertEquals("system.log", third.attributes["emb.type"])
     }
 
     @Test
@@ -132,7 +132,7 @@ internal class EmbraceLogServiceTest {
         assertNotNull(log.attributes["emb.log_id"])
         assertEquals("session-123", log.attributes["emb.session_id"])
         assertEquals("none", log.attributes["emb.exception_type"])
-        assertEquals("emb-log", log.attributes["emb.type"])
+        assertEquals("system.log", log.attributes["emb.type"])
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -181,7 +182,7 @@ internal class CurrentSessionSpanImplTests {
     @Test
     fun `add event forwarded to span`() {
         currentSessionSpan.addEvent("test-event") {
-            SpanEventData("my-type", this, 1000L, mapOf("key" to "value"))
+            SpanEventData(EmbType.System.Exit, this, 1000L, mapOf("key" to "value"))
         }
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session", span.name)
@@ -190,7 +191,7 @@ internal class CurrentSessionSpanImplTests {
         val testEvent = span.events.single()
         assertEquals("test-event", testEvent.name)
         assertEquals(1000, testEvent.timestampNanos.nanosToMillis())
-        assertEquals(mapOf("emb.type" to "my-type", "key" to "value"), testEvent.attributes)
+        assertEquals(mapOf("emb.type" to "system.exit", "key" to "value"), testEvent.attributes)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Extracts the possible values for `emb.type` into a separate source file. I have organised these as enums implementing a common interface to get a bit of type safety rather than throwing strings around everywhere.

#519 also takes this further with a POC for the rest of the strings.