### PR TITLE
[EMBR-3054] Generate LogEnvelope from LogOrchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImpl.kt
@@ -9,7 +9,7 @@ internal class LogPayloadSourceImpl(
 
     override fun getLogPayload(): LogPayload {
         return LogPayload(
-            logs = logSink.completedLogs()
+            logs = logSink.flushLogs()
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiService.kt
@@ -34,9 +34,9 @@ internal interface ApiService {
     /**
      * Sends a list of OTel Logs to the API.
      *
-     * @param logsEnvelope containing the logs
+     * @param logEnvelope containing the logs
      */
-    fun sendLogsEnvelope(logsEnvelope: Envelope<LogPayload>)
+    fun sendLogEnvelope(logEnvelope: Envelope<LogPayload>)
 
     /**
      * Sends an Application Exit Info (AEI) blob message to the API.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -124,9 +124,9 @@ internal class EmbraceApiService(
         post(eventMessage, mapper::logRequest)
     }
 
-    override fun sendLogsEnvelope(logsEnvelope: Envelope<LogPayload>) {
+    override fun sendLogEnvelope(logEnvelope: Envelope<LogPayload>) {
         val parameterizedType = Types.newParameterizedType(Envelope::class.java, LogPayload::class.java)
-        post(logsEnvelope, mapper::logsEnvelopeRequest, parameterizedType)
+        post(logEnvelope, mapper::logsEnvelopeRequest, parameterizedType)
     }
 
     override fun sendAEIBlob(blobMessage: BlobMessage) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.comms.delivery
 
+import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -13,7 +14,7 @@ internal interface DeliveryService {
     fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
     fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker)
     fun sendLog(eventMessage: EventMessage)
-    fun sendLogs(logPayload: LogPayload)
+    fun sendLogs(logEnvelope: Envelope<LogPayload>)
     fun sendNetworkCall(networkEvent: NetworkEvent)
     fun sendCrash(crash: EventMessage, processTerminating: Boolean)
     fun sendAEIBlob(blobMessage: BlobMessage)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -70,9 +70,8 @@ internal class EmbraceDeliveryService(
         apiService.sendLog(eventMessage)
     }
 
-    override fun sendLogs(logPayload: LogPayload) {
-        val logsEnvelope = Envelope(data = logPayload)
-        apiService.sendLogsEnvelope(logsEnvelope)
+    override fun sendLogs(logEnvelope: Envelope<LogPayload>) {
+        apiService.sendLogEnvelope(logEnvelope)
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -32,7 +32,8 @@ internal class CustomerLogModuleImpl(
     essentialServiceModule: EssentialServiceModule,
     deliveryModule: DeliveryModule,
     sessionProperties: EmbraceSessionProperties,
-    workerThreadModule: WorkerThreadModule
+    workerThreadModule: WorkerThreadModule,
+    payloadModule: PayloadModule,
 ) : CustomerLogModule {
 
     override val networkCaptureService: NetworkCaptureService by singleton {
@@ -87,7 +88,8 @@ internal class CustomerLogModuleImpl(
             workerThreadModule.scheduledWorker(WorkerName.REMOTE_LOGGING),
             initModule.clock,
             openTelemetryModule.logSink,
-            deliveryModule.deliveryService
+            deliveryModule.deliveryService,
+            payloadModule.logEnvelopeSource,
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -291,30 +291,6 @@ internal class ModuleInitBootstrapper(
                         )
                     }
 
-                    customerLogModule = init(CustomerLogModule::class) {
-                        customerLogModuleSupplier(
-                            initModule,
-                            coreModule,
-                            openTelemetryModule,
-                            androidServicesModule,
-                            essentialServiceModule,
-                            deliveryModule,
-                            sessionProperties,
-                            workerThreadModule
-                        )
-                    }
-
-                    postInit(CustomerLogModule::class) {
-                        serviceRegistry.registerServices(
-                            customerLogModule.logMessageService,
-                            customerLogModule.logService,
-                            customerLogModule.networkCaptureService,
-                            customerLogModule.networkLoggingService
-                        )
-                        // Start the log orchestrator
-                        customerLogModule.logOrchestrator
-                    }
-
                     nativeModule = init(NativeModule::class) {
                         nativeModuleSupplier(
                             coreModule,
@@ -374,6 +350,40 @@ internal class ModuleInitBootstrapper(
                         }
                     }
 
+                    payloadModule = init(PayloadModule::class) {
+                        payloadModuleSupplier(
+                            essentialServiceModule,
+                            nativeModule,
+                            openTelemetryModule,
+                            sdkObservabilityModule
+                        )
+                    }
+
+                    customerLogModule = init(CustomerLogModule::class) {
+                        customerLogModuleSupplier(
+                            initModule,
+                            coreModule,
+                            openTelemetryModule,
+                            androidServicesModule,
+                            essentialServiceModule,
+                            deliveryModule,
+                            sessionProperties,
+                            workerThreadModule,
+                            payloadModule
+                        )
+                    }
+
+                    postInit(CustomerLogModule::class) {
+                        serviceRegistry.registerServices(
+                            customerLogModule.logMessageService,
+                            customerLogModule.logService,
+                            customerLogModule.networkCaptureService,
+                            customerLogModule.networkLoggingService
+                        )
+                        // Start the log orchestrator
+                        customerLogModule.logOrchestrator
+                    }
+
                     dataContainerModule = init(DataContainerModule::class) {
                         dataContainerModuleSupplier(
                             initModule,
@@ -409,15 +419,6 @@ internal class ModuleInitBootstrapper(
                             systemServiceModule,
                             androidServicesModule,
                             workerThreadModule
-                        )
-                    }
-
-                    payloadModule = init(PayloadModule::class) {
-                        payloadModuleSupplier(
-                            essentialServiceModule,
-                            nativeModule,
-                            openTelemetryModule,
-                            sdkObservabilityModule
                         )
                     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
@@ -58,9 +58,10 @@ internal class LogOrchestrator(
         scheduledCheckFuture = null
         firstLogInBatchTime.set(0)
 
-        deliveryService.sendLogs(
-            logEnvelopeSource.getEnvelope()
-        )
+        val envelope = logEnvelopeSource.getEnvelope()
+        if (!envelope.data.logs.isNullOrEmpty()) {
+            deliveryService.sendLogs(envelope)
+        }
 
         return true
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.logs
 
+import io.embrace.android.embracesdk.capture.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.lang.Long.min
 import java.util.concurrent.ScheduledFuture
@@ -13,7 +13,8 @@ internal class LogOrchestrator(
     private val logOrchestratorScheduledWorker: ScheduledWorker,
     private val clock: Clock,
     private val sink: LogSink,
-    private val deliveryService: DeliveryService
+    private val deliveryService: DeliveryService,
+    private val logEnvelopeSource: LogEnvelopeSource,
 ) {
     @Volatile
     private var lastLogTime: AtomicLong = AtomicLong(0)
@@ -57,11 +58,9 @@ internal class LogOrchestrator(
         scheduledCheckFuture = null
         firstLogInBatchTime.set(0)
 
-        val storedLogs = sink.flushLogs()
-
-        if (storedLogs.isNotEmpty()) {
-            deliveryService.sendLogs(LogPayload(logs = storedLogs))
-        }
+        deliveryService.sendLogs(
+            logEnvelopeSource.getEnvelope()
+        )
 
         return true
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -143,7 +143,8 @@ internal typealias CustomerLogModuleSupplier = (
     essentialServiceModule: EssentialServiceModule,
     deliveryModule: DeliveryModule,
     sessionProperties: EmbraceSessionProperties,
-    workerThreadModule: WorkerThreadModule
+    workerThreadModule: WorkerThreadModule,
+    payloadModule: PayloadModule,
 ) -> CustomerLogModule
 
 /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
+import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -19,7 +20,7 @@ internal open class FakeDeliveryService : DeliveryService {
     var lastSentCrash: EventMessage? = null
     var lastSentEvent: EventMessage? = null
     val lastSentLogs: MutableList<EventMessage> = mutableListOf()
-    val lastSentLogPayloads: MutableList<LogPayload> = mutableListOf()
+    val lastSentLogPayloads: MutableList<Envelope<LogPayload>> = mutableListOf()
     val sentMoments: MutableList<EventMessage> = mutableListOf()
     var sendBackgroundActivitiesInvokedCount: Int = 0
     var lastSentBackgroundActivities: MutableList<SessionMessage> = mutableListOf()
@@ -56,8 +57,8 @@ internal open class FakeDeliveryService : DeliveryService {
         lastSentLogs.add(eventMessage)
     }
 
-    override fun sendLogs(logPayload: LogPayload) {
-        lastSentLogPayloads.add(logPayload)
+    override fun sendLogs(logEnvelope: Envelope<LogPayload>) {
+        lastSentLogPayloads.add(logEnvelope)
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImplTest.kt
@@ -24,6 +24,7 @@ internal class LogPayloadSourceImplTest {
     fun `test getLogPayload returns a correct payload`() {
         val payload = impl.getLogPayload()
         val log = checkNotNull(payload.logs?.single())
+        assertEquals(0, sink.completedLogs().size)
         assertEquals(1, payload.logs?.size)
         assertEquals(fakeLog.timestampEpochNanos, log.timeUnixNano)
         assertEquals(fakeLog.severityText, log.severityText)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -288,7 +288,7 @@ internal class EmbraceApiServiceTest {
         )
 
         fakeApiClient.queueResponse(successfulPostResponse)
-        apiService.sendLogsEnvelope(logsEnvelope)
+        apiService.sendLogEnvelope(logsEnvelope)
 
         val type: ParameterizedType = Types.newParameterizedType(Envelope::class.java, LogPayload::class.java)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeApiService.kt
@@ -42,8 +42,8 @@ internal class FakeApiService : ApiService {
         logRequests.add(eventMessage)
     }
 
-    override fun sendLogsEnvelope(logsEnvelope: Envelope<LogPayload>) {
-        logPayloads.add(logsEnvelope.data)
+    override fun sendLogEnvelope(logEnvelope: Envelope<LogPayload>) {
+        logPayloads.add(logEnvelope.data)
     }
 
     override fun sendNetworkCall(networkEvent: NetworkEvent) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadModule.kt
@@ -1,18 +1,27 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.capture.envelope.log.LogEnvelopeSource
+import io.embrace.android.embracesdk.capture.envelope.log.LogEnvelopeSourceImpl
+import io.embrace.android.embracesdk.capture.envelope.log.LogPayloadSource
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
+import io.embrace.android.embracesdk.capture.envelope.session.SessionPayloadSource
 import io.embrace.android.embracesdk.injection.PayloadModule
 
-internal class FakePayloadModule : PayloadModule {
+internal class FakePayloadModule(
+    sessionPayloadSource: SessionPayloadSource = FakeSessionPayloadSource(),
+    logPayloadSource: LogPayloadSource = FakeLogPayloadSource()
+) : PayloadModule {
 
     override val sessionEnvelopeSource: SessionEnvelopeSource = SessionEnvelopeSourceImpl(
         FakeEnvelopeMetadataSource(),
         FakeEnvelopeResourceSource(),
-        FakeSessionPayloadSource()
+        sessionPayloadSource
     )
 
-    override val logEnvelopeSource: LogEnvelopeSource
-        get() = TODO("Not yet implemented")
+    override val logEnvelopeSource: LogEnvelopeSource = LogEnvelopeSourceImpl(
+        FakeEnvelopeMetadataSource(),
+        FakeEnvelopeResourceSource(),
+        logPayloadSource
+    )
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CustomerLogModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CustomerLogModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
+import io.embrace.android.embracesdk.fakes.FakePayloadModule
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
@@ -23,7 +24,8 @@ internal class CustomerLogModuleImplTest {
             FakeEssentialServiceModule(),
             FakeDeliveryModule(),
             fakeEmbraceSessionProperties(),
-            WorkerThreadModuleImpl(initModule)
+            WorkerThreadModuleImpl(initModule),
+            FakePayloadModule(),
         )
 
         assertNotNull(module.networkCaptureService)


### PR DESCRIPTION
## Goal

- Logs were passed to the `DeliveryService`, but the envelope was not being generated through the `EnvelopeSource` in order to include metadata, resources, etc. 
- Now the `LogOrchestrator` asks the `EnvelopeSource` for the `envelope` and sends it to the `DeliveryService`. 
- `LogPayloadSource` is now responsible for doing the `flush()` on the `LogSink` and returning the `LogPayload` to form the `envelope`. 
## Testing

- Updated existing tests. 


