### PR TITLE
Add `AnrOtelMapper` to module & inject into necessary classes

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrStacktraceSampler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrStacktraceSampler.kt
@@ -99,7 +99,7 @@ internal class AnrStacktraceSampler(
     override fun cleanCollections() {
         anrMonitorWorker.submit {
             enforceThread(anrMonitorThread)
-            anrIntervals.clear()
+            anrIntervals.removeAll { it.endTime != null }
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/AnrModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/AnrModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import android.os.Looper
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.anr.AnrService
 import io.embrace.android.embracesdk.anr.EmbraceAnrService
 import io.embrace.android.embracesdk.anr.NoOpAnrService
@@ -26,6 +27,7 @@ import io.embrace.android.embracesdk.worker.WorkerThreadModule
 internal interface AnrModule {
     val googleAnrTimestampRepository: GoogleAnrTimestampRepository
     val anrService: AnrService
+    val anrOtelMapper: AnrOtelMapper
     val responsivenessMonitorService: ResponsivenessMonitorService
 }
 
@@ -60,6 +62,10 @@ internal class AnrModuleImpl(
         } else {
             NoOpAnrService()
         }
+    }
+
+    override val anrOtelMapper: AnrOtelMapper by singleton {
+        AnrOtelMapper(anrService)
     }
 
     override val responsivenessMonitorService: ResponsivenessMonitorService by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -429,7 +429,8 @@ internal class ModuleInitBootstrapper(
                             sdkObservabilityModule,
                             workerThreadModule,
                             dataSourceModule,
-                            payloadModule
+                            payloadModule,
+                            anrModule
                         )
                     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -40,7 +40,8 @@ internal class SessionModuleImpl(
     sdkObservabilityModule: SdkObservabilityModule,
     workerThreadModule: WorkerThreadModule,
     dataSourceModule: DataSourceModule,
-    payloadModule: PayloadModule
+    payloadModule: PayloadModule,
+    anrModule: AnrModule
 ) : SessionModule {
 
     override val v1PayloadMessageCollator: V1PayloadMessageCollator by singleton {
@@ -63,6 +64,7 @@ internal class SessionModuleImpl(
             openTelemetryModule.currentSessionSpan,
             sessionPropertiesService,
             dataCaptureServiceModule.startupService,
+            anrModule.anrOtelMapper,
             initModule.logger
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -212,7 +212,8 @@ internal typealias SessionModuleSupplier = (
     sdkObservabilityModule: SdkObservabilityModule,
     workerThreadModule: WorkerThreadModule,
     dataSourceModule: DataSourceModule,
-    payloadModule: PayloadModule
+    payloadModule: PayloadModule,
+    anrModule: AnrModule
 ) -> SessionModule
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/AnrInterval.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/AnrInterval.kt
@@ -46,6 +46,7 @@ internal data class AnrInterval @JvmOverloads constructor(
     @Json(name = "c")
     val code: Int? = CODE_DEFAULT
 ) {
+
     /**
      * The type of thread not responding. Currently only the UI thread is monitored.
      */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.session.message
 
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
@@ -46,6 +47,7 @@ internal class V1PayloadMessageCollator(
     private val currentSessionSpan: CurrentSessionSpan,
     private val sessionPropertiesService: SessionPropertiesService,
     private val startupService: StartupService,
+    @Suppress("UnusedPrivateProperty") private val anrOtelMapper: AnrOtelMapper,
     private val logger: InternalEmbraceLogger,
 ) : PayloadMessageCollator {
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/EmbraceAnrServiceTest.kt
@@ -93,14 +93,18 @@ internal class EmbraceAnrServiceTest {
     fun testCleanCollections() {
         with(rule) {
             // assert the ANR interval was added
-            anrService.stacktraceSampler.anrIntervals.add(AnrInterval(0))
-            assertEquals(1, anrService.stacktraceSampler.anrIntervals.size)
+            val anrIntervals = anrService.stacktraceSampler.anrIntervals
+            anrIntervals.add(AnrInterval(startTime = 15000000, endTime = 15000100))
+            val inProgressInterval = AnrInterval(startTime = 15000000, lastKnownTime = 15000100)
+            anrIntervals.add(inProgressInterval)
+            assertEquals(2, anrIntervals.size)
 
             // the ANR interval should be removed here
             anrService.cleanCollections()
             anrExecutorService.shutdownNow()
             anrExecutorService.awaitTermination(1, TimeUnit.SECONDS)
-            assertEquals(0, anrService.stacktraceSampler.anrIntervals.size)
+            assertEquals(1, anrIntervals.size)
+            assertEquals(inProgressInterval, anrIntervals.single())
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes.injection
 
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.anr.AnrService
 import io.embrace.android.embracesdk.anr.sigquit.GoogleAnrTimestampRepository
 import io.embrace.android.embracesdk.capture.monitor.NoOpResponsivenessMonitorService
@@ -10,6 +11,7 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 internal class FakeAnrModule(
     override val anrService: AnrService = FakeAnrService(),
+    override val anrOtelMapper: AnrOtelMapper = AnrOtelMapper(anrService),
     override val googleAnrTimestampRepository: GoogleAnrTimestampRepository = GoogleAnrTimestampRepository(
         InternalEmbraceLogger()
     ),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/AnrModuleImplTest.kt
@@ -36,6 +36,7 @@ internal class AnrModuleImplTest {
             WorkerThreadModuleImpl(FakeInitModule())
         )
         assertNotNull(module.anrService)
+        assertNotNull(module.anrOtelMapper)
         assertNotNull(module.googleAnrTimestampRepository)
         assertNotNull(module.responsivenessMonitorService)
     }
@@ -52,6 +53,7 @@ internal class AnrModuleImplTest {
         assertTrue(module.anrService is NoOpAnrService)
         assertTrue(module.responsivenessMonitorService is NoOpResponsivenessMonitorService)
         assertNotNull(module.googleAnrTimestampRepository)
+        assertNotNull(module.anrOtelMapper)
     }
 
     private fun createConfigServiceWithAnrDisabled() = FakeConfigService(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
@@ -13,6 +14,7 @@ import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.fakeBackgroundActivity
+import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -185,6 +187,7 @@ internal class PayloadFactoryBaTest {
             currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService(),
+            AnrOtelMapper(FakeAnrService()),
             logger
         )
         val sessionEnvelopeSource = SessionEnvelopeSourceImpl(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.capture.PerformanceInfoService
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
@@ -15,6 +16,7 @@ import io.embrace.android.embracesdk.config.local.SessionLocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
+import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -162,6 +164,7 @@ internal class SessionHandlerTest {
             initModule.openTelemetryModule.currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService(),
+            AnrOtelMapper(FakeAnrService()),
             logger
         )
         val v2Collator = V2PayloadMessageCollator(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.FakePayloadModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
+import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCustomerLogModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataCaptureServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDataContainerModule
@@ -57,7 +58,8 @@ internal class SessionModuleImplTest {
             FakeSdkObservabilityModule(),
             workerThreadModule,
             dataSourceModule,
-            FakePayloadModule()
+            FakePayloadModule(),
+            FakeAnrModule()
         )
         assertNotNull(module.v1PayloadMessageCollator)
         assertNotNull(module.v2PayloadMessageCollator)
@@ -94,7 +96,8 @@ internal class SessionModuleImplTest {
             FakeSdkObservabilityModule(),
             workerThreadModule,
             dataSourceModule,
-            FakePayloadModule()
+            FakePayloadModule(),
+            FakeAnrModule()
         )
         assertNotNull(module.v1PayloadMessageCollator)
         assertNotNull(module.v2PayloadMessageCollator)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
+import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeGatingService
@@ -67,6 +69,7 @@ internal class V1PayloadMessageCollatorTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
+            anrOtelMapper = AnrOtelMapper(FakeAnrService()),
             logger = initModule.logger
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -2,9 +2,11 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
@@ -66,6 +68,7 @@ internal class PayloadFactoryImplTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
+            anrOtelMapper = AnrOtelMapper(FakeAnrService()),
             logger = initModule.logger
         )
         val v2Collator = V2PayloadMessageCollator(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -2,7 +2,9 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
+import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
@@ -68,6 +70,7 @@ internal class V2PayloadMessageCollatorTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
+            anrOtelMapper = AnrOtelMapper(FakeAnrService()),
             logger = initModule.logger
         )
         val sessionEnvelopeSource = SessionEnvelopeSourceImpl(


### PR DESCRIPTION
## Goal

Add `AnrOtelMapper` to a dependency module & injects it into the necessary classes. This changeset does not hookup OTel capture, that will follow in a future changeset.

I also made a small change to the `AnrService` so that in-progress ANR intervals are not cleared when the session boundary changes.

## Testing

Added unit tests.

