### PR TITLE
Make session spans not private so they can be exported

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -237,7 +237,7 @@ internal class TracingApiTest {
                 expectedStartTimeMs = testStartTimeMs + 100,
                 expectedEndTimeMs = sessionEndTime,
                 expectedParentId = SpanId.getInvalid(),
-                private = true
+                private = false
             )
 
             assertEquals(2, checkNotNull(sessionMessage.spanSnapshots).size)
@@ -269,7 +269,7 @@ internal class TracingApiTest {
                 expectedEndTimeMs = 0L,
                 expectedParentId = SpanId.getInvalid(),
                 expectedStatus = StatusCode.UNSET,
-                private = true
+                private = false
             )
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -48,8 +48,16 @@ internal fun Tracer.embraceSpanBuilder(
     name: String,
     type: TelemetryType,
     internal: Boolean,
+    private: Boolean,
     parent: EmbraceSpan? = null
-): EmbraceSpanBuilder = EmbraceSpanBuilder(tracer = this, name = name, telemetryType = type, internal = internal, parent = parent)
+): EmbraceSpanBuilder = EmbraceSpanBuilder(
+    tracer = this,
+    name = name,
+    telemetryType = type,
+    internal = internal,
+    private = private,
+    parent = parent,
+)
 
 /**
  * Add the given list of [EmbraceSpanEvent] if they are valid

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
@@ -20,7 +20,8 @@ internal class EmbraceSpanBuilder(
     name: String,
     telemetryType: TelemetryType,
     internal: Boolean,
-    val parent: EmbraceSpan?
+    private: Boolean,
+    val parent: EmbraceSpan?,
 ) {
     val fixedAttributes = mutableListOf<FixedAttribute>(telemetryType)
     val spanName = if (internal) {
@@ -44,7 +45,7 @@ internal class EmbraceSpanBuilder(
             }
         }
 
-        if (internal) {
+        if (private) {
             fixedAttributes.add(PrivateSpan)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
@@ -15,6 +15,7 @@ internal interface EmbraceSpanFactory {
         name: String,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean = internal,
         parent: EmbraceSpan? = null
     ): PersistableEmbraceSpan
 }
@@ -29,9 +30,16 @@ internal class EmbraceSpanFactoryImpl(
         name: String,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         parent: EmbraceSpan?
     ): PersistableEmbraceSpan = EmbraceSpanImpl(
-        spanBuilder = tracer.embraceSpanBuilder(name, type, internal, parent),
+        spanBuilder = tracer.embraceSpanBuilder(
+            name = name,
+            type = type,
+            internal = internal,
+            private = private,
+            parent = parent
+        ),
         openTelemetryClock = openTelemetryClock,
         spanRepository = spanRepository
     )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -165,7 +166,7 @@ internal class EmbraceSpanImpl(
     override fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean =
         allAttributes().hasFixedAttribute(fixedAttribute)
 
-    override fun getAttributeWithKey(key: String): String? = allAttributes()[key]
+    override fun getAttribute(key: EmbraceAttributeKey): String? = allAttributes()[key.name]
 
     private fun allAttributes(): Map<String, String> = attributes + schemaAttributes
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.spans
 
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 
@@ -18,5 +19,5 @@ internal interface PersistableEmbraceSpan : EmbraceSpan {
     /**
      * Get the value of the attribute with the given key. Returns null if the attribute does not exist.
      */
-    fun getAttributeWithKey(key: String): String?
+    fun getAttribute(key: EmbraceAttributeKey): String?
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
@@ -108,7 +109,7 @@ internal class FakePersistableEmbraceSpan(
     override fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean =
         attributes.hasFixedAttribute(fixedAttribute)
 
-    override fun getAttributeWithKey(key: String): String? = "Test Attribute"
+    override fun getAttribute(key: EmbraceAttributeKey): String? = attributes[key.name]
 
     companion object {
         fun notStarted(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan =

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -184,7 +184,7 @@ internal class CurrentSessionSpanImplTests {
                 AppTerminationCause.Crash.toEmbraceKeyValuePair(),
                 EmbType.Ux.Session.toEmbraceKeyValuePair()
             ),
-            private = true
+            private = false
         )
 
         assertEmbraceSpanData(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -28,14 +29,39 @@ internal class EmbraceSpanFactoryImplTest {
     }
 
     @Test
-    fun `check span creation`() {
+    fun `check public span creation`() {
         val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = false)
         assertTrue(span.start(clock.now()))
         with(span) {
             assertTrue(hasEmbraceAttribute(EmbType.Performance.Default))
             assertNull(parent)
             assertFalse(hasEmbraceAttribute(PrivateSpan))
+            assertEquals("test", snapshot()?.name)
         }
         assertNotNull(spanRepository.getSpan(spanId = checkNotNull(span.spanId)))
+    }
+
+    @Test
+    fun `check internal span creation`() {
+        val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = true)
+        assertTrue(span.start(clock.now()))
+        with(span) {
+            assertTrue(hasEmbraceAttribute(EmbType.Performance.Default))
+            assertNull(parent)
+            assertTrue(hasEmbraceAttribute(PrivateSpan))
+            assertEquals("emb-test", snapshot()?.name)
+        }
+    }
+
+    @Test
+    fun `check internal span can be public`() {
+        val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = true, private = false)
+        assertTrue(span.start(clock.now()))
+        with(span) {
+            assertTrue(hasEmbraceAttribute(EmbType.Performance.Default))
+            assertNull(parent)
+            assertFalse(hasEmbraceAttribute(PrivateSpan))
+            assertEquals("emb-test", snapshot()?.name)
+        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -46,7 +46,8 @@ internal class EmbraceSpanImplTest {
             spanBuilder = tracer.embraceSpanBuilder(
                 name = EXPECTED_SPAN_NAME,
                 type = EmbType.Performance.Default,
-                internal = false
+                internal = false,
+                private = false
             ),
             openTelemetryClock = fakeInitModule.openTelemetryClock,
             spanRepository = spanRepository


### PR DESCRIPTION
## Goal

Make session spans public so they can be exported. To make this happen, we need to detach the notion of internal (i.e. logged by the SDK) with private (i.e. hidden from customers), so added support for that.

## Testing

Verify that session spans an be exported

