### PR TITLE
Send exceptions as events even if OTel logs are enabled

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
@@ -62,9 +62,12 @@ internal class CompositeLogService(
                     properties
                 )
             } else {
-                v2LogService.logException(
+                // Currently, the backend is not processing exceptions as OTel logs, so we must
+                // use v1. When the backend is ready, this must be replaced with a call
+                // to v2LogService.logException().
+                v1LogService.log(
                     message = message,
-                    severity = severity,
+                    type = type,
                     logExceptionType = logExceptionType,
                     properties = properties,
                     stackTraceElements = stackTraceElements,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
@@ -112,8 +112,10 @@ internal class CompositeLogServiceTest {
             exceptionName = null,
             exceptionMessage = null
         )
-        assertEquals(0, v1LogService.loggedMessages.size)
-        assertEquals(1, v2LogService.loggedExceptions.size)
+        // Currently, log exceptions must be sent through v1. Invert this validation once
+        // the backend can read exceptions sent as OTel logs
+        assertEquals(1, v1LogService.loggedMessages.size)
+        assertEquals(0, v2LogService.loggedExceptions.size)
     }
 
     @Test


### PR DESCRIPTION
## Goal

The backend is not processing exceptions as OTel logs yet, so send them as events even if the new payload remote config is enabled.

