### PR TITLE
Create a clean instance of the mock server so function tests don't bleed over

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/internal/TestServer.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/internal/TestServer.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.internal
 
 import io.embrace.android.embracesdk.EmbraceEndpoint
-import java.net.HttpURLConnection
-import java.util.concurrent.TimeUnit
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import java.net.HttpURLConnection
+import java.util.concurrent.TimeUnit
 
 /**
  * Mock network response to be delivered when calling an endpoint.
@@ -38,6 +38,7 @@ public class TestServer {
     }
 
     public fun stop() {
+        mockWebServer.dispatcher.shutdown()
         mockWebServer.shutdown()
     }
 


### PR DESCRIPTION
## Goal

This is why I need to delete that friggin static logger: now the internal errors won't bleed over between functional test cases so those tests won't flake. HALLELUJAH!!!

I had to tweak some of the test clean up as well but that damn logger was the main blocker.

## Testing

Functional tests won't flake after this.

