### PR TITLE
Add OTel conversion interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.anr
 
 import io.embrace.android.embracesdk.arch.DataCaptureService
+import io.embrace.android.embracesdk.arch.DataCaptureServiceOtelConverter
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.payload.AnrInterval
 import java.io.Closeable
@@ -8,7 +9,10 @@ import java.io.Closeable
 /**
  * Service which detects when the application is not responding.
  */
-internal interface AnrService : DataCaptureService<List<AnrInterval>>, Closeable {
+internal interface AnrService :
+    DataCaptureService<List<AnrInterval>>,
+    Closeable,
+    DataCaptureServiceOtelConverter {
 
     /**
      * Forces ANR tracking stop by closing the monitoring thread when a crash is

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.anr.sigquit.SigquitDetectionService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
@@ -106,6 +107,10 @@ internal class EmbraceAnrService(
         this.anrMonitorWorker.submit {
             targetThreadHeartbeatScheduler.stopMonitoringThread()
         }
+    }
+
+    override fun snapshot(): List<Span>? {
+        return null
     }
 
     override fun close() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/NoOpAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/NoOpAnrService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.anr
 
 import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.payload.AnrInterval
 
 internal class NoOpAnrService : AnrService {
@@ -24,5 +25,9 @@ internal class NoOpAnrService : AnrService {
     }
 
     override fun cleanCollections() {
+    }
+
+    override fun snapshot(): List<Span>? {
+        return emptyList()
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureServiceOtelConverter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureServiceOtelConverter.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.internal.payload.Span
+
+/**
+ * Converts the data captured by a [DataCaptureService] into OpenTelemetry spans. This approach
+ * can be desirable as opposed to using a [DataSource] when Embrace has requirements that are
+ * incompatible with OTel's restrictions.
+ *
+ * For example, if we want to limit SpanEvents so that only the last N are captured, it's
+ * non-trivial to attempt that with the OTel SDK. Instead, we should use this interface to
+ * convert existing services to OTel telemetry, and then add it directly to our payloads.
+ *
+ * This has the disadvantage of the data is not sent in exporters, so should be used sparingly.
+ */
+internal fun interface DataCaptureServiceOtelConverter {
+
+    /**
+     * Returns a snapshot of the data captured by the service as a list of spans.
+     */
+    fun snapshot(): List<Span>?
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAnrService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAnrService.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.anr.AnrService
 import io.embrace.android.embracesdk.anr.BlockedThreadListener
 import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.payload.AnrInterval
 
 internal class FakeAnrService : AnrService {
@@ -31,6 +32,10 @@ internal class FakeAnrService : AnrService {
     }
 
     override fun close() {
+        TODO("Not yet implemented")
+    }
+
+    override fun snapshot(): List<Span>? {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Goal

Adds an interface that converts data captured by `DataCaptureService` into OTel spans. This will be used by ANRs initially but likely other services where we want to limit data outside the limits (!) that OTel currently imposes on our limiting.

`snapshot()` will be invoked by the classes that generate the payload, and will construct OTel values from the legacy captured data.

