### PR TITLE
Extract wrapper for EmbraceSerializer

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.comms.delivery
 
 import com.squareup.moshi.Types
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -18,7 +18,7 @@ import kotlin.concurrent.write
  */
 internal class EmbraceCacheService(
     private val storageService: StorageService,
-    private val serializer: EmbraceSerializer,
+    private val serializer: PlatformSerializer,
     private val logger: InternalEmbraceLogger
 ) : CacheService {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/serialization/EmbraceSerializer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/serialization/EmbraceSerializer.kt
@@ -13,7 +13,7 @@ import java.lang.reflect.Type
 /**
  * A wrapper around the JSON library to allow for thread-safe serialization.
  */
-internal class EmbraceSerializer {
+internal class EmbraceSerializer : PlatformSerializer {
 
     private val impl by threadLocal {
         Moshi.Builder()
@@ -21,54 +21,54 @@ internal class EmbraceSerializer {
             .build()
     }
 
-    fun <T> toJson(src: T): String {
+    override fun <T> toJson(src: T): String {
         val clz = checkNotNull(src)::class.java
         val adapter = impl.adapter<T>(clz)
         return adapter.toJson(src) ?: error("Failed converting object to JSON.")
     }
 
-    fun <T> toJson(src: T, clz: Class<T>): String {
+    override fun <T> toJson(src: T, clz: Class<T>): String {
         val adapter = impl.adapter(clz)
         return adapter.toJson(src) ?: error("Failed converting object to JSON.")
     }
 
-    fun <T> toJson(src: T, type: Type): String {
+    override fun <T> toJson(src: T, type: Type): String {
         val adapter = impl.adapter<T>(type)
         return adapter.toJson(src) ?: error("Failed converting object to JSON.")
     }
 
-    fun <T> toJson(any: T, clazz: Class<T>, outputStream: OutputStream) {
+    override fun <T> toJson(any: T, clazz: Class<T>, outputStream: OutputStream) {
         outputStream.sink().buffer().use {
             val adapter = impl.adapter(clazz)
             adapter.toJson(it, any)
         }
     }
 
-    fun <T> toJson(any: T, type: ParameterizedType, outputStream: OutputStream) {
+    override fun <T> toJson(any: T, type: ParameterizedType, outputStream: OutputStream) {
         outputStream.sink().buffer().use {
             val adapter = impl.adapter<T>(type)
             adapter.toJson(it, any)
         }
     }
 
-    fun <T> fromJson(json: String, clz: Class<T>): T {
+    override fun <T> fromJson(json: String, clz: Class<T>): T {
         val adapter = impl.adapter(clz)
         return adapter.fromJson(json) ?: error("JSON conversion failed.")
     }
 
-    fun <T> fromJson(json: String, type: Type): T {
+    override fun <T> fromJson(json: String, type: Type): T {
         val adapter = impl.adapter<T>(type)
         return adapter.fromJson(json) ?: error("JSON conversion failed.")
     }
 
-    fun <T> fromJson(inputStream: InputStream, clz: Class<T>): T {
+    override fun <T> fromJson(inputStream: InputStream, clz: Class<T>): T {
         return inputStream.source().buffer().use {
             val adapter = impl.adapter(clz)
             adapter.fromJson(it) ?: error("JSON conversion failed.")
         }
     }
 
-    fun <T> fromJson(inputStream: InputStream, type: Type): T {
+    override fun <T> fromJson(inputStream: InputStream, type: Type): T {
         return inputStream.source().buffer().use {
             val adapter = impl.adapter<T>(type)
             adapter.fromJson(it) ?: error("JSON conversion failed.")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/serialization/PlatformSerializer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/serialization/PlatformSerializer.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.internal.serialization
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * Interface for JSON serializer wrapper than can then be wrapped for testing purposes
+ */
+internal interface PlatformSerializer {
+    fun <T> toJson(src: T): String
+    fun <T> toJson(src: T, clz: Class<T>): String
+    fun <T> toJson(src: T, type: Type): String
+    fun <T> toJson(any: T, clazz: Class<T>, outputStream: OutputStream)
+    fun <T> toJson(any: T, type: ParameterizedType, outputStream: OutputStream)
+    fun <T> fromJson(json: String, clz: Class<T>): T
+    fun <T> fromJson(json: String, type: Type): T
+    fun <T> fromJson(inputStream: InputStream, clz: Class<T>): T
+    fun <T> fromJson(inputStream: InputStream, type: Type): T
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -13,11 +13,11 @@ import io.embrace.android.embracesdk.comms.delivery.PendingApiCall
 import io.embrace.android.embracesdk.comms.delivery.PendingApiCalls
 import io.embrace.android.embracesdk.fakes.FakeLoggerAction
 import io.embrace.android.embracesdk.fakes.FakeStorageService
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fixtures.testSessionMessage
 import io.embrace.android.embracesdk.fixtures.testSessionMessage2
 import io.embrace.android.embracesdk.fixtures.testSessionMessageOneMinuteLater
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.network.http.HttpMethod
@@ -42,7 +42,7 @@ internal class EmbraceCacheServiceTest {
     private lateinit var storageManager: FakeStorageService
     private lateinit var loggerAction: FakeLoggerAction
     private lateinit var logger: InternalEmbraceLogger
-    private val serializer = EmbraceSerializer()
+    private val serializer = TestPlatformSerializer()
 
     @Before
     fun setUp() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/TestPlatformSerializer.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/TestPlatformSerializer.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+
+internal class TestPlatformSerializer(
+    realSerializer: PlatformSerializer = EmbraceSerializer()
+) : PlatformSerializer by realSerializer


### PR DESCRIPTION
## Goal

Allow EmbraceSerializer to be wrapped so we can modify the execution of the methods for tests.

This should not change anything in production but adds the bare scaffolding that will be added to later.

