### PR TITLE
Deemphasize the role of names to identify recorded telemetry

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
@@ -1,14 +1,17 @@
 package io.embrace.android.embracesdk
 
+import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 /**
- * Finds the span event matching the name.
+ * Finds the first Span Event matching the given [TelemetryType]
  */
-internal fun EmbraceSpanData.findEvent(name: String): EmbraceSpanEvent =
-    checkNotNull(events.single { it.name == name }) {
+internal fun EmbraceSpanData.findEventOfType(telemetryType: TelemetryType): EmbraceSpanEvent =
+    checkNotNull(events.single { it.attributes.hasFixedAttribute(telemetryType) }) {
         "Event not found: $name"
     }
 
@@ -29,36 +32,35 @@ internal fun EmbraceSpanEvent.findEventAttribute(key: String): String =
     }
 
 /**
- * Finds the emb-session span.
+ * Returns true if an event exists with the given [TelemetryType]
  */
-internal fun SessionMessage.findSessionSpan(): EmbraceSpanData = findSpan("emb-session")
+internal fun EmbraceSpanData.hasEventOfType(telemetryType: TelemetryType): Boolean =
+    events.find { it.attributes.hasFixedAttribute(telemetryType) } != null
 
 /**
- * Finds the span matching the name.
+ * Returns the Session Span
  */
