### PR TITLE
Refactor data source module to return data sources

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
  * place to coordinate everything in one place.
  */
 internal class DataCaptureOrchestrator(
-    private val dataSourceState: List<DataSourceState>,
+    private val dataSourceState: List<DataSourceState<*>>,
     private val logger: InternalEmbraceLogger
 ) : ConfigListener {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
@@ -8,14 +8,14 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  * that enable/disable the service, and creates new instances of the service as required.
  * It also is capable of disabling the service if the [SessionType] is not supported.
  */
-internal class DataSourceState(
+internal class DataSourceState<T : DataSource<*>>(
 
     /**
      * Provides instances of services. A service must define an interface
      * that extends [DataSource] for orchestration. This helps enforce testability
      * by making it impossible to register data capture without defining a testable interface.
      */
-    factory: Provider<DataSource<*>?>,
+    factory: Provider<T?>,
 
     /**
      * Predicate that determines if the service should be enabled or not, via a config value.
@@ -36,7 +36,9 @@ internal class DataSourceState(
 ) {
 
     private val enabledDataSource by lazy(factory)
-    private var dataSource: DataSource<*>? = null
+
+    var dataSource: T? = null
+        private set
 
     init {
         updateDataSource()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -4,6 +4,8 @@ import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.system.mockContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 internal class DataSourceStateTest {
@@ -19,6 +21,9 @@ internal class DataSourceStateTest {
             currentSessionType = null
         )
 
+        // data source not retrievable if not session type is null
+        assertNull(state.dataSource)
+
         // data capture is enabled by default.
         state.onConfigChange()
         state.onSessionTypeChange(null)
@@ -27,6 +32,7 @@ internal class DataSourceStateTest {
 
         // data capture enabled for a session
         state.onSessionTypeChange(SessionType.FOREGROUND)
+        assertSame(source, state.dataSource)
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
 
@@ -79,6 +85,9 @@ internal class DataSourceStateTest {
             configGate = { enabled },
             currentSessionType = SessionType.FOREGROUND
         )
+
+        // data source not retrievable if disabled
+        assertNull(state.dataSource)
 
         // data capture is disabled by default.
         assertEquals(0, source.enableDataCaptureCount)


### PR DESCRIPTION
## Goal

Datasources needs to be retrievable from the module so they can be used. Make DataSourceState typed so that it can return the appropriate typed DataSource

## Testing

Added tests to check the logic to obtain the data source 
