### PR TITLE
Reduce the direct use of the static logger so tests functional tests work properly

### DIFF
--- a/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
+++ b/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
@@ -33,7 +33,9 @@ public class NullParametersTest {
     private static final String NULL_STRING = null;
 
     @Rule
-    public IntegrationTestRule testRule = new IntegrationTestRule();
+    public IntegrationTestRule testRule = new IntegrationTestRule(
+            () -> IntegrationTestRule.Companion.newHarness(true)
+    );
 
     @NonNull
     private final Embrace embrace = testRule.getEmbrace();

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.IntegrationTestRule.*
+import io.embrace.android.embracesdk.IntegrationTestRule.Harness
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.getSentSessionMessages
 import io.embrace.android.embracesdk.hasEvent
 import io.embrace.android.embracesdk.hasSpan
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -43,8 +44,9 @@ internal class OtelSessionGatingTest {
         FakeConfigService(
             sessionBehavior = fakeSessionBehavior {
                 RemoteConfig(sessionConfig = gatingConfig)
-            }
-        )
+            },
+        ),
+        InternalEmbraceLogger()
     )
 
     @Rule

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.getLastSavedSessionMessage
 import io.embrace.android.embracesdk.getLastSentSessionMessage
 import io.embrace.android.embracesdk.recordSession
