### PR TITLE
Delete the static logger

### DIFF
--- a/embrace-android-fcm/src/main/java/io/embrace/android/embracesdk/fcm/swazzle/callback/com/android/fcm/FirebaseSwazzledHooks.java
+++ b/embrace-android-fcm/src/main/java/io/embrace/android/embracesdk/fcm/swazzle/callback/com/android/fcm/FirebaseSwazzledHooks.java
@@ -1,8 +1,7 @@
 package io.embrace.android.embracesdk.fcm.swazzle.callback.com.android.fcm;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
-
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -18,10 +17,8 @@ public final class FirebaseSwazzledHooks {
     @SuppressWarnings("MethodNameCheck")
     @InternalApi
     public static void _onMessageReceived(@NonNull RemoteMessage message) {
-        logger.logDebug("Embrace received push notification message");
-
         if (!Embrace.getInstance().isStarted()) {
-            logger.logError("Embrace received push notification data before the SDK was started");
+            logError("Embrace received push notification data before the SDK was started", null);
             return;
         }
 
@@ -37,21 +34,21 @@ public final class FirebaseSwazzledHooks {
             try {
                 messageId = message.getMessageId();
             } catch (Exception e) {
-                logger.logError("Failed to capture FCM messageId", e);
+                logError("Failed to capture FCM messageId", e);
             }
 
             String topic = null;
             try {
                 topic = message.getFrom();
             } catch (Exception e) {
-                logger.logError("Failed to capture FCM topic", e);
+                logError("Failed to capture FCM topic", e);
             }
 
             Integer messagePriority = null;
             try {
                 messagePriority = message.getPriority();
             } catch (Exception e) {
-                logger.logError("Failed to capture FCM message priority", e);
+                logError("Failed to capture FCM message priority", e);
             }
 
             RemoteMessage.Notification notification = null;
@@ -59,7 +56,7 @@ public final class FirebaseSwazzledHooks {
             try {
                 notification = message.getNotification();
             } catch (Exception e) {
-                logger.logError("Failed to capture FCM RemoteMessage Notification", e);
+                logError("Failed to capture FCM RemoteMessage Notification", e);
             }
 
             String title = null;
@@ -69,19 +66,19 @@ public final class FirebaseSwazzledHooks {
                 try {
                     title = notification.getTitle();
                 } catch (Exception e) {
-                    logger.logError("Failed to capture FCM title", e);
+                    logError("Failed to capture FCM title", e);
                 }
 
                 try {
                     body = notification.getBody();
                 } catch (Exception e) {
-                    logger.logError("Failed to capture FCM body", e);
+                    logError("Failed to capture FCM body", e);
                 }
 
                 try {
                     notificationPriority = notification.getNotificationPriority();
                 } catch (Exception e) {
-                    logger.logError("Failed to capture FCM notificationPriority", e);
+                    logError("Failed to capture FCM notificationPriority", e);
                 }
             }
 
@@ -100,10 +97,17 @@ public final class FirebaseSwazzledHooks {
                         hasData
                 );
             } catch (Exception e) {
-                logger.logError("Failed to log push Notification", e);
+                logError("Failed to log push Notification", e);
             }
         } catch (Exception e) {
-            logger.logError("Push Notification Error", e);
+            logError("Push Notification Error", e);
+        }
+    }
+
+    private static void logError(@NonNull String message, @Nullable Exception e) {
+        Embrace.getInstance().getInternalInterface().logError(message, null, null, false);
+        if (e != null) {
+            Embrace.getInstance().getInternalInterface().logInternalError(e);
         }
     }
 }

--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/swazzle/callback/okhttp3/OkHttpClient.java
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/swazzle/callback/okhttp3/OkHttpClient.java
@@ -1,9 +1,8 @@
 package io.embrace.android.embracesdk.okhttp3.swazzle.callback.okhttp3;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
-
 import java.util.List;
 
+import io.embrace.android.embracesdk.Embrace;
 import io.embrace.android.embracesdk.annotation.InternalApi;
 import io.embrace.android.embracesdk.okhttp3.EmbraceOkHttp3ApplicationInterceptor;
 import io.embrace.android.embracesdk.okhttp3.EmbraceOkHttp3NetworkInterceptor;
