### PR TITLE
Convert snapshots in cached sessions before sending

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
+import io.embrace.android.embracesdk.internal.payload.toFailedSpan
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
@@ -104,6 +105,17 @@ internal class EmbraceDeliveryService(
             val allSessions = cacheManager.getAllCachedSessionIds().filter {
                 it.sessionId != sessionIdTracker.getActiveSessionId()
             }
+
+            allSessions.map { it.sessionId }.forEach { sessionId ->
+                cacheManager.transformSession(sessionId = sessionId) { sessionMessage ->
+                    val spansToFail = sessionMessage.spanSnapshots?.map {
+                        it.toFailedSpan(sessionMessage.session.endTime ?: 0L)
+                    } ?: emptyList()
+                    val completedSpans = spansToFail + (sessionMessage.spans ?: emptyList())
+                    sessionMessage.copy(spans = completedSpans, spanSnapshots = emptyList())
+                }
+            }
+
             ndkService?.let { service ->
                 val nativeCrashData = service.checkForNativeCrash()
                 if (nativeCrashData != null) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
@@ -1,7 +1,14 @@
 package io.embrace.android.embracesdk.internal.payload
 
+import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
+import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.spans.setEmbraceAttribute
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 
 internal fun EmbraceSpanData.toNewPayload() = Span(
@@ -27,5 +34,35 @@ internal fun EmbraceSpanEvent.toNewPayload() = SpanEvent(
     attributes = attributes.toNewPayload()
 )
 
+internal fun SpanEvent.toOldPayload() = EmbraceSpanEvent(
+    name = name ?: "",
+    timestampNanos = timeUnixNano ?: 0,
+    attributes = attributes?.toOldPayload() ?: emptyMap()
+)
+
 internal fun Map<String, String>.toNewPayload(): List<Attribute> =
     map { (key, value) -> Attribute(key, value) }
+
+internal fun List<Attribute>.toOldPayload(): Map<String, String> =
+    associate { Pair(it.key ?: "", it.data ?: "") }.filterKeys { it.isNotBlank() }
+
+internal fun Span.toFailedSpan(endTimeMs: Long): EmbraceSpanData {
+    val newAttributes = attributes?.toOldPayload()?.toMutableMap()?.apply {
+        setEmbraceAttribute(ErrorCodeAttribute.Failure)
+        if (hasEmbraceAttribute(EmbType.Ux.Session)) {
+            setEmbraceAttribute(AppTerminationCause.Crash)
+        }
+    } ?: emptyMap()
+
+    return EmbraceSpanData(
+        traceId = traceId ?: "",
+        spanId = spanId ?: "",
+        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
+        name = name ?: "",
+        startTimeNanos = startTimeUnixNano ?: 0,
+        endTimeNanos = endTimeMs.millisToNanos(),
+        status = StatusCode.ERROR,
+        events = events?.map { it.toOldPayload() } ?: emptyList(),
+        attributes = newAttributes
+    )
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -134,3 +134,8 @@ internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIB
 
 internal fun Map<String, String>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
     this[embraceAttribute.otelAttributeName()] == embraceAttribute.attributeValue
+
+internal fun MutableMap<String, String>.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): Map<String, String> {
+    this[embraceAttribute.otelAttributeName()] = embraceAttribute.attributeValue
+    return this
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.fixtures.testSpan
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -25,6 +26,22 @@ internal fun fakeSession(
 
 internal fun fakeV1SessionMessage(): SessionMessage = SessionMessage(
     session = fakeSession()
+)
+
+internal fun fakeV1EndedSessionMessage(): SessionMessage = SessionMessage(
+    session = fakeSession().copy(endTime = 160000500000L),
+    spans = listOfNotNull(testSpan),
+    spanSnapshots = listOfNotNull(),
+)
+
+internal fun fakeV1EndedSessionMessageWithSnapshot(): SessionMessage = SessionMessage(
+    session = fakeSession().copy(
+        sessionId = "fakeSessionWithSnapshot",
+        startTime = 161000000000L,
+        endTime = 161000400000L
+    ),
+    spans = listOfNotNull(testSpan),
+    spanSnapshots = listOfNotNull(FakePersistableEmbraceSpan.started().snapshot()),
 )
 
 internal fun fakeV2SessionMessage(): SessionMessage = SessionMessage(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.fixtures
 
 import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -37,6 +39,18 @@ internal val testSpan = EmbraceSpanData(
     )
 )
 
+internal val testSpanSnapshot = Span(
+    traceId = "snapshot-trace-id",
+    spanId = "snapshot-span-id",
+    parentSpanId = null,
+    name = "snapshot",
+    startTimeUnixNano = DEFAULT_FAKE_CURRENT_TIME,
+    endTimeUnixNano = null,
+    status = Span.Status.UNSET,
+    events = emptyList(),
+    attributes = emptyList()
+)
+
 private fun createMapOfSize(size: Int): Map<String, String> {
     val mutableMap = mutableMapOf<String, String>()
     repeat(size) {
@@ -44,6 +58,7 @@ private fun createMapOfSize(size: Int): Map<String, String> {
     }
     return mutableMap
 }
+
 private fun createEventsListOfSize(size: Int): List<EmbraceSpanEvent> {
     val events = mutableListOf<EmbraceSpanEvent>()
     repeat(size) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
@@ -4,10 +4,9 @@ import com.squareup.moshi.JsonDataException
 import io.embrace.android.embracesdk.assertJsonMatchesGoldenFile
 import io.embrace.android.embracesdk.deserializeEmptyJsonString
 import io.embrace.android.embracesdk.deserializeJsonFromResource
-import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.fakeSession
+import io.embrace.android.embracesdk.fixtures.testSpanSnapshot
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -38,19 +37,8 @@ internal class SessionMessageTest {
             emptyList()
         )
     )
-    private val spanSnapshots = listOfNotNull(
-        Span(
-            traceId = "snapshot-trace-id",
-            spanId = "snapshot-span-id",
-            parentSpanId = null,
-            name = "snapshot",
-            startTimeUnixNano = DEFAULT_FAKE_CURRENT_TIME,
-            endTimeUnixNano = null,
-            status = Span.Status.UNSET,
-            events = emptyList(),
-            attributes = emptyList()
-        )
-    )
+
+    private val spanSnapshots = listOfNotNull(testSpanSnapshot)
 
     private val info = SessionMessage(
         session,


### PR DESCRIPTION
## Goal

Convert snap snapshots found in cached sessions found at SDK startup to failed spans. This ensures that the session span with all the telemetry that will be stored it will always be delivered even if the app process terminates before we could end it.

## Testing

Added tests in various layers to cover this. Codecov doesn't like how much test coverage I added because of the nullability of the new Span payload object and I didn't test those null case. Ah well.

An integration test will be added later that tests the case when the session span terminates. Stay tuned.
