### PR TITLE
Add in extension functions useful when working with EmbraceAttributes

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.assertions
 
+import io.embrace.android.embracesdk.arch.assertError
+import io.embrace.android.embracesdk.arch.assertIsKeySpan
+import io.embrace.android.embracesdk.arch.assertNotKeySpan
+import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.internal.spans.isKey
 import io.embrace.android.embracesdk.internal.spans.isPrivate
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -36,18 +39,20 @@ internal fun assertEmbraceSpanData(
             assertEquals(32, traceId.length)
         }
         assertEquals(expectedStatus, status)
-        errorCode?.run {
-            val errorCodeAttribute = fromErrorCode()
-            assertEquals(
-                errorCodeAttribute.attributeValue,
-                attributes[errorCodeAttribute.otelAttributeName()]
-            )
+        if (errorCode == null) {
+            assertSuccessful()
+        } else {
+            assertError(errorCode)
         }
         expectedCustomAttributes.forEach { entry ->
             assertEquals(entry.value, attributes[entry.key])
         }
         assertEquals(expectedEvents, events)
         assertEquals(private, isPrivate())
-        assertEquals(key, isKey())
+        if (key) {
+            assertIsKeySpan()
+        } else {
+            assertNotKeySpan()
+        }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -204,6 +204,7 @@ internal class TracingApiTest {
                 expectedParentId = traceRootSpan.spanId,
                 expectedTraceId = traceRootSpan.traceId,
                 expectedStatus = StatusCode.ERROR,
+                errorCode = ErrorCode.FAILURE,
                 expectedCustomAttributes = mapOf(Pair("test-attr", "false")),
                 expectedEvents = listOf(
                     checkNotNull(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
@@ -17,5 +17,5 @@ internal class LogEventData(
     val severity: Severity,
     val message: String
 ) {
-    val attributes = schemaType.attrs.plus(Pair(schemaType.telemetryType.otelAttributeName(), schemaType.telemetryType.attributeValue))
+    val attributes = schemaType.attrs.plus(schemaType.telemetryType.toOTelKeyValuePair())
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
@@ -13,5 +13,5 @@ internal class SpanEventData(
     val schemaType: SchemaType,
     val spanStartTimeMs: Long
 ) {
-    val attributes = schemaType.attrs.plus(Pair(schemaType.telemetryType.otelAttributeName(), schemaType.telemetryType.attributeValue))
+    val attributes = schemaType.attrs.plus(schemaType.telemetryType.toOTelKeyValuePair())
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
@@ -13,5 +13,5 @@ internal class StartSpanData(
     val schemaType: SchemaType,
     val spanStartTimeMs: Long,
 ) {
-    val attributes = schemaType.attrs.plus(Pair(schemaType.telemetryType.otelAttributeName(), schemaType.telemetryType.attributeValue))
+    val attributes = schemaType.attrs.plus(schemaType.telemetryType.toOTelKeyValuePair())
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
@@ -16,5 +16,13 @@ internal interface EmbraceAttribute {
      */
     val attributeValue: String
 
+    /**
+     * Return the appropriate key name for this attribute to use in an OpenTelemetry attribute
+     */
     fun otelAttributeName(): String = attributeName.toEmbraceAttributeName()
+
+    /**
+     * Return attribute as a key-value pair appropriate to use as an OpenTelemetry attribute
+     */
+    fun toOTelKeyValuePair() = Pair(otelAttributeName(), attributeValue)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/KeySpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/KeySpan.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.arch.schema
+
+/**
+ * Denotes an important span to be aggregated and displayed as such in the platform.
+ */
+internal object KeySpan : EmbraceAttribute {
+    override val attributeName: String = "key"
+    override val attributeValue: String = "true"
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.telemetry.TelemetryService
@@ -82,10 +83,7 @@ internal class CurrentSessionSpanImpl(
                 spanRepository.clearCompletedSpans()
                 sessionSpan.set(startSessionSpan(clock.now().nanosToMillis()))
             } else {
-                endingSessionSpan.addAttribute(
-                    appTerminationCause.otelAttributeName(),
-                    appTerminationCause.attributeValue
-                )
+                endingSessionSpan.setEmbraceAttribute(appTerminationCause)
                 endingSessionSpan.stop()
             }
             return spanSink.flushSpans()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
 import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -144,5 +145,10 @@ internal class EmbraceSpanImpl(
 
         internal fun attributeValid(key: String, value: String) =
             key.length <= MAX_ATTRIBUTE_KEY_LENGTH && value.length <= MAX_ATTRIBUTE_VALUE_LENGTH
+
+        internal fun EmbraceSpan.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): EmbraceSpan {
+            addAttribute(embraceAttribute.otelAttributeName(), embraceAttribute.attributeValue)
+            return this
+        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
@@ -1,0 +1,80 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.arch.destination.LogEventData
+import io.embrace.android.embracesdk.arch.destination.StartSpanData
+import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
+import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.arch.schema.KeySpan
+import io.embrace.android.embracesdk.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.spans.ErrorCode
+import io.opentelemetry.api.trace.StatusCode
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertFalse
+
+/**
+ * Assert [EmbraceSpanData] is of type [EmbType.Performance.Default]
+ */
+internal fun EmbraceSpanData.assertIsTypePerformance() = assertIsType(EmbType.Performance.Default)
+
+/**
+ * Assert [EmbraceSpanData] is of type [telemetryType]
+ */
+internal fun EmbraceSpanData.assertIsType(telemetryType: TelemetryType) = assertHasEmbraceAttribute(telemetryType)
+
+internal fun EmbraceSpanData.assertIsKeySpan() = assertHasEmbraceAttribute(KeySpan)
+
+internal fun EmbraceSpanData.assertNotKeySpan() = assertDoesNotHaveEmbraceAttribute(KeySpan)
+
+/**
+ * Assert [EmbraceSpanData] has the [EmbraceAttribute] defined by [embraceAttribute]
+ */
+internal fun EmbraceSpanData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
+    assertEquals(embraceAttribute.attributeValue, attributes[embraceAttribute.otelAttributeName()])
+}
+
+internal fun EmbraceSpanData.assertDoesNotHaveEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
+    assertFalse(attributes[embraceAttribute.otelAttributeName()]?.equals(embraceAttribute.attributeValue) ?: false)
+}
+
+/**
+ * Assert [EmbraceSpanData] has ended with the error defined by [errorCode]
+ */
+internal fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
+    assertEquals(StatusCode.ERROR, status)
+    assertHasEmbraceAttribute(errorCode.fromErrorCode())
+}
+
+/**
+ * Assert [EmbraceSpanData] has ended successfully
+ */
+internal fun EmbraceSpanData.assertSuccessful() {
+    assertEquals(StatusCode.OK, status)
+    assertNull(attributes[ErrorCodeAttribute.Failure.otelAttributeName()])
+}
+
+/**
+ * Assert [StartSpanData] is of type [telemetryType]
+ */
+internal fun StartSpanData.assertIsType(telemetryType: TelemetryType) = assertHasEmbraceAttribute(telemetryType)
+
+/**
+ * Assert [StartSpanData] has the [EmbraceAttribute] defined by [embraceAttribute]
+ */
+internal fun StartSpanData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
+    assertEquals(embraceAttribute.attributeValue, attributes[embraceAttribute.otelAttributeName()])
+}
+
+/**
+ * Assert [LogEventData] is of type [telemetryType]
+ */
+internal fun LogEventData.assertIsType(telemetryType: TelemetryType) = assertHasEmbraceAttribute(telemetryType)
+
+/**
+ * Assert [LogEventData] has the [EmbraceAttribute] defined by [embraceAttribute]
+ */
+internal fun LogEventData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
+    assertEquals(embraceAttribute.attributeValue, attributes[embraceAttribute.otelAttributeName()])
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -26,7 +26,7 @@ internal class SpanDataSourceKtTest {
             SchemaType.ViewBreadcrumb("my-view"),
             1500000000000
         )
-        assertEquals(EmbType.Ux.View.attributeValue, data.attributes[EmbType.Ux.View.otelAttributeName()])
+        data.assertIsType(EmbType.Ux.View)
         assertEquals("my-view", data.attributes["view.name"])
 
         val span = service.startSpanCapture("") { data }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.config.remote.AppExitInfoConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
@@ -361,7 +362,7 @@ internal class AeiDataSourceImplTest {
         val logEventData = logWriter.logEvents.single()
         assertEquals("aei-record", logEventData.schemaType.name)
         assertEquals(Severity.INFO, logEventData.severity)
-        assertEquals(EmbType.System.Exit.attributeValue, logEventData.attributes[EmbType.System.Exit.otelAttributeName()])
+        logEventData.assertIsType(EmbType.System.Exit)
         return logEventData.attributes
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -36,7 +36,7 @@ internal class CustomBreadcrumbDataSourceTest {
             assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
             assertEquals(
                 mapOf(
-                    EmbType.System.Breadcrumb.otelAttributeName() to EmbType.System.Breadcrumb.attributeValue,
+                    EmbType.System.Breadcrumb.toOTelKeyValuePair(),
                     "message" to "Hello, world!"
                 ),
                 attributes

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
@@ -40,7 +40,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         assertEquals(
             mapOf(
                 "view.name" to "my_fragment",
-                EmbType.Ux.View.otelAttributeName() to EmbType.Ux.View.attributeValue,
+                EmbType.Ux.View.toOTelKeyValuePair(),
             ),
             span.attributes
         )
@@ -59,7 +59,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         assertEquals(
             mapOf(
                 "view.name" to "my_fragment",
-                EmbType.Ux.View.otelAttributeName() to EmbType.Ux.View.attributeValue,
+                EmbType.Ux.View.toOTelKeyValuePair()
             ),
             span.attributes
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.capture.startup
 
-import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -50,10 +50,7 @@ internal class StartupServiceImplTest {
             assertEquals(SpanId.getInvalid(), parentSpanId)
             assertEquals(startTimeMillis, startTimeNanos.nanosToMillis())
             assertEquals(endTimeMillis, endTimeNanos.nanosToMillis())
-            assertEquals(
-                EmbType.Performance.Default.attributeValue,
-                attributes[EmbType.Performance.Default.otelAttributeName()]
-            )
+            assertIsTypePerformance()
             assertTrue(isPrivate())
             assertEquals(StatusCode.OK, status)
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -33,7 +33,7 @@ internal val testSpan = EmbraceSpanData(
     ),
     attributes = mapOf(
         Pair("emb.sequence_id", "3"),
-        EmbType.Performance.Default.otelAttributeName() to EmbType.Performance.Default.attributeValue,
+        EmbType.Performance.Default.toOTelKeyValuePair(),
     )
 )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
@@ -104,7 +105,7 @@ internal class EmbraceLogServiceTest {
         assertNotNull(third.attributes["emb.log_id"])
         assertEquals("session-123", third.attributes["emb.session_id"])
         assertNull(third.attributes["emb.exception_type"])
-        assertEquals(EmbType.System.Log.attributeValue, third.attributes[EmbType.System.Log.otelAttributeName()])
+        third.assertIsType(EmbType.System.Log)
     }
 
     @Test
@@ -133,7 +134,7 @@ internal class EmbraceLogServiceTest {
         assertNotNull(log.attributes["emb.log_id"])
         assertEquals("session-123", log.attributes["emb.session_id"])
         assertEquals("none", log.attributes["emb.exception_type"])
-        assertEquals(EmbType.System.Log.attributeValue, log.attributes[EmbType.System.Log.otelAttributeName()])
+        log.assertIsType(EmbType.System.Log)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -1,5 +1,9 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.assertHasEmbraceAttribute
+import io.embrace.android.embracesdk.arch.assertIsType
+import io.embrace.android.embracesdk.arch.assertNotKeySpan
+import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
@@ -9,7 +13,6 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -143,10 +146,10 @@ internal class CurrentSessionSpanImplTests {
             val lastFlushedSpan = flushedSpans[0]
             with(lastFlushedSpan) {
                 assertEquals("emb-session", name)
-                assertEquals(EmbType.Ux.Session.attributeValue, attributes[EmbType.Ux.Session.otelAttributeName()])
-                assertEquals(StatusCode.OK, status)
-                assertFalse(isKey())
-                assertEquals(cause.attributeValue, attributes[cause.otelAttributeName()])
+                assertIsType(EmbType.Ux.Session)
+                assertSuccessful()
+                assertNotKeySpan()
+                assertHasEmbraceAttribute(cause)
             }
 
             assertEquals(0, module.openTelemetryModule.spanSink.completedSpans().size)
@@ -193,7 +196,7 @@ internal class CurrentSessionSpanImplTests {
         assertEquals(1000, testEvent.timestampNanos.nanosToMillis())
         assertEquals(
             mapOf(
-                EmbType.System.Breadcrumb.otelAttributeName() to EmbType.System.Breadcrumb.attributeValue,
+                EmbType.System.Breadcrumb.toOTelKeyValuePair(),
                 "message" to "test-event"
             ),
             testEvent.attributes

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -87,10 +88,7 @@ internal class EmbraceSpanServiceTest {
             assertEquals(name, name)
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
-            assertEquals(
-                EmbType.Performance.Default.attributeValue,
-                attributes[EmbType.Performance.Default.otelAttributeName()]
-            )
+            assertIsTypePerformance()
             expectedAttributes.forEach {
                 assertEquals(it.value, attributes[it.key])
             }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -1,9 +1,13 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.arch.assertError
+import io.embrace.android.embracesdk.arch.assertIsKeySpan
+import io.embrace.android.embracesdk.arch.assertIsType
+import io.embrace.android.embracesdk.arch.assertIsTypePerformance
+import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.arch.schema.EmbType
-import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_SPAN_NAME
@@ -56,11 +60,8 @@ internal class SpanServiceImplTest {
         assertTrue(embraceSpan.stop())
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
             assertEquals(SpanId.getInvalid(), parentSpanId)
-            assertEquals(
-                EmbType.Performance.Default.attributeValue,
-                attributes[EmbType.Performance.Default.otelAttributeName()]
-            )
-            assertTrue(isKey())
+            assertIsTypePerformance()
+            assertIsKeySpan()
         }
     }
 
@@ -85,11 +86,8 @@ internal class SpanServiceImplTest {
         assertTrue(embraceSpan.stop())
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
             assertEquals(SpanId.getInvalid(), parentSpanId)
-            assertEquals(
-                EmbType.Performance.Default.attributeValue,
-                attributes[EmbType.Performance.Default.otelAttributeName()]
-            )
-            assertTrue(isKey())
+            assertIsTypePerformance()
+            assertIsKeySpan()
         }
     }
 
@@ -112,7 +110,7 @@ internal class SpanServiceImplTest {
             assertEquals("emb-child-span", name)
             assertEquals(childSpan.spanId, spanId)
             assertEquals(childSpan.traceId, traceId)
-            assertFalse(isKey())
+            assertNotKeySpan()
             assertTrue(isPrivate())
         }
 
@@ -121,7 +119,7 @@ internal class SpanServiceImplTest {
             assertEquals(SpanId.getInvalid(), parentSpanId)
             assertEquals(parentSpan.spanId, spanId)
             assertEquals(parentSpan.traceId, traceId)
-            assertTrue(isKey())
+            assertIsKeySpan()
             assertTrue(isPrivate())
         }
     }
@@ -181,11 +179,8 @@ internal class SpanServiceImplTest {
         assertEquals(1, completedSpans.size)
         with(completedSpans[0]) {
             assertTrue(isPrivate())
-            assertFalse(isKey())
-            assertEquals(
-                EmbType.Ux.View.attributeValue,
-                attributes[EmbType.Ux.View.otelAttributeName()]
-            )
+            assertNotKeySpan()
+            assertIsType(EmbType.Ux.View)
             assertEquals(childStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(childSpanEndTimeMs, endTimeNanos.nanosToMillis())
         }
@@ -218,12 +213,9 @@ internal class SpanServiceImplTest {
         with(verifyAndReturnSoleCompletedSpan("emb-$expectedName")) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
-            assertEquals(
-                EmbType.Performance.Default.attributeValue,
-                attributes[EmbType.Performance.Default.otelAttributeName()]
-            )
+            assertIsTypePerformance()
             assertEquals(SpanId.getInvalid(), parentSpanId)
-            assertTrue(isKey())
+            assertIsKeySpan()
             assertTrue(isPrivate())
             expectedAttributes.forEach {
                 assertEquals(it.value, attributes[it.key])
@@ -251,7 +243,7 @@ internal class SpanServiceImplTest {
         with(verifyAndReturnSoleCompletedSpan("emb-$expectedName")) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
-            assertFalse(isKey())
+            assertNotKeySpan()
             assertTrue(isPrivate())
         }
         assertTrue(parentSpan.stop())
@@ -307,11 +299,7 @@ internal class SpanServiceImplTest {
                 )
             )
             with(verifyAndReturnSoleCompletedSpan("emb-test${errorCode.name}")) {
-                val errorCodeAttribute = checkNotNull(errorCode.fromErrorCode())
-                assertEquals(
-                    errorCodeAttribute.attributeValue,
-                    attributes[errorCodeAttribute.otelAttributeName()]
-                )
+                assertError(errorCode)
             }
             spanSink.flushSpans()
         }
@@ -352,11 +340,8 @@ internal class SpanServiceImplTest {
         assertEquals(returnThis, lambdaReturn)
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
             assertEquals(SpanId.getInvalid(), parentSpanId)
-            assertEquals(
-                EmbType.Performance.Default.attributeValue,
-                attributes[EmbType.Performance.Default.otelAttributeName()]
-            )
-            assertTrue(isKey())
+            assertIsTypePerformance()
+            assertIsKeySpan()
             assertTrue(isPrivate())
         }
     }
@@ -378,7 +363,7 @@ internal class SpanServiceImplTest {
 
         with(currentSpans[0]) {
             assertEquals("emb-child-span", name)
-            assertFalse(isKey())
+            assertNotKeySpan()
             assertTrue(isPrivate())
         }
     }
@@ -418,10 +403,7 @@ internal class SpanServiceImplTest {
         }
 
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
-            assertEquals(
-                ErrorCodeAttribute.Failure.attributeValue,
-                attributes[ErrorCodeAttribute.Failure.otelAttributeName()]
-            )
+            assertError(ErrorCode.FAILURE)
         }
     }
 


### PR DESCRIPTION
## Goal

Add and use extension functions to test EmbraceAttributes values within generated data

Note: I accidentally merged in a commit that converts `emb.key` to an EmbraceAttribute, and since the changes were intermingled in the same file..... I'm just going to leave it and apologize 😅 

## Testing

Existing test cover this