### PR TITLE
Ensure spans aren't flushed twice

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -16,7 +16,8 @@ internal sealed class FinalEnvelopeParams(
     val lifeEventType: Session.LifeEventType?,
     crashId: String?,
     val endType: SessionSnapshotType,
-    val isCacheAttempt: Boolean
+    val isCacheAttempt: Boolean,
+    val captureSpans: Boolean
 ) {
 
     val crashId: String? = when {
@@ -37,6 +38,7 @@ internal sealed class FinalEnvelopeParams(
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,
+        captureSpans: Boolean = true,
         crashId: String? = null,
     ) : FinalEnvelopeParams(
         initial,
@@ -44,7 +46,8 @@ internal sealed class FinalEnvelopeParams(
         lifeEventType,
         crashId,
         endType,
-        lifeEventType == null
+        lifeEventType == null,
+        captureSpans
     ) {
         override val terminationTime: Long? = null
         override val receivedTermination: Boolean? = null
@@ -60,6 +63,7 @@ internal sealed class FinalEnvelopeParams(
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,
+        captureSpans: Boolean = true,
         crashId: String? = null,
     ) : FinalEnvelopeParams(
         initial,
@@ -67,7 +71,8 @@ internal sealed class FinalEnvelopeParams(
         lifeEventType,
         crashId,
         endType,
-        endType == SessionSnapshotType.PERIODIC_CACHE
+        endType == SessionSnapshotType.PERIODIC_CACHE,
+        captureSpans
     ) {
 
         override val terminationTime: Long? = when {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -155,10 +155,11 @@ internal class V1PayloadMessageCollator(
         params: FinalEnvelopeParams,
         finalPayload: Session,
         startTime: Long,
-        endTime: Long
+        endTime: Long,
     ): SessionMessage {
         val spans: List<EmbraceSpanData>? = captureDataSafely {
             when {
+                !params.captureSpans -> null
                 !params.isCacheAttempt -> {
                     val appTerminationCause = when {
                         finalPayload.crashReportId != null -> AppTerminationCause.Crash

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -21,13 +21,29 @@ internal class V2PayloadMessageCollator(
     }
 
     override fun buildFinalSessionMessage(params: FinalEnvelopeParams.SessionParams): SessionMessage {
-        return v1Collator.buildFinalSessionMessage(params)
-            .convertToV2Payload(params.endType)
+        val newParams = FinalEnvelopeParams.SessionParams(
+            initial = params.initial,
+            endTime = params.endTime,
+            lifeEventType = params.lifeEventType,
+            crashId = params.crashId,
+            endType = params.endType,
+            captureSpans = false
+        )
+        return v1Collator.buildFinalSessionMessage(newParams)
+            .convertToV2Payload(newParams.endType)
     }
 
     override fun buildFinalBackgroundActivityMessage(params: FinalEnvelopeParams.BackgroundActivityParams): SessionMessage {
-        return v1Collator.buildFinalBackgroundActivityMessage(params)
-            .convertToV2Payload(params.endType)
+        val newParams = FinalEnvelopeParams.BackgroundActivityParams(
+            initial = params.initial,
+            endTime = params.endTime,
+            lifeEventType = params.lifeEventType,
+            crashId = params.crashId,
+            endType = params.endType,
+            captureSpans = false
+        )
+        return v1Collator.buildFinalBackgroundActivityMessage(newParams)
+            .convertToV2Payload(newParams.endType)
     }
 
     private fun SessionMessage.convertToV2Payload(endType: SessionSnapshotType): SessionMessage {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -109,6 +109,7 @@ internal class V1PayloadMessageCollatorTest {
                 15000000000,
                 LifeEventType.BKGND_STATE,
                 SessionSnapshotType.NORMAL_END,
+                true,
                 "crashId"
             )
         )
@@ -135,6 +136,7 @@ internal class V1PayloadMessageCollatorTest {
                 15000000000,
                 LifeEventType.STATE,
                 SessionSnapshotType.NORMAL_END,
+                true,
                 "crashId"
             )
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -116,6 +116,7 @@ internal class V2PayloadMessageCollatorTest {
                 15000000000,
                 Session.LifeEventType.BKGND_STATE,
                 SessionSnapshotType.NORMAL_END,
+                true,
                 "crashId"
             )
         )
@@ -142,6 +143,7 @@ internal class V2PayloadMessageCollatorTest {
                 15000000000,
                 Session.LifeEventType.STATE,
                 SessionSnapshotType.NORMAL_END,
+                true,
                 "crashId",
             )
         )


### PR DESCRIPTION
## Goal

Ensures that spans aren't flushed twice as the `V1PayloadMessageCollator` is called by the `V2PayloadMessageCollator` when generating the payload. This should be a temporary state of affairs, but the fix is to disable flushing of spans within that class.

## Testing

Relied on existing test coverage.

