### PR TITLE
Make old fields null where possible

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -39,6 +39,14 @@ internal class V2PayloadMessageCollator(
             data = envelope.data,
             newVersion = envelope.version,
             type = envelope.type,
+
+            // make legacy fields null
+            userInfo = null,
+            version = null,
+            spans = null,
+
+            // future: make appInfo, deviceInfo, performanceInfo, breadcrumbs null.
+            // this is blocked until we can migrate others
         )
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -26,6 +26,7 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
@@ -151,7 +152,9 @@ internal class V2PayloadMessageCollatorTest {
     private fun SessionMessage.verifyFinalFieldsPopulated(
         payloadType: PayloadType
     ) {
-        assertNotNull(userInfo)
+        assertNull(userInfo)
+        assertNull(version)
+        assertNull(spans)
         assertNotNull(appInfo)
         assertNotNull(deviceInfo)
         assertNotNull(performanceInfo)


### PR DESCRIPTION
## Goal

Makes old fields in the payload null where possible. Some need to remain populated as we haven't fully migrated everything yet.

This only applies to the v2 session payload which is disabled by default, so should have no effect on our production payload.

## Testing

Updated unit tests.

