### PR TITLE
Increase log message size limit to 4000 characters

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/LogMessageBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/LogMessageBehavior.kt
@@ -20,7 +20,7 @@ internal class LogMessageBehavior(
         private const val DEFAULT_LOG_INFO_LIMIT = 100
         private const val DEFAULT_LOG_WARNING_LIMIT = 100
         private const val DEFAULT_LOG_ERROR_LIMIT = 250
-        internal const val LOG_MESSAGE_MAXIMUM_ALLOWED_LENGTH = 128
+        internal const val LOG_MESSAGE_MAXIMUM_ALLOWED_LENGTH = 4000
     }
 
     fun getLogMessageMaximumAllowedLength(): Int {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/LogMessageBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/LogMessageBehaviorTest.kt
@@ -17,7 +17,7 @@ internal class LogMessageBehaviorTest {
     @Test
     fun testDefaults() {
         with(fakeLogMessageBehavior()) {
-            assertEquals(128, getLogMessageMaximumAllowedLength())
+            assertEquals(4000, getLogMessageMaximumAllowedLength())
             assertEquals(100, getInfoLogLimit())
             assertEquals(100, getWarnLogLimit())
             assertEquals(250, getErrorLogLimit())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
@@ -241,10 +241,10 @@ internal class EmbraceLogMessageServiceTest {
     @Test
     fun testDefaultMaxMessageLength() {
         logMessageService = getLogMessageService()
-        simpleLog("Hi".repeat(65), EventType.INFO_LOG, null)
+        simpleLog("Hi".repeat(2001), EventType.INFO_LOG, null)
 
         val message = deliveryService.lastSentLogs.single()
-        assertTrue(message.event.name == "Hi".repeat(62) + "H...")
+        assertTrue(message.event.name == "Hi".repeat(1998) + "H...")
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -232,10 +232,10 @@ internal class EmbraceLogServiceTest {
     @Test
     fun testDefaultMaxMessageLength() {
         val logMessageService = getLogService()
-        logMessageService.log("Hi".repeat(65), Severity.INFO, null)
+        logMessageService.log("Hi".repeat(2001), Severity.INFO, null)
 
         val log = logWriter.logEvents.single()
-        Assert.assertTrue(log.message == "Hi".repeat(62) + "H...")
+        Assert.assertTrue(log.message == "Hi".repeat(1998) + "H...")
     }
 
     @Test


### PR DESCRIPTION
## Goal

Increase log message size limit to 4000 characters

## Testing

Tests were updated to receive the new message limit

