### PR TITLE
Avoid capturing build ID

### DIFF
--- a/embrace-android-sdk/src/main/cpp/file_writer.c
+++ b/embrace-android-sdk/src/main/cpp/file_writer.c
@@ -321,7 +321,6 @@ bool emb_add_frame_info_to_json(JSON_Object *frame_object, emb_sframe *frame) {/
     RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kOffsetAddrKey, frame->offset_addr));
     RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kModuleAddrKey, frame->module_addr));
     RETURN_ON_JSON_FAILURE(json_object_set_number(frame_object, kLineNumKey, frame->line_num));
-    RETURN_ON_JSON_FAILURE(json_object_set_string(frame_object, kBuildIdKey, frame->build_id));
     return true;
 }
 

--- a/embrace-android-sdk/src/main/cpp/unwinders/unwinder_stack.cpp
+++ b/embrace-android-sdk/src/main/cpp/unwinders/unwinder_stack.cpp
@@ -42,7 +42,6 @@ emb_process_stack(emb_env *env, siginfo_t *info, void *user_context) {
 
             data->frame_addr = frame.pc;
             const auto map_info = frame.map_info;
-            emb_strncpy(data->build_id, map_info->GetPrintableBuildID().c_str(), EMB_FRAME_STR_SIZE);
 
             // populate additional information.
             // FrameData
@@ -61,7 +60,6 @@ emb_process_stack(emb_env *env, siginfo_t *info, void *user_context) {
             data->offset = map_info->offset();
             data->flags = map_info->flags();
             emb_strncpy(data->full_name, map_info->GetFullName().c_str(), EMB_FRAME_STR_SIZE);
-            emb_strncpy(data->build_id, map_info->GetPrintableBuildID().c_str(), EMB_FRAME_STR_SIZE);
         }
     } else {
         return 0;


### PR DESCRIPTION
## Goal

Avoids capturing the build ID of the SO file for each stackframe as this function is not async safe & is currently unused by our backend.

