### PR TITLE
Add sanitizers for v2 envelope

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeResourceSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeResourceSanitizer.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.gating.v2
+
+import io.embrace.android.embracesdk.gating.Sanitizable
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+
+internal class EnvelopeResourceSanitizer(
+    private val resource: EnvelopeResource,
+    @Suppress("UnusedPrivateProperty") private val enabledComponents: Set<String>
+) : Sanitizable<EnvelopeResource> {
+
+    override fun sanitize(): EnvelopeResource {
+        return resource
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeSanitizerFacade.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeSanitizerFacade.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.gating.v2
 
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 
 internal class EnvelopeSanitizerFacade(
@@ -14,7 +15,12 @@ internal class EnvelopeSanitizerFacade(
             metadata = EnvelopeMetadataSanitizer(
                 envelope.metadata ?: EnvelopeMetadata(),
                 components
-            ).sanitize()
+            ).sanitize(),
+            resource = EnvelopeResourceSanitizer(
+                envelope.resource ?: EnvelopeResource(),
+                components
+            ).sanitize(),
+            data = SessionPayloadSanitizer(envelope.data, components).sanitize()
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/SessionPayloadSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/SessionPayloadSanitizer.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.gating.v2
+
+import io.embrace.android.embracesdk.gating.Sanitizable
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+
+internal class SessionPayloadSanitizer(
+    private val payload: SessionPayload,
+    @Suppress("UnusedPrivateProperty") private val enabledComponents: Set<String>
+) : Sanitizable<SessionPayload> {
+
+    override fun sanitize(): SessionPayload {
+        return payload
+    }
+}


### PR DESCRIPTION
## Goal

Adds sanitizers for the gating service for the new session envelope. These are currently no-ops and a future changeset will add functionality.

