### PR TITLE
Initialize native crash monitoring in a background thread

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -15,7 +15,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -116,9 +115,7 @@ internal class TracingApiTest {
                 embrace.endAppStartup()
             }
             results.add("\nSpans exported after session ends: ${spanExporter.exportedSpans.toList().map { it.name }}")
-            assertTrue("Timed out waiting for the expected spans: $results", spanExporter.awaitSpanExport(9))
             val sessionEndTime = harness.fakeClock.now()
-            assertEquals(2, harness.fakeDeliveryModule.deliveryService.lastSentSessions.size)
             val allSpans = getSdkInitSpanFromBackgroundActivity() +
                 checkNotNull(sessionMessage?.spans) +
                 checkNotNull(harness.openTelemetryModule.spanSink.completedSpans())

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
@@ -30,6 +30,12 @@ internal class SdkModeBehavior(
         private const val DEFAULT_BETA_FEATURES_PCT = 1.0f
 
         /**
+         * The percentage of devices that defer some expensive service initialization to a background
+         * thread to improve startup performance in exchange for delayed enablement of some features of the SDK
+         */
+        private const val DEFAULT_DEFER_SERVICE_INIT_PCT = 0.0f
+
+        /**
          * The default percentage of devices for which the SDK is enabled.
          */
         private const val DEFAULT_THRESHOLD = 100
@@ -55,6 +61,14 @@ internal class SdkModeBehavior(
         }
 
         val pct = remote?.pctBetaFeaturesEnabled ?: DEFAULT_BETA_FEATURES_PCT
+        return thresholdCheck.isBehaviorEnabled(pct)
+    }
+
+    /**
+     * Checks if an expanded list of services' initialization during startup will be done on a background thread
+     */
+    fun isServiceInitDeferred(): Boolean {
+        val pct = remote?.pctDeferServiceInitEnabled ?: DEFAULT_DEFER_SERVICE_INIT_PCT
         return thresholdCheck.isBehaviorEnabled(pct)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/RemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/RemoteConfig.kt
@@ -108,5 +108,12 @@ internal data class RemoteConfig(
      * Web view vitals settings
      */
     @Json(name = "webview_vitals_beta")
-    val webViewVitals: WebViewVitals? = null
+    val webViewVitals: WebViewVitals? = null,
+
+    /**
+     * Enable deferral of initialization of some services to a background thread during startup.
+     * Currently, the only feature that uses this is native crash capture
+     */
+    @Json(name = "pct_defer_service_init")
+    val pctDeferServiceInitEnabled: Float? = null,
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
@@ -49,7 +49,7 @@ internal class NativeModuleImpl(
                 embraceNdkServiceRepository,
                 NdkDelegateImpl(),
                 workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
-                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                workerThreadModule.backgroundWorker(WorkerName.SERVICE_INIT),
                 essentialServiceModule.deviceArchitecture,
                 coreModule.jsonSerializer
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.arch.SessionType
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -44,7 +45,7 @@ internal class SessionOrchestratorImpl(
 
     init {
         processStateService.addListener(this)
-        createInitialSession()
+        Systrace.traceSynchronous("start-first-session") { createInitialSession() }
     }
 
     private fun createInitialSession() {
@@ -240,6 +241,7 @@ internal class SessionOrchestratorImpl(
                     }
                 }
             }
+
             ProcessState.BACKGROUND -> scheduleBackgroundActivitySave(endProcessState, newState)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModule.kt
@@ -66,4 +66,9 @@ internal enum class WorkerName(internal val threadName: String) {
      * Monitor thread that checks the main thread for ANRs.
      */
     ANR_MONITOR("anr-monitor"),
+
+    /**
+     * Initialize services asynchronously
+     */
+    SERVICE_INIT("service-init"),
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehaviorTest.kt
@@ -36,6 +36,7 @@ internal class SdkModeBehaviorTest {
         ) {
             assertFalse(isBetaFeaturesEnabled())
             assertFalse(isSdkDisabled())
+            assertFalse(isServiceInitDeferred())
         }
     }
 
@@ -84,6 +85,28 @@ internal class SdkModeBehaviorTest {
                 remoteCfg = { RemoteConfig(pctBetaFeaturesEnabled = 0f) }
             )
         assertFalse(behavior.isBetaFeaturesEnabled())
+    }
+
+    @Test
+    fun `verify defer service init checks`() {
+        // Default is disabled regardless of the deviceId
+        assertFalse(fakeSdkModeBehavior(thresholdCheck = enabled).isServiceInitDeferred())
+
+        // Enabled if remote flag set to 100%
+        assertTrue(
+            fakeSdkModeBehavior(
+                thresholdCheck = enabled,
+                remoteCfg = { RemoteConfig(pctDeferServiceInitEnabled = 100f) }
+            ).isServiceInitDeferred()
+        )
+
+        // Disabled if remote flag set to 0% regardless of deviceId
+        assertFalse(
+            fakeSdkModeBehavior(
+                thresholdCheck = enabled,
+                remoteCfg = { RemoteConfig(pctDeferServiceInitEnabled = 0f) }
+            ).isServiceInitDeferred()
+        )
     }
 
     @Test


### PR DESCRIPTION
## Goal

Initialize crash monitoring on a background thread. This turns out to be super expensive, so doing it on a background thread, while delaying the signal handler install by ~500ms, dramatically improves SDK startup.

Given this is a bit controversial, I'm putting this up now, but we can talk about whether this is worth it. I personally think so. 