### PR TITLE
Convert EmbraceDeliveryServiceTest to use a real DeliveryCacheManager

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -23,7 +23,7 @@ internal class EmbraceDeliveryService(
     private val cacheManager: DeliveryCacheManager,
     private val apiService: ApiService,
     private val backgroundWorker: BackgroundWorker,
-    private val serializer: EmbraceSerializer,
+    private val serializer: PlatformSerializer,
     private val logger: InternalEmbraceLogger
 ) : DeliveryService {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -4,114 +4,118 @@ import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.EventType
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.fakes.FakeApiService
-import io.embrace.android.embracesdk.fakes.FakeDeliveryCacheManager
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.fakes.FakeStorageService
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.fakeV1SessionMessage
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
-import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.JVM_CRASH
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.NORMAL_END
-import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.PERIODIC_CACHE
 import io.embrace.android.embracesdk.worker.BackgroundWorker
-import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 internal class EmbraceDeliveryServiceTest {
 
-    private val session = fakeSession()
-    private val sessionMessage = fakeV1SessionMessage()
-    private val anotherMessage =
-        fakeV1SessionMessage().copy(session = session.copy(sessionId = "session2"))
-
+    private lateinit var fakeClock: FakeClock
     private lateinit var worker: BackgroundWorker
-    private lateinit var deliveryCacheManager: FakeDeliveryCacheManager
+    private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var apiService: FakeApiService
     private lateinit var ndkService: FakeNdkService
     private lateinit var gatingService: FakeGatingService
+    private lateinit var testPlatformSerializer: TestPlatformSerializer
+    private lateinit var fakeStorageService: FakeStorageService
+    private lateinit var cacheService: EmbraceCacheService
     private lateinit var logger: InternalEmbraceLogger
     private lateinit var deliveryService: EmbraceDeliveryService
     private lateinit var sessionIdTracker: FakeSessionIdTracker
 
     @Before
     fun setUp() {
+        fakeClock = FakeClock()
         worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
-        deliveryCacheManager = FakeDeliveryCacheManager()
         apiService = FakeApiService()
         ndkService = FakeNdkService()
         gatingService = FakeGatingService()
         logger = InternalEmbraceLogger()
         sessionIdTracker = FakeSessionIdTracker()
-    }
-
-    @After
-    fun after() {
-        gatingService.sessionMessagesFiltered.clear()
-    }
-
-    private fun initializeDeliveryService() {
+        fakeStorageService = FakeStorageService()
+        testPlatformSerializer = TestPlatformSerializer()
+        cacheService = EmbraceCacheService(
+            storageService = fakeStorageService,
+            serializer = testPlatformSerializer,
+            logger = logger
+        )
+        deliveryCacheManager = EmbraceDeliveryCacheManager(
+            cacheService = cacheService,
+            backgroundWorker = worker,
+            logger = logger,
+        )
         deliveryService = EmbraceDeliveryService(
             deliveryCacheManager,
             apiService,
             worker,
-            EmbraceSerializer(),
+            testPlatformSerializer,
             logger
         )
     }
 
     @Test
-    fun `cache current session successfully`() {
-        initializeDeliveryService()
+    fun `send session successfully`() {
         deliveryService.sendSession(sessionMessage, NORMAL_END)
-
-        val observed = deliveryCacheManager.saveSessionRequests.single()
-        assertEquals(Pair(sessionMessage, NORMAL_END), observed)
+        assertTrue(apiService.sessionRequests.contains(sessionMessage))
+        assertEquals(0, apiService.futureGetCount)
+        assertNull(cacheService.loadObject(sessionFileName, SessionMessage::class.java))
     }
 
     @Test
-    fun `cache periodic session successful`() {
-        initializeDeliveryService()
-        deliveryService.sendSession(sessionMessage, PERIODIC_CACHE)
-
-        val observed = deliveryCacheManager.saveSessionRequests.last()
-        assertEquals(Pair(sessionMessage, PERIODIC_CACHE), observed)
+    fun `cache session successfully`() {
+        deliveryService.sendSession(sessionMessage, SessionSnapshotType.PERIODIC_CACHE)
+        assertEquals(0, apiService.sessionRequests.size)
+        assertNotNull(cacheService.loadObject(sessionFileName, SessionMessage::class.java))
     }
 
     @Test
-    fun `cache session on crash successful`() {
-        initializeDeliveryService()
-        deliveryService.sendSession(sessionMessage, JVM_CRASH)
-
-        val observed = deliveryCacheManager.saveSessionRequests.last()
-        assertEquals(Pair(sessionMessage, JVM_CRASH), observed)
+    fun `send session synchronously on crash successfully`() {
+        deliveryService.sendSession(sessionMessage, SessionSnapshotType.JVM_CRASH)
+        assertTrue(apiService.sessionRequests.contains(sessionMessage))
+        assertEquals(1, apiService.futureGetCount)
+        assertNull(cacheService.loadObject(sessionFileName, SessionMessage::class.java))
     }
 
     @Test
     fun `if no previous cached session then send previous cached sessions should not send anything`() {
-        initializeDeliveryService()
         deliveryService.sendCachedSessions(null, sessionIdTracker)
         assertTrue(apiService.sessionRequests.isEmpty())
     }
 
     @Test
     fun `send previously cached sessions successfully`() {
-        initializeDeliveryService()
-        deliveryCacheManager.addCachedSessions(sessionMessage, anotherMessage)
-
+        assertNotNull(cacheService.writeSession(sessionFileName, sessionMessage))
+        assertNotNull(cacheService.writeSession(anotherMessageFileName, anotherMessage))
         deliveryService.sendCachedSessions(null, sessionIdTracker)
-        assertEquals(listOf(sessionMessage, anotherMessage), apiService.sessionRequests)
+        assertTrue(apiService.sessionRequests.contains(sessionMessage))
+        assertTrue(apiService.sessionRequests.contains(anotherMessage))
+        assertEquals(2, apiService.sessionRequests.size)
+        val sessionMap = apiService.sessionRequests.associateBy { it.session.sessionId }
+        assertEquals(sessionMessage, sessionMap[sessionMessage.session.sessionId])
+        assertEquals(anotherMessage, sessionMap[anotherMessage.session.sessionId])
     }
 
     @Test
     fun `ignore current session when sending previously cached sessions`() {
-        initializeDeliveryService()
-        deliveryCacheManager.addCachedSessions(sessionMessage, anotherMessage)
+        assertNotNull(cacheService.writeSession(sessionFileName, sessionMessage))
+        assertNotNull(cacheService.writeSession(anotherMessageFileName, anotherMessage))
         sessionIdTracker.sessionId = anotherMessage.session.sessionId
         deliveryService.sendCachedSessions(null, sessionIdTracker)
         assertEquals(listOf(sessionMessage), apiService.sessionRequests)
@@ -119,30 +123,20 @@ internal class EmbraceDeliveryServiceTest {
 
     @Test
     fun `if an exception is thrown while sending cached session then sendCachedSession should not crash`() {
-        initializeDeliveryService()
-        deliveryCacheManager.addCachedSessions(sessionMessage)
+        assertNotNull(cacheService.writeSession(sessionFileName, sessionMessage))
         apiService.throwExceptionSendSession = true
         deliveryService.sendCachedSessions(null, sessionIdTracker)
         assertTrue(apiService.sessionRequests.isEmpty())
     }
 
     @Test
-    fun `send session end with crash`() {
-        initializeDeliveryService()
-        deliveryService.sendSession(sessionMessage, JVM_CRASH)
-        assertEquals(sessionMessage, apiService.sessionRequests.last())
-    }
-
-    @Test
     fun `check for native crash info if ndk feature is enabled`() {
-        initializeDeliveryService()
         deliveryService.sendCachedSessions(ndkService, sessionIdTracker)
         assertEquals(1, ndkService.checkForNativeCrashCount)
     }
 
     @Test
     fun testSendEventAsync() {
-        initializeDeliveryService()
         val obj = EventMessage(Event(eventId = "abc", type = EventType.END))
         deliveryService.sendMoment(obj)
         assertEquals(obj, apiService.eventRequests.single())
@@ -150,10 +144,24 @@ internal class EmbraceDeliveryServiceTest {
 
     @Test
     fun testSaveCrash() {
-        initializeDeliveryService()
         val obj = EventMessage(Event(eventId = "abc", type = EventType.CRASH))
         deliveryService.sendCrash(obj, true)
-        assertEquals(obj, deliveryCacheManager.saveCrashRequests.single())
         assertEquals(obj, apiService.crashRequests.single())
+    }
+
+    companion object {
+        private val sessionMessage = fakeV1SessionMessage()
+        private val sessionFileName = CachedSession.create(
+            sessionMessage.session.sessionId,
+            sessionMessage.session.startTime,
+            false
+        ).filename
+        private val anotherMessage =
+            fakeV1SessionMessage().copy(session = fakeSession().copy(sessionId = "session2"))
+        private val anotherMessageFileName = CachedSession.create(
+            anotherMessage.session.sessionId,
+            anotherMessage.session.startTime,
+            false
+        ).filename
     }
 }


### PR DESCRIPTION
## Goal

The old test was not testing certain functionality that required the DeliveryCacheManager's implementation because it was using a fake. Convert this to use the real thing so the tests actually test the component in a realistic way.

Seeing as we don't have integration tests that cover this layer, it's crucial that these tests actually very the workflow happening in production

## Testing

Added to the fake ApiService in order to verify the behaviour at that layer.