### PR TITLE
Change the names used for emb.type

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -15,7 +15,8 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
     }
 
     /**
-     * Keys that track a point in time & is visual in nature. Applies to spans, logs, and span events.
+     * Keys that track telemetry that is explicitly tied to user behaviour or visual in nature.
+     * Applies to spans, logs, and span events.
      */
     internal sealed class Ux(subtype: String) : EmbType("ux", subtype) {
 
@@ -25,7 +26,8 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
     }
 
     /**
-     * Keys that track a point in time that is not visual in nature. Applies to spans, logs, and span events.
+     * Keys that track telemetry that is not explicitly tied to user behaviour and is not visual in nature.
+     * Applies to spans, logs, and span events.
      */
     internal sealed class System(subtype: String) : EmbType("sys", subtype) {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -7,11 +7,11 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
     /**
      * Keys that track how fast a time interval is. Only applies to spans.
      */
-    internal sealed class Performance(subtype: String?) : EmbType("performance", subtype) {
+    internal sealed class Performance(subtype: String?) : EmbType("perf", subtype) {
 
         internal object Default : Performance(null)
 
-        internal object Network : Performance("network")
+        internal object Network : Performance("network_request")
     }
 
     /**
@@ -27,9 +27,9 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
     /**
      * Keys that track a point in time that is not visual in nature. Applies to spans, logs, and span events.
      */
-    internal sealed class System(subtype: String) : EmbType("system", subtype) {
+    internal sealed class System(subtype: String) : EmbType("sys", subtype) {
 
-        internal object Breadcrumb : System("breadcrumb")
+        internal object Breadcrumb : System("custom_breadcrumb")
 
         internal object Log : System("log")
 

--- a/embrace-android-sdk/src/test/resources/span_expected.json
+++ b/embrace-android-sdk/src/test/resources/span_expected.json
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "emb.sequence_id": "3",
-    "emb.type": "performance"
+    "emb.type": "perf"
   },
   "end_time_unix_nano": 1681972471871000000,
   "events": [


### PR DESCRIPTION
## Goal

Changed the literal strings we use in the `emb.type` attribute to conform to the agreed to names.

