### PR TITLE
Add remove attribute method ot SessionWriter

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
@@ -24,5 +24,12 @@ internal interface SessionSpanWriter {
      *
      * Returns true if the attribute was added, otherwise false.
      */
-    fun addAttribute(attribute: SpanAttributeData): Boolean
+    fun addCustomAttribute(attribute: SpanAttributeData): Boolean
+
+    /**
+     * Remove the attribute with the given key
+     *
+     * Returns true if attribute was removed, otherwise false.
+     */
+    fun removeCustomAttribute(key: String): Boolean
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -108,9 +108,14 @@ internal class CurrentSessionSpanImpl(
         )
     }
 
-    override fun addAttribute(attribute: SpanAttributeData): Boolean {
+    override fun addCustomAttribute(attribute: SpanAttributeData): Boolean {
         val currentSession = sessionSpan.get() ?: return false
         return currentSession.addAttribute(attribute.key, attribute.value)
+    }
+
+    override fun removeCustomAttribute(key: String): Boolean {
+        val currentSession = sessionSpan.get() ?: return false
+        return currentSession.removeCustomAttribute(key)
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -167,6 +167,7 @@ internal class EmbraceSpanImpl(
         allAttributes().hasFixedAttribute(fixedAttribute)
 
     override fun getAttribute(key: EmbraceAttributeKey): String? = allAttributes()[key.name]
+    override fun removeCustomAttribute(key: String): Boolean = attributes.remove(key) != null
 
     private fun allAttributes(): Map<String, String> = attributes + schemaAttributes
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -14,10 +14,18 @@ internal interface PersistableEmbraceSpan : EmbraceSpan {
      */
     fun snapshot(): Span?
 
+    /**
+     * Checks to see if the given span has a particular [FixedAttribute]
+     */
     fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean
 
     /**
      * Get the value of the attribute with the given key. Returns null if the attribute does not exist.
      */
     fun getAttribute(key: EmbraceAttributeKey): String?
+
+    /**
+     * Remove the custom attribute with the given key name
+     */
+    fun removeCustomAttribute(key: String): Boolean
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -22,10 +22,9 @@ internal class FakeCurrentSessionSpan : CurrentSessionSpan {
         return true
     }
 
-    override fun addAttribute(attribute: SpanAttributeData): Boolean {
-        addedAttributes.add(attribute)
-        return true
-    }
+    override fun addCustomAttribute(attribute: SpanAttributeData): Boolean = addedAttributes.add(attribute)
+
+    override fun removeCustomAttribute(key: String): Boolean = addedAttributes.removeIf { it.key == key }
 
     override fun initialized(): Boolean {
         initializedCallCount++

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -24,7 +24,10 @@ internal class FakeCurrentSessionSpan : CurrentSessionSpan {
 
     override fun addCustomAttribute(attribute: SpanAttributeData): Boolean = addedAttributes.add(attribute)
 
-    override fun removeCustomAttribute(key: String): Boolean = addedAttributes.removeIf { it.key == key }
+    override fun removeCustomAttribute(key: String): Boolean {
+        val attributeToRemove = addedAttributes.find { it.key == key } ?: return false
+        return addedAttributes.remove(attributeToRemove)
+    }
 
     override fun initialized(): Boolean {
         initializedCallCount++

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -36,7 +36,7 @@ internal class FakeDataSource(
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         alterSessionSpan(inputValidation = { true }) {
-            addAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
+            addCustomAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -110,6 +110,7 @@ internal class FakePersistableEmbraceSpan(
         attributes.hasFixedAttribute(fixedAttribute)
 
     override fun getAttribute(key: EmbraceAttributeKey): String? = attributes[key.name]
+
     override fun removeCustomAttribute(key: String): Boolean = attributes.remove(key) != null
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -110,6 +110,7 @@ internal class FakePersistableEmbraceSpan(
         attributes.hasFixedAttribute(fixedAttribute)
 
     override fun getAttribute(key: EmbraceAttributeKey): String? = attributes[key.name]
+    override fun removeCustomAttribute(key: String): Boolean = attributes.remove(key) != null
 
     companion object {
         fun notStarted(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan =

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -250,12 +250,15 @@ internal class CurrentSessionSpanImplTests {
     }
 
     @Test
-    fun `add attribute forwarded to span`() {
+    fun `add and remove attribute forwarded to span`() {
         currentSessionSpan.addCustomAttribute(SpanAttributeData("my_key", "my_value"))
+        currentSessionSpan.addCustomAttribute(SpanAttributeData("missing", "my_value"))
+        currentSessionSpan.removeCustomAttribute("missing")
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session", span.name)
 
-        // verify attribute was added to the span
+        // verify attribute was added to the span if it wasn't removed
         assertEquals("my_value", span.attributes["my_key"])
+        assertNull(span.attributes["missing"])
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -251,7 +251,7 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add attribute forwarded to span`() {
-        currentSessionSpan.addAttribute(SpanAttributeData("my_key", "my_value"))
+        currentSessionSpan.addCustomAttribute(SpanAttributeData("my_key", "my_value"))
         val span = currentSessionSpan.endSession(null).single()
         assertEquals("emb-session", span.name)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -183,6 +183,16 @@ internal class EmbraceSpanImplTest {
     }
 
     @Test
+    fun `check adding and removing custom attributes`() {
+        with(embraceSpan) {
+            assertTrue(start())
+            assertTrue(addAttribute("test", "value"))
+            assertTrue(removeCustomAttribute("test"))
+            assertFalse(removeCustomAttribute("test"))
+        }
+    }
+
+    @Test
     fun `check attribute limits`() {
         with(embraceSpan) {
             assertTrue(start())


### PR DESCRIPTION
## Goal

Add methods to SessionWriter and the supporting span classes so a data source can remove as well as add attributes to the session span.

Also, changed the name of methods to denote the fact that only customer attributes can be added and removed - not attributes that come as part of the object schema