### PR TITLE
Remove the use of the word Breadcrumb from code not scheduled to be deleted

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/BreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/BreadcrumbFeatureTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-internal class CustomBreadcrumbFeatureTest {
+internal class BreadcrumbFeatureTest {
 
     @Rule
     @JvmField

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/FragmentViewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/FragmentViewFeatureTest.kt
@@ -13,14 +13,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-internal class FragmentBreadcrumbFeatureTest {
+internal class FragmentViewFeatureTest {
 
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
-    fun `fragment breadcrumb feature`() {
+    fun `fragment view feature`() {
         with(testRule) {
             var startTimeMs: Long = 0
             val message = checkNotNull(harness.recordSession {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.arch.schema
 
 import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.AEI_RECORD
-import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.CUSTOM_BREADCRUMB
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.BREADCRUMB
 import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.LOG
 import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.TAP
-import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.VIEW_BREADCRUMB
+import io.embrace.android.embracesdk.arch.schema.SchemaDefaultName.VIEW
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogAttributes
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import io.embrace.android.embracesdk.payload.AppExitInfoData
@@ -26,16 +26,16 @@ internal sealed class SchemaType(
      */
     fun attributes(): Map<String, String> = attrs.plus(telemetryType.toEmbraceKeyValuePair())
 
-    internal class CustomBreadcrumb(message: String) : SchemaType(
+    internal class Breadcrumb(message: String) : SchemaType(
         EmbType.System.Breadcrumb,
-        CUSTOM_BREADCRUMB
+        BREADCRUMB
     ) {
         override val attrs = mapOf("message" to message)
     }
 
-    internal class ViewBreadcrumb(viewName: String) : SchemaType(
+    internal class View(viewName: String) : SchemaType(
         EmbType.Ux.View,
-        VIEW_BREADCRUMB
+        VIEW
     ) {
         override val attrs = mapOf("view.name" to viewName)
     }
@@ -91,8 +91,8 @@ internal sealed class SchemaType(
  * Objects generated with a schema will always have the "emb-" prefixed added so the default name doesn't need to add it.
  */
 internal object SchemaDefaultName {
-    internal const val CUSTOM_BREADCRUMB = "breadcrumb"
-    internal const val VIEW_BREADCRUMB = "screen-view"
+    internal const val BREADCRUMB = "breadcrumb"
+    internal const val VIEW = "screen-view"
     internal const val TAP = "ui-tap"
     internal const val AEI_RECORD = "aei-record"
     internal const val LOG = "log"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
@@ -12,9 +12,9 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.CustomBreadcrumb
 
 /**
- * Captures custom breadcrumbs.
+ * Captures breadcrumbs.
  */
-internal class CustomBreadcrumbDataSource(
+internal class BreadcrumbDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
     writer: SessionSpanWriter,
     logger: InternalEmbraceLogger
@@ -39,7 +39,7 @@ internal class CustomBreadcrumbDataSource(
 
     override fun toSpanEventData(obj: CustomBreadcrumb): SpanEventData {
         return SpanEventData(
-            SchemaType.CustomBreadcrumb(obj.message ?: ""),
+            SchemaType.Breadcrumb(obj.message ?: ""),
             obj.timestamp.millisToNanos()
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -34,13 +34,13 @@ internal class EmbraceBreadcrumbService(
     private val logger: InternalEmbraceLogger
 ) : BreadcrumbService, ActivityLifecycleListener, MemoryCleanerListener {
 
-    private val customBreadcrumbDataSource =
-        CustomBreadcrumbDataSource(configService.breadcrumbBehavior, sessionSpanWriter, logger)
+    private val breadcrumbDataSource =
+        BreadcrumbDataSource(configService.breadcrumbBehavior, sessionSpanWriter, logger)
     private val webViewBreadcrumbDataSource = WebViewBreadcrumbDataSource(configService, logger)
     private val rnBreadcrumbDataSource = RnBreadcrumbDataSource(configService, logger)
     private val legacyTapBreadcrumbDataSource = LegacyTapBreadcrumbDataSource(configService, logger)
     private val viewBreadcrumbDataSource = ViewBreadcrumbDataSource(configService, clock, logger)
-    private val fragmentBreadcrumbDataSource = FragmentBreadcrumbDataSource(
+    private val fragmentViewDataSource = FragmentViewDataSource(
         configService.breadcrumbBehavior,
         clock,
         spanService,
@@ -58,11 +58,11 @@ internal class EmbraceBreadcrumbService(
     }
 
     override fun startView(name: String?): Boolean {
-        return fragmentBreadcrumbDataSource.startFragment(name)
+        return fragmentViewDataSource.startFragment(name)
     }
 
     override fun endView(name: String?): Boolean {
-        return fragmentBreadcrumbDataSource.endFragment(name)
+        return fragmentViewDataSource.endFragment(name)
     }
 
     override fun logTap(
@@ -75,7 +75,7 @@ internal class EmbraceBreadcrumbService(
     }
 
     override fun logCustom(message: String, timestamp: Long) {
-        customBreadcrumbDataSource.logCustom(message, timestamp)
+        breadcrumbDataSource.logCustom(message, timestamp)
     }
 
     override fun logRnAction(
@@ -138,7 +138,7 @@ internal class EmbraceBreadcrumbService(
             return
         }
         viewBreadcrumbDataSource.onViewClose()
-        fragmentBreadcrumbDataSource.onViewClose()
+        fragmentViewDataSource.onViewClose()
     }
 
     override fun cleanCollections() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentViewDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/FragmentViewDataSource.kt
@@ -15,9 +15,9 @@ import io.embrace.android.embracesdk.payload.FragmentBreadcrumb
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
- * Captures fragment breadcrumbs.
+ * Captures fragment views.
  */
-internal class FragmentBreadcrumbDataSource(
+internal class FragmentViewDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
     private val clock: Clock,
     spanService: SpanService,
@@ -73,7 +73,7 @@ internal class FragmentBreadcrumbDataSource(
 
     override fun toStartSpanData(obj: FragmentBreadcrumb): StartSpanData = with(obj) {
         StartSpanData(
-            schemaType = SchemaType.ViewBreadcrumb(name),
+            schemaType = SchemaType.View(name),
             spanStartTimeMs = start,
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
-import io.embrace.android.embracesdk.capture.crumbs.CustomBreadcrumbDataSource
-import io.embrace.android.embracesdk.capture.crumbs.FragmentBreadcrumbDataSource
+import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbDataSource
+import io.embrace.android.embracesdk.capture.crumbs.FragmentViewDataSource
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
@@ -23,9 +23,9 @@ internal interface DataSourceModule {
      */
     fun getDataSources(): List<DataSourceState>
 
-    val customBreadcrumbDataSource: DataSourceState
+    val breadcrumbDataSource: DataSourceState
 
-    val fragmentBreadcrumbDataSource: DataSourceState
+    val fragmentViewDataSource: DataSourceState
 }
 
 internal class DataSourceModuleImpl(
@@ -39,9 +39,9 @@ internal class DataSourceModuleImpl(
 
     private val values: MutableList<DataSourceState> = mutableListOf()
 
-    override val customBreadcrumbDataSource: DataSourceState by dataSource {
+    override val breadcrumbDataSource: DataSourceState by dataSource {
         DataSourceState({
-            CustomBreadcrumbDataSource(
+            BreadcrumbDataSource(
                 breadcrumbBehavior = essentialServiceModule.configService.breadcrumbBehavior,
                 writer = otelModule.currentSessionSpan,
                 logger = initModule.logger
@@ -49,10 +49,10 @@ internal class DataSourceModuleImpl(
         })
     }
 
-    override val fragmentBreadcrumbDataSource: DataSourceState by dataSource {
+    override val fragmentViewDataSource: DataSourceState by dataSource {
         DataSourceState(
             factory = {
-                FragmentBreadcrumbDataSource(
+                FragmentViewDataSource(
                     configService.breadcrumbBehavior,
                     initModule.clock,
                     otelModule.spanService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -23,7 +23,7 @@ internal class SpanDataSourceKtTest {
         service.initializeService(1500000000000)
 
         val data = StartSpanData(
-            SchemaType.ViewBreadcrumb("my-view"),
+            SchemaType.View("my-view"),
             1500000000000
         )
         data.assertIsType(EmbType.Ux.View)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSourceTest.kt
@@ -9,15 +9,15 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-internal class CustomBreadcrumbDataSourceTest {
+internal class BreadcrumbDataSourceTest {
 
-    private lateinit var source: CustomBreadcrumbDataSource
+    private lateinit var source: BreadcrumbDataSource
     private lateinit var writer: FakeCurrentSessionSpan
 
     @Before
     fun setUp() {
         writer = FakeCurrentSessionSpan()
-        source = CustomBreadcrumbDataSource(
+        source = BreadcrumbDataSource(
             FakeConfigService().breadcrumbBehavior,
             writer,
             InternalEmbraceLogger(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentViewDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentViewDataSourceTest.kt
@@ -11,19 +11,19 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-internal class FragmentBreadcrumbDataSourceTest {
+internal class FragmentViewDataSourceTest {
 
     private lateinit var configService: FakeConfigService
     private lateinit var clock: FakeClock
     private lateinit var spanService: FakeSpanService
-    private lateinit var dataSource: FragmentBreadcrumbDataSource
+    private lateinit var dataSource: FragmentViewDataSource
 
     @Before
     fun setUp() {
         configService = FakeConfigService()
         clock = FakeClock()
         spanService = FakeSpanService()
-        dataSource = FragmentBreadcrumbDataSource(
+        dataSource = FragmentViewDataSource(
             configService.breadcrumbBehavior,
             clock,
             spanService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -114,11 +114,11 @@ internal class FakePersistableEmbraceSpan(
      * Should only used if this is being used to fake a session span
      */
     fun addCustomBreadcrumb(name: String, timestampMs: Long?) {
-        val customBreadcrumb = SpanEventData(
-            schemaType = SchemaType.CustomBreadcrumb(name),
+        val breadcrumb = SpanEventData(
+            schemaType = SchemaType.Breadcrumb(name),
             spanStartTimeMs = timestampMs ?: fakeClock.now()
         )
-        addEvent(customBreadcrumb.schemaType.defaultName, customBreadcrumb.spanStartTimeMs, attributes)
+        addEvent(breadcrumb.schemaType.defaultName, breadcrumb.spanStartTimeMs, attributes)
     }
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -25,8 +25,8 @@ internal class DataSourceModuleImplTest {
             FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = WorkerName.BACKGROUND_REGISTRATION)
         )
         assertNotNull(module.getDataSources())
-        assertNotNull(module.customBreadcrumbDataSource)
-        assertNotNull(module.fragmentBreadcrumbDataSource)
+        assertNotNull(module.breadcrumbDataSource)
+        assertNotNull(module.fragmentViewDataSource)
         assertEquals(2, module.getDataSources().size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -232,7 +232,7 @@ internal class CurrentSessionSpanImplTests {
     @Test
     fun `add event forwarded to span`() {
         currentSessionSpan.addEvent("test-event") {
-            SpanEventData(SchemaType.CustomBreadcrumb(this), 1000L)
+            SpanEventData(SchemaType.Breadcrumb(this), 1000L)
         }
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session", span.name)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BreadcrumbTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BreadcrumbTest.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-internal class CustomBreadcrumbTest {
+internal class BreadcrumbTest {
 
     private val info = CustomBreadcrumb(
         "test",


### PR DESCRIPTION
## Goal

From this point forth, the word "Breadcrumb" will only apply to legacy code as well as the telemetry formerly known as "CustomBreadcrumb". So say we all

## Testing

Just a rename