### PR TITLE
Move from MetadataUtils to Device

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/CpuInfoDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/CpuInfoDelegate.kt
@@ -12,5 +12,5 @@ internal interface CpuInfoDelegate {
     /**
      * Get the ELG of the primary CPU of the device
      */
-    fun getElg(): String?
+    fun getEgl(): String?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
@@ -21,7 +21,7 @@ internal class EmbraceCpuInfoDelegate(
         }
     }
 
-    override fun getElg(): String? {
+    override fun getEgl(): String? {
         return if (sharedObjectLoader.loadEmbraceNative()) {
             try {
                 getNativeEgl()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
@@ -6,6 +6,7 @@ import android.os.StatFs
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.annotation.ChecksSdkIntAtLeast
+import io.embrace.android.embracesdk.capture.cpu.CpuInfoDelegate
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.prefs.PreferencesService
@@ -80,12 +81,27 @@ public interface Device {
      * @return the total free capacity of the internal storage of the device in bytes
      */
     public val internalStorageTotalCapacity: Lazy<Long>
+
+    /**
+     * The name of the primary CPU of the device, obtained with the system call 'ro.board.platform'.
+     *
+     * @return the name of the primary CPU of the device
+     */
+    public val cpuName: String?
+
+    /**
+     * The EGL (Embedded-System Graphics Library) information obtained with the system call 'ro.hardware.egl'
+     *
+     * @return the ELG of the primary CPU of the device
+     */
+    public val eglInfo: String?
 }
 
 internal class DeviceImpl(
     private val windowManager: WindowManager,
     private val preferencesService: PreferencesService,
-    private val backgroundWorker: BackgroundWorker
+    private val backgroundWorker: BackgroundWorker,
+    private val cpuInfoDelegate: CpuInfoDelegate
 ) : Device {
     override var isJailbroken: Boolean? = null
     override var screenResolution: String = ""
@@ -263,4 +279,8 @@ internal class DeviceImpl(
      * @return the total free capacity of the internal storage of the device in bytes
      */
     override val internalStorageTotalCapacity = lazy { StatFs(Environment.getDataDirectory().path).totalBytes }
+
+    override val cpuName: String? = cpuInfoDelegate.getCpuName()
+
+    override val eglInfo: String? = cpuInfoDelegate.getEgl()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
@@ -1,0 +1,266 @@
+package io.embrace.android.embracesdk.capture.envelope.resource
+
+import android.os.Build
+import android.os.Environment
+import android.os.StatFs
+import android.util.DisplayMetrics
+import android.view.WindowManager
+import androidx.annotation.ChecksSdkIntAtLeast
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
+import io.embrace.android.embracesdk.prefs.PreferencesService
+import io.embrace.android.embracesdk.worker.BackgroundWorker
+import java.io.File
+import java.util.Locale
+
+public interface Device {
+
+    /**
+     * Tries to determine whether the device is jailbroken by looking for specific directories which
+     * exist on jailbroken devices. Emulators are excluded and will always return false.
+     *
+     * @return true if the device is jailbroken and not an emulator, false otherwise
+     */
+    public var isJailbroken: Boolean?
+
+    /**
+     * Gets the device's screen resolution.
+     *
+     * @param windowManager the {@link WindowManager} from the {@link Context}
+     * @return the device's screen resolution
+     */
+    public var screenResolution: String
+
+    /**
+     * Gets the name of the manufacturer of the device.
+     *
+     * @return the name of the device manufacturer
+     */
+    public val manufacturer: String?
+
+    /**
+     * Gets the name of the model of the device.
+     *
+     * @return the name of the model of the device
+     */
+    public val model: String?
+
+    /**
+     * Gets the operating system of the device. This is hard-coded to Android OS.
+     *
+     * @return the device's operating system
+     */
+    public val operatingSystemType: String
+
+    /**
+     * Gets the version of the installed operating system on the device.
+     *
+     * @return the version of the operating system
+     */
+    public val operatingSystemVersion: String?
+
+    /**
+     * Gets the version code of the running Android SDK.
+     *
+     * @return the running Android SDK version code
+     */
+    public val operatingSystemVersionCode: Int
+
+    /**
+     * Get the number of available cores for device info
+     *
+     * @return Number of cores in long
+     */
+    public val numberOfCores: Int
+
+    /**
+     * Gets the free capacity of the internal storage of the device.
+     *
+     * @param statFs the {@link StatFs} service for the device
+     * @return the total free capacity of the internal storage of the device in bytes
+     */
+    public val internalStorageTotalCapacity: Lazy<Long>
+}
+
+internal class DeviceImpl(
+    private val windowManager: WindowManager,
+    private val preferencesService: PreferencesService,
+    private val backgroundWorker: BackgroundWorker
+) : Device {
+    override var isJailbroken: Boolean? = null
+    override var screenResolution: String = ""
+    private val jailbreakLocations: List<String> = mutableListOf(
+        "/sbin/",
+        "/system/bin/",
+        "/system/xbin/",
+        "/data/local/xbin/",
+        "/data/local/bin/",
+        "/system/sd/xbin/",
+        "/system/bin/failsafe/",
+        "/data/local/"
+    )
+    
+    init {
+        logDeveloper(
+            "Device",
+            "Precomputing values asynchronously: Jailbroken/ScreenResolution/DiskUsage"
+        )
+        asyncRetrieveIsJailbroken()
+        asyncRetrieveScreenResolution()
+    }
+
+    private fun asyncRetrieveScreenResolution() {
+        // if the screenResolution exists in memory, don't try to retrieve it
+        if (screenResolution.isNotEmpty()) {
+            logDeveloper("Device", "Screen resolution already exists")
+            return
+        }
+        backgroundWorker.submit {
+            logDeveloper("Device", "Async retrieve screen resolution")
+            val storedScreenResolution = preferencesService.screenResolution
+            // get from shared preferences
+            if (storedScreenResolution != null) {
+                logDeveloper("Device", "Screen resolution is present, loading from store")
+                screenResolution = storedScreenResolution
+            } else {
+                screenResolution = getScreenResolution(windowManager)
+                preferencesService.screenResolution = screenResolution
+                logDeveloper("Device", "Screen resolution computed and stored")
+            }
+        }
+    }
+
+    private fun getScreenResolution(windowManager: WindowManager): String {
+        return try {
+            logDeveloper("Device", "Computing screen resolution")
+            val display = windowManager.defaultDisplay
+            val displayMetrics = DisplayMetrics()
+            display.getMetrics(displayMetrics)
+            String.format(
+                Locale.US,
+                "%dx%d",
+                displayMetrics.widthPixels,
+                displayMetrics.heightPixels
+            )
+        } catch (ex: Exception) {
+            logDebug("Could not determine screen resolution", ex)
+            ""
+        }
+    }
+
+    private fun asyncRetrieveIsJailbroken() {
+        logDeveloper("Device", "Async retrieve Jailbroken")
+
+        // if the isJailbroken property exists in memory, don't try to retrieve it
+        if (isJailbroken != null) {
+            logDeveloper("Device", "Jailbroken already exists")
+            return
+        }
+        backgroundWorker.submit {
+            logDeveloper("Device", "Async retrieve jailbroken")
+            val storedIsJailbroken = preferencesService.jailbroken
+            // load value from shared preferences
+            if (storedIsJailbroken != null) {
+                logDeveloper("Device", "Jailbroken is present, loading from store")
+                isJailbroken = storedIsJailbroken
+            } else {
+                isJailbroken = checkIfIsJailbroken()
+                preferencesService.jailbroken = isJailbroken
+                logDeveloper("Device", "Jailbroken processed and stored")
+            }
+            logDeveloper("Device", "Jailbroken: $isJailbroken")
+        }
+    }
+
+    /**
+     * Tries to determine whether the device is jailbroken by looking for specific directories which
+     * exist on jailbroken devices. Emulators are excluded and will always return false.
+     *
+     * @return true if the device is jailbroken and not an emulator, false otherwise
+     */
+    private fun checkIfIsJailbroken(): Boolean {
+        logDeveloper("Device", "Processing jailbroken")
+        if (isEmulator()) {
+            logDeveloper("Device", "Device is an emulator, Jailbroken=false")
+            return false
+        }
+        for (location in jailbreakLocations) {
+            if (File(location + "su").exists()) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Tries to determine whether the device is an emulator by looking for known models and
+     * manufacturers which correspond to emulators.
+     *
+     * @return true if the device is detected to be an emulator, false otherwise
+     */
+    private fun isEmulator(): Boolean {
+        val isEmulator = Build.FINGERPRINT.startsWith("generic") ||
+                Build.FINGERPRINT.startsWith("unknown") ||
+                Build.FINGERPRINT.contains("emulator") ||
+                Build.MODEL.contains("google_sdk") ||
+                Build.MODEL.contains("sdk_gphone64") ||
+                Build.MODEL.contains("Emulator") ||
+                Build.MODEL.contains("Android SDK built for") ||
+                Build.MANUFACTURER.contains("Genymotion") ||
+                Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic") ||
+                Build.PRODUCT.equals("google_sdk")
+        logDeveloper("MetadataUtils", "Device is an Emulator = $isEmulator")
+        return isEmulator
+    }
+
+    /**
+     * Gets the name of the manufacturer of the device.
+     *
+     * @return the name of the device manufacturer
+     */
+    override val manufacturer: String? = Build.MANUFACTURER
+
+    /**
+     * Gets the name of the model of the device.
+     *
+     * @return the name of the model of the device
+     */
+    override val model: String? = Build.MODEL
+
+    /**
+     * Gets the operating system of the device. This is hard-coded to Android OS.
+     *
+     * @return the device's operating system
+     */
+    override val operatingSystemType: String = "Android OS"
+
+    /**
+     * Gets the version of the installed operating system on the device.
+     *
+     * @return the version of the operating system
+     */
+    override val operatingSystemVersion: String? = Build.VERSION.RELEASE
+
+    /**
+     * Gets the version code of the running Android SDK.
+     *
+     * @return the running Android SDK version code
+     */
+    @ChecksSdkIntAtLeast(parameter = 0)
+    override val operatingSystemVersionCode: Int = Build.VERSION.SDK_INT
+
+    /**
+     * Get the number of available cores for device info
+     *
+     * @return Number of cores in long
+     */
+    override val numberOfCores: Int = Runtime.getRuntime().availableProcessors()
+
+    /**
+     * Gets the free capacity of the internal storage of the device.
+     *
+     * @param statFs the {@link StatFs} service for the device
+     * @return the total free capacity of the internal storage of the device in bytes
+     */
+    override val internalStorageTotalCapacity = lazy { StatFs(Environment.getDataDirectory().path).totalBytes }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -1,20 +1,23 @@
 package io.embrace.android.embracesdk.capture.envelope.resource
 
+import android.content.pm.PackageInfo
 import io.embrace.android.embracesdk.Embrace.AppFramework
+import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.payload.AppInfo
-import io.embrace.android.embracesdk.payload.DeviceInfo
 
 internal class EnvelopeResourceSourceImpl(
-    private val deviceInfo: DeviceInfo,
     private val appInfo: AppInfo,
-    private val packageName: String,
-    private val appFramework: AppFramework
+    private val packageInfo: PackageInfo,
+    private val appFramework: AppFramework,
+    private val deviceArchitecture: DeviceArchitecture,
+    private val device: Device
 ) : EnvelopeResourceSource {
+
     override fun getEnvelopeResource(): EnvelopeResource {
         return EnvelopeResource(
             appVersion = appInfo.appVersion,
-            appEcosystemId = packageName,
+            appEcosystemId = packageInfo.packageName,
             appFramework = mapFramework(appFramework),
             buildId = appInfo.buildId,
             buildType = appInfo.buildType,
@@ -28,16 +31,16 @@ internal class EnvelopeResourceSourceImpl(
             hostedPlatformVersion = appInfo.hostedPlatformVersion,
             hostedSdkVersion = appInfo.hostedSdkVersion,
             unityBuildId = appInfo.buildGuid,
-            deviceManufacturer = deviceInfo.manufacturer,
-            deviceModel = deviceInfo.model,
-            deviceArchitecture = deviceInfo.architecture,
-            jailbroken = deviceInfo.jailbroken,
-            diskTotalCapacity = deviceInfo.internalStorageTotalCapacity,
-            osType = deviceInfo.operatingSystemType,
-            osVersion = deviceInfo.operatingSystemVersion,
-            osCode = deviceInfo.operatingSystemVersionCode.toString(),
-            screenResolution = deviceInfo.screenResolution,
-            numCores = deviceInfo.cores,
+            deviceManufacturer = device.manufacturer,
+            deviceModel = device.model,
+            deviceArchitecture = deviceArchitecture.architecture,
+            jailbroken = device.isJailbroken,
+            diskTotalCapacity = device.internalStorageTotalCapacity.value,
+            osType = device.operatingSystemType,
+            osVersion = device.operatingSystemVersion,
+            osCode = device.operatingSystemVersionCode.toString(),
+            screenResolution = device.screenResolution,
+            numCores = device.numberOfCores,
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -155,7 +155,7 @@ internal class EmbraceMetadataService private constructor(
             if (storedEgl != null) {
                 egl = storedEgl
             } else {
-                egl = embraceCpuInfoDelegate.getElg()
+                egl = embraceCpuInfoDelegate.getEgl()
                 preferencesService.egl = egl
                 logDeveloper("EmbraceMetadataService", "egl computed and stored")
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -176,9 +176,18 @@ internal data class EnvelopeResource(
 
     /* (Android) The number of CPU cores the device has. Previous name: d.nc */
     @Json(name = "num_cores")
-    val numCores: Int? = null
+    val numCores: Int? = null,
 
-) {
+    /* (Android) The name of the primary CPU of the device, obtained with the system call 'ro.board.platform'.
+    Previous name: d.pt */
+    @Json(name = "cpu_name")
+    val cpuName: kotlin.Int? = null,
+
+    /* (Android) The EGL (Embedded-System Graphics Library) information obtained with the system call
+    'ro.hardware.egl'. Previous name: d.gp */
+    @Json(name = "egl_info")
+    val eglInfo: kotlin.Int? = null
+){
 
     /**
      * The frameworks in use by the app. Previous name: a.f

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegateTest.kt
@@ -32,6 +32,6 @@ internal class EmbraceCpuInfoDelegateTest {
         every { mockSharedObjectLoader.loadEmbraceNative() } returns false
 
         assertEquals(null, cpuInfoDelegate.getCpuName())
-        assertEquals(null, cpuInfoDelegate.getElg())
+        assertEquals(null, cpuInfoDelegate.getEgl())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/DeviceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/DeviceImplTest.kt
@@ -1,0 +1,84 @@
+package io.embrace.android.embracesdk.capture.envelope.resource
+
+import android.os.Environment
+import android.view.WindowManager
+import com.google.common.util.concurrent.MoreExecutors
+import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
+import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
+import io.embrace.android.embracesdk.worker.BackgroundWorker
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import java.io.File
+
+
+internal class DeviceImplTest {
+
+    companion object {
+        private val preferencesService: EmbracePreferencesService = mockk(relaxed = true)
+        private val cpuInfoDelegate: FakeCpuInfoDelegate = FakeCpuInfoDelegate()
+        private val windowManager = mockk<WindowManager>()
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            mockkStatic(Environment::class)
+
+            initPreferences()
+
+            every { Environment.getDataDirectory() }.returns(File("ANDROID_DATA"))
+        }
+
+        @After
+        fun tearDown() {
+            unmockkAll()
+        }
+
+        private fun initPreferences() {
+            every { preferencesService.screenResolution }.returns("200x300")
+        }
+    }
+    @Before
+    fun setUp() {
+        clearAllMocks(
+            answers = false,
+            objectMocks = false,
+            constructorMocks = false,
+            staticMocks = false
+        )
+    }
+
+    @Test
+    fun `test screen resolution from preferences`() {
+        val device = DeviceImpl(windowManager, preferencesService,
+            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            cpuInfoDelegate)
+
+        assertEquals("200x300", device.screenResolution)
+    }
+
+    @Test
+    fun getCpuName() {
+        val device = DeviceImpl(windowManager, preferencesService,
+            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            cpuInfoDelegate)
+
+        assertEquals("fake_cpu", device.cpuName)
+    }
+
+    @Test
+    fun getEgl() {
+        val device = DeviceImpl(windowManager, preferencesService,
+            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            cpuInfoDelegate)
+
+        assertEquals("fake_egl", device.eglInfo)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -1,19 +1,58 @@
 package io.embrace.android.embracesdk.capture.envelope.resource
 
+import android.content.pm.PackageInfo
+import android.os.Environment
+import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.fakes.FakeDevice
+import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.BeforeClass
 import org.junit.Test
+import java.io.File
 
 internal class EnvelopeResourceSourceImplTest {
+
+    companion object {
+        private val packageInfo = PackageInfo()
+        private val fakeArchitecture = FakeDeviceArchitecture()
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            mockkStatic(Environment::class)
+
+            initContext()
+
+            every { Environment.getDataDirectory() }.returns(File("ANDROID_DATA"))
+            //every { MetadataUtils.getInternalStorageFreeCapacity(any()) }.returns(123L)
+        }
+
+        @After
+        fun tearDown() {
+            unmockkAll()
+        }
+
+        @Suppress("DEPRECATION")
+        private fun initContext() {
+            packageInfo.packageName = "com.embrace.fake"
+        }
+    }
 
     @Test
     fun getEnvelopeResource() {
         val metadataService = FakeMetadataService()
         val source = EnvelopeResourceSourceImpl(
-            metadataService.getDeviceInfo(),
             metadataService.getAppInfo(),
-            metadataService
+            packageInfo,
+            Embrace.AppFramework.NATIVE,
+            fakeArchitecture,
+            FakeDevice()
         )
         val envelope = source.getEnvelopeResource()
 
@@ -33,14 +72,14 @@ internal class EnvelopeResourceSourceImplTest {
         assertEquals("19", envelope.hostedPlatformVersion)
         assertEquals("5092abc", envelope.unityBuildId)
         assertEquals("Samsung", envelope.deviceManufacturer)
-        assertEquals("SM-G950U", envelope.deviceModel)
+        assertEquals("Galaxy S10", envelope.deviceModel)
         assertEquals("arm64-v8a", envelope.deviceArchitecture)
         assertEquals(false, envelope.jailbroken)
         assertEquals(10000000L, envelope.diskTotalCapacity)
         assertEquals("Android", envelope.osType)
         assertEquals("8.0.0", envelope.osVersion)
         assertEquals("26", envelope.osCode)
-        assertEquals("1080x720", envelope.screenResolution)
+        assertEquals("1920x1080", envelope.screenResolution)
         assertEquals(8, envelope.numCores)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCpuInfoDelegate.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCpuInfoDelegate.kt
@@ -4,9 +4,9 @@ import io.embrace.android.embracesdk.capture.cpu.CpuInfoDelegate
 
 internal class FakeCpuInfoDelegate(
     private val cpuName: String? = "fake_cpu",
-    private val elg: String = "fake_elg"
+    private val egl: String = "fake_egl"
 ) : CpuInfoDelegate {
     override fun getCpuName(): String? = cpuName
 
-    override fun getElg(): String? = elg
+    override fun getEgl(): String? = egl
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDevice.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDevice.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.capture.envelope.resource.Device
+
+public class FakeDevice(
+    override var isJailbroken: Boolean? = false,
+    override var screenResolution: String = "1920x1080",
+    override val manufacturer: String? = "Samsung",
+    override val model: String? = "Galaxy S10",
+    override val operatingSystemType: String = "Android",
+    override val operatingSystemVersion: String? = "8.0.0",
+    override val operatingSystemVersionCode: Int = 26 ,
+    override val numberOfCores: Int = 8,
+    override val internalStorageTotalCapacity: Lazy<Long> = lazy { 10000000L }
+) : Device

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDevice.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDevice.kt
@@ -9,7 +9,9 @@ public class FakeDevice(
     override val model: String? = "Galaxy S10",
     override val operatingSystemType: String = "Android",
     override val operatingSystemVersion: String? = "8.0.0",
-    override val operatingSystemVersionCode: Int = 26 ,
+    override val operatingSystemVersionCode: Int = 26,
     override val numberOfCores: Int = 8,
-    override val internalStorageTotalCapacity: Lazy<Long> = lazy { 10000000L }
+    override val internalStorageTotalCapacity: Lazy<Long> = lazy { 10000000L },
+    override val cpuName: String? = "fake_cpu",
+    override val eglInfo: String? = "fake_elg"
 ) : Device


### PR DESCRIPTION
## Goal

Avoid using legacy dataclass `DeviceInfo` and static `MetadataUtils`

Fixes typo on *EGL* `(Embedded-System Graphics Library)`

## Testing

Unit tests
