### PR TITLE
Extract common interface from LogService and LogMessageService

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/LogMessageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/LogMessageService.kt
@@ -3,13 +3,13 @@ package io.embrace.android.embracesdk.event
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.EventType
 import io.embrace.android.embracesdk.LogExceptionType
+import io.embrace.android.embracesdk.internal.logs.BaseLogService
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
-import io.embrace.android.embracesdk.session.MemoryCleanerListener
 
 /**
  * Logs messages remotely, so that they can be viewed as events during a user's session.
  */
-internal interface LogMessageService : MemoryCleanerListener {
+internal interface LogMessageService : BaseLogService {
 
     /**
      * Creates a network event.
@@ -46,33 +46,6 @@ internal interface LogMessageService : MemoryCleanerListener {
     )
 
     /**
-     * Finds all IDs of log events at info level within the given time window.
-     *
-     * @param startTime the beginning of the time window
-     * @param endTime   the end of the time window
-     * @return the list of log IDs within the specified range
-     */
-    fun findInfoLogIds(startTime: Long, endTime: Long): List<String>
-
-    /**
-     * Finds all IDs of log events at warning level within the given time window.
-     *
-     * @param startTime the beginning of the time window
-     * @param endTime   the end of the time window
-     * @return the list of log IDs within the specified range
-     */
-    fun findWarningLogIds(startTime: Long, endTime: Long): List<String>
-
-    /**
-     * Finds all IDs of log events at error level within the given time window.
-     *
-     * @param startTime the beginning of the time window
-     * @param endTime   the end of the time window
-     * @return the list of log IDs within the specified range
-     */
-    fun findErrorLogIds(startTime: Long, endTime: Long): List<String>
-
-    /**
      * Finds all IDs of log network events within the given time window.
      *
      * @param startTime the beginning of the time window
@@ -80,21 +53,4 @@ internal interface LogMessageService : MemoryCleanerListener {
      * @return the list of log IDs within the specified range
      */
     fun findNetworkLogIds(startTime: Long, endTime: Long): List<String>
-
-    /**
-     * The total number of info logs that the app attempted to send.
-     */
-    fun getInfoLogsAttemptedToSend(): Int
-
-    /**
-     * The total number of warning logs that the app attempted to send.
-     */
-    fun getWarnLogsAttemptedToSend(): Int
-
-    /**
-     * The total number of error logs that the app attempted to send.
-     */
-    fun getErrorLogsAttemptedToSend(): Int
-
-    fun getUnhandledExceptionsSent(): Int
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/BaseLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/BaseLogService.kt
@@ -1,0 +1,52 @@
+package io.embrace.android.embracesdk.internal.logs
+
+import io.embrace.android.embracesdk.session.MemoryCleanerListener
+
+internal interface BaseLogService : MemoryCleanerListener {
+    /**
+     * Finds all IDs of log events at info level within the given time window.
+     *
+     * @param startTime the beginning of the time window
+     * @param endTime   the end of the time window
+     * @return the list of log IDs within the specified range
+     */
+    fun findInfoLogIds(startTime: Long, endTime: Long): List<String>
+
+    /**
+     * Finds all IDs of log events at warning level within the given time window.
+     *
+     * @param startTime the beginning of the time window
+     * @param endTime   the end of the time window
+     * @return the list of log IDs within the specified range
+     */
+    fun findWarningLogIds(startTime: Long, endTime: Long): List<String>
+
+    /**
+     * Finds all IDs of log events at error level within the given time window.
+     *
+     * @param startTime the beginning of the time window
+     * @param endTime   the end of the time window
+     * @return the list of log IDs within the specified range
+     */
+    fun findErrorLogIds(startTime: Long, endTime: Long): List<String>
+
+    /**
+     * The total number of info logs that the app attempted to send.
+     */
+    fun getInfoLogsAttemptedToSend(): Int
+
+    /**
+     * The total number of warning logs that the app attempted to send.
+     */
+    fun getWarnLogsAttemptedToSend(): Int
+
+    /**
+     * The total number of error logs that the app attempted to send.
+     */
+    fun getErrorLogsAttemptedToSend(): Int
+
+    /**
+     * The total number of unhandled exceptions sent.
+     */
+    fun getUnhandledExceptionsSent(): Int
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -50,6 +50,8 @@ internal class EmbraceLogService(
         )
     )
 
+    private var unhandledExceptionsCount = 0
+
     override fun log(
         message: String,
         severity: Severity,
@@ -71,6 +73,9 @@ internal class EmbraceLogService(
         exceptionName: String?,
         exceptionMessage: String?
     ) {
+        if (logExceptionType == LogExceptionType.UNHANDLED) {
+            unhandledExceptionsCount++
+        }
         val attributes = EmbraceLogAttributes(properties)
         attributes.setExceptionType(logExceptionType)
         attributes.setAppFramework(framework)
@@ -104,6 +109,10 @@ internal class EmbraceLogService(
 
     override fun findErrorLogIds(startTime: Long, endTime: Long): List<String> {
         return logCounters.getValue(Severity.ERROR).findLogIds(startTime, endTime)
+    }
+
+    override fun getUnhandledExceptionsSent(): Int {
+        return unhandledExceptionsCount
     }
 
     override fun cleanCollections() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -3,12 +3,11 @@ package io.embrace.android.embracesdk.internal.logs
 import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.session.MemoryCleanerListener
 
 /**
  * Creates log records to be sent using the Open Telemetry Logs data model.
  */
-internal interface LogService : MemoryCleanerListener {
+internal interface LogService : BaseLogService {
 
     /**
      * Creates a log record.
@@ -51,46 +50,4 @@ internal interface LogService : MemoryCleanerListener {
         exceptionName: String?,
         exceptionMessage: String?
     )
-
-    /**
-     * Finds all IDs of log events at info level within the given time window.
-     *
-     * @param startTime the beginning of the time window
-     * @param endTime   the end of the time window
-     * @return the list of log IDs within the specified range
-     */
-    fun findInfoLogIds(startTime: Long, endTime: Long): List<String>
-
-    /**
-     * Finds all IDs of log events at warning level within the given time window.
-     *
-     * @param startTime the beginning of the time window
-     * @param endTime   the end of the time window
-     * @return the list of log IDs within the specified range
-     */
-    fun findWarningLogIds(startTime: Long, endTime: Long): List<String>
-
-    /**
-     * Finds all IDs of log events at error level within the given time window.
-     *
-     * @param startTime the beginning of the time window
-     * @param endTime   the end of the time window
-     * @return the list of log IDs within the specified range
-     */
-    fun findErrorLogIds(startTime: Long, endTime: Long): List<String>
-
-    /**
-     * The total number of info logs that the app attempted to send.
-     */
-    fun getInfoLogsAttemptedToSend(): Int
-
-    /**
-     * The total number of warning logs that the app attempted to send.
-     */
-    fun getWarnLogsAttemptedToSend(): Int
-
-    /**
-     * The total number of error logs that the app attempted to send.
-     */
-    fun getErrorLogsAttemptedToSend(): Int
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -116,7 +116,7 @@ internal class EmbraceLogServiceTest {
         logService.logException(
             "Hello world",
             Severity.WARNING,
-            LogExceptionType.NONE,
+            LogExceptionType.HANDLED,
             null,
             exception.stackTrace,
             null,
@@ -128,6 +128,7 @@ internal class EmbraceLogServiceTest {
         )
 
         val log = logWriter.logEvents.single()
+        assertEquals(0, logService.getUnhandledExceptionsSent())
         assertEquals("Hello world", log.message)
         assertEquals(Severity.WARNING, log.severity)
         assertEquals("NullPointerException", log.attributes["emb.exception_name"])
@@ -135,7 +136,39 @@ internal class EmbraceLogServiceTest {
         assertEquals(AppFramework.NATIVE.value.toString(), log.attributes["emb.app_framework"])
         assertNotNull(log.attributes["emb.log_id"])
         assertEquals("session-123", log.attributes["emb.session_id"])
-        assertEquals("none", log.attributes["emb.exception_type"])
+        assertEquals(LogExceptionType.HANDLED.value, log.attributes["emb.exception_type"])
+        log.assertIsType(EmbType.System.Log)
+    }
+
+    @Test
+    fun testUnhandledExceptionLog() {
+        val logService = getLogService()
+        val exception = NullPointerException("exception message")
+
+        logService.logException(
+            "Hello world",
+            Severity.WARNING,
+            LogExceptionType.UNHANDLED,
+            null,
+            exception.stackTrace,
+            null,
+            AppFramework.UNITY,
+            null,
+            null,
+            exception.javaClass.simpleName,
+            exception.message,
+        )
+
+        val log = logWriter.logEvents.single()
+        assertEquals(1, logService.getUnhandledExceptionsSent())
+        assertEquals("Hello world", log.message)
+        assertEquals(Severity.WARNING, log.severity)
+        assertEquals("NullPointerException", log.attributes["emb.exception_name"])
+        assertEquals("exception message", log.attributes["emb.exception_message"])
+        assertEquals(AppFramework.UNITY.value.toString(), log.attributes["emb.app_framework"])
+        assertNotNull(log.attributes["emb.log_id"])
+        assertEquals("session-123", log.attributes["emb.session_id"])
+        assertEquals(LogExceptionType.UNHANDLED.value, log.attributes["emb.exception_type"])
         log.assertIsType(EmbType.System.Log)
     }
 


### PR DESCRIPTION
## Goal

Extract methods from `LogMessageService` and `LogService` to a shared interface to make it easier to switch between them based on a feature flag.

