### PR TITLE
Avoid retrying functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -73,21 +73,8 @@ jobs:
 
       - name: Run Functional Tests
         uses: embrace-io/android-emulator-runner@v2
-        id: runFunctionalTests1
+        id: runFunctionalTests
         continue-on-error: true
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: x86_64
-          profile: Nexus 6
-          # Grab the failures from the device so we can include them in results.
-          # Exit with non-zero so GH checks still fail.
-          script: ./gradlew connectedCheck --stacktrace || (adb logcat '[Embrace]:d' '*:S' -t 100000 > emulator_logcat.log && adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/ && exit 127)
-
-      - name: Retry Functional Tests
-        uses: embrace-io/android-emulator-runner@v2
-        id: runFunctionalTests2
-        if: steps.runFunctionalTests1.outcome == 'failure'
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -109,14 +96,8 @@ jobs:
 
       - name: Post workflow result
         id: slack
-        if: ${{steps.runFunctionalTests1.outcome == 'failure'}}
+        if: ${{steps.runFunctionalTests.outcome == 'failure'}}
         uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "functional_test_retried": "${{steps.runFunctionalTests1.outcome == 'failure'}}",
-              "workflow_failed": "${{steps.runFunctionalTests1.outcome == 'failure' && steps.runFunctionalTests2.outcome == 'failure'}}"
-            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Goal

Avoids retrying the functional tests. Since #521 was merged CI is much more reliable, so IMO this isn't required. If CI does fail, it'd be good to know about it the first time so we can dedicate the time to tweak the tests.

