### PR TITLE
Populate v2 session payload with active span snapshots

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/PayloadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/PayloadModule.kt
@@ -38,7 +38,8 @@ internal class PayloadModuleImpl(
             sdkObservabilityModule.internalErrorService,
             nativeModule.nativeThreadSamplerService,
             otelModule.spanSink,
-            otelModule.currentSessionSpan
+            otelModule.currentSessionSpan,
+            otelModule.spanRepository
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -4,25 +4,34 @@ import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.opentelemetry.sdk.trace.IdGenerator
+import java.util.concurrent.ConcurrentLinkedQueue
 
 internal class FakePersistableEmbraceSpan(
     override val parent: EmbraceSpan?,
     val name: String? = null,
     val type: TelemetryType = EmbType.Performance.Default,
-    val internal: Boolean = true
+    val internal: Boolean = true,
+    private val fakeClock: FakeClock = FakeClock()
 ) : PersistableEmbraceSpan {
 
     val attributes = mutableMapOf<String, String>()
-    val events = mutableListOf<SpanEventData>()
+    val events = ConcurrentLinkedQueue<EmbraceSpanEvent>()
 
     private var started = false
     private var stopped = false
     private var errorCode: ErrorCode? = null
+    private var spanStartTimeMs: Long? = null
+    private var spanEndTimeMs: Long? = null
+    private var status = Span.Status.UNSET
 
     override var traceId: String? = parent?.traceId
 
@@ -46,18 +55,26 @@ internal class FakePersistableEmbraceSpan(
     override fun stop(errorCode: ErrorCode?, endTimeMs: Long?): Boolean {
         if (!stopped) {
             this.errorCode = errorCode
+            status = if (errorCode == null) {
+                Span.Status.OK
+            } else {
+                Span.Status.ERROR
+            }
             stopped = true
         }
         return true
     }
 
-    override fun addEvent(name: String): Boolean {
-        events.add(SpanEventData(SchemaType.CustomBreadcrumb(name), 0))
-        return true
-    }
+    override fun addEvent(name: String): Boolean = addEvent(name)
 
     override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean {
-        events.add(SpanEventData(SchemaType.CustomBreadcrumb(name), checkNotNull(timestampMs)))
+        events.add(
+            EmbraceSpanEvent.create(
+                name = name,
+                timestampMs = timestampMs?.normalizeTimestampAsMillis() ?: fakeClock.now(),
+                attributes = attributes
+            )
+        )
         return true
     }
 
@@ -67,7 +84,32 @@ internal class FakePersistableEmbraceSpan(
     }
 
     override fun snapshot(): Span? {
-        TODO("Not yet implemented")
+        return if (spanId == null) {
+            null
+        } else {
+            Span(
+                traceId = traceId,
+                spanId = spanId,
+                parentSpanId = parent?.spanId,
+                name = name,
+                startTimeUnixNano = spanStartTimeMs?.millisToNanos(),
+                endTimeUnixNano = spanEndTimeMs?.millisToNanos(),
+                status = status,
+                events = events.map(EmbraceSpanEvent::toNewPayload),
+                attributes = attributes.toNewPayload()
+            )
+        }
+    }
+
+    /**
+     * Should only used if this is being used to fake a session span
+     */
+    fun addCustomBreadcrumb(name: String, timestampMs: Long?) {
+        val customBreadcrumb = SpanEventData(
+            schemaType = SchemaType.CustomBreadcrumb(name),
+            spanStartTimeMs = timestampMs ?: fakeClock.now()
+        )
+        addEvent(customBreadcrumb.schemaType.name, customBreadcrumb.spanStartTimeMs, attributes)
     }
 
     companion object {


### PR DESCRIPTION
## Goal

Populate the v2 payload with snapshots of the current active spans. Tweaked the fake to emulate the snapshotting.

## Testing
Added to the unit test to validate that a snapshot is take, but since the span is a fake one, I didn't validate the contents. I ain't validating no fake lol
