### PR TITLE
Implement session gating for user personas in new session payload

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/GatingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/GatingService.kt
@@ -21,9 +21,13 @@ internal interface GatingService {
      * Breadcrumbs, session properties, ANRs, logs, etc can be removed from the session payload.
      * This method should be called before send the session message to the ApiClient class.
      *
+     * @param sessionMessage to be sanitized
      * @param envelope to be sanitized
      */
-    fun gateSessionEnvelope(envelope: Envelope<SessionPayload>): Envelope<SessionPayload>
+    fun gateSessionEnvelope(
+        sessionMessage: SessionMessage,
+        envelope: Envelope<SessionPayload>
+    ): Envelope<SessionPayload>
 
     /**
      * Sanitizes an event message before send it to backend based on the Gating configuration.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeMetadataSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeMetadataSanitizer.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.gating.v2
+
+import io.embrace.android.embracesdk.gating.Sanitizable
+import io.embrace.android.embracesdk.gating.SessionGatingKeys.USER_PERSONAS
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+
+internal class EnvelopeMetadataSanitizer(
+    private val metadata: EnvelopeMetadata,
+    private val enabledComponents: Set<String>
+) : Sanitizable<EnvelopeMetadata> {
+
+    override fun sanitize(): EnvelopeMetadata {
+        if (!shouldSendUserPersonas()) {
+            return metadata.copy(personas = null)
+        }
+        return metadata
+    }
+
+    private fun shouldSendUserPersonas() =
+        enabledComponents.contains(USER_PERSONAS)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeSanitizerFacade.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeSanitizerFacade.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.gating.v2
+
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+
+internal class EnvelopeSanitizerFacade(
+    private val envelope: Envelope<SessionPayload>,
+    private val components: Set<String>
+) {
+
+    fun sanitize(): Envelope<SessionPayload> {
+        return envelope.copy(
+            metadata = EnvelopeMetadataSanitizer(
+                envelope.metadata ?: EnvelopeMetadata(),
+                components
+            ).sanitize()
+        )
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/EnvelopeMetadata.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/EnvelopeMetadata.kt
@@ -19,7 +19,7 @@ internal data class EnvelopeMetadata(
     val username: String? = null,
 
     @Json(name = "personas")
-    val personas: Set<String> = emptySet(),
+    val personas: Set<String>? = null,
 
     @Json(name = "timezone_description")
     val timezoneDescription: String? = null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -31,7 +31,7 @@ internal class V2PayloadMessageCollator(
     }
 
     private fun SessionMessage.convertToV2Payload(endType: SessionSnapshotType): SessionMessage {
-        val envelope = gatingService.gateSessionEnvelope(sessionEnvelopeSource.getEnvelope(endType))
+        val envelope = gatingService.gateSessionEnvelope(this, sessionEnvelopeSource.getEnvelope(endType))
         return copy(
             // future work: make legacy fields null here.
             resource = envelope.resource,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
@@ -60,7 +60,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-internal class EmbraceGatingServiceTest {
+internal class EmbraceGatingServiceV1PayloadTest {
 
     private lateinit var localConfig: LocalConfig
     private lateinit var gatingService: EmbraceGatingService

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV2PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV2PayloadTest.kt
@@ -1,0 +1,102 @@
+package io.embrace.android.embracesdk
+
+import io.embrace.android.embracesdk.config.behavior.SessionBehavior
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.fakeSession
+import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.fakeV1SessionMessage
+import io.embrace.android.embracesdk.gating.EmbraceGatingService
+import io.embrace.android.embracesdk.gating.SessionGatingKeys
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.payload.SessionMessage
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+internal class EmbraceGatingServiceV2PayloadTest {
+
+    private val envelope = Envelope(
+        data = SessionPayload(),
+        metadata = EnvelopeMetadata(
+            personas = setOf("persona1", "persona2")
+        )
+    )
+
+    private lateinit var gatingService: EmbraceGatingService
+    private lateinit var configService: FakeConfigService
+    private lateinit var sessionBehavior: SessionBehavior
+    private var cfg: RemoteConfig? = RemoteConfig()
+
+    @Before
+    fun setUp() {
+        sessionBehavior = fakeSessionBehavior { cfg }
+        configService = FakeConfigService(sessionBehavior = fakeSessionBehavior { cfg })
+        gatingService = EmbraceGatingService(configService)
+    }
+
+    @Test
+    fun `sessions are not gated by default`() {
+        val result = gatingService.gateSessionEnvelope(fakeV1SessionMessage(), envelope)
+        assertNotNull(checkNotNull(result.metadata).personas)
+    }
+
+    @Test
+    fun `sessions with error log are not gated`() {
+        cfg = buildCustomRemoteConfig(
+            setOf(),
+            setOf(SessionGatingKeys.FULL_SESSION_ERROR_LOGS)
+        )
+        val sessionMessage = SessionMessage(
+            fakeSession().copy(
+                errorLogIds = listOf("id1"),
+            )
+        )
+        // result shouldn't be sanitized.
+        val result = gatingService.gateSessionEnvelope(sessionMessage, envelope)
+        assertNotNull(checkNotNull(result.metadata).personas)
+    }
+
+    @Test
+    fun `sessions with crash are not gated`() {
+        cfg = buildCustomRemoteConfig(
+            setOf(),
+            setOf(SessionGatingKeys.FULL_SESSION_ERROR_LOGS)
+        )
+        val sessionMessage = SessionMessage(
+            fakeSession().copy(
+                crashReportId = "crashReportId",
+            )
+        )
+        // result shouldn't be sanitized.
+        val result = gatingService.gateSessionEnvelope(sessionMessage, envelope)
+        assertNotNull(checkNotNull(result.metadata).personas)
+    }
+
+    @Test
+    fun `regular sessions are gated`() {
+        val session = fakeSession().copy(
+            properties = mapOf("key" to "value")
+        )
+        cfg = buildCustomRemoteConfig(setOf(), null)
+
+        // only check for session properties. Other assertions should go in OtelSessionGatingTest
+        // as it's more comprehensive than this unit test.
+        val sessionMessage = SessionMessage(session)
+        val result = gatingService.gateSessionEnvelope(sessionMessage, envelope)
+        assertNull(checkNotNull(result.metadata).personas)
+    }
+
+    private fun buildCustomRemoteConfig(components: Set<String>?, fullSessionEvents: Set<String>?) =
+        RemoteConfig(
+            sessionConfig = SessionRemoteConfig(
+                isEnabled = true,
+                sessionComponents = components,
+                fullSessionEvents = fullSessionEvents
+            )
+        )
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
@@ -25,8 +25,11 @@ internal class FakeGatingService(configService: ConfigService = FakeConfigServic
         return filteredMessage
     }
 
-    override fun gateSessionEnvelope(envelope: Envelope<SessionPayload>): Envelope<SessionPayload> {
-        val filteredMessage = realGatingService.gateSessionEnvelope(envelope)
+    override fun gateSessionEnvelope(
+        sessionMessage: SessionMessage,
+        envelope: Envelope<SessionPayload>
+    ): Envelope<SessionPayload> {
+        val filteredMessage = realGatingService.gateSessionEnvelope(sessionMessage, envelope)
         envelopesFiltered.add(filteredMessage)
         return envelope
     }


### PR DESCRIPTION
## Goal

Implements session gating for user personas in the new session payload. This is a steel thread that allows us to expand gating to other fields as we move them over.

## Testing

Added unit tests.

