### PR TITLE
Use the safe write method to write to disk for all objects

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CacheService.kt
@@ -8,12 +8,14 @@ import io.embrace.android.embracesdk.payload.SessionMessage
  */
 internal interface CacheService {
     /**
-     * Caches the specified object.
+     * Writes a JSON-serializable object to a file.
      *
-     * @param name   the name of the object to cache
-     * @param objectToCache the object to cache
-     * @param clazz  the class of the object to cache
-     * @param <T>    the type of the object
+     * If writing the object to the cache fails, an exception is logged.
+     *
+     * @param name   the unique name to identify this object which will form the basis of the file name that stores it
+     * @param objectToCache the object to write
+     * @param clazz  the [Class] object of the object to write
+     * @param T    the class of the object to write
      */
     fun <T> cacheObject(name: String, objectToCache: T, clazz: Class<T>)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -60,13 +60,17 @@ internal class EmbraceCacheServiceTest {
     }
 
     @Test
-    fun `test cacheObject with non-writable file does not throw exception`() {
+    fun `cacheObject in non-writable directory and file does not throw exception`() {
+        val directory = File(storageManager.filesDirectory, "")
         val cacheFile = File(storageManager.filesDirectory, "emb_$CUSTOM_OBJECT_1_FILE_NAME")
-        cacheFile.writeText("locked file")
+        service.cacheObject(CUSTOM_OBJECT_1_FILE_NAME, "old data", String::class.java)
+        assertEquals("old data", service.loadObject(CUSTOM_OBJECT_1_FILE_NAME, String::class.java))
+        directory.setReadOnly()
         cacheFile.setReadOnly()
 
         service.cacheObject(CUSTOM_OBJECT_1_FILE_NAME, "data", String::class.java)
-        assertNull(service.loadObject(CUSTOM_OBJECT_1_FILE_NAME, String::class.java))
+        service.cacheObject(CUSTOM_OBJECT_1_FILE_NAME, "tha new new", String::class.java)
+        assertEquals("old data", service.loadObject(CUSTOM_OBJECT_1_FILE_NAME, String::class.java))
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheServiceConcurrentAccessTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheServiceConcurrentAccessTest.kt
@@ -43,8 +43,8 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
     @Test
     fun `concurrent write attempts to the same non-existent session file should lead to last finished persist`() {
         executionCoordinator.executeOperations(
-            first = { embraceCacheService.writeSession(FILENAME, testSessionMessage) },
-            second = { embraceCacheService.writeSession(FILENAME, testSessionMessageOneMinuteLater) },
+            first = { embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java) },
+            second = { embraceCacheService.cacheObject(FILENAME, testSessionMessageOneMinuteLater, SessionMessage::class.java) },
             firstBlocksSecond = true
         )
 
@@ -57,10 +57,10 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
 
     @Test
     fun `accessing sessions with different names should not block`() {
-        embraceCacheService.writeSession(FILENAME, testSessionMessage2)
+        embraceCacheService.cacheObject(FILENAME, testSessionMessage2, SessionMessage::class.java)
 
         executionCoordinator.executeOperations(
-            first = { embraceCacheService.writeSession(FILENAME, testSessionMessage) },
+            first = { embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java) },
             second = { embraceCacheService.loadObject(FILENAME_2, SessionMessage::class.java) },
             firstBlocksSecond = false
         )
@@ -68,7 +68,7 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
 
     @Test
     fun `reading a session should not block other reads to same session`() {
-        embraceCacheService.writeSession(FILENAME, testSessionMessage)
+        embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java)
 
         executionCoordinator.executeOperations(
             first = { embraceCacheService.loadObject(FILENAME, SessionMessage::class.java) },
@@ -79,11 +79,11 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
 
     @Test
     fun `reads should block writes`() {
-        embraceCacheService.writeSession(FILENAME, testSessionMessage)
+        embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java)
 
         executionCoordinator.executeOperations(
             first = { embraceCacheService.loadObject(FILENAME, SessionMessage::class.java) },
-            second = { embraceCacheService.writeSession(FILENAME, testSessionMessageOneMinuteLater) },
+            second = { embraceCacheService.cacheObject(FILENAME, testSessionMessageOneMinuteLater, SessionMessage::class.java) },
             firstBlocksSecond = true
         )
 
@@ -99,7 +99,7 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
         var readSession: SessionMessage? = null
 
         executionCoordinator.executeOperations(
-            first = { embraceCacheService.writeSession(FILENAME, testSessionMessage) },
+            first = { embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java) },
             second = { readSession = embraceCacheService.loadObject(FILENAME, SessionMessage::class.java) },
             firstBlocksSecond = true
         )
@@ -110,10 +110,10 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
     @Test
     fun `reading a file that is being rewritten to should block and succeed`() {
         var readSession: SessionMessage? = null
-        embraceCacheService.writeSession(FILENAME, testSessionMessage)
+        embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java)
 
         executionCoordinator.executeOperations(
-            first = { embraceCacheService.writeSession(FILENAME, testSessionMessageOneMinuteLater) },
+            first = { embraceCacheService.cacheObject(FILENAME, testSessionMessageOneMinuteLater, SessionMessage::class.java) },
             second = { readSession = embraceCacheService.loadObject(FILENAME, SessionMessage::class.java) },
             firstBlocksSecond = true
         )
@@ -124,7 +124,7 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
     @Test
     fun `interrupting a session write should not leave a file`() {
         executionCoordinator.executeOperations(
-            first = { embraceCacheService.writeSession(FILENAME, testSessionMessage) },
+            first = { embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java) },
             second = { executionCoordinator.shutdownFirstThread() },
             firstBlocksSecond = false,
             firstOperationFails = true
@@ -135,10 +135,10 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
 
     @Test
     fun `interrupting a session rewrite should not overwrite the file`() {
-        embraceCacheService.writeSession(FILENAME, testSessionMessage)
+        embraceCacheService.cacheObject(FILENAME, testSessionMessage, SessionMessage::class.java)
 
         executionCoordinator.executeOperations(
-            first = { embraceCacheService.writeSession(FILENAME, testSessionMessageOneMinuteLater) },
+            first = { embraceCacheService.cacheObject(FILENAME, testSessionMessageOneMinuteLater, SessionMessage::class.java) },
             second = { executionCoordinator.shutdownFirstThread() },
             firstBlocksSecond = false,
             firstOperationFails = true


### PR DESCRIPTION
## Goal

Move the safe write logic one level higher to `cacheObject`, which `writeSession` basically just wraps. Changed the session tests to test a generic object (which happens to be a session...) and voila, tested.

Note, cachePayload is just tested with the existing tests for now, but the logic is close enough that deferring explicitly testing it is probably OK for now.

## Testing

Existing test repurposed to test the more generic workflow