### PR TITLE
Added typeMappings and languageSpecificPrimitives to avoid full imports

### DIFF
--- a/embrace-android-sdk/build.gradle
+++ b/embrace-android-sdk/build.gradle
@@ -162,9 +162,32 @@ openApiGenerate {
             models: ""
     ])
 
-    // replace data with envelopeData to avoid conflict with kotlin keyword
+    // replace data with envelopeData to avoid conflict with kotlin keyword (avoids having to use backticks)
     nameMappings = [
             "data": "envelopeData",
+    ]
+
+    // adding typeMappings and languageSpecificPrimitives avoids classes with full import paths (like kotlin.String)
+    typeMappings = [
+            "double": "Double",
+            "number": "Double",
+            "string": "String",
+            "array": "List",
+            "boolean": "Boolean",
+            "integer": "Int",
+            "long": "Long",
+            "map": "Map"
+    ]
+
+    languageSpecificPrimitives = [
+            "String",
+            "Double",
+            "Array",
+            "List",
+            "Int",
+            "Boolean",
+            "Long",
+            "Map"
     ]
 
     // see further options for configuring kotlin codegen here:


### PR DESCRIPTION
Added typeMappings and languageSpecificPrimitives to avoid classes with full import paths (like kotlin.String and kotlin.collections.Map)

This doesn't work with List, it's probably a problem in the generator. I tried having a look at the source code but it's a mess 😅 
