### PR TITLE
Use the session start time for the file name used to store a session

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
@@ -55,8 +55,7 @@ internal class StorageModuleImpl(
         EmbraceDeliveryCacheManager(
             cacheService,
             workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
-            coreModule.logger,
-            initModule.clock
+            coreModule.logger
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheCurrentAccessTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheCurrentAccessTest.kt
@@ -45,8 +45,7 @@ internal class EmbraceDeliveryCacheCurrentAccessTest {
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService,
             worker,
-            logger,
-            fakeClock
+            logger
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -73,8 +73,7 @@ internal class EmbraceDeliveryCacheManagerTest {
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService,
             worker,
-            logger,
-            fakeClock
+            logger
         )
     }
 


### PR DESCRIPTION
## Goal

Use the session start time for the file name rather than the time session was first saved. While it doesn't effect how it's used, this will make the file name deterministic and predictable, which wasn't the case before.

## Testing

A test was added in [this PR](https://github.com/embrace-io/embrace-android-sdk/pull/620) that tests that the file name doesn't matter when delivering a cached session file.

