### PR TITLE
Alter where session gating happens

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
 import io.embrace.android.embracesdk.comms.api.ApiService
-import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
@@ -23,7 +22,6 @@ import java.util.concurrent.TimeUnit
 internal class EmbraceDeliveryService(
     private val cacheManager: DeliveryCacheManager,
     private val apiService: ApiService,
-    private val gatingService: GatingService,
     private val backgroundWorker: BackgroundWorker,
     private val serializer: EmbraceSerializer,
     private val logger: InternalEmbraceLogger
@@ -40,8 +38,7 @@ internal class EmbraceDeliveryService(
      * point.
      */
     override fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
-        val sanitizedSessionMessage = gatingService.gateSessionMessage(sessionMessage)
-        cacheManager.saveSession(sanitizedSessionMessage, snapshotType)
+        cacheManager.saveSession(sessionMessage, snapshotType)
         if (snapshotType == SessionSnapshotType.PERIODIC_CACHE) {
             return
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
@@ -1,11 +1,12 @@
 package io.embrace.android.embracesdk.gating
 
 import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
-import io.embrace.android.embracesdk.payload.isV2Payload
 
 /**
  * Receives the local and remote config to build the Gating config and define the amount of
@@ -38,12 +39,7 @@ internal class EmbraceGatingService(
      *  regardless of the 'components' list status.
      *
      */
-    override fun gateSessionMessage(sessionMessage: SessionMessage): SessionMessage = when {
-        sessionMessage.isV2Payload() -> gateV2Message(sessionMessage)
-        else -> gateV1Message(sessionMessage)
-    }
-
-    private fun gateV1Message(sessionMessage: SessionMessage): SessionMessage {
+    override fun gateSessionMessage(sessionMessage: SessionMessage): SessionMessage {
         val components = configService.sessionBehavior.getSessionComponents()
         if (components != null && configService.sessionBehavior.isGatingFeatureEnabled()) {
             InternalStaticEmbraceLogger.logDebug("Session gating feature enabled. Attempting to sanitize the session message")
@@ -75,10 +71,9 @@ internal class EmbraceGatingService(
         return sessionMessage
     }
 
-    private fun gateV2Message(sessionMessage: SessionMessage): SessionMessage {
-        // future: need to gate the v2 message here. Temporarily we will just return the
-        // ungated message
-        return sessionMessage
+    override fun gateSessionEnvelope(envelope: Envelope<SessionPayload>): Envelope<SessionPayload> {
+        // future: gate the session envelope
+        return envelope
     }
 
     override fun gateEventMessage(eventMessage: EventMessage): EventMessage {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/GatingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/GatingService.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.gating
 
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 
@@ -13,6 +15,15 @@ internal interface GatingService {
      * @param sessionMessage to be sanitized
      */
     fun gateSessionMessage(sessionMessage: SessionMessage): SessionMessage
+
+    /**
+     * Sanitizes a v2 session message before sending it to the backend based on the Gating configuration.
+     * Breadcrumbs, session properties, ANRs, logs, etc can be removed from the session payload.
+     * This method should be called before send the session message to the ApiClient class.
+     *
+     * @param envelope to be sanitized
+     */
+    fun gateSessionEnvelope(envelope: Envelope<SessionPayload>): Envelope<SessionPayload>
 
     /**
      * Sanitizes an event message before send it to backend based on the Gating configuration.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
@@ -20,7 +20,6 @@ internal class DeliveryModuleImpl(
         EmbraceDeliveryService(
             storageModule.deliveryCacheManager,
             essentialServiceModule.apiService,
-            essentialServiceModule.gatingService,
             workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
             coreModule.jsonSerializer,
             coreModule.logger

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -47,6 +47,7 @@ internal class SessionModuleImpl(
 
     override val v1PayloadMessageCollator: V1PayloadMessageCollator by singleton {
         V1PayloadMessageCollator(
+            essentialServiceModule.gatingService,
             essentialServiceModule.configService,
             essentialServiceModule.metadataService,
             dataContainerModule.eventService,
@@ -68,6 +69,7 @@ internal class SessionModuleImpl(
 
     override val v2PayloadMessageCollator: V2PayloadMessageCollator by singleton {
         V2PayloadMessageCollator(
+            essentialServiceModule.gatingService,
             v1PayloadMessageCollator,
             payloadModule.sessionEnvelopeSource
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.capture.webview.WebViewService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
+import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanSink
@@ -25,6 +26,7 @@ import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 internal class V1PayloadMessageCollator(
+    private val gatingService: GatingService,
     private val configService: ConfigService,
     private val metadataService: MetadataService,
     private val eventService: EventService,
@@ -96,7 +98,8 @@ internal class V1PayloadMessageCollator(
             betaFeatures = betaFeatures,
             symbols = captureDataSafely { nativeThreadSamplerService?.getNativeSymbols() }
         )
-        return buildWrapperEnvelope(params, endSession, initial.startTime, endTime)
+        val envelope = buildWrapperEnvelope(params, endSession, initial.startTime, endTime)
+        return gatingService.gateSessionMessage(envelope)
     }
 
     /**
@@ -108,7 +111,8 @@ internal class V1PayloadMessageCollator(
         val msg = buildFinalBackgroundActivity(params)
         val startTime = msg.startTime
         val endTime = params.endTime
-        return buildWrapperEnvelope(params, msg, startTime, endTime)
+        val envelope = buildWrapperEnvelope(params, msg, startTime, endTime)
+        return gatingService.gateSessionMessage(envelope)
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -10,6 +11,7 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
  * backwards compatibility.
  */
 internal class V2PayloadMessageCollator(
+    private val gatingService: GatingService,
     private val v1Collator: V1PayloadMessageCollator,
     private val sessionEnvelopeSource: SessionEnvelopeSource
 ) : PayloadMessageCollator {
@@ -29,7 +31,7 @@ internal class V2PayloadMessageCollator(
     }
 
     private fun SessionMessage.convertToV2Payload(endType: SessionSnapshotType): SessionMessage {
-        val envelope = sessionEnvelopeSource.getEnvelope(endType)
+        val envelope = gatingService.gateSessionEnvelope(sessionEnvelopeSource.getEnvelope(endType))
         return copy(
             // future work: make legacy fields null here.
             resource = envelope.resource,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -59,7 +59,6 @@ internal class EmbraceDeliveryServiceTest {
         deliveryService = EmbraceDeliveryService(
             deliveryCacheManager,
             apiService,
-            gatingService,
             worker,
             EmbraceSerializer(),
             logger
@@ -73,7 +72,6 @@ internal class EmbraceDeliveryServiceTest {
 
         val observed = deliveryCacheManager.saveSessionRequests.single()
         assertEquals(Pair(sessionMessage, NORMAL_END), observed)
-        assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     @Test
@@ -83,7 +81,6 @@ internal class EmbraceDeliveryServiceTest {
 
         val observed = deliveryCacheManager.saveSessionRequests.last()
         assertEquals(Pair(sessionMessage, PERIODIC_CACHE), observed)
-        assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     @Test
@@ -93,7 +90,6 @@ internal class EmbraceDeliveryServiceTest {
 
         val observed = deliveryCacheManager.saveSessionRequests.last()
         assertEquals(Pair(sessionMessage, JVM_CRASH), observed)
-        assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     @Test
@@ -135,7 +131,6 @@ internal class EmbraceDeliveryServiceTest {
         initializeDeliveryService()
         deliveryService.sendSession(sessionMessage, JVM_CRASH)
         assertEquals(sessionMessage, apiService.sessionRequests.last())
-        assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.GatingService
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 
@@ -12,6 +14,7 @@ import io.embrace.android.embracesdk.payload.SessionMessage
 internal class FakeGatingService(configService: ConfigService = FakeConfigService()) :
     GatingService {
     val sessionMessagesFiltered = mutableListOf<SessionMessage>()
+    val envelopesFiltered = mutableListOf<Envelope<SessionPayload>>()
     val eventMessagesFiltered = mutableListOf<EventMessage>()
 
     private val realGatingService = EmbraceGatingService(configService)
@@ -20,6 +23,12 @@ internal class FakeGatingService(configService: ConfigService = FakeConfigServic
         val filteredMessage = realGatingService.gateSessionMessage(sessionMessage)
         sessionMessagesFiltered.add(sessionMessage)
         return filteredMessage
+    }
+
+    override fun gateSessionEnvelope(envelope: Envelope<SessionPayload>): Envelope<SessionPayload> {
+        val filteredMessage = realGatingService.gateSessionEnvelope(envelope)
+        envelopesFiltered.add(filteredMessage)
+        return envelope
     }
 
     override fun gateEventMessage(eventMessage: EventMessage): EventMessage {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -18,6 +18,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeEventService
+import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
@@ -158,7 +159,9 @@ internal class PayloadFactoryBaTest {
     }
 
     private fun createService(createInitialSession: Boolean = true): PayloadFactoryImpl {
+        val gatingService = FakeGatingService()
         val collator = V1PayloadMessageCollator(
+            gatingService,
             configService,
             metadataService,
             eventService,
@@ -181,7 +184,7 @@ internal class PayloadFactoryBaTest {
             resourceSource = FakeEnvelopeResourceSource(),
             sessionPayloadSource = FakeSessionPayloadSource()
         )
-        val v2Collator = V2PayloadMessageCollator(collator, sessionEnvelopeSource)
+        val v2Collator = V2PayloadMessageCollator(gatingService, collator, sessionEnvelopeSource)
         return PayloadFactoryImpl(collator, v2Collator, configService).apply {
             if (createInitialSession) {
                 startPayloadWithState(ProcessState.BACKGROUND, clock.now(), true)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
+import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -97,7 +98,7 @@ internal class PayloadFactorySessionTest {
             sessionPayloadSource = FakeSessionPayloadSource()
         )
         val v1Collator = mockk<V1PayloadMessageCollator>(relaxed = true)
-        val v2Collator = V2PayloadMessageCollator(v1Collator, sessionEnvelopeSource)
+        val v2Collator = V2PayloadMessageCollator(FakeGatingService(), v1Collator, sessionEnvelopeSource)
         service = PayloadFactoryImpl(v1Collator, v2Collator, FakeConfigService())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -141,6 +141,7 @@ internal class SessionHandlerTest {
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
         val payloadMessageCollator = V1PayloadMessageCollator(
+            gatingService,
             configService,
             metadataService,
             eventService,
@@ -159,6 +160,7 @@ internal class SessionHandlerTest {
             FakeStartupService()
         )
         val v2Collator = V2PayloadMessageCollator(
+            gatingService,
             payloadMessageCollator,
             SessionEnvelopeSource(
                 metadataSource = FakeEnvelopeMetadataSource(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
+import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
@@ -33,6 +34,7 @@ internal class V1PayloadMessageCollatorTest {
 
     private lateinit var initModule: FakeInitModule
     private lateinit var collator: PayloadMessageCollator
+    private lateinit var gatingService: FakeGatingService
 
     private enum class PayloadType {
         BACKGROUND_ACTIVITY,
@@ -42,7 +44,9 @@ internal class V1PayloadMessageCollatorTest {
     @Before
     fun setUp() {
         initModule = FakeInitModule()
+        gatingService = FakeGatingService()
         collator = V1PayloadMessageCollator(
+            gatingService = gatingService,
             configService = FakeConfigService(),
             nativeThreadSamplerService = null,
             thermalStatusService = FakeThermalStatusService(),
@@ -109,6 +113,7 @@ internal class V1PayloadMessageCollatorTest {
             )
         )
         payload.verifyFinalFieldsPopulated(PayloadType.BACKGROUND_ACTIVITY)
+        assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     @Test
@@ -134,6 +139,7 @@ internal class V1PayloadMessageCollatorTest {
             )
         )
         payload.verifyFinalFieldsPopulated(PayloadType.SESSION)
+        assertEquals(1, gatingService.sessionMessagesFiltered.size)
     }
 
     private fun SessionMessage.verifyFinalFieldsPopulated(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeEventService
+import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
@@ -45,6 +46,7 @@ internal class PayloadFactoryImplTest {
         )
         val initModule = FakeInitModule()
         val v1Collator = V1PayloadMessageCollator(
+            gatingService = FakeGatingService(),
             configService = FakeConfigService(),
             nativeThreadSamplerService = null,
             thermalStatusService = FakeThermalStatusService(),
@@ -65,6 +67,7 @@ internal class PayloadFactoryImplTest {
             startupService = FakeStartupService()
         )
         val v2Collator = V2PayloadMessageCollator(
+            FakeGatingService(),
             v1Collator,
             SessionEnvelopeSource(
                 FakeEnvelopeMetadataSource(),


### PR DESCRIPTION
## Goal

Alters session gating so that it happens in the `PayloadMessageCollator` implementations. This facilitates the gating of the new session payload, which will happen in future changesets.

## Testing

Added unit tests.

