### PR TITLE
Do not export spans marked as private

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
@@ -33,6 +33,11 @@ internal class EmbraceAttributeKey(
     } else {
         id.toEmbraceAttributeName()
     }
+
+    /**
+     * The [AttributeKey] equivalent for this object to be used in conjunction with OTel objects
+     */
+    val attributeKey: AttributeKey<String> = otelAttributeKey ?: AttributeKey.stringKey(name)
 }
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
@@ -11,7 +11,7 @@ internal class TelemetryAttributes(
     private val sessionProperties: EmbraceSessionProperties? = null,
     private val customAttributes: Map<String, String>? = null
 ) {
-    private val map: MutableMap<String, String> = mutableMapOf()
+    private val map: MutableMap<AttributeKey<String>, String> = mutableMapOf()
 
     /**
      * Return a snapshot of the current values of the attributes set on this as a [Map]. Schema keys will always overwrite any previous
@@ -20,15 +20,15 @@ internal class TelemetryAttributes(
     fun snapshot(): Map<String, String> =
         (customAttributes ?: emptyMap())
             .plus(sessionProperties?.get()?.mapKeys { "properties.".toEmbraceAttributeName() + it.key } ?: emptyMap())
-            .plus(map.mapKeys { it.key })
+            .plus(map.mapKeys { it.key.key })
 
     fun setAttribute(key: EmbraceAttributeKey, value: String) {
-        map[key.name] = value
+        setAttribute(key.attributeKey, value)
     }
 
     fun setAttribute(key: AttributeKey<String>, value: String) {
-        map[key.key] = value
+        map[key] = value
     }
 
-    fun getAttribute(key: EmbraceAttributeKey): String? = map[key.name]
+    fun getAttribute(key: EmbraceAttributeKey): String? = map[key.attributeKey]
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.TimeUnit
 
 /**
@@ -114,6 +115,9 @@ internal fun String.toEmbraceAttributeName(): String = EMBRACE_ATTRIBUTE_NAME_PR
  * Return the appropriate internal Embrace attribute usage name given the current string
  */
 internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX + this
+
+internal fun SpanData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
+    attributes.asMap()[fixedAttribute.key.attributeKey] == fixedAttribute.value
 
 internal fun EmbraceSpanData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
     fixedAttribute.value == attributes[fixedAttribute.key.name]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanExporter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanExporter.kt
@@ -1,21 +1,29 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.export.SpanExporter
 
 /**
- * Exports the given completed [Span] to the given [SpanService]
- *
- * Note: no explicit tests exist for this as its functionality is tested via the tests for [SpanServiceImpl]
+ * Exports the given completed [Span] to the given [SpanSink] as well as any configured external [SpanExporter]
  */
 @InternalApi
-internal class EmbraceSpanExporter(private val spanSink: SpanSink) : SpanExporter {
+internal class EmbraceSpanExporter(
+    private val spanSink: SpanSink,
+    private val externalSpanExporter: SpanExporter
+) : SpanExporter {
     @Synchronized
-    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode =
-        spanSink.storeCompletedSpans(spans.toList())
+    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
+        val result = spanSink.storeCompletedSpans(spans.toList())
+        if (result == CompletableResultCode.ofSuccess()) {
+            return externalSpanExporter.export(spans.filterNot { it.hasFixedAttribute(PrivateSpan) })
+        }
+
+        return result
+    }
 
     override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
@@ -35,12 +35,15 @@ internal class OpenTelemetryConfiguration(
         .put(deviceModelName, systemInfo.deviceModel)
         .build()
 
-    private val spanExporters = mutableListOf<SpanExporter>(EmbraceSpanExporter(spanSink))
+    private val externalSpanExporters = mutableListOf<SpanExporter>()
     private val logExporters = mutableListOf<LogRecordExporter>(EmbraceLogRecordExporter(logSink))
 
     val spanProcessor: SpanProcessor by lazy {
         EmbraceSpanProcessor(
-            SpanExporter.composite(spanExporters),
+            EmbraceSpanExporter(
+                spanSink = spanSink,
+                externalSpanExporter = SpanExporter.composite(externalSpanExporters)
+            ),
             processIdentifier
         )
     }
@@ -50,7 +53,7 @@ internal class OpenTelemetryConfiguration(
     }
 
     fun addSpanExporter(spanExporter: SpanExporter) {
-        spanExporters.add(spanExporter)
+        externalSpanExporters.add(spanExporter)
     }
 
     fun addLogExporter(logExporter: LogRecordExporter) {


### PR DESCRIPTION
## Goal

Only export spans that are not marked as private, which is considered internal Embrace metadata and not part of the set of telemetry logged and visible to SDK users.

## Testing

Modified existing tests to cover the new use case
