### PR TITLE
Include spanId and traceId in OTel logs only if valid.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/LogMapper.kt
@@ -3,15 +3,18 @@ package io.embrace.android.embracesdk.internal.payload
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.logs.data.LogRecordData
 
-internal fun LogRecordData.toNewPayload(): Log = Log(
-    traceId = spanContext.traceId,
-    spanId = spanContext.spanId,
-    timeUnixNano = observedTimestampEpochNanos,
-    severityNumber = severity.severityNumber,
-    severityText = severityText,
-    body = body.asString(),
-    attributes = attributes.toNewPayload()
-)
+internal fun LogRecordData.toNewPayload(): Log {
+    val isSpanContextValid = spanContext.isValid
+    return Log(
+        traceId = if (isSpanContextValid) spanContext.traceId else null,
+        spanId = if (isSpanContextValid) spanContext.spanId else null,
+        timeUnixNano = observedTimestampEpochNanos,
+        severityNumber = severity.severityNumber,
+        severityText = severityText,
+        body = body.asString(),
+        attributes = attributes.toNewPayload()
+    )
+}
 
 internal fun Attributes.toNewPayload(): List<Attribute> =
     this.asMap().entries.map { Attribute(it.key.key, it.value.toString()) }


### PR DESCRIPTION
## Goal

- Even when doesn't apply we were sending spanId and traceId in this way
```
        "span_id": "0000000000000000",
        "trace_id": "00000000000000000000000000000000"
```
which is the INVALID value. 
- As these are optional in the Log Model, it's better not to set anything to them. 

## Testing

Relied on existing unit tests. 



