### PR TITLE
Add span snapshots to the v1 payload for caching purposes

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -7,11 +7,16 @@ import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 
 /**
  * Assert the [EmbraceSpanData] is as expected
@@ -59,5 +64,53 @@ internal fun assertEmbraceSpanData(
         } else {
             assertNotKeySpan()
         }
+    }
+}
+
+internal fun Span.assertSpanPayload(
+    expectedStartTimeMs: Long,
+    expectedEndTimeMs: Long?,
+    expectedParentId: String?,
+    expectedTraceId: String? = null,
+    errorCode: ErrorCode? = null,
+    expectedCustomAttributes: Map<String, String> = emptyMap(),
+    expectedEvents: List<SpanEvent> = emptyList(),
+    private: Boolean = false,
+    key: Boolean = false,
+) {
+    assertEquals(expectedStartTimeMs, startTimeUnixNano?.nanosToMillis())
+    assertEquals(expectedEndTimeMs, endTimeUnixNano?.nanosToMillis())
+    assertEquals(expectedParentId, parentSpanId)
+    if (expectedTraceId != null) {
+        assertEquals(expectedTraceId, traceId)
+    } else {
+        assertEquals(32, traceId?.length)
+    }
+
+    if (endTimeUnixNano == null) {
+        assertEquals(Span.Status.UNSET, status)
+    } else if (errorCode == null) {
+        assertSuccessful()
+    } else {
+        assertError(errorCode)
+    }
+
+    val attributeSet = attributes?.toHashSet() ?: emptySet()
+    expectedCustomAttributes.toNewPayload().forEach {
+        assertTrue("$it is missing", attributeSet.contains(it))
+    }
+
+    assertArrayEquals(expectedEvents.toList().toTypedArray(), checkNotNull(events).toTypedArray())
+
+    if (private) {
+        assertIsPrivateSpan()
+    } else {
+        assertNotPrivateSpan()
+    }
+
+    if (key) {
+        assertIsKeySpan()
+    } else {
+        assertNotKeySpan()
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -60,6 +60,7 @@ internal class SessionModuleImpl(
             dataCaptureServiceModule.breadcrumbService,
             essentialServiceModule.userService,
             androidServicesModule.preferencesService,
+            openTelemetryModule.spanRepository,
             openTelemetryModule.spanSink,
             openTelemetryModule.currentSessionSpan,
             sessionPropertiesService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionMessage.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionMessage.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.comms.api.ApiClient
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 
 /**
@@ -53,6 +54,9 @@ internal data class SessionMessage @JvmOverloads internal constructor(
 
     @Json(name = "spans")
     val spans: List<EmbraceSpanData>? = null,
+
+    @Json(name = "span_snapshots")
+    val spanSnapshots: List<Span>? = null,
 
     @Json(name = "v")
     val version: Int? = ApiClient.MESSAGE_VERSION,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
@@ -4,8 +4,10 @@ import com.squareup.moshi.JsonDataException
 import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
 import io.embrace.android.embracesdk.deserializeEmptyJsonString
 import io.embrace.android.embracesdk.deserializeJsonFromResource
+import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -36,6 +38,19 @@ internal class SessionMessageTest {
             emptyList()
         )
     )
+    private val spanSnapshots = listOfNotNull(
+        Span(
+            traceId = "snapshot-trace-id",
+            spanId = "snapshot-span-id",
+            parentSpanId = null,
+            name = "snapshot",
+            startTimeUnixNano = DEFAULT_FAKE_CURRENT_TIME,
+            endTimeUnixNano = null,
+            status = Span.Status.UNSET,
+            events = emptyList(),
+            attributes = emptyList()
+        )
+    )
 
     private val info = SessionMessage(
         session,
@@ -44,7 +59,8 @@ internal class SessionMessageTest {
         deviceInfo,
         performanceInfo,
         breadcrumbs,
-        spans
+        spans,
+        spanSnapshots
     )
 
     @Test
@@ -63,6 +79,7 @@ internal class SessionMessageTest {
         assertEquals(performanceInfo, obj.performanceInfo)
         assertEquals(breadcrumbs, obj.breadcrumbs)
         assertEquals(spans, obj.spans)
+        assertEquals(spanSnapshots, obj.spanSnapshots)
     }
 
     @Test(expected = JsonDataException::class)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -34,6 +34,7 @@ import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.logging.InternalErrorService
@@ -64,6 +65,7 @@ internal class PayloadFactoryBaTest {
     private lateinit var ndkService: FakeNdkService
     private lateinit var configService: FakeConfigService
     private lateinit var localConfig: LocalConfig
+    private lateinit var spanRepository: SpanRepository
     private lateinit var spanSink: SpanSink
     private lateinit var currentSessionSpan: CurrentSessionSpan
     private lateinit var spanService: SpanService
@@ -86,6 +88,7 @@ internal class PayloadFactoryBaTest {
         preferencesService = FakePreferenceService(backgroundActivityEnabled = true)
         userService = FakeUserService()
         val initModule = FakeInitModule(clock = clock)
+        spanRepository = initModule.openTelemetryModule.spanRepository
         spanSink = initModule.openTelemetryModule.spanSink
         currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
         spanService = initModule.openTelemetryModule.spanService
@@ -174,6 +177,7 @@ internal class PayloadFactoryBaTest {
             breadcrumbService,
             userService,
             preferencesService,
+            spanRepository,
             spanSink,
             currentSessionSpan,
             FakeSessionPropertiesService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -154,6 +154,7 @@ internal class SessionHandlerTest {
             breadcrumbService,
             userService,
             preferencesService,
+            initModule.openTelemetryModule.spanRepository,
             initModule.openTelemetryModule.spanSink,
             initModule.openTelemetryModule.currentSessionSpan,
             FakeSessionPropertiesService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -59,10 +59,11 @@ internal class V1PayloadMessageCollatorTest {
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),
+            spanRepository = initModule.openTelemetryModule.spanRepository,
             spanSink = initModule.openTelemetryModule.spanSink,
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
-            startupService = FakeStartupService()
+            startupService = FakeStartupService(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -61,6 +61,7 @@ internal class PayloadFactoryImplTest {
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),
+            spanRepository = initModule.openTelemetryModule.spanRepository,
             spanSink = initModule.openTelemetryModule.spanSink,
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -60,10 +60,11 @@ internal class V2PayloadMessageCollatorTest {
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),
+            spanRepository = initModule.openTelemetryModule.spanRepository,
             spanSink = initModule.openTelemetryModule.spanSink,
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
-            startupService = FakeStartupService()
+            startupService = FakeStartupService(),
         )
         val sessionEnvelopeSource = SessionEnvelopeSourceImpl(
             metadataSource = FakeEnvelopeMetadataSource(),

--- a/embrace-android-sdk/src/test/resources/session_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_message_expected.json
@@ -45,5 +45,16 @@
       "attributes": {}
     }
   ],
+  "span_snapshots": [
+    {
+      "trace_id": "snapshot-trace-id",
+      "span_id": "snapshot-span-id",
+      "name": "snapshot",
+      "start_time_unix_nano": 1692201601000,
+      "status": "Unset",
+      "events": [],
+      "attributes": []
+    }
+  ],
   "v": 13
 }


### PR DESCRIPTION
## Goal

Add snapshots to v1 payload so we can revive any unterminated spans when we send a crashed session payload. This will ensure that any data stored in a session span will not be lost, and any spans terminated by a crash that isn't terminated during the crash can be terminated after the fact.

## Testing

Updated payload tests and the tracing integration test