### PR TITLE
Split EnvelopeSource into LogEnvelopeSource and SessionEnvelopeSource

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/EnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/EnvelopeSource.kt
@@ -1,8 +1,0 @@
-package io.embrace.android.embracesdk.capture.envelope
-
-import io.embrace.android.embracesdk.internal.payload.Envelope
-import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
-
-internal fun interface EnvelopeSource<T> {
-    fun getEnvelope(endType: SessionSnapshotType): Envelope<T>
-}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSource.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.capture.envelope.log
+
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.LogPayload
+
+internal fun interface LogEnvelopeSource {
+    fun getEnvelope(): Envelope<LogPayload>
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImpl.kt
@@ -1,19 +1,16 @@
-package io.embrace.android.embracesdk.capture.envelope
+package io.embrace.android.embracesdk.capture.envelope.log
 
-import io.embrace.android.embracesdk.capture.envelope.log.LogPayloadSource
 import io.embrace.android.embracesdk.capture.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.capture.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.payload.Envelope
-import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
-internal class LogEnvelopeSource(
+internal class LogEnvelopeSourceImpl(
     private val metadataSource: EnvelopeMetadataSource,
     private val resourceSource: EnvelopeResourceSource,
     private val logPayloadSource: LogPayloadSource,
-) : EnvelopeSource<LogPayload> {
+) : LogEnvelopeSource {
 
-    override fun getEnvelope(endType: SessionSnapshotType) = Envelope(
+    override fun getEnvelope() = Envelope(
         resourceSource.getEnvelopeResource(),
         metadataSource.getEnvelopeMetadata(),
         null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSource.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.capture.envelope.session
+
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
+
+internal fun interface SessionEnvelopeSource {
+    fun getEnvelope(endType: SessionSnapshotType): Envelope<SessionPayload>
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImpl.kt
@@ -1,17 +1,16 @@
-package io.embrace.android.embracesdk.capture.envelope
+package io.embrace.android.embracesdk.capture.envelope.session
 
 import io.embrace.android.embracesdk.capture.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.capture.envelope.resource.EnvelopeResourceSource
-import io.embrace.android.embracesdk.capture.envelope.session.SessionPayloadSource
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
-internal class SessionEnvelopeSource(
+internal class SessionEnvelopeSourceImpl(
     private val metadataSource: EnvelopeMetadataSource,
     private val resourceSource: EnvelopeResourceSource,
     private val sessionPayloadSource: SessionPayloadSource,
-) : EnvelopeSource<SessionPayload> {
+) : SessionEnvelopeSource {
 
     override fun getEnvelope(endType: SessionSnapshotType): Envelope<SessionPayload> {
         return Envelope(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/PayloadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/PayloadModule.kt
@@ -1,10 +1,12 @@
 package io.embrace.android.embracesdk.injection
 
-import io.embrace.android.embracesdk.capture.envelope.LogEnvelopeSource
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.log.LogEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.log.LogEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.envelope.log.LogPayloadSourceImpl
 import io.embrace.android.embracesdk.capture.envelope.metadata.EnvelopeMetadataSourceImpl
 import io.embrace.android.embracesdk.capture.envelope.resource.EnvelopeResourceSourceImpl
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.envelope.session.SessionPayloadSourceImpl
 import io.embrace.android.embracesdk.ndk.NativeModule
 
@@ -47,10 +49,10 @@ internal class PayloadModuleImpl(
     }
 
     override val sessionEnvelopeSource: SessionEnvelopeSource by singleton {
-        SessionEnvelopeSource(metadataSource, resourceSource, sessionPayloadSource)
+        SessionEnvelopeSourceImpl(metadataSource, resourceSource, sessionPayloadSource)
     }
 
     override val logEnvelopeSource: LogEnvelopeSource by singleton {
-        LogEnvelopeSource(metadataSource, resourceSource, logPayloadSource)
+        LogEnvelopeSourceImpl(metadataSource, resourceSource, logPayloadSource)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.session.message
 
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImplTest.kt
@@ -1,26 +1,25 @@
-package io.embrace.android.embracesdk.capture.envelope
+package io.embrace.android.embracesdk.capture.envelope.log
 
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeLogPayloadSource
-import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
-internal class LogEnvelopeSourceTest {
+internal class LogEnvelopeSourceImplTest {
 
     @Test
     fun getEnvelope() {
         val metadataSource = FakeEnvelopeMetadataSource()
         val resourceSource = FakeEnvelopeResourceSource()
         val logSource = FakeLogPayloadSource()
-        val source = LogEnvelopeSource(
+        val source = LogEnvelopeSourceImpl(
             metadataSource,
             resourceSource,
             logSource,
         )
-        val payload = source.getEnvelope(SessionSnapshotType.NORMAL_END)
+        val payload = source.getEnvelope()
         assertEquals(metadataSource.metadata, payload.metadata)
         assertEquals(resourceSource.resource, payload.resource)
         assertEquals(logSource.logs, payload.data)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImplTest.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.capture.envelope
+package io.embrace.android.embracesdk.capture.envelope.session
 
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
@@ -7,14 +7,14 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-internal class SessionEnvelopeSourceTest {
+internal class SessionEnvelopeSourceImplTest {
 
     @Test
     fun getEnvelope() {
         val metadataSource = FakeEnvelopeMetadataSource()
         val resourceSource = FakeEnvelopeResourceSource()
         val sessionPayloadSource = FakeSessionPayloadSource()
-        val source = SessionEnvelopeSource(
+        val source = SessionEnvelopeSourceImpl(
             metadataSource,
             resourceSource,
             sessionPayloadSource,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadModule.kt
@@ -1,12 +1,13 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.capture.envelope.LogEnvelopeSource
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.log.LogEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.injection.PayloadModule
 
 internal class FakePayloadModule : PayloadModule {
 
-    override val sessionEnvelopeSource: SessionEnvelopeSource = SessionEnvelopeSource(
+    override val sessionEnvelopeSource: SessionEnvelopeSource = SessionEnvelopeSourceImpl(
         FakeEnvelopeMetadataSource(),
         FakeEnvelopeResourceSource(),
         FakeSessionPayloadSource()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
@@ -179,7 +179,7 @@ internal class PayloadFactoryBaTest {
             FakeSessionPropertiesService(),
             FakeStartupService()
         )
-        val sessionEnvelopeSource = SessionEnvelopeSource(
+        val sessionEnvelopeSource = SessionEnvelopeSourceImpl(
             metadataSource = FakeEnvelopeMetadataSource(),
             resourceSource = FakeEnvelopeResourceSource(),
             sessionPayloadSource = FakeSessionPayloadSource()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.FakeDeliveryService
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -92,7 +92,7 @@ internal class PayloadFactorySessionTest {
     ) {
         processStateService.isInBackground = isActivityInBackground
 
-        val sessionEnvelopeSource = SessionEnvelopeSource(
+        val sessionEnvelopeSource = SessionEnvelopeSourceImpl(
             metadataSource = FakeEnvelopeMetadataSource(),
             resourceSource = FakeEnvelopeResourceSource(),
             sessionPayloadSource = FakeSessionPayloadSource()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
 import io.embrace.android.embracesdk.capture.webview.WebViewService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
@@ -162,7 +162,7 @@ internal class SessionHandlerTest {
         val v2Collator = V2PayloadMessageCollator(
             gatingService,
             payloadMessageCollator,
-            SessionEnvelopeSource(
+            SessionEnvelopeSourceImpl(
                 metadataSource = FakeEnvelopeMetadataSource(),
                 resourceSource = FakeEnvelopeResourceSource(),
                 sessionPayloadSource = FakeSessionPayloadSource()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -69,7 +69,7 @@ internal class PayloadFactoryImplTest {
         val v2Collator = V2PayloadMessageCollator(
             FakeGatingService(),
             v1Collator,
-            SessionEnvelopeSource(
+            SessionEnvelopeSourceImpl(
                 FakeEnvelopeMetadataSource(),
                 FakeEnvelopeResourceSource(),
                 FakeSessionPayloadSource()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.capture.envelope.SessionEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
@@ -65,7 +65,7 @@ internal class V2PayloadMessageCollatorTest {
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService()
         )
-        val sessionEnvelopeSource = SessionEnvelopeSource(
+        val sessionEnvelopeSource = SessionEnvelopeSourceImpl(
             metadataSource = FakeEnvelopeMetadataSource(),
             resourceSource = FakeEnvelopeResourceSource(),
             sessionPayloadSource = FakeSessionPayloadSource()


### PR DESCRIPTION
## Goal

- Split EnvelopeSource interface into LogEnvelopeSource and SessionEnvelopeSource.

## Testing

Relied on existing unit tests. 

