### PR TITLE
add span_snapshot to session-end.json

### DIFF
--- a/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
+++ b/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
@@ -163,5 +163,6 @@
       "trace_id": "__EMBRACE_TEST_IGNORE__"
     }
   ],
+  "span_snapshots":"__EMBRACE_TEST_IGNORE__",
   "v": 13
 }


### PR DESCRIPTION
## Goal

Fix functional tests: `sessionEndMessageTest()` is failing

* expecting `s.span_snapshots` as array
* expecting  `br.vb.en` View Breadcrumb end time (?)


