### PR TITLE
Fix race condition for logs.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -26,9 +26,10 @@ internal class LogSinkImpl : LogSink {
 
     override fun flushLogs(max: Int?): List<EmbraceLogRecordData> {
         synchronized(flushLock) {
+            val currentSize = storedLogs.size
             val maxIndex = max?.let {
-                minOf(storedLogs.size, it)
-            } ?: storedLogs.size
+                minOf(currentSize, it)
+            } ?: currentSize
             val flushedLogs = storedLogs.take(maxIndex)
             storedLogs.removeAll(flushedLogs.toSet())
             return flushedLogs


### PR DESCRIPTION
## Goal

There was a test failing because of a race condition when a log was added by another thread in the middle of the flushing event. 

## Testing

Relied on the existent test. 


