### PR TITLE
Preserve moments across session boundaries

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/MomentBoundaryTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/MomentBoundaryTest.kt
@@ -1,0 +1,108 @@
+package io.embrace.android.embracesdk.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.EventType
+import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.recordSession
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Asserts that moments (including startup moments) remain between session boundaries.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class MomentBoundaryTest {
+
+    companion object {
+        private const val MOMENT_NAME = "my_moment"
+    }
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule()
+
+    @Test
+    fun `startup moment completes within one session`() {
+        with(testRule) {
+            val message = harness.recordSession {
+                embrace.endAppStartup()
+                embrace.startMoment(MOMENT_NAME)
+                embrace.endMoment(MOMENT_NAME)
+            }
+            checkNotNull(message)
+
+            val moments = fetchDeliveredEvents()
+            assertEquals(4, moments.size)
+            val startMoment = moments[0]
+            val endMoment = moments[1]
+            val myStartMoment = moments[2]
+            val myEndMoment = moments[3]
+
+            assertEquals("_startup", startMoment.event.name)
+            assertEquals(EventType.START, startMoment.event.type)
+            assertEquals(message.session.sessionId, startMoment.event.sessionId)
+
+            assertEquals("_startup", endMoment.event.name)
+            assertEquals(EventType.END, endMoment.event.type)
+            assertEquals(message.session.sessionId, endMoment.event.sessionId)
+
+            assertEquals(MOMENT_NAME, myStartMoment.event.name)
+            assertEquals(EventType.START, myStartMoment.event.type)
+            assertEquals(message.session.sessionId, myStartMoment.event.sessionId)
+
+            assertEquals(MOMENT_NAME, myEndMoment.event.name)
+            assertEquals(EventType.END, myEndMoment.event.type)
+            assertEquals(message.session.sessionId, myEndMoment.event.sessionId)
+
+            val expectedEventIds = listOf(startMoment.event.eventId, myStartMoment.event.eventId)
+            assertEquals(expectedEventIds, message.session.eventIds)
+        }
+    }
+
+    @Test
+    fun `startup moment completes within two sessions`() {
+        with(testRule) {
+            val firstMessage = harness.recordSession {
+                embrace.startMoment(MOMENT_NAME)
+            }
+            val secondMessage = harness.recordSession {
+                embrace.endAppStartup()
+                embrace.endMoment(MOMENT_NAME)
+            }
+            checkNotNull(firstMessage)
+            checkNotNull(secondMessage)
+
+            val moments = fetchDeliveredEvents()
+            assertEquals(4, moments.size)
+            val startMoment = moments[0]
+            val myStartMoment = moments[1]
+            val endMoment = moments[2]
+            val myEndMoment = moments[3]
+
+            assertEquals("_startup", startMoment.event.name)
+            assertEquals(EventType.START, startMoment.event.type)
+            assertEquals(firstMessage.session.sessionId, startMoment.event.sessionId)
+
+            assertEquals(MOMENT_NAME, myStartMoment.event.name)
+            assertEquals(EventType.START, myStartMoment.event.type)
+            assertEquals(firstMessage.session.sessionId, myStartMoment.event.sessionId)
+
+            assertEquals("_startup", endMoment.event.name)
+            assertEquals(EventType.END, endMoment.event.type)
+            assertEquals(secondMessage.session.sessionId, endMoment.event.sessionId)
+
+            assertEquals(MOMENT_NAME, myEndMoment.event.name)
+            assertEquals(EventType.END, myEndMoment.event.type)
+            assertEquals(secondMessage.session.sessionId, myEndMoment.event.sessionId)
+
+            val expectedEventIds = listOf(startMoment.event.eventId, myStartMoment.event.eventId)
+            assertEquals(expectedEventIds, firstMessage.session.eventIds)
+            assertEquals(expectedEventIds, secondMessage.session.eventIds)
+        }
+    }
+
+    private fun IntegrationTestRule.fetchDeliveredEvents() =
+        harness.fakeDeliveryModule.deliveryService.sentMoments
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventService.kt
@@ -96,11 +96,9 @@ internal interface EventService : Closeable {
     /**
      * Finds all event IDs (event UUIDs) within the given time window.
      *
-     * @param startTime the start time of the window to search
-     * @param endTime   the end time of the window to search
      * @return the list of story IDs within the specified range
      */
-    fun findEventIdsForSession(startTime: Long, endTime: Long): List<String>
+    fun findEventIdsForSession(): List<String>
 
     /**
      * Gets all of the IDs of the currently active moments.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -121,10 +121,7 @@ internal class PayloadMessageCollator(
         return initial.copy(
             endTime = endTime,
             eventIds = captureDataSafely {
-                eventService.findEventIdsForSession(
-                    startTime,
-                    endTime
-                )
+                eventService.findEventIdsForSession()
             },
             infoLogIds = captureDataSafely { logMessageService.findInfoLogIds(startTime, endTime) },
             warningLogIds = captureDataSafely {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEventService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEventService.kt
@@ -41,7 +41,7 @@ internal class FakeEventService : EventService {
         TODO("Not yet implemented")
     }
 
-    override fun findEventIdsForSession(startTime: Long, endTime: Long): List<String> {
+    override fun findEventIdsForSession(): List<String> {
         return emptyList()
     }
 


### PR DESCRIPTION
## Goal

Preserves moments across session boundaries if they are considered 'active' (i.e. they have not ended yet). The current implementation simply cleared all the events in our collections; however, it does not seem this behavior was ever hooked up properly until the recent `SessionOrchestrator` refactor. This meant that moments would be cleared when the session boundary was transitioned - which happened frequently for the app startup moment.

## Testing

Added integration + unit test coverage.
