### PR TITLE
Add log payload models

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Log.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Log.kt
@@ -1,0 +1,54 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import com.squareup.moshi.Json
+
+/**
+ * A recording of an event. Typically the record includes a timestamp indicating when the event
+ * happened, as well as other data that describes what happened, where it happened, etc.
+ *
+ * @param timeUnixNano The time the log was captured, in nanoseconds since the Unix epoch
+ * @param severityNumber Numerical value of the severity, normalized to values going from 1 to 24,
+ * where 1 is the least severe and 24 is the most severe. The ranges are as follows: 1-4: Trace,
+ * 5-8: Debug, 9-12: Info, 13-16: Warn, 17-20: Error, 21-24: Fatal.
+ * @param severityText Also known as log level. This is the original string representation of the
+ * severity as it is known at the source.
+ * @param body
+ * @param attributes
+ * @param traceId Request trace ID as defined in W3C Trace Context. Can be set for logs that are
+ * part of request processing and have an assigned trace id.
+ * @param spanId The span ID of the log. Can be set for logs that are part of a particular
+ * processing span. If span_id is present, trace_id SHOULD be also present.
+ */
+internal data class Log(
+
+    /* The time the log was captured, in nanoseconds since the Unix epoch */
+    @Json(name = "time_unix_nano")
+    val timeUnixNano: Long? = null,
+
+    /* Numerical value of the severity, normalized to values going from 1 to 24, where
+    1 is the least severe and 24 is the most severe. The ranges are as follows: 1-4: Trace,
+     5-8: Debug, 9-12: Info, 13-16: Warn, 17-20: Error, 21-24: Fatal. */
+    @Json(name = "severity_number")
+    val severityNumber: Int? = null,
+
+    /* Also known as log level. This is the original string representation of the severity
+    as it is known at the source. */
+    @Json(name = "severity_text")
+    val severityText: String? = null,
+
+    @Json(name = "body")
+    val body: LogBody? = null,
+
+    @Json(name = "attributes")
+    val attributes: List<Attribute>? = null,
+
+    /* Request trace ID as defined in W3C Trace Context. Can be set for logs that are part of
+    request processing and have an assigned trace id. */
+    @Json(name = "trace_id")
+    val traceId: String? = null,
+
+    /* The span ID of the log. Can be set for logs that are part of a particular processing span.
+     If span_id is present, trace_id SHOULD be also present. */
+    @Json(name = "span_id")
+    val spanId: String? = null
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogBody.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogBody.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import com.squareup.moshi.Json
+
+/**
+ * A value containing the body of the log record
+ *
+ * @param message The log message
+ */
+internal data class LogBody(
+
+    /* The log message */
+    @Json(name = "message")
+    val message: String? = null
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogMapper.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import io.opentelemetry.sdk.logs.data.LogRecordData
+
+internal fun LogRecordData.toNewPayload(): Log = Log(
+    timeUnixNano = observedTimestampEpochNanos,
+    severityNumber = severity.severityNumber,
+    severityText = severityText,
+    body = LogBody(body.asString()),
+    attributes = attributes.asMap().map { (key, value) -> Attribute(key.key, value.toString()) },
+    traceId = spanContext.traceId,
+    spanId = spanContext.spanId,
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogPayload.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogPayload.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import com.squareup.moshi.Json
+
+/**
+ * A set of log messages sent by the user
+ *
+ * @param logs
+ */
+internal data class LogPayload(
+
+    @Json(name = "logs")
+    val logs: List<Log>? = null
+)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/payload/LogMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/payload/LogMapperTest.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.embracesdk.internal.payload
+
+import io.embrace.android.embracesdk.fakes.FakeLogRecordData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class LogMapperTest {
+
+    @Test
+    fun `convert to new payload`() {
+        val input = FakeLogRecordData()
+        val output = input.toNewPayload()
+        assertEquals(input.observedTimestampEpochNanos, output.timeUnixNano)
+        assertEquals(input.severity.severityNumber, output.severityNumber)
+        assertEquals(input.severityText, output.severityText)
+        assertEquals(input.body.asString(), checkNotNull(output.body).message)
+        assertEquals(input.spanContext.traceId, output.traceId)
+        assertEquals(input.spanContext.spanId, output.spanId)
+
+        val inputMap = input.attributes.asMap().mapKeys { it.key.toString() }.mapValues { it.value.toString() }
+        val outputMap = checkNotNull(output.attributes).associateBy { it.key }.mapValues { it.value.data }
+        assertEquals(inputMap, outputMap)
+    }
+}


### PR DESCRIPTION
## Goal

Adds model classes for the new log payloads. This is mostly generated via OpenAPI but tweaked manually for style reasons.

## Testing

Added unit test to confirm new model can be constructed from old one.

