### PR TITLE
Enable view breadcrumb OTel capture

### DIFF
--- a/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
+++ b/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
@@ -16,7 +16,7 @@
   },
   "br": {
     "cb": "__EMBRACE_TEST_IGNORE__",
-    "cv": [],
+    "cv": "__EMBRACE_TEST_IGNORE__",
     "rna": [],
     "pn": [],
     "tb": [],

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
@@ -42,6 +42,14 @@ internal fun SessionMessage.findSpan(name: String): EmbraceSpanData =
     }
 
 /**
+ * Finds the span matching the name.
+ */
+internal fun SessionMessage.findSpans(name: String): List<EmbraceSpanData> =
+    checkNotNull(spans?.filter { it.name == name }) {
+        "Could not find spans: $name"
+    }
+
+/**
  * Returns true if a span exists with the given name.
  */
 internal fun SessionMessage.hasSpan(name: String): Boolean {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/CustomBreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/CustomBreadcrumbFeatureTest.kt
@@ -2,9 +2,14 @@ package io.embrace.android.embracesdk.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.getSentSessionMessages
+import io.embrace.android.embracesdk.arch.schema.SchemaKeys
+import io.embrace.android.embracesdk.findEvent
+import io.embrace.android.embracesdk.findEventAttribute
+import io.embrace.android.embracesdk.findSessionSpan
+import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
-import io.embrace.android.embracesdk.verifySessionHappened
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -21,13 +26,17 @@ internal class CustomBreadcrumbFeatureTest {
     fun `custom breadcrumb feature`() {
         with(testRule) {
             var captureTime: Long = 0
-            val message = harness.recordSession {
+            val message = checkNotNull(harness.recordSession {
                 captureTime = harness.fakeClock.now()
                 embrace.addBreadcrumb("Hello, world!")
-            }
-            val breadcrumb = checkNotNull(message?.breadcrumbs?.customBreadcrumbs?.single())
+            })
+
+            val breadcrumb = checkNotNull(message.breadcrumbs?.customBreadcrumbs?.single())
             assertEquals("Hello, world!", breadcrumb.message)
             assertEquals(captureTime, breadcrumb.getStartTime())
+
+            val span = message.findSessionSpan().findEvent(SchemaKeys.CUSTOM_BREADCRUMB)
+            assertEquals("Hello, world!", span.findEventAttribute("message"))
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
@@ -93,13 +93,13 @@ internal class OtelSessionGatingTest {
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
     private fun assertSessionGating(
         payload: SessionMessage,
         gated: Boolean
     ) {
         val sessionSpan = payload.findSessionSpan()
         assertNotNull(sessionSpan)
+        assertEquals(!gated, sessionSpan.hasEvent("emb-custom-breadcrumb"))
     }
 
     private fun IntegrationTestRule.simulateSession(action: () -> Unit = {}) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.getSentSessionMessages
 import io.embrace.android.embracesdk.hasEvent
+import io.embrace.android.embracesdk.hasSpan
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -100,11 +101,14 @@ internal class OtelSessionGatingTest {
         val sessionSpan = payload.findSessionSpan()
         assertNotNull(sessionSpan)
         assertEquals(!gated, sessionSpan.hasEvent("emb-custom-breadcrumb"))
+        assertEquals(!gated, payload.hasSpan("emb-screen-view"))
     }
 
     private fun IntegrationTestRule.simulateSession(action: () -> Unit = {}) {
         harness.recordSession {
             embrace.addBreadcrumb("Hello, world!")
+            embrace.startView("MyActivity")
+            embrace.endView("MyActivity")
             harness.fakeClock.tick(10000) // enough to trigger new session
             action()
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
@@ -40,9 +40,9 @@ internal interface SpanDataSource : DataSource<SpanService> {
 internal fun <T> SpanService.startSpanCapture(obj: T, mapper: T.() -> StartSpanData): EmbraceSpan? {
     val data = obj.mapper()
     return createSpan(data.schemaType.name)?.apply {
+        start()
         data.attributes.forEach {
             addAttribute(it.key, it.value)
         }
-        start()
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 
 internal object SchemaKeys {
-    internal const val CUSTOM_BREADCRUMB = "custom-breadcrumb"
+    internal const val CUSTOM_BREADCRUMB = "emb-custom-breadcrumb"
     internal const val VIEW_BREADCRUMB = "view-breadcrumb"
     internal const val AEI_RECORD = "aei-record"
     internal const val LOG = "emb-log"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.payload.AppExitInfoData
 
 internal object SchemaKeys {
     internal const val CUSTOM_BREADCRUMB = "emb-custom-breadcrumb"
-    internal const val VIEW_BREADCRUMB = "view-breadcrumb"
+    internal const val VIEW_BREADCRUMB = "screen-view"
     internal const val AEI_RECORD = "aei-record"
     internal const val LOG = "emb-log"
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -5,6 +5,7 @@ import android.util.Pair
 import io.embrace.android.embracesdk.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Breadcrumbs
@@ -31,6 +32,7 @@ internal class EmbraceBreadcrumbService(
     private val configService: ConfigService,
     private val activityTracker: ActivityTracker,
     sessionSpanWriter: SessionSpanWriter,
+    spanService: SpanService,
     private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : BreadcrumbService, ActivityLifecycleListener, MemoryCleanerListener {
 
@@ -41,10 +43,15 @@ internal class EmbraceBreadcrumbService(
     private val rnBreadcrumbDataSource = RnBreadcrumbDataSource(configService)
     private val tapBreadcrumbDataSource = TapBreadcrumbDataSource(configService)
     private val viewBreadcrumbDataSource = ViewBreadcrumbDataSource(configService, clock)
-    private val fragmentBreadcrumbDataSource = LegacyFragmentBreadcrumbDataSource(configService, clock)
+    private val legacyFragmentBreadcrumbDataSource = LegacyFragmentBreadcrumbDataSource(configService, clock)
+    private val fragmentBreadcrumbDataSource = FragmentBreadcrumbDataSource(
+        configService.breadcrumbBehavior,
+        clock,
+        spanService
+    )
     private val pushNotificationBreadcrumbDataSource =
         PushNotificationBreadcrumbDataSource(configService, clock)
-    val fragmentStack = fragmentBreadcrumbDataSource.fragmentStack
+    val fragmentStack = legacyFragmentBreadcrumbDataSource.fragmentStack
 
     override fun logView(screen: String?, timestamp: Long) {
         viewBreadcrumbDataSource.addToViewLogsQueue(screen, timestamp, false)
@@ -54,8 +61,15 @@ internal class EmbraceBreadcrumbService(
         viewBreadcrumbDataSource.addToViewLogsQueue(screen, timestamp, true)
     }
 
-    override fun startView(name: String?): Boolean = fragmentBreadcrumbDataSource.startFragment(name)
-    override fun endView(name: String?): Boolean = fragmentBreadcrumbDataSource.endFragment(name)
+    override fun startView(name: String?): Boolean {
+        fragmentBreadcrumbDataSource.startFragment(name)
+        return legacyFragmentBreadcrumbDataSource.startFragment(name)
+    }
+
+    override fun endView(name: String?): Boolean {
+        fragmentBreadcrumbDataSource.endFragment(name)
+        return legacyFragmentBreadcrumbDataSource.endFragment(name)
+    }
 
     override fun logTap(
         point: Pair<Float?, Float?>,
@@ -91,7 +105,7 @@ internal class EmbraceBreadcrumbService(
         tapBreadcrumbs = tapBreadcrumbDataSource.getCapturedData(),
         viewBreadcrumbs = viewBreadcrumbDataSource.getCapturedData(),
         webViewBreadcrumbs = webViewBreadcrumbDataSource.getCapturedData(),
-        fragmentBreadcrumbs = fragmentBreadcrumbDataSource.getCapturedData(),
+        fragmentBreadcrumbs = legacyFragmentBreadcrumbDataSource.getCapturedData(),
         rnActionBreadcrumbs = rnBreadcrumbDataSource.getCapturedData(),
         pushNotifications = pushNotificationBreadcrumbDataSource.getCapturedData()
     )
@@ -134,6 +148,7 @@ internal class EmbraceBreadcrumbService(
         }
         viewBreadcrumbDataSource.onViewClose()
         fragmentBreadcrumbDataSource.onViewClose()
+        legacyFragmentBreadcrumbDataSource.onViewClose()
     }
 
     override fun cleanCollections() {
@@ -141,7 +156,7 @@ internal class EmbraceBreadcrumbService(
         tapBreadcrumbDataSource.cleanCollections()
         legacyCustomBreadcrumbDataSource.cleanCollections()
         webViewBreadcrumbDataSource.cleanCollections()
-        fragmentBreadcrumbDataSource.cleanCollections()
+        legacyFragmentBreadcrumbDataSource.cleanCollections()
         pushNotificationBreadcrumbDataSource.cleanCollections()
         rnBreadcrumbDataSource.cleanCollections()
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
@@ -1,11 +1,13 @@
 package io.embrace.android.embracesdk.gating
 
+import io.embrace.android.embracesdk.arch.schema.SchemaKeys
+import io.embrace.android.embracesdk.gating.SessionGatingKeys.BREADCRUMBS_CUSTOM
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 internal class SpanSanitizer(
     private val spans: List<EmbraceSpanData>?,
-    @Suppress("UnusedPrivateProperty") private val enabledComponents: Set<String>
+    private val enabledComponents: Set<String>
 ) : Sanitizable<List<EmbraceSpanData>> {
 
     override fun sanitize(): List<EmbraceSpanData>? {
@@ -40,8 +42,12 @@ internal class SpanSanitizer(
         return true
     }
 
-    @Suppress("UNUSED_PARAMETER", "FunctionOnlyReturningConstant")
     private fun sanitizeEvents(event: EmbraceSpanEvent): Boolean {
+        if (event.name == SchemaKeys.CUSTOM_BREADCRUMB && !shouldAddCustomBreadcrumbs()) {
+            return false
+        }
         return true
     }
+
+    private fun shouldAddCustomBreadcrumbs() = enabledComponents.contains(BREADCRUMBS_CUSTOM)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
@@ -37,8 +37,10 @@ internal class SpanSanitizer(
         return sanitizedSpans
     }
 
-    @Suppress("UNUSED_PARAMETER", "FunctionOnlyReturningConstant")
     private fun sanitizeSpans(span: EmbraceSpanData): Boolean {
+        if (span.name == "emb-${SchemaKeys.VIEW_BREADCRUMB}" && !shouldAddViewBreadcrumbs()) {
+            return false
+        }
         return true
     }
 
@@ -50,4 +52,7 @@ internal class SpanSanitizer(
     }
 
     private fun shouldAddCustomBreadcrumbs() = enabledComponents.contains(BREADCRUMBS_CUSTOM)
+
+    private fun shouldAddViewBreadcrumbs() =
+        enabledComponents.contains(SessionGatingKeys.BREADCRUMBS_VIEWS)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -137,6 +137,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
                 configService,
                 essentialServiceModule.activityLifecycleTracker,
                 openTelemetryModule.currentSessionSpan,
+                openTelemetryModule.spanService,
                 coreModule.logger
             )
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -136,6 +136,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
                 initModule.clock,
                 configService,
                 essentialServiceModule.activityLifecycleTracker,
+                openTelemetryModule.currentSessionSpan,
                 coreModule.logger
             )
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.capture.crumbs.CustomBreadcrumbDataSource
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
@@ -20,18 +21,29 @@ internal interface DataSourceModule {
      * Returns a list of all the data sources that are defined in this module.
      */
     fun getDataSources(): List<DataSourceState>
+
+    val customBreadcrumbDataSource: DataSourceState
 }
 
 internal class DataSourceModuleImpl(
     essentialServiceModule: EssentialServiceModule,
     @Suppress("UNUSED_PARAMETER") initModule: InitModule,
-    @Suppress("UNUSED_PARAMETER") otelModule: OpenTelemetryModule,
+    otelModule: OpenTelemetryModule,
     @Suppress("UNUSED_PARAMETER") systemServiceModule: SystemServiceModule,
     @Suppress("UNUSED_PARAMETER") androidServicesModule: AndroidServicesModule,
     @Suppress("UNUSED_PARAMETER") workerThreadModule: WorkerThreadModule,
 ) : DataSourceModule {
 
     private val values: MutableList<DataSourceState> = mutableListOf()
+
+    override val customBreadcrumbDataSource: DataSourceState by dataSource {
+        DataSourceState({
+            CustomBreadcrumbDataSource(
+                breadcrumbBehavior = essentialServiceModule.configService.breadcrumbBehavior,
+                writer = otelModule.currentSessionSpan
+            )
+        })
+    }
 
     /* Implementation details */
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbsSanitizerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbsSanitizerTest.kt
@@ -33,7 +33,6 @@ internal class BreadcrumbsSanitizerTest {
 
         assertNotNull(result?.tapBreadcrumbs)
         assertNotNull(result?.viewBreadcrumbs)
-        assertNotNull(result?.customBreadcrumbs)
         assertNotNull(result?.webViewBreadcrumbs)
         assertNotNull(result?.customBreadcrumbs)
     }
@@ -47,7 +46,6 @@ internal class BreadcrumbsSanitizerTest {
 
         assertNull(result?.tapBreadcrumbs)
         assertNull(result?.viewBreadcrumbs)
-        assertNull(result?.customBreadcrumbs)
         assertNull(result?.webViewBreadcrumbs)
         assertNull(result?.customBreadcrumbs)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -32,7 +32,7 @@ internal class CustomBreadcrumbDataSourceTest {
     fun `add breadcrumb`() {
         source.logCustom("Hello, world!", 15000000000)
         with(writer.addedEvents.single()) {
-            assertEquals("custom-breadcrumb", this.schemaType.name)
+            assertEquals("emb-custom-breadcrumb", this.schemaType.name)
             assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
             assertEquals(
                 mapOf(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.fakes.fakeSession
@@ -85,7 +86,8 @@ internal class EmbraceBreadcrumbServiceTest {
         val service = EmbraceBreadcrumbService(
             clock,
             configService,
-            FakeActivityTracker()
+            FakeActivityTracker(),
+            FakeCurrentSessionSpan()
         )
         service.logView("viewA", clock.now())
         clock.tickSecond()
@@ -592,7 +594,8 @@ internal class EmbraceBreadcrumbServiceTest {
         val service = EmbraceBreadcrumbService(
             clock,
             configService,
-            activityTracker
+            activityTracker,
+            FakeCurrentSessionSpan()
         )
         service.addFirstViewBreadcrumbForSession(5)
         val crumb = checkNotNull(service.getBreadcrumbs().viewBreadcrumbs).single()
@@ -603,7 +606,8 @@ internal class EmbraceBreadcrumbServiceTest {
     private fun initializeBreadcrumbService() = EmbraceBreadcrumbService(
         clock,
         configService,
-        FakeActivityTracker()
+        FakeActivityTracker(),
+        FakeCurrentSessionSpan()
     )
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.system.mockActivity
@@ -31,6 +32,7 @@ import java.util.concurrent.CountDownLatch
 
 internal class EmbraceBreadcrumbServiceTest {
 
+    private lateinit var spanService: FakeSpanService
     private lateinit var configService: ConfigService
     private lateinit var processStateService: ProcessStateService
     private lateinit var memoryCleanerService: EmbraceMemoryCleanerService
@@ -39,6 +41,7 @@ internal class EmbraceBreadcrumbServiceTest {
 
     @Before
     fun createMocks() {
+        spanService = FakeSpanService()
         configService = FakeConfigService(
             breadcrumbBehavior = fakeBreadcrumbBehavior(
                 localCfg = {
@@ -87,7 +90,8 @@ internal class EmbraceBreadcrumbServiceTest {
             clock,
             configService,
             FakeActivityTracker(),
-            FakeCurrentSessionSpan()
+            FakeCurrentSessionSpan(),
+            spanService
         )
         service.logView("viewA", clock.now())
         clock.tickSecond()
@@ -595,7 +599,8 @@ internal class EmbraceBreadcrumbServiceTest {
             clock,
             configService,
             activityTracker,
-            FakeCurrentSessionSpan()
+            FakeCurrentSessionSpan(),
+            spanService
         )
         service.addFirstViewBreadcrumbForSession(5)
         val crumb = checkNotNull(service.getBreadcrumbs().viewBreadcrumbs).single()
@@ -607,7 +612,8 @@ internal class EmbraceBreadcrumbServiceTest {
         clock,
         configService,
         FakeActivityTracker(),
-        FakeCurrentSessionSpan()
+        FakeCurrentSessionSpan(),
+        spanService
     )
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
@@ -34,7 +34,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         dataSource.startFragment("my_fragment")
 
         val span = spanService.createdSpans.single()
-        assertEquals("view-breadcrumb", span.name)
+        assertEquals("screen-view", span.name)
         assertEquals(EmbType.Performance.Default, span.type)
         assertTrue(span.isRecording)
         assertEquals(
@@ -53,7 +53,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         dataSource.endFragment("my_fragment")
 
         val span = spanService.createdSpans.single()
-        assertEquals("view-breadcrumb", span.name)
+        assertEquals("screen-view", span.name)
         assertEquals(EmbType.Performance.Default, span.type)
         assertFalse(span.isRecording)
         assertEquals(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -24,6 +24,7 @@ internal class DataSourceModuleImplTest {
             FakeWorkerThreadModule(FakeInitModule(), WorkerName.BACKGROUND_REGISTRATION)
         )
         assertNotNull(module.getDataSources())
-        assertEquals(0, module.getDataSources().size)
+        assertNotNull(module.customBreadcrumbDataSource)
+        assertEquals(1, module.getDataSources().size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -25,6 +25,7 @@ internal class DataSourceModuleImplTest {
         )
         assertNotNull(module.getDataSources())
         assertNotNull(module.customBreadcrumbDataSource)
-        assertEquals(1, module.getDataSources().size)
+        assertNotNull(module.fragmentBreadcrumbDataSource)
+        assertEquals(2, module.getDataSources().size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -238,7 +238,7 @@ internal class CurrentSessionSpanImplTests {
 
         // verify event was added to the span
         val testEvent = span.events.single()
-        assertEquals("custom-breadcrumb", testEvent.name)
+        assertEquals("emb-custom-breadcrumb", testEvent.name)
         assertEquals(1000, testEvent.timestampNanos.nanosToMillis())
         assertEquals(
             mapOf(


### PR DESCRIPTION
## Goal

Enables the capture of view breadcrumbs via OTel. View breadcrumbs are captured as spans. The legacy mechanism that adds directly to the session payload is running simultaneously - a future PR will remove this mechanism.

## Testing

Added unit tests.
