### PR TITLE
Fix race condition in Log Sink.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
@@ -57,7 +57,7 @@ internal class LogOrchestrator(
         scheduledCheckFuture = null
         firstLogInBatchTime.set(0)
 
-        val storedLogs = sink.flushLogs(MAX_LOGS_PER_BATCH)
+        val storedLogs = sink.flushLogs()
 
         if (storedLogs.isNotEmpty()) {
             deliveryService.sendLogs(LogPayload(logs = storedLogs))
@@ -89,7 +89,7 @@ internal class LogOrchestrator(
         return firstLogInBatchTime != 0L && now - firstLogInBatchTime > MAX_BATCH_TIME
     }
     companion object {
-        private const val MAX_LOGS_PER_BATCH = 50
+        const val MAX_LOGS_PER_BATCH = 50
         private const val MAX_BATCH_TIME = 5000L // In milliseconds
         private const val MAX_INACTIVITY_TIME = 2000L // In milliseconds
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
@@ -23,9 +23,8 @@ internal interface LogSink {
     /**
      * Returns and clears the currently stored Logs. Implementations of this method must make sure the clearing and returning is
      * atomic, i.e. logs cannot be added during this operation.
-     * @param max The maximum number of logs to flush. If null, all logs are flushed.
      */
-    fun flushLogs(max: Int? = null): List<Log>
+    fun flushLogs(): List<Log>
 
     /**
      * Registers a callback to be called when logs are stored.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -32,7 +32,7 @@ internal class LogSinkImpl : LogSink {
             val maxIndex = max?.let {
                 minOf(currentSize, it)
             } ?: currentSize
-            val flushedLogs = storedLogs.take(maxIndex)
+            val flushedLogs = storedLogs.toList().subList(0, maxIndex)
             storedLogs.removeAll(flushedLogs.toSet())
             return flushedLogs
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.logs
 
+import io.embrace.android.embracesdk.internal.logs.LogOrchestrator.Companion.MAX_LOGS_PER_BATCH
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.opentelemetry.sdk.common.CompletableResultCode
@@ -26,13 +27,11 @@ internal class LogSinkImpl : LogSink {
         return storedLogs.toList()
     }
 
-    override fun flushLogs(max: Int?): List<Log> {
+    override fun flushLogs(): List<Log> {
         synchronized(flushLock) {
             val currentSize = storedLogs.size
-            val maxIndex = max?.let {
-                minOf(currentSize, it)
-            } ?: currentSize
-            val flushedLogs = storedLogs.toList().subList(0, maxIndex)
+            val maxIndex = minOf(currentSize, MAX_LOGS_PER_BATCH)
+            val flushedLogs = storedLogs.toList().take(maxIndex)
             storedLogs.removeAll(flushedLogs.toSet())
             return flushedLogs
         }


### PR DESCRIPTION
## Goal

- There was a race condition with the `take()` method. If `storedLogs` is modified by another thread after calling `take(maxIndex)`, the  `flushedLogs` list could contain more elements than expected. 
- Replaced `take()` with `toList().sublist()` that returns a copy and will always have a fixed number of elements. 

## Testing

- Reproduced with the test and always getting green after the changes. 


