### PR TITLE
Add flush to log orchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
@@ -53,7 +53,11 @@ internal class LogOrchestrator(
         if (!shouldSendLogs) {
             return false
         }
+        flush()
+        return true
+    }
 
+    fun flush() {
         scheduledCheckFuture?.cancel(false)
         scheduledCheckFuture = null
         firstLogInBatchTime.set(0)
@@ -62,8 +66,6 @@ internal class LogOrchestrator(
         if (!envelope.data.logs.isNullOrEmpty()) {
             deliveryService.sendLogs(envelope)
         }
-
-        return true
     }
 
     private fun scheduleCheck() {
@@ -88,6 +90,7 @@ internal class LogOrchestrator(
         val firstLogInBatchTime = firstLogInBatchTime.get()
         return firstLogInBatchTime != 0L && now - firstLogInBatchTime > MAX_BATCH_TIME
     }
+
     companion object {
         const val MAX_LOGS_PER_BATCH = 50
         private const val MAX_BATCH_TIME = 5000L // In milliseconds

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
@@ -104,6 +104,27 @@ internal class LogOrchestratorTest {
     }
 
     @Test
+    fun `flushing logs`() {
+        val timeStep = 1100L
+
+        repeat(4) {
+            logSink.storeLogs(listOf(FakeLogRecordData()))
+            moveTimeAhead(timeStep)
+        }
+
+        // Verify no logs have been sent
+        assertFalse(logSink.completedLogs().isEmpty())
+        verifyPayloadNotSent()
+
+        // flush the logs
+        logOrchestrator.flush()
+
+        // Verify the logs are sent
+        assertTrue(logSink.completedLogs().isEmpty())
+        verifyPayload(4)
+    }
+
+    @Test
     fun `simulate race condition`() {
         val fakeLog = FakeLogRecordData()
         val fakeLogs = mutableListOf<LogRecordData>()


### PR DESCRIPTION
## Goal

Adds a flush function to the `LogOrchestrator` class. This isn't invoked by any production code yet but will be. I primarily need this for writing tests.

