### PR TITLE
Use v1 endpoint for now

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapper.kt
@@ -68,11 +68,9 @@ internal class ApiRequestMapper(
         return requestBuilder(url)
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun sessionRequest(v2Payload: Boolean): ApiRequest {
-        val url = when {
-            v2Payload -> Endpoint.SESSIONS_V2
-            else -> Endpoint.SESSIONS
-        }
+        val url = Endpoint.SESSIONS // send to v1 endpoint for now.
         return requestBuilder(url.asEmbraceUrl())
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiRequestMapperTest.kt
@@ -94,7 +94,7 @@ internal class ApiRequestMapperTest {
     @Test
     fun testV2SessionRequest() {
         val request = mapper.sessionRequest(true)
-        request.assertCoreFieldsPopulated("/v2/spans")
+        request.assertCoreFieldsPopulated("/v1/log/sessions")
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -263,7 +263,7 @@ internal class EmbraceApiServiceTest {
         var finished = false
         apiService.sendSession(true, { it.write(payload) }) { finished = true }
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/spans",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/sessions",
             expectedPayload = payload
         )
         assertTrue(finished)


### PR DESCRIPTION
## Goal

Send v2 payloads to the v1 endpoint for now, as it's capable of processing incomplete payloads whereas the v2 endpoint will not accept legacy fields.
