### PR TITLE
End all active spans if the current session span is termianted because of a crash

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -27,8 +26,7 @@ internal fun assertEmbraceSpanData(
     expectedEndTimeMs: Long,
     expectedParentId: String,
     expectedTraceId: String? = null,
-    expectedStatus: StatusCode = StatusCode.OK,
-    errorCode: ErrorCode? = null,
+    expectedErrorCode: ErrorCode? = null,
     expectedCustomAttributes: Map<String, String> = emptyMap(),
     expectedEvents: List<EmbraceSpanEvent> = emptyList(),
     private: Boolean = false,
@@ -44,11 +42,10 @@ internal fun assertEmbraceSpanData(
         } else {
             assertEquals(32, traceId.length)
         }
-        assertEquals(expectedStatus, status)
-        if (errorCode == null) {
+        if (expectedErrorCode == null) {
             assertSuccessful()
         } else {
-            assertError(errorCode)
+            assertError(expectedErrorCode)
         }
         expectedCustomAttributes.forEach { entry ->
             assertEquals(entry.value, attributes[entry.key])

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -17,7 +17,6 @@ import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -201,8 +200,7 @@ internal class TracingApiTest {
                 expectedEndTimeMs = testStartTimeMs + 400,
                 expectedParentId = traceRootSpan.spanId,
                 expectedTraceId = traceRootSpan.traceId,
-                expectedStatus = StatusCode.ERROR,
-                errorCode = ErrorCode.FAILURE,
+                expectedErrorCode = ErrorCode.FAILURE,
                 expectedCustomAttributes = mapOf(Pair("test-attr", "false")),
                 expectedEvents = listOf(
                     checkNotNull(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
@@ -8,7 +8,8 @@ import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
  */
 internal interface EmbraceAttribute {
     /**
-     * The unique name given to the attribute
+     * The unique name given to the attribute.
+     * Don't use this to look up the existence of an attribute in a log or span - use [otelAttributeName] instead
      */
     val attributeName: String
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.telemetry.TelemetryService
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
@@ -82,8 +83,10 @@ internal class CurrentSessionSpanImpl(
                 spanRepository.clearCompletedSpans()
                 sessionSpan.set(startSessionSpan(openTelemetryClock.now().nanosToMillis()))
             } else {
+                val crashTime = openTelemetryClock.now().nanosToMillis()
+                spanRepository.failActiveSpans(crashTime)
                 endingSessionSpan.setEmbraceAttribute(appTerminationCause)
-                endingSessionSpan.stop()
+                endingSessionSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
             }
             return spanSink.flushSpans()
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -131,3 +131,6 @@ internal fun String.toEmbraceAttributeName(): String = EMBRACE_ATTRIBUTE_NAME_PR
  * Return the appropriate internal Embrace attribute usage name given the current string
  */
 internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX + this
+
+internal fun Map<String, String>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
+    this[embraceAttribute.otelAttributeName()] == embraceAttribute.attributeValue

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -160,6 +160,8 @@ internal class EmbraceSpanImpl(
         }
     }
 
+    override fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean = allAttributes().hasEmbraceAttribute(embraceAttribute)
+
     private fun allAttributes(): Map<String, String> = attributes + schemaAttributes
 
     private fun canSnapshot(): Boolean = spanId != null && spanStartTimeMs != null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.utils.lockAndRun
 import java.util.concurrent.ConcurrentHashMap
@@ -62,6 +64,18 @@ internal class SpanRepository {
      */
     fun getCompletedSpans(): List<EmbraceSpan> = synchronized(spanIdsInProcess) { completedSpans.values.toList() }
 
+    /**
+     * Stop the existing active spans and mark them as failed
+     */
+    fun failActiveSpans(failureTimeMs: Long) {
+        getActiveSpans().filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) }.forEach { span ->
+            span.stop(ErrorCode.FAILURE, failureTimeMs)
+        }
+    }
+
+    /**
+     * Clear the spans this repository is tracking
+     */
     fun clearCompletedSpans() {
         synchronized(spanIdsInProcess) {
             completedSpans.clear()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.spans
 
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 
 /**
@@ -11,4 +12,6 @@ internal interface PersistableEmbraceSpan : EmbraceSpan {
      * Create a snapshot of the current state of the object
      */
     fun snapshot(): Span?
+
+    fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -2,12 +2,14 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -25,10 +27,10 @@ internal class FakePersistableEmbraceSpan(
 
     val attributes = mutableMapOf<String, String>()
     val events = ConcurrentLinkedQueue<EmbraceSpanEvent>()
+    var started = false
+    var stopped = false
+    var errorCode: ErrorCode? = null
 
-    private var started = false
-    private var stopped = false
-    private var errorCode: ErrorCode? = null
     private var spanStartTimeMs: Long? = null
     private var spanEndTimeMs: Long? = null
     private var status = Span.Status.UNSET
@@ -100,6 +102,9 @@ internal class FakePersistableEmbraceSpan(
             )
         }
     }
+
+    override fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
+        attributes.hasEmbraceAttribute(embraceAttribute)
 
     /**
      * Should only used if this is being used to fake a session span

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanRepositoryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanRepositoryTest.kt
@@ -2,9 +2,12 @@ package io.embrace.android.embracesdk.internal.spans
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.spans.ErrorCode
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -89,5 +92,20 @@ internal class SpanRepositoryTest {
         repository.clearCompletedSpans()
         assertNull(repository.getSpan(checkNotNull(completedSpan.spanId)))
         assertEquals(0, repository.getCompletedSpans().size)
+    }
+
+    @Test
+    fun `active spans become failed and complete when they are forced to fail`() {
+        val startedSpan = FakePersistableEmbraceSpan.started()
+        repository.trackStartedSpan(startedSpan)
+
+        assertSame(startedSpan, repository.getActiveSpans().single())
+        assertFalse(startedSpan.stopped)
+        assertNull(startedSpan.errorCode)
+
+        repository.failActiveSpans(100L)
+
+        assertTrue(startedSpan.stopped)
+        assertEquals(ErrorCode.FAILURE, startedSpan.errorCode)
     }
 }


### PR DESCRIPTION
## Goal

End all active spans when a crash happens. Also changed the testing infra to make testing this and other things easier.

## Testing

Added unit tests. Integration tests will come later
