### PR TITLE
Relax assertions on ANR functional test

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/AnrIntegrationTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/AnrIntegrationTest.kt
@@ -98,9 +98,9 @@ internal class AnrIntegrationTest : BaseTest() {
         // validate each interval contains the fields we would expect
         intervals.forEachIndexed { _, interval ->
             assertNotNull(interval.startTime)
-            assertNull(interval.lastKnownTime)
-            assertNotNull(interval.endTime)
-            assertTrue(checkNotNull(interval.endTime) > checkNotNull(interval.startTime))
+            interval.endTime?.let { endTime ->
+                assertTrue(endTime > checkNotNull(interval.startTime))
+            }
             assertEquals(AnrInterval.Type.UI, interval.type)
             assertNotNull(interval.code)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
@@ -38,7 +38,7 @@ internal class EmbraceNativeThreadSamplerService @JvmOverloads constructor(
         fun setupNativeThreadSampler(is32Bit: Boolean): Boolean
         fun monitorCurrentThread(): Boolean
         fun startSampling(unwinderOrdinal: Int, intervalMs: Long)
-        fun finishSampling(): List<NativeThreadAnrSample>?
+        fun finishSampling(): List<NativeThreadAnrSample>? // TODO: call this when entering bg!
     }
 
     internal var ignored = true


### PR DESCRIPTION
## Goal

Relaxes assertions on the ANR functional test as we can't guarantee that the last ANR interval has always ended (if emulator performance is poor). Therefore don't assert the end time/last known time to avoid test failures [like this](https://github.com/embrace-io/embrace-android-sdk/actions/runs/8392459359/job/22985149740?pr=613#step:8:486).

