### PR TITLE
Create a factory to instantiate EmbraceSpanImpl objects

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.telemetry.TelemetryService
-import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
@@ -21,7 +20,7 @@ internal class CurrentSessionSpanImpl(
     private val telemetryService: TelemetryService,
     private val spanRepository: SpanRepository,
     private val spanSink: SpanSink,
-    private val tracerSupplier: Provider<Tracer>,
+    private val embraceSpanFactorySupplier: Provider<EmbraceSpanFactory>,
 ) : CurrentSessionSpan, SessionSpanWriter {
 
     /**
@@ -113,14 +112,10 @@ internal class CurrentSessionSpanImpl(
     private fun startSessionSpan(startTimeMs: Long): EmbraceSpan {
         traceCount.set(0)
 
-        return EmbraceSpanImpl(
-            spanBuilder = tracerSupplier().embraceSpanBuilder(
-                name = "session",
-                type = EmbType.Ux.Session,
-                internal = true
-            ),
-            openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository
+        return embraceSpanFactorySupplier().create(
+            name = "session",
+            type = EmbType.Ux.Session,
+            internal = true
         ).apply {
             start(startTimeMs = startTimeMs)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.common.Clock
+
+/**
+ * Creates instances of [PersistableEmbraceSpan] for internal usage. Using this factory is preferred to invoking the constructor
+ * because of the it requires several services that may not be easily available.
+ */
+internal interface EmbraceSpanFactory {
+    fun create(
+        name: String,
+        type: TelemetryType,
+        internal: Boolean,
+        parent: EmbraceSpan? = null
+    ): PersistableEmbraceSpan
+}
+
+internal class EmbraceSpanFactoryImpl(
+    private val tracer: Tracer,
+    private val openTelemetryClock: Clock,
+    private val spanRepository: SpanRepository
+) : EmbraceSpanFactory {
+
+    override fun create(
+        name: String,
+        type: TelemetryType,
+        internal: Boolean,
+        parent: EmbraceSpan?
+    ): PersistableEmbraceSpan = EmbraceSpanImpl(
+        spanBuilder = tracer.embraceSpanBuilder(name, type, internal, parent),
+        openTelemetryClock = openTelemetryClock,
+        spanRepository = spanRepository
+    )
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -6,8 +6,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.sdk.common.Clock
 
 /**
  * A [SpanService] that can be instantiated quickly. At that time, it will defer calls an implementation that handles the case when
@@ -15,10 +13,9 @@ import io.opentelemetry.sdk.common.Clock
  * instantiate and initialize [SpanServiceImpl] to provide the span recording functionality.
  */
 internal class EmbraceSpanService(
-    private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
     private val currentSessionSpan: CurrentSessionSpan,
-    private val tracerSupplier: Provider<Tracer>,
+    private val embraceSpanFactorySupplier: Provider<EmbraceSpanFactory>,
 ) : SpanService {
     private val uninitializedSdkSpansService: UninitializedSdkSpanService = UninitializedSdkSpanService()
 
@@ -30,10 +27,9 @@ internal class EmbraceSpanService(
             synchronized(currentDelegate) {
                 if (!initialized()) {
                     val realSpansService = SpanServiceImpl(
-                        openTelemetryClock = openTelemetryClock,
                         spanRepository = spanRepository,
+                        embraceSpanFactory = embraceSpanFactorySupplier(),
                         currentSessionSpan = currentSessionSpan,
-                        tracer = tracerSupplier(),
                     )
                     realSpansService.initializeService(sdkInitStartTimeMs)
                     if (realSpansService.initialized()) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceKtTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.destination.StartSpanData
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanFactoryImpl
 import io.embrace.android.embracesdk.internal.spans.SpanServiceImpl
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -15,10 +16,13 @@ internal class SpanDataSourceKtTest {
     fun `start span`() {
         val initModule = FakeInitModule()
         val service = SpanServiceImpl(
-            openTelemetryClock = initModule.openTelemetryClock,
             spanRepository = initModule.openTelemetryModule.spanRepository,
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
-            tracer = initModule.openTelemetryModule.tracer
+            embraceSpanFactory = EmbraceSpanFactoryImpl(
+                tracer = initModule.openTelemetryModule.tracer,
+                openTelemetryClock = initModule.openTelemetryClock,
+                spanRepository = initModule.openTelemetryModule.spanRepository
+            )
         )
         service.initializeService(1500000000000)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class EmbraceSpanFactoryImplTest {
+    private val clock = FakeClock()
+    private lateinit var embraceSpanFactory: EmbraceSpanFactoryImpl
+    private lateinit var spanRepository: SpanRepository
+
+    @Before
+    fun setup() {
+        val initModule = FakeInitModule(clock)
+        spanRepository = initModule.openTelemetryModule.spanRepository
+        embraceSpanFactory = EmbraceSpanFactoryImpl(
+            tracer = initModule.openTelemetryModule.tracer,
+            openTelemetryClock = initModule.openTelemetryClock,
+            spanRepository = spanRepository
+        )
+    }
+
+    @Test
+    fun `check span creation`() {
+        val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = false)
+        assertTrue(span.start(clock.now()))
+        with(span) {
+            assertTrue(hasEmbraceAttribute(EmbType.Performance.Default))
+            assertNull(parent)
+            assertFalse(hasEmbraceAttribute(PrivateSpan))
+        }
+        assertNotNull(spanRepository.getSpan(spanId = checkNotNull(span.spanId)))
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -46,10 +46,13 @@ internal class SpanServiceImplTest {
         spanSink = initModule.openTelemetryModule.spanSink
         currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
         spansService = SpanServiceImpl(
-            openTelemetryClock = initModule.openTelemetryClock,
             spanRepository = initModule.openTelemetryModule.spanRepository,
             currentSessionSpan = currentSessionSpan,
-            tracer = initModule.openTelemetryModule.tracer
+            embraceSpanFactory = EmbraceSpanFactoryImpl(
+                tracer = initModule.openTelemetryModule.tracer,
+                openTelemetryClock = initModule.openTelemetryClock,
+                spanRepository = initModule.openTelemetryModule.spanRepository
+            )
         )
         spansService.initializeService(initModule.clock.now())
     }


### PR DESCRIPTION
## Goal

Instead of passing the dependencies into the constructor all the time, just do it in a separate class. Yes, I just created a factory provider, which is hilarious since this isn't even Java.

