### PR TITLE
Genericize EmbraceAttribute to support attributes that don't have fixed values

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/AppTerminationCause.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/AppTerminationCause.kt
@@ -4,9 +4,9 @@ package io.embrace.android.embracesdk.arch.schema
  * Attribute that stores the reason an app instance terminated
  */
 internal sealed class AppTerminationCause(
-    override val attributeValue: String
-) : EmbraceAttribute {
-    override val attributeName: String = "termination_cause"
+    override val value: String
+) : FixedAttribute {
+    override val key = EmbraceAttributeKey(id = "termination_cause")
 
     internal object Crash : AppTerminationCause("crash")
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.arch.schema
 
 internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
-    override val attributeName: String = "type"
-    override val attributeValue = type + (subtype?.run { ".$this" } ?: "")
+    override val key = EmbraceAttributeKey(id = "type")
+    override val value = type + (subtype?.run { ".$this" } ?: "")
 
     /**
      * Keys that track how fast a time interval is. Only applies to spans.
@@ -44,4 +44,4 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
  * a visual event around a UI element. ux is the type, and view is the subtype. This tells the
  * backend that it can assume the data in the event follows a particular schema.
  */
-internal interface TelemetryType : EmbraceAttribute
+internal interface TelemetryType : FixedAttribute

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
@@ -2,34 +2,58 @@ package io.embrace.android.embracesdk.arch.schema
 
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
+import io.opentelemetry.api.common.AttributeKey
 
 /**
- * Instance of a valid value for an attribute that has special meaning in the Embrace platform.
+ * An attribute to be used in telemetry objects and payload envelopes
  */
 internal interface EmbraceAttribute {
     /**
      * The unique name given to the attribute.
-     * Don't use this to look up the existence of an attribute in a log or span - use [otelAttributeName] instead
+     * Don't use this to look up the existence of an attribute in a log or span - use [name] instead
      */
-    val attributeName: String
+    val id: String
+
+    /**
+     * Return the appropriate name for this attribute to be use in the representation of a telemetry object
+     */
+    val name: String
+}
+
+/**
+ * Defines a unique object to represent a [EmbraceAttribute]
+ */
+internal class EmbraceAttributeKey(
+    override val id: String,
+    otelAttributeKey: AttributeKey<String>? = null,
+    useIdAsAttributeName: Boolean = false
+) : EmbraceAttribute {
+    override val name: String = if (!useIdAsAttributeName && otelAttributeKey?.key != null) {
+        otelAttributeKey.key
+    } else {
+        id.toEmbraceAttributeName()
+    }
+}
+
+/**
+ * Instance of a fixed key-value pair for a attribute, used for low cardinality dimensions with a known, fixed set of valid values.
+ */
+internal interface FixedAttribute {
+
+    val key: EmbraceAttributeKey
 
     /**
      * The value of the particular instance of the attribute
      */
-    val attributeValue: String
+    val value: String
 
     /**
-     * Return the appropriate key name for this attribute to use in an OpenTelemetry attribute
+     * Return as a key-value pair appropriate to use as an OpenTelemetry attribute
      */
-    fun otelAttributeName(): String = attributeName.toEmbraceAttributeName()
+    fun toEmbraceKeyValuePair() = Pair(key.name, value)
 
     /**
-     * Return attribute as a key-value pair appropriate to use as an OpenTelemetry attribute
+     * Return as a [Attribute] representation, to be used used for Embrace payloads
      */
-    fun toOTelKeyValuePair() = Pair(otelAttributeName(), attributeValue)
-
-    /**
-     * Return attribute as [Attribute]
-     */
-    fun toAttributePayload() = Attribute(otelAttributeName(), attributeValue)
+    fun toPayload() = Attribute(key.name, value)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/ErrorCodeAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/ErrorCodeAttribute.kt
@@ -8,9 +8,9 @@ import java.util.Locale
  */
 internal sealed class ErrorCodeAttribute(
     errorCode: ErrorCode
-) : EmbraceAttribute {
-    override val attributeName: String = "error_code"
-    override val attributeValue: String = errorCode.name.toLowerCase(Locale.ENGLISH)
+) : FixedAttribute {
+    override val key = EmbraceAttributeKey(id = "error_code")
+    override val value: String = errorCode.name.toLowerCase(Locale.ENGLISH)
 
     internal object Failure : ErrorCodeAttribute(ErrorCode.FAILURE)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/KeySpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/KeySpan.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.arch.schema
 /**
  * Denotes an important span to be aggregated and displayed as such in the platform.
  */
-internal object KeySpan : EmbraceAttribute {
-    override val attributeName: String = "key"
-    override val attributeValue: String = "true"
+internal object KeySpan : FixedAttribute {
+    override val key = EmbraceAttributeKey(id = "key")
+    override val value: String = "true"
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/PrivateSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/PrivateSpan.kt
@@ -4,7 +4,7 @@ package io.embrace.android.embracesdk.arch.schema
  * Denotes a private span recorded by Embrace for diagnostic or internal usage purposes that is not meant to be consumed directly by
  * users of the SDK, nor is considered part of the public API.
  */
-internal object PrivateSpan : EmbraceAttribute {
-    override val attributeName: String = "private"
-    override val attributeValue: String = "true"
+internal object PrivateSpan : FixedAttribute {
+    override val key = EmbraceAttributeKey(id = "private")
+    override val value: String = "true"
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -23,7 +23,7 @@ internal sealed class SchemaType(
     /**
      * The attributes defined fo this schema that should be used to populate telemetry objects
      */
-    fun attributes(): Map<String, String> = attrs.plus(telemetryType.toOTelKeyValuePair())
+    fun attributes(): Map<String, String> = attrs.plus(telemetryType.toEmbraceKeyValuePair())
 
     internal class CustomBreadcrumb(message: String) : SchemaType(
         EmbType.System.Breadcrumb,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SpanSanitizer.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.gating
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.BREADCRUMBS_CUSTOM
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 internal class SpanSanitizer(
@@ -39,11 +39,11 @@ internal class SpanSanitizer(
     }
 
     private fun sanitizeSpans(span: EmbraceSpanData): Boolean {
-        return !(span.hasEmbraceAttribute(EmbType.Ux.View) && !shouldAddViewBreadcrumbs())
+        return !(span.hasFixedAttribute(EmbType.Ux.View) && !shouldAddViewBreadcrumbs())
     }
 
     private fun sanitizeEvents(event: EmbraceSpanEvent): Boolean {
-        return !(event.hasEmbraceAttribute(EmbType.System.Breadcrumb) && !shouldAddCustomBreadcrumbs())
+        return !(event.hasFixedAttribute(EmbType.System.Breadcrumb) && !shouldAddCustomBreadcrumbs())
     }
 
     private fun shouldAddCustomBreadcrumbs() = enabledComponents.contains(BREADCRUMBS_CUSTOM)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
-import io.embrace.android.embracesdk.internal.spans.setEmbraceAttribute
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
+import io.embrace.android.embracesdk.internal.spans.setFixedAttribute
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
@@ -48,9 +48,9 @@ internal fun List<Attribute>.toOldPayload(): Map<String, String> =
 
 internal fun Span.toFailedSpan(endTimeMs: Long): EmbraceSpanData {
     val newAttributes = attributes?.toOldPayload()?.toMutableMap()?.apply {
-        setEmbraceAttribute(ErrorCodeAttribute.Failure)
-        if (hasEmbraceAttribute(EmbType.Ux.Session)) {
-            setEmbraceAttribute(AppTerminationCause.Crash)
+        setFixedAttribute(ErrorCodeAttribute.Failure)
+        if (hasFixedAttribute(EmbType.Ux.Session)) {
+            setFixedAttribute(AppTerminationCause.Crash)
         }
     } ?: emptyMap()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setEmbraceAttribute
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setFixedAttribute
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -85,7 +85,7 @@ internal class CurrentSessionSpanImpl(
             } else {
                 val crashTime = openTelemetryClock.now().nanosToMillis()
                 spanRepository.failActiveSpans(crashTime)
-                endingSessionSpan.setEmbraceAttribute(appTerminationCause)
+                endingSessionSpan.setFixedAttribute(appTerminationCause)
                 endingSessionSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
             }
             return spanSink.flushSpans()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
+import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -81,8 +81,8 @@ internal fun Span.setSequenceId(id: Long): Span {
     return this
 }
 
-internal fun Span.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): Span {
-    setAttribute(embraceAttribute.otelAttributeName(), embraceAttribute.attributeValue)
+internal fun Span.setFixedAttribute(fixedAttribute: FixedAttribute): Span {
+    setAttribute(fixedAttribute.key.name, fixedAttribute.value)
     return this
 }
 
@@ -95,7 +95,7 @@ internal fun Span.endSpan(errorCode: ErrorCode? = null, endTimeMs: Long? = null)
         setStatus(StatusCode.OK)
     } else {
         setStatus(StatusCode.ERROR)
-        setEmbraceAttribute(errorCode.fromErrorCode())
+        setFixedAttribute(errorCode.fromErrorCode())
     }
 
     if (endTimeMs != null) {
@@ -132,16 +132,16 @@ internal fun String.toEmbraceAttributeName(): String = EMBRACE_ATTRIBUTE_NAME_PR
  */
 internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX + this
 
-internal fun EmbraceSpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
-    embraceAttribute.attributeValue == attributes[embraceAttribute.otelAttributeName()]
+internal fun EmbraceSpanData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
+    fixedAttribute.value == attributes[fixedAttribute.key.name]
 
-internal fun EmbraceSpanEvent.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
-    embraceAttribute.attributeValue == attributes[embraceAttribute.otelAttributeName()]
+internal fun EmbraceSpanEvent.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
+    fixedAttribute.value == attributes[fixedAttribute.key.name]
 
-internal fun Map<String, String>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
-    this[embraceAttribute.otelAttributeName()] == embraceAttribute.attributeValue
+internal fun Map<String, String>.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
+    this[fixedAttribute.key.name] == fixedAttribute.value
 
-internal fun MutableMap<String, String>.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): Map<String, String> {
-    this[embraceAttribute.otelAttributeName()] = embraceAttribute.attributeValue
+internal fun MutableMap<String, String>.setFixedAttribute(fixedAttribute: FixedAttribute): Map<String, String> {
+    this[fixedAttribute.key.name] = fixedAttribute.value
     return this
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.arch.schema.EmbType
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
+import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.arch.schema.KeySpan
 import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
@@ -16,7 +16,7 @@ internal class EmbraceSpanBuilder(
     telemetryType: TelemetryType,
     parent: EmbraceSpan?
 ) {
-    val embraceAttributes = mutableListOf<EmbraceAttribute>(telemetryType)
+    val fixedAttributes = mutableListOf<FixedAttribute>(telemetryType)
 
     /**
      * Extract the parent span from an [EmbraceSpan] and set it as the parent
@@ -36,8 +36,8 @@ internal class EmbraceSpanBuilder(
 
     fun startSpan(startTimeMs: Long): Span {
         val startedSpan = otelSpanBuilder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS).startSpan()
-        embraceAttributes.forEach { embraceAttribute ->
-            startedSpan.setEmbraceAttribute(embraceAttribute)
+        fixedAttributes.forEach { attribute ->
+            startedSpan.setFixedAttribute(attribute)
         }
         return startedSpan
     }
@@ -59,10 +59,10 @@ internal class EmbraceSpanBuilder(
     }
 
     /**
-     * Sets an [EmbraceAttribute] on the given [SpanBuilder] and return it
+     * Sets an [FixedAttribute] on the given [SpanBuilder] and return it
      */
-    private fun setEmbraceAttribute(embraceAttribute: EmbraceAttribute): EmbraceSpanBuilder {
-        embraceAttributes.add(embraceAttribute)
+    private fun setEmbraceAttribute(fixedAttribute: FixedAttribute): EmbraceSpanBuilder {
+        fixedAttributes.add(fixedAttribute)
         return this
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
+import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
@@ -32,7 +32,9 @@ internal class EmbraceSpanImpl(
     private var spanEndTimeMs: Long? = null
     private var status = Span.Status.UNSET
     private val events = ConcurrentLinkedQueue<EmbraceSpanEvent>()
-    private val schemaAttributes = spanBuilder.embraceAttributes.associate { it.toOTelKeyValuePair() }.toMutableMap()
+    private val schemaAttributes = spanBuilder.fixedAttributes.associate {
+        it.toEmbraceKeyValuePair()
+    }.toMutableMap()
     private val attributes = ConcurrentHashMap<String, String>()
 
     // size for ConcurrentLinkedQueues is not a constant operation, so it could be subject to race conditions
@@ -160,7 +162,8 @@ internal class EmbraceSpanImpl(
         }
     }
 
-    override fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean = allAttributes().hasEmbraceAttribute(embraceAttribute)
+    override fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean =
+        allAttributes().hasFixedAttribute(fixedAttribute)
 
     private fun allAttributes(): Map<String, String> = attributes + schemaAttributes
 
@@ -188,8 +191,8 @@ internal class EmbraceSpanImpl(
         internal fun attributeValid(key: String, value: String) =
             key.length <= MAX_ATTRIBUTE_KEY_LENGTH && value.length <= MAX_ATTRIBUTE_VALUE_LENGTH
 
-        internal fun EmbraceSpan.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): EmbraceSpan {
-            addAttribute(embraceAttribute.otelAttributeName(), embraceAttribute.attributeValue)
+        internal fun EmbraceSpan.setFixedAttribute(fixedAttribute: FixedAttribute): EmbraceSpan {
+            addAttribute(fixedAttribute.key.name, fixedAttribute.value)
             return this
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.spans
 
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
+import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 
 /**
@@ -13,5 +13,5 @@ internal interface PersistableEmbraceSpan : EmbraceSpan {
      */
     fun snapshot(): Span?
 
-    fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean
+    fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
@@ -3,14 +3,14 @@ package io.embrace.android.embracesdk.arch
 import io.embrace.android.embracesdk.arch.destination.LogEventData
 import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.arch.schema.EmbType
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
 import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.arch.schema.KeySpan
 import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -37,14 +37,14 @@ internal fun EmbraceSpanData.assertIsPrivateSpan() = assertHasEmbraceAttribute(P
 internal fun EmbraceSpanData.assertNotPrivateSpan() = assertDoesNotHaveEmbraceAttribute(PrivateSpan)
 
 /**
- * Assert [EmbraceSpanData] has the [EmbraceAttribute] defined by [embraceAttribute]
+ * Assert [EmbraceSpanData] has the [FixedAttribute] defined by [fixedAttribute]
  */
-internal fun EmbraceSpanData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertTrue(hasEmbraceAttribute(embraceAttribute))
+internal fun EmbraceSpanData.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
+    assertTrue(hasFixedAttribute(fixedAttribute))
 }
 
-internal fun EmbraceSpanData.assertDoesNotHaveEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertFalse(attributes[embraceAttribute.otelAttributeName()]?.equals(embraceAttribute.attributeValue) ?: false)
+internal fun EmbraceSpanData.assertDoesNotHaveEmbraceAttribute(fixedAttribute: FixedAttribute) {
+    assertFalse(attributes[fixedAttribute.key.name]?.equals(fixedAttribute.value) ?: false)
 }
 
 /**
@@ -60,7 +60,7 @@ internal fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
  */
 internal fun EmbraceSpanData.assertSuccessful() {
     assertEquals(StatusCode.OK, status)
-    assertNull(attributes[ErrorCodeAttribute.Failure.otelAttributeName()])
+    assertNull(attributes[ErrorCodeAttribute.Failure.key.name])
 }
 
 internal fun Span.assertIsTypePerformance() = assertIsType(EmbType.Performance.Default)
@@ -75,12 +75,12 @@ internal fun Span.assertIsPrivateSpan() = assertHasEmbraceAttribute(PrivateSpan)
 
 internal fun Span.assertNotPrivateSpan() = assertDoesNotHaveEmbraceAttribute(PrivateSpan)
 
-internal fun Span.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertTrue(checkNotNull(attributes).contains(embraceAttribute.toAttributePayload()))
+internal fun Span.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
+    assertTrue(checkNotNull(attributes).contains(fixedAttribute.toPayload()))
 }
 
-internal fun Span.assertDoesNotHaveEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertFalse(checkNotNull(attributes).contains(embraceAttribute.toAttributePayload()))
+internal fun Span.assertDoesNotHaveEmbraceAttribute(fixedAttribute: FixedAttribute) {
+    assertFalse(checkNotNull(attributes).contains(fixedAttribute.toPayload()))
 }
 
 internal fun Span.assertError(errorCode: ErrorCode) {
@@ -90,7 +90,7 @@ internal fun Span.assertError(errorCode: ErrorCode) {
 
 internal fun Span.assertSuccessful() {
     assertEquals(Span.Status.OK, status)
-    assertEquals(0, checkNotNull(attributes).filter { it.key == ErrorCodeAttribute.Failure.otelAttributeName() }.size)
+    assertEquals(0, checkNotNull(attributes).filter { it.key == ErrorCodeAttribute.Failure.key.name }.size)
 }
 
 /**
@@ -99,10 +99,10 @@ internal fun Span.assertSuccessful() {
 internal fun StartSpanData.assertIsType(telemetryType: TelemetryType) = assertHasEmbraceAttribute(telemetryType)
 
 /**
- * Assert [StartSpanData] has the [EmbraceAttribute] defined by [embraceAttribute]
+ * Assert [StartSpanData] has the [FixedAttribute] defined by [fixedAttribute]
  */
-internal fun StartSpanData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertEquals(embraceAttribute.attributeValue, schemaType.attributes()[embraceAttribute.otelAttributeName()])
+internal fun StartSpanData.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
+    assertEquals(fixedAttribute.value, schemaType.attributes()[fixedAttribute.key.name])
 }
 
 /**
@@ -111,8 +111,8 @@ internal fun StartSpanData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAt
 internal fun LogEventData.assertIsType(telemetryType: TelemetryType) = assertHasEmbraceAttribute(telemetryType)
 
 /**
- * Assert [LogEventData] has the [EmbraceAttribute] defined by [embraceAttribute]
+ * Assert [LogEventData] has the [FixedAttribute] defined by [fixedAttribute]
  */
-internal fun LogEventData.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertEquals(embraceAttribute.attributeValue, schemaType.attributes()[embraceAttribute.otelAttributeName()])
+internal fun LogEventData.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
+    assertEquals(fixedAttribute.value, schemaType.attributes()[fixedAttribute.key.name])
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -38,7 +38,7 @@ internal class CustomBreadcrumbDataSourceTest {
             assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
             assertEquals(
                 mapOf(
-                    EmbType.System.Breadcrumb.toOTelKeyValuePair(),
+                    EmbType.System.Breadcrumb.toEmbraceKeyValuePair(),
                     "message" to "Hello, world!"
                 ),
                 schemaType.attributes()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentBreadcrumbDataSourceTest.kt
@@ -41,7 +41,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         assertEquals(
             mapOf(
                 "view.name" to "my_fragment",
-                EmbType.Ux.View.toOTelKeyValuePair(),
+                EmbType.Ux.View.toEmbraceKeyValuePair(),
             ),
             span.attributes
         )
@@ -59,7 +59,7 @@ internal class FragmentBreadcrumbDataSourceTest {
         assertEquals(
             mapOf(
                 "view.name" to "my_fragment",
-                EmbType.Ux.View.toOTelKeyValuePair()
+                EmbType.Ux.View.toEmbraceKeyValuePair()
             ),
             span.attributes
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -137,7 +137,7 @@ internal class EmbraceDeliveryServiceTest {
             expectedParentId = SpanId.getInvalid(),
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
-                EmbType.Performance.Default.toOTelKeyValuePair()
+                EmbType.Performance.Default.toEmbraceKeyValuePair()
             )
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -2,15 +2,15 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.EmbType
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttribute
+import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setEmbraceAttribute
-import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setFixedAttribute
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -26,7 +26,7 @@ internal class FakePersistableEmbraceSpan(
     private val fakeClock: FakeClock = FakeClock()
 ) : PersistableEmbraceSpan {
 
-    val attributes = mutableMapOf(type.toOTelKeyValuePair())
+    val attributes = mutableMapOf(type.toEmbraceKeyValuePair())
     val events = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     var started = false
     var stopped = false
@@ -62,7 +62,7 @@ internal class FakePersistableEmbraceSpan(
             status = if (errorCode == null) {
                 Span.Status.OK
             } else {
-                setEmbraceAttribute(errorCode.fromErrorCode())
+                setFixedAttribute(errorCode.fromErrorCode())
                 Span.Status.ERROR
             }
             spanEndTimeMs = endTimeMs ?: fakeClock.now()
@@ -107,8 +107,8 @@ internal class FakePersistableEmbraceSpan(
         }
     }
 
-    override fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
-        attributes.hasEmbraceAttribute(embraceAttribute)
+    override fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean =
+        attributes.hasFixedAttribute(fixedAttribute)
 
     /**
      * Should only used if this is being used to fake a session span

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -31,8 +31,8 @@ internal class FakeSpanData(
     private var attributes: Attributes =
         Attributes.builder().fromMap(
             mapOf(
-                EmbType.Performance.Default.toOTelKeyValuePair(),
-                KeySpan.toOTelKeyValuePair(),
+                EmbType.Performance.Default.toEmbraceKeyValuePair(),
+                KeySpan.toEmbraceKeyValuePair(),
                 Pair("my-key", "my-value")
             )
         ).build(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -35,7 +35,7 @@ internal val testSpan = EmbraceSpanData(
     ),
     attributes = mapOf(
         Pair("emb.sequence_id", "3"),
-        EmbType.Performance.Default.toOTelKeyValuePair(),
+        EmbType.Performance.Default.toEmbraceKeyValuePair(),
     )
 )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -180,8 +180,8 @@ internal class CurrentSessionSpanImplTests {
             expectedParentId = SpanId.getInvalid(),
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
-                AppTerminationCause.Crash.toOTelKeyValuePair(),
-                EmbType.Ux.Session.toOTelKeyValuePair()
+                AppTerminationCause.Crash.toEmbraceKeyValuePair(),
+                EmbType.Ux.Session.toEmbraceKeyValuePair()
             ),
             private = true
         )
@@ -193,7 +193,7 @@ internal class CurrentSessionSpanImplTests {
             expectedParentId = SpanId.getInvalid(),
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
-                EmbType.Performance.Default.toOTelKeyValuePair()
+                EmbType.Performance.Default.toEmbraceKeyValuePair()
             ),
             key = true
         )
@@ -242,7 +242,7 @@ internal class CurrentSessionSpanImplTests {
         assertEquals(1000, testEvent.timestampNanos.nanosToMillis())
         assertEquals(
             mapOf(
-                EmbType.System.Breadcrumb.toOTelKeyValuePair(),
+                EmbType.System.Breadcrumb.toEmbraceKeyValuePair(),
                 "message" to "test-event"
             ),
             testEvent.attributes


### PR DESCRIPTION
## Goal

Create an Embrace analog to the OTel `AttributeKey` and use that as the basis for `FixedAttribute`, formerly known as `EmbraceAttribute`. This genericization always allows us to use this concept to declare well-known attribute keys that can be used in OTel payloads as well as payload envelopes in the future, even if we need to use different names (i.e. key names with no periods so JSON tooling doesn't puke).

A category log these keys can then be generated so the code base can refer to these a singletons, much like how OTel semantic convention key names are defined.

## Testing

Existing tests verify that the underlying functionality still works. Additional test infra was added so future tests can be written easier.

