### PR TITLE
Add session properties to OTel Logs.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -74,12 +74,13 @@ internal class CustomerLogModuleImpl(
     private val v2LogService: LogService by singleton {
         EmbraceLogService(
             openTelemetryModule.logWriter,
-            initModule.clock,
             essentialServiceModule.metadataService,
             essentialServiceModule.configService,
             coreModule.appFramework,
             essentialServiceModule.sessionIdTracker,
-            workerThreadModule.backgroundWorker(WorkerName.REMOTE_LOGGING)
+            sessionProperties,
+            workerThreadModule.backgroundWorker(WorkerName.REMOTE_LOGGING),
+            initModule.clock,
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogAttributes.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogAttributes.kt
@@ -12,6 +12,11 @@ internal class EmbraceLogAttributes(properties: Map<String, Any>?) {
         private const val EMBRACE_ATTRIBUTE_NAME_PREFIX = "emb."
 
         /**
+         * Prefix added to all attribute keys for all session properties added by the SDK
+         */
+        private const val SESSION_PROPERTIES_NAME_PREFIX = EMBRACE_ATTRIBUTE_NAME_PREFIX + "properties."
+
+        /**
          * Attribute name for the application state (foreground/background) at the time the log was recorded
          */
         private const val APP_STATE_ATTRIBUTE_NAME = EMBRACE_ATTRIBUTE_NAME_PREFIX + "state"
@@ -70,6 +75,15 @@ internal class EmbraceLogAttributes(properties: Map<String, Any>?) {
         // Currently the backend only supports string attributes for logs
         properties?.forEach {
             attributes[it.key] = it.value.toString()
+        }
+    }
+
+    /**
+     * Add session properties as attributes to the log
+     */
+    fun setSessionProperties(sessionProperties: Map<String, String>) {
+        sessionProperties.forEach {
+            attributes["$SESSION_PROPERTIES_NAME_PREFIX${it.key}"] = it.value
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logWarning
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.util.NavigableMap
 import java.util.concurrent.ConcurrentSkipListMap
@@ -24,12 +25,13 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 internal class EmbraceLogService(
     private val logWriter: LogWriter,
-    private val clock: Clock,
     private val metadataService: MetadataService,
     private val configService: ConfigService,
     private val appFramework: AppFramework,
     private val sessionIdTracker: SessionIdTracker,
-    private val backgroundWorker: BackgroundWorker
+    private val sessionProperties: EmbraceSessionProperties,
+    private val backgroundWorker: BackgroundWorker,
+    clock: Clock,
 ) : LogService {
 
     private val logCounters = mapOf(
@@ -138,6 +140,7 @@ internal class EmbraceLogService(
             sessionIdTracker.getActiveSessionId()?.let { attributes.setSessionId(it) }
             metadataService.getAppState()?.let { attributes.setAppState(it) }
             attributes.setLogId(messageId)
+            attributes.setSessionProperties(sessionProperties.get())
 
             val logEventData = LogEventData(
                 schemaType = SchemaType.Log(attributes),


### PR DESCRIPTION
## Goal

- Added session properties to OTel log attributes with prefix `emb.properties.`

## Testing

- Added unit test to verify session properties are added correctly.

