### PR TITLE
Defer the registration of thermal and power save mode listners to background thread

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
@@ -67,9 +67,8 @@ internal class EmbracePowerSaveModeServiceTest {
         service = EmbracePowerSaveModeService(
             context,
             worker,
-            fakeClock,
-            powerManager
-        )
+            fakeClock
+        ) { powerManager }
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceThermalStatusServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceThermalStatusServiceTest.kt
@@ -1,11 +1,12 @@
 package io.embrace.android.embracesdk
 
 import android.os.PowerManager
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.capture.thermalstate.EmbraceThermalStatusService
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.system.mockPowerManager
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.ThermalState
+import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -17,11 +18,10 @@ internal class EmbraceThermalStatusServiceTest {
     @Before
     fun setUp() {
         service = EmbraceThermalStatusService(
-            MoreExecutors.directExecutor(),
+            BackgroundWorker(BlockableExecutorService()),
             { 0 },
-            InternalEmbraceLogger(),
-            mockPowerManager()
-        )
+            InternalEmbraceLogger()
+        ) { mockPowerManager() }
     }
 
     @Test


### PR DESCRIPTION
## Goal

The services require making a system call to initialize the PowerManager, which can be expensive and take an unpredictable amount of time. Doing that on the main thread on startup isn't ideal, defer the init to a background thread.

## Testing

Covered by existing tests