### PR TITLE
Tweak SchemaType to consolidate logic for creating attributes

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/CustomBreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/CustomBreadcrumbFeatureTest.kt
@@ -2,14 +2,10 @@ package io.embrace.android.embracesdk.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.arch.schema.SchemaKeys
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName
 import io.embrace.android.embracesdk.findEvent
 import io.embrace.android.embracesdk.findSessionSpan
-import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
-import io.embrace.android.embracesdk.verifySessionHappened
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -28,7 +24,7 @@ internal class CustomBreadcrumbFeatureTest {
             val message = checkNotNull(harness.recordSession {
                 embrace.addBreadcrumb("Hello, world!")
             })
-            val breadcrumb = message.findSessionSpan().findEvent(SchemaKeys.CUSTOM_BREADCRUMB)
+            val breadcrumb = message.findSessionSpan().findEvent(SchemaDefaultName.CUSTOM_BREADCRUMB)
             assertEquals("Hello, world!", breadcrumb.attributes["message"])
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/FragmentBreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/FragmentBreadcrumbFeatureTest.kt
@@ -2,9 +2,10 @@ package io.embrace.android.embracesdk.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.arch.schema.SchemaKeys
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName
 import io.embrace.android.embracesdk.findSpanAttribute
 import io.embrace.android.embracesdk.findSpans
+import io.embrace.android.embracesdk.internal.spans.toEmbraceObjectName
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -32,7 +33,7 @@ internal class FragmentBreadcrumbFeatureTest {
                 embrace.endView("AnotherView")
             })
 
-            val fragmentBreadcrumbs = message.findSpans("emb-${SchemaKeys.VIEW_BREADCRUMB}")
+            val fragmentBreadcrumbs = message.findSpans(SchemaDefaultName.VIEW_BREADCRUMB.toEmbraceObjectName())
             assertEquals(2, fragmentBreadcrumbs.size)
 
             val breadcrumb1 = fragmentBreadcrumbs[0]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
