### PR TITLE
Route new sessions to correct endpoint

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
@@ -68,9 +68,12 @@ internal class ApiRequestMapper(
         return requestBuilder(url)
     }
 
-    fun sessionRequest(): ApiRequest {
-        val url = Endpoint.SESSIONS.asEmbraceUrl()
-        return requestBuilder(url)
+    fun sessionRequest(v2Payload: Boolean): ApiRequest {
+        val url = when {
+            v2Payload -> Endpoint.SESSIONS_V2
+            else -> Endpoint.SESSIONS
+        }
+        return requestBuilder(url.asEmbraceUrl())
     }
 
     fun eventMessageRequest(eventMessage: EventMessage): ApiRequest {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.comms.api
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -40,13 +39,6 @@ internal interface ApiService {
     fun sendLogsEnvelope(logsEnvelope: Envelope<LogPayload>)
 
     /**
-     * Sends a session to the API.
-     *
-     * @param sessionEnvelope containing the session
-     */
-    fun sendSessionEnvelope(sessionEnvelope: Envelope<SessionPayload>)
-
-    /**
      * Sends an Application Exit Info (AEI) blob message to the API.
      *
      * @param blobMessage the blob message containing the AEI data
@@ -74,5 +66,10 @@ internal interface ApiService {
      * @param crash the event message containing the crash
      */
     fun sendCrash(crash: EventMessage): Future<*>
-    fun sendSession(action: SerializationAction, onFinish: (() -> Unit)?): Future<*>?
+
+    /**
+     * Sends a session to the API. This can be either a v1 or v2 session - the implementation
+     * is responsible for routing the payload correctly.
+     */
+    fun sendSession(isV2: Boolean, action: SerializationAction, onFinish: (() -> Unit)?): Future<*>?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -130,11 +129,6 @@ internal class EmbraceApiService(
         post(logsEnvelope, mapper::logsEnvelopeRequest, parameterizedType)
     }
 
-    override fun sendSessionEnvelope(sessionEnvelope: Envelope<SessionPayload>) {
-        val parameterizedType = Types.newParameterizedType(Envelope::class.java, SessionPayload::class.java)
-        post(sessionEnvelope, mapper::sessionEnvelopeRequest, parameterizedType)
-    }
-
     override fun sendAEIBlob(blobMessage: BlobMessage) {
         post(blobMessage, mapper::aeiBlobRequest)
     }
@@ -151,8 +145,8 @@ internal class EmbraceApiService(
         return post(crash, mapper::eventMessageRequest) { cacheManager.deleteCrash() }
     }
 
-    override fun sendSession(action: SerializationAction, onFinish: (() -> Unit)?): Future<*> {
-        return postOnWorker(action, mapper.sessionRequest(), onFinish)
+    override fun sendSession(isV2: Boolean, action: SerializationAction, onFinish: (() -> Unit)?): Future<*> {
+        return postOnWorker(action, mapper.sessionRequest(isV2), onFinish)
     }
 
     private inline fun <reified T> post(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -15,7 +14,6 @@ internal interface DeliveryService {
     fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker)
     fun sendLog(eventMessage: EventMessage)
     fun sendLogs(logPayload: LogPayload)
-    fun sendSessionV2(sessionPayload: SessionPayload)
     fun sendNetworkCall(networkEvent: NetworkEvent)
     fun sendCrash(crash: EventMessage, processTerminating: Boolean)
     fun sendAEIBlob(blobMessage: BlobMessage)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -59,10 +58,6 @@ internal open class FakeDeliveryService : DeliveryService {
 
     override fun sendLogs(logPayload: LogPayload) {
         lastSentLogPayloads.add(logPayload)
-    }
-
-    override fun sendSessionV2(sessionPayload: SessionPayload) {
-        TODO("Not yet implemented")
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakePayloadFactory.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakePayloadFactory.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.fakes.fakeSession
-import io.embrace.android.embracesdk.fakes.fakeSessionMessage
+import io.embrace.android.embracesdk.fakes.fakeV1SessionMessage
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
@@ -102,7 +102,7 @@ internal class FakePayloadFactory : PayloadFactory {
     private fun endSessionWithState(timestamp: Long): SessionMessage {
         endSessionTimestamps.add(timestamp)
         activeSession = null
-        return fakeSessionMessage()
+        return fakeV1SessionMessage()
     }
 
     var crashId: String? = null
@@ -110,13 +110,13 @@ internal class FakePayloadFactory : PayloadFactory {
     private fun endSessionWithCrash(crashId: String): SessionMessage {
         this.crashId = crashId
         activeSession = null
-        return fakeSessionMessage()
+        return fakeV1SessionMessage()
     }
 
     override fun endSessionWithManual(timestamp: Long, initial: Session): SessionMessage {
         manualSessionEndCount++
         activeSession = null
-        return fakeSessionMessage()
+        return fakeV1SessionMessage()
     }
 
     private fun snapshotSession(): SessionMessage? {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
@@ -86,9 +86,15 @@ internal class ApiRequestMapperTest {
     }
 
     @Test
-    fun testSessionRequest() {
-        val request = mapper.sessionRequest()
+    fun testV1SessionRequest() {
+        val request = mapper.sessionRequest(false)
         request.assertCoreFieldsPopulated("/v1/log/sessions")
+    }
+
+    @Test
+    fun testV2SessionRequest() {
+        val request = mapper.sessionRequest(true)
+        request.assertCoreFieldsPopulated("/v2/sessions")
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeDeliveryCacheManager
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.fakeSession
-import io.embrace.android.embracesdk.fakes.fakeSessionMessage
+import io.embrace.android.embracesdk.fakes.fakeV1SessionMessage
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Event
@@ -26,9 +26,9 @@ import org.junit.Test
 internal class EmbraceDeliveryServiceTest {
 
     private val session = fakeSession()
-    private val sessionMessage = fakeSessionMessage()
+    private val sessionMessage = fakeV1SessionMessage()
     private val anotherMessage =
-        fakeSessionMessage().copy(session = session.copy(sessionId = "session2"))
+        fakeV1SessionMessage().copy(session = session.copy(sessionId = "session2"))
 
     private lateinit var worker: BackgroundWorker
     private lateinit var deliveryCacheManager: FakeDeliveryCacheManager

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -287,7 +287,7 @@ internal class EmbracePendingApiCallsSenderTest {
         assertEquals("il:message_id_6", pendingApiCalls.pollNextPendingApiCall()?.apiRequest?.logId)
 
         // now add some sessions for retry and verify they are returned first
-        val sessionRequest = mapper.sessionRequest().copy(logId = "is:session_id_0")
+        val sessionRequest = mapper.sessionRequest(false).copy(logId = "is:session_id_0")
         pendingApiCallsSender.savePendingApiCall(sessionRequest) {}
         pendingApiCallsSender.scheduleRetry(ApiResponse.Incomplete(Throwable()))
         assertEquals(sessionRequest, pendingApiCalls.pollNextPendingApiCall()?.apiRequest)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.comms.api.CachedConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -47,10 +46,6 @@ internal class FakeApiService : ApiService {
         logPayloads.add(logsEnvelope.data)
     }
 
-    override fun sendSessionEnvelope(sessionEnvelope: Envelope<SessionPayload>) {
-        TODO("Not yet implemented")
-    }
-
     override fun sendNetworkCall(networkEvent: NetworkEvent) {
         networkCallRequests.add(networkEvent)
     }
@@ -68,7 +63,7 @@ internal class FakeApiService : ApiService {
         blobRequests.add(blobMessage)
     }
 
-    override fun sendSession(action: SerializationAction, onFinish: (() -> Unit)?): Future<*>? {
+    override fun sendSession(isV2: Boolean, action: SerializationAction, onFinish: (() -> Unit)?): Future<*>? {
         if (throwExceptionSendSession) {
             error("FakeApiService.sendSession")
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.Companion.APPLICATION_STATE_FOREGROUND
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -20,6 +23,13 @@ internal fun fakeSession(
     messageType = Session.MESSAGE_TYPE_END
 )
 
-internal fun fakeSessionMessage(): SessionMessage = SessionMessage(
+internal fun fakeV1SessionMessage(): SessionMessage = SessionMessage(
     session = fakeSession()
+)
+
+internal fun fakeV2SessionMessage(): SessionMessage = SessionMessage(
+    session = fakeSession(),
+    metadata = EnvelopeMetadata(),
+    resource = EnvelopeResource(),
+    data = SessionPayload()
 )


### PR DESCRIPTION
## Goal

Routes v2 session payloads to the correct endpoint & ensures that the `GatingService` is aware they need to be sanitised. This changeset routes the new v2 session correctly if the remote config field is enabled (currently this is disabled by default).

A future changeset needs to handle cached sessions correctly. I plan on addressing this by encoding the version info in the payload so we don't need to load the session & introspect its contents.

## Testing

Added unit tests.
