### PR TITLE
Replace data with envelopeData to avoid quotes in the class

### DIFF
--- a/embrace-android-sdk/build.gradle
+++ b/embrace-android-sdk/build.gradle
@@ -162,6 +162,11 @@ openApiGenerate {
             models: ""
     ])
 
+    // replace data with envelopeData to avoid conflict with kotlin keyword
+    nameMappings = [
+            "data": "envelopeData",
+    ]
+
     // see further options for configuring kotlin codegen here:
     // https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/kotlin.md
     additionalProperties = [


### PR DESCRIPTION
Added nameMappings in openApiGenerate to avoid the data property in Envelope looking like this: 


 ```
val `data`: EnvelopeData
```