### PR TITLE
Add app framework value to v2 logs

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogAttributes.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogAttributes.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.logs
 
+import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.LogExceptionType
 
 internal class EmbraceLogAttributes(properties: Map<String, Any>?) {
@@ -42,6 +43,12 @@ internal class EmbraceLogAttributes(properties: Map<String, Any>?) {
          */
         private const val EXCEPTION_MESSAGE_ATTRIBUTE_NAME =
             EMBRACE_ATTRIBUTE_NAME_PREFIX + "exception_message"
+
+        /**
+         * Attribute name for the app framework for a log representing an exception
+         */
+        private const val APP_FRAMEWORK_ATTRIBUTE_NAME =
+            EMBRACE_ATTRIBUTE_NAME_PREFIX + "app_framework"
 
         /**
          * Attribute name for the exception context in a log representing an exception
@@ -106,6 +113,13 @@ internal class EmbraceLogAttributes(properties: Map<String, Any>?) {
      */
     fun setExceptionMessage(exceptionMessage: String) {
         attributes[EXCEPTION_MESSAGE_ATTRIBUTE_NAME] = exceptionMessage
+    }
+
+    /**
+     * Set an app framework (native, unity, react native or flutter) for the log
+     */
+    fun setAppFramework(framework: AppFramework) {
+        attributes[APP_FRAMEWORK_ATTRIBUTE_NAME] = framework.value.toString()
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -73,6 +73,7 @@ internal class EmbraceLogService(
     ) {
         val attributes = EmbraceLogAttributes(properties)
         attributes.setExceptionType(logExceptionType)
+        attributes.setAppFramework(framework)
         // TBD: Add stacktrace elements
         exceptionName?.let { attributes.setExceptionName(it) }
         exceptionMessage?.let { attributes.setExceptionMessage(it) }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -65,6 +65,7 @@ internal class EmbraceLogService(
         properties: Map<String, Any>?,
         stackTraceElements: Array<StackTraceElement>?,
         customStackTrace: String?,
+        framework: AppFramework,
         context: String?,
         library: String?,
         exceptionName: String?,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -31,11 +31,13 @@ internal interface LogService : MemoryCleanerListener {
      * @param properties         custom properties to send as part of the event
      * @param stackTraceElements the stacktrace elements of a throwable
      * @param customStackTrace   stacktrace string for non-JVM exceptions
+     * @param framework          the app framework (Native, Unity, etc) for the exception
      * @param context            context for a Dart exception from the Flutter SDK
      * @param library            library from a Dart exception from the Flutter SDK
      * @param exceptionName      the exception name of a Throwable is it is present
      * @param exceptionMessage   the exception message of a Throwable is it is present
      */
+    @Suppress("LongParameterList")
     fun logException(
         message: String,
         severity: Severity,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.logs
 
+import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
@@ -42,6 +43,7 @@ internal interface LogService : MemoryCleanerListener {
         properties: Map<String, Any>?,
         stackTraceElements: Array<StackTraceElement>?,
         customStackTrace: String?,
+        framework: AppFramework,
         context: String?,
         library: String?,
         exceptionName: String?,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -120,6 +120,7 @@ internal class EmbraceLogServiceTest {
             null,
             exception.stackTrace,
             null,
+            AppFramework.NATIVE,
             null,
             null,
             exception.javaClass.simpleName,
@@ -131,6 +132,7 @@ internal class EmbraceLogServiceTest {
         assertEquals(Severity.WARNING, log.severity)
         assertEquals("NullPointerException", log.attributes["emb.exception_name"])
         assertEquals("exception message", log.attributes["emb.exception_message"])
+        assertEquals(AppFramework.NATIVE.value.toString(), log.attributes["emb.app_framework"])
         assertNotNull(log.attributes["emb.log_id"])
         assertEquals("session-123", log.attributes["emb.session_id"])
         assertEquals("none", log.attributes["emb.exception_type"])
@@ -230,6 +232,7 @@ internal class EmbraceLogServiceTest {
             null,
             null,
             "my stacktrace",
+            AppFramework.UNITY,
             null,
             null,
             null,
@@ -239,6 +242,7 @@ internal class EmbraceLogServiceTest {
         val log = logWriter.logEvents.single()
         assertEquals("Unity".repeat(1000), log.message) // log limit higher on unity
         // TBD: Assert stacktrace
+        assertEquals(AppFramework.UNITY.value.toString(), log.attributes["emb.app_framework"])
         assertEquals(LogExceptionType.HANDLED.value, log.attributes["emb.exception_type"])
         // TBD: Assert unhandled exceptions
         // assertEquals(0, logMessageService.getUnhandledExceptionsSent())


### PR DESCRIPTION
## Goal

Add the "app framework" attribute for logs that was missing.