@@ -35,13 +34,13 @@ public final class OkHttpClient {
          */
         @SuppressWarnings("MethodNameCheck")
         public static void _preBuild(okhttp3.OkHttpClient.Builder thiz) {
-            logger.logDebug("Embrace OkHTTP Wrapper; onPrebuild");
+            logInfo("Embrace OkHTTP Wrapper; onPrebuild");
             addEmbraceInterceptors(thiz);
         }
 
         @SuppressWarnings("MethodNameCheck")
         public static void _constructorOnPostBody(okhttp3.OkHttpClient.Builder thiz) {
-            logger.logDebug("Embrace OkHTTP Wrapper; onPostBody");
+            logInfo("Embrace OkHTTP Wrapper; onPostBody");
             addEmbraceInterceptors(thiz);
         }
 
@@ -52,16 +51,15 @@ public final class OkHttpClient {
          */
         private static void addEmbraceInterceptors(okhttp3.OkHttpClient.Builder thiz) {
             try {
-                logger.logDebug("Embrace OkHTTP Wrapper; Adding interceptors");
+                logInfo("Embrace OkHTTP Wrapper; Adding interceptors");
                 addInterceptor(thiz.interceptors(), new EmbraceOkHttp3ApplicationInterceptor());
                 addInterceptor(thiz.networkInterceptors(), new EmbraceOkHttp3NetworkInterceptor());
             } catch (NoSuchMethodError exception) {
                 // The customer may be overwriting OkHttpClient with their own implementation, and some of the
                 // methods we use are missing.
-                logger.logError("Altered OkHttpClient implementation, could not add OkHttp interceptor. ",
-                    exception);
+                logError("Altered OkHttpClient implementation, could not add OkHttp interceptor. ", exception);
             } catch (Exception exception) {
-                logger.logError("Could not add OkHttp interceptor. ", exception);
+                logError("Could not add OkHttp interceptor. ", exception);
             }
         }
 
@@ -76,8 +74,8 @@ public final class OkHttpClient {
             if (interceptors != null && !containsInstance(interceptors, interceptor.getClass())) {
                 interceptors.add(0, interceptor);
             } else {
-                logger.logDebug(
-                    "Not adding interceptor [" + interceptor.getClass().getSimpleName() + "]"
+                logInfo(
+                        "Not adding interceptor [" + interceptor.getClass().getSimpleName() + "]"
                 );
             }
         }
@@ -94,13 +92,22 @@ public final class OkHttpClient {
                                                     Class<? extends T> clazz) {
             for (T classInstance : elementsList) {
                 if (clazz.isInstance(classInstance)) {
-                    logger.logDebug(
-                        "[" + clazz.getSimpleName() + "] already present in list"
+                    logInfo(
+                            "[" + clazz.getSimpleName() + "] already present in list"
                     );
                     return true;
                 }
             }
             return false;
+        }
+
+        private static void logInfo(String message) {
+            Embrace.getInstance().getInternalInterface().logInfo(message, null);
+        }
+
+        private static void logError(String message, Throwable throwable) {
+            Embrace.getInstance().getInternalInterface().logError(message, null, null, false);
+            Embrace.getInstance().getInternalInterface().logInternalError(throwable);
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -4,11 +4,8 @@ import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.assertions.assertInternalErrorLogged
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.internal.TraceparentGeneratorTest.Companion.validPattern
-import io.embrace.android.embracesdk.internalErrorService
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -137,25 +134,6 @@ internal class PublicApiTest {
             repeat(100) {
                 assertTrue(validPattern.matches(embrace.generateW3cTraceparent()))
             }
-        }
-    }
-
-    @Test
-    fun `static logger and SDK logger instance log to the same internal error service`() {
-        with(testRule) {
-            embrace.start(harness.fakeCoreModule.context)
-            InternalStaticEmbraceLogger.logger.logError("not-used", RuntimeException("static"), true)
-            assertInternalErrorLogged(
-                checkNotNull(internalErrorService()).currentExceptionError,
-                checkNotNull(RuntimeException::class.qualifiedName),
-                "static"
-            )
-            harness.initModule.logger.logError("not-used", RuntimeException("non-static"), true)
-            assertInternalErrorLogged(
-                checkNotNull(internalErrorService()).currentExceptionError,
-                checkNotNull(RuntimeException::class.qualifiedName),
-                "non-static"
-            )
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceSamples.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceSamples.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.annotation.InternalApi
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger
 import io.embrace.android.embracesdk.samples.EmbraceCrashSamples
 
 /**
@@ -15,7 +14,7 @@ import io.embrace.android.embracesdk.samples.EmbraceCrashSamples
 public object EmbraceSamples {
 
     private val embraceCrashSamples = EmbraceCrashSamples
-    private val embraceAutomaticVerification = EmbraceAutomaticVerification(logger = logger)
+    private val embraceAutomaticVerification = EmbraceAutomaticVerification()
 
     /**
      * Starts an automatic verification of the following Embrace features:

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
@@ -1,8 +1,9 @@
 package io.embrace.android.embracesdk;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
-
 import android.util.Pair;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
 import io.embrace.android.embracesdk.payload.TapBreadcrumb.TapBreadcrumbType;
@@ -33,13 +34,19 @@ public final class ViewSwazzledHooks {
                 point = new Pair<>(0.0F, 0.0F);
             }
             Embrace.getImpl().logTap(point, viewName, breadcrumbType);
-        } catch (NoSuchMethodError exception) {
+        } catch (NoSuchMethodError error) {
             // The customer may be overwriting View with their own implementation, and some of the
             // methods we use are missing.
-            logger.logError("Could not log onClickEvent. Some methods are missing. ",
-                exception);
+            logError("Could not log onClickEvent. Some methods are missing. ", error);
         } catch (Exception exception) {
-            logger.logError("Could not log onClickEvent.", exception);
+            logError("Could not log onClickEvent.", exception);
+        }
+    }
+
+    private static void logError(@NonNull String message, @Nullable Throwable throwable) {
+        Embrace.getInstance().getInternalInterface().logError(message, null, null, false);
+        if (throwable != null) {
+            Embrace.getInstance().getInternalInterface().logInternalError(throwable);
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
-
 import android.webkit.ConsoleMessage;
 
 import androidx.annotation.NonNull;
@@ -19,6 +17,6 @@ public final class WebViewChromeClientSwazzledHooks {
 
     @SuppressWarnings("MethodNameCheck")
     public static void _preOnConsoleMessage(@NonNull ConsoleMessage consoleMessage) {
-        logger.logInfo("webview _preOnConsoleMessage");
+        Embrace.getInstance().getInternalInterface().logInfo("webview _preOnConsoleMessage", null);
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -27,7 +27,6 @@ import io.embrace.android.embracesdk.internal.utils.SystemServiceModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.utils.WorkerThreadModuleSupplier
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.ndk.NativeModule
 import io.embrace.android.embracesdk.ndk.NativeModuleImpl
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -283,7 +282,6 @@ internal class ModuleInitBootstrapper(
                     postInit(SdkObservabilityModule::class) {
                         serviceRegistry.registerService(sdkObservabilityModule.internalErrorService)
                         initModule.logger.addLoggerAction(sdkObservabilityModule.reportingLoggerAction)
-                        InternalStaticEmbraceLogger.logger.addLoggerAction(sdkObservabilityModule.reportingLoggerAction)
                     }
 
                     val sessionProperties = Systrace.traceSynchronous("session-properties-init") {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpPathOverride.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpPathOverride.java
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -9,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
+import io.embrace.android.embracesdk.Embrace;
 import io.embrace.android.embracesdk.annotation.InternalApi;
 
 @InternalApi
@@ -55,34 +54,38 @@ public class EmbraceHttpPathOverride {
 
     private static Boolean validatePathOverride(String path) {
         if (path == null) {
-            logger.logError("URL relative path cannot be null");
+            logError("URL relative path cannot be null");
             return false;
         }
         if (path.isEmpty()) {
-            logger.logError("Relative path must have non-zero length");
+            logError("Relative path must have non-zero length");
             return false;
         }
         if (path.length() > RELATIVE_PATH_MAX_LENGTH) {
-            logger.logError(String.format(Locale.US,
+            logError(String.format(Locale.US,
                     "Relative path %s is greater than the maximum allowed length of %d. It will be ignored",
                     path, RELATIVE_PATH_MAX_LENGTH));
             return false;
         }
         if (!StandardCharsets.US_ASCII.newEncoder().canEncode(path)) {
-            logger.logError("Relative path must not contain unicode " +
+            logError("Relative path must not contain unicode " +
                     "characters. Relative path " + path + " will be ignored.");
             return false;
         }
         if (!path.startsWith("/")) {
-            logger.logError("Relative path must start with a /");
+            logError("Relative path must start with a /");
             return false;
         }
         if (!RELATIVE_PATH_PATTERN.matcher(path).matches()) {
-            logger.logError("Relative path contains invalid chars. " +
+            logError("Relative path contains invalid chars. " +
                     "Relative path " + path + " will be ignored.");
             return false;
         }
 
         return true;
+    }
+    
+    private static void logError(@NonNull String message) {
+        Embrace.getInstance().getInternalInterface().logError(message, null, null, false);
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlConnectionOverride.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlConnectionOverride.java
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import io.embrace.android.embracesdk.Embrace;
 
 class EmbraceHttpUrlConnectionOverride implements HttpPathOverrideRequest {
 
@@ -30,7 +30,8 @@ class EmbraceHttpUrlConnectionOverride implements HttpPathOverrideRequest {
             return new URL(connection.getURL().getProtocol(), connection.getURL().getHost(),
                 connection.getURL().getPort(), pathOverride + "?" + connection.getURL().getQuery()).toString();
         } catch (MalformedURLException e) {
-            logger.logError("Failed to override path of " + connection.getURL() + " with " + pathOverride);
+            Embrace.getInstance().getInternalInterface().logError(
+                    "Failed to override path of " + connection.getURL() + " with " + pathOverride, null, null, false);
             return connection.getURL().toString();
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
 import static io.embrace.android.embracesdk.config.behavior.NetworkSpanForwardingBehavior.TRACEPARENT_HEADER_NAME;
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
 
 import android.annotation.TargetApi;
 import android.os.Build;
@@ -621,7 +620,7 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
                     );
                 }
             } catch (Exception e) {
-                logger.logError("Error logging native network request", e);
+                logError(e);
             }
         }
     }
@@ -698,7 +697,8 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
             try {
                 traceId = getRequestProperty(embrace.getTraceIdHeader());
             } catch (Exception e) {
-                logger.logDebug("Failed to retrieve actual trace id header. Current: " + traceId);
+                Embrace.getInstance().getInternalInterface().logWarning(
+                        "Failed to retrieve actual trace id header. Current: " + traceId, null, null);
             }
         }
     }
@@ -926,5 +926,9 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
     private boolean shouldCaptureNetworkData() {
         return (hasNetworkCaptureRules() && (enableWrapIoStreams || inputStreamAccessException != null)) &&
             (networkCaptureData.get() == null || networkCaptureData.get().getCapturedResponseBody() == null);
+    }
+
+    private void logError(@NonNull Throwable t) {
+        Embrace.getInstance().getInternalInterface().logInternalError(t);
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerFactory.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerFactory.java
@@ -1,11 +1,14 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
-import static io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger.logger;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import java.util.HashMap;
 import java.util.Map;
+
+import io.embrace.android.embracesdk.Embrace;
 
 /**
  * Custom implementation of URLStreamHandlerFactory that is able to return URLStreamHandlers that log network data to
@@ -25,7 +28,7 @@ final class EmbraceUrlStreamHandlerFactory implements URLStreamHandlerFactory {
             handlers.put(PROTOCOL_HTTP, new EmbraceHttpUrlStreamHandler(newUrlStreamHandler(CLASS_HTTP_OKHTTP_STREAM_HANDLER)));
             handlers.put(PROTOCOL_HTTPS, new EmbraceHttpsUrlStreamHandler(newUrlStreamHandler(CLASS_HTTPS_OKHTTP_STREAM_HANDLER)));
         } catch (Exception ex) {
-            logger.logError("Failed initialize EmbraceUrlStreamHandlerFactory", ex);
+            logError("Failed initialize EmbraceUrlStreamHandlerFactory", ex);
         }
     }
 
@@ -35,8 +38,15 @@ final class EmbraceUrlStreamHandlerFactory implements URLStreamHandlerFactory {
         } catch (Exception e) {
             // We catch Exception here instead of the specific exceptions that can be thrown due to a change in the way some
             // of these exceptions are compiled on different OS versions.
-            logger.logError("Failed to instantiate new URLStreamHandler instance: " + className, e);
+            logError("Failed to instantiate new URLStreamHandler instance: " + className, e);
             return null;
+        }
+    }
+
+    private static void logError(@NonNull String message, @Nullable Throwable throwable) {
+        Embrace.getInstance().getInternalInterface().logError(message, null, null, false);
+        if (throwable != null) {
+            Embrace.getInstance().getInternalInterface().logInternalError(throwable);
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalStaticEmbraceLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalStaticEmbraceLogger.kt
@@ -1,9 +1,0 @@
-package io.embrace.android.embracesdk.logging
-
-/**
- * A version of the logger used when the SDK instance is not readily available
- */
-internal object InternalStaticEmbraceLogger {
-    @JvmField
-    val logger = InternalEmbraceLogger()
-}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationChecker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationChecker.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.samples
 
 import android.app.Activity
+import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import java.io.File
 import java.io.FileNotFoundException
 
-internal class AutomaticVerificationChecker(
-    private val logger: InternalEmbraceLogger
-) {
+internal class AutomaticVerificationChecker {
     private val fileName = "emb_marker_file.txt"
     private val verificationResult = VerificationResult()
     private lateinit var file: File
@@ -62,7 +60,8 @@ internal class AutomaticVerificationChecker(
                 }
             }
         } catch (e: FileNotFoundException) {
-            logger.logError("cannot open file", e)
+            Embrace.getInstance().internalInterface.logError("Cannot open file", null, null, false)
+            Embrace.getInstance().internalInterface.logInternalError(e)
         }
         return null
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAutomaticVerificationTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceAutomaticVerificationTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk
 import android.app.Activity
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
 import io.embrace.android.embracesdk.fakes.system.mockActivity
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -33,8 +33,8 @@ internal class EmbraceAutomaticVerificationTest {
         fun beforeClass() {
             mockkStatic(ScheduledExecutorService::class)
             mockkStatic(ExecutorService::class)
-            mockkStatic(EmbraceImpl::class)
             mockkStatic(Embrace::class)
+            mockkStatic(EmbraceImpl::class)
         }
 
         @AfterClass
@@ -46,8 +46,8 @@ internal class EmbraceAutomaticVerificationTest {
 
     @Before
     fun setup() {
-        every { Embrace.getImpl() } returns mockk(relaxed = true)
-        embraceSamples = EmbraceAutomaticVerification(scheduledExecutorService, InternalEmbraceLogger())
+        every { Embrace.getInstance().internalInterface } answers { mockk<EmbraceInternalInterface>(relaxed = true) }
+        embraceSamples = EmbraceAutomaticVerification(scheduledExecutorService)
     }
 
     @After

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -8,10 +8,8 @@ import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalStaticEmbraceLogger
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -83,26 +81,6 @@ internal class ModuleInitBootstrapperTest {
                 appFramework = Embrace.AppFramework.NATIVE,
                 sdkStartTimeMs = 0L,
             )
-        )
-    }
-
-    @Test
-    fun `internal error service hooked up to both static and non-static SDK instance`() {
-        assertTrue(
-            moduleInitBootstrapper.init(
-                context = context,
-                enableIntegrationTesting = false,
-                appFramework = Embrace.AppFramework.NATIVE,
-                sdkStartTimeMs = 0L,
-            )
-        )
-
-        InternalStaticEmbraceLogger.logger.logError("not-used", RuntimeException("static"), true)
-        logger.logError("not-used", RuntimeException("non-static"), true)
-
-        assertEquals(
-            2,
-            moduleInitBootstrapper.sdkObservabilityModule.internalErrorService.currentExceptionError?.exceptionErrors?.size
         )
     }
 


### PR DESCRIPTION
## Goal

Burn this sucker down with gasoline. We have internal APIs that we expose so hosted SDKs can log stuff like internal errors - just the same APIs in various places so the static logger won't have to be used.

For now, we add helpers in each class so we don't have to make the same internal API calls with default parameters that aren't used. But we should really revisiting our logging strategy, not only in these classes, but elsewhere too. 

There doesn't seem to be a rhyme or reason why we log debug/info/error and when we include an exception. Only the ones with exceptions will make it back to the server - the rest, we are just outputting to the logger which likely won't be looked at by anyone. So why even bother? In the off chance we need to see a client logging put to debug a problem? That's a lot of overhead for a very limited use case.

BTW, I touched some Swazzled code, so I'm including @cesarmax22 to make sure this is fine. It should be?

## Testing

Modified existing tests to work. CodeConv is yelling again because of some of the exception case logging not being tested. Boo effing hoo. 