-internal fun SessionMessage.findSpan(name: String): EmbraceSpanData =
-    checkNotNull(spans?.single { it.name == name }) {
-        "Span not found: $name"
+internal fun SessionMessage.findSessionSpan(): EmbraceSpanData = findSpanOfType(EmbType.Ux.Session)
+
+/**
+ * Finds the span matching the given [TelemetryType].
+ */
+internal fun SessionMessage.findSpanOfType(telemetryType: TelemetryType): EmbraceSpanData =
+    checkNotNull(spans?.single { it.hasFixedAttribute(telemetryType) }) {
+        "Span of type not found: ${telemetryType.key}"
     }
 
 /**
- * Finds the span matching the name.
+ * Finds the span matching the given [TelemetryType].
  */
-internal fun SessionMessage.findSpans(name: String): List<EmbraceSpanData> =
-    checkNotNull(spans?.filter { it.name == name }) {
-        "Could not find spans: $name"
+internal fun SessionMessage.findSpansOfType(telemetryType: TelemetryType): List<EmbraceSpanData> =
+    checkNotNull(spans?.filter { it.hasFixedAttribute(telemetryType) }) {
+        "Spans of type not found: ${telemetryType.key}"
     }
 
 /**
- * Returns true if a span exists with the given name.
+ * Returns true if a span exists with the given [TelemetryType].
  */
-internal fun SessionMessage.hasSpan(name: String): Boolean {
-    return spans?.singleOrNull { it.name == name } != null
-}
-
-/**
- * Returns true if an event exists with the given name.
- */
-internal fun EmbraceSpanData.hasEvent(name: String): Boolean {
-    return events.singleOrNull { it.name == name } != null
+internal fun SessionMessage.hasSpanOfType(telemetryType: TelemetryType): Boolean {
+    return spans?.find { it.attributes.hasFixedAttribute(telemetryType) } != null
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/CustomBreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/CustomBreadcrumbFeatureTest.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName
-import io.embrace.android.embracesdk.findEvent
+import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.findEventOfType
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
@@ -24,7 +24,7 @@ internal class CustomBreadcrumbFeatureTest {
             val message = checkNotNull(harness.recordSession {
                 embrace.addBreadcrumb("Hello, world!")
             })
-            val breadcrumb = message.findSessionSpan().findEvent(SchemaDefaultName.CUSTOM_BREADCRUMB)
+            val breadcrumb = message.findSessionSpan().findEventOfType(EmbType.System.Breadcrumb)
             assertEquals("Hello, world!", breadcrumb.attributes["message"])
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.IntegrationTestRule.Harness
+import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -14,8 +15,8 @@ import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.getSentSessionMessages
-import io.embrace.android.embracesdk.hasEvent
-import io.embrace.android.embracesdk.hasSpan
+import io.embrace.android.embracesdk.hasEventOfType
+import io.embrace.android.embracesdk.hasSpanOfType
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
@@ -102,8 +103,8 @@ internal class OtelSessionGatingTest {
     ) {
         val sessionSpan = payload.findSessionSpan()
         assertNotNull(sessionSpan)
-        assertEquals(!gated, sessionSpan.hasEvent("emb-custom-breadcrumb"))
-        assertEquals(!gated, payload.hasSpan("emb-screen-view"))
+        assertEquals(!gated, sessionSpan.hasEventOfType(EmbType.System.Breadcrumb))
+        assertEquals(!gated, payload.hasSpanOfType(EmbType.Ux.View))
     }
 
     private fun IntegrationTestRule.simulateSession(action: () -> Unit = {}) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -88,12 +88,12 @@ internal sealed class SchemaType(
 }
 
 /**
- * Note: Spans marked as internal will always be prefixed with "emb-", so the default name doesn't need to add this.
+ * Objects generated with a schema will always have the "emb-" prefixed added so the default name doesn't need to add it.
  */
 internal object SchemaDefaultName {
-    internal const val CUSTOM_BREADCRUMB = "emb-custom-breadcrumb"
+    internal const val CUSTOM_BREADCRUMB = "breadcrumb"
     internal const val VIEW_BREADCRUMB = "screen-view"
     internal const val TAP = "ui-tap"
-    internal const val AEI_RECORD = "emb-aei-record"
-    internal const val LOG = "emb-log"
+    internal const val AEI_RECORD = "aei-record"
+    internal const val LOG = "log"
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -95,7 +95,11 @@ internal class CurrentSessionSpanImpl(
     override fun <T> addEvent(obj: T, mapper: T.() -> SpanEventData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
         val event = obj.mapper()
-        return currentSession.addEvent(event.schemaType.defaultName, event.spanStartTimeMs, event.schemaType.attributes())
+        return currentSession.addEvent(
+            event.schemaType.defaultName.toEmbraceObjectName(),
+            event.spanStartTimeMs,
+            event.schemaType.attributes()
+        )
     }
 
     override fun addAttribute(attribute: SpanAttributeData): Boolean {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -33,7 +33,7 @@ internal class SpanServiceImpl(
 
     override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): PersistableEmbraceSpan? {
         return if (EmbraceSpanImpl.inputsValid(name) && currentSessionSpan.canStartNewSpan(parent, internal)) {
-            val spanName = getSpanName(name = name, internal = internal)
+            val spanName = createSpanName(name = name, internal = internal)
             EmbraceSpanImpl(
                 spanName = spanName,
                 openTelemetryClock = openTelemetryClock,
@@ -97,7 +97,7 @@ internal class SpanServiceImpl(
         }
 
         return if (EmbraceSpanImpl.inputsValid(name, events, attributes) && currentSessionSpan.canStartNewSpan(parent, internal)) {
-            tracer.embraceSpanBuilder(name = getSpanName(name, internal), type = type, internal = internal, parent = parent)
+            tracer.embraceSpanBuilder(name = createSpanName(name, internal), type = type, internal = internal, parent = parent)
                 .startSpan(startTimeMs)
                 .setAllAttributes(Attributes.builder().fromMap(attributes).build())
                 .addEvents(events)
@@ -110,7 +110,7 @@ internal class SpanServiceImpl(
 
     override fun getSpan(spanId: String): EmbraceSpan? = spanRepository.getSpan(spanId = spanId)
 
-    private fun getSpanName(name: String, internal: Boolean): String =
+    private fun createSpanName(name: String, internal: Boolean): String =
         if (internal) {
             name.toEmbraceObjectName()
         } else {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
@@ -363,7 +363,6 @@ internal class AeiDataSourceImplTest {
 
     private fun getAeiLogAttrs(): Map<String, String> {
         val logEventData = logWriter.logEvents.single()
-        assertEquals("emb-aei-record", logEventData.schemaType.defaultName)
         assertEquals(Severity.INFO, logEventData.severity)
         logEventData.assertIsType(EmbType.System.Exit)
         return logEventData.schemaType.attributes()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/CustomBreadcrumbDataSourceTest.kt
@@ -34,7 +34,7 @@ internal class CustomBreadcrumbDataSourceTest {
     fun `add breadcrumb`() {
         source.logCustom("Hello, world!", 15000000000)
         with(writer.addedEvents.single()) {
-            assertEquals("emb-custom-breadcrumb", schemaType.defaultName)
+            assertEquals("breadcrumb", schemaType.defaultName)
             assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
             assertEquals(
                 mapOf(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSourceTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.TapBreadcrumb
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -35,9 +36,9 @@ internal class TapBreadcrumbDataSourceTest {
             TapBreadcrumb.TapBreadcrumbType.TAP
         )
         with(writer.addedEvents.single()) {
-            Assert.assertEquals("ui-tap", schemaType.defaultName)
-            Assert.assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
-            Assert.assertEquals(
+            assertEquals("ui-tap", schemaType.defaultName)
+            assertEquals(15000000000.millisToNanos(), spanStartTimeMs)
+            assertEquals(
                 mapOf(
                     EmbType.Ux.Tap.toEmbraceKeyValuePair(),
                     "view.name" to "my-button-id",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.findEventOfType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -237,8 +238,7 @@ internal class CurrentSessionSpanImplTests {
         assertEquals("emb-session", span.name)
 
         // verify event was added to the span
-        val testEvent = span.events.single()
-        assertEquals("emb-custom-breadcrumb", testEvent.name)
+        val testEvent = span.findEventOfType(EmbType.System.Breadcrumb)
         assertEquals(1000, testEvent.timestampNanos.nanosToMillis())
         assertEquals(
             mapOf(


### PR DESCRIPTION
## Goal

Names of objects of specific telemetry types should not hold much meaning, especially if they are the same over and over again and don't provide value.

So to identify that something is of a particular type, the value in `emb.type` should be used instead. To do that, I modified testing code to always look for things by their type, and also made the name used to generate these objects in `SchemaType` optional, as Log objects don't have names, per se.

## Testing

Modified testing coding to not look for a particular name but for objects with a particular type.

