### PR TITLE
Fix the log ids that are defined in the session payload for OTel logs.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -137,7 +137,7 @@ internal class EmbraceLogService(
             // Set these after the custom properties so they can't be overridden
             sessionIdTracker.getActiveSessionId()?.let { attributes.setSessionId(it) }
             metadataService.getAppState()?.let { attributes.setAppState(it) }
-            attributes.setLogId(Uuid.getEmbUuid())
+            attributes.setLogId(messageId)
 
             val logEventData = LogEventData(
                 schemaType = SchemaType.Log(attributes),


### PR DESCRIPTION
## Goal

- The logId referenced in the session payload for the fields `il, el, wl` was not the correct logId of the logs v2.
- Updated to use the same log id. 

## Testing

Relied on existing unit tests. 