-import io.embrace.android.embracesdk.worker.WorkerName.*
+import io.embrace.android.embracesdk.worker.WorkerName.PERIODIC_CACHE
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -29,7 +29,7 @@ internal class PeriodicSessionCacheTest {
         IntegrationTestRule.Harness(
             fakeClock = clock,
             initModule = fakeInitModule,
-            workerThreadModule = FakeWorkerThreadModule(fakeInitModule, PERIODIC_CACHE)
+            workerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = PERIODIC_CACHE)
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.webkit.ConsoleMessage;
@@ -15,8 +13,6 @@ import java.util.Map;
 import io.embrace.android.embracesdk.annotation.InternalApi;
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface;
 import io.embrace.android.embracesdk.internal.Systrace;
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger;
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger;
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest;
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb;
 import io.embrace.android.embracesdk.spans.EmbraceSpan;
@@ -41,9 +37,6 @@ public final class Embrace implements EmbraceAndroidApi {
     private static final Embrace embrace = new Embrace();
 
     private static EmbraceImpl impl = Systrace.traceSynchronous("embrace-impl-init", EmbraceImpl::new);
-
-    @NonNull
-    private final InternalEmbraceLogger internalEmbraceLogger = InternalStaticEmbraceLogger.logger;
 
     static final String NULL_PARAMETER_ERROR_MESSAGE_TEMPLATE = " cannot be invoked because it contains null parameters";
 
@@ -560,13 +553,13 @@ public final class Embrace implements EmbraceAndroidApi {
                                     @NonNull Boolean hasData) {
         if (verifyNonNullParameters("logPushNotification", messageDeliveredPriority, isNotification, hasData)) {
             impl.logPushNotification(
-                title,
-                body,
-                topic,
-                id,
-                notificationPriority,
-                messageDeliveredPriority,
-                PushNotificationBreadcrumb.NotificationType.Builder.notificationTypeFor(hasData, isNotification)
+                    title,
+                    body,
+                    topic,
+                    id,
+                    notificationPriority,
+                    messageDeliveredPriority,
+                    PushNotificationBreadcrumb.NotificationType.Builder.notificationTypeFor(hasData, isNotification)
             );
         }
     }
@@ -576,8 +569,6 @@ public final class Embrace implements EmbraceAndroidApi {
         if (verifyNonNullParameters("trackWebViewPerformance", tag, consoleMessage)) {
             if (consoleMessage.message() != null) {
                 trackWebViewPerformance(tag, consoleMessage.message());
-            } else {
-                logger.logDebug("Empty WebView console message.");
             }
         }
     }
@@ -652,9 +643,7 @@ public final class Embrace implements EmbraceAndroidApi {
             if (param == null) {
                 final String errorMessage = functionName + NULL_PARAMETER_ERROR_MESSAGE_TEMPLATE;
                 if (isStarted()) {
-                    internalEmbraceLogger.logError(errorMessage, new IllegalArgumentException(errorMessage), true);
-                } else {
-                    internalEmbraceLogger.logSDKNotInitialized(errorMessage);
+                    impl.getEmbraceInternalInterface().logInternalError(new IllegalArgumentException(errorMessage));
                 }
                 return false;
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceSamples.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceSamples.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.samples.EmbraceCrashSamples
 
 /**
@@ -14,7 +15,7 @@ import io.embrace.android.embracesdk.samples.EmbraceCrashSamples
 public object EmbraceSamples {
 
     private val embraceCrashSamples = EmbraceCrashSamples
-    private val embraceAutomaticVerification = EmbraceAutomaticVerification()
+    private val embraceAutomaticVerification = EmbraceAutomaticVerification(logger = InternalStaticEmbraceLogger.logger)
 
     /**
      * Starts an automatic verification of the following Embrace features:

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/InternalInterfaceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/InternalInterfaceModule.kt
@@ -36,7 +36,7 @@ internal class InternalInterfaceModuleImpl(
             crashModule.crashService,
             essentialServiceModule.metadataService,
             essentialServiceModule.hostedSdkVersionInfo,
-            coreModule.logger
+            initModule.logger
         )
     }
 
@@ -45,7 +45,7 @@ internal class InternalInterfaceModuleImpl(
             embrace,
             embraceInternalInterface,
             essentialServiceModule.hostedSdkVersionInfo,
-            coreModule.logger
+            initModule.logger
         )
     }
 
@@ -54,7 +54,7 @@ internal class InternalInterfaceModuleImpl(
             embrace,
             embraceInternalInterface,
             essentialServiceModule.hostedSdkVersionInfo,
-            coreModule.logger
+            initModule.logger
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterfaceImpl.kt
@@ -28,13 +28,11 @@ internal class UnityInternalInterfaceImpl(
                 )
                 return
             }
-            if (unitySdkVersion == null) {
-                logger.logDeveloper("Embrace", "Unity SDK version is null.")
-                return
+            if (unitySdkVersion != null) {
+                hostedSdkVersionInfo.hostedPlatformVersion = unityVersion
+                hostedSdkVersionInfo.hostedSdkVersion = unitySdkVersion
+                hostedSdkVersionInfo.unityBuildIdNumber = buildGuid
             }
-            hostedSdkVersionInfo.hostedPlatformVersion = unityVersion
-            hostedSdkVersionInfo.hostedSdkVersion = unitySdkVersion
-            hostedSdkVersionInfo.unityBuildIdNumber = buildGuid
         } else {
             logger.logSDKNotInitialized("set Unity metadata")
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
@@ -74,7 +74,6 @@ internal class EmbraceAnrService(
         stacktraceSampler.setConfigService(configService)
         sigquitDetectionService.configService = configService
         targetThreadHeartbeatScheduler.configService = configService
-        logger.logDeveloper("EmbraceAnrService", "Finish initialization")
         sigquitDetectionService.initializeGoogleAnrTracking()
         startAnrCapture()
     }
@@ -139,7 +138,6 @@ internal class EmbraceAnrService(
     internal fun processAnrTick(timestamp: Long) {
         // Check if ANR capture is enabled
         if (!configService.anrBehavior.isAnrCaptureEnabled()) {
-            logger.logDeveloper("EmbraceAnrService", "ANR capture is disabled, ignoring ANR tick")
             return
         }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetector.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.ResponsivenessSnapshot
 import java.util.concurrent.atomic.AtomicReference
 
@@ -38,7 +37,7 @@ internal class BlockedThreadDetector(
     var listener: BlockedThreadListener? = null,
     private val state: ThreadMonitoringState,
     private val targetThread: Thread,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger,
+    private val logger: InternalEmbraceLogger,
     private val anrMonitorThread: AtomicReference<Thread>
 ) {
     private val heartbeatResponseMonitor = ResponsivenessMonitor(clock = clock, name = "heartbeatResponse")
@@ -140,7 +139,6 @@ internal class BlockedThreadDetector(
         // the current time so that we can start monitoring for ANRs again.
         // https://developer.android.com/guide/components/activities/process-lifecycle
         if (monitorThreadLag > MONITOR_THREAD_TIMEOUT_MS) {
-            logger.logDeveloper("EmbraceAnrService", "Exceeded monitor thread timeout")
             val now = clock.now()
             state.lastTargetThreadResponseMs = now
             state.lastMonitorThreadResponseMs = now

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.ResponsivenessSnapshot
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
@@ -30,7 +29,7 @@ internal class LivenessCheckScheduler internal constructor(
     private val state: ThreadMonitoringState,
     private val targetThreadHandler: TargetThreadHandler,
     private val blockedThreadDetector: BlockedThreadDetector,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger,
+    private val logger: InternalEmbraceLogger,
     private val anrMonitorThread: AtomicReference<Thread>
 ) {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
@@ -7,7 +7,7 @@ import android.os.MessageQueue
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logError
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicReference
@@ -30,7 +30,8 @@ internal class TargetThreadHandler(
     private val anrMonitorThread: AtomicReference<Thread>,
     private val configService: ConfigService,
     private val messageQueue: MessageQueue? = LooperCompat.getMessageQueue(looper),
-    private val clock: Clock
+    private val logger: InternalEmbraceLogger,
+    private val clock: Clock,
 ) : Handler(looper) {
 
     lateinit var action: (time: Long) -> Unit
@@ -65,7 +66,7 @@ internal class TargetThreadHandler(
                 }
             }
         } catch (ex: Exception) {
-            logError("ANR healthcheck failed in main (monitored) thread", ex, true)
+            logger.logError("ANR healthcheck failed in main (monitored) thread", ex, true)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
@@ -2,10 +2,9 @@ package io.embrace.android.embracesdk.anr.detection
 
 import io.embrace.android.embracesdk.anr.BlockedThreadListener
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
 internal class UnbalancedCallDetector(
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) : BlockedThreadListener {
 
     @Volatile

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDetectionService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDetectionService.kt
@@ -36,10 +36,6 @@ internal class SigquitDetectionService(
     }
 
     fun initializeGoogleAnrTracking() {
-        logger.logDeveloper(
-            "EmbraceAnrService",
-            "Deciding whether to initialize Google ANR Tracking"
-        )
         if (configService.anrBehavior.isGoogleAnrCaptureEnabled()) {
             setupGoogleAnrTracking()
         } else {
@@ -51,12 +47,11 @@ internal class SigquitDetectionService(
 
     private fun setupGoogleAnrTracking() {
         if (configService.anrBehavior.isGoogleAnrCaptureEnabled() && !googleAnrTrackerInstalled.getAndSet(true)) {
-            ThreadUtils.runOnMainThread { setupGoogleAnrHandler() }
+            ThreadUtils.runOnMainThread(logger) { setupGoogleAnrHandler() }
         }
     }
 
     fun setupGoogleAnrHandler() {
-        logger.logDeveloper("EmbraceAnrService", "Setting up Google ANR Handler")
         // TODO: split up the ANR tracking and NDK crash reporter libs
         if (!sharedObjectLoader.loadEmbraceNative()) {
             googleAnrTrackerInstalled.set(false)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.config.ConfigListener
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
 /**
  * Orchestrates all data sources that could potentially be used in the SDK. This is a convenient
@@ -12,7 +11,7 @@ import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
  */
 internal class DataCaptureOrchestrator(
     private val dataSourceState: List<DataSourceState>,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) : ConfigListener {
 
     override fun onConfigChange(configService: ConfigService) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
@@ -2,15 +2,14 @@ package io.embrace.android.embracesdk.arch.datasource
 
 import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
 /**
  * Base class for data sources.
  */
 internal abstract class DataSourceImpl<T>(
     private val destination: T,
+    private val logger: InternalEmbraceLogger,
     private val limitStrategy: LimitStrategy,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataSource<T> {
 
     override fun enableDataCapture() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSourceImpl.kt
@@ -3,19 +3,18 @@ package io.embrace.android.embracesdk.arch.datasource
 import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
 /**
  * Base class for data sources.
  */
 internal abstract class SpanDataSourceImpl(
     destination: SpanService,
-    limitStrategy: LimitStrategy,
-    logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    logger: InternalEmbraceLogger,
+    limitStrategy: LimitStrategy
 ) : SpanDataSource, DataSourceImpl<SpanService>(
-    destination,
-    limitStrategy,
-    logger
+    destination = destination,
+    logger = logger,
+    limitStrategy = limitStrategy,
 ) {
 
     override fun captureSpanData(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
@@ -2,14 +2,13 @@ package io.embrace.android.embracesdk.arch.limits
 
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
 /**
  * Allows capturing data up until a limit, then stops capturing.
  */
 internal class UpToLimitStrategy(
+    private val logger: InternalEmbraceLogger,
     private val limitProvider: Provider<Int>,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : LimitStrategy {
 
     private var lock = Any()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -16,9 +16,7 @@ import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.config.behavior.AppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logInfoWithException
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logWarningWithException
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.BlobSession
@@ -39,10 +37,12 @@ internal class AeiDataSourceImpl(
     private val sessionIdTracker: SessionIdTracker,
     private val userService: UserService,
     logWriter: LogWriter,
+    private val logger: InternalEmbraceLogger,
     private val buildVersionChecker: VersionChecker = BuildVersionChecker,
 ) : AeiDataSource, LogEventMapper<BlobMessage>, LogDataSourceImpl(
     logWriter,
-    limitStrategy = UpToLimitStrategy({ SDK_AEI_SEND_LIMIT })
+    logger,
+    limitStrategy = UpToLimitStrategy(logger) { SDK_AEI_SEND_LIMIT }
 ) {
 
     companion object {
@@ -62,7 +62,7 @@ internal class AeiDataSourceImpl(
             try {
                 processApplicationExitInfo()
             } catch (exc: Throwable) {
-                logWarningWithException(
+                logger.logWarningWithException(
                     "AEI - Failed to process AEIs due to unexpected error",
                     exc,
                     true
@@ -76,7 +76,7 @@ internal class AeiDataSourceImpl(
             backgroundExecution?.cancel(true)
             backgroundExecution = null
         } catch (t: Throwable) {
-            logWarningWithException(
+            logger.logWarningWithException(
                 "AEI - Failed to disable EmbraceApplicationExitInfoService work",
                 t
             )
@@ -123,7 +123,7 @@ internal class AeiDataSourceImpl(
                 ?: return emptyList()
 
         if (historicalProcessExitReasons.size > SDK_AEI_SEND_LIMIT) {
-            logInfoWithException("AEI - size greater than $SDK_AEI_SEND_LIMIT")
+            logger.logInfoWithException("AEI - size greater than $SDK_AEI_SEND_LIMIT")
             historicalProcessExitReasons = historicalProcessExitReasons.take(SDK_AEI_SEND_LIMIT)
         }
 
@@ -220,25 +220,25 @@ internal class AeiDataSourceImpl(
             val trace = readTraceAsString(appExitInfo)
 
             if (trace == null) {
-                logDebug("AEI - No info trace collected")
+                logger.logDebug("AEI - No info trace collected")
                 return null
             }
 
             val traceMaxLimit = appExitInfoBehavior.getTraceMaxLimit()
             if (trace.length > traceMaxLimit) {
-                logInfoWithException("AEI - Blob size was reduced. Current size is ${trace.length} and the limit is $traceMaxLimit")
+                logger.logInfoWithException("AEI - Blob size was reduced. Current size is ${trace.length} and the limit is $traceMaxLimit")
                 return AppExitInfoBehavior.CollectTracesResult.TooLarge(trace.take(traceMaxLimit))
             }
 
             return AppExitInfoBehavior.CollectTracesResult.Success(trace)
         } catch (e: IOException) {
-            logWarningWithException("AEI - IOException: ${e.message}", e, true)
+            logger.logWarningWithException("AEI - IOException: ${e.message}", e, true)
             return AppExitInfoBehavior.CollectTracesResult.TraceException(("ioexception: ${e.message}"))
         } catch (e: OutOfMemoryError) {
-            logWarningWithException("AEI - Out of Memory: ${e.message}", e, true)
+            logger.logWarningWithException("AEI - Out of Memory: ${e.message}", e, true)
             return AppExitInfoBehavior.CollectTracesResult.TraceException(("oom: ${e.message}"))
         } catch (tr: Throwable) {
-            logWarningWithException("AEI - An error occurred: ${tr.message}", tr, true)
+            logger.logWarningWithException("AEI - An error occurred: ${tr.message}", tr, true)
             return AppExitInfoBehavior.CollectTracesResult.TraceException(("error: ${tr.message}"))
         }
     }
@@ -248,7 +248,7 @@ internal class AeiDataSourceImpl(
             val bytes = appExitInfo.traceInputStream?.readBytes()
 
             if (bytes == null) {
-                logDebug("AEI - No info trace collected")
+                logger.logDebug("AEI - No info trace collected")
                 return null
             }
             return bytesToUTF8String(bytes)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -8,7 +8,6 @@ import android.net.ConnectivityManager
 import io.embrace.android.embracesdk.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
 import io.embrace.android.embracesdk.payload.Interval
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.net.Inet4Address
@@ -43,7 +42,6 @@ internal class EmbraceNetworkConnectivityService(
     override fun onReceive(context: Context, intent: Intent) = handleNetworkStatus(true)
 
     override fun getCapturedData(): List<Interval> {
-        logger.logDeveloper("EmbraceNetworkConnectivityService", "getNetworkInterfaceIntervals")
         val endTime = clock.now()
         synchronized(this) {
             val results: MutableList<Interval> = ArrayList()
@@ -59,7 +57,6 @@ internal class EmbraceNetworkConnectivityService(
 
     private fun handleNetworkStatus(notifyListeners: Boolean, timestamp: Long = clock.now()) {
         try {
-            logger.logDeveloper("EmbraceNetworkConnectivityService", "handleNetworkStatus")
             val networkStatus = getCurrentNetworkStatus()
             if (didNetworkStatusChange(networkStatus)) {
                 lastNetworkStatus = networkStatus
@@ -84,32 +81,19 @@ internal class EmbraceNetworkConnectivityService(
                 // Network is reachable
                 when (networkInfo.type) {
                     ConnectivityManager.TYPE_WIFI -> {
-                        logger.logDeveloper(
-                            "EmbraceNetworkConnectivityService",
-                            "Network connected to WIFI"
-                        )
                         networkStatus = NetworkStatus.WIFI
                     }
 
                     ConnectivityManager.TYPE_MOBILE -> {
-                        logger.logDeveloper(
-                            "EmbraceNetworkConnectivityService",
-                            "Network connected to MOBILE"
-                        )
                         networkStatus = NetworkStatus.WAN
                     }
 
                     else -> {
-                        logger.logDeveloper(
-                            "EmbraceNetworkConnectivityService",
-                            "Network is reachable but type is not WIFI or MOBILE"
-                        )
                         networkStatus = NetworkStatus.UNKNOWN
                     }
                 }
             } else {
                 // Network is not reachable
-                logger.logDeveloper("EmbraceNetworkConnectivityService", "Network not reachable")
                 networkStatus = NetworkStatus.NOT_REACHABLE
             }
         } catch (e: java.lang.Exception) {
@@ -146,12 +130,10 @@ internal class EmbraceNetworkConnectivityService(
 
     override fun close() {
         context.unregisterReceiver(this)
-        logger.logDeveloper("EmbraceNetworkConnectivityService", "closed")
     }
 
     override fun cleanCollections() {
         networkReachable.clear()
-        logger.logDeveloper("EmbraceNetworkConnectivityService", "Collections cleaned")
     }
 
     /**
@@ -188,7 +170,7 @@ internal class EmbraceNetworkConnectivityService(
                 }
             }
         } catch (ex: Exception) {
-            logDebug("Cannot get IP Address")
+            logger.logDebug("Cannot get IP Address")
         }
         return null
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.capture.crash
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 /**
  * Intercepts uncaught exceptions from the JVM and forwards them to the Embrace API. Once handled,
@@ -16,20 +16,21 @@ internal class EmbraceUncaughtExceptionHandler(
     /**
      * The crash service which will submit the exception to the API as a crash
      */
-    private val crashService: CrashService
+    private val crashService: CrashService,
+    private val logger: InternalEmbraceLogger
 ) : Thread.UncaughtExceptionHandler {
 
     init {
-        logDebug("Registered EmbraceUncaughtExceptionHandler")
+        logger.logDebug("Registered EmbraceUncaughtExceptionHandler")
     }
 
     override fun uncaughtException(thread: Thread, exception: Throwable) {
         try {
             crashService.handleCrash(thread, exception)
         } catch (ex: Exception) {
-            logDebug("Error occurred in the uncaught exception handler", ex)
+            logger.logDebug("Error occurred in the uncaught exception handler", ex)
         } finally {
-            logDebug("Finished handling exception. Delegating to default handler.", exception)
+            logger.logDebug("Finished handling exception. Delegating to default handler.", exception)
             defaultHandler?.uncaughtException(thread, exception)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbsSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbsSanitizer.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.gating.Sanitizable
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.BREADCRUMBS_TAPS
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.BREADCRUMBS_VIEWS
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.BREADCRUMBS_WEB_VIEWS
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Breadcrumbs
 
 internal class BreadcrumbsSanitizer(
@@ -13,36 +12,20 @@ internal class BreadcrumbsSanitizer(
 ) : Sanitizable<Breadcrumbs> {
 
     override fun sanitize(): Breadcrumbs? {
-        InternalStaticEmbraceLogger.logger.logDeveloper(
-            "BreadcrumbsSanitizer",
-            "sanitize: " + (breadcrumbs != null).toString()
-        )
         return breadcrumbs?.let {
             val viewBreadcrumbs = if (shouldAddViewBreadcrumbs()) {
-                InternalStaticEmbraceLogger.logger.logDeveloper(
-                    "BreadcrumbsSanitizer",
-                    "shouldAddViewBreadcrumbs"
-                )
                 breadcrumbs.viewBreadcrumbs
             } else {
                 null
             }
 
             val tapBreadcrumbs = if (shouldAddTapBreadcrumbs()) {
-                InternalStaticEmbraceLogger.logger.logDeveloper(
-                    "BreadcrumbsSanitizer",
-                    "shouldAddTapBreadcrumbs"
-                )
                 breadcrumbs.tapBreadcrumbs
             } else {
                 null
             }
 
             val webViewBreadcrumbs = if (shouldAddWebViewBreadcrumbs()) {
-                InternalStaticEmbraceLogger.logger.logDeveloper(
-                    "BreadcrumbsSanitizer",
-                    "shouldAddWebViewBreadcrumbs"
-                )
                 breadcrumbs.webViewBreadcrumbs
             } else {
                 null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSource.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.CustomBreadcrumb
 
 /**
@@ -15,10 +16,12 @@ import io.embrace.android.embracesdk.payload.CustomBreadcrumb
  */
 internal class CustomBreadcrumbDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
-    writer: SessionSpanWriter
+    writer: SessionSpanWriter,
+    logger: InternalEmbraceLogger
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
-    limitStrategy = UpToLimitStrategy(breadcrumbBehavior::getCustomBreadcrumbLimit)
+    logger = logger,
+    limitStrategy = UpToLimitStrategy(logger, breadcrumbBehavior::getCustomBreadcrumbLimit)
 ),
     SpanEventMapper<CustomBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Breadcrumbs
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb.NotificationType
 import io.embrace.android.embracesdk.payload.TapBreadcrumb.TapBreadcrumbType
@@ -33,22 +32,23 @@ internal class EmbraceBreadcrumbService(
     private val activityTracker: ActivityTracker,
     sessionSpanWriter: SessionSpanWriter,
     spanService: SpanService,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) : BreadcrumbService, ActivityLifecycleListener, MemoryCleanerListener {
 
     private val customBreadcrumbDataSource =
-        CustomBreadcrumbDataSource(configService.breadcrumbBehavior, sessionSpanWriter)
-    private val webViewBreadcrumbDataSource = WebViewBreadcrumbDataSource(configService)
-    private val rnBreadcrumbDataSource = RnBreadcrumbDataSource(configService)
-    private val tapBreadcrumbDataSource = TapBreadcrumbDataSource(configService)
-    private val viewBreadcrumbDataSource = ViewBreadcrumbDataSource(configService, clock)
+        CustomBreadcrumbDataSource(configService.breadcrumbBehavior, sessionSpanWriter, logger)
+    private val webViewBreadcrumbDataSource = WebViewBreadcrumbDataSource(configService, logger)
+    private val rnBreadcrumbDataSource = RnBreadcrumbDataSource(configService, logger)
+    private val tapBreadcrumbDataSource = TapBreadcrumbDataSource(configService, logger)
+    private val viewBreadcrumbDataSource = ViewBreadcrumbDataSource(configService, clock, logger)
     private val fragmentBreadcrumbDataSource = FragmentBreadcrumbDataSource(
         configService.breadcrumbBehavior,
         clock,
-        spanService
+        spanService,
+        logger
     )
     private val pushNotificationBreadcrumbDataSource =
-        PushNotificationBreadcrumbDataSource(configService, clock)
+        PushNotificationBreadcrumbDataSource(configService, clock, logger)
 
     override fun logView(screen: String?, timestamp: Long) {
         viewBreadcrumbDataSource.addToViewLogsQueue(screen, timestamp, false)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSource.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.FragmentBreadcrumb
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
@@ -19,10 +20,12 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 internal class FragmentBreadcrumbDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
     private val clock: Clock,
-    spanService: SpanService
+    spanService: SpanService,
+    logger: InternalEmbraceLogger
 ) : SpanDataSourceImpl(
     spanService,
-    UpToLimitStrategy({ breadcrumbBehavior.getFragmentBreadcrumbLimit() })
+    logger,
+    UpToLimitStrategy(logger) { breadcrumbBehavior.getFragmentBreadcrumbLimit() }
 ),
     StartSpanMapper<FragmentBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/LegacyCustomBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/LegacyCustomBreadcrumbDataSource.kt
@@ -4,7 +4,6 @@ import android.text.TextUtils
 import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.CustomBreadcrumb
 
 /**
@@ -15,7 +14,7 @@ internal class LegacyCustomBreadcrumbDataSource(
     private val store: BreadcrumbDataStore<CustomBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
     },
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) : DataCaptureService<List<CustomBreadcrumb>> by store {
 
     fun logCustom(message: String, timestamp: Long) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/LegacyFragmentBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/LegacyFragmentBreadcrumbDataSource.kt
@@ -3,8 +3,6 @@ package io.embrace.android.embracesdk.capture.crumbs
 import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.FragmentBreadcrumb
 import io.embrace.android.embracesdk.utils.filter
 import java.util.Collections
@@ -17,8 +15,7 @@ internal class LegacyFragmentBreadcrumbDataSource(
     private val clock: Clock,
     private val store: BreadcrumbDataStore<FragmentBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getFragmentBreadcrumbLimit()
-    },
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    }
 ) : DataCaptureService<List<FragmentBreadcrumb>> by store {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationBreadcrumbDataSource.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 
 /**
@@ -13,10 +12,10 @@ import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 internal class PushNotificationBreadcrumbDataSource(
     private val configService: ConfigService,
     private val clock: Clock,
+    private val logger: InternalEmbraceLogger,
     private val store: BreadcrumbDataStore<PushNotificationBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
     },
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataCaptureService<List<PushNotificationBreadcrumb>> by store {
 
     fun logPushNotification(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnBreadcrumbDataSource.kt
@@ -4,7 +4,6 @@ import android.text.TextUtils
 import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.RnActionBreadcrumb
 
 /**
@@ -12,10 +11,10 @@ import io.embrace.android.embracesdk.payload.RnActionBreadcrumb
  */
 internal class RnBreadcrumbDataSource(
     private val configService: ConfigService,
+    private val logger: InternalEmbraceLogger,
     private val store: BreadcrumbDataStore<RnActionBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
     },
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataCaptureService<List<RnActionBreadcrumb>> by store {
 
     fun logRnAction(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSource.kt
@@ -4,7 +4,6 @@ import android.util.Pair
 import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.TapBreadcrumb
 
 /**
@@ -12,10 +11,10 @@ import io.embrace.android.embracesdk.payload.TapBreadcrumb
  */
 internal class TapBreadcrumbDataSource(
     private val configService: ConfigService,
+    private val logger: InternalEmbraceLogger,
     private val store: BreadcrumbDataStore<TapBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getTapBreadcrumbLimit()
     },
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataCaptureService<List<TapBreadcrumb>> by store {
 
     fun logTap(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewBreadcrumbDataSource.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.ViewBreadcrumb
 
 /**
@@ -13,10 +12,10 @@ import io.embrace.android.embracesdk.payload.ViewBreadcrumb
 internal class ViewBreadcrumbDataSource(
     private val configService: ConfigService,
     private val clock: Clock,
+    private val logger: InternalEmbraceLogger,
     private val store: BreadcrumbDataStore<ViewBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getViewBreadcrumbLimit()
     },
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataCaptureService<List<ViewBreadcrumb>> by store {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewBreadcrumbDataSource.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.capture.crumbs
 import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
 
 /**
@@ -11,10 +10,10 @@ import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
  */
 internal class WebViewBreadcrumbDataSource(
     private val configService: ConfigService,
+    private val logger: InternalEmbraceLogger,
     private val store: BreadcrumbDataStore<WebViewBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getWebViewBreadcrumbLimit()
     },
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 ) : DataCaptureService<List<WebViewBreadcrumb>> by store {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
@@ -7,8 +7,7 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.annotation.ChecksSdkIntAtLeast
 import io.embrace.android.embracesdk.capture.cpu.CpuInfoDelegate
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.io.File
@@ -101,7 +100,8 @@ internal class DeviceImpl(
     private val windowManager: WindowManager?,
     private val preferencesService: PreferencesService,
     private val backgroundWorker: BackgroundWorker,
-    cpuInfoDelegate: CpuInfoDelegate
+    cpuInfoDelegate: CpuInfoDelegate,
+    private val logger: InternalEmbraceLogger
 ) : Device {
     override var isJailbroken: Boolean? = null
     override var screenResolution: String = ""
@@ -117,10 +117,6 @@ internal class DeviceImpl(
     )
 
     init {
-        logDeveloper(
-            "Device",
-            "Precomputing values asynchronously: Jailbroken/ScreenResolution/DiskUsage"
-        )
         asyncRetrieveIsJailbroken()
         asyncRetrieveScreenResolution()
     }
@@ -154,7 +150,7 @@ internal class DeviceImpl(
                 displayMetrics.heightPixels
             )
         } catch (ex: Exception) {
-            logDebug("Could not determine screen resolution", ex)
+            logger.logDebug("Could not determine screen resolution", ex)
             ""
         }
     }
@@ -183,9 +179,7 @@ internal class DeviceImpl(
      * @return true if the device is jailbroken and not an emulator, false otherwise
      */
     private fun checkIfIsJailbroken(): Boolean {
-        logDeveloper("Device", "Processing jailbroken")
         if (isEmulator()) {
-            logDeveloper("Device", "Device is an emulator, Jailbroken=false")
             return false
         }
         for (location in jailbreakLocations) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackService.kt
@@ -3,12 +3,13 @@ package io.embrace.android.embracesdk.capture.memory
 import android.app.Application
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import java.io.Closeable
 
 internal class ComponentCallbackService(
     private val application: Application,
-    private val memoryService: MemoryService
+    private val memoryService: MemoryService,
+    private val logger: InternalEmbraceLogger
 ) : ComponentCallbacks2, Closeable {
 
     init {
@@ -22,15 +23,11 @@ internal class ComponentCallbackService(
      * @param trimLevel the context of the trim, giving a hint of the amount of trimming.
      */
     override fun onTrimMemory(trimLevel: Int) {
-        InternalStaticEmbraceLogger.logDeveloper(
-            "ComponentCallbackService",
-            "onTrimMemory(). TrimLevel: $trimLevel"
-        )
         if (trimLevel == ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
             try {
                 memoryService.onMemoryWarning()
             } catch (ex: Exception) {
-                InternalStaticEmbraceLogger.logDebug(
+                logger.logDebug(
                     "Failed to handle onTrimMemory (low memory) event",
                     ex
                 )
@@ -45,7 +42,7 @@ internal class ComponentCallbackService(
         try {
             application.applicationContext.unregisterComponentCallbacks(this)
         } catch (ex: Exception) {
-            InternalStaticEmbraceLogger.logDebug(
+            logger.logDebug(
                 "Error when closing ComponentCallbackService",
                 ex
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/EmbraceMemoryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/EmbraceMemoryService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.capture.memory
 
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.MemoryWarning
 import java.util.NavigableMap
 import java.util.concurrent.ConcurrentSkipListMap
@@ -19,10 +18,6 @@ internal class EmbraceMemoryService(
     private var offset = 0
 
     override fun onMemoryWarning() {
-        InternalStaticEmbraceLogger.logDeveloper(
-            "EmbraceMemoryService",
-            "Memory warning number: $offset"
-        )
         if (offset < MAX_CAPTURED_MEMORY_WARNINGS) {
             memoryTimestamps[offset] = clock.now()
             offset++

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataUtils.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataUtils.java
@@ -1,28 +1,14 @@
 package io.embrace.android.embracesdk.capture.metadata;
 
-import android.annotation.TargetApi;
-import android.app.usage.StorageStats;
-import android.app.usage.StorageStatsManager;
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Process;
 import android.os.StatFs;
-import android.os.storage.StorageManager;
-import android.util.DisplayMetrics;
-import android.view.Display;
-import android.view.WindowManager;
-
-import androidx.annotation.Nullable;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
-
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger;
 
 /**
  * Utilities for retrieving metadata from the device's {@link Context}. This metadata is passed
@@ -96,27 +82,6 @@ final class MetadataUtils {
     }
 
     /**
-     * Gets the device's screen resolution.
-     *
-     * @param windowManager the {@link WindowManager} from the {@link Context}
-     * @return the device's screen resolution
-     */
-    @Nullable
-    @SuppressWarnings("deprecation")
-    static String getScreenResolution(WindowManager windowManager) {
-        try {
-            InternalStaticEmbraceLogger.logDeveloper("MetadataUtils", "Computing screen resolution");
-            Display display = windowManager.getDefaultDisplay();
-            DisplayMetrics displayMetrics = new DisplayMetrics();
-            display.getMetrics(displayMetrics);
-            return String.format(Locale.US, "%dx%d", displayMetrics.widthPixels, displayMetrics.heightPixels);
-        } catch (Exception ex) {
-            InternalStaticEmbraceLogger.logDebug("Could not determine screen resolution", ex);
-            return null;
-        }
-    }
-
-    /**
      * Gets a ID of the device's timezone, e.g. 'Europe/London'.
      *
      * @return the ID of the device's timezone
@@ -142,44 +107,7 @@ final class MetadataUtils {
      * @return the total free capacity of the internal storage of the device in bytes
      */
     static long getInternalStorageFreeCapacity(StatFs statFs) {
-        InternalStaticEmbraceLogger.logDeveloper("MetadataUtils", "Getting internal storage free capacity");
         return statFs.getFreeBytes();
-    }
-
-    /**
-     * Attempts to determine the disk usage of the app on the device.
-     * <p>
-     * If the disk usage cannot be determined, null is returned.
-     *
-     * @param storageStatsManager the {@link StorageStatsManager}
-     * @param packageManager      the {@link PackageManager}
-     * @param contextPackageName  the name of the package from the {@link Context}
-     * @return optionally the disk usage of the app on the device
-     */
-    @TargetApi(Build.VERSION_CODES.O)
-    @Nullable
-    @SuppressWarnings("deprecation")
-    static Long getDeviceDiskAppUsage(
-        StorageStatsManager storageStatsManager,
-        PackageManager packageManager,
-        String contextPackageName) {
-        InternalStaticEmbraceLogger.logDeveloper("MetadataUtils", "Getting device disk app usage");
-        try {
-            PackageInfo packageInfo = packageManager.getPackageInfo(contextPackageName, 0);
-            if (packageInfo != null && packageInfo.packageName != null) {
-                StorageStats stats = storageStatsManager.queryStatsForPackage(
-                    StorageManager.UUID_DEFAULT,
-                    packageInfo.packageName,
-                    Process.myUserHandle());
-                return stats.getAppBytes() + stats.getDataBytes() + stats.getCacheBytes();
-            } else {
-                InternalStaticEmbraceLogger.logDeveloper("MetadataUtils", "Cannot get disk usage, packageInfo is null");
-            }
-        } catch (Exception ex) {
-            // The package name and storage volume should always exist
-            InternalStaticEmbraceLogger.logError("Error retrieving device disk usage", ex);
-        }
-        return null;
     }
 
     /**
@@ -189,10 +117,7 @@ final class MetadataUtils {
      * @return true if the device is jailbroken and not an emulator, false otherwise
      */
     static boolean isJailbroken() {
-        InternalStaticEmbraceLogger.logDeveloper("MetadataUtils", "Processing jailbroken");
-
         if (isEmulator()) {
-            InternalStaticEmbraceLogger.logDeveloper("MetadataUtils", "Device is an emulator, Jailbroken=false");
             return false;
         }
 
@@ -211,7 +136,7 @@ final class MetadataUtils {
      * @return true if the device is detected to be an emulator, false otherwise
      */
     static boolean isEmulator() {
-        boolean isEmulator = Build.FINGERPRINT.startsWith("generic") ||
+        return Build.FINGERPRINT.startsWith("generic") ||
             Build.FINGERPRINT.startsWith("unknown") ||
             Build.FINGERPRINT.contains("emulator") ||
             Build.MODEL.contains("google_sdk") ||
@@ -221,9 +146,6 @@ final class MetadataUtils {
             Build.MANUFACTURER.contains("Genymotion") ||
             Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic") ||
             "google_sdk".equals(Build.PRODUCT);
-
-        InternalStaticEmbraceLogger.logDeveloper("MetadataUtils", "Device is an Emulator = " + isEmulator);
-        return isEmulator;
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/orientation/EmbraceOrientationService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/orientation/EmbraceOrientationService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.capture.orientation
 
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.payload.Orientation
 import java.util.LinkedList
 
@@ -15,10 +14,8 @@ internal class EmbraceOrientationService(
     private val orientations = LinkedList<Orientation>()
 
     override fun onOrientationChanged(orientation: Int?) {
-        logDeveloper("EmbraceOrientationService", "onOrientationChanged")
         if (orientation != null && (orientations.isEmpty() || orientations.last.internalOrientation != orientation)) {
             orientations.add(Orientation(orientation, clock.now()))
-            logDeveloper("EmbraceOrientationService", "added new orientation $orientation")
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/EmbracePowerSaveModeService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/EmbracePowerSaveModeService.kt
@@ -9,9 +9,7 @@ import android.os.PowerManager.ACTION_POWER_SAVE_MODE_CHANGED
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.PowerModeInterval
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -20,6 +18,7 @@ internal class EmbracePowerSaveModeService(
     private val context: Context,
     private val backgroundWorker: BackgroundWorker,
     private val clock: Clock,
+    private val logger: InternalEmbraceLogger,
     powerManagerProvider: Provider<PowerManager?>
 ) : BroadcastReceiver(), PowerSaveModeService, ProcessStateListener {
 
@@ -45,10 +44,9 @@ internal class EmbracePowerSaveModeService(
                 try {
                     if (powerManager != null) {
                         context.registerReceiver(this, powerSaveIntentFilter)
-                        logDeveloper(tag, "registered power save mode changed")
                     }
                 } catch (ex: Exception) {
-                    InternalStaticEmbraceLogger.logError(
+                    logger.logError(
                         "Failed to register: $tag broadcast receiver. Power save mode status will be unavailable.",
                         ex
                     )
@@ -64,7 +62,6 @@ internal class EmbracePowerSaveModeService(
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        logDeveloper(tag, "onReceive")
         try {
             when (intent.action) {
                 ACTION_POWER_SAVE_MODE_CHANGED ->
@@ -76,7 +73,7 @@ internal class EmbracePowerSaveModeService(
                     )
             }
         } catch (ex: Exception) {
-            InternalStaticEmbraceLogger.logError("Failed to handle " + intent.action, ex)
+            logger.logError("Failed to handle " + intent.action, ex)
         }
     }
 
@@ -110,7 +107,7 @@ internal class EmbracePowerSaveModeService(
     }
 
     override fun close() {
-        logDebug("Stopping $tag")
+        logger.logDebug("Stopping $tag")
         context.unregisterReceiver(this)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/EmbraceWebViewService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/EmbraceWebViewService.kt
@@ -2,14 +2,15 @@ package io.embrace.android.embracesdk.capture.webview
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.WebViewInfo
 import io.embrace.android.embracesdk.payload.WebVitalType
 import java.util.EnumMap
 
 internal class EmbraceWebViewService(
     val configService: ConfigService,
-    private val serializer: EmbraceSerializer
+    private val serializer: EmbraceSerializer,
+    private val logger: InternalEmbraceLogger
 ) : WebViewService {
 
     /**
@@ -21,7 +22,7 @@ internal class EmbraceWebViewService(
         if (message.contains(MESSAGE_KEY_FOR_METRICS)) {
             collectWebVital(message, tag)
         } else {
-            InternalStaticEmbraceLogger.logger.logDebug("WebView console message ignored.")
+            logger.logDebug("WebView console message ignored.")
         }
     }
 
@@ -30,10 +31,8 @@ internal class EmbraceWebViewService(
     }
 
     private fun collectWebVital(message: String, tag: String) {
-        InternalStaticEmbraceLogger.logger.logDeveloper("EmbraceWebViewService", "Collecting web metric")
-
         if (webViewInfoMap.size >= configService.webViewVitalsBehavior.getMaxWebViewVitals()) {
-            InternalStaticEmbraceLogger.logger.logDebug("Max webview vitals per session exceeded")
+            logger.logDebug("Max webview vitals per session exceeded")
             return
         }
         val collectedWebVitals = parseWebVital(message)
@@ -91,10 +90,10 @@ internal class EmbraceWebViewService(
             if (message.length < SCRIPT_MESSAGE_MAXIMUM_ALLOWED_LENGTH) {
                 return serializer.fromJson(message, WebViewInfo::class.java)
             } else {
-                InternalStaticEmbraceLogger.logger.logError("Web Vital info is too large to parse")
+                logger.logError("Web Vital info is too large to parse")
             }
         } catch (e: Exception) {
-            InternalStaticEmbraceLogger.logger.logError("Cannot parse Web Vital", e)
+            logger.logError("Cannot parse Web Vital", e)
         }
         return null
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
@@ -4,7 +4,6 @@ import android.net.http.HttpResponseCache
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.storage.StorageService
 import java.io.Closeable
 import java.io.IOException
@@ -20,10 +19,10 @@ import java.net.URI
  * means the eTag can be set in the request header & we can avoid unnecessary work on the client
  * & on the server.
  */
-internal class ApiResponseCache @JvmOverloads constructor(
+internal class ApiResponseCache(
     private val serializer: EmbraceSerializer,
     private val storageService: StorageService,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) : Closeable {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -156,8 +156,6 @@ internal class EmbraceApiService(
         noinline onComplete: ((successful: Boolean) -> Unit)? = null,
     ): Future<*> {
         val request: ApiRequest = mapper(payload)
-        logger.logDeveloper(TAG, "Post event")
-
         val action: SerializationAction = { stream ->
             ConditionalGzipOutputStream(stream).use {
                 if (type != null) {
@@ -230,5 +228,3 @@ internal class EmbraceApiService(
     private fun executePost(request: ApiRequest, action: SerializationAction) =
         apiClient.executePost(request, action)
 }
-
-private const val TAG = "EmbraceApiService"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiUrlBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiUrlBuilder.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.comms.api
 
 import android.os.Build
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 
 internal class EmbraceApiUrlBuilder(
     private val coreBaseUrl: String,
@@ -24,10 +23,6 @@ internal class EmbraceApiUrlBuilder(
     }
 
     override fun getEmbraceUrlWithSuffix(apiVersion: String, suffix: String): String {
-        InternalStaticEmbraceLogger.logDeveloper(
-            "ApiUrlBuilder",
-            "getEmbraceUrlWithSuffix - apiVersion: $apiVersion - suffix: $suffix"
-        )
         val fullSuffix = if (apiVersion == "v1") "log/$suffix" else suffix
         return "$coreBaseUrl/$apiVersion/$fullSuffix"
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CachedSession.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/CachedSession.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.comms.delivery
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
-
 /**
  * Represents a session that is cached on disk. The cached session encodes information in its
  * filename such as sessionId, timestamp, and payload version. This allows the SDK to process
@@ -41,20 +39,18 @@ internal class CachedSession private constructor(
          */
         fun fromFilename(filename: String): CachedSession? {
             val values = filename.split('.')
-            if (values.size < 4 || values.size > 5) {
-                InternalStaticEmbraceLogger.logError("Unrecognized cached file: $filename")
-                return null
-            }
-            val v2Payload = isV2Payload(filename)
-            val encodedInfo = when {
-                v2Payload -> values.take(4)
-                else -> values
-            }
+            if (values.size == 4 || values.size == 5) {
+                val v2Payload = isV2Payload(filename)
+                val encodedInfo = when {
+                    v2Payload -> values.take(4)
+                    else -> values
+                }
 
-            val timestamp = encodedInfo[1].toLongOrNull()
-            timestamp?.also { ts ->
-                val sessionId = encodedInfo[2]
-                return create(sessionId, ts, v2Payload)
+                val timestamp = encodedInfo[1].toLongOrNull()
+                timestamp?.also { ts ->
+                    val sessionId = encodedInfo[2]
+                    return create(sessionId, ts, v2Payload)
+                }
             }
             return null
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -47,7 +47,6 @@ internal class EmbraceCacheService(
      */
     override fun loadPayload(name: String): SerializationAction {
         return { stream ->
-            logger.logDeveloper(TAG, "Attempting to read bytes from $name")
             findLock(name).read {
                 val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
                 try {
@@ -87,10 +86,6 @@ internal class EmbraceCacheService(
 
     override fun deleteFile(name: String): Boolean {
         val success = findLock(name).write {
-            logger.logDeveloper(
-                "EmbraceCacheService",
-                "Attempting to delete file from cache: $name"
-            )
             val file = storageService.getFileForRead(EMBRACE_PREFIX + name)
             try {
                 file.delete()
@@ -259,7 +254,6 @@ internal class EmbraceCacheService(
          * preserve backward compatibility, SESSION_FILE_PREFIX must be the start of OLD_VERSION_FILE_NAME
          */
         private const val OLD_VERSION_FILE_NAME = "last_session.json"
-        private const val TAG = "EmbraceCacheService"
 
         const val EMBRACE_PREFIX = "emb_"
         const val OLD_COPY_SUFFIX = "-old"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -29,7 +29,6 @@ internal class EmbraceDeliveryService(
 ) : DeliveryService {
 
     companion object {
-        private const val TAG = "EmbraceDeliveryService"
         private const val SEND_SESSION_TIMEOUT = 1L
         private const val CRASH_TIMEOUT = 1L // Seconds to wait before timing out when sending a crash
     }
@@ -145,11 +144,6 @@ internal class EmbraceDeliveryService(
         nativeCrashData: NativeCrashData,
         sessionMessage: SessionMessage
     ): SessionMessage {
-        logger.logDeveloper(
-            TAG,
-            "Attaching native crash ${nativeCrashData.nativeCrashId} to session ${sessionMessage.session.sessionId}"
-        )
-
         val session = sessionMessage.session.copy(crashReportId = nativeCrashData.nativeCrashId)
         return sessionMessage.copy(session = session)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/LocalConfigParser.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/LocalConfigParser.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.AndroidResourcesService
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 internal object LocalConfigParser {
 
@@ -41,7 +41,8 @@ internal object LocalConfigParser {
         resources: AndroidResourcesService,
         packageName: String,
         customAppId: String?,
-        serializer: EmbraceSerializer
+        serializer: EmbraceSerializer,
+        logger: InternalEmbraceLogger
     ): LocalConfig {
         return try {
             val appId: String = customAppId ?: resources.getString(
@@ -73,7 +74,7 @@ internal object LocalConfigParser {
 
                 else -> null
             }
-            buildConfig(appId, ndkEnabled, sdkConfigJson, serializer)
+            buildConfig(appId, ndkEnabled, sdkConfigJson, serializer, logger)
         } catch (ex: Exception) {
             throw IllegalStateException("Failed to load local config from resources.", ex)
         }
@@ -83,7 +84,8 @@ internal object LocalConfigParser {
         appId: String?,
         ndkEnabled: Boolean,
         sdkConfigs: String?,
-        serializer: EmbraceSerializer
+        serializer: EmbraceSerializer,
+        logger: InternalEmbraceLogger
     ): LocalConfig {
         require(!appId.isNullOrEmpty()) { "Embrace AppId cannot be null or empty." }
 
@@ -91,13 +93,13 @@ internal object LocalConfigParser {
             ndkEnabled -> "enabled"
             else -> "disabled"
         }
-        InternalStaticEmbraceLogger.logInfo("Native crash capture is $enabledStr")
+        logger.logInfo("Native crash capture is $enabledStr")
         var configs: SdkLocalConfig? = null
         if (!sdkConfigs.isNullOrEmpty()) {
             try {
                 configs = serializer.fromJson(sdkConfigs, SdkLocalConfig::class.java)
             } catch (ex: Exception) {
-                InternalStaticEmbraceLogger.logError(
+                logger.logError(
                     "Failed to parse Embrace config from config json file.",
                     ex
                 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BehaviorThresholdCheck.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BehaviorThresholdCheck.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.config.behavior
 
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logger
 import kotlin.math.pow
 
 /**
@@ -39,7 +38,6 @@ internal class BehaviorThresholdCheck(
      */
     fun isBehaviorEnabled(pctEnabled: Float): Boolean {
         if (pctEnabled <= 0 || pctEnabled > 100) {
-            logger.logDeveloper("EmbraceConfigService", "behaviour enabled")
             return false
         }
         val deviceId = getNormalizedLargeDeviceId()
@@ -63,8 +61,6 @@ internal class BehaviorThresholdCheck(
         val radix = 16
         val space = (radix.toDouble().pow(digits.toDouble()) - 1).toInt()
         val value = Integer.valueOf(finalChars, radix)
-        val normalizedDeviceId = value.toFloat() / space * 100
-        logger.logDeveloper("EmbraceConfigService", "normalizedDeviceId: $normalizedDeviceId")
-        return normalizedDeviceId
+        return value.toFloat() / space * 100
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanName
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
@@ -83,7 +82,6 @@ internal class EmbraceEventService(
     }
 
     override fun onForeground(coldStart: Boolean, timestamp: Long) {
-        logDeveloper("EmbraceEventService", "coldStart: $coldStart")
         if (coldStart) {
             // Using the system current timestamp here as the startup timestamp is related to the
             // the actual SDK starts ( when the app context starts ). The app context can start
@@ -96,20 +94,14 @@ internal class EmbraceEventService(
     override fun applicationStartupComplete() {
         if (processStartedByNotification) {
             activeEvents.remove(STARTUP_EVENT_NAME)
-            logDeveloper("EmbraceEventService", "Application startup started by data notification")
         } else if (configService.startupBehavior.isAutomaticEndEnabled()) {
-            logDeveloper("EmbraceEventService", "Automatically ending startup event")
             endEvent(STARTUP_EVENT_NAME)
-        } else {
-            logDeveloper("EmbraceEventService", "Application startup automatically end is disabled")
         }
     }
 
     override fun sendStartupMoment() {
-        logDeveloper("EmbraceEventService", "sendStartupMoment")
         synchronized(this) {
             if (startupSent) {
-                logDeveloper("EmbraceEventService", "Startup is already sent")
                 return
             }
             startupSent = true
@@ -148,14 +140,11 @@ internal class EmbraceEventService(
     ) {
         var sanitizedStartTime = startTime
         try {
-            logDeveloper("EmbraceEventService", "Start event: $name")
             if (!eventHandler.isAllowedToStart(name)) {
-                logDeveloper("EmbraceEventService", "Event handler not allowed to start ")
                 return
             }
             val eventKey = getInternalEventKey(name, identifier)
             if (activeEvents.containsKey(eventKey)) {
-                logDeveloper("EmbraceEventService", "Ending previous event with same name")
                 endEvent(name, identifier, false, null)
             }
             val now = clock.now()
@@ -175,7 +164,6 @@ internal class EmbraceEventService(
 
             // event started, update active events
             activeEvents[eventKey] = eventDescription
-            logDeveloper("EmbraceEventService", "Event started : $name")
         } catch (ex: Exception) {
             logger.logError(
                 "Cannot start event with name: $name, identifier: $identifier due to an exception",
@@ -208,7 +196,6 @@ internal class EmbraceEventService(
         properties: Map<String, Any>?
     ) {
         try {
-            logDeveloper("EmbraceEventService", "Ending event: $name")
             val eventKey = getInternalEventKey(name, identifier)
             val originEventDescription: EventDescription? = when {
                 late -> activeEvents[eventKey]
@@ -234,7 +221,6 @@ internal class EmbraceEventService(
                 if (!late) {
                     logStartupSpan()
                 }
-                logDeveloper("EmbraceEventService", "Ending Startup Ending")
                 startupEventInfo = eventHandler.buildStartupEventInfo(
                     originEventDescription.event,
                     event

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EventSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EventSanitizer.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.gating
 import io.embrace.android.embracesdk.EventType
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.LOG_PROPERTIES
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_PROPERTIES
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Event
 
 internal class EventSanitizer(
@@ -12,29 +11,16 @@ internal class EventSanitizer(
 ) : Sanitizable<Event> {
 
     override fun sanitize(): Event {
-        InternalStaticEmbraceLogger.logger.logDeveloper("EventSanitizer", "sanitize")
         var customPropertiesMap = event.customProperties
         var sessionPropertiesMap = event.sessionProperties
 
-        InternalStaticEmbraceLogger.logger.logDeveloper(
-            "EventSanitizer",
-            "isLogEvent: " + isLogEvent()
-        )
         if (isLogEvent()) {
             if (!shouldSendLogProperties()) {
-                InternalStaticEmbraceLogger.logger.logDeveloper(
-                    "EventSanitizer",
-                    "not shouldSendLogProperties"
-                )
                 customPropertiesMap = null
             }
         }
 
         if (!shouldSendSessionProperties()) {
-            InternalStaticEmbraceLogger.logger.logDeveloper(
-                "EventSanitizer",
-                "not shouldSendSessionProperties"
-            )
             sessionPropertiesMap = null
         }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EventSanitizerFacade.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EventSanitizerFacade.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.gating
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.EventMessage
 
 internal class EventSanitizerFacade(
@@ -9,10 +8,6 @@ internal class EventSanitizerFacade(
 ) {
 
     fun getSanitizedMessage(): EventMessage {
-        InternalStaticEmbraceLogger.logger.logDeveloper(
-            "EventSanitizerFacade",
-            "getSanitizedMessage"
-        )
         val sanitizedEvent = EventSanitizer(eventMessage.event, components).sanitize()
         val sanitizedUserInfo = UserInfoSanitizer(eventMessage.userInfo, components).sanitize()
         val sanitizedPerformanceInfo =

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizer.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_ORIENTATIO
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_PROPERTIES
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_USER_TERMINATION
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.STARTUP_MOMENT
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logger
 import io.embrace.android.embracesdk.payload.Session
 
 internal class SessionSanitizer(
@@ -17,8 +16,6 @@ internal class SessionSanitizer(
 
     @Suppress("ComplexMethod")
     override fun sanitize(): Session {
-        logger.logDeveloper("SessionSanitizer", "sanitize")
-
         val properties = when {
             !shouldSendSessionProperties() -> null
             else -> session.properties

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizerFacade.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizerFacade.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.gating
 
 import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbsSanitizer
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal class SessionSanitizerFacade(
@@ -10,10 +9,6 @@ internal class SessionSanitizerFacade(
 ) {
 
     fun getSanitizedMessage(): SessionMessage {
-        InternalStaticEmbraceLogger.logger.logDeveloper(
-            "SessionSanitizerFacade",
-            "getSanitizedMessage"
-        )
         val sanitizedSession = SessionSanitizer(sessionMessage.session, components).sanitize()
         val sanitizedUserInfo = UserInfoSanitizer(sessionMessage.userInfo, components).sanitize()
         val sanitizedPerformanceInfo = PerformanceInfoSanitizer(sessionMessage.performanceInfo, components).sanitize()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/UserInfoSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/UserInfoSanitizer.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.gating
 
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.USER_PERSONAS
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.UserInfo
 
 internal class UserInfoSanitizer(
@@ -15,17 +14,9 @@ internal class UserInfoSanitizer(
         }
 
         if (!shouldSendUserPersonas()) {
-            InternalStaticEmbraceLogger.logger.logDeveloper(
-                "UserInfoSanitizer",
-                "not shouldSendUserPersonas"
-            )
             return userInfo.copy(personas = null)
         }
 
-        InternalStaticEmbraceLogger.logger.logDeveloper(
-            "UserInfoSanitizer",
-            "sanitize - userInfo: " + userInfo.userId
-        )
         return userInfo
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/AnrModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/AnrModule.kt
@@ -31,7 +31,6 @@ internal interface AnrModule {
 
 internal class AnrModuleImpl(
     initModule: InitModule,
-    coreModule: CoreModule,
     essentialServiceModule: EssentialServiceModule,
     workerModule: WorkerThreadModule,
 ) : AnrModule {
@@ -40,7 +39,7 @@ internal class AnrModuleImpl(
     private val configService = essentialServiceModule.configService
 
     override val googleAnrTimestampRepository: GoogleAnrTimestampRepository by singleton {
-        GoogleAnrTimestampRepository(coreModule.logger)
+        GoogleAnrTimestampRepository(initModule.logger)
     }
 
     override val anrService: AnrService by singleton {
@@ -50,7 +49,7 @@ internal class AnrModuleImpl(
             EmbraceAnrService(
                 configService = configService,
                 looper = looper,
-                logger = coreModule.logger,
+                logger = initModule.logger,
                 sigquitDetectionService = sigquitDetectionService,
                 livenessCheckScheduler = livenessCheckScheduler,
                 anrMonitorWorker = anrMonitorWorker,
@@ -83,7 +82,8 @@ internal class AnrModuleImpl(
             anrMonitorWorker = anrMonitorWorker,
             anrMonitorThread = workerModule.anrMonitorThread,
             configService = configService,
-            clock = initModule.clock
+            logger = initModule.logger,
+            clock = initModule.clock,
         )
     }
 
@@ -93,7 +93,8 @@ internal class AnrModuleImpl(
             clock = initModule.clock,
             state = state,
             targetThread = looper.thread,
-            anrMonitorThread = workerModule.anrMonitorThread
+            anrMonitorThread = workerModule.anrMonitorThread,
+            logger = initModule.logger,
         )
     }
 
@@ -105,7 +106,8 @@ internal class AnrModuleImpl(
             state = state,
             targetThreadHandler = targetThreadHandler,
             blockedThreadDetector = blockedThreadDetector,
-            anrMonitorThread = workerModule.anrMonitorThread
+            anrMonitorThread = workerModule.anrMonitorThread,
+            logger = initModule.logger,
         )
     }
 
@@ -113,16 +115,16 @@ internal class AnrModuleImpl(
         val filesDelegate = FilesDelegate()
 
         SigquitDetectionService(
-            sharedObjectLoader = SharedObjectLoader(),
+            sharedObjectLoader = SharedObjectLoader(logger = initModule.logger),
             findGoogleThread = FindGoogleThread(
-                coreModule.logger,
+                initModule.logger,
                 GetThreadsInCurrentProcess(filesDelegate),
                 GetThreadCommand(filesDelegate)
             ),
-            googleAnrHandlerNativeDelegate = GoogleAnrHandlerNativeDelegate(googleAnrTimestampRepository, coreModule.logger),
+            googleAnrHandlerNativeDelegate = GoogleAnrHandlerNativeDelegate(googleAnrTimestampRepository, initModule.logger),
             googleAnrTimestampRepository = googleAnrTimestampRepository,
             configService = configService,
-            logger = coreModule.logger
+            logger = initModule.logger
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CoreModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CoreModule.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.internal.BuildInfo.Companion.fromResources
 import io.embrace.android.embracesdk.internal.EmbraceAndroidResourcesService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.registry.ServiceRegistry
 
 /**
@@ -38,11 +37,6 @@ internal interface CoreModule {
     val appFramework: AppFramework
 
     /**
-     * Returns an interface that logs messages
-     */
-    val logger: InternalEmbraceLogger
-
-    /**
      * Returns the service registry. This is used to register services that need to be closed
      */
     val serviceRegistry: ServiceRegistry
@@ -67,7 +61,8 @@ internal interface CoreModule {
 
 internal class CoreModuleImpl(
     ctx: Context,
-    override val appFramework: AppFramework
+    override val appFramework: AppFramework,
+    logger: InternalEmbraceLogger
 ) : CoreModule {
 
     override val context: Context by singleton {
@@ -82,8 +77,6 @@ internal class CoreModuleImpl(
         get() = context.packageManager.getPackageInfo(context.packageName, 0)
 
     override val application by singleton { context as Application }
-
-    override val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
 
     override val serviceRegistry: ServiceRegistry by singleton {
         ServiceRegistry(logger)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
@@ -32,11 +32,11 @@ internal class CrashModuleImpl(
         val markerFile = lazy {
             storageModule.storageService.getFileForWrite(CrashFileMarker.CRASH_MARKER_FILE_NAME)
         }
-        CrashFileMarker(markerFile)
+        CrashFileMarker(markerFile, initModule.logger)
     }
 
     override val lastRunCrashVerifier: LastRunCrashVerifier by singleton {
-        LastRunCrashVerifier(crashMarker)
+        LastRunCrashVerifier(crashMarker, initModule.logger)
     }
 
     override val crashService: CrashService by singleton {
@@ -54,12 +54,13 @@ internal class CrashModuleImpl(
             essentialServiceModule.gatingService,
             androidServicesModule.preferencesService,
             crashMarker,
-            initModule.clock
+            initModule.clock,
+            initModule.logger
         )
     }
 
     override val automaticVerificationExceptionHandler: AutomaticVerificationExceptionHandler by singleton {
         val prevHandler = Thread.getDefaultUncaughtExceptionHandler()
-        AutomaticVerificationExceptionHandler(prevHandler)
+        AutomaticVerificationExceptionHandler(prevHandler, initModule.logger)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -43,14 +43,15 @@ internal class CustomerLogModuleImpl(
             androidServicesModule.preferencesService,
             logMessageService,
             essentialServiceModule.configService,
-            coreModule.jsonSerializer
+            coreModule.jsonSerializer,
+            initModule.logger
         )
     }
 
     override val networkLoggingService: NetworkLoggingService by singleton {
         EmbraceNetworkLoggingService(
             essentialServiceModule.configService,
-            coreModule.logger,
+            initModule.logger,
             networkCaptureService
         )
     }
@@ -63,7 +64,7 @@ internal class CustomerLogModuleImpl(
             essentialServiceModule.userService,
             essentialServiceModule.configService,
             sessionProperties,
-            coreModule.logger,
+            initModule.logger,
             initModule.clock,
             essentialServiceModule.gatingService,
             essentialServiceModule.networkConnectivityService,
@@ -80,12 +81,13 @@ internal class CustomerLogModuleImpl(
             essentialServiceModule.sessionIdTracker,
             sessionProperties,
             workerThreadModule.backgroundWorker(WorkerName.REMOTE_LOGGING),
+            initModule.logger,
             initModule.clock,
         )
     }
 
     override val logMessageService: LogMessageService by singleton {
-        CompositeLogService(v1LogService, v2LogService, essentialServiceModule.configService)
+        CompositeLogService(v1LogService, v2LogService, essentialServiceModule.configService, initModule.logger)
     }
 
     override val logOrchestrator: LogOrchestrator by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -107,7 +107,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
 
     override val componentCallbackService: ComponentCallbackService by singleton {
         Systrace.traceSynchronous("component-callback-service-init") {
-            ComponentCallbackService(coreModule.application, memoryService)
+            ComponentCallbackService(coreModule.application, memoryService, initModule.logger)
         }
     }
 
@@ -118,7 +118,8 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
                     coreModule.context,
                     backgroundWorker,
                     initModule.clock,
-                    powerManagerProvider
+                    initModule.logger,
+                    powerManagerProvider,
                 )
             } else {
                 NoOpPowerSaveModeService()
@@ -127,7 +128,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     }
 
     override val webviewService: WebViewService by singleton {
-        EmbraceWebViewService(configService, coreModule.jsonSerializer)
+        EmbraceWebViewService(configService, coreModule.jsonSerializer, initModule.logger)
     }
 
     override val breadcrumbService: BreadcrumbService by singleton {
@@ -138,7 +139,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
                 essentialServiceModule.activityLifecycleTracker,
                 openTelemetryModule.currentSessionSpan,
                 openTelemetryModule.spanService,
-                coreModule.logger
+                initModule.logger
             )
         }
     }
@@ -146,7 +147,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     override val pushNotificationService: PushNotificationCaptureService by singleton {
         PushNotificationCaptureService(
             breadcrumbService,
-            coreModule.logger
+            initModule.logger
         )
     }
 
@@ -157,7 +158,6 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
                 EmbraceThermalStatusService(
                     backgroundWorker,
                     initModule.clock,
-                    coreModule.logger,
                     powerManagerProvider
                 )
             } else {
@@ -180,14 +180,14 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
             spanService = openTelemetryModule.spanService,
             backgroundWorker = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
             versionChecker = versionChecker,
-            logger = coreModule.logger
+            logger = initModule.logger
         )
     }
 
     override val startupTracker: StartupTracker by singleton {
         StartupTracker(
             appStartupTraceEmitter = appStartupTraceEmitter,
-            logger = coreModule.logger,
+            logger = initModule.logger,
             versionChecker = versionChecker,
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
@@ -27,7 +27,6 @@ internal interface DataContainerModule {
 internal class DataContainerModuleImpl(
     initModule: InitModule,
     openTelemetryModule: OpenTelemetryModule,
-    coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
     systemServiceModule: SystemServiceModule,
     androidServicesModule: AndroidServicesModule,
@@ -51,7 +50,8 @@ internal class DataContainerModuleImpl(
                 deliveryModule.deliveryService,
                 essentialServiceModule.metadataService,
                 essentialServiceModule.sessionIdTracker,
-                essentialServiceModule.userService
+                essentialServiceModule.userService,
+                initModule.logger
             )
         } else {
             NoOpApplicationExitInfoService()
@@ -69,7 +69,8 @@ internal class DataContainerModuleImpl(
             anrModule.googleAnrTimestampRepository,
             applicationExitInfoService,
             nativeModule.nativeThreadSamplerService,
-            anrModule.responsivenessMonitorService
+            anrModule.responsivenessMonitorService,
+            initModule.logger
         )
     }
 
@@ -83,7 +84,7 @@ internal class DataContainerModuleImpl(
             performanceInfoService,
             essentialServiceModule.userService,
             sessionProperties,
-            coreModule.logger,
+            initModule.logger,
             workerThreadModule,
             initModule.clock,
             openTelemetryModule.spanService

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -29,9 +29,9 @@ internal interface DataSourceModule {
 }
 
 internal class DataSourceModuleImpl(
-    essentialServiceModule: EssentialServiceModule,
     initModule: InitModule,
     otelModule: OpenTelemetryModule,
+    essentialServiceModule: EssentialServiceModule,
     @Suppress("UNUSED_PARAMETER") systemServiceModule: SystemServiceModule,
     @Suppress("UNUSED_PARAMETER") androidServicesModule: AndroidServicesModule,
     @Suppress("UNUSED_PARAMETER") workerThreadModule: WorkerThreadModule,
@@ -43,7 +43,8 @@ internal class DataSourceModuleImpl(
         DataSourceState({
             CustomBreadcrumbDataSource(
                 breadcrumbBehavior = essentialServiceModule.configService.breadcrumbBehavior,
-                writer = otelModule.currentSessionSpan
+                writer = otelModule.currentSessionSpan,
+                logger = initModule.logger
             )
         })
     }
@@ -54,7 +55,8 @@ internal class DataSourceModuleImpl(
                 FragmentBreadcrumbDataSource(
                     configService.breadcrumbBehavior,
                     initModule.clock,
-                    otelModule.spanService
+                    otelModule.spanService,
+                    initModule.logger
                 )
             },
             configGate = { configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled() }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
@@ -10,6 +10,7 @@ internal interface DeliveryModule {
 }
 
 internal class DeliveryModuleImpl(
+    initModule: InitModule,
     coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
     storageModule: StorageModule,
@@ -22,7 +23,7 @@ internal class DeliveryModuleImpl(
             essentialServiceModule.apiService,
             workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
             coreModule.jsonSerializer,
-            coreModule.logger
+            initModule.logger
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.injection
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import io.embrace.android.embracesdk.telemetry.TelemetryService
 
@@ -24,12 +25,18 @@ internal interface InitModule {
      * Service to track usage of public APIs and other internal metrics
      */
     val telemetryService: TelemetryService
+
+    /**
+     * Logger used by the SDK
+     */
+    val logger: InternalEmbraceLogger
 }
 
 internal class InitModuleImpl(
     override val clock: io.embrace.android.embracesdk.internal.clock.Clock =
         NormalizedIntervalClock(systemClock = SystemClock()),
-    override val openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(embraceClock = clock)
+    override val openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(embraceClock = clock),
+    override val logger: InternalEmbraceLogger = InternalEmbraceLogger()
 ) : InitModule {
 
     override val telemetryService: TelemetryService by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/PayloadModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/PayloadModule.kt
@@ -23,14 +23,15 @@ internal interface PayloadModule {
 }
 
 internal class PayloadModuleImpl(
-    private val essentialServiceModule: EssentialServiceModule,
-    private val coreModule: CoreModule,
-    private val androidServicesModule: AndroidServicesModule,
+    initModule: InitModule,
+    coreModule: CoreModule,
+    androidServicesModule: AndroidServicesModule,
+    essentialServiceModule: EssentialServiceModule,
     systemServiceModule: SystemServiceModule,
     workerThreadModule: WorkerThreadModule,
-    private val nativeModule: NativeModule,
-    private val otelModule: OpenTelemetryModule,
-    private val sdkObservabilityModule: SdkObservabilityModule
+    nativeModule: NativeModule,
+    otelModule: OpenTelemetryModule,
+    sdkObservabilityModule: SdkObservabilityModule
 ) : PayloadModule {
 
     private val backgroundWorker =
@@ -52,7 +53,8 @@ internal class PayloadModuleImpl(
                 systemServiceModule.windowManager,
                 androidServicesModule.preferencesService,
                 backgroundWorker,
-                essentialServiceModule.cpuInfoDelegate
+                essentialServiceModule.cpuInfoDelegate,
+                initModule.logger
             ),
             essentialServiceModule.metadataService
         )
@@ -64,7 +66,8 @@ internal class PayloadModuleImpl(
             nativeModule.nativeThreadSamplerService,
             otelModule.spanSink,
             otelModule.currentSessionSpan,
-            otelModule.spanRepository
+            otelModule.spanRepository,
+            initModule.logger
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -64,7 +64,8 @@ internal class SessionModuleImpl(
             openTelemetryModule.spanSink,
             openTelemetryModule.currentSessionSpan,
             sessionPropertiesService,
-            dataCaptureServiceModule.startupService
+            dataCaptureServiceModule.startupService,
+            initModule.logger
         )
     }
 
@@ -72,7 +73,8 @@ internal class SessionModuleImpl(
         V2PayloadMessageCollator(
             essentialServiceModule.gatingService,
             v1PayloadMessageCollator,
-            payloadModule.sessionEnvelopeSource
+            payloadModule.sessionEnvelopeSource,
+            initModule.logger
         )
     }
 
@@ -91,13 +93,14 @@ internal class SessionModuleImpl(
     }
 
     override val periodicSessionCacher: PeriodicSessionCacher by singleton {
-        PeriodicSessionCacher(workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE))
+        PeriodicSessionCacher(workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE), initModule.logger)
     }
 
     override val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher by singleton {
         PeriodicBackgroundActivityCacher(
             initModule.clock,
-            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE)
+            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE),
+            initModule.logger
         )
     }
 
@@ -105,7 +108,8 @@ internal class SessionModuleImpl(
         PayloadFactoryImpl(
             v1PayloadMessageCollator,
             v2PayloadMessageCollator,
-            essentialServiceModule.configService
+            essentialServiceModule.configService,
+            initModule.logger
         )
     }
 
@@ -123,7 +127,7 @@ internal class SessionModuleImpl(
 
     override val dataCaptureOrchestrator: DataCaptureOrchestrator by singleton {
         val dataSources = dataSourceModule.getDataSources()
-        DataCaptureOrchestrator(dataSources).apply {
+        DataCaptureOrchestrator(dataSources, initModule.logger).apply {
             essentialServiceModule.configService.addListener(this)
         }
     }
@@ -139,7 +143,8 @@ internal class SessionModuleImpl(
             deliveryModule.deliveryService,
             periodicSessionCacher,
             periodicBackgroundActivityCacher,
-            dataCaptureOrchestrator
+            dataCaptureOrchestrator,
+            initModule.logger
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/StorageModule.kt
@@ -40,6 +40,7 @@ internal class StorageModuleImpl(
         ApiResponseCache(
             coreModule.jsonSerializer,
             storageService,
+            initModule.logger
         )
     }
 
@@ -47,7 +48,7 @@ internal class StorageModuleImpl(
         EmbraceCacheService(
             storageService,
             coreModule.jsonSerializer,
-            coreModule.logger
+            initModule.logger
         )
     }
 
@@ -55,7 +56,7 @@ internal class StorageModuleImpl(
         EmbraceDeliveryCacheManager(
             cacheService,
             workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
-            coreModule.logger
+            initModule.logger
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/SharedObjectLoader.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/SharedObjectLoader.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.internal
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Component to load native binaries
  */
-internal class SharedObjectLoader {
+internal class SharedObjectLoader(
+    private val logger: InternalEmbraceLogger
+) {
     val loaded = AtomicBoolean(false)
 
     /**
@@ -24,7 +26,7 @@ internal class SharedObjectLoader {
                     }
                     loaded.set(true)
                 } catch (exc: UnsatisfiedLinkError) {
-                    InternalStaticEmbraceLogger.logError("Failed to load SO file embrace-native", exc)
+                    logger.logError("Failed to load SO file embrace-native", exc)
                     return false
                 }
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarker.kt
@@ -1,14 +1,16 @@
 package io.embrace.android.embracesdk.internal.crash
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import java.io.File
-import java.lang.Exception
 
 /**
  * CrashFileMarker uses a file to indicate that a crash has occurred. This file is accessed in the
  * next launch of the app to determine if a crash occurred in the previous launch.
  */
-internal class CrashFileMarker(private val markerFile: Lazy<File>) {
+internal class CrashFileMarker(
+    private val markerFile: Lazy<File>,
+    private val logger: InternalEmbraceLogger
+) {
 
     private val lock = Any()
 
@@ -66,7 +68,7 @@ internal class CrashFileMarker(private val markerFile: Lazy<File>) {
             markerFile.value.writeText(CRASH_MARKER_SOURCE_JVM)
             true
         } catch (e: Exception) {
-            InternalStaticEmbraceLogger.logError("Error creating the marker file: ${markerFile.value.path}", e)
+            logger.logError("Error creating the marker file: ${markerFile.value.path}", e)
             false
         }
     }
@@ -75,14 +77,14 @@ internal class CrashFileMarker(private val markerFile: Lazy<File>) {
         return try {
             val deleted = markerFile.value.delete()
             if (!deleted) {
-                InternalStaticEmbraceLogger.logError(
+                logger.logError(
                     "Error deleting the marker file: ${markerFile.value.path}.",
                     Throwable("File not deleted")
                 )
             }
             deleted
         } catch (e: SecurityException) {
-            InternalStaticEmbraceLogger.logError("Error deleting the marker file: ${markerFile.value.path}.", e)
+            logger.logError("Error deleting the marker file: ${markerFile.value.path}.", e)
             false
         }
     }
@@ -91,7 +93,7 @@ internal class CrashFileMarker(private val markerFile: Lazy<File>) {
         return try {
             return markerFile.value.exists()
         } catch (e: SecurityException) {
-            InternalStaticEmbraceLogger.logError("Error checking the marker file: ${markerFile.value.path}", e)
+            logger.logError("Error checking the marker file: ${markerFile.value.path}", e)
             null
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifier.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifier.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.crash
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -9,7 +9,10 @@ import java.util.concurrent.TimeUnit
  * Verifies if the last run crashed.
  * This is done by checking if the crash marker file exists.
  */
-internal class LastRunCrashVerifier(private val crashFileMarker: CrashFileMarker) {
+internal class LastRunCrashVerifier(
+    private val crashFileMarker: CrashFileMarker,
+    private val logger: InternalEmbraceLogger
+) {
 
     private var didLastRunCrashFuture: Future<Boolean>? = null
     private var didLastRunCrash: Boolean? = null
@@ -22,7 +25,7 @@ internal class LastRunCrashVerifier(private val crashFileMarker: CrashFileMarker
             try {
                 future.get(2, TimeUnit.SECONDS)
             } catch (e: Throwable) {
-                InternalStaticEmbraceLogger.logError("[Embrace] didLastRunCrash: error while getting the result", e)
+                logger.logError("[Embrace] didLastRunCrash: error while getting the result", e)
                 null
             }
         } ?: readAndCleanMarker()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 
 /**
@@ -17,7 +17,8 @@ import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 internal class CompositeLogService(
     private val v1LogService: LogMessageService,
     private val v2LogService: LogService,
-    private val configService: ConfigService
+    private val configService: ConfigService,
+    private val logger: InternalEmbraceLogger
 ) : LogMessageService {
 
     private val useV2LogService: Boolean
@@ -51,7 +52,7 @@ internal class CompositeLogService(
             // WARNING_LOG, or ERROR_LOG, since it is taken from the fromSeverity() method
             // in EventType.
             if (type.getSeverity() == null) {
-                InternalStaticEmbraceLogger.logError("Invalid event type for log: $type")
+                logger.logError("Invalid event type for log: $type")
                 return
             }
             val severity = type.getSeverity() ?: Severity.INFO

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -20,6 +20,7 @@ import io.embrace.android.embracesdk.injection.SdkObservabilityModule
 import io.embrace.android.embracesdk.injection.SessionModule
 import io.embrace.android.embracesdk.injection.StorageModule
 import io.embrace.android.embracesdk.injection.SystemServiceModule
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NativeModule
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
@@ -39,7 +40,11 @@ internal typealias UnimplementedConfig = Unit?
 /**
  * Function that returns an instance of [CoreModule]. Matches the signature of the constructor for [CoreModuleImpl]
  */
-internal typealias CoreModuleSupplier = (context: Context, appFramework: Embrace.AppFramework) -> CoreModule
+internal typealias CoreModuleSupplier = (
+    context: Context,
+    appFramework: Embrace.AppFramework,
+    logger: InternalEmbraceLogger
+) -> CoreModule
 
 /**
  * Function that returns an instance of [WorkerThreadModule]. Matches the signature of the constructor for [WorkerThreadModuleImpl]
@@ -105,6 +110,7 @@ internal typealias DataCaptureServiceModuleSupplier = (
  * Function that returns an instance of [DeliveryModule]. Matches the signature of the constructor for [DeliveryModuleImpl]
  */
 internal typealias DeliveryModuleSupplier = (
+    initModule: InitModule,
     coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
     storageModule: StorageModule,
@@ -117,7 +123,6 @@ internal typealias DeliveryModuleSupplier = (
 
 internal typealias AnrModuleSupplier = (
     initModule: InitModule,
-    coreModule: CoreModule,
     essentialServiceModule: EssentialServiceModule,
     workerModule: WorkerThreadModule,
 ) -> AnrModule
@@ -152,6 +157,7 @@ internal typealias CustomerLogModuleSupplier = (
  */
 
 internal typealias NativeModuleSupplier = (
+    initModule: InitModule,
     coreModule: CoreModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
@@ -167,7 +173,6 @@ internal typealias NativeModuleSupplier = (
 internal typealias DataContainerModuleSupplier = (
     initModule: InitModule,
     openTelemetryModule: OpenTelemetryModule,
-    coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
     systemServiceModule: SystemServiceModule,
     androidServicesModule: AndroidServicesModule,
@@ -186,9 +191,9 @@ internal typealias DataContainerModuleSupplier = (
  */
 
 internal typealias DataSourceModuleSupplier = (
-    essentialServiceModule: EssentialServiceModule,
     initModule: InitModule,
     openTelemetryModule: OpenTelemetryModule,
+    essentialServiceModule: EssentialServiceModule,
     systemServiceModule: SystemServiceModule,
     androidServicesModule: AndroidServicesModule,
     workerThreadModule: WorkerThreadModule,
@@ -235,9 +240,10 @@ internal typealias CrashModuleSupplier = (
  * Function that returns an instance of [PayloadModule]. Matches the signature of the constructor for [PayloadModuleImpl]
  */
 internal typealias PayloadModuleSupplier = (
-    essentialServiceModule: EssentialServiceModule,
+    initModule: InitModule,
     coreModule: CoreModule,
     androidServicesModule: AndroidServicesModule,
+    essentialServiceModule: EssentialServiceModule,
     systemServiceModule: SystemServiceModule,
     workerThreadModule: WorkerThreadModule,
     nativeModule: NativeModule,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/AndroidLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/AndroidLogger.kt
@@ -8,16 +8,16 @@ private const val DEVELOPER_EMBRACE_TAG = "[EmbraceDev]"
 internal class AndroidLogger : InternalEmbraceLogger.LoggerAction {
     override fun log(
         msg: String,
-        severity: InternalStaticEmbraceLogger.Severity,
+        severity: InternalEmbraceLogger.Severity,
         throwable: Throwable?,
         logStacktrace: Boolean
     ) {
         val exception = throwable?.takeIf { logStacktrace }
         when (severity) {
-            InternalStaticEmbraceLogger.Severity.DEBUG -> Log.d(EMBRACE_TAG, msg, exception)
-            InternalStaticEmbraceLogger.Severity.INFO -> Log.i(EMBRACE_TAG, msg, exception)
-            InternalStaticEmbraceLogger.Severity.WARNING -> Log.w(EMBRACE_TAG, msg, exception)
-            InternalStaticEmbraceLogger.Severity.DEVELOPER -> Log.d(DEVELOPER_EMBRACE_TAG, msg, exception)
+            InternalEmbraceLogger.Severity.DEBUG -> Log.d(EMBRACE_TAG, msg, exception)
+            InternalEmbraceLogger.Severity.INFO -> Log.i(EMBRACE_TAG, msg, exception)
+            InternalEmbraceLogger.Severity.WARNING -> Log.w(EMBRACE_TAG, msg, exception)
+            InternalEmbraceLogger.Severity.DEVELOPER -> Log.d(DEVELOPER_EMBRACE_TAG, msg, exception)
             else -> Log.e(EMBRACE_TAG, msg, exception)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.logging
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import java.net.BindException
@@ -61,10 +59,6 @@ internal class EmbraceInternalErrorService(
     ): Boolean {
         return if (throwable != null) {
             if (ignoredExceptionClasses.contains(throwable.javaClass)) {
-                logDeveloper(
-                    "EmbraceInternalErrorService",
-                    "Exception ignored: " + throwable.javaClass
-                )
                 true
             } else {
                 /* if Hashset#add returns true means that the throwable was properly added,
@@ -80,9 +74,7 @@ internal class EmbraceInternalErrorService(
 
     @Synchronized
     override fun handleInternalError(throwable: Throwable) {
-        logDebug("ignoreThrowableCause - handleInternalError")
         if (ignoredExceptionClasses.contains(throwable.javaClass)) {
-            logDeveloper("EmbraceInternalErrorService", "Exception ignored: " + throwable.javaClass)
             return
         } else {
             val capturedThrowable = HashSet<Throwable>()
@@ -100,7 +92,6 @@ internal class EmbraceInternalErrorService(
                     .toTypedArray()[0]
             )
         ) {
-            logDeveloper("EmbraceInternalErrorService", "Ignored exception: $throwable")
             return
         }
         if (err == null) {
@@ -109,10 +100,6 @@ internal class EmbraceInternalErrorService(
 
         // if the config service has not been set yet, capture the exception
         if (configService == null || configService?.dataCaptureEventBehavior?.isInternalExceptionCaptureEnabled() == true) {
-            logDeveloper(
-                "EmbraceInternalErrorService",
-                "Capturing exception, config service is not set yet: $throwable"
-            )
             err?.addException(
                 throwable,
                 getApplicationState(),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalEmbraceLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalEmbraceLogger.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.logging
 
 import android.util.Log
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Severity
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -14,13 +13,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 // perform as fast as possible.
 @Suppress("NOTHING_TO_INLINE")
 internal class InternalEmbraceLogger {
-    private val defaultLogger = AndroidLogger()
-    private val loggerActions = CopyOnWriteArrayList<LoggerAction>()
-
-    init {
-        setToDefault()
-    }
-
+    private val loggerActions = CopyOnWriteArrayList<LoggerAction>(listOf(AndroidLogger()))
     private var threshold = Severity.INFO
 
     interface LoggerAction {
@@ -29,11 +22,6 @@ internal class InternalEmbraceLogger {
 
     inline fun addLoggerAction(action: LoggerAction) {
         loggerActions.add(action)
-    }
-
-    @JvmOverloads
-    inline fun logDeveloper(className: String, msg: String, throwable: Throwable? = null) {
-        log("[$className] $msg", Severity.DEVELOPER, throwable, true)
     }
 
     @JvmOverloads
@@ -92,17 +80,13 @@ internal class InternalEmbraceLogger {
         }
     }
 
-    private fun shouldTriggerLoggerActions(severity: Severity) =
-        ApkToolsConfig.IS_DEVELOPER_LOGGING_ENABLED || severity >= threshold
-
     fun setThreshold(severity: Severity) {
         threshold = severity
     }
 
-    internal fun setToDefault() {
-        if (loggerActions.isNotEmpty()) {
-            loggerActions.clear()
-        }
-        loggerActions.add(defaultLogger)
+    private fun shouldTriggerLoggerActions(severity: Severity) = ApkToolsConfig.IS_DEVELOPER_LOGGING_ENABLED || severity >= threshold
+
+    enum class Severity {
+        DEVELOPER, DEBUG, INFO, WARNING, ERROR, NONE
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorLogger.kt
@@ -12,12 +12,12 @@ internal class InternalErrorLogger(
     // and add it to the Q2 stability work
     override fun log(
         msg: String,
-        severity: InternalStaticEmbraceLogger.Severity,
+        severity: InternalEmbraceLogger.Severity,
         throwable: Throwable?,
         logStacktrace: Boolean
     ) {
         val finalThrowable = when {
-            logStrictMode && severity == InternalStaticEmbraceLogger.Severity.ERROR && throwable == null -> LogStrictModeException(
+            logStrictMode && severity == InternalEmbraceLogger.Severity.ERROR && throwable == null -> LogStrictModeException(
                 msg
             )
             else -> throwable
@@ -27,13 +27,12 @@ internal class InternalErrorLogger(
             try {
                 internalErrorService.handleInternalError(finalThrowable)
             } catch (exc: Exception) {
-                logger.log(exc.localizedMessage ?: "", InternalStaticEmbraceLogger.Severity.ERROR, null, false)
+                logger.log(exc.localizedMessage ?: "", InternalEmbraceLogger.Severity.ERROR, null, false)
             }
         }
     }
 
     class LogStrictModeException(msg: String) : Exception(msg)
-    class IntegrationModeException(msg: String) : Exception(msg)
     class InternalError(msg: String) : Exception(msg)
     class NotAnException(msg: String) : Exception(msg)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalStaticEmbraceLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalStaticEmbraceLogger.kt
@@ -1,20 +1,9 @@
 package io.embrace.android.embracesdk.logging
 
-import android.util.Log
-
-/**
- * Wrapper for the Android [Log] utility.
- * Can only be used internally, it's not part of the public API.
- */
-
 // Suppressing "Nothing to inline". These functions are used all around the codebase, pretty often, so we want them to
 // perform as fast as possible.
 @Suppress("NOTHING_TO_INLINE")
 internal class InternalStaticEmbraceLogger private constructor() {
-
-    enum class Severity {
-        DEVELOPER, DEBUG, INFO, WARNING, ERROR, NONE
-    }
 
     companion object : InternalEmbraceLogger.LoggerAction {
 
@@ -22,46 +11,36 @@ internal class InternalStaticEmbraceLogger private constructor() {
         val logger = InternalEmbraceLogger()
 
         @JvmStatic
-        inline fun logDeveloper(className: String, msg: String, throwable: Throwable) {
-            log("[$className] $msg", Severity.DEVELOPER, throwable, true)
-        }
-
-        @JvmStatic
-        inline fun logDeveloper(className: String, msg: String) {
-            log("[$className] $msg", Severity.DEVELOPER, null, true)
-        }
-
-        @JvmStatic
         @JvmOverloads
         inline fun logDebug(msg: String, throwable: Throwable? = null) {
-            log(msg, Severity.DEBUG, throwable, true)
+            log(msg, InternalEmbraceLogger.Severity.DEBUG, throwable, true)
         }
 
         @JvmStatic
         inline fun logInfo(msg: String) {
-            log(msg, Severity.INFO, null, true)
+            log(msg, InternalEmbraceLogger.Severity.INFO, null, true)
         }
 
         @JvmStatic
         @JvmOverloads
         inline fun logWarning(msg: String, throwable: Throwable? = null) {
-            log(msg, Severity.WARNING, throwable, true)
+            log(msg, InternalEmbraceLogger.Severity.WARNING, throwable, true)
         }
 
         @JvmStatic
         @JvmOverloads
         inline fun logError(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false) {
-            log(msg, Severity.ERROR, throwable, logStacktrace)
+            log(msg, InternalEmbraceLogger.Severity.ERROR, throwable, logStacktrace)
         }
 
         // Log with INFO severity that always contains a throwable as an internal exception to be sent to Grafana
         inline fun logInfoWithException(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false) {
-            log(msg, Severity.INFO, throwable ?: InternalErrorLogger.NotAnException(msg), logStacktrace)
+            log(msg, InternalEmbraceLogger.Severity.INFO, throwable ?: InternalErrorLogger.NotAnException(msg), logStacktrace)
         }
 
         // Log with WARNING severity that always contains a throwable as an internal exception to be sent to Grafana
         inline fun logWarningWithException(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false) {
-            log(msg, Severity.WARNING, throwable ?: InternalErrorLogger.NotAnException(msg), logStacktrace)
+            log(msg, InternalEmbraceLogger.Severity.WARNING, throwable ?: InternalErrorLogger.NotAnException(msg), logStacktrace)
         }
 
         /**
@@ -76,13 +55,12 @@ internal class InternalStaticEmbraceLogger private constructor() {
         @JvmStatic
         override fun log(
             msg: String,
-            severity: Severity,
+            severity: InternalEmbraceLogger.Severity,
             throwable: Throwable?,
             logStacktrace: Boolean
-        ) =
-            logger.log(msg, severity, throwable, logStacktrace)
+        ) = logger.log(msg, severity, throwable, logStacktrace)
 
         @JvmStatic
-        fun setThreshold(severity: Severity) = logger.setThreshold(severity)
+        fun setThreshold(severity: InternalEmbraceLogger.Severity) = logger.setThreshold(severity)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
@@ -219,10 +219,6 @@ internal class EmbraceNetworkLoggingService(
                 // Track the number of calls for each domain (or configured suffix)
                 suffix?.let {
                     callsPerDomainSuffix[it] = DomainCount(countPerSuffix.requestCount + 1, limit)
-                    logger.logDeveloper(
-                        "EmbraceNetworkLoggingService",
-                        "Call per domain $domain ${countPerSuffix.requestCount + 1}"
-                    )
                 }
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManager.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManager.java
@@ -19,7 +19,7 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger;
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger;
 
 /**
  * API to encrypt/decrypt data
@@ -31,6 +31,12 @@ class NetworkCaptureEncryptionManager {
     private static final int mEncryptionBlockSize = 245;
     private static final int mDecryptionBlockSize = 256;
 
+    @NonNull
+    private final InternalEmbraceLogger logger;
+
+    NetworkCaptureEncryptionManager(@NonNull InternalEmbraceLogger logger) {
+        this.logger = logger;
+    }
 
     /**
      * @return encrypted data in Base64 String or null if any error occur.
@@ -42,11 +48,11 @@ class NetworkCaptureEncryptionManager {
             if (publicKey != null) {
                 return encrypt(data, publicKey);
             } else {
-                InternalStaticEmbraceLogger.logError("wrong public key");
+                logger.logError("wrong public key");
                 return null;
             }
         } catch (Exception e) {
-            InternalStaticEmbraceLogger.logError("data cannot be encrypted", e);
+            logger.logError("data cannot be encrypted", e);
             return null;
         }
     }
@@ -68,7 +74,7 @@ class NetworkCaptureEncryptionManager {
             result += encodedString;
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | BadPaddingException |
                  IllegalBlockSizeException | IOException e) {
-            InternalStaticEmbraceLogger.logError("data cannot be encrypted", e);
+            logger.logError("data cannot be encrypted", e);
         }
         return result;
     }
@@ -91,7 +97,7 @@ class NetworkCaptureEncryptionManager {
             result = new String(decodedData, UTF_8);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
                  BadPaddingException | IllegalBlockSizeException | IOException e) {
-            InternalStaticEmbraceLogger.logError("data cannot be encrypted", e);
+            logger.logError("data cannot be encrypted", e);
         }
         return result;
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.payload.extensions
 import android.util.Base64
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Crash
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
@@ -23,6 +23,7 @@ internal object CrashFactory {
      * @return a crash
      */
     fun ofThrowable(
+        logger: InternalEmbraceLogger,
         throwable: Throwable?,
         jsException: JsException?,
         crashNumber: Int,
@@ -31,7 +32,7 @@ internal object CrashFactory {
         return Crash(
             crashId,
             exceptionInfo(throwable),
-            jsExceptions(jsException),
+            jsExceptions(jsException, logger),
             threadsInfo(),
             crashNumber
         )
@@ -66,7 +67,7 @@ internal object CrashFactory {
      * @return a list of [String] representing the javascript stacktrace of the crash.
      */
     @JvmStatic
-    private fun jsExceptions(jsException: JsException?): List<String>? {
+    private fun jsExceptions(jsException: JsException?, logger: InternalEmbraceLogger): List<String>? {
         var jsExceptions: List<String>? = null
         if (jsException != null) {
             try {
@@ -74,7 +75,7 @@ internal object CrashFactory {
                 val encodedString = Base64.encodeToString(jsonException, Base64.NO_WRAP)
                 jsExceptions = listOf(encodedString)
             } catch (ex: Exception) {
-                InternalStaticEmbraceLogger.logError(
+                logger.logError(
                     "Failed to parse javascript exception",
                     ex,
                     true

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.util.concurrent.Callable
@@ -47,7 +46,6 @@ internal class EmbracePreferencesService(
     private fun alterStartupStatus(status: String) {
         backgroundWorker.submit {
             Systrace.traceSynchronous("set-startup-status") {
-                logDeveloper("EmbracePreferencesService", "Startup key: $status")
                 prefs.setStringPreference(SDK_STARTUP_STATUS_KEY, status)
             }
         }
@@ -69,7 +67,6 @@ internal class EmbracePreferencesService(
     }
 
     private fun SharedPreferences.setStringPreference(key: String, value: String?) {
-        logDeveloper("EmbracePreferencesService", "Set $key: ${value ?: ""}")
         val editor = edit()
         editor.putString(key, value)
         editor.apply()
@@ -84,8 +81,6 @@ internal class EmbracePreferencesService(
     }
 
     private fun SharedPreferences.setLongPreference(key: String, value: Long?) {
-        logDeveloper("EmbracePreferencesService", "Set $key: ${value ?: ""}")
-
         if (value != null) {
             val editor = edit()
             editor.putLong(key, value)
@@ -102,7 +97,6 @@ internal class EmbracePreferencesService(
     }
 
     private fun SharedPreferences.setIntegerPreference(key: String, value: Int) {
-        logDeveloper("EmbracePreferencesService", "Set $key: $value")
         val editor = edit()
         editor.putInt(key, value)
         editor.apply()
@@ -119,7 +113,6 @@ internal class EmbracePreferencesService(
         key: String,
         value: Boolean?
     ) {
-        logDeveloper("EmbracePreferencesService", "Set $key: ${value ?: ""}")
         if (value != null) {
             val editor = edit()
             editor.putBoolean(key, value)
@@ -131,7 +124,6 @@ internal class EmbracePreferencesService(
         key: String,
         value: Set<String>?
     ) {
-        logDeveloper("EmbracePreferencesService", "Set $key: ${value ?: ""}")
         val editor = edit()
         editor.putStringSet(key, value)
         editor.apply()
@@ -145,7 +137,6 @@ internal class EmbracePreferencesService(
         key: String,
         value: Map<String, String>?
     ) {
-        logDeveloper("EmbracePreferencesService", "Set $key: ${value ?: ""}")
         val editor = edit()
         val mapString = when (value) {
             null -> null
@@ -182,10 +173,6 @@ internal class EmbracePreferencesService(
                 return deviceId
             }
             val newId = getEmbUuid()
-            logDeveloper(
-                "EmbracePreferencesService",
-                "Device ID is null, created new one: $newId"
-            )
             deviceIdentifier = newId
             return newId
         }
@@ -256,7 +243,6 @@ internal class EmbracePreferencesService(
             prefs.setIntegerPreference(key, ordinal)
             ordinal
         } catch (tr: Throwable) {
-            logDeveloper("EmbracePreferencesService", "Error incrementing $key", tr)
             -1
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.registry
 import io.embrace.android.embracesdk.config.ConfigListener
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
@@ -18,7 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * to remember to set callbacks & close resources when creating a new service.
  */
 internal class ServiceRegistry(
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) : Closeable {
 
     private val registry = mutableListOf<Any>()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationChecker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationChecker.kt
@@ -2,11 +2,13 @@ package io.embrace.android.embracesdk.samples
 
 import android.app.Activity
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import java.io.File
 import java.io.FileNotFoundException
 
-internal class AutomaticVerificationChecker {
+internal class AutomaticVerificationChecker(
+    private val logger: InternalEmbraceLogger
+) {
     private val fileName = "emb_marker_file.txt"
     private val verificationResult = VerificationResult()
     private lateinit var file: File
@@ -60,14 +62,14 @@ internal class AutomaticVerificationChecker {
                 }
             }
         } catch (e: FileNotFoundException) {
-            InternalStaticEmbraceLogger.logger.logError("cannot open file", e)
+            logger.logError("cannot open file", e)
         }
         return null
     }
 
     fun addException(e: Throwable) {
         verificationResult.exceptions.add(e)
-        file.writeText(serializer.toJson(verificationResult).toString())
+        file.writeText(serializer.toJson(verificationResult))
     }
 
     fun getExceptions(): List<Throwable> {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationExceptionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationExceptionHandler.kt
@@ -1,14 +1,15 @@
 package io.embrace.android.embracesdk.samples
 
 import io.embrace.android.embracesdk.EmbraceAutomaticVerification
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 /**
  * Exception Handler that verifies if a VerifyIntegrationException was received,
  * in order to execute restartAppFromPendingIntent
  */
-internal class AutomaticVerificationExceptionHandler constructor(
-    private val defaultHandler: Thread.UncaughtExceptionHandler?
+internal class AutomaticVerificationExceptionHandler(
+    private val defaultHandler: Thread.UncaughtExceptionHandler?,
+    private val logger: InternalEmbraceLogger
 ) :
 
     Thread.UncaughtExceptionHandler {
@@ -17,7 +18,7 @@ internal class AutomaticVerificationExceptionHandler constructor(
         if (exception.cause?.cause?.javaClass == VerifyIntegrationException::class.java) {
             EmbraceAutomaticVerification.instance.restartAppFromPendingIntent()
         }
-        InternalStaticEmbraceLogger.logDebug(
+        logger.logDebug(
             "Finished handling exception. Delegating to default handler.",
             exception
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/VerificationActions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/VerificationActions.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.EmbraceAutomaticVerification
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.json.JSONObject
 import java.io.DataOutputStream
 import java.net.HttpURLConnection
@@ -28,7 +28,8 @@ import java.net.URL
  */
 internal class VerificationActions(
     private val embraceInstance: Embrace,
-    private val automaticVerificationChecker: AutomaticVerificationChecker
+    private val logger: InternalEmbraceLogger,
+    private val automaticVerificationChecker: AutomaticVerificationChecker,
 ) {
 
     companion object {
@@ -87,7 +88,7 @@ internal class VerificationActions(
      *  - Throw an Exception
      */
     fun runActions() {
-        InternalStaticEmbraceLogger.logger.logInfo("${EmbraceAutomaticVerification.TAG} Starting Verification...")
+        logger.logInfo("${EmbraceAutomaticVerification.TAG} Starting Verification...")
         embraceInstance.addBreadcrumb("This is a breadcrumb")
         actionsToVerify.forEach {
             verifyAction(it.first, it.second)
@@ -97,12 +98,12 @@ internal class VerificationActions(
     private fun verifyAction(action: () -> Unit, message: String) {
         currentStep++
         try {
-            InternalStaticEmbraceLogger.logger.logInfo(
+            logger.logInfo(
                 "${EmbraceAutomaticVerification.TAG} ✓ Step $currentStep/$totalSteps: $message"
             )
             action.invoke()
         } catch (e: Throwable) {
-            InternalStaticEmbraceLogger.logger.logError(
+            logger.logError(
                 "${EmbraceAutomaticVerification.TAG} -- $message ERROR ${e.localizedMessage}"
             )
             automaticVerificationChecker.addException(e)
@@ -162,7 +163,7 @@ internal class VerificationActions(
         val currentVersion = BuildConfig.VERSION_NAME
 
         if (ComparableVersion(currentVersion) < ComparableVersion(latestEmbraceVersion)) {
-            InternalStaticEmbraceLogger.logger.logWarning(
+            logger.logWarning(
                 "${EmbraceAutomaticVerification.TAG} Note that there is a newer version of Embrace available 🙌! " +
                     "You can read the changelog for $latestEmbraceVersion here: $embraceChangelogLink"
             )
@@ -191,7 +192,7 @@ internal class VerificationActions(
 
     private fun triggerAnr() {
         handler.post { Thread.sleep(ANR_DURATION_MILLIS) }
-        InternalStaticEmbraceLogger.logger.logInfo("${EmbraceAutomaticVerification.TAG} ANR Finished")
+        logger.logInfo("${EmbraceAutomaticVerification.TAG} ANR Finished")
     }
 
     private fun throwAnException() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
@@ -1,12 +1,11 @@
 package io.embrace.android.embracesdk.session
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.logging.InternalErrorService
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDeveloper
 import io.embrace.android.embracesdk.utils.stream
 import java.util.concurrent.CopyOnWriteArrayList
 
-internal class EmbraceMemoryCleanerService : MemoryCleanerService {
+internal class EmbraceMemoryCleanerService(private val logger: InternalEmbraceLogger) : MemoryCleanerService {
 
     /**
      * List of listeners that subscribe to clean services collections.
@@ -17,13 +16,11 @@ internal class EmbraceMemoryCleanerService : MemoryCleanerService {
     override fun cleanServicesCollections(
         internalErrorService: InternalErrorService
     ) {
-        logDeveloper("EmbraceMemoryCleanerService", "Clean services collections")
-
         stream(listeners) { listener: MemoryCleanerListener ->
             try {
                 listener.cleanCollections()
             } catch (ex: Exception) {
-                logDebug("Failed to clean collections on service listener", ex)
+                logger.logDebug("Failed to clean collections on service listener", ex)
             }
         }
         internalErrorService.resetExceptionErrorObject()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
@@ -1,19 +1,19 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 /**
  * Captures a block of data safely, logging any exceptions that occur as an internal error.
  * This is intended for use when building the session/background activity payloads. If an
  * exception is thrown during capture, then we still want to send the request.
  */
-internal inline fun <R> captureDataSafely(result: Provider<R>): R? {
+internal inline fun <R> captureDataSafely(logger: InternalEmbraceLogger, result: Provider<R>): R? {
     return try {
         result()
     } catch (exc: Throwable) {
-        InternalStaticEmbraceLogger.logger.logError(
-            "Exception thrown capturing session data",
+        logger.logError(
+            "Exception thrown capturing data",
             exc
         )
         null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.session.caching
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
@@ -13,7 +12,7 @@ import kotlin.math.max
 internal class PeriodicBackgroundActivityCacher(
     private val clock: Clock,
     private val scheduledWorker: ScheduledWorker,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.session.caching
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
@@ -11,7 +10,7 @@ import java.util.concurrent.TimeUnit
 
 internal class PeriodicSessionCacher(
     private val sessionPeriodicCacheScheduledWorker: ScheduledWorker,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
@@ -2,11 +2,12 @@ package io.embrace.android.embracesdk.session.id
 
 import android.app.ActivityManager
 import android.os.Build
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 
 internal class SessionIdTrackerImpl(
-    private val activityManager: ActivityManager?
+    private val activityManager: ActivityManager?,
+    private val logger: InternalEmbraceLogger
 ) : SessionIdTracker {
 
     @Volatile
@@ -44,7 +45,7 @@ internal class SessionIdTrackerImpl(
                 try {
                     activityManager?.setProcessStateSummary(sessionId.toByteArray())
                 } catch (e: Throwable) {
-                    InternalStaticEmbraceLogger.logError("Couldn't set Process State Summary", e)
+                    logger.logError("Couldn't set Process State Summary", e)
                 }
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.internal.StartupEventInfo
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -17,7 +18,8 @@ internal sealed class FinalEnvelopeParams(
     crashId: String?,
     val endType: SessionSnapshotType,
     val isCacheAttempt: Boolean,
-    val captureSpans: Boolean
+    val captureSpans: Boolean,
+    val logger: InternalEmbraceLogger
 ) {
 
     val crashId: String? = when {
@@ -38,6 +40,7 @@ internal sealed class FinalEnvelopeParams(
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,
+        logger: InternalEmbraceLogger,
         captureSpans: Boolean = true,
         crashId: String? = null,
     ) : FinalEnvelopeParams(
@@ -47,7 +50,8 @@ internal sealed class FinalEnvelopeParams(
         crashId,
         endType,
         lifeEventType == null,
-        captureSpans
+        captureSpans,
+        logger
     ) {
         override val terminationTime: Long? = null
         override val receivedTermination: Boolean? = null
@@ -63,6 +67,7 @@ internal sealed class FinalEnvelopeParams(
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,
+        logger: InternalEmbraceLogger,
         captureSpans: Boolean = true,
         crashId: String? = null,
     ) : FinalEnvelopeParams(
@@ -72,7 +77,8 @@ internal sealed class FinalEnvelopeParams(
         crashId,
         endType,
         endType == SessionSnapshotType.PERIODIC_CACHE,
-        captureSpans
+        captureSpans,
+        logger
     ) {
 
         override val terminationTime: Long? = when {
@@ -92,7 +98,7 @@ internal sealed class FinalEnvelopeParams(
         }
 
         override fun getStartupEventInfo(eventService: EventService) = when {
-            initial.isColdStart -> captureDataSafely(eventService::getStartupMomentInfo)
+            initial.isColdStart -> captureDataSafely(logger, eventService::getStartupMomentInfo)
             else -> null
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -10,7 +11,8 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 internal class PayloadFactoryImpl(
     private val v1payloadMessageCollator: V1PayloadMessageCollator,
     private val v2payloadMessageCollator: V2PayloadMessageCollator,
-    private val configService: ConfigService
+    private val configService: ConfigService,
+    private val logger: InternalEmbraceLogger
 ) : PayloadFactory {
 
     private val collator: PayloadMessageCollator
@@ -63,7 +65,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endTime = timestamp,
                 lifeEventType = LifeEventType.MANUAL,
-                endType = SessionSnapshotType.NORMAL_END
+                endType = SessionSnapshotType.NORMAL_END,
+                logger = logger
             )
         )
     }
@@ -104,7 +107,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endTime = timestamp,
                 lifeEventType = LifeEventType.STATE,
-                endType = SessionSnapshotType.NORMAL_END
+                endType = SessionSnapshotType.NORMAL_END,
+                logger = logger
             )
         )
     }
@@ -121,7 +125,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endTime = timestamp - 1,
                 lifeEventType = LifeEventType.BKGND_STATE,
-                endType = SessionSnapshotType.NORMAL_END
+                endType = SessionSnapshotType.NORMAL_END,
+                logger = logger
             )
         )
     }
@@ -137,7 +142,8 @@ internal class PayloadFactoryImpl(
                 endTime = timestamp,
                 lifeEventType = LifeEventType.STATE,
                 crashId = crashId,
-                endType = SessionSnapshotType.JVM_CRASH
+                endType = SessionSnapshotType.JVM_CRASH,
+                logger = logger
             )
         )
     }
@@ -156,7 +162,8 @@ internal class PayloadFactoryImpl(
                 endTime = timestamp,
                 lifeEventType = LifeEventType.BKGND_STATE,
                 crashId = crashId,
-                endType = SessionSnapshotType.JVM_CRASH
+                endType = SessionSnapshotType.JVM_CRASH,
+                logger = logger
             )
         )
     }
@@ -170,7 +177,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endTime = timestamp,
                 lifeEventType = LifeEventType.STATE,
-                endType = SessionSnapshotType.PERIODIC_CACHE
+                endType = SessionSnapshotType.PERIODIC_CACHE,
+                logger = logger
             )
         )
     }
@@ -184,7 +192,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endTime = timestamp,
                 lifeEventType = null,
-                endType = SessionSnapshotType.PERIODIC_CACHE
+                endType = SessionSnapshotType.PERIODIC_CACHE,
+                logger = logger
             )
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.gating.GatingService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -13,7 +14,8 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 internal class V2PayloadMessageCollator(
     private val gatingService: GatingService,
     private val v1Collator: V1PayloadMessageCollator,
-    private val sessionEnvelopeSource: SessionEnvelopeSource
+    private val sessionEnvelopeSource: SessionEnvelopeSource,
+    private val logger: InternalEmbraceLogger
 ) : PayloadMessageCollator {
 
     override fun buildInitialSession(params: InitialEnvelopeParams): Session {
@@ -27,7 +29,8 @@ internal class V2PayloadMessageCollator(
             lifeEventType = params.lifeEventType,
             crashId = params.crashId,
             endType = params.endType,
-            captureSpans = false
+            captureSpans = false,
+            logger = logger
         )
         return v1Collator.buildFinalSessionMessage(newParams)
             .convertToV2Payload(newParams.endType)
@@ -40,7 +43,8 @@ internal class V2PayloadMessageCollator(
             lifeEventType = params.lifeEventType,
             crashId = params.crashId,
             endType = params.endType,
-            captureSpans = false
+            captureSpans = false,
+            logger = logger
         )
         return v1Collator.buildFinalBackgroundActivityMessage(newParams)
             .convertToV2Payload(newParams.endType)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.session.orchestrator
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 
@@ -19,7 +18,7 @@ internal fun shouldEndManualSession(
     clock: Clock,
     activeSession: Session?,
     state: ProcessState,
-    logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    logger: InternalEmbraceLogger
 ): Boolean {
     if (state == ProcessState.BACKGROUND) {
         logger.logWarning("Cannot manually end session while in background.")
@@ -45,7 +44,7 @@ internal fun shouldEndManualSession(
 
 internal fun shouldRunOnBackground(
     state: ProcessState,
-    logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    logger: InternalEmbraceLogger
 ): Boolean {
     return if (state == ProcessState.BACKGROUND) {
         logger.logWarning("Detected unbalanced call to onBackground. Ignoring..")
@@ -57,7 +56,7 @@ internal fun shouldRunOnBackground(
 
 internal fun shouldRunOnForeground(
     state: ProcessState,
-    logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    logger: InternalEmbraceLogger
 ): Boolean {
     return if (state == ProcessState.FOREGROUND) {
         logger.logWarning("Detected unbalanced call to onForeground. Ignoring..")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
@@ -3,14 +3,13 @@ package io.embrace.android.embracesdk.session.properties
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import java.util.concurrent.atomic.AtomicReference
 
 internal class EmbraceSessionProperties(
     private val preferencesService: PreferencesService,
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val logger: InternalEmbraceLogger
 ) {
     private val temporary: MutableMap<String, String> = HashMap()
     private val permanentPropertiesReference = AtomicReference(NOT_LOADED)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesService.kt
@@ -1,39 +1,24 @@
 package io.embrace.android.embracesdk.session.properties
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 
 internal class EmbraceSessionPropertiesService(
     private val ndkService: NdkService,
-    private val sessionProperties: EmbraceSessionProperties,
-    private val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger
+    private val sessionProperties: EmbraceSessionProperties
 ) : SessionPropertiesService {
 
-    companion object {
-        private const val TAG = "SessionPropertiesService"
-    }
-
     override fun addProperty(key: String, value: String, permanent: Boolean): Boolean {
-        logger.logDeveloper(TAG, "Add Property: $key - $value")
         val added = sessionProperties.add(key, value, permanent)
         if (added) {
-            logger.logDeveloper(TAG, "Session properties updated")
             ndkService.onSessionPropertiesUpdate(sessionProperties.get())
-        } else {
-            logger.logDeveloper(TAG, "Cannot add property: $key")
         }
         return added
     }
 
     override fun removeProperty(key: String): Boolean {
-        logger.logDeveloper(TAG, "Remove Property: $key")
         val removed = sessionProperties.remove(key)
         if (removed) {
-            logger.logDeveloper(TAG, "Session properties updated")
             ndkService.onSessionPropertiesUpdate(sessionProperties.get())
-        } else {
-            logger.logDeveloper(TAG, "Cannot remove property: $key")
         }
         return removed
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/NetworkUtils.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/NetworkUtils.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.utils
 
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logDebug
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logWarning
 import java.net.MalformedURLException
 import java.net.URL
 import java.nio.charset.Charset
@@ -22,17 +20,14 @@ internal object NetworkUtils {
     @JvmStatic
     fun getValidTraceId(traceId: String?): String? {
         if (traceId == null) {
-            logDebug("Ignoring null traceId")
             return null
         }
 
         if (!Charset.forName("US-ASCII").newEncoder().canEncode(traceId)) {
-            logDebug("Relative path must not contain unicode characters. Relative path $traceId will be ignored.")
             return null
         }
 
         return if (traceId.length > TRACE_ID_MAXIMUM_ALLOWED_LENGTH) {
-            logWarning("Truncating traceId to ${traceId.length} characters")
             traceId.substring(0, TRACE_ID_MAXIMUM_ALLOWED_LENGTH)
         } else {
             traceId

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/PropertyUtils.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/PropertyUtils.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.utils
 
 import android.os.Parcelable
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logWarning
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import java.io.Serializable
 
 /**
@@ -22,25 +22,25 @@ internal object PropertyUtils {
      * @return a normalized Map of the provided properties.
      */
     @JvmStatic
-    fun sanitizeProperties(properties: Map<String?, Any?>?): Map<String, Any> {
+    fun sanitizeProperties(properties: Map<String?, Any?>?, logger: InternalEmbraceLogger): Map<String, Any> {
         properties ?: return emptyMap()
 
         if (properties.size > MAX_PROPERTY_SIZE) {
-            logWarning("The maximum number of properties is $MAX_PROPERTY_SIZE, the rest will be ignored.")
+            logger.logWarning("The maximum number of properties is $MAX_PROPERTY_SIZE, the rest will be ignored.")
         }
         return properties.entries
             .filter { it.key != null }
             .take(MAX_PROPERTY_SIZE)
-            .associate { Pair(it.key ?: "null", checkIfSerializable(it.key ?: "", it.value)) }
+            .associate { Pair(it.key ?: "null", checkIfSerializable(it.key ?: "", it.value, logger)) }
     }
 
-    private fun checkIfSerializable(key: String, value: Any?): Any {
+    private fun checkIfSerializable(key: String, value: Any?, logger: InternalEmbraceLogger): Any {
         if (value == null) {
             return "null"
         }
         if (!(value is Parcelable || value is Serializable)) {
             val msg = "The property with key $key has an entry that cannot be serialized. It will be ignored."
-            logWarning(msg)
+            logger.logWarning(msg)
             return "not serializable"
         }
         return value

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/ThreadUtils.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/ThreadUtils.kt
@@ -2,19 +2,19 @@ package io.embrace.android.embracesdk.utils
 
 import android.os.Handler
 import android.os.Looper
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Companion.logError
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 internal object ThreadUtils {
 
     private val mainLooper = Looper.getMainLooper()
     private val mainThread = mainLooper.thread
 
-    fun runOnMainThread(runnable: Runnable) {
+    fun runOnMainThread(logger: InternalEmbraceLogger, runnable: Runnable) {
         val wrappedRunnable = Runnable {
             try {
                 runnable.run()
             } catch (ex: Exception) {
-                logError("Failed to run wrapped runnable on Main thread.", ex)
+                logger.logError("Failed to run wrapped runnable on Main thread.", ex)
             }
         }
         if (Thread.currentThread() !== mainThread) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImpl.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.worker
 
 import io.embrace.android.embracesdk.injection.InitModule
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -15,10 +14,11 @@ import java.util.concurrent.atomic.AtomicReference
 // This lint error seems spurious as it only flags methods annotated with @JvmStatic even though the accessor is generated regardless
 // for lazily initialized members
 internal class WorkerThreadModuleImpl(
-    initModule: InitModule
+    initModule: InitModule,
 ) : WorkerThreadModule, RejectedExecutionHandler {
 
     private val clock = initModule.clock
+    private val logger = initModule.logger
     private val executors: MutableMap<WorkerName, ExecutorService> = ConcurrentHashMap()
     private val backgroundWorkers: MutableMap<WorkerName, BackgroundWorker> = ConcurrentHashMap()
     private val scheduledWorkers: MutableMap<WorkerName, ScheduledWorker> = ConcurrentHashMap()
@@ -64,7 +64,7 @@ internal class WorkerThreadModuleImpl(
      * never return a value.
      */
     override fun rejectedExecution(runnable: Runnable, executor: ThreadPoolExecutor) {
-        InternalStaticEmbraceLogger.logger.logWarning(
+        logger.logWarning(
             "Rejected execution of $runnable on $executor. Ignoring - the process is likely terminating."
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAnrServiceRule.kt
@@ -57,14 +57,16 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             anrMonitorWorker = worker,
             anrMonitorThread = anrMonitorThread,
             configService = fakeConfigService,
-            clock = clock
+            clock = clock,
+            logger = logger
         )
         blockedThreadDetector = BlockedThreadDetector(
             configService = fakeConfigService,
             clock = clock,
             state = state,
             targetThread = Thread.currentThread(),
-            anrMonitorThread = anrMonitorThread
+            anrMonitorThread = anrMonitorThread,
+            logger = logger
         )
         livenessCheckScheduler = LivenessCheckScheduler(
             configService = fakeConfigService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceApplicationExitInfoServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceApplicationExitInfoServiceTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
@@ -88,7 +89,8 @@ internal class EmbraceApplicationExitInfoServiceTest {
             deliveryService,
             metadataService,
             sessionIdTracker,
-            userService
+            userService,
+            InternalEmbraceLogger()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAutomaticVerificationTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAutomaticVerificationTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk
 import android.app.Activity
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
 import io.embrace.android.embracesdk.fakes.system.mockActivity
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -46,7 +47,7 @@ internal class EmbraceAutomaticVerificationTest {
     @Before
     fun setup() {
         every { Embrace.getImpl() } returns mockk(relaxed = true)
-        embraceSamples = EmbraceAutomaticVerification(scheduledExecutorService)
+        embraceSamples = EmbraceAutomaticVerification(scheduledExecutorService, InternalEmbraceLogger())
     }
 
     @After

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.fixtures.testSessionMessage
 import io.embrace.android.embracesdk.fixtures.testSessionMessage2
 import io.embrace.android.embracesdk.fixtures.testSessionMessageOneMinuteLater
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -360,7 +359,7 @@ internal class EmbraceCacheServiceTest {
         assertEquals(1, filesAgain.size)
         assertEquals(files[0], filesAgain[0])
 
-        val errors = loggerAction.msgQueue.filter { it.severity == InternalStaticEmbraceLogger.Severity.ERROR }
+        val errors = loggerAction.msgQueue.filter { it.severity == InternalEmbraceLogger.Severity.ERROR }
         assertEquals("The following errors were logged: $errors", 0, errors.size)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
@@ -98,7 +98,8 @@ internal class EmbraceGatingServiceV1PayloadTest {
         configService = FakeConfigService(sessionBehavior = fakeSessionBehavior { cfg })
         internalEmbraceLogger = InternalEmbraceLogger()
         gatingService = EmbraceGatingService(
-            configService
+            configService,
+            InternalEmbraceLogger()
         )
     }
 
@@ -181,7 +182,8 @@ internal class EmbraceGatingServiceV1PayloadTest {
                 "\"mts_st\"" +
                 "]" +
                 "}}",
-            EmbraceSerializer()
+            EmbraceSerializer(),
+            InternalEmbraceLogger()
         )
 
         cfg = buildCustomRemoteConfig(
@@ -190,7 +192,8 @@ internal class EmbraceGatingServiceV1PayloadTest {
         )
 
         gatingService = EmbraceGatingService(
-            configService
+            configService,
+            internalEmbraceLogger
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV2PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV2PayloadTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -36,7 +37,7 @@ internal class EmbraceGatingServiceV2PayloadTest {
     fun setUp() {
         sessionBehavior = fakeSessionBehavior { cfg }
         configService = FakeConfigService(sessionBehavior = fakeSessionBehavior { cfg })
-        gatingService = EmbraceGatingService(configService)
+        gatingService = EmbraceGatingService(configService, InternalEmbraceLogger())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
@@ -46,7 +46,8 @@ internal class EmbracePerformanceInfoServiceTest {
             googleAnrTimestampRepository,
             applicationExitInfoService,
             null,
-            monitoringServiceRule
+            monitoringServiceRule,
+            InternalEmbraceLogger()
         )
         googleAnrTimestampRepository.add(150209234099)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePowerSaveModeServiceTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.system.mockContext
 import io.embrace.android.embracesdk.fakes.system.mockIntent
 import io.embrace.android.embracesdk.fakes.system.mockPowerManager
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -67,7 +68,8 @@ internal class EmbracePowerSaveModeServiceTest {
         service = EmbracePowerSaveModeService(
             context,
             worker,
-            fakeClock
+            fakeClock,
+            InternalEmbraceLogger()
         ) { powerManager }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceThermalStatusServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceThermalStatusServiceTest.kt
@@ -4,7 +4,6 @@ import android.os.PowerManager
 import io.embrace.android.embracesdk.capture.thermalstate.EmbraceThermalStatusService
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.system.mockPowerManager
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.ThermalState
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
@@ -19,8 +18,7 @@ internal class EmbraceThermalStatusServiceTest {
     fun setUp() {
         service = EmbraceThermalStatusService(
             BackgroundWorker(BlockableExecutorService()),
-            { 0 },
-            InternalEmbraceLogger()
+            { 0 }
         ) { mockPowerManager() }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceUncaughtExceptionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceUncaughtExceptionHandlerTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.capture.crash.CrashService
 import io.embrace.android.embracesdk.capture.crash.EmbraceUncaughtExceptionHandler
 import io.embrace.android.embracesdk.fakes.FakeCrashService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.JsException
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -24,7 +25,7 @@ internal class EmbraceUncaughtExceptionHandlerTest {
      */
     @Test
     fun testNullArg1() {
-        EmbraceUncaughtExceptionHandler(null, FakeCrashService())
+        EmbraceUncaughtExceptionHandler(null, FakeCrashService(), InternalEmbraceLogger())
     }
 
     /**
@@ -35,7 +36,7 @@ internal class EmbraceUncaughtExceptionHandlerTest {
     fun testExceptionHandler() {
         val defaultHandler = TestUncaughtExceptionHandler()
         val fakeCrashService = FakeCrashService()
-        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, fakeCrashService)
+        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, fakeCrashService, InternalEmbraceLogger())
 
         val testException = RuntimeException("Test exception")
         handler.uncaughtException(Thread.currentThread(), testException)
@@ -57,7 +58,7 @@ internal class EmbraceUncaughtExceptionHandlerTest {
     fun testCrashingExceptionHandler() {
         val defaultHandler = TestUncaughtExceptionHandler()
         val crashingCrashService = CrashingCrashService()
-        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, crashingCrashService)
+        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, crashingCrashService, InternalEmbraceLogger())
         val testException = RuntimeException("Test exception")
         handler.uncaughtException(Thread.currentThread(), testException)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.config.remote.WebViewVitals
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeWebViewVitalsBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.WebVitalType
 import io.embrace.android.embracesdk.utils.at
 import org.junit.Assert.assertEquals
@@ -40,7 +41,7 @@ internal class EmbraceWebViewServiceTest {
     fun setup() {
         cfg = RemoteConfig(webViewVitals = WebViewVitals(100f, 50))
         configService = FakeConfigService(webViewVitalsBehavior = fakeWebViewVitalsBehavior { cfg })
-        embraceWebViewService = EmbraceWebViewService(configService, EmbraceSerializer())
+        embraceWebViewService = EmbraceWebViewService(configService, EmbraceSerializer(), InternalEmbraceLogger())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
@@ -72,9 +72,10 @@ internal class EssentialServiceModuleImplTest {
     fun testConfigServiceProvider() {
         val fakeConfigService = FakeConfigService()
         val initModule = InitModuleImpl()
+        val fakeCoreModule = FakeCoreModule()
         val module = EssentialServiceModuleImpl(
             initModule = initModule,
-            coreModule = FakeCoreModule(),
+            coreModule = fakeCoreModule,
             workerThreadModule = WorkerThreadModuleImpl(initModule),
             systemServiceModule = FakeSystemServiceModule(),
             androidServicesModule = FakeAndroidServicesModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.config.LocalConfigParser
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -12,10 +13,11 @@ import org.junit.Test
 internal class LocalConfigTest {
 
     private val serializer = EmbraceSerializer()
+    private val logger = InternalEmbraceLogger()
 
     @Test
     fun testEmptyConfig() {
-        val localConfig = LocalConfigParser.buildConfig("GrCPU", false, null, serializer)
+        val localConfig = LocalConfigParser.buildConfig("GrCPU", false, null, serializer, logger)
         assertNotNull(localConfig)
     }
 
@@ -26,7 +28,8 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"app\": {\"report_disk_usage\": false}}",
-                serializer
+                serializer,
+                logger
             )
         assertFalse(checkNotNull(localConfig.sdkConfig.app?.reportDiskUsage))
     }
@@ -35,7 +38,7 @@ internal class LocalConfigTest {
     fun testBetaFunctionalityOnlyConfig() {
         // disabled explicitly
         var localConfig =
-            LocalConfigParser.buildConfig("GrCPU", false, "{\"beta_features_enabled\": false}", serializer)
+            LocalConfigParser.buildConfig("GrCPU", false, "{\"beta_features_enabled\": false}", serializer, logger)
         assertFalse(checkNotNull(localConfig.sdkConfig.betaFeaturesEnabled))
 
         // enabled explicitly
@@ -43,12 +46,13 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"beta_features_enabled\": true}",
-            serializer
+            serializer,
+            logger
         )
         assertTrue(checkNotNull(localConfig.sdkConfig.betaFeaturesEnabled))
 
         // enabled by default
-        localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer)
+        localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer, logger)
         assertNull(localConfig.sdkConfig.betaFeaturesEnabled)
     }
 
@@ -56,7 +60,7 @@ internal class LocalConfigTest {
     fun testSigHandlerDetectionOnlyConfig() {
         // disabled explicitly
         var localConfig =
-            LocalConfigParser.buildConfig("GrCPU", false, "{\"sig_handler_detection\": false}", serializer)
+            LocalConfigParser.buildConfig("GrCPU", false, "{\"sig_handler_detection\": false}", serializer, logger)
         assertFalse(checkNotNull(localConfig.sdkConfig.sigHandlerDetection))
 
         // enabled explicitly
@@ -64,12 +68,13 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"sig_handler_detection\": true}",
-            serializer
+            serializer,
+            logger
         )
         assertTrue(checkNotNull(localConfig.sdkConfig.sigHandlerDetection))
 
         // enabled by default
-        localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer)
+        localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer, logger)
         assertNull(localConfig.sdkConfig.sigHandlerDetection)
     }
 
@@ -79,7 +84,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"base_urls\": {\"config\": \"custom_config\"}}",
-            serializer
+            serializer,
+            logger
         )
         assertEquals(localConfig.sdkConfig.baseUrls?.config, "custom_config")
         localConfig =
@@ -87,14 +93,16 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"base_urls\": {\"data\": \"custom_data\"}}",
-                serializer
+                serializer,
+                logger
             )
         assertEquals(localConfig.sdkConfig.baseUrls?.data, "custom_data")
         localConfig = LocalConfigParser.buildConfig(
             "GrCPU",
             false,
             "{\"base_urls\": {\"data_dev\": \"custom_data_dev\"}}",
-            serializer
+            serializer,
+            logger
         )
         assertEquals(
             localConfig.sdkConfig.baseUrls?.dataDev,
@@ -104,14 +112,15 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"base_urls\": {\"images\": \"custom_images\"}}",
-            serializer
+            serializer,
+            logger
         )
         assertEquals(localConfig.sdkConfig.baseUrls?.images, "custom_images")
     }
 
     @Test
     fun testViewConfigOnlyConfig() {
-        var localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer)
+        var localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer, logger)
         assertNull(
             localConfig.sdkConfig.viewConfig?.enableAutomaticActivityCapture,
         )
@@ -119,7 +128,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"view_config\":{\"enable_automatic_activity_capture\":false}}",
-            serializer
+            serializer,
+            logger
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.viewConfig?.enableAutomaticActivityCapture))
     }
@@ -131,7 +141,8 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"crash_handler\": {\"enabled\": false}}",
-                serializer
+                serializer,
+                logger
             )
         assertFalse(checkNotNull(localConfig.sdkConfig.crashHandler?.enabled))
         localConfig =
@@ -139,7 +150,8 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"crash_handler\": {\"ndk_enabled\": false}}",
-                serializer
+                serializer,
+                logger
             )
         assertFalse(localConfig.ndkEnabled)
     }
@@ -150,7 +162,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"session\": {\"error_log_strict_mode\": true}}",
-            serializer
+            serializer,
+            logger
         )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.sessionConfig?.sessionEnableErrorLogStrictMode)
@@ -161,7 +174,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"session\": {\"components\": [\"breadcrumbs_taps\"]}}",
-            serializer
+            serializer,
+            logger
         )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.sessionConfig?.sessionComponents)
@@ -174,7 +188,8 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"session\": {\"send_full_for\": []}}",
-                serializer
+                serializer,
+                logger
             )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.sessionConfig?.fullSessionEvents).isEmpty()
@@ -185,7 +200,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"session\": {\"send_full_for\": [\"crashes\"]}}",
-            serializer
+            serializer,
+            logger
         )
         val sessionConfig = localConfig.sdkConfig.sessionConfig
         assertFalse(
@@ -202,7 +218,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"startup_moment\": {\"automatically_end\": false}}",
-            serializer
+            serializer,
+            logger
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.startupMoment?.automaticallyEnd))
     }
@@ -214,7 +231,8 @@ internal class LocalConfigTest {
                 "GrCPU",
                 false,
                 "{\"taps\": {\"capture_coordinates\": false}}",
-                serializer
+                serializer,
+                logger
             )
         assertFalse(checkNotNull(localConfig.sdkConfig.taps?.captureCoordinates))
     }
@@ -225,7 +243,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"networking\": {\"capture_request_content_length\": true}}",
-            serializer
+            serializer,
+            logger
         )
         assertTrue(
             checkNotNull(localConfig.sdkConfig.networking?.captureRequestContentLength)
@@ -235,14 +254,16 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"networking\": {\"enable_native_monitoring\": true}}",
-            serializer
+            serializer,
+            logger
         )
         assertTrue(checkNotNull(localConfig.sdkConfig.networking?.enableNativeMonitoring))
         localConfig = LocalConfigParser.buildConfig(
             "GrCPU",
             false,
             "{\"networking\": {\"trace_id_header\": \"custom-value\"}}",
-            serializer
+            serializer,
+            logger
         )
         assertEquals(
             checkNotNull(localConfig.sdkConfig.networking?.traceIdHeader),
@@ -252,7 +273,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"networking\": {\"disabled_url_patterns\": [\"a.b.c\", \"https://example.com\", \"https://example2.com/foo/123/bar\"]}}",
-            serializer
+            serializer,
+            logger
         )
         assertEquals(
             3,
@@ -266,14 +288,16 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"webview\": {\"enable\": false}}",
-            serializer
+            serializer,
+            logger
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.webViewConfig?.captureWebViews))
         localConfig = LocalConfigParser.buildConfig(
             "GrCPU",
             false,
             "{\"webview\": {\"capture_query_params\": false}}",
-            serializer
+            serializer,
+            logger
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.webViewConfig?.captureQueryParams))
     }
@@ -284,7 +308,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {}}",
-            serializer
+            serializer,
+            logger
         )
         var backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertNull(
@@ -303,7 +328,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true}}",
-            serializer
+            serializer,
+            logger
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
 
@@ -314,7 +340,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true, \"manual_background_activity_limit\": 50}}",
-            serializer
+            serializer,
+            logger
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertTrue(
@@ -328,7 +355,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true, \"min_background_activity_duration\": 300}}",
-            serializer
+            serializer,
+            logger
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertTrue(
@@ -342,7 +370,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"background_activity\": {\"capture_enabled\": true, \"max_cached_activities\": 50}}",
-            serializer
+            serializer,
+            logger
         )
         backgroundActivityCfg = checkNotNull(localConfig.sdkConfig.backgroundActivityConfig)
         assertTrue(
@@ -356,7 +385,7 @@ internal class LocalConfigTest {
 
     @Test
     fun testComposeConfig() {
-        var localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer)
+        var localConfig = LocalConfigParser.buildConfig("GrCPU", false, "{}", serializer, logger)
         assertNull(
             localConfig.sdkConfig.composeConfig?.captureComposeOnClick,
         )
@@ -364,7 +393,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"compose\":{\"capture_compose_onclick\":false}}",
-            serializer
+            serializer,
+            logger
         )
         assertFalse(checkNotNull(localConfig.sdkConfig.composeConfig?.captureComposeOnClick))
     }
@@ -375,7 +405,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"memory_info\": false}}",
-            serializer
+            serializer,
+            logger
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertFalse(
@@ -385,7 +416,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"memory_info\": true}}",
-            serializer
+            serializer,
+            logger
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertTrue(
@@ -399,7 +431,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"power_save_mode_info\": false}}",
-            serializer
+            serializer,
+            logger
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertFalse(
@@ -409,7 +442,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"power_save_mode_info\": true}}",
-            serializer
+            serializer,
+            logger
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertTrue(
@@ -423,7 +457,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"network_connectivity_info\": false}}",
-            serializer
+            serializer,
+            logger
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
 
@@ -434,7 +469,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"network_connectivity_info\": true}}",
-            serializer
+            serializer,
+            logger
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
 
@@ -449,7 +485,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"anr_info\": false}}",
-            serializer
+            serializer,
+            logger
         )
         var cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertFalse(
@@ -459,7 +496,8 @@ internal class LocalConfigTest {
             "GrCPU",
             false,
             "{\"automatic_data_capture\": { \"anr_info\": true}}",
-            serializer
+            serializer,
+            logger
         )
         cfg = checkNotNull(localConfig.sdkConfig.automaticDataCaptureConfig)
         assertTrue(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/NativeThreadSamplerInstallerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/NativeThreadSamplerInstallerTest.kt
@@ -36,7 +36,7 @@ internal class NativeThreadSamplerInstallerTest {
 
         cfg = AnrRemoteConfig(pctNativeThreadAnrSamplingEnabled = 100f)
         configService = FakeConfigService(anrBehavior = fakeAnrBehavior { cfg })
-        installer = NativeThreadSamplerInstaller(sharedObjectLoader = sharedObjectLoader)
+        installer = NativeThreadSamplerInstaller(sharedObjectLoader = sharedObjectLoader, mockk(relaxed = true))
         every { sharedObjectLoader.loadEmbraceNative() } returns true
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PropertiesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PropertiesTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.utils.PropertyUtils
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -17,7 +18,7 @@ internal class PropertiesTest {
         for (i in 1..9) {
             sourceMap["Key$i"] = "Value$i"
         }
-        val resultMap = PropertyUtils.sanitizeProperties(sourceMap)
+        val resultMap = PropertyUtils.sanitizeProperties(sourceMap, InternalEmbraceLogger())
         assertTrue(
             "Unexpected normalized map size.",
             resultMap.size <= PropertyUtils.MAX_PROPERTY_SIZE

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetectorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetectorTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.fakes.FakeBlockedThreadListener
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -35,7 +36,8 @@ internal class BlockedThreadDetectorTest {
             listener,
             state,
             Thread.currentThread(),
-            anrMonitorThread = anrMonitorThread
+            anrMonitorThread = anrMonitorThread,
+            logger = InternalEmbraceLogger()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
@@ -57,7 +57,8 @@ internal class LivenessCheckSchedulerTest {
             clock = fakeClock,
             state = state,
             targetThread = Thread.currentThread(),
-            anrMonitorThread = anrMonitorThread
+            anrMonitorThread = anrMonitorThread,
+            logger = InternalEmbraceLogger()
         )
         fakeTargetThreadHandler = mockk(relaxUnitFun = true) {
             every { action = any() } returns Unit

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.fakes.system.mockMessage
 import io.embrace.android.embracesdk.fakes.system.mockMessageQueue
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.mockk
 import io.mockk.verify
@@ -50,7 +51,8 @@ internal class TargetThreadHandlerTest {
             ScheduledWorker(executorService),
             anrMonitorThread = anrMonitorThread,
             configService,
-            messageQueue
+            messageQueue,
+            logger = InternalEmbraceLogger()
         ) { FAKE_TIME_MS }.apply {
             action = {}
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetectorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetectorTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.anr.detection
 
 import io.embrace.android.embracesdk.fakes.FakeLoggerAction
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -77,7 +76,7 @@ internal class UnbalancedCallDetectorTest {
 
     private fun verifyInternalErrorLogs(expectedCount: Int) {
         val messages = action.msgQueue.filter { msg ->
-            msg.severity == InternalStaticEmbraceLogger.Severity.ERROR && msg.logStacktrace
+            msg.severity == InternalEmbraceLogger.Severity.ERROR && msg.logStacktrace
         }
         assertEquals(expectedCount, messages.size)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.system.mockContext
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -24,7 +25,8 @@ internal class DataCaptureOrchestratorTest {
                     configGate = { enabled },
                     currentSessionType = null
                 )
-            )
+            ),
+            InternalEmbraceLogger()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -37,7 +38,7 @@ internal class DataSourceImplTest {
     @Test
     fun `capture data respects limits`() {
         val dst = FakeCurrentSessionSpan()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -51,7 +52,7 @@ internal class DataSourceImplTest {
     @Test
     fun `capture data respects validation`() {
         val dst = FakeCurrentSessionSpan()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -66,7 +67,7 @@ internal class DataSourceImplTest {
         dst: FakeCurrentSessionSpan,
         limitStrategy: LimitStrategy = NoopLimitStrategy
     ) :
-        DataSourceImpl<FakeCurrentSessionSpan>(dst, limitStrategy) {
+        DataSourceImpl<FakeCurrentSessionSpan>(dst, InternalEmbraceLogger(), limitStrategy) {
 
         override fun enableDataCapture() {
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -37,7 +38,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `capture data respects limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -51,7 +52,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `capture data respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -87,7 +88,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `start span respects limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -101,7 +102,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `start span respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -137,7 +138,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `stop span does not increment limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -151,7 +152,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `stop span respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy({ 2 }))
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -165,5 +166,5 @@ internal class SpanDataSourceImplTest {
     private class FakeDataSourceImpl(
         dst: FakeSpanService,
         limitStrategy: LimitStrategy = NoopLimitStrategy
-    ) : SpanDataSourceImpl(dst, limitStrategy)
+    ) : SpanDataSourceImpl(dst, InternalEmbraceLogger(), limitStrategy)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch.limits
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -10,7 +11,7 @@ internal class UpToLimitStrategyTest {
 
     @Test
     fun shouldCapture() {
-        val strategy = UpToLimitStrategy(provider)
+        val strategy = UpToLimitStrategy(InternalEmbraceLogger(), provider)
         repeat(10) {
             assertTrue(strategy.shouldCapture())
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
@@ -55,6 +56,7 @@ internal class AeiDataSourceImplTest {
     private val metadataService = FakeMetadataService()
     private val sessionIdTracker = FakeSessionIdTracker()
     private val userService = FakeUserService()
+    private val logger = InternalEmbraceLogger()
 
     private val mockActivityManager: ActivityManager = mockk {
         every { getHistoricalProcessExitReasons(any(), any(), any()) } returns emptyList()
@@ -91,7 +93,8 @@ internal class AeiDataSourceImplTest {
             metadataService,
             sessionIdTracker,
             userService,
-            logWriter
+            logWriter,
+            logger
         ).apply(AeiDataSourceImpl::enableDataCapture)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.every
@@ -159,6 +160,7 @@ internal class AeiNdkCrashProtobufSendTest {
             metadataService,
             sessionIdTracker,
             FakeUserService(),
+            InternalEmbraceLogger(),
             VersionChecker { ndkTraceFile }
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -18,7 +19,8 @@ internal class CustomBreadcrumbDataSourceTest {
         writer = FakeCurrentSessionSpan()
         source = CustomBreadcrumbDataSource(
             FakeConfigService().breadcrumbBehavior,
-            writer
+            writer,
+            InternalEmbraceLogger(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -26,6 +27,7 @@ internal class FragmentBreadcrumbDataSourceTest {
             configService.breadcrumbBehavior,
             clock,
             spanService,
+            InternalEmbraceLogger(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/DeviceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/DeviceImplTest.kt
@@ -4,6 +4,7 @@ import android.os.Environment
 import android.view.WindowManager
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.clearAllMocks
@@ -61,7 +62,8 @@ internal class DeviceImplTest {
             windowManager,
             preferencesService,
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
-            cpuInfoDelegate
+            cpuInfoDelegate,
+            InternalEmbraceLogger(),
         )
 
         assertEquals("200x300", device.screenResolution)
@@ -73,7 +75,8 @@ internal class DeviceImplTest {
             windowManager,
             preferencesService,
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
-            cpuInfoDelegate
+            cpuInfoDelegate,
+            InternalEmbraceLogger(),
         )
 
         assertEquals("fake_cpu", device.cpuName)
@@ -85,7 +88,8 @@ internal class DeviceImplTest {
             windowManager,
             preferencesService,
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
-            cpuInfoDelegate
+            cpuInfoDelegate,
+            InternalEmbraceLogger(),
         )
 
         assertEquals("fake_egl", device.eglInfo)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
@@ -46,7 +47,8 @@ internal class SessionPayloadSourceImplTest {
             FakeNativeThreadSamplerService(),
             sink,
             currentSessionSpan,
-            spanRepository
+            spanRepository,
+            InternalEmbraceLogger(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackServiceTest.kt
@@ -5,6 +5,7 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import io.embrace.android.embracesdk.fakes.FakeMemoryService
 import io.embrace.android.embracesdk.fakes.system.mockContext
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -41,7 +42,8 @@ internal class ComponentCallbackServiceTest {
 
         service = ComponentCallbackService(
             application,
-            memoryService
+            memoryService,
+            InternalEmbraceLogger(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
@@ -84,7 +84,8 @@ internal class EmbraceMetadataReactNativeTest {
         deviceArchitecture,
         lazy { "" },
         lazy { "" },
-        hostedSdkVersionInfo
+        hostedSdkVersionInfo,
+        InternalEmbraceLogger(),
     )
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -24,6 +24,7 @@ import io.embrace.android.embracesdk.fakes.system.mockStorageStatsManager
 import io.embrace.android.embracesdk.fakes.system.mockWindowManager
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.clearAllMocks
@@ -54,6 +55,7 @@ internal class EmbraceMetadataServiceTest {
         private val fakeArchitecture = FakeDeviceArchitecture()
         private val storageStatsManager = mockk<StorageStatsManager>()
         private val windowManager = mockk<WindowManager>()
+        private val logger = InternalEmbraceLogger()
 
         @BeforeClass
         @JvmStatic
@@ -143,7 +145,8 @@ internal class EmbraceMetadataServiceTest {
             fakeArchitecture,
             lazy { packageInfo.versionName },
             lazy { packageInfo.versionCode.toString() },
-            hostedSdkVersionInfo
+            hostedSdkVersionInfo,
+            InternalEmbraceLogger(),
         ).apply { precomputeValues() }
     }
 
@@ -257,7 +260,8 @@ internal class EmbraceMetadataServiceTest {
             fakeArchitecture,
             lazy { packageInfo.versionName },
             lazy { packageInfo.versionCode.toString() },
-            hostedSdkVersionInfo
+            hostedSdkVersionInfo,
+            logger
         )
 
         val deviceInfo = serializer.toJson(metadataService.getDeviceInfo())
@@ -285,18 +289,6 @@ internal class EmbraceMetadataServiceTest {
 
         assertEquals("appId", metadataService.getAppId())
         assertEquals("10", metadataService.getAppVersionCode())
-    }
-
-    @Test
-    fun `test disk usage`() {
-        every {
-            MetadataUtils.getDeviceDiskAppUsage(any(), any(), any())
-        }.returns(123L)
-
-        val service = getMetadataService()
-        service.asyncRetrieveDiskUsage(true)
-
-        assertEquals(123L, service.getDiskUsage()?.appDiskUsage)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheServiceConcurrentAccessTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheServiceConcurrentAccessTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.fixtures.testSessionMessage
 import io.embrace.android.embracesdk.fixtures.testSessionMessage2
 import io.embrace.android.embracesdk.fixtures.testSessionMessageOneMinuteLater
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -153,7 +152,7 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
 
     private fun getErrorLogs() = loggerAction
         .msgQueue
-        .filter { it.severity == InternalStaticEmbraceLogger.Severity.ERROR }
+        .filter { it.severity == InternalEmbraceLogger.Severity.ERROR }
         .toList()
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.comms.api.Endpoint
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.worker.ScheduledWorker
@@ -314,6 +315,7 @@ internal class EmbracePendingApiCallsSenderTest {
             scheduledWorker = worker,
             networkConnectivityService = networkConnectivityService,
             cacheManager = mockCacheManager,
+            logger = InternalEmbraceLogger(),
             clock = FakeClock()
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -146,7 +147,7 @@ internal class NetworkBehaviorTest {
     @Test
     fun testGetCapturePublicKey() {
         val json = ResourceReader.readResourceAsText("public_key_config.json")
-        val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer())
+        val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), InternalEmbraceLogger())
         val behavior = fakeNetworkBehavior(localCfg = localConfig::sdkConfig)
         assertEquals(testCleanPublicKey, behavior.getCapturePublicKey())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
@@ -107,11 +107,11 @@ internal class EmbraceLogMessageServiceTest {
                 cfg
             }
         )
-        gatingService = EmbraceGatingService(configService)
+        gatingService = EmbraceGatingService(configService, logcat)
         sessionIdTracker.setActiveSessionId("session-123", true)
         metadataService.setAppForeground()
         metadataService.setAppId("appId")
-        sessionProperties = EmbraceSessionProperties(FakePreferenceService(), configService)
+        sessionProperties = EmbraceSessionProperties(FakePreferenceService(), configService, logcat)
     }
 
     private fun getLogMessageService(): EmbraceLogMessageService {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
@@ -85,7 +85,7 @@ internal class EventHandlerTest {
             sessionBehavior = fakeSessionBehavior { cfg },
             dataCaptureEventBehavior = fakeDataCaptureEventBehavior { cfg }
         )
-        sessionProperties = EmbraceSessionProperties(FakePreferenceService(), configService)
+        sessionProperties = EmbraceSessionProperties(FakePreferenceService(), configService, logger)
 
         clock = FakeClock()
         blockingScheduledExecutorService = BlockingScheduledExecutorService()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 
@@ -17,7 +18,7 @@ internal class FakeGatingService(configService: ConfigService = FakeConfigServic
     val envelopesFiltered = mutableListOf<Envelope<SessionPayload>>()
     val eventMessagesFiltered = mutableListOf<EventMessage>()
 
-    private val realGatingService = EmbraceGatingService(configService)
+    private val realGatingService = EmbraceGatingService(configService, InternalEmbraceLogger())
 
     override fun gateSessionMessage(sessionMessage: SessionMessage): SessionMessage {
         val filteredMessage = realGatingService.gateSessionMessage(sessionMessage)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLoggerAction.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLoggerAction.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Severity
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger.Severity
 import java.util.LinkedList
 
 internal class FakeLoggerAction : InternalEmbraceLogger.LoggerAction {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -26,7 +26,7 @@ internal class FakeOpenTelemetryModule(
     override val tracer: Tracer
         get() = TODO()
     override val spanService: SpanService
-        get() = TODO()
+        get() = FakeSpanService()
     override val embraceTracer: EmbraceTracer
         get() = TODO()
     override val internalTracer: InternalTracer

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.registry.ServiceRegistry
 import io.mockk.every
 import io.mockk.isMockKMock
@@ -22,13 +21,13 @@ import org.robolectric.RuntimeEnvironment
  * If used in a Robolectric test, [application] and [context] will be fakes supplied by the Robolectric framework
  */
 internal class FakeCoreModule(
+    val logger: InternalEmbraceLogger = InternalEmbraceLogger(),
     override val application: Application =
         if (RuntimeEnvironment.getApplication() == null) mockApplication() else RuntimeEnvironment.getApplication(),
     override val context: Context =
         if (isMockKMock(application)) getMockedContext() else application.applicationContext,
     override val appFramework: AppFramework = AppFramework.NATIVE,
-    override val logger: InternalEmbraceLogger = InternalStaticEmbraceLogger.logger,
-    override val serviceRegistry: ServiceRegistry = ServiceRegistry(),
+    override val serviceRegistry: ServiceRegistry = ServiceRegistry(logger),
     override val jsonSerializer: EmbraceSerializer = EmbraceSerializer(),
     override val resources: FakeAndroidResourcesService = FakeAndroidResourcesService(),
     override val isDebug: Boolean = if (isMockKMock(context)) false else AppEnvironment(context.applicationInfo).isDebug,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCrashModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCrashModule.kt
@@ -8,7 +8,11 @@ import io.embrace.android.embracesdk.samples.AutomaticVerificationExceptionHandl
 import io.mockk.mockk
 
 internal class FakeCrashModule : CrashModule {
-    override val lastRunCrashVerifier = LastRunCrashVerifier(CrashFileMarker(mockk(relaxed = true)))
+    override val lastRunCrashVerifier = LastRunCrashVerifier(
+        CrashFileMarker(mockk(relaxed = true), mockk(relaxed = true)),
+        mockk(relaxed = true)
+    )
     override val crashService = FakeCrashService()
-    override val automaticVerificationExceptionHandler = AutomaticVerificationExceptionHandler(null)
+    override val automaticVerificationExceptionHandler =
+        AutomaticVerificationExceptionHandler(null, mockk(relaxed = true))
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
@@ -19,13 +19,15 @@ import io.embrace.android.embracesdk.fakes.FakeMemoryService
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.injection.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 internal class FakeDataCaptureServiceModule(
     override val thermalStatusService: ThermalStatusService = NoOpThermalStatusService(),
     override val powerSaveModeService: PowerSaveModeService = NoOpPowerSaveModeService(),
     override val memoryService: MemoryService = FakeMemoryService(),
     override val breadcrumbService: BreadcrumbService = FakeBreadcrumbService(),
-    override val webviewService: WebViewService = EmbraceWebViewService(FakeConfigService(), EmbraceSerializer()),
+    override val webviewService: WebViewService =
+        EmbraceWebViewService(FakeConfigService(), EmbraceSerializer(), InternalEmbraceLogger()),
 ) : DataCaptureServiceModule {
 
     override val pushNotificationService: PushNotificationCaptureService

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -32,6 +32,7 @@ import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
@@ -48,7 +49,7 @@ internal class FakeEssentialServiceModule(
     override val orientationService: OrientationService = NoOpOrientationService(),
     override val apiClient: ApiClient = FakeApiClient(),
     override val userService: UserService = FakeUserService(),
-    override val sharedObjectLoader: SharedObjectLoader = SharedObjectLoader(),
+    override val sharedObjectLoader: SharedObjectLoader = SharedObjectLoader(InternalEmbraceLogger()),
     override val deviceArchitecture: DeviceArchitecture = FakeDeviceArchitecture(),
     override val apiService: ApiService = FakeApiService(),
     override val networkConnectivityService: NetworkConnectivityService = NoOpNetworkConnectivityService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -9,11 +9,13 @@ import io.embrace.android.embracesdk.injection.OpenTelemetryModuleImpl
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 internal class FakeInitModule(
     clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
     openTelemetryClock: io.opentelemetry.sdk.common.Clock = FakeOpenTelemetryClock(clock),
-    initModule: InitModule = InitModuleImpl(clock = clock, openTelemetryClock = openTelemetryClock)
+    logger: InternalEmbraceLogger = InternalEmbraceLogger(),
+    initModule: InitModule = InitModuleImpl(clock = clock, openTelemetryClock = openTelemetryClock, logger = logger)
 ) : InitModule by initModule {
     val openTelemetryModule: OpenTelemetryModule = OpenTelemetryModuleImpl(initModule)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.injection.SessionModule
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.message.PayloadFactory
@@ -32,5 +33,5 @@ internal class FakeSessionModule(
         get() = TODO("Not yet implemented")
 
     override val dataCaptureOrchestrator: DataCaptureOrchestrator =
-        DataCaptureOrchestrator(emptyList())
+        DataCaptureOrchestrator(emptyList(), InternalEmbraceLogger())
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 
 internal class FakeWorkerThreadModule(
-    fakeInitModule: FakeInitModule,
-    private val name: WorkerName,
+    fakeInitModule: FakeInitModule = FakeInitModule(),
+    private val name: WorkerName? = null,
     private val base: WorkerThreadModule = WorkerThreadModuleImpl(fakeInitModule)
 ) : WorkerThreadModule by base {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AndroidServicesModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AndroidServicesModuleImplTest.kt
@@ -11,9 +11,10 @@ internal class AndroidServicesModuleImplTest {
     @Test
     fun testDefault() {
         val initModule = InitModuleImpl()
+        val coreModule = FakeCoreModule()
         val module = AndroidServicesModuleImpl(
             initModule = initModule,
-            coreModule = FakeCoreModule(),
+            coreModule = coreModule,
             workerThreadModule = WorkerThreadModuleImpl(initModule)
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
@@ -8,8 +8,9 @@ import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import io.mockk.every
@@ -29,12 +30,10 @@ internal class AnrModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
-        val initModule = InitModuleImpl()
         val module = AnrModuleImpl(
-            initModule,
-            FakeCoreModule(),
+            FakeInitModule(),
             FakeEssentialServiceModule(),
-            WorkerThreadModuleImpl(initModule)
+            WorkerThreadModuleImpl(FakeInitModule())
         )
         assertNotNull(module.anrService)
         assertNotNull(module.googleAnrTimestampRepository)
@@ -43,14 +42,12 @@ internal class AnrModuleImplTest {
 
     @Test
     fun testBehaviorDisabled() {
-        val initModule = InitModuleImpl()
         val module = AnrModuleImpl(
-            initModule,
-            FakeCoreModule(),
+            FakeInitModule(),
             FakeEssentialServiceModule(
                 configService = createConfigServiceWithAnrDisabled()
             ),
-            WorkerThreadModuleImpl(initModule)
+            FakeWorkerThreadModule()
         )
         assertTrue(module.anrService is NoOpAnrService)
         assertTrue(module.responsivenessMonitorService is NoOpResponsivenessMonitorService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CoreModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CoreModuleImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.injection
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.capture.metadata.AppEnvironment
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
@@ -17,10 +17,10 @@ internal class CoreModuleImplTest {
     @Test
     fun testApplicationObject() {
         val ctx = RuntimeEnvironment.getApplication().applicationContext
-        val module = CoreModuleImpl(ctx, Embrace.AppFramework.NATIVE)
+        val logger = InternalEmbraceLogger()
+        val module = CoreModuleImpl(ctx, Embrace.AppFramework.NATIVE, logger)
         assertSame(ctx, module.context)
         assertSame(ctx, module.application)
-        assertSame(InternalStaticEmbraceLogger.logger, module.logger)
         assertNotNull(module.serviceRegistry)
         assertNotNull(module.jsonSerializer)
     }
@@ -30,7 +30,7 @@ internal class CoreModuleImplTest {
         val application = RuntimeEnvironment.getApplication()
         val isDebug = AppEnvironment(application.applicationInfo).isDebug
         val ctx = application.applicationContext
-        val module = CoreModuleImpl(ctx, Embrace.AppFramework.NATIVE)
+        val module = CoreModuleImpl(ctx, Embrace.AppFramework.NATIVE, InternalEmbraceLogger())
         assertSame(application, module.application)
         assertEquals(isDebug, module.isDebug)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CustomerLogModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CustomerLogModuleImplTest.kt
@@ -16,9 +16,10 @@ internal class CustomerLogModuleImplTest {
     @Test
     fun testDefaultImplementations() {
         val initModule = InitModuleImpl()
+        val fakeCoreModule = FakeCoreModule()
         val module = CustomerLogModuleImpl(
             initModule,
-            FakeCoreModule(),
+            fakeCoreModule,
             FakeOpenTelemetryModule(),
             FakeAndroidServicesModule(),
             FakeEssentialServiceModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataContainerModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataContainerModuleImplTest.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
-import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCustomerLogModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataCaptureServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
-import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
+import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -19,12 +19,10 @@ internal class DataContainerModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
-        val initModule = FakeInitModule()
         val module = DataContainerModuleImpl(
-            initModule,
-            initModule.openTelemetryModule,
-            FakeCoreModule(),
-            WorkerThreadModuleImpl(initModule),
+            FakeInitModule(),
+            FakeOpenTelemetryModule(),
+            FakeWorkerThreadModule(),
             FakeSystemServiceModule(),
             FakeAndroidServicesModule(),
             FakeEssentialServiceModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -15,13 +15,14 @@ internal class DataSourceModuleImplTest {
 
     @Test
     fun `test default behavior`() {
+        val fakeInitModule = FakeInitModule()
         val module = DataSourceModuleImpl(
-            FakeEssentialServiceModule(),
-            FakeInitModule(),
+            fakeInitModule,
             FakeOpenTelemetryModule(),
+            FakeEssentialServiceModule(),
             FakeSystemServiceModule(),
             FakeAndroidServicesModule(),
-            FakeWorkerThreadModule(FakeInitModule(), WorkerName.BACKGROUND_REGISTRATION)
+            FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = WorkerName.BACKGROUND_REGISTRATION)
         )
         assertNotNull(module.getDataSources())
         assertNotNull(module.customBreadcrumbDataSource)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DeliveryModuleImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import org.junit.Assert.assertNotNull
@@ -11,8 +12,11 @@ internal class DeliveryModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
+        val initModule = FakeInitModule()
+        val coreModule = FakeCoreModule()
         val module = DeliveryModuleImpl(
-            FakeCoreModule(),
+            initModule,
+            coreModule,
             WorkerThreadModuleImpl(InitModuleImpl()),
             FakeStorageModule(),
             FakeEssentialServiceModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadModuleImplTest.kt
@@ -16,12 +16,14 @@ internal class PayloadModuleImplTest {
     @Test
     fun `module default values`() {
         val initModule = InitModuleImpl()
+        val coreModule = FakeCoreModule()
         val module = PayloadModuleImpl(
-            FakeEssentialServiceModule(),
-            FakeCoreModule(),
+            initModule,
+            coreModule,
             FakeAndroidServicesModule(),
+            FakeEssentialServiceModule(),
             FakeSystemServiceModule(),
-            workerThreadModule = WorkerThreadModuleImpl(initModule),
+            WorkerThreadModuleImpl(initModule),
             FakeNativeModule(),
             FakeOpenTelemetryModule(),
             FakeSdkObservabilityModule()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/StorageModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/StorageModuleImplTest.kt
@@ -14,9 +14,10 @@ internal class StorageModuleImplTest {
     @Test
     fun testDefaultImplementations() {
         val initModule = InitModuleImpl()
+        val coreModule = FakeCoreModule()
         val module = StorageModuleImpl(
             initModule = initModule,
-            coreModule = FakeCoreModule(),
+            coreModule = coreModule,
             workerThreadModule = WorkerThreadModuleImpl(initModule),
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarkerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarkerTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.crash
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -37,7 +38,7 @@ internal class CrashFileMarkerTest {
         testFile = File(tempFolder.root.path, CrashFileMarker.CRASH_MARKER_FILE_NAME)
         mockFile = testFile
         markerLazyFile = lazy { mockFile }
-        crashMarker = CrashFileMarker(markerLazyFile)
+        crashMarker = CrashFileMarker(markerLazyFile, InternalEmbraceLogger())
     }
 
     @After

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.crash
 
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.mockk.every
@@ -23,7 +24,7 @@ internal class LastRunCrashVerifierTest {
     @Before
     fun setUp() {
         mockCrashFileMarker = mockk()
-        lastRunCrashVerifier = LastRunCrashVerifier(mockCrashFileMarker)
+        lastRunCrashVerifier = LastRunCrashVerifier(mockCrashFileMarker, InternalEmbraceLogger())
         fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), name = WorkerName.BACKGROUND_REGISTRATION)
         worker = fakeWorkerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakeLogService
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -34,7 +35,8 @@ internal class CompositeLogServiceTest {
         compositeLogService = CompositeLogService(
             v1LogService = v1LogService,
             v2LogService = v2LogService,
-            configService = configService
+            configService = configService,
+            logger = InternalEmbraceLogger()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -20,6 +20,7 @@ import io.embrace.android.embracesdk.fakes.fakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.Assert
@@ -64,7 +65,8 @@ internal class EmbraceLogServiceTest {
         sessionIdTracker.setActiveSessionId("session-123", true)
         sessionProperties = EmbraceSessionProperties(
             FakePreferenceService(),
-            FakeConfigService()
+            FakeConfigService(),
+            InternalEmbraceLogger()
         )
         cfg = RemoteConfig()
         configService = FakeConfigService(
@@ -384,6 +386,7 @@ internal class EmbraceLogServiceTest {
             sessionIdTracker,
             sessionProperties,
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            InternalEmbraceLogger(),
             clock,
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalEmbraceLoggerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalEmbraceLoggerTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.logging
 
 import io.embrace.android.embracesdk.fakes.FakeLoggerAction
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.Severity
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger.Severity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalErrorLoggerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalErrorLoggerTest.kt
@@ -44,7 +44,7 @@ internal class InternalErrorLoggerTest {
     @Test
     fun `if no throwable then do not handle exception`() {
         setupService()
-        internalErrorLogger.log("message", InternalStaticEmbraceLogger.Severity.DEBUG, null, true)
+        internalErrorLogger.log("message", InternalEmbraceLogger.Severity.DEBUG, null, true)
 
         verify { internalErrorService wasNot Called }
     }
@@ -53,7 +53,7 @@ internal class InternalErrorLoggerTest {
     fun `if throwable available, then do handle exception`() {
         setupService()
         val exception = Exception()
-        internalErrorLogger.log("message", InternalStaticEmbraceLogger.Severity.DEBUG, exception, true)
+        internalErrorLogger.log("message", InternalEmbraceLogger.Severity.DEBUG, exception, true)
 
         verify { internalErrorService.handleInternalError(exception) }
     }
@@ -68,11 +68,11 @@ internal class InternalErrorLoggerTest {
             exceptionMessage
         )
 
-        internalErrorLogger.log(msg, InternalStaticEmbraceLogger.Severity.DEBUG, exception, true)
+        internalErrorLogger.log(msg, InternalEmbraceLogger.Severity.DEBUG, exception, true)
 
         verify { internalErrorService.handleInternalError(exception) }
         loggerAction.msgQueue.single {
-            it.msg == exceptionMessage && it.severity == InternalStaticEmbraceLogger.Severity.ERROR &&
+            it.msg == exceptionMessage && it.severity == InternalEmbraceLogger.Severity.ERROR &&
                 it.throwable == null && !it.logStacktrace
         }
     }
@@ -84,12 +84,12 @@ internal class InternalErrorLoggerTest {
         val msg = "message"
         every { internalErrorService.handleInternalError(exception) } throws RuntimeException()
 
-        internalErrorLogger.log(msg, InternalStaticEmbraceLogger.Severity.DEBUG, exception, true)
+        internalErrorLogger.log(msg, InternalEmbraceLogger.Severity.DEBUG, exception, true)
 
         verify { internalErrorService.handleInternalError(exception) }
 
         loggerAction.msgQueue.single {
-            it.msg == "" && it.severity == InternalStaticEmbraceLogger.Severity.ERROR &&
+            it.msg == "" && it.severity == InternalEmbraceLogger.Severity.ERROR &&
                 it.throwable == null && !it.logStacktrace
         }
     }
@@ -99,7 +99,7 @@ internal class InternalErrorLoggerTest {
         setupService(true)
         val exception = Exception()
         val errorMsg = "Error message"
-        internalErrorLogger.log(errorMsg, InternalStaticEmbraceLogger.Severity.ERROR, exception, true)
+        internalErrorLogger.log(errorMsg, InternalEmbraceLogger.Severity.ERROR, exception, true)
 
         verify { internalErrorService.handleInternalError(exception) }
     }
@@ -108,7 +108,7 @@ internal class InternalErrorLoggerTest {
     fun `if logStrictMode is enabled and a throwable is not available with ERROR severity then handle exception`() {
         setupService(true)
         val errorMsg = "Error message"
-        internalErrorLogger.log(errorMsg, InternalStaticEmbraceLogger.Severity.ERROR, null, true)
+        internalErrorLogger.log(errorMsg, InternalEmbraceLogger.Severity.ERROR, null, true)
 
         verify(exactly = 1) {
             internalErrorService.handleInternalError(
@@ -121,7 +121,7 @@ internal class InternalErrorLoggerTest {
     fun `if logStrictMode is enabled and a throwable is not available with INFO severity then dont handle exception`() {
         setupService(true)
         val errorMsg = "Error message"
-        internalErrorLogger.log(errorMsg, InternalStaticEmbraceLogger.Severity.INFO, null, true)
+        internalErrorLogger.log(errorMsg, InternalEmbraceLogger.Severity.INFO, null, true)
 
         verify(exactly = 0) { internalErrorService.handleInternalError(any() as Exception) }
     }
@@ -131,7 +131,7 @@ internal class InternalErrorLoggerTest {
         setupService(false)
         val exception = Exception()
         val errorMsg = "Error message"
-        internalErrorLogger.log(errorMsg, InternalStaticEmbraceLogger.Severity.ERROR, exception, true)
+        internalErrorLogger.log(errorMsg, InternalEmbraceLogger.Severity.ERROR, exception, true)
 
         verify { internalErrorService.handleInternalError(exception) }
     }
@@ -148,12 +148,12 @@ internal class InternalErrorLoggerTest {
             exceptionMessage
         )
 
-        internalErrorLogger.log(msg, InternalStaticEmbraceLogger.Severity.DEBUG, exception, true)
+        internalErrorLogger.log(msg, InternalEmbraceLogger.Severity.DEBUG, exception, true)
 
         verify { internalErrorService.handleInternalError(any() as InternalErrorLogger.LogStrictModeException) }
 
         loggerAction.msgQueue.single {
-            it.msg == exceptionMessage && it.severity == InternalStaticEmbraceLogger.Severity.ERROR &&
+            it.msg == exceptionMessage && it.severity == InternalEmbraceLogger.Severity.ERROR &&
                 it.throwable == null && !it.logStacktrace
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -116,7 +116,7 @@ internal class EmbraceNdkServiceTest {
         deliveryService = FakeDeliveryService()
         userService = FakeUserService()
         preferencesService = FakePreferenceService()
-        sessionProperties = EmbraceSessionProperties(preferencesService, configService)
+        sessionProperties = EmbraceSessionProperties(preferencesService, configService, InternalEmbraceLogger())
         appFramework = Embrace.AppFramework.NATIVE
         sharedObjectLoader = mockk()
         logger = InternalEmbraceLogger()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
@@ -16,8 +17,10 @@ internal class NativeModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
+        val coreModule = FakeCoreModule()
         val module = NativeModuleImpl(
-            FakeCoreModule(),
+            FakeInitModule(),
+            coreModule,
             FakeStorageModule(),
             FakeEssentialServiceModule(),
             FakeDeliveryModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.fakes.fakeSdkEndpointBehavior
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.mockk.clearAllMocks
 import io.mockk.unmockkAll
 import org.junit.AfterClass
@@ -54,7 +55,8 @@ internal class EmbraceNetworkCaptureServiceTest {
                     "GrCPU",
                     false,
                     "{\"base_urls\": {\"data\": \"https://data.emb-api.com\"}}",
-                    EmbraceSerializer()
+                    EmbraceSerializer(),
+                    InternalEmbraceLogger()
                 )
         }
 
@@ -226,7 +228,8 @@ internal class EmbraceNetworkCaptureServiceTest {
         preferenceService,
         logMessageService,
         configService,
-        EmbraceSerializer()
+        EmbraceSerializer(),
+        InternalEmbraceLogger()
     )
 
     private fun getDefaultRule(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManagerTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.network.logging
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -17,8 +18,7 @@ internal class NetworkCaptureEncryptionManagerTest {
 
     @Before
     fun setup() {
-        networkCaptureEncryptionManager =
-            NetworkCaptureEncryptionManager()
+        networkCaptureEncryptionManager = NetworkCaptureEncryptionManager(InternalEmbraceLogger())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/registry/ServiceRegistryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/registry/ServiceRegistryTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeActivityTracker
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
@@ -19,7 +20,7 @@ internal class ServiceRegistryTest {
 
     @Test
     fun testServiceRegistration() {
-        val registry = ServiceRegistry()
+        val registry = ServiceRegistry(InternalEmbraceLogger())
         val service = FakeService()
         val obj = "test_obj"
         registry.registerServices(service, obj)
@@ -34,7 +35,7 @@ internal class ServiceRegistryTest {
 
     @Test
     fun testListeners() {
-        val registry = ServiceRegistry()
+        val registry = ServiceRegistry(InternalEmbraceLogger())
         val service = FakeService()
         registry.registerService(service)
         val expected = listOf(service)
@@ -62,7 +63,7 @@ internal class ServiceRegistryTest {
 
     @Test(expected = IllegalStateException::class)
     fun testClosedRegistration() {
-        val registry = ServiceRegistry()
+        val registry = ServiceRegistry(InternalEmbraceLogger())
         registry.closeRegistration()
         registry.registerService(FakeService())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ActivityLifecycleTrackerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ActivityLifecycleTrackerTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeOrientationService
 import io.embrace.android.embracesdk.fakes.system.mockApplication
 import io.embrace.android.embracesdk.fakes.system.mockLooper
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleTracker
 import io.mockk.Called
@@ -80,6 +81,7 @@ internal class ActivityLifecycleTrackerTest {
         activityLifecycleTracker = ActivityLifecycleTracker(
             application,
             orientationService,
+            InternalEmbraceLogger()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerServiceTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerListener
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.utils.at
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -15,7 +16,7 @@ internal class EmbraceMemoryCleanerServiceTest {
     @Before
     fun setUp() {
         internalErrorService = FakeInternalErrorService()
-        service = EmbraceMemoryCleanerService()
+        service = EmbraceMemoryCleanerService(InternalEmbraceLogger())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateListener
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.session.lifecycle.EmbraceProcessStateService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
@@ -238,7 +237,7 @@ internal class EmbraceProcessStateServiceTest {
     }
 
     private fun fetchLogMessages() = logger.msgQueue.filter {
-        it.severity >= InternalStaticEmbraceLogger.Severity.ERROR
+        it.severity >= InternalEmbraceLogger.Severity.ERROR
     }
 
     private class DecoratedListener(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
@@ -97,8 +98,9 @@ internal class PayloadFactorySessionTest {
             resourceSource = FakeEnvelopeResourceSource(),
             sessionPayloadSource = FakeSessionPayloadSource()
         )
+        val logger = InternalEmbraceLogger()
         val v1Collator = mockk<V1PayloadMessageCollator>(relaxed = true)
-        val v2Collator = V2PayloadMessageCollator(FakeGatingService(), v1Collator, sessionEnvelopeSource)
-        service = PayloadFactoryImpl(v1Collator, v2Collator, FakeConfigService())
+        val v2Collator = V2PayloadMessageCollator(FakeGatingService(), v1Collator, sessionEnvelopeSource, logger)
+        service = PayloadFactoryImpl(v1Collator, v2Collator, FakeConfigService(), logger)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -41,6 +41,7 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.logging.EmbraceInternalErrorService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
@@ -99,11 +100,13 @@ internal class SessionHandlerTest {
     private lateinit var payloadFactory: PayloadFactory
     private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var scheduledWorker: ScheduledWorker
+    private lateinit var logger: InternalEmbraceLogger
 
     @Before
     fun before() {
         executorService = BlockingScheduledExecutorService()
         scheduledWorker = ScheduledWorker(executorService)
+        logger = InternalEmbraceLogger()
         clock.setCurrentTime(now)
         activeSession = fakeSession()
         every { sessionProperties.get() } returns emptyMapSessionProperties
@@ -158,7 +161,8 @@ internal class SessionHandlerTest {
             initModule.openTelemetryModule.spanSink,
             initModule.openTelemetryModule.currentSessionSpan,
             FakeSessionPropertiesService(),
-            FakeStartupService()
+            FakeStartupService(),
+            logger
         )
         val v2Collator = V2PayloadMessageCollator(
             gatingService,
@@ -167,9 +171,10 @@ internal class SessionHandlerTest {
                 metadataSource = FakeEnvelopeMetadataSource(),
                 resourceSource = FakeEnvelopeResourceSource(),
                 sessionPayloadSource = FakeSessionPayloadSource()
-            )
+            ),
+            logger
         )
-        payloadFactory = PayloadFactoryImpl(payloadMessageCollator, v2Collator, configService)
+        payloadFactory = PayloadFactoryImpl(payloadMessageCollator, v2Collator, configService, logger)
     }
 
     @After

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -24,30 +24,30 @@ import org.junit.Test
 
 internal class SessionModuleImplTest {
 
-    private val fakeInitModule = FakeInitModule()
-
-    private val workerThreadModule = FakeWorkerThreadModule(fakeInitModule, WorkerName.BACKGROUND_REGISTRATION)
-
-    private val configService = FakeConfigService()
     private val initModule = FakeInitModule()
     private val otelModule = FakeOpenTelemetryModule()
     private val systemServiceModule = FakeSystemServiceModule()
     private val androidServicesModule = FakeAndroidServicesModule()
+    private val configService = FakeConfigService()
+    private val workerThreadModule = FakeWorkerThreadModule(
+        fakeInitModule = initModule,
+        name = WorkerName.BACKGROUND_REGISTRATION
+    )
 
     @Test
     fun testDefaultImplementations() {
         val essentialServiceModule = FakeEssentialServiceModule(configService = configService)
         val dataSourceModule = DataSourceModuleImpl(
-            essentialServiceModule,
             initModule,
             otelModule,
+            essentialServiceModule,
             systemServiceModule,
             androidServicesModule,
             workerThreadModule
         )
         val module = SessionModuleImpl(
-            fakeInitModule,
-            fakeInitModule.openTelemetryModule,
+            initModule,
+            initModule.openTelemetryModule,
             FakeAndroidServicesModule(),
             essentialServiceModule,
             FakeNativeModule(),
@@ -75,17 +75,17 @@ internal class SessionModuleImplTest {
     fun testEnabledBehaviors() {
         val essentialServiceModule = createEnabledBehavior()
         val dataSourceModule = DataSourceModuleImpl(
-            essentialServiceModule,
             initModule,
             otelModule,
+            essentialServiceModule,
             systemServiceModule,
             androidServicesModule,
             workerThreadModule
         )
 
         val module = SessionModuleImpl(
-            fakeInitModule,
-            fakeInitModule.openTelemetryModule,
+            initModule,
+            initModule.openTelemetryModule,
             FakeAndroidServicesModule(),
             essentialServiceModule,
             FakeNativeModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
+import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.payload.Session
@@ -33,6 +34,7 @@ import org.junit.Test
 internal class V1PayloadMessageCollatorTest {
 
     private lateinit var initModule: FakeInitModule
+    private lateinit var coreModule: FakeCoreModule
     private lateinit var collator: PayloadMessageCollator
     private lateinit var gatingService: FakeGatingService
 
@@ -44,6 +46,7 @@ internal class V1PayloadMessageCollatorTest {
     @Before
     fun setUp() {
         initModule = FakeInitModule()
+        coreModule = FakeCoreModule()
         gatingService = FakeGatingService()
         collator = V1PayloadMessageCollator(
             gatingService = gatingService,
@@ -64,6 +67,7 @@ internal class V1PayloadMessageCollatorTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
+            logger = initModule.logger
         )
     }
 
@@ -110,6 +114,7 @@ internal class V1PayloadMessageCollatorTest {
                 15000000000,
                 LifeEventType.BKGND_STATE,
                 SessionSnapshotType.NORMAL_END,
+                initModule.logger,
                 true,
                 "crashId"
             )
@@ -137,6 +142,7 @@ internal class V1PayloadMessageCollatorTest {
                 15000000000,
                 LifeEventType.STATE,
                 SessionSnapshotType.NORMAL_END,
+                initModule.logger,
                 true,
                 "crashId"
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.session.id
 
 import io.embrace.android.embracesdk.FakeNdkService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -13,7 +14,7 @@ internal class SessionIdTrackerImplTest {
 
     @Before
     fun setUp() {
-        tracker = SessionIdTrackerImpl(null)
+        tracker = SessionIdTrackerImpl(null, InternalEmbraceLogger())
         ndkService = FakeNdkService()
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -65,7 +65,8 @@ internal class PayloadFactoryImplTest {
             spanSink = initModule.openTelemetryModule.spanSink,
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
-            startupService = FakeStartupService()
+            startupService = FakeStartupService(),
+            logger = initModule.logger
         )
         val v2Collator = V2PayloadMessageCollator(
             FakeGatingService(),
@@ -74,12 +75,14 @@ internal class PayloadFactoryImplTest {
                 FakeEnvelopeMetadataSource(),
                 FakeEnvelopeResourceSource(),
                 FakeSessionPayloadSource()
-            )
+            ),
+            initModule.logger
         )
         factory = PayloadFactoryImpl(
             v1payloadMessageCollator = v1Collator,
             v2payloadMessageCollator = v2Collator,
-            configService = configService
+            configService = configService,
+            logger = initModule.logger
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -18,6 +18,7 @@ import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeThermalStatusService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
+import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.payload.Session
@@ -33,6 +34,7 @@ import org.junit.Test
 internal class V2PayloadMessageCollatorTest {
 
     private lateinit var initModule: FakeInitModule
+    private lateinit var coreModule: FakeCoreModule
     private lateinit var v1collator: V1PayloadMessageCollator
     private lateinit var v2collator: V2PayloadMessageCollator
     private lateinit var gatingService: FakeGatingService
@@ -45,6 +47,7 @@ internal class V2PayloadMessageCollatorTest {
     @Before
     fun setUp() {
         initModule = FakeInitModule()
+        coreModule = FakeCoreModule()
         gatingService = FakeGatingService()
         v1collator = V1PayloadMessageCollator(
             gatingService = gatingService,
@@ -65,13 +68,14 @@ internal class V2PayloadMessageCollatorTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
+            logger = initModule.logger
         )
         val sessionEnvelopeSource = SessionEnvelopeSourceImpl(
             metadataSource = FakeEnvelopeMetadataSource(),
             resourceSource = FakeEnvelopeResourceSource(),
             sessionPayloadSource = FakeSessionPayloadSource()
         )
-        v2collator = V2PayloadMessageCollator(gatingService, v1collator, sessionEnvelopeSource)
+        v2collator = V2PayloadMessageCollator(gatingService, v1collator, sessionEnvelopeSource, initModule.logger)
     }
 
     @Test
@@ -117,6 +121,7 @@ internal class V2PayloadMessageCollatorTest {
                 15000000000,
                 Session.LifeEventType.BKGND_STATE,
                 SessionSnapshotType.NORMAL_END,
+                initModule.logger,
                 true,
                 "crashId"
             )
@@ -144,6 +149,7 @@ internal class V2PayloadMessageCollatorTest {
                 15000000000,
                 Session.LifeEventType.STATE,
                 SessionSnapshotType.NORMAL_END,
+                initModule.logger,
                 true,
                 "crashId",
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.session.properties
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -15,7 +16,8 @@ internal class EmbraceSessionPropertiesServiceTest {
 
     @Before
     fun setUp() {
-        props = EmbraceSessionProperties(FakePreferenceService(), FakeConfigService())
+        val logger = InternalEmbraceLogger()
+        props = EmbraceSessionProperties(FakePreferenceService(), FakeConfigService(), logger)
         ndkService = FakeNdkService()
         service = EmbraceSessionPropertiesService(ndkService, props)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/utils/PropertyUtilsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/utils/PropertyUtilsTest.kt
@@ -1,15 +1,18 @@
 package io.embrace.android.embracesdk.utils
 
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.utils.PropertyUtils.sanitizeProperties
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class PropertyUtilsTest {
 
+    private val logger = InternalEmbraceLogger()
+
     @Test
     fun testEmptyCase() {
-        assertEquals(emptyMap<String, String>(), sanitizeProperties(null))
-        assertEquals(emptyMap<String, String>(), sanitizeProperties(emptyMap()))
+        assertEquals(emptyMap<String, String>(), sanitizeProperties(null, logger))
+        assertEquals(emptyMap<String, String>(), sanitizeProperties(emptyMap(), logger))
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -17,23 +20,23 @@ internal class PropertyUtilsTest {
     fun testPropertyLimitExceeded() {
         val input = (0..20).associateBy { "$it" }
         val expected = (0..9).associateBy { "$it" }
-        assertEquals(expected, sanitizeProperties(input as Map<String?, Any>?))
+        assertEquals(expected, sanitizeProperties(input as Map<String?, Any>?, logger))
     }
 
     @Test
     fun testNullValue() {
-        assertEquals("null", sanitizeProperties(mapOf("a" to null))["a"])
+        assertEquals("null", sanitizeProperties(mapOf("a" to null), logger)["a"])
     }
 
     @Test
     fun testSerializableValue() {
         val obj = SerializableClass()
-        assertEquals(obj, sanitizeProperties(mapOf("a" to obj))["a"])
+        assertEquals(obj, sanitizeProperties(mapOf("a" to obj), logger)["a"])
     }
 
     @Test
     fun testUnserializableValue() {
-        assertEquals("not serializable", sanitizeProperties(mapOf("a" to UnSerializableClass()))["a"])
+        assertEquals("not serializable", sanitizeProperties(mapOf("a" to UnSerializableClass()), logger)["a"])
     }
 
     private class SerializableClass : java.io.Serializable


### PR DESCRIPTION
## Goal

Removed most of the direct use of the static logger, and instead rely on an instance that gets passed in that will be created in the InitModule. I also removed a lot of useless dev logging.

The crux of he change involved using the instance that get passed down via the modules init chain, and in places where it's not convenient, rely on the static logger instead. Both are hooked into the same internal error service instance so internal exceptions are reported.

The static logger will be slimmed down then completely removed, but I couldn't get away from having at least one massive change. There was no easy way of teasing these out without risking mistakes, and most of the changes are at least trivial. 

There are other refactors that I wanted to do and they were done in subsequent PRs. 

I'll will point to the right places to look but most of the other changes are just removing dev logging, adding the logger to a constructor, and passing it in when creating instances.

## Testing

Tests were modified as needed. Relying on existing coverage to ensure functionality worked as before, except for adding a test that verifies the static and instance loggers are both hooked up to the same internal error service.

