### PR TITLE
Add ability to create v2 collator from module

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -394,6 +394,15 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
+                    payloadModule = init(PayloadModule::class) {
+                        payloadModuleSupplier(
+                            essentialServiceModule,
+                            nativeModule,
+                            openTelemetryModule,
+                            sdkObservabilityModule
+                        )
+                    }
+
                     sessionModule = init(SessionModule::class) {
                         sessionModuleSupplier(
                             initModule,
@@ -408,7 +417,8 @@ internal class ModuleInitBootstrapper(
                             customerLogModule,
                             sdkObservabilityModule,
                             workerThreadModule,
-                            dataSourceModule
+                            dataSourceModule,
+                            payloadModule
                         )
                     }
 
@@ -423,15 +433,6 @@ internal class ModuleInitBootstrapper(
                             anrModule,
                             dataContainerModule,
                             androidServicesModule
-                        )
-                    }
-
-                    payloadModule = init(PayloadModule::class) {
-                        payloadModuleSupplier(
-                            essentialServiceModule,
-                            nativeModule,
-                            openTelemetryModule,
-                            sdkObservabilityModule
                         )
                     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -210,7 +210,8 @@ internal typealias SessionModuleSupplier = (
     customerLogModule: CustomerLogModule,
     sdkObservabilityModule: SdkObservabilityModule,
     workerThreadModule: WorkerThreadModule,
-    dataSourceModule: DataSourceModule
+    dataSourceModule: DataSourceModule,
+    payloadModule: PayloadModule
 ) -> SessionModule
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -8,7 +8,8 @@ import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal class PayloadFactoryImpl(
-    private val payloadMessageCollator: PayloadMessageCollator,
+    private val v1payloadMessageCollator: V1PayloadMessageCollator,
+    @Suppress("UnusedPrivateProperty") private val v2payloadMessageCollator: V2PayloadMessageCollator,
     private val configService: ConfigService
 ) : PayloadFactory {
 
@@ -41,7 +42,7 @@ internal class PayloadFactoryImpl(
         }
 
     override fun startSessionWithManual(timestamp: Long): Session {
-        return payloadMessageCollator.buildInitialSession(
+        return v1payloadMessageCollator.buildInitialSession(
             InitialEnvelopeParams.SessionParams(
                 false,
                 LifeEventType.MANUAL,
@@ -51,7 +52,7 @@ internal class PayloadFactoryImpl(
     }
 
     override fun endSessionWithManual(timestamp: Long, initial: Session): SessionMessage {
-        return payloadMessageCollator.buildFinalSessionMessage(
+        return v1payloadMessageCollator.buildFinalSessionMessage(
             FinalEnvelopeParams.SessionParams(
                 initial = initial,
                 endTime = timestamp,
@@ -62,7 +63,7 @@ internal class PayloadFactoryImpl(
     }
 
     private fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session {
-        return payloadMessageCollator.buildInitialSession(
+        return v1payloadMessageCollator.buildInitialSession(
             InitialEnvelopeParams.SessionParams(
                 coldStart,
                 LifeEventType.STATE,
@@ -82,7 +83,7 @@ internal class PayloadFactoryImpl(
             coldStart -> timestamp
             else -> timestamp + 1
         }
-        return payloadMessageCollator.buildInitialSession(
+        return v1payloadMessageCollator.buildInitialSession(
             InitialEnvelopeParams.BackgroundActivityParams(
                 coldStart = coldStart,
                 startType = LifeEventType.BKGND_STATE,
@@ -92,7 +93,7 @@ internal class PayloadFactoryImpl(
     }
 
     private fun endSessionWithState(initial: Session, timestamp: Long): SessionMessage {
-        return payloadMessageCollator.buildFinalSessionMessage(
+        return v1payloadMessageCollator.buildFinalSessionMessage(
             FinalEnvelopeParams.SessionParams(
                 initial = initial,
                 endTime = timestamp,
@@ -109,7 +110,7 @@ internal class PayloadFactoryImpl(
 
         // kept for backwards compat. the backend expects the start time to be 1 ms greater
         // than the adjacent session, and manually adjusts.
-        return payloadMessageCollator.buildFinalBackgroundActivityMessage(
+        return v1payloadMessageCollator.buildFinalBackgroundActivityMessage(
             FinalEnvelopeParams.BackgroundActivityParams(
                 initial = initial,
                 endTime = timestamp - 1,
@@ -124,7 +125,7 @@ internal class PayloadFactoryImpl(
         timestamp: Long,
         crashId: String
     ): SessionMessage {
-        return payloadMessageCollator.buildFinalSessionMessage(
+        return v1payloadMessageCollator.buildFinalSessionMessage(
             FinalEnvelopeParams.SessionParams(
                 initial = initial,
                 endTime = timestamp,
@@ -143,7 +144,7 @@ internal class PayloadFactoryImpl(
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }
-        return payloadMessageCollator.buildFinalBackgroundActivityMessage(
+        return v1payloadMessageCollator.buildFinalBackgroundActivityMessage(
             FinalEnvelopeParams.BackgroundActivityParams(
                 initial = initial,
                 endTime = timestamp,
@@ -158,7 +159,7 @@ internal class PayloadFactoryImpl(
      * Called when the session is persisted every 2s to cache its state.
      */
     private fun snapshotSession(initial: Session, timestamp: Long): SessionMessage {
-        return payloadMessageCollator.buildFinalSessionMessage(
+        return v1payloadMessageCollator.buildFinalSessionMessage(
             FinalEnvelopeParams.SessionParams(
                 initial = initial,
                 endTime = timestamp,
@@ -172,7 +173,7 @@ internal class PayloadFactoryImpl(
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }
-        return payloadMessageCollator.buildFinalBackgroundActivityMessage(
+        return v1payloadMessageCollator.buildFinalBackgroundActivityMessage(
             FinalEnvelopeParams.BackgroundActivityParams(
                 initial = initial,
                 endTime = timestamp,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadModule.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.capture.envelope.LogEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.injection.PayloadModule
+
+internal class FakePayloadModule : PayloadModule {
+
+    override val sessionEnvelopeSource: SessionEnvelopeSource = SessionEnvelopeSource(
+        FakeEnvelopeMetadataSource(),
+        FakeEnvelopeResourceSource(),
+        FakeSessionPayloadSource()
+    )
+
+    override val logEnvelopeSource: LogEnvelopeSource
+        get() = TODO("Not yet implemented")
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -8,7 +8,8 @@ import io.embrace.android.embracesdk.injection.SessionModule
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.message.PayloadFactory
-import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
+import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
+import io.embrace.android.embracesdk.session.message.V2PayloadMessageCollator
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
@@ -18,7 +19,10 @@ internal class FakeSessionModule(
     override val sessionOrchestrator: SessionOrchestrator = FakeSessionOrchestrator()
 ) : SessionModule {
 
-    override val payloadMessageCollator: PayloadMessageCollator
+    override val v1PayloadMessageCollator: V1PayloadMessageCollator
+        get() = TODO("Not yet implemented")
+
+    override val v2PayloadMessageCollator: V2PayloadMessageCollator
         get() = TODO("Not yet implemented")
 
     override val periodicSessionCacher: PeriodicSessionCacher

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -1,14 +1,20 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.FakeDeliveryService
+import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
+import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
+import io.embrace.android.embracesdk.session.message.V2PayloadMessageCollator
 import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -84,6 +90,14 @@ internal class PayloadFactorySessionTest {
         isActivityInBackground: Boolean = true
     ) {
         processStateService.isInBackground = isActivityInBackground
-        service = PayloadFactoryImpl(mockk(relaxed = true), FakeConfigService())
+
+        val sessionEnvelopeSource = SessionEnvelopeSource(
+            metadataSource = FakeEnvelopeMetadataSource(),
+            resourceSource = FakeEnvelopeResourceSource(),
+            sessionPayloadSource = FakeSessionPayloadSource()
+        )
+        val v1Collator = mockk<V1PayloadMessageCollator>(relaxed = true)
+        val v2Collator = V2PayloadMessageCollator(v1Collator, sessionEnvelopeSource)
+        service = PayloadFactoryImpl(v1Collator, v2Collator, FakeConfigService())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
+import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
 import io.embrace.android.embracesdk.capture.webview.WebViewService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
@@ -16,6 +17,8 @@ import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
@@ -25,6 +28,7 @@ import io.embrace.android.embracesdk.fakes.FakePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
@@ -43,6 +47,7 @@ import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
+import io.embrace.android.embracesdk.session.message.V2PayloadMessageCollator
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.clearAllMocks
@@ -153,7 +158,15 @@ internal class SessionHandlerTest {
             FakeSessionPropertiesService(),
             FakeStartupService()
         )
-        payloadFactory = PayloadFactoryImpl(payloadMessageCollator, configService)
+        val v2Collator = V2PayloadMessageCollator(
+            payloadMessageCollator,
+            SessionEnvelopeSource(
+                metadataSource = FakeEnvelopeMetadataSource(),
+                resourceSource = FakeEnvelopeResourceSource(),
+                sessionPayloadSource = FakeSessionPayloadSource()
+            )
+        )
+        payloadFactory = PayloadFactoryImpl(payloadMessageCollator, v2Collator, configService)
     }
 
     @After

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
+import io.embrace.android.embracesdk.fakes.FakePayloadModule
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCustomerLogModule
@@ -57,9 +58,11 @@ internal class SessionModuleImplTest {
             FakeCustomerLogModule(),
             FakeSdkObservabilityModule(),
             workerThreadModule,
-            dataSourceModule
+            dataSourceModule,
+            FakePayloadModule()
         )
-        assertNotNull(module.payloadMessageCollator)
+        assertNotNull(module.v1PayloadMessageCollator)
+        assertNotNull(module.v2PayloadMessageCollator)
         assertNotNull(module.sessionPropertiesService)
         assertNotNull(module.payloadFactory)
         assertNotNull(module.sessionOrchestrator)
@@ -93,9 +96,11 @@ internal class SessionModuleImplTest {
             FakeCustomerLogModule(),
             FakeSdkObservabilityModule(),
             workerThreadModule,
-            dataSourceModule
+            dataSourceModule,
+            FakePayloadModule()
         )
-        assertNotNull(module.payloadMessageCollator)
+        assertNotNull(module.v1PayloadMessageCollator)
+        assertNotNull(module.v2PayloadMessageCollator)
         assertNotNull(module.sessionPropertiesService)
         assertNotNull(module.payloadFactory)
         assertNotNull(module.sessionOrchestrator)


### PR DESCRIPTION
## Goal

Adds the ability to create a v2 payload collator in the modules. This is not hooked up to production code yet - that will come in a future PR.

## Testing

Updated unit tests.

