### PR TITLE
Make the snap snapshot in the v1 sessions payload use the old payload format

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.arch.assertIsPrivateSpan
 import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.arch.assertSuccessful
+import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
@@ -13,8 +14,10 @@ import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 
 /**
@@ -26,6 +29,7 @@ internal fun assertEmbraceSpanData(
     expectedEndTimeMs: Long,
     expectedParentId: String,
     expectedTraceId: String? = null,
+    expectedStatus: StatusCode = StatusCode.OK,
     expectedErrorCode: ErrorCode? = null,
     expectedCustomAttributes: Map<String, String> = emptyMap(),
     expectedEvents: List<EmbraceSpanEvent> = emptyList(),
@@ -42,11 +46,14 @@ internal fun assertEmbraceSpanData(
         } else {
             assertEquals(32, traceId.length)
         }
-        if (expectedErrorCode == null) {
-            assertSuccessful()
-        } else {
+
+        if (expectedErrorCode != null) {
             assertError(expectedErrorCode)
+        } else {
+            assertEquals(expectedStatus, status)
+            assertNull(attributes[ErrorCodeAttribute.Failure.key.name])
         }
+
         expectedCustomAttributes.forEach { entry ->
             assertEquals(entry.value, attributes[entry.key])
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionMessage.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionMessage.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.comms.api.ApiClient
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 
 /**
@@ -56,7 +55,7 @@ internal data class SessionMessage @JvmOverloads internal constructor(
     val spans: List<EmbraceSpanData>? = null,
 
     @Json(name = "span_snapshots")
-    val spanSnapshots: List<Span>? = null,
+    val spanSnapshots: List<EmbraceSpanData>? = null,
 
     @Json(name = "v")
     val version: Int? = ApiClient.MESSAGE_VERSION,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.gating.GatingService
+import io.embrace.android.embracesdk.internal.payload.toOldPayload
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
@@ -182,7 +183,7 @@ internal class V1PayloadMessageCollator(
             }
         }
         val spanSnapshots = captureDataSafely(logger) {
-            spanRepository.getActiveSpans().mapNotNull { it.snapshot() }
+            spanRepository.getActiveSpans().mapNotNull { it.snapshot()?.toOldPayload() }
         }
 
         return SessionMessage(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.fakeV1EndedSessionMessage
 import io.embrace.android.embracesdk.fakes.fakeV1EndedSessionMessageWithSnapshot
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Event
@@ -132,7 +131,7 @@ internal class EmbraceDeliveryServiceTest {
         val snapshot = checkNotNull(sessionWithSnapshot.spanSnapshots).single()
         assertEmbraceSpanData(
             span = sentSession.spans?.single { it.spanId == snapshot.spanId },
-            expectedStartTimeMs = checkNotNull(snapshot.startTimeUnixNano?.nanosToMillis()),
+            expectedStartTimeMs = checkNotNull(snapshot.startTimeNanos.nanosToMillis()),
             expectedEndTimeMs = checkNotNull(sessionWithSnapshot.session.endTime),
             expectedParentId = SpanId.getInvalid(),
             expectedErrorCode = ErrorCode.FAILURE,
@@ -146,7 +145,7 @@ internal class EmbraceDeliveryServiceTest {
     fun `do not add failed span from a snapshot if a span with the same id is already in the payload`() {
         val startedSnapshot = EmbraceSpanData(perfSpanSnapshot)
         val completedSpan = startedSnapshot.copy(status = StatusCode.OK, endTimeNanos = startedSnapshot.startTimeNanos + 10000000L)
-        val snapshots = listOfNotNull(startedSnapshot.toNewPayload())
+        val snapshots = listOfNotNull(startedSnapshot)
         val spans = listOf(completedSpan)
         val messedUpSession = fakeV1EndedSessionMessage().copy(spans = spans, spanSnapshots = snapshots)
         assertEquals(1, messedUpSession.spans?.size)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.fixtures.testSpan
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.toOldPayload
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.Companion.APPLICATION_STATE_FOREGROUND
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -41,7 +42,7 @@ internal fun fakeV1EndedSessionMessageWithSnapshot(): SessionMessage = SessionMe
         endTime = 161000400000L
     ),
     spans = listOfNotNull(testSpan),
-    spanSnapshots = listOfNotNull(FakePersistableEmbraceSpan.started().snapshot()),
+    spanSnapshots = listOfNotNull(FakePersistableEmbraceSpan.started().snapshot()?.toOldPayload()),
 )
 
 internal fun fakeV2SessionMessage(): SessionMessage = SessionMessage(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.deserializeJsonFromResource
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fixtures.testSpanSnapshot
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.toOldPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
@@ -38,7 +39,7 @@ internal class SessionMessageTest {
         )
     )
 
-    private val spanSnapshots = listOfNotNull(testSpanSnapshot)
+    private val spanSnapshots = listOfNotNull(testSpanSnapshot.toOldPayload())
 
     private val info = SessionMessage(
         session,

--- a/embrace-android-sdk/src/test/resources/session_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_message_expected.json
@@ -49,11 +49,13 @@
     {
       "trace_id": "snapshot-trace-id",
       "span_id": "snapshot-span-id",
+      "parent_span_id": "0000000000000000",
       "name": "snapshot",
       "start_time_unix_nano": 1692201601000,
-      "status": "Unset",
+      "end_time_unix_nano": 0,
+      "status": "UNSET",
       "events": [],
-      "attributes": []
+      "attributes": {}
     }
   ],
   "v": 13


### PR DESCRIPTION
## Goal

Change the span snapshot to use the old spans serialization format in the v1 session payload. This is because the backend folks are testing the v1 payload with span snapshots and want to make sure they conform of the expected v1 span format, in case v1 payloads in prod will ever have span snapshots.

## Testing
Change tests to match
