### PR TITLE
Remove unused methods in CacheService and modify tests to use different ones

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
@@ -28,14 +28,6 @@ internal interface CacheService {
     fun <T> loadObject(name: String, clazz: Class<T>): T?
 
     /**
-     * Caches a byte array to disk.
-     *
-     * @param name   the name of this cache in disk
-     * @param bytes  the bytes to write
-     */
-    fun cacheBytes(name: String, bytes: ByteArray?)
-
-    /**
      * Caches a payload to disk.
      *
      * @param name   the name of this cache in disk
@@ -49,14 +41,6 @@ internal interface CacheService {
      * is successfully written to disk
      */
     fun writeSession(name: String, sessionMessage: SessionMessage)
-
-    /**
-     * Reads the bytes from a cached file, if it exists.
-     *
-     * @param name  the name of the file to read
-     * @return the byte array, if it can be read successfully
-     */
-    fun loadBytes(name: String): ByteArray?
 
     /**
      * Provides a function that writes the bytes from a cached file, if it exists, to an

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryCacheManager.kt
@@ -15,7 +15,6 @@ internal interface DeliveryCacheManager {
     fun loadCrash(): EventMessage?
     fun deleteCrash()
     fun savePayload(action: SerializationAction): String
-    fun loadPayload(name: String): ByteArray?
     fun loadPayloadAsAction(name: String): SerializationAction
     fun deletePayload(name: String)
     fun savePendingApiCalls(pendingApiCalls: PendingApiCalls)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -31,39 +31,6 @@ internal class EmbraceCacheService(
      */
     private val fileLocks = ConcurrentHashMap<String, ReentrantReadWriteLock>()
 
-    override fun cacheBytes(name: String, bytes: ByteArray?) {
-        findLock(name).write {
-            logger.logDeveloper(TAG, "Attempting to write bytes to $name")
-            if (bytes != null) {
-                val file = storageService.getFileForWrite(EMBRACE_PREFIX + name)
-                try {
-                    storageService.writeBytesToFile(file, bytes)
-                    logger.logDeveloper(TAG, "Bytes cached")
-                } catch (ex: Exception) {
-                    logger.logWarning("Failed to store cache object " + file.path, ex)
-                    deleteFile(name)
-                }
-            } else {
-                logger.logWarning("No bytes to save to file $name")
-            }
-        }
-    }
-
-    override fun loadBytes(name: String): ByteArray? {
-        findLock(name).read {
-            logger.logDeveloper(TAG, "Attempting to read bytes from $name")
-            val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
-            try {
-                return storageService.readBytesFromFile(file)
-            } catch (ex: FileNotFoundException) {
-                logger.logWarning("Cache file cannot be found " + file.path)
-            } catch (ex: Exception) {
-                logger.logWarning("Failed to read cache object " + file.path, ex)
-            }
-            return null
-        }
-    }
-
     override fun cachePayload(name: String, action: SerializationAction) {
         findLock(name).write {
             logger.logDeveloper(TAG, "Attempting to write bytes to $name")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -119,10 +119,6 @@ internal class EmbraceDeliveryCacheManager(
         return name
     }
 
-    override fun loadPayload(name: String): ByteArray? {
-        return cacheService.loadBytes(name)
-    }
-
     override fun loadPayloadAsAction(name: String): SerializationAction {
         return cacheService.loadPayload(name)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/EmbraceStorageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/EmbraceStorageService.kt
@@ -41,12 +41,6 @@ internal class EmbraceStorageService(
         return File(filesDirectory, name)
     }
 
-    override fun readBytesFromFile(file: File): ByteArray = file.readBytes()
-
-    override fun writeBytesToFile(file: File, bytes: ByteArray) {
-        file.writeBytes(bytes)
-    }
-
     override fun getConfigCacheDir(): File {
         return File(cacheDirectory, EMBRACE_CONFIG_CACHE_DIRECTORY)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/storage/StorageService.kt
@@ -21,16 +21,6 @@ internal interface StorageService {
     fun getFileForWrite(name: String): File
 
     /**
-     * Read from the given file and return the retrieved [ByteArray]
-     */
-    fun readBytesFromFile(file: File): ByteArray
-
-    /**
-     * Write the given [ByteArray] to the file and replace its existing content if applicable
-     */
-    fun writeBytesToFile(file: File, bytes: ByteArray)
-
-    /**
      * Returns a [File] instance referencing the directory where the config cache is stored.
      */
     fun getConfigCacheDir(): File

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCacheService.kt
@@ -14,14 +14,6 @@ internal class FakeCacheService : CacheService {
         TODO("Not yet implemented")
     }
 
-    override fun cacheBytes(name: String, bytes: ByteArray?) {
-        TODO("Not yet implemented")
-    }
-
-    override fun loadBytes(name: String): ByteArray? {
-        TODO("Not yet implemented")
-    }
-
     override fun deleteFile(name: String): Boolean {
         TODO("Not yet implemented")
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -52,10 +52,6 @@ internal class FakeDeliveryCacheManager : DeliveryCacheManager {
         TODO("Not yet implemented")
     }
 
-    override fun loadPayload(name: String): ByteArray? {
-        TODO("Not yet implemented")
-    }
-
     override fun deletePayload(name: String) {
         TODO("Not yet implemented")
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
@@ -20,12 +20,6 @@ internal class FakeStorageService : StorageService {
     override fun getFileForWrite(name: String) =
         File(filesDirectory, name)
 
-    override fun readBytesFromFile(file: File): ByteArray = file.readBytes()
-
-    override fun writeBytesToFile(file: File, bytes: ByteArray) {
-        file.writeBytes(bytes)
-    }
-
     override fun getConfigCacheDir() =
         File(cacheDirectory, "emb_config_cache")
 


### PR DESCRIPTION
## Goal

These methods are no longer used in production - we always serialize an object or payload now, never a byte array, so I removed them