### PR TITLE
Make EmbraceSpan snapshottable

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/OpenTelemetryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/OpenTelemetryModule.kt
@@ -114,7 +114,7 @@ internal class OpenTelemetryModuleImpl(
 
     override val currentSessionSpan: CurrentSessionSpan by lazy {
         CurrentSessionSpanImpl(
-            clock = initModule.openTelemetryClock,
+            openTelemetryClock = initModule.openTelemetryClock,
             telemetryService = initModule.telemetryService,
             spanRepository = spanRepository,
             spanSink = spanSink,
@@ -124,6 +124,7 @@ internal class OpenTelemetryModuleImpl(
 
     override val spanService: SpanService by singleton {
         EmbraceSpanService(
+            openTelemetryClock = initModule.openTelemetryClock,
             spanRepository = spanRepository,
             currentSessionSpan = currentSessionSpan,
             tracerSupplier = { tracer },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
 import io.embrace.android.embracesdk.arch.schema.KeySpan
 import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
-import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -44,11 +43,11 @@ private const val EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX = "emb.usage."
 private const val SEQUENCE_ID_ATTRIBUTE_NAME = EMBRACE_ATTRIBUTE_NAME_PREFIX + "sequence_id"
 
 /**
- * Creates a new [SpanBuilder] with the correctly prefixed name, to be used for recording Spans in the SDK internally
+ * Creates a new [SpanBuilder] that marks the resulting span as private if [internal] is true
  */
 internal fun Tracer.embraceSpanBuilder(name: String, internal: Boolean): SpanBuilder {
     return if (internal) {
-        spanBuilder(EMBRACE_SPAN_NAME_PREFIX + name).makePrivate()
+        spanBuilder(name).makePrivate()
     } else {
         spanBuilder(name)
     }
@@ -127,31 +126,6 @@ internal fun Span.addEvents(events: List<EmbraceSpanEvent>): Span {
         }
     }
     return this
-}
-
-/**
- * Allow a [SpanBuilder] to take in a lambda around which a span will be created for its execution
- */
-internal fun <T> SpanBuilder.record(
-    attributes: Map<String, String>,
-    events: List<EmbraceSpanEvent>,
-    code: Provider<T>
-): T {
-    val returnValue: T
-    var span: Span? = null
-
-    try {
-        span = startSpan()
-            .setAllAttributes(Attributes.builder().fromMap(attributes).build())
-            .addEvents(events)
-        returnValue = code()
-        span.endSpan()
-    } catch (t: Throwable) {
-        span?.endSpan(ErrorCode.FAILURE)
-        throw t
-    }
-
-    return returnValue
 }
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.common.Clock
 
 /**
  * A [SpanService] that can be instantiated quickly. At that time, it will defer calls an implementation that handles the case when
@@ -13,6 +14,7 @@ import io.opentelemetry.api.trace.Tracer
  * instantiate and initialize [SpanServiceImpl] to provide the span recording functionality.
  */
 internal class EmbraceSpanService(
+    private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
     private val currentSessionSpan: CurrentSessionSpan,
     private val tracerSupplier: Provider<Tracer>,
@@ -27,6 +29,7 @@ internal class EmbraceSpanService(
             synchronized(currentDelegate) {
                 if (!initialized()) {
                     val realSpansService = SpanServiceImpl(
+                        openTelemetryClock = openTelemetryClock,
                         spanRepository = spanRepository,
                         currentSessionSpan = currentSessionSpan,
                         tracer = tracerSupplier(),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -112,14 +112,14 @@ internal class SpanServiceImpl(
 
     override fun getSpan(spanId: String): EmbraceSpan? = spanRepository.getSpan(spanId = spanId)
 
+    private fun getSpanName(name: String, internal: Boolean): String =
+        if (internal) {
+            name.toEmbraceSpanName()
+        } else {
+            name
+        }
+
     companion object {
         const val MAX_NON_INTERNAL_SPANS_PER_SESSION = 500
-
-        private fun getSpanName(name: String, internal: Boolean): String =
-            if (internal) {
-                name.toEmbraceSpanName()
-            } else {
-                name
-            }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -1,11 +1,13 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -13,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Implementation of the core logic for [SpanService]
  */
 internal class SpanServiceImpl(
+    private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
     private val currentSessionSpan: CurrentSessionSpan,
     private val tracer: Tracer,
@@ -30,8 +33,11 @@ internal class SpanServiceImpl(
 
     override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): EmbraceSpan? {
         return if (EmbraceSpanImpl.inputsValid(name) && currentSessionSpan.canStartNewSpan(parent, internal)) {
+            val spanName = getSpanName(name = name, internal = internal)
             EmbraceSpanImpl(
-                spanBuilder = createRootSpanBuilder(tracer = tracer, name = name, type = type, internal = internal),
+                spanName = spanName,
+                openTelemetryClock = openTelemetryClock,
+                spanBuilder = createRootSpanBuilder(tracer = tracer, name = spanName, type = type, internal = internal),
                 parent = parent,
                 spanRepository = spanRepository
             )
@@ -49,13 +55,30 @@ internal class SpanServiceImpl(
         events: List<EmbraceSpanEvent>,
         code: () -> T
     ): T {
-        return if (EmbraceSpanImpl.inputsValid(name) && currentSessionSpan.canStartNewSpan(parent, internal)) {
-            createRootSpanBuilder(tracer = tracer, name = name, type = type, internal = internal)
-                .updateParent(parent)
-                .record(attributes, events, code)
-        } else {
-            code()
+        val returnValue: T
+        val span = createSpan(name = name, parent = parent, type = type, internal = internal)
+        try {
+            val started = span?.start() ?: false
+            if (started) {
+                attributes.forEach { attribute ->
+                    span?.addAttribute(attribute.key, attribute.value)
+                }
+                events.forEach { event ->
+                    span?.addEvent(
+                        event.name,
+                        event.timestampNanos.nanosToMillis(),
+                        event.attributes
+                    )
+                }
+            }
+            returnValue = code()
+            span?.stop()
+        } catch (t: Throwable) {
+            span?.stop(ErrorCode.FAILURE)
+            throw t
         }
+
+        return returnValue
     }
 
     override fun recordCompletedSpan(
@@ -73,10 +96,8 @@ internal class SpanServiceImpl(
             return false
         }
 
-        return if (EmbraceSpanImpl.inputsValid(name, events, attributes) &&
-            currentSessionSpan.canStartNewSpan(parent, internal)
-        ) {
-            createRootSpanBuilder(tracer = tracer, name = name, type = type, internal = internal)
+        return if (EmbraceSpanImpl.inputsValid(name, events, attributes) && currentSessionSpan.canStartNewSpan(parent, internal)) {
+            createRootSpanBuilder(tracer = tracer, name = getSpanName(name, internal), type = type, internal = internal)
                 .updateParent(parent)
                 .setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
                 .startSpan()
@@ -93,5 +114,12 @@ internal class SpanServiceImpl(
 
     companion object {
         const val MAX_NON_INTERNAL_SPANS_PER_SESSION = 500
+
+        private fun getSpanName(name: String, internal: Boolean): String =
+            if (internal) {
+                name.toEmbraceSpanName()
+            } else {
+                name
+            }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.spans
+
+import io.embrace.android.embracesdk.internal.payload.Span
+
+/**
+ * An [EmbraceSpan] that has can generate a snapshot of its current state for persistence
+ */
+internal interface PersistableEmbraceSpan : EmbraceSpan {
+
+    /**
+     * Create a snapshot of the current state of the object
+     */
+    fun snapshot(): Span?
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.arch.datasource.startSpanCapture
 import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.SchemaType
-import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanServiceImpl
 import org.junit.Assert.assertEquals
@@ -14,8 +13,9 @@ internal class SpanDataSourceKtTest {
 
     @Test
     fun `start span`() {
-        val initModule = FakeInitModule(FakeClock())
+        val initModule = FakeInitModule()
         val service = SpanServiceImpl(
+            openTelemetryClock = initModule.openTelemetryClock,
             spanRepository = initModule.openTelemetryModule.spanRepository,
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             tracer = initModule.openTelemetryModule.tracer

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -38,19 +38,20 @@ internal class SpanServiceImplTest {
     private lateinit var spanSink: SpanSink
     private lateinit var currentSessionSpan: CurrentSessionSpan
     private lateinit var spansService: SpanServiceImpl
-    private val clock = FakeClock(1000L)
+    private val clock = FakeClock()
 
     @Before
     fun setup() {
-        val initModule = FakeInitModule(clock = clock)
+        val initModule = FakeInitModule(clock)
         spanSink = initModule.openTelemetryModule.spanSink
         currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
         spansService = SpanServiceImpl(
+            openTelemetryClock = initModule.openTelemetryClock,
             spanRepository = initModule.openTelemetryModule.spanRepository,
             currentSessionSpan = currentSessionSpan,
             tracer = initModule.openTelemetryModule.tracer
         )
-        spansService.initializeService(clock.now())
+        spansService.initializeService(initModule.clock.now())
     }
 
     @Test


### PR DESCRIPTION
## Goal

We need to persist active spans when we have unexpected terminations so we can send the data associated with them in case we can't terminate them in time. 

To do this, I will first make their current state serializable as without needing to end them and make the OTel SDK turn them into `EmbraceSpanData`. 

The tricky part of this is that the `Span` returned by the OTel SDK after a span has started cannot be read - that is, key details like the name, start/end times, in additional to attributes and events, cannot be accessed until a span goes through the export process after it is stopped. Boo!

To get around this, we keep all the data we are interested in in the wrapper, and only add it to the OTel Span object when we are about to stop it. That way, we can always snapshot an `EmbraceSpan`.

## Testing

Add unit tests to verify the snapshot. The logic to move the span data to the wrapper layer is validated by the existing tests.