### PR TITLE
Encode session payload version in file

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CachedSession.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CachedSession.kt
@@ -1,0 +1,74 @@
+package io.embrace.android.embracesdk.comms.delivery
+
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+
+/**
+ * Represents a session that is cached on disk. The cached session encodes information in its
+ * filename such as sessionId, timestamp, and payload version. This allows the SDK to process
+ * cached sessions without deserializing the JSON.
+ */
+internal class CachedSession private constructor(
+    val sessionId: String,
+    val timestampMs: Long,
+    val filename: String,
+    val v2Payload: Boolean
+) {
+
+    companion object {
+        private const val V2_PREFIX = "v2"
+
+        /**
+         * Creates a [CachedSession] from a session id and timestamp.
+         */
+        fun create(sessionId: String, timestampMs: Long, v2Payload: Boolean): CachedSession {
+            val filename = when {
+                v2Payload -> getV2FileNameForSession(
+                    sessionId,
+                    timestampMs
+                )
+                else -> getV1FileNameForSession(sessionId, timestampMs)
+            }
+            return CachedSession(
+                sessionId,
+                timestampMs,
+                filename,
+                v2Payload
+            )
+        }
+
+        /**
+         * Creates a [CachedSession] from a filename.
+         */
+        fun fromFilename(filename: String): CachedSession? {
+            val values = filename.split('.')
+            if (values.size < 4 || values.size > 5) {
+                InternalStaticEmbraceLogger.logError("Unrecognized cached file: $filename")
+                return null
+            }
+            val v2Payload = isV2Payload(filename)
+            val encodedInfo = when {
+                v2Payload -> values.take(4)
+                else -> values
+            }
+
+            val timestamp = encodedInfo[1].toLongOrNull()
+            timestamp?.also { ts ->
+                val sessionId = encodedInfo[2]
+                return create(sessionId, ts, v2Payload)
+            }
+            return null
+        }
+
+        private fun getV1FileNameForSession(
+            sessionId: String,
+            timestampMs: Long
+        ): String = "${EmbraceCacheService.SESSION_FILE_PREFIX}.$timestampMs.$sessionId.json"
+
+        private fun getV2FileNameForSession(
+            sessionId: String,
+            timestampMs: Long
+        ): String = "${EmbraceCacheService.SESSION_FILE_PREFIX}.$timestampMs.$sessionId.$V2_PREFIX.json"
+
+        private fun isV2Payload(filename: String): Boolean = filename.endsWith("$V2_PREFIX.json")
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -10,7 +10,7 @@ internal interface DeliveryCacheManager {
     fun transformSession(sessionId: String, transformer: (SessionMessage) -> SessionMessage)
     fun loadSessionAsAction(sessionId: String): SerializationAction?
     fun deleteSession(sessionId: String)
-    fun getAllCachedSessionIds(): List<String>
+    fun getAllCachedSessionIds(): List<CachedSession>
     fun saveCrash(crash: EventMessage)
     fun loadCrash(): EventMessage?
     fun deleteCrash()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -187,7 +187,7 @@ internal class EmbraceCacheService(
                 previousSdkSession?.also { sessionMessage ->
                     runCatching {
                         val session = sessionMessage.session
-                        val properSessionFilename = getFileNameForSession(session.sessionId, session.startTime)
+                        val properSessionFilename = CachedSession.create(session.sessionId, session.startTime, false).filename
                         if (!sessionFileNames.contains(properSessionFilename)) {
                             replaceSessionFile(properSessionFilename, filename)
                             properSessionFileIds.add(properSessionFilename)
@@ -298,7 +298,7 @@ internal class EmbraceCacheService(
         /**
          * File names for all cached sessions start with this prefix
          */
-        private const val SESSION_FILE_PREFIX = "last_session"
+        internal const val SESSION_FILE_PREFIX = "last_session"
 
         /**
          * Full file name for a session saved with a previous version of the SDK. Note that to
@@ -311,7 +311,5 @@ internal class EmbraceCacheService(
         const val OLD_COPY_SUFFIX = "-old"
         const val TEMP_COPY_SUFFIX = "-tmp"
         const val NEW_COPY_SUFFIX = "-new"
-
-        fun getFileNameForSession(sessionId: String, timestampMs: Long): String = "$SESSION_FILE_PREFIX.$timestampMs.$sessionId.json"
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.comms.api.ApiRequest
 import io.embrace.android.embracesdk.comms.api.EmbraceUrl
+import io.embrace.android.embracesdk.comms.delivery.CachedSession
 import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService
 import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryCacheManager
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
@@ -147,20 +148,20 @@ internal class EmbraceDeliveryCacheManagerTest {
     @Test
     fun `read cached sessions`() {
         cacheService.writeSession(
-            EmbraceCacheService.getFileNameForSession("session1", clockInit - 300000),
+            CachedSession.create("session1", clockInit - 300000, false).filename,
             testSessionMessage.copy(session = testSessionMessage.session.copy(sessionId = "session1", startTime = clockInit - 300000))
         )
         cacheService.writeSession(
-            EmbraceCacheService.getFileNameForSession("session2", clockInit - 360000),
+            CachedSession.create("session2", clockInit - 360000, false).filename,
             testSessionMessage.copy(session = testSessionMessage.session.copy(sessionId = "session2", startTime = clockInit - 360000))
         )
         cacheService.writeSession(
-            EmbraceCacheService.getFileNameForSession("session3", clockInit - 420000),
+            CachedSession.create("session3", clockInit - 420000, false).filename,
             testSessionMessage.copy(session = testSessionMessage.session.copy(sessionId = "session3", startTime = clockInit - 420000))
         )
         assertEquals(
             setOf("session1", "session2", "session3"),
-            deliveryCacheManager.getAllCachedSessionIds().toSet()
+            deliveryCacheManager.getAllCachedSessionIds().map(CachedSession::sessionId).toSet()
         )
     }
 
@@ -184,7 +185,7 @@ internal class EmbraceDeliveryCacheManagerTest {
             fakeClock.tick()
         }
 
-        val cachedSessions = deliveryCacheManager.getAllCachedSessionIds()
+        val cachedSessions = deliveryCacheManager.getAllCachedSessionIds().map(CachedSession::sessionId)
         assertEquals(EmbraceDeliveryCacheManager.MAX_SESSIONS_CACHED, cachedSessions.size)
         for (i in (100 - EmbraceDeliveryCacheManager.MAX_SESSIONS_CACHED)..99) {
             assertTrue(cachedSessions.contains("test$i"))
@@ -198,7 +199,7 @@ internal class EmbraceDeliveryCacheManagerTest {
 
         val allSessions = deliveryCacheManager.getAllCachedSessionIds()
         assertEquals(1, allSessions.size)
-        assertNotNull(deliveryCacheManager.loadSessionAsAction(allSessions[0]))
+        assertNotNull(deliveryCacheManager.loadSessionAsAction(allSessions[0].sessionId))
         assertNull(cacheService.loadBytes("last_session.json"))
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/CachedSessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/CachedSessionTest.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.embracesdk.comms.delivery
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class CachedSessionTest {
+
+    @Test
+    fun `create cached session`() {
+        assertEquals(
+            "last_session.5000.sessionId.json",
+            CachedSession.create("sessionId", 5000, false).filename
+        )
+        assertEquals(
+            "last_session.5000.sessionId.v2.json",
+            CachedSession.create("sessionId", 5000, true).filename
+        )
+    }
+
+    @Test
+    fun `decode filename`() {
+        val v1Session = checkNotNull(CachedSession.fromFilename("last_session.5000.sessionId.json"))
+        assertEquals("sessionId", v1Session.sessionId)
+        assertEquals(5000, v1Session.timestampMs)
+        assertEquals("last_session.5000.sessionId.json", v1Session.filename)
+        assertFalse(v1Session.v2Payload)
+
+        val v2Session = checkNotNull(CachedSession.fromFilename("last_session.5000.sessionId.v2.json"))
+        assertEquals("sessionId", v2Session.sessionId)
+        assertEquals(5000, v2Session.timestampMs)
+        assertEquals("last_session.5000.sessionId.v2.json", v2Session.filename)
+        assertTrue(v2Session.v2Payload)
+
+        val invalidSession = CachedSession.fromFilename("myfoo.json")
+        assertNull(invalidSession)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.comms.delivery.CachedSession
 import io.embrace.android.embracesdk.comms.delivery.DeliveryCacheManager
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
@@ -35,8 +36,8 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
         TODO("Not yet implemented")
     }
 
-    override fun getAllCachedSessionIds(): List<String> {
-        return cachedSessions.map { it.session.sessionId }
+    override fun getAllCachedSessionIds(): List<CachedSession> {
+        return cachedSessions.map { CachedSession.create(it.session.sessionId, 0, false) }
     }
 
     override fun saveCrash(crash: EventMessage) {


### PR DESCRIPTION
## Goal

This changeset encodes the session payload version in the file so it's possible to route cached sessions to the correct endpoint. I chose to consolidate most of the existing logic that is related to this change into the existing `CachedSession` class, so it's easier to reason about future changes to information encoded in filenames in future.

## Testing

Added unit tests.

