### PR TITLE
[EMBR-2802] Fix race condition on LogSink and LogOrchestrator.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
@@ -22,8 +22,9 @@ internal interface LogSink {
     /**
      * Returns and clears the currently stored Logs. Implementations of this method must make sure the clearing and returning is
      * atomic, i.e. logs cannot be added during this operation.
+     * @param max The maximum number of logs to flush. If null, all logs are flushed.
      */
-    fun flushLogs(): List<EmbraceLogRecordData>
+    fun flushLogs(max: Int? = null): List<EmbraceLogRecordData>
 
     /**
      * Registers a callback to be called when logs are stored.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -2,16 +2,16 @@ package io.embrace.android.embracesdk.internal.logs
 
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.data.LogRecordData
+import java.util.concurrent.ConcurrentLinkedQueue
 
 internal class LogSinkImpl : LogSink {
-    private val storedLogs: MutableList<EmbraceLogRecordData> = mutableListOf()
+    private val storedLogs: ConcurrentLinkedQueue<EmbraceLogRecordData> = ConcurrentLinkedQueue()
     private var onLogsStored: (() -> Unit)? = null
+    private val flushLock = Any()
 
     override fun storeLogs(logs: List<LogRecordData>): CompletableResultCode {
         try {
-            synchronized(storedLogs) {
-                storedLogs += logs.map { EmbraceLogRecordData(logRecordData = it) }
-            }
+            storedLogs.addAll(logs.map { EmbraceLogRecordData(logRecordData = it) })
             onLogsStored?.invoke()
         } catch (t: Throwable) {
             return CompletableResultCode.ofFailure()
@@ -21,15 +21,16 @@ internal class LogSinkImpl : LogSink {
     }
 
     override fun completedLogs(): List<EmbraceLogRecordData> {
-        synchronized(storedLogs) {
-            return storedLogs.toList()
-        }
+        return storedLogs.toList()
     }
 
-    override fun flushLogs(): List<EmbraceLogRecordData> {
-        synchronized(storedLogs) {
-            val flushedLogs = storedLogs.toList()
-            storedLogs.clear()
+    override fun flushLogs(max: Int?): List<EmbraceLogRecordData> {
+        synchronized(flushLock) {
+            val maxIndex = max?.let {
+                minOf(storedLogs.size, it)
+            } ?: storedLogs.size
+            val flushedLogs = storedLogs.toList().subList(0, maxIndex)
+            storedLogs.removeAll(flushedLogs.toSet())
             return flushedLogs
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -29,7 +29,7 @@ internal class LogSinkImpl : LogSink {
             val maxIndex = max?.let {
                 minOf(storedLogs.size, it)
             } ?: storedLogs.size
-            val flushedLogs = storedLogs.toList().subList(0, maxIndex)
+            val flushedLogs = storedLogs.take(maxIndex)
             storedLogs.removeAll(flushedLogs.toSet())
             return flushedLogs
         }


### PR DESCRIPTION
## Goal

- Converted the list on LogSink into a `ConcurrentLinkedQueue` to use thread-safe operations. 
- Added a lock on the flush method, so no more than one thread can execute the flush at the same time. 
- Added a param to the flushLogs method to provide the max number of  logs to flush. 
- Converted properties that hold time in LogOrchestrator to AtomicLong. 

## Testing

Added a method created by Hanson to emulate the race condition. 


