### PR TITLE
Switch between event and OTel log services based on configuration

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EventType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EventType.kt
@@ -56,4 +56,13 @@ internal enum class EventType(
             }
         }
     }
+
+    fun getSeverity(): Severity? {
+        return when (this) {
+            INFO_LOG -> Severity.INFO
+            WARNING_LOG -> Severity.WARNING
+            ERROR_LOG -> Severity.ERROR
+            else -> null
+        }
+    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.event.EmbraceLogMessageService
 import io.embrace.android.embracesdk.event.LogMessageService
+import io.embrace.android.embracesdk.internal.logs.CompositeLogService
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogService
 import io.embrace.android.embracesdk.internal.logs.LogOrchestrator
 import io.embrace.android.embracesdk.internal.logs.LogService
@@ -20,7 +21,6 @@ internal interface CustomerLogModule {
     val networkCaptureService: NetworkCaptureService
     val networkLoggingService: NetworkLoggingService
     val logMessageService: LogMessageService
-    val logService: LogService
     val logOrchestrator: LogOrchestrator
 }
 
@@ -54,7 +54,7 @@ internal class CustomerLogModuleImpl(
         )
     }
 
-    override val logMessageService: LogMessageService by singleton {
+    private val v1LogService: LogMessageService by singleton {
         EmbraceLogMessageService(
             essentialServiceModule.metadataService,
             essentialServiceModule.sessionIdTracker,
@@ -70,7 +70,7 @@ internal class CustomerLogModuleImpl(
         )
     }
 
-    override val logService: LogService by singleton {
+    private val v2LogService: LogService by singleton {
         EmbraceLogService(
             openTelemetryModule.logWriter,
             initModule.clock,
@@ -80,6 +80,10 @@ internal class CustomerLogModuleImpl(
             essentialServiceModule.sessionIdTracker,
             workerThreadModule.backgroundWorker(WorkerName.REMOTE_LOGGING)
         )
+    }
+
+    override val logMessageService: LogMessageService by singleton {
+        CompositeLogService(v1LogService, v2LogService, essentialServiceModule.configService)
     }
 
     override val logOrchestrator: LogOrchestrator by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -307,7 +307,6 @@ internal class ModuleInitBootstrapper(
                     postInit(CustomerLogModule::class) {
                         serviceRegistry.registerServices(
                             customerLogModule.logMessageService,
-                            customerLogModule.logService,
                             customerLogModule.networkCaptureService,
                             customerLogModule.networkLoggingService
                         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
@@ -1,0 +1,132 @@
+package io.embrace.android.embracesdk.internal.logs
+
+import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.EventType
+import io.embrace.android.embracesdk.LogExceptionType
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.event.LogMessageService
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.payload.NetworkCapturedCall
+
+/**
+ * Allows to switch between the current service that sends Embrace logs as Events and the new one
+ * that sends them as OTel logs, based on a remote configuration. Once the SDK is expected to send
+ * only OTel logs, this class can be removed.
+ */
+internal class CompositeLogService(
+    private val v1LogService: LogMessageService,
+    private val v2LogService: LogService,
+    private val configService: ConfigService
+) : LogMessageService {
+
+    private val useV2LogService: Boolean
+        get() = configService.sessionBehavior.useV2Payload()
+
+    private val baseLogService: BaseLogService
+        get() = if (useV2LogService) v2LogService else v1LogService
+
+    override fun logNetwork(networkCaptureCall: NetworkCapturedCall?) {
+        // Network logs are still always handled by the v1 LogMessageService
+        v1LogService.logNetwork(networkCaptureCall)
+    }
+
+    override fun log(
+        message: String,
+        type: EventType,
+        logExceptionType: LogExceptionType,
+        properties: Map<String, Any>?,
+        stackTraceElements: Array<StackTraceElement>?,
+        customStackTrace: String?,
+        framework: Embrace.AppFramework,
+        context: String?,
+        library: String?,
+        exceptionName: String?,
+        exceptionMessage: String?
+    ) {
+        // When LogMessageService is removed, the cascade calling of event-based logMessage()
+        // in EmbraceImpl can be replaced with different calls to LogService
+        if (useV2LogService) {
+            // Currently, any call to this log method can only have an event type of INFO_LOG,
+            // WARNING_LOG, or ERROR_LOG, since it is taken from the fromSeverity() method
+            // in EventType.
+            if (type.getSeverity() == null) {
+                InternalStaticEmbraceLogger.logError("Invalid event type for log: $type")
+                return
+            }
+            val severity = type.getSeverity() ?: Severity.INFO
+            if (logExceptionType == LogExceptionType.NONE) {
+                v2LogService.log(
+                    message,
+                    severity,
+                    properties
+                )
+            } else {
+                v2LogService.logException(
+                    message = message,
+                    severity = severity,
+                    logExceptionType = logExceptionType,
+                    properties = properties,
+                    stackTraceElements = stackTraceElements,
+                    customStackTrace = customStackTrace,
+                    framework = framework,
+                    context = context,
+                    library = library,
+                    exceptionName = exceptionName,
+                    exceptionMessage = exceptionMessage
+                )
+            }
+        } else {
+            v1LogService.log(
+                message = message,
+                type = type,
+                logExceptionType = logExceptionType,
+                properties = properties,
+                stackTraceElements = stackTraceElements,
+                customStackTrace = customStackTrace,
+                framework = framework,
+                context = context,
+                library = library,
+                exceptionName = exceptionName,
+                exceptionMessage = exceptionMessage
+            )
+        }
+    }
+
+    override fun findInfoLogIds(startTime: Long, endTime: Long): List<String> {
+        return baseLogService.findInfoLogIds(startTime, endTime)
+    }
+
+    override fun findWarningLogIds(startTime: Long, endTime: Long): List<String> {
+        return baseLogService.findWarningLogIds(startTime, endTime)
+    }
+
+    override fun findErrorLogIds(startTime: Long, endTime: Long): List<String> {
+        return baseLogService.findErrorLogIds(startTime, endTime)
+    }
+
+    override fun findNetworkLogIds(startTime: Long, endTime: Long): List<String> {
+        // Network logs are still always handled by the v1 LogMessageService
+        return v1LogService.findNetworkLogIds(startTime, endTime)
+    }
+
+    override fun getInfoLogsAttemptedToSend(): Int {
+        return baseLogService.getInfoLogsAttemptedToSend()
+    }
+
+    override fun getWarnLogsAttemptedToSend(): Int {
+        return baseLogService.getWarnLogsAttemptedToSend()
+    }
+
+    override fun getErrorLogsAttemptedToSend(): Int {
+        return baseLogService.getErrorLogsAttemptedToSend()
+    }
+
+    override fun getUnhandledExceptionsSent(): Int {
+        return baseLogService.getUnhandledExceptionsSent()
+    }
+
+    override fun cleanCollections() {
+        return baseLogService.cleanCollections()
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -1,23 +1,22 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.Embrace
-import io.embrace.android.embracesdk.EventType
 import io.embrace.android.embracesdk.LogExceptionType
-import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.payload.NetworkCapturedCall
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.internal.logs.LogService
 
-internal class FakeLogMessageService : LogMessageService {
+internal class FakeLogService : LogService {
 
     val loggedMessages = mutableListOf<String>()
-    val networkCalls = mutableListOf<NetworkCapturedCall>()
+    val loggedExceptions = mutableListOf<String>()
 
-    override fun logNetwork(networkCaptureCall: NetworkCapturedCall?) {
-        networkCaptureCall?.let(networkCalls::add)
+    override fun log(message: String, severity: Severity, properties: Map<String, Any>?) {
+        loggedMessages.add(message)
     }
 
-    override fun log(
+    override fun logException(
         message: String,
-        type: EventType,
+        severity: Severity,
         logExceptionType: LogExceptionType,
         properties: Map<String, Any>?,
         stackTraceElements: Array<StackTraceElement>?,
@@ -28,41 +27,38 @@ internal class FakeLogMessageService : LogMessageService {
         exceptionName: String?,
         exceptionMessage: String?
     ) {
-        loggedMessages.add(message)
+        loggedExceptions.add(message)
     }
 
     override fun findInfoLogIds(startTime: Long, endTime: Long): List<String> {
-        return emptyList()
+        TODO("Not yet implemented")
     }
 
     override fun findWarningLogIds(startTime: Long, endTime: Long): List<String> {
-        return emptyList()
+        TODO("Not yet implemented")
     }
 
     override fun findErrorLogIds(startTime: Long, endTime: Long): List<String> {
-        return emptyList()
-    }
-
-    override fun findNetworkLogIds(startTime: Long, endTime: Long): List<String> {
-        return emptyList()
+        TODO("Not yet implemented")
     }
 
     override fun getInfoLogsAttemptedToSend(): Int {
-        return 0
+        TODO("Not yet implemented")
     }
 
     override fun getWarnLogsAttemptedToSend(): Int {
-        return 0
+        TODO("Not yet implemented")
     }
 
     override fun getErrorLogsAttemptedToSend(): Int {
-        return 0
+        TODO("Not yet implemented")
     }
 
     override fun getUnhandledExceptionsSent(): Int {
-        return 0
+        TODO("Not yet implemented")
     }
 
     override fun cleanCollections() {
+        TODO("Not yet implemented")
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -33,7 +33,7 @@ internal class FakeOpenTelemetryModule(
     override val internalTracer: InternalTracer
         get() = TODO()
     override val logWriter: LogWriter
-        get() = TODO()
+        get() = FakeLogWriter()
     override val logger: Logger
-        get() = TODO()
+        get() = FakeOtelLogger()
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCustomerLogModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCustomerLogModule.kt
@@ -15,7 +15,6 @@ import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.injection.CustomerLogModule
 import io.embrace.android.embracesdk.internal.logs.LogOrchestrator
-import io.embrace.android.embracesdk.internal.logs.LogService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.network.logging.NetworkCaptureService
 import io.embrace.android.embracesdk.network.logging.NetworkLoggingService
@@ -40,9 +39,6 @@ internal class FakeCustomerLogModule(
 ) : CustomerLogModule {
 
     override val networkCaptureService: NetworkCaptureService
-        get() = TODO("Not yet implemented")
-
-    override val logService: LogService
         get() = TODO("Not yet implemented")
 
     override val logOrchestrator: LogOrchestrator

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
@@ -1,0 +1,140 @@
+package io.embrace.android.embracesdk.internal.logs
+
+import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.EventType
+import io.embrace.android.embracesdk.LogExceptionType
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeLogMessageService
+import io.embrace.android.embracesdk.fakes.FakeLogService
+import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class CompositeLogServiceTest {
+
+    private var sessionConfig = SessionRemoteConfig()
+    private lateinit var compositeLogService: CompositeLogService
+    private lateinit var v1LogService: FakeLogMessageService
+    private lateinit var v2LogService: FakeLogService
+
+    @Before
+    fun setUp() {
+        val configService = FakeConfigService(
+            sessionBehavior = fakeSessionBehavior(
+                remoteCfg = {
+                    RemoteConfig(sessionConfig = sessionConfig)
+                }
+            )
+        )
+        v1LogService = FakeLogMessageService()
+        v2LogService = FakeLogService()
+        compositeLogService = CompositeLogService(
+            v1LogService = v1LogService,
+            v2LogService = v2LogService,
+            configService = configService
+        )
+    }
+
+    @Test
+    fun testLogV1() {
+        compositeLogService.log(
+            message = "simple log",
+            type = EventType.INFO_LOG,
+            logExceptionType = LogExceptionType.NONE,
+            properties = null,
+            stackTraceElements = null,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.NATIVE,
+            context = null,
+            library = null,
+            exceptionName = null,
+            exceptionMessage = null
+        )
+        assertEquals(1, v1LogService.loggedMessages.size)
+        assertEquals(0, v2LogService.loggedMessages.size)
+    }
+
+    @Test
+    fun testLogV2() {
+        sessionConfig = SessionRemoteConfig(useV2Payload = true)
+        compositeLogService.log(
+            message = "simple log",
+            type = EventType.INFO_LOG,
+            logExceptionType = LogExceptionType.NONE,
+            properties = null,
+            stackTraceElements = null,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.NATIVE,
+            context = null,
+            library = null,
+            exceptionName = null,
+            exceptionMessage = null
+        )
+        assertEquals(0, v1LogService.loggedMessages.size)
+        assertEquals(1, v2LogService.loggedMessages.size)
+    }
+
+    @Test
+    fun testLogExceptionV1() {
+        compositeLogService.log(
+            message = "simple log",
+            type = EventType.INFO_LOG,
+            logExceptionType = LogExceptionType.HANDLED,
+            properties = null,
+            stackTraceElements = null,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.NATIVE,
+            context = null,
+            library = null,
+            exceptionName = null,
+            exceptionMessage = null
+        )
+        assertEquals(1, v1LogService.loggedMessages.size)
+        assertEquals(0, v2LogService.loggedExceptions.size)
+    }
+
+    @Test
+    fun testLogExceptionV2() {
+        sessionConfig = SessionRemoteConfig(useV2Payload = true)
+        compositeLogService.log(
+            message = "simple log",
+            type = EventType.INFO_LOG,
+            logExceptionType = LogExceptionType.HANDLED,
+            properties = null,
+            stackTraceElements = null,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.NATIVE,
+            context = null,
+            library = null,
+            exceptionName = null,
+            exceptionMessage = null
+        )
+        assertEquals(0, v1LogService.loggedMessages.size)
+        assertEquals(1, v2LogService.loggedExceptions.size)
+    }
+
+    @Test
+    fun testWrongEventType() {
+        // The log service can handle only INFO_LOG, WARNING_LOG and ERROR_LOG event types
+        sessionConfig = SessionRemoteConfig(useV2Payload = true)
+        compositeLogService.log(
+            message = "simple log",
+            type = EventType.CRASH,
+            logExceptionType = LogExceptionType.HANDLED,
+            properties = null,
+            stackTraceElements = null,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.NATIVE,
+            context = null,
+            library = null,
+            exceptionName = null,
+            exceptionMessage = null
+        )
+        assertEquals(0, v1LogService.loggedMessages.size)
+        assertEquals(0, v2LogService.loggedMessages.size)
+        assertEquals(0, v2LogService.loggedExceptions.size)
+    }
+}


### PR DESCRIPTION
## Goal

Create a `CompositeLogService` that can switch between `LogMessageService` and `LogService` based on a remote config.

## Testing

Updated tests and ran the test app.


