### PR TITLE
Add tests for emb_unwind_dlinfo

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/sampler/UnwinderDlinfoTestSuite.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/sampler/UnwinderDlinfoTestSuite.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.ndk.sampler
+
+import io.embrace.android.embracesdk.ndk.NativeTestSuite
+import org.junit.Test
+
+internal class UnwinderDlinfoTestSuite: NativeTestSuite() {
+
+    external fun run(): Int
+
+    @Test
+    fun testUnwinderDlinfo() = runNativeTestSuite(::run)
+}

--- a/embrace-android-sdk/src/main/cpp/sampler/stacktrace_sampler_jni.c
+++ b/embrace-android-sdk/src/main/cpp/sampler/stacktrace_sampler_jni.c
@@ -4,6 +4,7 @@
 #include "../utils/utilities.h"
 #include "../safejni/safe_jni.h"
 #include "../utils/emb_log.h"
+#include "../utils/string_utils.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -141,10 +142,6 @@ static bool init_jni_cache(JNIEnv *env) {
     return cache->initialized;
 }
 
-void convert_to_hex_addr(uint64_t addr, char *buffer) {
-    snprintf(buffer, kEMBSampleAddrLen, "0x%lx", (unsigned long) addr);
-}
-
 static bool add_element_to_sample_list(JNIEnv *env, emb_sample *sample,
                                        jobject frames, int index) {
     bool success = false;
@@ -153,8 +150,8 @@ static bool add_element_to_sample_list(JNIEnv *env, emb_sample *sample,
     // convert pointers to hex addresses.
     char pc_buf[kEMBSampleAddrLen] = {0};
     char load_buf[kEMBSampleAddrLen] = {0};
-    convert_to_hex_addr(frame->pc, pc_buf);
-    convert_to_hex_addr(frame->so_load_addr, load_buf);
+    emb_convert_to_hex_addr(frame->pc, pc_buf);
+    emb_convert_to_hex_addr(frame->so_load_addr, load_buf);
 
     jstring pc = NULL;
     jstring so_load_addr = NULL;

--- a/embrace-android-sdk/src/main/cpp/sampler/unwinder_dlinfo.c
+++ b/embrace-android-sdk/src/main/cpp/sampler/unwinder_dlinfo.c
@@ -6,56 +6,7 @@
 #include "unwinder_dlinfo.h"
 #include "../utils/string_utils.h"
 
-// controls whether extra debug info is logged for development purposes
-#define EMB_LOG_DLADDR_INFO false
-
-void convert_to_hex_addr(uint64_t addr, char *buffer);
-
-static void emb_log_debug_info(uint64_t ip, size_t index, const emb_sample_stackframe *frame,
-                               const Dl_info *info, int result) {
-    char frame_buf[kEMBSampleAddrLen] = {0};
-    char symbol_buf[kEMBSampleAddrLen] = {0};
-    char load_buf[kEMBSampleAddrLen] = {0};
-
-    convert_to_hex_addr(frame->pc, frame_buf);
-    convert_to_hex_addr(frame->so_load_addr, load_buf);
-
-    // now get the symbol address (if it was set)
-    if (info->dli_saddr != NULL && info->dli_sname != NULL) {
-        convert_to_hex_addr((uint64_t) info->dli_saddr, symbol_buf);
-    }
-
-    if (result == 0) {
-        EMB_LOGINFO("Frame %d: the address %s could not be matched to a shared object.",
-                    (int) index, frame_buf);
-    } else {
-        if (info->dli_saddr == NULL && info->dli_sname == NULL) {
-            uint64_t base_addr = ip - (uint64_t) info->dli_fbase;
-            convert_to_hex_addr(base_addr, symbol_buf);
-
-            EMB_LOGINFO(
-                    "Frame %d: the address was matched to a shared object, "
-                    "but not a symbol within the shared object. so_path=%s, pc=%s, so_load_addr=%s, base_addr=%s",
-                    (int) index,
-                    frame->so_path,
-                    frame_buf,
-                    load_buf,
-                    symbol_buf
-            );
-        } else {
-            EMB_LOGINFO("Frame %d: %s %s, pc=%s, so_load_addr=%s, so_symbol_addr=%s",
-                        (int) index,
-                        frame->so_path,
-                        info->dli_sname,
-                        frame_buf,
-                        load_buf,
-                        symbol_buf
-            );
-        }
-    }
-}
-
-int emb_get_dlinfo_for_ip(uint64_t ip, size_t index, emb_sample_stackframe *frame) {
+int emb_get_dlinfo_for_ip(uint64_t ip, emb_sample_stackframe *frame) {
     size_t size = sizeof(Dl_info);
     Dl_info info = {0};
     memset(&info, 0, size);
@@ -71,21 +22,13 @@ int emb_get_dlinfo_for_ip(uint64_t ip, size_t index, emb_sample_stackframe *fram
             emb_strncpy((char *) frame->so_path, path, sizeof frame->so_path);
         }
     }
-
-#pragma clang diagnostic push
-#pragma ide diagnostic ignored "Simplify"
-    if (EMB_LOG_DLADDR_INFO) {
-        emb_log_debug_info(ip, index, frame, &info, result);
-    }
-#pragma clang diagnostic pop
-
     return result;
 }
 
 void emb_symbolicate_stacktrace(emb_sample *sample) {
     for (int k = 0; k < sample->num_sframes; k++) {
         emb_sample_stackframe *frame = &sample->stack[k];
-        emb_get_dlinfo_for_ip(frame->pc, k, frame);
+        emb_get_dlinfo_for_ip(frame->pc, frame);
     }
 }
 

--- a/embrace-android-sdk/src/main/cpp/sampler/unwinder_dlinfo.h
+++ b/embrace-android-sdk/src/main/cpp/sampler/unwinder_dlinfo.h
@@ -2,25 +2,11 @@
 #define EMBRACE_UNWINDER_DLINFO_H
 
 #include "sampler_unwinder_unwind.h"
+#include "../schema/unwind_state.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct {
-    uint64_t stack[kEMBSampleUnwindLimit]; // unwind up to 256, then copy everything to other struct.
-    uint16_t num_sframes;
-    uint8_t result;
-} emb_unwind_state;
-
-/**
- * Uses dladdr to get information on the shared object load address, symbol address, and path.
- * This information may not always be available.
- *
- * Returns the result from dladdr.
- * See: https://man7.org/linux/man-pages/man3/dladdr.3.html
- */
-int emb_get_dlinfo_for_ip(uint64_t ip, size_t index, emb_sample_stackframe *frame);
 
 /**
  * Uses dladdr to get information on the shared object load address, symbol address, and path

--- a/embrace-android-sdk/src/main/cpp/schema/unwind_state.h
+++ b/embrace-android-sdk/src/main/cpp/schema/unwind_state.h
@@ -1,0 +1,7 @@
+#include "stack_frames.h"
+
+typedef struct {
+    uint64_t stack[kEMBSampleUnwindLimit]; // unwind up to 256, then copy everything to other struct.
+    uint16_t num_sframes;
+    uint8_t result;
+} emb_unwind_state;

--- a/embrace-android-sdk/src/main/cpp/utils/string_utils.c
+++ b/embrace-android-sdk/src/main/cpp/utils/string_utils.c
@@ -1,4 +1,5 @@
 #include "string_utils.h"
+#include "../schema/stack_frames.h"
 
 void emb_strncpy(char *dst, const char *src, size_t len) {
     if (dst == NULL || src == NULL) {
@@ -13,4 +14,8 @@ void emb_strncpy(char *dst, const char *src, size_t len) {
         }
         i++;
     }
+}
+
+void emb_convert_to_hex_addr(uint64_t addr, char *buffer) {
+    snprintf(buffer, kEMBSampleAddrLen, "0x%lx", (unsigned long) addr);
 }

--- a/embrace-android-sdk/src/main/cpp/utils/string_utils.h
+++ b/embrace-android-sdk/src/main/cpp/utils/string_utils.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 void emb_strncpy(char *dst, const char *src, size_t len);
+void emb_convert_to_hex_addr(uint64_t addr, char *buffer);
 
 #ifdef __cplusplus
 }

--- a/embrace-android-sdk/src/test/cpp/CMakeLists.txt
+++ b/embrace-android-sdk/src/test/cpp/CMakeLists.txt
@@ -16,5 +16,6 @@ include_directories(
 add_library(embrace-native-test SHARED
         main.c
         testcases/utilities/test_string_utils.c
+        testcases/sampler/test_unwinder_dlinfo.c
 )
 target_link_libraries(embrace-native-test embrace-native)

--- a/embrace-android-sdk/src/test/cpp/main.c
+++ b/embrace-android-sdk/src/test/cpp/main.c
@@ -16,6 +16,7 @@ GREATEST_MAIN_DEFS();
 /* Forward declarations of test suites. These should live in separate files to avoid
  * bloating this file. */
 SUITE(suite_utilities);
+SUITE(suite_unwinder_dlinfo);
 
 /* Runs a suite of tests and returns 0 if they succeeded, 1 otherwise.*/
 int run_test_suite(void (*suite)(void)) {
@@ -31,4 +32,9 @@ int run_test_suite(void (*suite)(void)) {
 JNIEXPORT int JNICALL
 Java_io_embrace_android_embracesdk_ndk_utils_StringUtilsTestSuite_run(JNIEnv *_env, jobject _this) {
     return run_test_suite(suite_utilities);
+}
+
+JNIEXPORT int JNICALL
+Java_io_embrace_android_embracesdk_ndk_sampler_UnwinderDlinfoTestSuite_run(JNIEnv *_env, jobject _this) {
+    return run_test_suite(suite_unwinder_dlinfo);
 }

--- a/embrace-android-sdk/src/test/cpp/testcases/sampler/test_unwinder_dlinfo.c
+++ b/embrace-android-sdk/src/test/cpp/testcases/sampler/test_unwinder_dlinfo.c
@@ -1,0 +1,68 @@
+#include <stdlib.h>
+#include "greatest/greatest.h"
+#include "unwinder_dlinfo.h"
+#include "utilities.h"
+
+TEST empty_structs(void) {
+    emb_sample sample = {0};
+    emb_unwind_state unwind_state = {0};
+    emb_copy_frames(&sample, &unwind_state);
+    ASSERT_EQ(0, sample.result);
+    ASSERT_EQ(0, sample.num_sframes);
+    PASS();
+}
+
+TEST small_stacktrace(void) {
+    emb_sample sample = {0};
+    emb_unwind_state unwind_state = {0};
+    unwind_state.num_sframes = 3;
+
+    for (int k = 0; k < unwind_state.num_sframes; k++) {
+        unwind_state.stack[k] = k;
+    }
+    emb_copy_frames(&sample, &unwind_state);
+
+    ASSERT_EQ(0, sample.result);
+    ASSERT_EQ(3, sample.num_sframes);
+    for (int k = 0; k < unwind_state.num_sframes; k++) {
+        ASSERT_EQ(k, sample.stack[k].pc);
+    }
+    PASS();
+}
+
+TEST truncated_stacktrace(void) {
+    emb_sample sample = {0};
+    emb_unwind_state unwind_state = {0};
+    unwind_state.num_sframes = 200;
+
+    for (int k = 0; k < unwind_state.num_sframes; k++) {
+        unwind_state.stack[k] = k;
+    }
+    emb_copy_frames(&sample, &unwind_state);
+
+    ASSERT_EQ(EMB_ERROR_TRUNCATED_STACKTRACE, sample.result);
+    ASSERT_EQ(kEMBMaxSampleSFrames, sample.num_sframes);
+    for (int k = 0; k < sample.num_sframes; k++) {
+        ASSERT_EQ(k + 100, sample.stack[k].pc);
+    }
+    PASS();
+}
+
+TEST symbolicate_stacktrace(void) {
+    emb_sample sample = {0};
+    sample.num_sframes = 1;
+    sample.stack[0].pc = (uint64_t) &truncated_stacktrace;
+    emb_symbolicate_stacktrace(&sample);
+
+    ASSERT_NEQ(0, sample.stack[0].so_load_addr);
+    char *path = (char *) sample.stack[0].so_path;
+    ASSERT_NEQ(NULL, strstr(path, "libembrace-native-test.so"));
+    PASS();
+}
+
+SUITE(suite_unwinder_dlinfo) {
+    RUN_TEST(empty_structs);
+    RUN_TEST(small_stacktrace);
+    RUN_TEST(truncated_stacktrace);
+    RUN_TEST(symbolicate_stacktrace);
+}

--- a/embrace-android-sdk/src/test/cpp/testcases/utilities/test_string_utils.c
+++ b/embrace-android-sdk/src/test/cpp/testcases/utilities/test_string_utils.c
@@ -22,8 +22,16 @@ TEST string_null_dst(void) {
     PASS(); // don't crash on null
 }
 
+TEST convert_to_hex(void) {
+    char a[kEMBSampleAddrLen] = {0};
+    emb_convert_to_hex_addr(0x12345678, a);
+    ASSERT_STR_EQ(a, "0x12345678");
+    PASS();
+}
+
 SUITE(suite_utilities) {
     RUN_TEST(string_copy_success);
     RUN_TEST(string_null_src);
     RUN_TEST(string_null_dst);
+    RUN_TEST(convert_to_hex);
 }


### PR DESCRIPTION
## Goal

Adds unit tests for the `emb_unwind_dlinfo` source file that truncates a stacktrace & symbolicates it using `dladdr`. I have also removed some dead code & moved structs/functions into separate source files where appropriate.

