### PR TITLE
Make Span services consume PersistableEmbraceSpan

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
 
@@ -46,7 +47,7 @@ internal class EmbraceSpanService(
 
     override fun initialized(): Boolean = currentDelegate is SpanServiceImpl
 
-    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): EmbraceSpan? =
+    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): PersistableEmbraceSpan? =
         currentDelegate.createSpan(name = name, parent = parent, type = type, internal = internal)
 
     override fun <T> recordSpan(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.utils.lockAndRun
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -9,14 +10,14 @@ import java.util.concurrent.atomic.AtomicInteger
  * Allows the tracking of [EmbraceSpan] instances so that their references can be retrieved with its associated spanId
  */
 internal class SpanRepository {
-    private val activeSpans: MutableMap<String, EmbraceSpan> = mutableMapOf()
+    private val activeSpans: MutableMap<String, PersistableEmbraceSpan> = mutableMapOf()
     private val completedSpans: MutableMap<String, EmbraceSpan> = mutableMapOf()
     private val spanIdsInProcess: MutableMap<String, AtomicInteger> = ConcurrentHashMap()
 
     /**
      * Track the [EmbraceSpan] if it has been started and it's not already tracked.
      */
-    fun trackStartedSpan(embraceSpan: EmbraceSpan) {
+    fun trackStartedSpan(embraceSpan: PersistableEmbraceSpan) {
         val spanId = embraceSpan.spanId ?: return
 
         if (notTracked(spanId)) {
@@ -54,7 +55,7 @@ internal class SpanRepository {
     /**
      * Get a list of active spans that are being tracked
      */
-    fun getActiveSpans(): List<EmbraceSpan> = synchronized(spanIdsInProcess) { activeSpans.values.toList() }
+    fun getActiveSpans(): List<PersistableEmbraceSpan> = synchronized(spanIdsInProcess) { activeSpans.values.toList() }
 
     /**
      * Get a list of completed spans that are being tracked.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.Initializable
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 
 /**
  * Internal service that supports the creation and recording of [EmbraceSpan]
@@ -20,7 +21,7 @@ internal interface SpanService : Initializable {
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true
-    ): EmbraceSpan?
+    ): PersistableEmbraceSpan?
 
     /**
      * Create, start, and return a new [EmbraceSpan] with the given parameters
@@ -31,7 +32,7 @@ internal interface SpanService : Initializable {
         startTimeMs: Long? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true
-    ): EmbraceSpan? {
+    ): PersistableEmbraceSpan? {
         createSpan(
             name = name,
             parent = parent,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
@@ -31,7 +32,7 @@ internal class SpanServiceImpl(
 
     override fun initialized(): Boolean = initialized.get()
 
-    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): EmbraceSpan? {
+    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): PersistableEmbraceSpan? {
         return if (EmbraceSpanImpl.inputsValid(name) && currentSessionSpan.canStartNewSpan(parent, internal)) {
             val spanName = getSpanName(name = name, internal = internal)
             EmbraceSpanImpl(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
@@ -22,7 +23,7 @@ internal class UninitializedSdkSpanService : SpanService {
 
     override fun initialized(): Boolean = true
 
-    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): EmbraceSpan? = null
+    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): PersistableEmbraceSpan? = null
 
     override fun <T> recordSpan(
         name: String,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -19,10 +19,9 @@ internal class FakeOpenTelemetryModule(
     override val currentSessionSpan: CurrentSessionSpan = FakeCurrentSessionSpan(),
     override val spanSink: SpanSink = SpanSinkImpl(),
     override val logSink: LogSink = LogSinkImpl(),
+    override val spanRepository: SpanRepository = SpanRepository(),
 ) : OpenTelemetryModule {
     override val openTelemetryConfiguration: OpenTelemetryConfiguration
-        get() = TODO()
-    override val spanRepository: SpanRepository
         get() = TODO()
     override val tracer: Tracer
         get() = TODO()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -4,16 +4,18 @@ import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.opentelemetry.sdk.trace.IdGenerator
 
-internal class FakeEmbraceSpan(
+internal class FakePersistableEmbraceSpan(
     override val parent: EmbraceSpan?,
     val name: String? = null,
     val type: TelemetryType = EmbType.Performance.Default,
     val internal: Boolean = true
-) : EmbraceSpan {
+) : PersistableEmbraceSpan {
 
     val attributes = mutableMapOf<String, String>()
     val events = mutableListOf<SpanEventData>()
@@ -64,16 +66,20 @@ internal class FakeEmbraceSpan(
         return true
     }
 
-    companion object {
-        fun notStarted(parent: EmbraceSpan? = null): FakeEmbraceSpan = FakeEmbraceSpan(parent)
+    override fun snapshot(): Span? {
+        TODO("Not yet implemented")
+    }
 
-        fun started(parent: EmbraceSpan? = null): FakeEmbraceSpan {
+    companion object {
+        fun notStarted(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan = FakePersistableEmbraceSpan(parent)
+
+        fun started(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan {
             val span = notStarted(parent)
             span.start()
             return span
         }
 
-        fun stopped(parent: EmbraceSpan? = null): FakeEmbraceSpan {
+        fun stopped(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan {
             val span = started(parent)
             span.stop()
             return span

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -5,10 +5,11 @@ import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 
 internal class FakeSpanService : SpanService {
 
-    val createdSpans = mutableListOf<FakeEmbraceSpan>()
+    val createdSpans = mutableListOf<FakePersistableEmbraceSpan>()
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
     }
@@ -20,7 +21,7 @@ internal class FakeSpanService : SpanService {
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean
-    ): EmbraceSpan = FakeEmbraceSpan(null, name, type, internal).apply {
+    ): PersistableEmbraceSpan = FakePersistableEmbraceSpan(null, name, type, internal).apply {
         createdSpans.add(this)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanRepositoryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanRepositoryTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -26,7 +26,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `started span tracked`() {
-        val startedSpan = FakeEmbraceSpan.started()
+        val startedSpan = FakePersistableEmbraceSpan.started()
         repository.trackStartedSpan(startedSpan)
         assertSame(startedSpan, checkNotNull(repository.getSpan(checkNotNull(startedSpan.spanId))))
         assertEquals(1, repository.getActiveSpans().size)
@@ -35,7 +35,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `completed span tracked`() {
-        val completedSpan = FakeEmbraceSpan.stopped()
+        val completedSpan = FakePersistableEmbraceSpan.stopped()
         repository.trackStartedSpan(completedSpan)
         assertSame(completedSpan, checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId))))
         assertEquals(0, repository.getActiveSpans().size)
@@ -44,14 +44,14 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `not started span not tracked`() {
-        repository.trackStartedSpan(FakeEmbraceSpan.notStarted())
+        repository.trackStartedSpan(FakePersistableEmbraceSpan.notStarted())
         assertEquals(0, repository.getActiveSpans().size)
         assertEquals(0, repository.getCompletedSpans().size)
     }
 
     @Test
     fun `tracked span moved to complete only if it is actually complete`() {
-        val span = FakeEmbraceSpan.started()
+        val span = FakePersistableEmbraceSpan.started()
         val spanId = checkNotNull(span.spanId)
         repository.trackStartedSpan(span)
         repository.trackedSpanStopped(spanId)
@@ -67,7 +67,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `spans not tracked twice`() {
-        val span = FakeEmbraceSpan.started()
+        val span = FakePersistableEmbraceSpan.started()
         val spanId = checkNotNull(span.spanId)
         repository.trackStartedSpan(span)
         repository.trackStartedSpan(span)
@@ -82,7 +82,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `completed span not available after clearing but existing reference still valid`() {
-        val completedSpan = FakeEmbraceSpan.stopped()
+        val completedSpan = FakePersistableEmbraceSpan.stopped()
         repository.trackStartedSpan(completedSpan)
         checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId)))
         assertEquals(1, repository.getCompletedSpans().size)


### PR DESCRIPTION
## Goal

Hook up the various span services to use the `PersistableEmbraceSpan` interface internally. This is in preparation of the snapshotting to be done when we save the payload.
