### PR TITLE
Use the emb.private prefix to denote private attributes that will not appear in the UI

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
@@ -26,12 +26,13 @@ internal interface EmbraceAttribute {
 internal class EmbraceAttributeKey(
     override val id: String,
     otelAttributeKey: AttributeKey<String>? = null,
-    useIdAsAttributeName: Boolean = false
+    useIdAsAttributeName: Boolean = false,
+    isPrivate: Boolean = false
 ) : EmbraceAttribute {
     override val name: String = if (!useIdAsAttributeName && otelAttributeKey?.key != null) {
         otelAttributeKey.key
     } else {
-        id.toEmbraceAttributeName()
+        id.toEmbraceAttributeName(isPrivate)
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -22,17 +22,22 @@ import java.util.concurrent.TimeUnit
  */
 
 /**
- * Prefix added to [Span] names for all Spans recorded internally by the SDK
+ * Prefix added to OTel signal object names recorded by the SDK
  */
 private const val EMBRACE_OBJECT_NAME_PREFIX = "emb-"
 
 /**
- * Prefix added to all [Span] attribute keys for all attributes added by the SDK
+ * Prefix added to all attribute keys for all attributes with a specific meaning to the Embrace platform
  */
 private const val EMBRACE_ATTRIBUTE_NAME_PREFIX = "emb."
 
 /**
- * Prefix added to all [Span] attribute keys for all usage attributes added by the SDK
+ * Prefix added to all Embrace attribute keys that are meant to be internal to Embrace
+ */
+private const val EMBRACE_PRIVATE_ATTRIBUTE_NAME_PREFIX = "emb.private."
+
+/**
+ * Prefix added to all attribute keys for all usage attributes added by the SDK
  */
 private const val EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX = "emb.usage."
 
@@ -109,7 +114,14 @@ internal fun String.toEmbraceObjectName(): String = EMBRACE_OBJECT_NAME_PREFIX +
 /**
  * Return the appropriate internal Embrace attribute name given the current string
  */
-internal fun String.toEmbraceAttributeName(): String = EMBRACE_ATTRIBUTE_NAME_PREFIX + this
+internal fun String.toEmbraceAttributeName(isPrivate: Boolean = false): String {
+    val prefix = if (isPrivate) {
+        EMBRACE_PRIVATE_ATTRIBUTE_NAME_PREFIX
+    } else {
+        EMBRACE_ATTRIBUTE_NAME_PREFIX
+    }
+    return prefix + this
+}
 
 /**
  * Return the appropriate internal Embrace attribute usage name given the current string

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -20,7 +20,7 @@ internal val embProcessIdentifier: EmbraceAttributeKey = EmbraceAttributeKey("pr
 /**
  * Attribute name for the unique ID assigned to each app instance
  */
-internal val embSequenceId: EmbraceAttributeKey = EmbraceAttributeKey("sequence_id")
+internal val embSequenceId: EmbraceAttributeKey = EmbraceAttributeKey(id = "sequence_id", isPrivate = true)
 
 /**
  * Attribute name for the Embrace Sesssion

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURR
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl
+import io.embrace.android.embracesdk.opentelemetry.embSequenceId
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
@@ -34,7 +35,7 @@ internal val testSpan = EmbraceSpanData(
         )
     ),
     attributes = mapOf(
-        Pair("emb.sequence_id", "3"),
+        Pair(embSequenceId.name, "3"),
         EmbType.Performance.Default.toEmbraceKeyValuePair(),
     )
 )

--- a/embrace-android-sdk/src/test/resources/span_expected.json
+++ b/embrace-android-sdk/src/test/resources/span_expected.json
@@ -1,6 +1,6 @@
 {
   "attributes": {
-    "emb.sequence_id": "3",
+    "emb.private.sequence_id": "3",
     "emb.type": "perf"
   },
   "end_time_unix_nano": 1681972471871000000,


### PR DESCRIPTION
## Goal

Use a different attribute prefix to denote private embrace attributes that should be not be shown in the UI. These are not filtered out yet in the exporter but can be done later, as there's nothing that are that important there right now.

## Testing

Add/fix appropriate tests