@@ -39,9 +39,12 @@ internal interface SpanDataSource : DataSource<SpanService> {
  */
 internal fun <T> SpanService.startSpanCapture(obj: T, mapper: T.() -> StartSpanData): EmbraceSpan? {
     val data = obj.mapper()
-    return createSpan(data.schemaType.name)?.apply {
-        start()
-        data.attributes.forEach {
+    return startSpan(
+        name = data.schemaType.defaultName,
+        type = data.schemaType.telemetryType,
+        startTimeMs = data.spanStartTimeMs
+    )?.apply {
+        data.schemaType.attributes().forEach {
             addAttribute(it.key, it.value)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogEventData.kt
@@ -16,6 +16,4 @@ internal class LogEventData(
     val schemaType: SchemaType,
     val severity: Severity,
     val message: String
-) {
-    val attributes = schemaType.attrs.plus(schemaType.telemetryType.toOTelKeyValuePair())
-}
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -15,7 +15,7 @@ internal class LogWriterImpl(private val logger: Logger) : LogWriter {
             .setSeverity(logEventData.severity.toOtelSeverity())
             .setSeverityText(logEventData.severity.name)
 
-        logEventData.attributes.forEach {
+        logEventData.schemaType.attributes().forEach {
             builder.setAttribute(AttributeKey.stringKey(it.key), it.value)
         }
         builder.emit()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanEventData.kt
@@ -12,6 +12,4 @@ import io.embrace.android.embracesdk.arch.schema.SchemaType
 internal class SpanEventData(
     val schemaType: SchemaType,
     val spanStartTimeMs: Long
-) {
-    val attributes = schemaType.attrs.plus(schemaType.telemetryType.toOTelKeyValuePair())
-}
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/StartSpanData.kt
@@ -12,6 +12,4 @@ import io.embrace.android.embracesdk.arch.schema.SchemaType
 internal class StartSpanData(
     val schemaType: SchemaType,
     val spanStartTimeMs: Long,
-) {
-    val attributes = schemaType.attrs.plus(schemaType.telemetryType.toOTelKeyValuePair())
-}
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -1,25 +1,29 @@
 package io.embrace.android.embracesdk.arch.schema
 
-import io.embrace.android.embracesdk.arch.schema.SchemaKeys.AEI_RECORD
-import io.embrace.android.embracesdk.arch.schema.SchemaKeys.CUSTOM_BREADCRUMB
-import io.embrace.android.embracesdk.arch.schema.SchemaKeys.LOG
-import io.embrace.android.embracesdk.arch.schema.SchemaKeys.VIEW_BREADCRUMB
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.AEI_RECORD
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.CUSTOM_BREADCRUMB
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.LOG
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.VIEW_BREADCRUMB
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogAttributes
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 
-internal object SchemaKeys {
-    internal const val CUSTOM_BREADCRUMB = "emb-custom-breadcrumb"
-    internal const val VIEW_BREADCRUMB = "screen-view"
-    internal const val AEI_RECORD = "aei-record"
-    internal const val LOG = "emb-log"
-}
-
+/**
+ * The collections of attribute schemas used by the associated telemetry types.
+ *
+ * Each schema contains a [TelemetryType] that it is being applied to, as well as a [defaultName] used for the generated
+ * telemetry data object if a fixed one is being used.
+ */
 internal sealed class SchemaType(
     val telemetryType: TelemetryType,
-    val name: String,
+    val defaultName: String,
 ) {
-    abstract val attrs: Map<String, String>
+    protected abstract val attrs: Map<String, String>
+
+    /**
+     * The attributes defined fo this schema that should be used to populate telemetry objects
+     */
+    fun attributes(): Map<String, String> = attrs.plus(telemetryType.toOTelKeyValuePair())
 
     internal class CustomBreadcrumb(message: String) : SchemaType(
         EmbType.System.Breadcrumb,
@@ -59,4 +63,14 @@ internal sealed class SchemaType(
     ) {
         override val attrs = attributes.toMap()
     }
+}
+
+/**
+ * Note: Spans marked as internal will always be prefixed with "emb-", so the default name doesn't need to add this.
+ */
+internal object SchemaDefaultName {
+    internal const val CUSTOM_BREADCRUMB = "emb-custom-breadcrumb"
+    internal const val VIEW_BREADCRUMB = "screen-view"
+    internal const val AEI_RECORD = "emb-aei-record"
+    internal const val LOG = "emb-log"
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.EventDescription
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.SpanService
-import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanName
+import io.embrace.android.embracesdk.internal.spans.toEmbraceObjectName
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
@@ -279,7 +279,7 @@ internal class EmbraceEventService(
 
     companion object {
         const val STARTUP_EVENT_NAME = "_startup"
-        private val STARTUP_SPAN_NAME = "startup-moment".toEmbraceSpanName()
+        private val STARTUP_SPAN_NAME = "startup-moment".toEmbraceObjectName()
 
         internal fun getInternalEventKey(eventName: String, identifier: String?): String =
             when (identifier) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
@@ -1,8 +1,9 @@
 package io.embrace.android.embracesdk.gating
 
-import io.embrace.android.embracesdk.arch.schema.SchemaKeys
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.BREADCRUMBS_CUSTOM
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 internal class SpanSanitizer(
@@ -38,17 +39,11 @@ internal class SpanSanitizer(
     }
 
     private fun sanitizeSpans(span: EmbraceSpanData): Boolean {
-        if (span.name == "emb-${SchemaKeys.VIEW_BREADCRUMB}" && !shouldAddViewBreadcrumbs()) {
-            return false
-        }
-        return true
+        return !(span.hasEmbraceAttribute(EmbType.Ux.View) && !shouldAddViewBreadcrumbs())
     }
 
     private fun sanitizeEvents(event: EmbraceSpanEvent): Boolean {
-        if (event.name == SchemaKeys.CUSTOM_BREADCRUMB && !shouldAddCustomBreadcrumbs()) {
-            return false
-        }
-        return true
+        return !(event.hasEmbraceAttribute(EmbType.System.Breadcrumb) && !shouldAddCustomBreadcrumbs())
     }
 
     private fun shouldAddCustomBreadcrumbs() = enabledComponents.contains(BREADCRUMBS_CUSTOM)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -95,7 +95,7 @@ internal class CurrentSessionSpanImpl(
     override fun <T> addEvent(obj: T, mapper: T.() -> SpanEventData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
         val event = obj.mapper()
-        return currentSession.addEvent(event.schemaType.name, event.spanStartTimeMs, event.attributes)
+        return currentSession.addEvent(event.schemaType.defaultName, event.spanStartTimeMs, event.schemaType.attributes())
     }
 
     override fun addAttribute(attribute: SpanAttributeData): Boolean {
@@ -109,7 +109,7 @@ internal class CurrentSessionSpanImpl(
     private fun startSessionSpan(startTimeMs: Long): EmbraceSpan {
         traceCount.set(0)
 
-        val spanName = "session".toEmbraceSpanName()
+        val spanName = "session".toEmbraceObjectName()
         return EmbraceSpanImpl(
             spanName = spanName,
             openTelemetryClock = openTelemetryClock,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Prefix added to [Span] names for all Spans recorded internally by the SDK
  */
-private const val EMBRACE_SPAN_NAME_PREFIX = "emb-"
+private const val EMBRACE_OBJECT_NAME_PREFIX = "emb-"
 
 /**
  * Prefix added to all [Span] attribute keys for all attributes added by the SDK
@@ -118,9 +118,9 @@ internal fun AttributesBuilder.fromMap(attributes: Map<String, String>): Attribu
 }
 
 /**
- * Return the appropriate internal Embrace Span name given the current value
+ * Return the appropriate name used for telemetry created by Embrace given the current value
  */
-internal fun String.toEmbraceSpanName(): String = EMBRACE_SPAN_NAME_PREFIX + this
+internal fun String.toEmbraceObjectName(): String = EMBRACE_OBJECT_NAME_PREFIX + this
 
 /**
  * Return the appropriate internal Embrace attribute name given the current string
@@ -131,6 +131,12 @@ internal fun String.toEmbraceAttributeName(): String = EMBRACE_ATTRIBUTE_NAME_PR
  * Return the appropriate internal Embrace attribute usage name given the current string
  */
 internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX + this
+
+internal fun EmbraceSpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
+    embraceAttribute.attributeValue == attributes[embraceAttribute.otelAttributeName()]
+
+internal fun EmbraceSpanEvent.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
+    embraceAttribute.attributeValue == attributes[embraceAttribute.otelAttributeName()]
 
 internal fun Map<String, String>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
     this[embraceAttribute.otelAttributeName()] == embraceAttribute.attributeValue

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -112,7 +112,7 @@ internal class SpanServiceImpl(
 
     private fun getSpanName(name: String, internal: Boolean): String =
         if (internal) {
-            name.toEmbraceSpanName()
+            name.toEmbraceObjectName()
         } else {
             name
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -39,7 +40,7 @@ internal fun EmbraceSpanData.assertNotPrivateSpan() = assertDoesNotHaveEmbraceAt
  * Assert [EmbraceSpanData] has the [EmbraceAttribute] defined by [embraceAttribute]
  */
 internal fun EmbraceSpanData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertEquals(embraceAttribute.attributeValue, attributes[embraceAttribute.otelAttributeName()])
+    assertTrue(hasEmbraceAttribute(embraceAttribute))
 }
 
 internal fun EmbraceSpanData.assertDoesNotHaveEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
@@ -101,7 +102,7 @@ internal fun StartSpanData.assertIsType(telemetryType: TelemetryType) = assertHa
  * Assert [StartSpanData] has the [EmbraceAttribute] defined by [embraceAttribute]
  */
 internal fun StartSpanData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertEquals(embraceAttribute.attributeValue, attributes[embraceAttribute.otelAttributeName()])
+    assertEquals(embraceAttribute.attributeValue, schemaType.attributes()[embraceAttribute.otelAttributeName()])
 }
 
 /**
@@ -113,5 +114,5 @@ internal fun LogEventData.assertIsType(telemetryType: TelemetryType) = assertHas
  * Assert [LogEventData] has the [EmbraceAttribute] defined by [embraceAttribute]
  */
 internal fun LogEventData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertEquals(embraceAttribute.attributeValue, attributes[embraceAttribute.otelAttributeName()])
+    assertEquals(embraceAttribute.attributeValue, schemaType.attributes()[embraceAttribute.otelAttributeName()])
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -27,7 +27,7 @@ internal class SpanDataSourceKtTest {
             1500000000000
         )
         data.assertIsType(EmbType.Ux.View)
-        assertEquals("my-view", data.attributes["view.name"])
+        assertEquals("my-view", data.schemaType.attributes()["view.name"])
 
         val span = service.startSpanCapture("") { data }
         checkNotNull(span)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
@@ -363,9 +363,9 @@ internal class AeiDataSourceImplTest {
 
     private fun getAeiLogAttrs(): Map<String, String> {
         val logEventData = logWriter.logEvents.single()
-        assertEquals("aei-record", logEventData.schemaType.name)
+        assertEquals("emb-aei-record", logEventData.schemaType.defaultName)
         assertEquals(Severity.INFO, logEventData.severity)
         logEventData.assertIsType(EmbType.System.Exit)
-        return logEventData.attributes
+        return logEventData.schemaType.attributes()
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -34,14 +34,14 @@ internal class CustomBreadcrumbDataSourceTest {
     fun `add breadcrumb`() {
         source.logCustom("Hello, world!", 15000000000)
         with(writer.addedEvents.single()) {
-            assertEquals("emb-custom-breadcrumb", this.schemaType.name)
+            assertEquals("emb-custom-breadcrumb", schemaType.defaultName)
             assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
             assertEquals(
                 mapOf(
                     EmbType.System.Breadcrumb.toOTelKeyValuePair(),
                     "message" to "Hello, world!"
                 ),
-                attributes
+                schemaType.attributes()
             )
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
@@ -36,8 +36,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         dataSource.startFragment("my_fragment")
 
         val span = spanService.createdSpans.single()
-        assertEquals("screen-view", span.name)
-        assertEquals(EmbType.Performance.Default, span.type)
+        assertEquals(EmbType.Ux.View, span.type)
         assertTrue(span.isRecording)
         assertEquals(
             mapOf(
@@ -55,8 +54,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         dataSource.endFragment("my_fragment")
 
         val span = spanService.createdSpans.single()
-        assertEquals("screen-view", span.name)
-        assertEquals(EmbType.Performance.Default, span.type)
+        assertEquals(EmbType.Ux.View, span.type)
         assertFalse(span.isRecording)
         assertEquals(
             mapOf(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -118,7 +118,7 @@ internal class FakePersistableEmbraceSpan(
             schemaType = SchemaType.CustomBreadcrumb(name),
             spanStartTimeMs = timestampMs ?: fakeClock.now()
         )
-        addEvent(customBreadcrumb.schemaType.name, customBreadcrumb.spanStartTimeMs, attributes)
+        addEvent(customBreadcrumb.schemaType.defaultName, customBreadcrumb.spanStartTimeMs, attributes)
     }
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -96,24 +96,24 @@ internal class EmbraceLogServiceTest {
         val first = logs[0]
         assertEquals("Hello world", first.message)
         assertEquals(Severity.INFO, first.severity)
-        assertEquals("bar", first.attributes["foo"])
-        assertNotNull(first.attributes["emb.log_id"])
-        assertEquals("session-123", first.attributes["emb.session_id"])
-        assertNull(first.attributes["emb.exception_type"])
+        assertEquals("bar", first.schemaType.attributes()["foo"])
+        assertNotNull(first.schemaType.attributes()["emb.log_id"])
+        assertEquals("session-123", first.schemaType.attributes()["emb.session_id"])
+        assertNull(first.schemaType.attributes()["emb.exception_type"])
 
         val second = logs[1]
         assertEquals("Warning world", second.message)
         assertEquals(Severity.WARNING, second.severity)
-        assertNotNull(second.attributes["emb.log_id"])
-        assertEquals("session-123", second.attributes["emb.session_id"])
-        assertNull(second.attributes["emb.exception_type"])
+        assertNotNull(second.schemaType.attributes()["emb.log_id"])
+        assertEquals("session-123", second.schemaType.attributes()["emb.session_id"])
+        assertNull(second.schemaType.attributes()["emb.exception_type"])
 
         val third = logs[2]
         assertEquals("Hello errors", third.message)
         assertEquals(Severity.ERROR, third.severity)
-        assertNotNull(third.attributes["emb.log_id"])
-        assertEquals("session-123", third.attributes["emb.session_id"])
-        assertNull(third.attributes["emb.exception_type"])
+        assertNotNull(third.schemaType.attributes()["emb.log_id"])
+        assertEquals("session-123", third.schemaType.attributes()["emb.session_id"])
+        assertNull(third.schemaType.attributes()["emb.exception_type"])
         third.assertIsType(EmbType.System.Log)
     }
 
@@ -140,12 +140,12 @@ internal class EmbraceLogServiceTest {
         assertEquals(0, logService.getUnhandledExceptionsSent())
         assertEquals("Hello world", log.message)
         assertEquals(Severity.WARNING, log.severity)
-        assertEquals("NullPointerException", log.attributes["emb.exception_name"])
-        assertEquals("exception message", log.attributes["emb.exception_message"])
-        assertEquals(AppFramework.NATIVE.value.toString(), log.attributes["emb.app_framework"])
-        assertNotNull(log.attributes["emb.log_id"])
-        assertEquals("session-123", log.attributes["emb.session_id"])
-        assertEquals(LogExceptionType.HANDLED.value, log.attributes["emb.exception_type"])
+        assertEquals("NullPointerException", log.schemaType.attributes()["emb.exception_name"])
+        assertEquals("exception message", log.schemaType.attributes()["emb.exception_message"])
+        assertEquals(AppFramework.NATIVE.value.toString(), log.schemaType.attributes()["emb.app_framework"])
+        assertNotNull(log.schemaType.attributes()["emb.log_id"])
+        assertEquals("session-123", log.schemaType.attributes()["emb.session_id"])
+        assertEquals(LogExceptionType.HANDLED.value, log.schemaType.attributes()["emb.exception_type"])
         log.assertIsType(EmbType.System.Log)
     }
 
@@ -172,12 +172,12 @@ internal class EmbraceLogServiceTest {
         assertEquals(1, logService.getUnhandledExceptionsSent())
         assertEquals("Hello world", log.message)
         assertEquals(Severity.WARNING, log.severity)
-        assertEquals("NullPointerException", log.attributes["emb.exception_name"])
-        assertEquals("exception message", log.attributes["emb.exception_message"])
-        assertEquals(AppFramework.UNITY.value.toString(), log.attributes["emb.app_framework"])
-        assertNotNull(log.attributes["emb.log_id"])
-        assertEquals("session-123", log.attributes["emb.session_id"])
-        assertEquals(LogExceptionType.UNHANDLED.value, log.attributes["emb.exception_type"])
+        assertEquals("NullPointerException", log.schemaType.attributes()["emb.exception_name"])
+        assertEquals("exception message", log.schemaType.attributes()["emb.exception_message"])
+        assertEquals(AppFramework.UNITY.value.toString(), log.schemaType.attributes()["emb.app_framework"])
+        assertNotNull(log.schemaType.attributes()["emb.log_id"])
+        assertEquals("session-123", log.schemaType.attributes()["emb.session_id"])
+        assertEquals(LogExceptionType.UNHANDLED.value, log.schemaType.attributes()["emb.exception_type"])
         log.assertIsType(EmbType.System.Log)
     }
 
@@ -189,8 +189,8 @@ internal class EmbraceLogServiceTest {
         logService.log("Hello world", Severity.INFO, null)
 
         val log = logWriter.logEvents.single()
-        assertEquals("session_val_1", log.attributes["emb.properties.session_prop_1"])
-        assertEquals("session_val_2", log.attributes["emb.properties.session_prop_2"])
+        assertEquals("session_val_1", log.schemaType.attributes()["emb.properties.session_prop_1"])
+        assertEquals("session_val_2", log.schemaType.attributes()["emb.properties.session_prop_2"])
     }
 
     @Test
@@ -202,8 +202,8 @@ internal class EmbraceLogServiceTest {
         val log = logWriter.logEvents.single()
         assertEquals("Hello world", log.message)
         assertEquals(Severity.INFO, log.severity)
-        assertNotNull(log.attributes["emb.log_id"])
-        assertEquals("session-123", log.attributes["emb.session_id"])
+        assertNotNull(log.schemaType.attributes()["emb.log_id"])
+        assertEquals("session-123", log.schemaType.attributes()["emb.session_id"])
     }
 
     @Test
@@ -296,8 +296,8 @@ internal class EmbraceLogServiceTest {
         val log = logWriter.logEvents.single()
         assertEquals("Unity".repeat(1000), log.message) // log limit higher on unity
         // TBD: Assert stacktrace
-        assertEquals(AppFramework.UNITY.value.toString(), log.attributes["emb.app_framework"])
-        assertEquals(LogExceptionType.HANDLED.value, log.attributes["emb.exception_type"])
+        assertEquals(AppFramework.UNITY.value.toString(), log.schemaType.attributes()["emb.app_framework"])
+        assertEquals(LogExceptionType.HANDLED.value, log.schemaType.attributes()["emb.exception_type"])
         // TBD: Assert unhandled exceptions
         // assertEquals(0, logMessageService.getUnhandledExceptionsSent())
     }


### PR DESCRIPTION
## Goal

Add functionality to SchemaType so data capture services and the infra around adding telemetry can leverage that solely to populate objects. After this change, calling `attributes()` on SchemaType will return all attributes that are specific to this schema, including the `emb.type` the schema is associated with.

## Testing

Modified existing tests to ensure things work and changed some to leverage the new testing infra.