### PR TITLE
Fix functional test flakes

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/AnrIntegrationTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/AnrIntegrationTest.kt
@@ -75,10 +75,10 @@ internal class AnrIntegrationTest : BaseTest() {
         sendBackground()
 
         // ignore startup moment end request that is validated in other tests
-        waitForRequest()
+        waitForRequest(RequestValidator(EmbraceEndpoint.EVENTS) {})
 
         // validate ANRs with JUnit assertions rather than golden file
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.SESSIONS) { request ->
             val payload = readBodyAsSessionMessage(request)
             assertNotNull(payload)
             val perfInfo by lazy { serializer.toJson(payload.performanceInfo) }
@@ -86,7 +86,7 @@ internal class AnrIntegrationTest : BaseTest() {
                 "No ANR intervals in payload. p=$perfInfo"
             }
             validateIntervals(intervals)
-        }
+        })
     }
 
     private fun validateIntervals(intervals: List<AnrInterval>) {

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/LogMessageTest.kt
@@ -29,9 +29,9 @@ internal class LogMessageTest : BaseTest() {
         logTestMessage("Adding info log to Embrace.")
         Embrace.getInstance().logInfo("Test log info")
 
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.LOGGING) { request ->
             validateMessageAgainstGoldenFile(request, "log-info-event.json")
-        }
+        })
     }
 
     @Test
@@ -42,9 +42,9 @@ internal class LogMessageTest : BaseTest() {
         properties["info"] = "test property"
         Embrace.getInstance().logMessage("Test log info with property", Severity.INFO, properties)
 
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.LOGGING) { request ->
             validateMessageAgainstGoldenFile(request, "log-info-with-property-event.json")
-        }
+        })
     }
 
     private fun validateFileContent(file: File) {
@@ -68,9 +68,9 @@ internal class LogMessageTest : BaseTest() {
         logTestMessage("Adding error log to Embrace.")
         Embrace.getInstance().logError("Test log error")
 
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.LOGGING) { request ->
             validateMessageAgainstGoldenFile(request, "log-error-event.json")
-        }
+        })
     }
 
     @Test
@@ -81,9 +81,9 @@ internal class LogMessageTest : BaseTest() {
 
         Embrace.getInstance().logMessage("Test log error", Severity.ERROR, properties)
 
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.LOGGING) { request ->
             validateMessageAgainstGoldenFile(request, "log-error-with-property-event.json")
-        }
+        })
     }
 
     @Test
@@ -91,9 +91,9 @@ internal class LogMessageTest : BaseTest() {
         logTestMessage("Adding exception log to Embrace.")
         Embrace.getInstance().logException(Exception("Another log error"))
 
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.LOGGING) { request ->
             validateMessageAgainstGoldenFile(request, "log-error-with-exception-event.json")
-        }
+        })
     }
 
     @Test
@@ -102,12 +102,9 @@ internal class LogMessageTest : BaseTest() {
         val exception = java.lang.NullPointerException("Exception message")
         Embrace.getInstance().logException(exception, Severity.ERROR, mapOf(), "log message")
 
-        waitForRequest { request ->
-            validateMessageAgainstGoldenFile(
-                request,
-                "log-error-with-exception-and-message-event.json"
-            )
-        }
+        waitForRequest(RequestValidator(EmbraceEndpoint.LOGGING) { request ->
+            validateMessageAgainstGoldenFile(request, "log-error-with-exception-and-message-event.json")
+        })
     }
 
     @Test
@@ -115,8 +112,8 @@ internal class LogMessageTest : BaseTest() {
         logTestMessage("Adding warning log to Embrace.")
         Embrace.getInstance().logWarning("Test log warning")
 
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.LOGGING) { request ->
             validateMessageAgainstGoldenFile(request, "log-warning-event.json")
-        }
+        })
     }
 }

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/MomentMessageTest.kt
@@ -35,18 +35,18 @@ internal class MomentMessageTest : BaseTest() {
         Embrace.getInstance().startMoment(MOMENT_NAME)
 
         // Validate start moment request
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.EVENTS) { request ->
             validateMessageAgainstGoldenFile(request, "moment-custom-start-event.json")
-        }
+        })
 
         // Send end moment
         logTestMessage("Ending start moment to Embrace.")
         Embrace.getInstance().endMoment(MOMENT_NAME)
 
         // Validate end moment request
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.EVENTS) { request ->
             validateMessageAgainstGoldenFile(request, "moment-custom-end-event.json")
-        }
+        })
     }
 
     /**
@@ -57,7 +57,7 @@ internal class MomentMessageTest : BaseTest() {
         // ignore startup event
         logTestMessage("Ending appStartup moment in Embrace.")
         Embrace.getInstance().endAppStartup()
-        waitForRequest()
+        waitForRequest(RequestValidator(EmbraceEndpoint.EVENTS) {})
 
         logTestMessage("Sending moment in Embrace.")
         val properties = HashMap<String, Any>()
@@ -68,25 +68,24 @@ internal class MomentMessageTest : BaseTest() {
         Embrace.getInstance().startMoment(MOMENT_NAME, MOMENT_NAME, properties)
 
         // Validate start moment request with properties
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.EVENTS) { request ->
             validateMessageAgainstGoldenFile(
                 request,
                 "moment-custom-with-properties-start-event.json"
             )
-        }
+        })
 
         // Send end moment
         logTestMessage("Ending moment in Embrace.")
         Embrace.getInstance().endMoment(MOMENT_NAME)
 
         // Validate end moment request
-        waitForRequest { request ->
+        waitForRequest(RequestValidator(EmbraceEndpoint.EVENTS) { request ->
             validateMessageAgainstGoldenFile(
                 request,
                 "moment-custom-with-properties-end-event.json"
             )
-        }
-
+        })
     }
 
     private fun validateFileContent(file: File) {

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/RequestValidator.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/RequestValidator.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk
+
+import okhttp3.mockwebserver.RecordedRequest
+
+internal class RequestValidator(
+    val endpoint: EmbraceEndpoint,
+    val validate: (response: RecordedRequest) -> Unit
+)

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/SessionMessageTest.kt
@@ -20,18 +20,21 @@ internal class SessionMessageTest : BaseTest() {
         addCoreWebVitals()
         sendBackground()
 
-        waitForRequest { request ->
-            validateMessageAgainstGoldenFile(request, "moment-startup-end-event.json")
-        }
-
-        waitForRequest { request ->
-            validateMessageAgainstGoldenFile(request, "session-end.json")
-        }
+        waitForRequest(
+            listOf(
+                RequestValidator(EmbraceEndpoint.EVENTS) { request ->
+                    validateMessageAgainstGoldenFile(request, "moment-startup-end-event.json")
+                },
+                RequestValidator(EmbraceEndpoint.SESSIONS) { request ->
+                    validateMessageAgainstGoldenFile(request, "session-end.json")
+                })
+        )
     }
 
     private fun addCoreWebVitals() {
         val webViewExpectedLog =
-            mContext.assets.open("golden-files/${"expected-webview-core-vital.json"}").bufferedReader().readText()
+            mContext.assets.open("golden-files/${"expected-webview-core-vital.json"}")
+                .bufferedReader().readText()
         Embrace.getInstance().trackWebViewPerformance("myWebView", webViewExpectedLog)
     }
 }


### PR DESCRIPTION
## Goal

Refactors the functional tests so that they do not require requests to be sent in a specific order. Additionally, I've altered the test cases to ensure they specify what endpoint should be specified for each comparison against a golden file. This should hopefully eliminate one source of the flakes (where requests are sent in different orders due to natural fluctuations in timing & our tests didn't account for that)

