### PR TITLE
Add span assertions for tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
@@ -1,0 +1,56 @@
+package io.embrace.android.embracesdk
+
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+
+/**
+ * Finds the span event matching the name.
+ */
+internal fun EmbraceSpanData.findEvent(name: String): EmbraceSpanEvent =
+    checkNotNull(events.single { it.name == name }) {
+        "Event not found: $name"
+    }
+
+/**
+ * Finds the span attribute matching the name.
+ */
+internal fun EmbraceSpanData.findSpanAttribute(key: String): String =
+    checkNotNull(attributes[key]) {
+        "Attribute not found: $key"
+    }
+
+/**
+ * Finds the event attribute matching the name.
+ */
+internal fun EmbraceSpanEvent.findEventAttribute(key: String): String =
+    checkNotNull(attributes[key]) {
+        "Attribute not found: $key"
+    }
+
+/**
+ * Finds the emb-session span.
+ */
+internal fun SessionMessage.findSessionSpan(): EmbraceSpanData = findSpan("emb-session")
+
+/**
+ * Finds the span matching the name.
+ */
+internal fun SessionMessage.findSpan(name: String): EmbraceSpanData =
+    checkNotNull(spans?.single { it.name == name }) {
+        "Span not found: $name"
+    }
+
+/**
+ * Returns true if a span exists with the given name.
+ */
+internal fun SessionMessage.hasSpan(name: String): Boolean {
+    return spans?.singleOrNull { it.name == name } != null
+}
+
+/**
+ * Returns true if an event exists with the given name.
+ */
+internal fun EmbraceSpanData.hasEvent(name: String): Boolean {
+    return events.singleOrNull { it.name == name } != null
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
@@ -4,25 +4,23 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.IntegrationTestRule.*
-import io.embrace.android.embracesdk.IntegrationTestRule.Harness
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
+import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.getSentSessionMessages
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.hasEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.verifySessionHappened
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -111,17 +109,6 @@ internal class OtelSessionGatingTest {
             action()
         }
     }
-
-    private fun SessionMessage.findSessionSpan(): EmbraceSpanData =
-        checkNotNull(findSpan("emb-session")) {
-            "Session span not found"
-        }
-
-    private fun SessionMessage.findSpan(name: String): EmbraceSpanData? =
-        spans?.singleOrNull { it.name == name }
-
-    private fun EmbraceSpanData.findEvent(name: String): EmbraceSpanEvent? =
-        events.singleOrNull { it.name == name }
 
     /**
      * Wraps a fake delivery service around the [GatingService] so we can assert against

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -1,8 +1,19 @@
 package io.embrace.android.embracesdk.arch.schema
 
+import io.embrace.android.embracesdk.arch.schema.SchemaKeys.AEI_RECORD
+import io.embrace.android.embracesdk.arch.schema.SchemaKeys.CUSTOM_BREADCRUMB
+import io.embrace.android.embracesdk.arch.schema.SchemaKeys.LOG
+import io.embrace.android.embracesdk.arch.schema.SchemaKeys.VIEW_BREADCRUMB
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogAttributes
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import io.embrace.android.embracesdk.payload.AppExitInfoData
+
+internal object SchemaKeys {
+    internal const val CUSTOM_BREADCRUMB = "custom-breadcrumb"
+    internal const val VIEW_BREADCRUMB = "view-breadcrumb"
+    internal const val AEI_RECORD = "aei-record"
+    internal const val LOG = "emb-log"
+}
 
 internal sealed class SchemaType(
     val telemetryType: TelemetryType,
@@ -12,21 +23,21 @@ internal sealed class SchemaType(
 
     internal class CustomBreadcrumb(message: String) : SchemaType(
         EmbType.System.Breadcrumb,
-        "custom-breadcrumb"
+        CUSTOM_BREADCRUMB
     ) {
         override val attrs = mapOf("message" to message)
     }
 
     internal class ViewBreadcrumb(viewName: String) : SchemaType(
         EmbType.Ux.View,
-        "view-breadcrumb"
+        VIEW_BREADCRUMB
     ) {
         override val attrs = mapOf("view.name" to viewName)
     }
 
     internal class AeiLog(message: AppExitInfoData) : SchemaType(
         EmbType.System.Exit,
-        "aei-record"
+        AEI_RECORD
     ) {
         override val attrs = mapOf(
             "session-id" to message.sessionId,
@@ -44,7 +55,7 @@ internal sealed class SchemaType(
 
     internal class Log(attributes: EmbraceLogAttributes) : SchemaType(
         EmbType.System.Log,
-        "emb-log"
+        LOG
     ) {
         override val attrs = attributes.toMap()
     }


### PR DESCRIPTION
## Goal

Adds assertions that will be used for writing tests on spans. Additionally refactored the `SchemaType` so that string literals are defined in constants.

