### PR TITLE
Move property validation to the service

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
@@ -33,44 +33,8 @@ internal class EmbraceSessionProperties(
         return permanentProperties().containsKey(key) || temporary.containsKey(key)
     }
 
-    private fun isValidKey(key: String?): Boolean {
-        if (key == null) {
-            logger.logError("Session property key cannot be null")
-            return false
-        }
-        if (key == "") {
-            logger.logError("Session property key cannot be empty string")
-            return false
-        }
-        return true
-    }
-
-    private fun isValidValue(key: String?): Boolean {
-        if (key == null) {
-            logger.logError("Session property value cannot be null")
-            return false
-        }
-        return true
-    }
-
-    private fun enforceLength(value: String, maxLength: Int): String {
-        if (value.length <= maxLength) {
-            return value
-        }
-        val endChars = "..."
-        return value.substring(0, maxLength - endChars.length) + endChars
-    }
-
-    fun add(key: String, value: String, isPermanent: Boolean): Boolean {
+    fun add(sanitizedKey: String, sanitizedValue: String, isPermanent: Boolean): Boolean {
         synchronized(permanentPropertiesReference) {
-            if (!isValidKey(key)) {
-                return false
-            }
-            val sanitizedKey = enforceLength(key, SESSION_PROPERTY_KEY_LIMIT)
-            if (!isValidValue(value)) {
-                return false
-            }
-            val sanitizedValue = enforceLength(value, SESSION_PROPERTY_VALUE_LIMIT)
             val maxSessionProperties = configService.sessionBehavior.getMaxSessionProperties()
             if (size() > maxSessionProperties || size() == maxSessionProperties && !haveKey(sanitizedKey)) {
                 logger.logError("Session property count is at its limit. Rejecting.")
@@ -95,12 +59,8 @@ internal class EmbraceSessionProperties(
         }
     }
 
-    fun remove(key: String): Boolean {
+    fun remove(sanitizedKey: String): Boolean {
         synchronized(permanentPropertiesReference) {
-            if (!isValidKey(key)) {
-                return false
-            }
-            val sanitizedKey = enforceLength(key, SESSION_PROPERTY_KEY_LIMIT)
             var existed = false
             if (temporary.remove(sanitizedKey) != null) {
                 existed = true
@@ -123,15 +83,6 @@ internal class EmbraceSessionProperties(
     fun clearTemporary() = temporary.clear()
 
     companion object {
-        /**
-         * The maximum number of characters of a session property key
-         */
-        private const val SESSION_PROPERTY_KEY_LIMIT = 128
-
-        /**
-         * The maximum number of characters of a session property value
-         */
-        private const val SESSION_PROPERTY_VALUE_LIMIT = 1024
         private val NOT_LOADED = mutableMapOf<String, String>()
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesService.kt
@@ -10,22 +10,37 @@ internal class EmbraceSessionPropertiesService(
     private val dataSourceProvider: Provider<SessionPropertiesDataSource?>
 ) : SessionPropertiesService {
 
-    override fun addProperty(key: String, value: String, permanent: Boolean): Boolean {
-        val added = sessionProperties.add(key, value, permanent)
+    override fun addProperty(originalKey: String, originalValue: String, permanent: Boolean): Boolean {
+        if (!isValidKey(originalKey)) {
+            return false
+        }
+        val sanitizedKey = enforceLength(originalKey, SESSION_PROPERTY_KEY_LIMIT)
+
+        if (!isValidValue(originalValue)) {
+            return false
+        }
+        val sanitizedValue = enforceLength(originalValue, SESSION_PROPERTY_VALUE_LIMIT)
+
+        val added = sessionProperties.add(sanitizedKey, sanitizedValue, permanent)
         if (added) {
             dataSourceProvider()?.apply {
-                addProperty(key, value)
+                addProperty(sanitizedKey, sanitizedValue)
             }
             ndkService.onSessionPropertiesUpdate(sessionProperties.get())
         }
         return added
     }
 
-    override fun removeProperty(key: String): Boolean {
-        val removed = sessionProperties.remove(key)
+    override fun removeProperty(originalKey: String): Boolean {
+        if (!isValidKey(originalKey)) {
+            return false
+        }
+        val sanitizedKey = enforceLength(originalKey, SESSION_PROPERTY_KEY_LIMIT)
+
+        val removed = sessionProperties.remove(sanitizedKey)
         if (removed) {
             dataSourceProvider()?.apply {
-                removeProperty(key)
+                removeProperty(sanitizedKey)
             }
             ndkService.onSessionPropertiesUpdate(sessionProperties.get())
         }
@@ -35,4 +50,28 @@ internal class EmbraceSessionPropertiesService(
     override fun getProperties(): Map<String, String> = sessionProperties.get()
 
     override fun populateCurrentSession(): Boolean = dataSourceProvider()?.addProperties(getProperties()) ?: false
+
+    private fun isValidKey(key: String?): Boolean = !key.isNullOrEmpty()
+
+    private fun isValidValue(key: String?): Boolean = key != null
+
+    private fun enforceLength(value: String, maxLength: Int): String {
+        if (value.length <= maxLength) {
+            return value
+        }
+        val endChars = "..."
+        return value.substring(0, maxLength - endChars.length) + endChars
+    }
+
+    companion object {
+        /**
+         * The maximum number of characters of a session property key
+         */
+        private const val SESSION_PROPERTY_KEY_LIMIT = 128
+
+        /**
+         * The maximum number of characters of a session property value
+         */
+        private const val SESSION_PROPERTY_VALUE_LIMIT = 1024
+    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/SessionPropertiesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/SessionPropertiesService.kt
@@ -8,23 +8,23 @@ internal interface SessionPropertiesService {
      * device, use this for properties such as work site, building, owner. A non-permanent property
      * is added to only the currently active session.
      *
-     * There is a maximum of 10 total properties in a session.
+     * The default maximum is 10 total properties in a session.
      *
-     * @param key       The key for this property, must be unique within session properties
-     * @param value     The value to store for this property
+     * @param originalKey       The key for this property, must be unique within session properties
+     * @param originalValue     The value to store for this property
      * @param permanent If true the property is applied to all sessions going forward, persist
      * through app launches.
      * @return A boolean indicating whether the property was added or not
      */
-    fun addProperty(key: String, value: String, permanent: Boolean): Boolean
+    fun addProperty(originalKey: String, originalValue: String, permanent: Boolean): Boolean
 
     /**
      * Removes a property from the session. If that property was permanent then it is removed from
      * all future sessions as well.
      *
-     * @param key the key to be removed
+     * @param originalKey the key to be removed
      */
-    fun removeProperty(key: String): Boolean
+    fun removeProperty(originalKey: String): Boolean
 
     /**
      * Get a read-only representation of the currently set session properties. You can query and

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceSessionPropertiesTest.kt
@@ -83,12 +83,6 @@ internal class EmbraceSessionPropertiesTest {
     }
 
     @Test
-    fun addSessionPropertyInvalidKey() {
-        assertFalse(sessionProperties.add("", VALUE_VALID, false))
-        assertTrue(sessionProperties.get().isEmpty())
-    }
-
-    @Test
     fun addSessionPropertyInvalidValue() {
         assertTrue(sessionProperties.get().isEmpty())
     }
@@ -110,24 +104,6 @@ internal class EmbraceSessionPropertiesTest {
         // permanent property should no longer have been persisted
         val sessionProperties3 = EmbraceSessionProperties(preferencesService, configService, logger)
         assertTrue(sessionProperties3.get().isEmpty())
-    }
-
-    @Test
-    fun addSessionPropertyKeyTooLong() {
-        val longKey = "a".repeat(129)
-        assertTrue(sessionProperties.add(longKey, VALUE_VALID, false))
-        assertEquals(1, sessionProperties.get().size.toLong())
-        val key = "a".repeat(125) + "..."
-        assertEquals(VALUE_VALID, sessionProperties.get()[key])
-    }
-
-    @Test
-    fun addSessionPropertyValueTooLong() {
-        val longValue = "a".repeat(1025)
-        assertTrue(sessionProperties.add(KEY_VALID, longValue, false))
-        assertEquals(1, sessionProperties.get().size.toLong())
-        val value = "a".repeat(1021) + "..."
-        assertEquals(value, sessionProperties.get()[KEY_VALID])
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionPropertiesService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeSessionPropertiesService.kt
@@ -3,11 +3,11 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 internal class FakeSessionPropertiesService : SessionPropertiesService {
-    override fun addProperty(key: String, value: String, permanent: Boolean): Boolean {
+    override fun addProperty(originalKey: String, originalValue: String, permanent: Boolean): Boolean {
         TODO("Not yet implemented")
     }
 
-    override fun removeProperty(key: String): Boolean {
+    override fun removeProperty(originalKey: String): Boolean {
         TODO("Not yet implemented")
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -57,5 +58,29 @@ internal class EmbraceSessionPropertiesServiceTest {
         assertTrue(fakeCurrentSessionSpan.addedAttributes.isEmpty())
         assertTrue(service.populateCurrentSession())
         assertEquals(2, fakeCurrentSessionSpan.addedAttributes.size)
+    }
+
+    @Test
+    fun addSessionPropertyInvalidKey() {
+        assertFalse(service.addProperty("", "value", false))
+        assertTrue(service.getProperties().isEmpty())
+    }
+
+    @Test
+    fun addSessionPropertyKeyTooLong() {
+        val longKey = "a".repeat(129)
+        assertTrue(service.addProperty(longKey, "value", false))
+        assertEquals(1, service.getProperties().size.toLong())
+        val key = "a".repeat(125) + "..."
+        assertEquals("value", service.getProperties()[key])
+    }
+
+    @Test
+    fun addSessionPropertyValueTooLong() {
+        val longValue = "a".repeat(1025)
+        assertTrue(service.addProperty("key", longValue, false))
+        assertEquals(1, service.getProperties().size.toLong())
+        val value = "a".repeat(1021) + "..."
+        assertEquals(value, service.getProperties()["key"])
     }
 }


### PR DESCRIPTION
## Goal

Key/value validation was done at too low of a level. Move that up to the service so when we try to add it to the backing preferences store, they should already be validated.

## Testing
Move tests from one layer to another.
