### PR TITLE
Add V2 payload message collator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
-import io.embrace.android.embracesdk.session.message.PayloadMessageCollatorImpl
+import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
 import io.embrace.android.embracesdk.session.orchestrator.OrchestratorBoundaryDelegate
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestratorImpl
@@ -44,7 +44,7 @@ internal class SessionModuleImpl(
 ) : SessionModule {
 
     override val payloadMessageCollator: PayloadMessageCollator by singleton {
-        PayloadMessageCollatorImpl(
+        V1PayloadMessageCollator(
             essentialServiceModule.configService,
             essentialServiceModule.metadataService,
             dataContainerModule.eventService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -24,7 +24,7 @@ import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
-internal class PayloadMessageCollatorImpl(
+internal class V1PayloadMessageCollator(
     private val configService: ConfigService,
     private val metadataService: MetadataService,
     private val eventService: EventService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.session.message
+
+import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
+
+/**
+ * Generates a V2 payload. This currently calls through to the V1 collator for
+ * backwards compatibility.
+ */
+internal class V2PayloadMessageCollator(
+    private val v1Collator: V1PayloadMessageCollator
+) : PayloadMessageCollator {
+
+    override fun buildInitialSession(params: InitialEnvelopeParams): Session {
+        return v1Collator.buildInitialSession(params)
+    }
+
+    override fun buildFinalSessionMessage(params: FinalEnvelopeParams.SessionParams): SessionMessage {
+        return v1Collator.buildFinalSessionMessage(params)
+    }
+
+    override fun buildFinalBackgroundActivityMessage(params: FinalEnvelopeParams.BackgroundActivityParams): SessionMessage {
+        return v1Collator.buildFinalBackgroundActivityMessage(params)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -34,7 +34,7 @@ import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
-import io.embrace.android.embracesdk.session.message.PayloadMessageCollatorImpl
+import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -153,7 +153,7 @@ internal class PayloadFactoryBaTest {
     }
 
     private fun createService(createInitialSession: Boolean = true): PayloadFactoryImpl {
-        val collator = PayloadMessageCollatorImpl(
+        val collator = V1PayloadMessageCollator(
             configService,
             metadataService,
             eventService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -42,7 +42,7 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
-import io.embrace.android.embracesdk.session.message.PayloadMessageCollatorImpl
+import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.clearAllMocks
@@ -135,7 +135,7 @@ internal class SessionHandlerTest {
         val initModule = FakeInitModule(clock = clock)
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
-        val payloadMessageCollator = PayloadMessageCollatorImpl(
+        val payloadMessageCollator = V1PayloadMessageCollator(
             configService,
             metadataService,
             eventService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -21,7 +21,7 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams
 import io.embrace.android.embracesdk.session.message.InitialEnvelopeParams
 import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
-import io.embrace.android.embracesdk.session.message.PayloadMessageCollatorImpl
+import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -29,7 +29,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 
-internal class PayloadMessageCollatorTest {
+internal class V1PayloadMessageCollatorTest {
 
     private lateinit var initModule: FakeInitModule
     private lateinit var collator: PayloadMessageCollator
@@ -42,7 +42,7 @@ internal class PayloadMessageCollatorTest {
     @Before
     fun setUp() {
         initModule = FakeInitModule()
-        collator = PayloadMessageCollatorImpl(
+        collator = V1PayloadMessageCollator(
             configService = FakeConfigService(),
             nativeThreadSamplerService = null,
             thermalStatusService = FakeThermalStatusService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -1,0 +1,190 @@
+package io.embrace.android.embracesdk.session.message
+
+import io.embrace.android.embracesdk.FakeBreadcrumbService
+import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEventService
+import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.fakes.FakeLogMessageService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
+import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
+import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeStartupService
+import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
+import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.fakes.FakeWebViewService
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.payload.LegacyExceptionError
+import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+internal class V2PayloadMessageCollatorTest {
+
+    private lateinit var initModule: FakeInitModule
+    private lateinit var v1collator: V1PayloadMessageCollator
+    private lateinit var v2collator: V2PayloadMessageCollator
+
+    private enum class PayloadType {
+        BACKGROUND_ACTIVITY,
+        SESSION
+    }
+
+    @Before
+    fun setUp() {
+        initModule = FakeInitModule()
+        v1collator = V1PayloadMessageCollator(
+            configService = FakeConfigService(),
+            nativeThreadSamplerService = null,
+            thermalStatusService = FakeThermalStatusService(),
+            webViewService = FakeWebViewService(),
+            userService = FakeUserService(),
+            preferencesService = FakePreferenceService(),
+            eventService = FakeEventService(),
+            logMessageService = FakeLogMessageService(),
+            internalErrorService = FakeInternalErrorService().apply { currentExceptionError = LegacyExceptionError() },
+            breadcrumbService = FakeBreadcrumbService(),
+            metadataService = FakeMetadataService(),
+            performanceInfoService = FakePerformanceInfoService(),
+            spanSink = initModule.openTelemetryModule.spanSink,
+            currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
+            sessionPropertiesService = FakeSessionPropertiesService(),
+            startupService = FakeStartupService()
+        )
+        v2collator = V2PayloadMessageCollator(v1collator)
+    }
+
+    @Test
+    fun `create background activity initial message`() {
+        val msg = v2collator.buildInitialSession(
+            InitialEnvelopeParams.BackgroundActivityParams(
+                false,
+                Session.LifeEventType.BKGND_STATE,
+                5
+            )
+        )
+        msg.verifyInitialFieldsPopulated(PayloadType.BACKGROUND_ACTIVITY)
+    }
+
+    @Test
+    fun `create session initial message`() {
+        val msg = v2collator.buildInitialSession(
+            InitialEnvelopeParams.SessionParams(
+                false,
+                Session.LifeEventType.STATE,
+                5
+            )
+        )
+        msg.verifyInitialFieldsPopulated(PayloadType.SESSION)
+    }
+
+    @Test
+    fun `create background activity end message`() {
+        // create start message
+        val startMsg = v2collator.buildInitialSession(
+            InitialEnvelopeParams.BackgroundActivityParams(
+                false,
+                Session.LifeEventType.BKGND_STATE,
+                5
+            )
+        )
+        startMsg.verifyInitialFieldsPopulated(PayloadType.BACKGROUND_ACTIVITY)
+
+        // create session
+        val payload = v2collator.buildFinalBackgroundActivityMessage(
+            FinalEnvelopeParams.BackgroundActivityParams(
+                startMsg,
+                15000000000,
+                Session.LifeEventType.BKGND_STATE,
+                "crashId"
+            )
+        )
+        payload.verifyFinalFieldsPopulated(PayloadType.BACKGROUND_ACTIVITY)
+    }
+
+    @Test
+    fun `create session end message`() {
+        // create start message
+        val startMsg = v2collator.buildInitialSession(
+            InitialEnvelopeParams.SessionParams(
+                false,
+                Session.LifeEventType.STATE,
+                5
+            )
+        )
+        startMsg.verifyInitialFieldsPopulated(PayloadType.SESSION)
+
+        // create session
+        val payload = v2collator.buildFinalSessionMessage(
+            FinalEnvelopeParams.SessionParams(
+                startMsg,
+                15000000000,
+                Session.LifeEventType.STATE,
+                "crashId",
+                SessionSnapshotType.NORMAL_END
+            )
+        )
+        payload.verifyFinalFieldsPopulated(PayloadType.SESSION)
+    }
+
+    private fun SessionMessage.verifyFinalFieldsPopulated(
+        payloadType: PayloadType
+    ) {
+        assertNotNull(userInfo)
+        assertNotNull(appInfo)
+        assertNotNull(deviceInfo)
+        assertNotNull(performanceInfo)
+        assertNotNull(breadcrumbs)
+        session.verifyInitialFieldsPopulated(payloadType)
+        session.verifyFinalFieldsPopulated(payloadType)
+    }
+
+    private fun Session.verifyInitialFieldsPopulated(payloadType: PayloadType) {
+        assertNotNull(sessionId)
+        assertEquals(5L, startTime)
+        Assert.assertFalse(isColdStart)
+        assertNotNull(number)
+
+        val expectedState = when (payloadType) {
+            PayloadType.BACKGROUND_ACTIVITY -> Session.APPLICATION_STATE_BACKGROUND
+            PayloadType.SESSION -> Session.APPLICATION_STATE_FOREGROUND
+        }
+        val expectedStartType = when (payloadType) {
+            PayloadType.BACKGROUND_ACTIVITY -> Session.LifeEventType.BKGND_STATE
+            PayloadType.SESSION -> Session.LifeEventType.STATE
+        }
+        val expectedSessionProps = when (payloadType) {
+            PayloadType.BACKGROUND_ACTIVITY -> null
+            PayloadType.SESSION -> emptyMap<String, String>()
+        }
+        assertEquals(expectedState, appState)
+        assertEquals(expectedStartType, startType)
+        assertEquals(Session.MESSAGE_TYPE_END, messageType)
+        assertEquals(expectedSessionProps, properties)
+    }
+
+    private fun Session.verifyFinalFieldsPopulated(payloadType: PayloadType) {
+        val expectedEndType = when (payloadType) {
+            PayloadType.BACKGROUND_ACTIVITY -> Session.LifeEventType.BKGND_STATE
+            PayloadType.SESSION -> Session.LifeEventType.STATE
+        }
+        assertEquals(15000000000L, endTime)
+        assertEquals(expectedEndType, endType)
+        assertEquals(15000000000L, lastHeartbeatTime)
+        assertEquals("crashId", crashReportId)
+        assertNotNull(eventIds)
+        assertNotNull(infoLogIds)
+        assertNotNull(warningLogIds)
+        assertNotNull(errorLogIds)
+        assertNotNull(infoLogsAttemptedToSend)
+        assertNotNull(warnLogsAttemptedToSend)
+        assertNotNull(errorLogsAttemptedToSend)
+        assertNotNull(exceptionError)
+        assertNotNull(unhandledExceptions)
+    }
+}


### PR DESCRIPTION
## Goal

Adds the skeleton of a V2 payload message collator. Currently this just calls into the v1 collator but will be updated in a future changeset to populate the new fields.

## Testing

Reused test coverage from old collator.

