### PR TITLE
Add a version of take() that is threadsafe

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanSinkImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.utils.threadSafeTake
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.Queue
@@ -22,7 +23,7 @@ internal class SpanSinkImpl : SpanSink {
 
     override fun completedSpans(): List<EmbraceSpanData> {
         val spansToReturn = completedSpans.size
-        return completedSpans.take(spansToReturn)
+        return completedSpans.threadSafeTake(spansToReturn)
     }
 
     override fun flushSpans(): List<EmbraceSpanData> {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/CollectionExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/CollectionExtensions.kt
@@ -45,3 +45,30 @@ internal fun <T> MutableMap<String, AtomicInteger>.lockAndRun(key: String, code:
         }
     }
 }
+
+/**
+ * A version of [take] that is useful for a [Collection] expected to be threadsafe but doesn't synchronize the reads with writes such
+ * that the underlying data change during iteration. [take] has an optimization that returns the whole [Collection] if the size is less than
+ * or equal to the size of the number of elements requested, but since the underlying data can change after the size check, you can
+ * get more elements than requested if they were added during the [toList] call.
+ */
+internal fun <T> Collection<T>.threadSafeTake(n: Int): List<T> {
+    return if (n == 0) {
+        emptyList()
+    } else {
+        val returnList = ArrayList<T>(n)
+
+        for ((count, item) in this.withIndex()) {
+            returnList.add(item)
+            if (count + 1 == n) {
+                break
+            }
+        }
+
+        return if (returnList.size <= 1) {
+            take(returnList.size)
+        } else {
+            returnList
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Add a threadsafe version of take that doesn't return toList() and use it when we want the first N elements of a thread-safe collection.

## Testing

Existing tests cover the current use case. A better test will be written that tests the function later.