### PR TITLE
Use log.record.uid for the ID of an Embrace log

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -37,12 +37,7 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
 
         internal object Breadcrumb : System("breadcrumb")
 
-        internal object Log : System("log") {
-            /**
-             * Attribute name for a unique id identifying the log
-             */
-            val embLogId = EmbraceAttributeKey("log_id")
-        }
+        internal object Log : System("log")
 
         internal object Exception : System("exception")
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
@@ -31,4 +31,6 @@ internal class TelemetryAttributes(
     }
 
     fun getAttribute(key: EmbraceAttributeKey): String? = map[key.attributeKey]
+
+    fun getAttribute(key: AttributeKey<String>): String? = map[key]
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.arch.destination.LogEventData
 import io.embrace.android.embracesdk.arch.destination.LogWriter
 import io.embrace.android.embracesdk.arch.schema.EmbType.System.FlutterException.embFlutterExceptionContext
 import io.embrace.android.embracesdk.arch.schema.EmbType.System.FlutterException.embFlutterExceptionLibrary
-import io.embrace.android.embracesdk.arch.schema.EmbType.System.Log.embLogId
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.arch.schema.SchemaType.Exception
 import io.embrace.android.embracesdk.arch.schema.SchemaType.FlutterException
@@ -26,6 +25,7 @@ import io.embrace.android.embracesdk.opentelemetry.embState
 import io.embrace.android.embracesdk.opentelemetry.exceptionMessage
 import io.embrace.android.embracesdk.opentelemetry.exceptionStacktrace
 import io.embrace.android.embracesdk.opentelemetry.exceptionType
+import io.embrace.android.embracesdk.opentelemetry.logRecordUid
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -197,7 +197,7 @@ internal class EmbraceLogService(
             customAttributes = customProperties?.mapValues { it.value.toString() } ?: emptyMap()
         )
 
-        attributes.setAttribute(embLogId, Uuid.getEmbUuid())
+        attributes.setAttribute(logRecordUid, Uuid.getEmbUuid())
         sessionIdTracker.getActiveSessionId()?.let { attributes.setAttribute(embSessionId, it) }
         metadataService.getAppState()?.let { attributes.setAttribute(embState, it) }
 
@@ -227,7 +227,7 @@ internal class EmbraceLogService(
             return
         }
 
-        val logId = attributes.getAttribute(embLogId)
+        val logId = attributes.getAttribute(logRecordUid)
         if (logId == null || !logCounters.getValue(severity).addIfAllowed(logId)) {
             return
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryAttributeKeys.kt
@@ -15,6 +15,8 @@ internal val deviceManufacturer: AttributeKey<String> = AttributeKey.stringKey("
 internal val deviceModelIdentifier: AttributeKey<String> = AttributeKey.stringKey("os.model.identifier")
 internal val deviceModelName: AttributeKey<String> = AttributeKey.stringKey("os.model.name")
 
+internal val logRecordUid: AttributeKey<String> = AttributeKey.stringKey("log.record.uid")
+
 internal val osName: AttributeKey<String> = AttributeKey.stringKey("os.name")
 internal val osVersion: AttributeKey<String> = AttributeKey.stringKey("os.version")
 internal val osType: AttributeKey<String> = AttributeKey.stringKey("os.type")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
@@ -38,6 +38,8 @@ internal class TelemetryAttributesTest {
         assertEquals(2, attributes.size)
         assertEquals(sessionId, attributes[embSessionId.name])
         assertEquals("exceptionValue", attributes[exceptionType.key])
+        assertEquals(sessionId, telemetryAttributes.getAttribute(embSessionId))
+        assertEquals("exceptionValue", telemetryAttributes.getAttribute(exceptionType))
     }
 
     @Test


### PR DESCRIPTION
## Goal

Change the attribute name used to identify an embrace log to `log.record.uid` per the semantic conventions

## Testing
Change tests to look for the new key
