### PR TITLE
Use behavior classes directly rather than config service

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
-import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.behavior.AppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
@@ -33,7 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 @RequiresApi(VERSION_CODES.R)
 internal class AeiDataSourceImpl(
     private val backgroundWorker: BackgroundWorker,
-    private val configService: ConfigService,
+    private val appExitInfoBehavior: AppExitInfoBehavior,
     private val activityManager: ActivityManager?,
     private val preferencesService: PreferencesService,
     private val metadataService: MetadataService,
@@ -117,7 +116,7 @@ internal class AeiDataSourceImpl(
 
         // number of results to be returned; a value of 0 means to ignore this parameter and return
         // all matching records with a maximum of 16 entries
-        val maxNum = configService.appExitInfoBehavior.appExitInfoMaxNum()
+        val maxNum = appExitInfoBehavior.appExitInfoMaxNum()
 
         var historicalProcessExitReasons: List<ApplicationExitInfo> =
             activityManager?.getHistoricalProcessExitReasons(null, pid, maxNum)
@@ -225,7 +224,7 @@ internal class AeiDataSourceImpl(
                 return null
             }
 
-            val traceMaxLimit = configService.appExitInfoBehavior.getTraceMaxLimit()
+            val traceMaxLimit = appExitInfoBehavior.getTraceMaxLimit()
             if (trace.length > traceMaxLimit) {
                 logInfoWithException("AEI - Blob size was reduced. Current size is ${trace.length} and the limit is $traceMaxLimit")
                 return AppExitInfoBehavior.CollectTracesResult.TooLarge(trace.take(traceMaxLimit))

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.destination.SpanEventMapper
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
-import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.payload.CustomBreadcrumb
 
@@ -14,11 +14,11 @@ import io.embrace.android.embracesdk.payload.CustomBreadcrumb
  * Captures custom breadcrumbs.
  */
 internal class CustomBreadcrumbDataSource(
-    configService: ConfigService,
+    breadcrumbBehavior: BreadcrumbBehavior,
     writer: SessionSpanWriter
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
-    limitStrategy = UpToLimitStrategy(configService.breadcrumbBehavior::getCustomBreadcrumbLimit)
+    limitStrategy = UpToLimitStrategy(breadcrumbBehavior::getCustomBreadcrumbLimit)
 ),
     SpanEventMapper<CustomBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSource.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.arch.destination.StartSpanMapper
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
-import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.payload.FragmentBreadcrumb
@@ -17,12 +17,12 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
  * Captures fragment breadcrumbs.
  */
 internal class FragmentBreadcrumbDataSource(
-    configService: ConfigService,
+    breadcrumbBehavior: BreadcrumbBehavior,
     private val clock: Clock,
     spanService: SpanService
 ) : SpanDataSourceImpl(
     spanService,
-    UpToLimitStrategy({ configService.breadcrumbBehavior.getFragmentBreadcrumbLimit() })
+    UpToLimitStrategy({ breadcrumbBehavior.getFragmentBreadcrumbLimit() })
 ),
     StartSpanMapper<FragmentBreadcrumb> {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
@@ -83,7 +83,7 @@ internal class AeiDataSourceImplTest {
         logWriter = FakeLogWriter()
         applicationExitInfoService = AeiDataSourceImpl(
             worker,
-            configService,
+            configService.appExitInfoBehavior,
             mockActivityManager,
             preferenceService,
             metadataService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -16,7 +16,7 @@ internal class CustomBreadcrumbDataSourceTest {
     fun setUp() {
         writer = FakeCurrentSessionSpan()
         source = CustomBreadcrumbDataSource(
-            FakeConfigService(),
+            FakeConfigService().breadcrumbBehavior,
             writer
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
@@ -23,7 +23,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         clock = FakeClock()
         spanService = FakeSpanService()
         dataSource = FragmentBreadcrumbDataSource(
-            configService,
+            configService.breadcrumbBehavior,
             clock,
             spanService,
         )


### PR DESCRIPTION
## Goal

Use behavior classes directly rather than `ConfigService`. This will allow us to eventually get rid of the `ConfigService` if we wish.

## Testing

Updated test coverage.