### PR TITLE
Add test for JNI sampling calls

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/sampler/SamplerJniCallTestSuite.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/sampler/SamplerJniCallTestSuite.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.embracesdk.ndk.sampler
+
+import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerNdkDelegate
+import io.embrace.android.embracesdk.ndk.NativeTestSuite
+import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class SamplerJniCallTestSuite : NativeTestSuite() {
+
+    private val delegate = NativeThreadSamplerNdkDelegate()
+
+    external fun run()
+
+    @Test
+    fun testNoSamples() {
+        assertEquals(emptyList<NativeThreadAnrSample>(), delegate.finishSampling())
+    }
+
+    @Test
+    fun testSamplesSerialized() {
+        run()
+        val samples = checkNotNull(delegate.finishSampling())
+        assertEquals(3, samples.size)
+        verifySampleCaptured(samples[0], 0x12345678)
+        verifySampleCaptured(samples[1], 0x12300000)
+        verifySampleCaptured(samples[2], 0x10090000)
+    }
+
+    private fun verifySampleCaptured(sample: NativeThreadAnrSample, pc: Int) {
+        assertEquals(0, sample.result)
+        assertEquals(9L, sample.sampleDurationMs)
+        assertEquals(1500000000L, sample.sampleTimestamp)
+
+        val frames = checkNotNull(sample.stackframes)
+        val frame = frames.single()
+        assertEquals(1, frames.size)
+        assertEquals("0x" + pc.toString(16), frame.pc)
+        assertEquals("0x" + 0x87654321.toString(16), frame.soLoadAddr)
+        assertEquals(0, frame.result)
+        assertEquals("libtest.so", frame.soPath)
+    }
+}

--- a/embrace-android-sdk/src/test/cpp/CMakeLists.txt
+++ b/embrace-android-sdk/src/test/cpp/CMakeLists.txt
@@ -18,5 +18,6 @@ add_library(embrace-native-test SHARED
         testcases/utilities/test_string_utils.c
         testcases/sampler/test_unwinder_dlinfo.c
         testcases/sampler/test_sampler_stack_unwind.c
+        testcases/sampler/test_sampler_jni_call.c
 )
 target_link_libraries(embrace-native-test embrace-native)

--- a/embrace-android-sdk/src/test/cpp/main.c
+++ b/embrace-android-sdk/src/test/cpp/main.c
@@ -45,3 +45,10 @@ Java_io_embrace_android_embracesdk_ndk_sampler_SamplerStackUnwindTestSuite_run(J
     return run_test_suite(suite_sampler_stack_unwind);
 }
 
+void emb_setup_fake_intervals();
+
+JNIEXPORT void JNICALL
+Java_io_embrace_android_embracesdk_ndk_sampler_SamplerJniCallTestSuite_run(JNIEnv *_env, jobject _this) {
+    emb_setup_fake_intervals();
+}
+

--- a/embrace-android-sdk/src/test/cpp/testcases/sampler/test_sampler_jni_call.c
+++ b/embrace-android-sdk/src/test/cpp/testcases/sampler/test_sampler_jni_call.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <string.h>
+#include "stacktrace_sampler.h"
+
+void emb_add_fake_sample(emb_sample *sample, int pc) {
+    sample->num_sframes = 1;
+    sample->timestamp_ms = 1500000000;
+    sample->duration_ms = 9;
+
+    emb_sample_stackframe *frame = &(sample->stack[0]);
+    frame->pc = pc;
+    frame->so_load_addr = 0x87654321;
+    frame->result = 0;
+    strncpy((char *) frame->so_path, "libtest.so", kEMBSamplePathMaxLen);
+}
+
+void emb_setup_fake_intervals() {
+    emb_interval *interval = emb_current_interval();
+    emb_add_fake_sample(&(interval->samples[0]), 0x12345678);
+    emb_add_fake_sample(&(interval->samples[1]), 0x12300000);
+    emb_add_fake_sample(&(interval->samples[2]), 0x10090000);
+    interval->num_samples = 3;
+}
+


### PR DESCRIPTION
## Goal

Adds a test that checks the Unity ANR capture samples can be serialized into Java objects via the JNI bridge.