### PR TITLE
Hook up properties data source to service

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -240,8 +239,7 @@ internal class TracingApiTest {
                 private = false
             )
 
-            assertEquals(2, checkNotNull(sessionMessage.spanSnapshots).size)
-            val snapshots = sessionMessage.spanSnapshots.associateBy { it.name }
+            val snapshots = checkNotNull(sessionMessage.spanSnapshots).associateBy { it.name }
             val unendingSpanSnapshot = checkNotNull(snapshots["unending-span"])
             unendingSpanSnapshot.assertIsTypePerformance()
             assertEmbraceSpanData(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -80,7 +80,7 @@ internal class SessionModuleImpl(
         EmbraceSessionPropertiesService(
             nativeModule.ndkService,
             essentialServiceModule.sessionProperties,
-            dataSourceModule.sessionPropertiesDataSource.enabledDataSource
+            dataSourceModule.sessionPropertiesDataSource.dataSource
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -79,7 +79,8 @@ internal class SessionModuleImpl(
     override val sessionPropertiesService: SessionPropertiesService by singleton {
         EmbraceSessionPropertiesService(
             nativeModule.ndkService,
-            essentialServiceModule.sessionProperties
+            essentialServiceModule.sessionProperties,
+            dataSourceModule.sessionPropertiesDataSource.enabledDataSource
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
@@ -123,11 +123,14 @@ internal class EmbraceSessionProperties(
     fun clearTemporary() = temporary.clear()
 
     companion object {
-
         /**
-         * The maximum number of properties that can be attached to a session
+         * The maximum number of characters of a session property key
          */
         private const val SESSION_PROPERTY_KEY_LIMIT = 128
+
+        /**
+         * The maximum number of characters of a session property value
+         */
         private const val SESSION_PROPERTY_VALUE_LIMIT = 1024
         private val NOT_LOADED = mutableMapOf<String, String>()
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesService.kt
@@ -1,15 +1,20 @@
 package io.embrace.android.embracesdk.session.properties
 
+import io.embrace.android.embracesdk.capture.session.SessionPropertiesDataSource
 import io.embrace.android.embracesdk.ndk.NdkService
 
 internal class EmbraceSessionPropertiesService(
     private val ndkService: NdkService,
-    private val sessionProperties: EmbraceSessionProperties
+    private val sessionProperties: EmbraceSessionProperties,
+    private val sessionPropertiesDataSource: SessionPropertiesDataSource?
 ) : SessionPropertiesService {
 
     override fun addProperty(key: String, value: String, permanent: Boolean): Boolean {
         val added = sessionProperties.add(key, value, permanent)
         if (added) {
+            sessionPropertiesDataSource?.apply {
+                addProperty(key, value)
+            }
             ndkService.onSessionPropertiesUpdate(sessionProperties.get())
         }
         return added
@@ -18,6 +23,9 @@ internal class EmbraceSessionPropertiesService(
     override fun removeProperty(key: String): Boolean {
         val removed = sessionProperties.remove(key)
         if (removed) {
+            sessionPropertiesDataSource?.apply {
+                removeProperty(key)
+            }
             ndkService.onSessionPropertiesUpdate(sessionProperties.get())
         }
         return removed


### PR DESCRIPTION
## Goal

Hook up data source to EmbraceSessionPropertiesService so any changes to that will propagate to the session span
