### PR TITLE
Alter signatures on PayloadFactory class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -89,7 +89,7 @@ internal class SessionModuleImpl(
     }
 
     override val payloadFactory: PayloadFactory by singleton {
-        PayloadFactoryImpl(payloadMessageCollator)
+        PayloadFactoryImpl(payloadMessageCollator, essentialServiceModule.configService)
     }
 
     private val boundaryDelegate by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactory.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 
 /**
  * Factory that creates session + background activity payloads.
@@ -11,7 +12,27 @@ internal interface PayloadFactory {
     /**
      * Starts a session in response to a state event.
      */
-    fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session
+    fun startPayloadWithState(state: ProcessState, timestamp: Long, coldStart: Boolean): Session?
+
+    /**
+     * Ends a session in response to a state event.
+     */
+    fun endPayloadWithState(state: ProcessState, timestamp: Long, initial: Session): SessionMessage?
+
+    /**
+     * Handles an uncaught exception, ending the session and saving the session to disk.
+     */
+    fun endPayloadWithCrash(
+        state: ProcessState,
+        timestamp: Long,
+        initial: Session,
+        crashId: String
+    ): SessionMessage?
+
+    /**
+     * Provides a snapshot of the active session
+     */
+    fun snapshotPayload(state: ProcessState, timestamp: Long, initial: Session): SessionMessage?
 
     /**
      * Starts a session manually.
@@ -19,42 +40,7 @@ internal interface PayloadFactory {
     fun startSessionWithManual(timestamp: Long): Session
 
     /**
-     * Ends a background activity in response to a state event.
-     */
-    fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): Session
-
-    /**
-     * Handles an uncaught exception, ending the session and saving the activity to disk.
-     */
-    fun endBackgroundActivityWithCrash(initial: Session, timestamp: Long, crashId: String): SessionMessage
-
-    /**
-     * Starts a background activity in response to a state event.
-     */
-    fun endBackgroundActivityWithState(initial: Session, timestamp: Long): SessionMessage
-
-    /**
-     * Ends a session in response to a state event.
-     */
-    fun endSessionWithState(initial: Session, timestamp: Long): SessionMessage
-
-    /**
      * Ends a session manually.
      */
-    fun endSessionWithManual(initial: Session, timestamp: Long): SessionMessage
-
-    /**
-     * Handles an uncaught exception, ending the session and saving the session to disk.
-     */
-    fun endSessionWithCrash(initial: Session, timestamp: Long, crashId: String): SessionMessage
-
-    /**
-     * Provides a snapshot of the active session
-     */
-    fun snapshotSession(initial: Session, timestamp: Long): SessionMessage?
-
-    /**
-     * Provides a snapshot of the active background activity
-     */
-    fun snapshotBackgroundActivity(initial: Session, timestamp: Long): SessionMessage
+    fun endSessionWithManual(timestamp: Long, initial: Session): SessionMessage
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
 import io.mockk.clearAllMocks
@@ -69,7 +70,7 @@ internal class PayloadFactorySessionTest {
         initializeSessionService()
         val coldStart = true
 
-        service.startSessionWithState(456, coldStart)
+        service.startPayloadWithState(ProcessState.FOREGROUND, 456, coldStart)
         assertNull(deliveryService.lastSentCachedSession)
     }
 
@@ -83,6 +84,6 @@ internal class PayloadFactorySessionTest {
         isActivityInBackground: Boolean = true
     ) {
         processStateService.isInBackground = isActivityInBackground
-        service = PayloadFactoryImpl(mockk(relaxed = true))
+        service = PayloadFactoryImpl(mockk(relaxed = true), FakeConfigService())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -26,7 +26,6 @@ import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -171,16 +170,6 @@ internal class SessionOrchestratorTest {
         assertEquals(0, payloadFactory.manualSessionEndCount)
         assertEquals(0, payloadFactory.manualSessionStartCount)
         assertEquals(0, deliveryService.lastSentSessions.size)
-    }
-
-    @Test
-    fun `test background activity capture disabled`() {
-        configService = FakeConfigService(backgroundActivityCaptureEnabled = false)
-        createOrchestrator(false)
-        orchestrator.onBackground(TIMESTAMP)
-        assertEquals(2, memoryCleanerService.callCount)
-        assertTrue(payloadFactory.startBaTimestamps.isEmpty())
-        assertEquals(1, deliveryService.lastSentSessions.size)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Alters the `PayloadFactory` interface so that callers don't need to know whether a session/background activity is being constructed. This is done by passing the process state, and having the implementation call the appropriate function. This refactor will make it easier to switch over to using the new payload.

## Testing

Relied on existing unit test coverage for the session orchestrator.

