### PR TITLE
Add remote config that controls whether v2 payload is sent or not

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
@@ -116,6 +116,11 @@ internal class SessionBehavior(
         getFullSessionEvents().contains(SessionGatingKeys.FULL_SESSION_ERROR_LOGS)
 
     /**
+     * Whether to use the V2 payload format for sending sessions.
+     */
+    fun useV2Payload() = remote?.sessionConfig?.useV2Payload ?: false
+
+    /**
      * Checks whether a feature should be gated.
      * If [getSessionComponents] is null, this will return false.
      * If [getSessionComponents] is empty, this will return true.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/remote/SessionRemoteConfig.kt
@@ -13,6 +13,9 @@ internal data class SessionRemoteConfig(
     @Json(name = "enable")
     val isEnabled: Boolean? = null,
 
+    @Json(name = "use_v2_payload")
+    val useV2Payload: Boolean? = null,
+
     /**
      * A list of session components (i.e. Breadcrumbs, Session properties, etc) that will be
      * included in the session payload. If components list exists, the services should restrict

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceTest.kt
@@ -478,9 +478,9 @@ internal class EmbraceGatingServiceTest {
     private fun buildCustomRemoteConfig(components: Set<String>?, fullSessionEvents: Set<String>?) =
         RemoteConfig(
             sessionConfig = SessionRemoteConfig(
-                true,
-                components,
-                fullSessionEvents
+                isEnabled = true,
+                sessionComponents = components,
+                fullSessionEvents = fullSessionEvents
             )
         )
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SessionBehaviorTest.kt
@@ -21,6 +21,7 @@ internal class SessionBehaviorTest {
     private val remote = RemoteConfig(
         sessionConfig = SessionRemoteConfig(
             isEnabled = true,
+            useV2Payload = true,
             sessionComponents = setOf("test"),
             fullSessionEvents = setOf("test2")
         ),
@@ -36,6 +37,7 @@ internal class SessionBehaviorTest {
             assertFalse(isGatingFeatureEnabled())
             assertFalse(isSessionControlEnabled())
             assertEquals(10, getMaxSessionProperties())
+            assertFalse(useV2Payload())
         }
     }
 
@@ -46,6 +48,7 @@ internal class SessionBehaviorTest {
             assertEquals(setOf("breadcrumbs"), getSessionComponents())
             assertEquals(setOf("crash"), getFullSessionEvents())
             assertTrue(isGatingFeatureEnabled())
+            assertFalse(useV2Payload())
         }
     }
 
@@ -57,6 +60,7 @@ internal class SessionBehaviorTest {
             assertEquals(setOf("test"), getSessionComponents())
             assertEquals(setOf("test2"), getFullSessionEvents())
             assertEquals(57, getMaxSessionProperties())
+            assertTrue(useV2Payload())
         }
     }
 


### PR DESCRIPTION
## Goal

Add remote config that controls whether a v2 session payload is sent or whether the SDK should default to the v1 payload scheme. This changeset defaults to using v1 but this will change soon once the new payload class is fully hooked up.

## Testing

Added unit tests.
