### PR TITLE
Add tests for stack unwinding

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/sampler/SamplerStackUnwindTestSuite.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/sampler/SamplerStackUnwindTestSuite.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.ndk.sampler
+
+import io.embrace.android.embracesdk.ndk.NativeTestSuite
+import org.junit.Test
+
+internal class SamplerStackUnwindTestSuite: NativeTestSuite() {
+
+    external fun run(): Int
+
+    @Test
+    fun testStackUnwind() = runNativeTestSuite(::run)
+}

--- a/embrace-android-sdk/src/main/cpp/sampler/sampler_unwinder_unwind.c
+++ b/embrace-android-sdk/src/main/cpp/sampler/sampler_unwinder_unwind.c
@@ -105,7 +105,7 @@ size_t emb_unwind_with_libunwind(emb_env *_env, emb_sample *sample, bool is32bit
         sample->result = calculate_unwind_result(code);
     }
 
-    // copy frames from temporary unwind_state struct to more permament emb_sample
+    // copy frames from temporary unwind_state struct to more permanent emb_sample
     // (allows truncating the stack)
     emb_copy_frames(sample, unwind_state);
     emb_symbolicate_stacktrace(sample);

--- a/embrace-android-sdk/src/test/cpp/CMakeLists.txt
+++ b/embrace-android-sdk/src/test/cpp/CMakeLists.txt
@@ -17,5 +17,6 @@ add_library(embrace-native-test SHARED
         main.c
         testcases/utilities/test_string_utils.c
         testcases/sampler/test_unwinder_dlinfo.c
+        testcases/sampler/test_sampler_stack_unwind.c
 )
 target_link_libraries(embrace-native-test embrace-native)

--- a/embrace-android-sdk/src/test/cpp/main.c
+++ b/embrace-android-sdk/src/test/cpp/main.c
@@ -17,6 +17,7 @@ GREATEST_MAIN_DEFS();
  * bloating this file. */
 SUITE(suite_utilities);
 SUITE(suite_unwinder_dlinfo);
+SUITE(suite_sampler_stack_unwind);
 
 /* Runs a suite of tests and returns 0 if they succeeded, 1 otherwise.*/
 int run_test_suite(void (*suite)(void)) {
@@ -38,3 +39,9 @@ JNIEXPORT int JNICALL
 Java_io_embrace_android_embracesdk_ndk_sampler_UnwinderDlinfoTestSuite_run(JNIEnv *_env, jobject _this) {
     return run_test_suite(suite_unwinder_dlinfo);
 }
+
+JNIEXPORT int JNICALL
+Java_io_embrace_android_embracesdk_ndk_sampler_SamplerStackUnwindTestSuite_run(JNIEnv *_env, jobject _this) {
+    return run_test_suite(suite_sampler_stack_unwind);
+}
+

--- a/embrace-android-sdk/src/test/cpp/testcases/sampler/test_sampler_stack_unwind.c
+++ b/embrace-android-sdk/src/test/cpp/testcases/sampler/test_sampler_stack_unwind.c
@@ -1,0 +1,70 @@
+#include <stdlib.h>
+#include "greatest/greatest.h"
+#include "unwinder_dlinfo.h"
+#include "utilities.h"
+#include "sampler_unwinder_stack.h"
+
+TEST unwind_with_libunwind(void) {
+    emb_env env = {0};
+    emb_sample sample = {0};
+    int result = emb_unwind_with_libunwind(&env, &sample, false, NULL, NULL);
+    ASSERT_EQ(0, sample.result);
+    ASSERT_EQ(result, sample.num_sframes);
+    ASSERT_NEQ(0, sample.num_sframes);
+
+    for (int k = 0; k < sample.num_sframes; k++) {
+        emb_sample_stackframe frame = sample.stack[k];
+        ASSERT_EQ(0, frame.result);
+        ASSERT_NEQ(0, frame.pc);
+        ASSERT_NEQ(0, frame.so_load_addr);
+        ASSERT_NEQ(NULL, frame.so_path);
+    }
+    PASS();
+}
+
+TEST libunwind_currently_handling(void) {
+    emb_env env = {0};
+    env.currently_handling = true;
+    emb_sample sample = {0};
+    int result = emb_unwind_with_libunwind(&env, &sample, false, NULL, NULL);
+    ASSERT_EQ(0, sample.result);
+    ASSERT_EQ(result, sample.num_sframes);
+    ASSERT_EQ(0, sample.num_sframes);
+    PASS();
+}
+
+TEST unwind_with_libunwindstack(void) {
+    emb_env env = {0};
+    emb_sample sample = {0};
+
+    // provide dummy data for context that is used to construct register info
+    emb_env data = {0};
+    int result = emb_unwind_with_libunwindstack(&env, &sample, &data);
+    ASSERT_EQ(1, result);
+    ASSERT_EQ(0, sample.result);
+    ASSERT_EQ(1, sample.num_sframes);
+
+    emb_sample_stackframe frame = sample.stack[0];
+    ASSERT_EQ(0, frame.pc);
+    ASSERT_EQ(0, frame.result);
+    ASSERT_EQ(0, frame.so_load_addr);
+    PASS();
+}
+
+TEST libunwindstack_currently_handling(void) {
+    emb_env env = {0};
+    env.currently_handling = true;
+    emb_sample sample = {0};
+    int result = emb_unwind_with_libunwindstack(&env, &sample, NULL);
+    ASSERT_EQ(EMB_ERROR_ENV_TERMINATING, sample.result);
+    ASSERT_EQ(result, sample.num_sframes);
+    ASSERT_EQ(0, sample.num_sframes);
+    PASS();
+}
+
+SUITE(suite_sampler_stack_unwind) {
+    RUN_TEST(unwind_with_libunwind);
+    RUN_TEST(libunwind_currently_handling);
+    RUN_TEST(unwind_with_libunwindstack);
+    RUN_TEST(libunwindstack_currently_handling);
+}


### PR DESCRIPTION
## Goal

Adds tests for the NDK stack unwinding that happens during sampling of a Unity ANR. The test cases are not exhaustive & are simply meant as a sanity check that the functionality is working rather than testing the internals of the unwinders.

