### PR TITLE
Use FakeInitModule in tests when possible

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
@@ -11,11 +11,11 @@ import io.embrace.android.embracesdk.config.EmbraceConfigService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.injection.EssentialServiceModuleImpl
-import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
 import io.embrace.android.embracesdk.session.EmbraceMemoryCleanerService
 import io.embrace.android.embracesdk.session.lifecycle.EmbraceProcessStateService
@@ -36,7 +36,7 @@ internal class EssentialServiceModuleImplTest {
         every { Looper.getMainLooper() } returns mockk(relaxed = true)
 
         val coreModule = FakeCoreModule()
-        val initModule = InitModuleImpl()
+        val initModule = FakeInitModule()
         val module = EssentialServiceModuleImpl(
             initModule = initModule,
             coreModule = coreModule,
@@ -71,7 +71,7 @@ internal class EssentialServiceModuleImplTest {
     @Test
     fun testConfigServiceProvider() {
         val fakeConfigService = FakeConfigService()
-        val initModule = InitModuleImpl()
+        val initModule = FakeInitModule()
         val fakeCoreModule = FakeCoreModule()
         val module = EssentialServiceModuleImpl(
             initModule = initModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AndroidServicesModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AndroidServicesModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import org.junit.Assert.assertTrue
@@ -10,7 +11,7 @@ internal class AndroidServicesModuleImplTest {
 
     @Test
     fun testDefault() {
-        val initModule = InitModuleImpl()
+        val initModule = FakeInitModule()
         val coreModule = FakeCoreModule()
         val module = AndroidServicesModuleImpl(
             initModule = initModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataContainerModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSessionModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
@@ -16,7 +17,7 @@ internal class CrashModuleImplTest {
     @Test
     fun testDefaultImplementations() {
         val module = CrashModuleImpl(
-            InitModuleImpl(),
+            FakeInitModule(),
             FakeStorageModule(),
             FakeEssentialServiceModule(),
             FakeDeliveryModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CustomerLogModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CustomerLogModuleImplTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -15,7 +16,7 @@ internal class CustomerLogModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
-        val initModule = InitModuleImpl()
+        val initModule = FakeInitModule()
         val fakeCoreModule = FakeCoreModule()
         val module = CustomerLogModuleImpl(
             initModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DeliveryModuleImplTest.kt
@@ -17,7 +17,7 @@ internal class DeliveryModuleImplTest {
         val module = DeliveryModuleImpl(
             initModule,
             coreModule,
-            WorkerThreadModuleImpl(InitModuleImpl()),
+            WorkerThreadModuleImpl(FakeInitModule()),
             FakeStorageModule(),
             FakeEssentialServiceModule(),
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/OpenTelemetryModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/OpenTelemetryModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.arch.destination.LogWriterImpl
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanService
@@ -12,7 +13,7 @@ import org.junit.Test
 internal class OpenTelemetryModuleImplTest {
     @Test
     fun testInitModuleImplDefaults() {
-        val openTelemetryModule = OpenTelemetryModuleImpl(InitModuleImpl())
+        val openTelemetryModule = OpenTelemetryModuleImpl(FakeInitModule())
         assertTrue(openTelemetryModule.spanSink is SpanSinkImpl)
         assertTrue(openTelemetryModule.spanService is EmbraceSpanService)
         assertTrue(openTelemetryModule.currentSessionSpan is CurrentSessionSpanImpl)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadModuleImplTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSdkObservabilityModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
@@ -15,7 +16,7 @@ internal class PayloadModuleImplTest {
 
     @Test
     fun `module default values`() {
-        val initModule = InitModuleImpl()
+        val initModule = FakeInitModule()
         val coreModule = FakeCoreModule()
         val module = PayloadModuleImpl(
             initModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/SdkObservabilityModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/SdkObservabilityModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -9,7 +10,7 @@ internal class SdkObservabilityModuleImplTest {
     @Test
     fun testDefaultImplementations() {
         val module = SdkObservabilityModuleImpl(
-            InitModuleImpl(),
+            FakeInitModule(),
             FakeEssentialServiceModule()
         )
         assertNotNull(module.internalErrorService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/StorageModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/StorageModuleImplTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.injection
 import io.embrace.android.embracesdk.comms.delivery.EmbraceCacheService
 import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryCacheManager
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.storage.EmbraceStorageService
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import org.junit.Assert.assertNotNull
@@ -13,7 +14,7 @@ internal class StorageModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
-        val initModule = InitModuleImpl()
+        val initModule = FakeInitModule()
         val coreModule = FakeCoreModule()
         val module = StorageModuleImpl(
             initModule = initModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
-import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -26,7 +25,7 @@ internal class NativeModuleImplTest {
             FakeDeliveryModule(),
             FakeAndroidServicesModule(),
             fakeEmbraceSessionProperties(),
-            WorkerThreadModuleImpl(InitModuleImpl())
+            WorkerThreadModuleImpl(FakeInitModule())
         )
         assertNotNull(module.ndkService)
         assertNull(module.nativeThreadSamplerService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
@@ -2,9 +2,9 @@ package io.embrace.android.embracesdk.worker
 
 import io.embrace.android.embracesdk.fakes.FakeLoggerAction
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.injection.InitModule
-import io.embrace.android.embracesdk.injection.InitModuleImpl
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
@@ -23,7 +23,7 @@ internal class WorkerThreadModuleImplTest {
     fun setup() {
         action = FakeLoggerAction()
         logger = InternalEmbraceLogger().apply { addLoggerAction(action) }
-        initModule = InitModuleImpl(logger = logger)
+        initModule = FakeInitModule(logger = logger)
         coreModule = FakeCoreModule(logger = logger)
     }
 


### PR DESCRIPTION
## Goal

Tweak tests so InitModule won't have to be used if not necessary. It will require some Android stuff now later so test that don't use the right test runner will puke when trying to instantiate the `Embrace` class. 

The next PR will take care of this, but lets just do this so it won't actually be necessary.

## Testing

Only tests are changed

