### PR TITLE
Populate fields from new payload

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSource.kt
@@ -17,8 +17,8 @@ internal class SessionEnvelopeSource(
         return Envelope(
             resourceSource.getEnvelopeResource(),
             metadataSource.getEnvelopeMetadata(),
-            null,
-            null,
+            "0.1.0",
+            "session",
             sessionPayloadSource.getSessionPayload(endType)
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionMessage.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionMessage.kt
@@ -55,7 +55,7 @@ internal data class SessionMessage @JvmOverloads internal constructor(
     val spans: List<EmbraceSpanData>? = null,
 
     @Json(name = "v")
-    val version: Int = ApiClient.MESSAGE_VERSION,
+    val version: Int? = ApiClient.MESSAGE_VERSION,
 
     /*
      * Values below this point are copied temporarily from [Envelope]. Eventually we will migrate

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -15,6 +15,7 @@ internal sealed class FinalEnvelopeParams(
     val endTime: Long,
     val lifeEventType: Session.LifeEventType?,
     crashId: String?,
+    val endType: SessionSnapshotType,
     val isCacheAttempt: Boolean
 ) {
 
@@ -35,12 +36,14 @@ internal sealed class FinalEnvelopeParams(
         initial: Session,
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
-        crashId: String? = null
+        endType: SessionSnapshotType,
+        crashId: String? = null,
     ) : FinalEnvelopeParams(
         initial,
         endTime,
         lifeEventType,
         crashId,
+        endType,
         lifeEventType == null
     ) {
         override val terminationTime: Long? = null
@@ -56,13 +59,14 @@ internal sealed class FinalEnvelopeParams(
         initial: Session,
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
+        endType: SessionSnapshotType,
         crashId: String? = null,
-        val endType: SessionSnapshotType
     ) : FinalEnvelopeParams(
         initial,
         endTime,
         lifeEventType,
         crashId,
+        endType,
         endType == SessionSnapshotType.PERIODIC_CACHE
     ) {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -113,7 +113,8 @@ internal class PayloadFactoryImpl(
             FinalEnvelopeParams.BackgroundActivityParams(
                 initial = initial,
                 endTime = timestamp - 1,
-                lifeEventType = LifeEventType.BKGND_STATE
+                lifeEventType = LifeEventType.BKGND_STATE,
+                endType = SessionSnapshotType.NORMAL_END
             )
         )
     }
@@ -147,7 +148,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endTime = timestamp,
                 lifeEventType = LifeEventType.BKGND_STATE,
-                crashId = crashId
+                crashId = crashId,
+                endType = SessionSnapshotType.JVM_CRASH
             )
         )
     }
@@ -174,7 +176,8 @@ internal class PayloadFactoryImpl(
             FinalEnvelopeParams.BackgroundActivityParams(
                 initial = initial,
                 endTime = timestamp,
-                lifeEventType = null
+                lifeEventType = null,
+                endType = SessionSnapshotType.PERIODIC_CACHE
             )
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/SessionEnvelopeSourceTest.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class SessionEnvelopeSourceTest {
@@ -24,9 +23,7 @@ internal class SessionEnvelopeSourceTest {
         assertEquals(metadataSource.metadata, payload.metadata)
         assertEquals(resourceSource.resource, payload.resource)
         assertEquals(sessionPayloadSource.sessionPayload, payload.data)
-
-        // future fields that need populating:
-        assertNull(payload.type)
-        assertNull(payload.version)
+        assertEquals("session", payload.type)
+        assertEquals("0.1.0", payload.version)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -104,6 +104,7 @@ internal class V1PayloadMessageCollatorTest {
                 startMsg,
                 15000000000,
                 LifeEventType.BKGND_STATE,
+                SessionSnapshotType.NORMAL_END,
                 "crashId"
             )
         )
@@ -128,8 +129,8 @@ internal class V1PayloadMessageCollatorTest {
                 startMsg,
                 15000000000,
                 LifeEventType.STATE,
-                "crashId",
-                SessionSnapshotType.NORMAL_END
+                SessionSnapshotType.NORMAL_END,
+                "crashId"
             )
         )
         payload.verifyFinalFieldsPopulated(PayloadType.SESSION)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -2,13 +2,17 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
@@ -56,7 +60,12 @@ internal class V2PayloadMessageCollatorTest {
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService()
         )
-        v2collator = V2PayloadMessageCollator(v1collator)
+        val sessionEnvelopeSource = SessionEnvelopeSource(
+            metadataSource = FakeEnvelopeMetadataSource(),
+            resourceSource = FakeEnvelopeResourceSource(),
+            sessionPayloadSource = FakeSessionPayloadSource()
+        )
+        v2collator = V2PayloadMessageCollator(v1collator, sessionEnvelopeSource)
     }
 
     @Test
@@ -101,6 +110,7 @@ internal class V2PayloadMessageCollatorTest {
                 startMsg,
                 15000000000,
                 Session.LifeEventType.BKGND_STATE,
+                SessionSnapshotType.NORMAL_END,
                 "crashId"
             )
         )
@@ -125,8 +135,8 @@ internal class V2PayloadMessageCollatorTest {
                 startMsg,
                 15000000000,
                 Session.LifeEventType.STATE,
+                SessionSnapshotType.NORMAL_END,
                 "crashId",
-                SessionSnapshotType.NORMAL_END
             )
         )
         payload.verifyFinalFieldsPopulated(PayloadType.SESSION)
@@ -140,6 +150,11 @@ internal class V2PayloadMessageCollatorTest {
         assertNotNull(deviceInfo)
         assertNotNull(performanceInfo)
         assertNotNull(breadcrumbs)
+        assertNotNull(resource)
+        assertNotNull(metadata)
+        assertNotNull(data)
+        assertNotNull(newVersion)
+        assertNotNull(type)
         session.verifyInitialFieldsPopulated(payloadType)
         session.verifyFinalFieldsPopulated(payloadType)
     }


### PR DESCRIPTION
## Goal

Populates the `SessionMessage` with fields from the new payload. This is not hooked up yet so won't send any changes to our production API.

## Testing

Added unit test coverage.

