### PR TITLE
Create a central location to store the EmbraceAttributeKeys used by the SDK

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -5,6 +5,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.opentelemetry.assertExpectedAttributes
+import io.embrace.android.embracesdk.opentelemetry.assertHasEmbraceAttribute
+import io.embrace.android.embracesdk.opentelemetry.embProcessIdentifier
+import io.embrace.android.embracesdk.opentelemetry.embSequenceId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -36,8 +39,8 @@ internal class SpanTest {
             val exportedSpans = fakeSpanExporter.exportedSpans.filter { it.name == "emb-sdk-init" }
             assertEquals(1, exportedSpans.size)
             val exportedSpan = exportedSpans[0]
-            assertEquals(1, exportedSpan.attributes.asMap().keys.filter { it.key == "emb.sequence_id" }.size)
-            assertEquals(1, exportedSpan.attributes.asMap().keys.filter { it.key == "emb.process_identifier" }.size)
+            exportedSpan.assertHasEmbraceAttribute(embSequenceId, "2")
+            exportedSpan.assertHasEmbraceAttribute(embProcessIdentifier, harness.initModule.processIdentifier)
             exportedSpan.resource.assertExpectedAttributes(
                 expectedServiceName = harness.openTelemetryModule.openTelemetryConfiguration.embraceServiceName,
                 expectedServiceVersion = harness.openTelemetryModule.openTelemetryConfiguration.embraceVersionName,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -35,16 +36,6 @@ private const val EMBRACE_ATTRIBUTE_NAME_PREFIX = "emb."
 private const val EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX = "emb.usage."
 
 /**
- * Attribute name for the monotonically increasing sequence ID given to completed [Span] that expected to sent to the server
- */
-private const val SEQUENCE_ID_ATTRIBUTE_NAME = EMBRACE_ATTRIBUTE_NAME_PREFIX + "sequence_id"
-
-/**
- * Attribute name for the unique ID assigned to each app instance
- */
-private const val PROCESS_IDENTIFIER_ATTRIBUTE_NAME = EMBRACE_ATTRIBUTE_NAME_PREFIX + "process_identifier"
-
-/**
  * Creates a new [SpanBuilder] that marks the resulting span as private if [internal] is true
  */
 internal fun Tracer.embraceSpanBuilder(
@@ -78,26 +69,12 @@ internal fun Span.addEvents(events: List<EmbraceSpanEvent>): Span {
     return this
 }
 
-/**
- * Monotonically increasing ID given to completed [Span] that expected to sent to the server. Can be used to track data loss on the server.
- */
-internal fun Span.setSequenceId(id: Long): Span {
-    setAttribute(SEQUENCE_ID_ATTRIBUTE_NAME, id)
+internal fun Span.setEmbraceAttribute(key: EmbraceAttributeKey, value: String): Span {
+    setAttribute(key.name, value)
     return this
 }
 
-/**
- * Set the unique ID for this app launch
- */
-internal fun Span.setProcessIdentifier(id: String): Span {
-    setAttribute(PROCESS_IDENTIFIER_ATTRIBUTE_NAME, id)
-    return this
-}
-
-internal fun Span.setFixedAttribute(fixedAttribute: FixedAttribute): Span {
-    setAttribute(fixedAttribute.key.name, fixedAttribute.value)
-    return this
-}
+internal fun Span.setFixedAttribute(fixedAttribute: FixedAttribute): Span = setEmbraceAttribute(fixedAttribute.key, fixedAttribute.value)
 
 /**
  * Ends the given [Span], and setting the correct properties per the optional [ErrorCode] passed in. If [errorCode]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanProcessor.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.android.embracesdk.opentelemetry.embProcessIdentifier
+import io.embrace.android.embracesdk.opentelemetry.embSequenceId
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.trace.ReadWriteSpan
@@ -21,8 +23,8 @@ internal class EmbraceSpanProcessor(
     private val counter = AtomicLong(1)
 
     override fun onStart(parentContext: Context, span: ReadWriteSpan) {
-        span.setSequenceId(counter.getAndIncrement())
-        span.setProcessIdentifier(processIdentifier)
+        span.setEmbraceAttribute(embSequenceId, counter.getAndIncrement().toString())
+        span.setEmbraceAttribute(embProcessIdentifier, processIdentifier)
     }
 
     override fun onEnd(span: ReadableSpan) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
+
+/**
+ * Monotonically increasing sequence ID given to completed span that is expected to be sent to the server
+ */
+internal val embProcessIdentifier: EmbraceAttributeKey = EmbraceAttributeKey("process_identifier")
+
+/**
+ * Attribute name for the unique ID assigned to each app instance
+ */
+internal val embSequenceId: EmbraceAttributeKey = EmbraceAttributeKey("sequence_id")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OTelAssertions.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OTelAssertions.kt
@@ -1,7 +1,10 @@
 package io.embrace.android.embracesdk.opentelemetry
 
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.SystemInfo
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.data.SpanData
 import org.junit.Assert.assertEquals
 
 internal fun Resource.assertExpectedAttributes(
@@ -19,4 +22,8 @@ internal fun Resource.assertExpectedAttributes(
     assertEquals(systemInfo.deviceManufacturer, getAttribute(deviceManufacturer))
     assertEquals(systemInfo.deviceModel, getAttribute(deviceModelIdentifier))
     assertEquals(systemInfo.deviceModel, getAttribute(deviceModelName))
+}
+
+internal fun SpanData.assertHasEmbraceAttribute(key: EmbraceAttributeKey, value: String) {
+    assertEquals(value, attributes.get(AttributeKey.stringKey(key.name)))
 }


### PR DESCRIPTION
## Goal

Consolidate definition of canonical Embrace attributes into a set of `EmbraceAttributeKeys` so they can be better organized and be referenced from the same place. EmbraceExtensions was a poor place for it given how many we're going to be getting.
