### PR TITLE
Apply session properties prefix whenever we write to a span

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SessionPropertiesTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
@@ -28,9 +29,9 @@ internal class SessionPropertiesTest {
             })
 
             with(checkNotNull(session1.spans?.find { it.hasFixedAttribute(EmbType.Ux.Session) })) {
-                assertEquals("thurr", attributes["always"])
-                assertEquals("permVal", attributes["perm"])
-                assertEquals("tempVal", attributes["temp"])
+                assertEquals("thurr", getSessionProperty("always"))
+                assertEquals("permVal", getSessionProperty("perm"))
+                assertEquals("tempVal", getSessionProperty("temp"))
             }
 
             val session2 = checkNotNull(harness.recordSession {
@@ -39,10 +40,10 @@ internal class SessionPropertiesTest {
             })
 
             with(checkNotNull(session2.spans?.find { it.hasFixedAttribute(EmbType.Ux.Session) })) {
-                assertEquals("thurr", attributes["always"])
-                assertEquals("value", attributes["newTemp"])
-                assertNull(attributes["perm"])
-                assertNull(attributes["temp"])
+                assertEquals("thurr", getSessionProperty("always"))
+                assertEquals("value", getSessionProperty("newTemp"))
+                assertNull(getSessionProperty("perm"))
+                assertNull(getSessionProperty("temp"))
             }
 
             val attributesFromSdk = checkNotNull(embrace.getSessionProperties())

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.arch.schema
 
-import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
+import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.opentelemetry.api.common.AttributeKey
 
@@ -19,7 +19,7 @@ internal class TelemetryAttributes(
      */
     fun snapshot(): Map<String, String> =
         (customAttributes ?: emptyMap())
-            .plus(sessionProperties?.get()?.mapKeys { "properties.".toEmbraceAttributeName() + it.key } ?: emptyMap())
+            .plus(sessionProperties?.get()?.mapKeys { it.key.toSessionPropertyAttributeName() } ?: emptyMap())
             .plus(map.mapKeys { it.key.key })
 
     fun setAttribute(key: EmbraceAttributeKey, value: String) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.config.behavior.SessionBehavior
+import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 
 internal class SessionPropertiesDataSource(
@@ -23,7 +24,7 @@ internal class SessionPropertiesDataSource(
         alterSessionSpan(
             inputValidation = { true },
             captureAction = {
-                addCustomAttribute(SpanAttributeData(key, value))
+                addAttribute(key, value)
             }
         )
 
@@ -32,7 +33,7 @@ internal class SessionPropertiesDataSource(
             inputValidation = { true },
             captureAction = {
                 properties.forEach { property ->
-                    addCustomAttribute(SpanAttributeData(property.key, property.value))
+                    addAttribute(property.key, property.value)
                 }
             }
         )
@@ -42,9 +43,12 @@ internal class SessionPropertiesDataSource(
         alterSessionSpan(
             inputValidation = { true },
             captureAction = {
-                success = removeCustomAttribute(key)
+                success = removeCustomAttribute(key.toSessionPropertyAttributeName())
             }
         )
         return success
     }
+
+    private fun SessionSpanWriter.addAttribute(key: String, value: String) =
+        addCustomAttribute(SpanAttributeData(key.toSessionPropertyAttributeName(), value))
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -37,6 +37,11 @@ private const val EMBRACE_ATTRIBUTE_NAME_PREFIX = "emb."
 private const val EMBRACE_PRIVATE_ATTRIBUTE_NAME_PREFIX = "emb.private."
 
 /**
+ * Prefix added to all Embrace attribute keys that represent session properties that are set via the SDK
+ */
+private const val EMBRACE_SESSION_PROPERTY_NAME_PREFIX = "emb.properties."
+
+/**
  * Prefix added to all attribute keys for all usage attributes added by the SDK
  */
 private const val EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX = "emb.usage."
@@ -131,6 +136,8 @@ internal fun String.toEmbraceAttributeName(isPrivate: Boolean = false): String {
     return prefix + this
 }
 
+internal fun String.toSessionPropertyAttributeName(): String = EMBRACE_SESSION_PROPERTY_NAME_PREFIX + this
+
 /**
  * Return the appropriate internal Embrace attribute usage name given the current string
  */
@@ -145,6 +152,8 @@ internal fun EmbraceSpanData.hasFixedAttribute(fixedAttribute: FixedAttribute): 
 internal fun EmbraceSpanEvent.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
     fixedAttribute.value == attributes[fixedAttribute.key.name]
 
+internal fun EmbraceSpanData.getSessionProperty(key: String): String? = attributes[key.toSessionPropertyAttributeName()]
+
 internal fun Map<String, String>.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
     this[fixedAttribute.key.name] == fixedAttribute.value
 
@@ -152,3 +161,5 @@ internal fun MutableMap<String, String>.setFixedAttribute(fixedAttribute: FixedA
     this[fixedAttribute.key.name] = fixedAttribute.value
     return this
 }
+
+internal fun Map<String, String>.getSessionProperty(key: String): String? = this[key.toSessionPropertyAttributeName()]

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.arch.schema
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
@@ -54,11 +55,11 @@ internal class TelemetryAttributesTest {
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals("attributeValue", attributes["custom"])
-        assertEquals("permVal", attributes["emb.properties.perm"])
-        assertEquals("tempVal", attributes["emb.properties.temp"])
+        assertEquals("permVal", attributes.getSessionProperty("perm"))
+        assertEquals("tempVal", attributes.getSessionProperty("temp"))
         assertEquals(sessionId, attributes[embSessionId.name])
         sessionProperties.add("temp", "newVal", false)
-        assertEquals("newVal", telemetryAttributes.snapshot()["emb.properties.temp"])
+        assertEquals("newVal", telemetryAttributes.snapshot().getSessionProperty("temp"))
     }
 
     @Test
@@ -76,8 +77,8 @@ internal class TelemetryAttributesTest {
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(3, attributes.size)
-        assertEquals("newPermVal", attributes["emb.properties.perm"])
-        assertEquals("newTempVal", attributes["emb.properties.temp"])
+        assertEquals("newPermVal", attributes.getSessionProperty("perm"))
+        assertEquals("newTempVal", attributes.getSessionProperty("temp"))
         assertEquals(newSessionId, attributes[embSessionId.name])
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSourceTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.capture.session
 
-import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -27,9 +27,9 @@ internal class SessionPropertiesDataSourceTest {
     @Test
     fun `add and remove custom property`() {
         assertTrue(dataSource.addProperty("blah", "value"))
-        assertEquals(SpanAttributeData("blah", "value"), fakeCurrentSessionSpan.addedAttributes.single())
+        assertEquals("value", fakeCurrentSessionSpan.getAttribute("blah".toSessionPropertyAttributeName()))
         assertTrue(dataSource.removeProperty("blah"))
         assertFalse(dataSource.removeProperty("blah"))
-        assertTrue(fakeCurrentSessionSpan.addedAttributes.isEmpty())
+        assertEquals(0, fakeCurrentSessionSpan.attributeCount())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -11,8 +11,8 @@ internal class FakeCurrentSessionSpan : CurrentSessionSpan {
 
     var initializedCallCount = 0
     var addedEvents = mutableListOf<SpanEventData>()
-    var addedAttributes = mutableListOf<SpanAttributeData>()
     var spanData = listOf<EmbraceSpanData>()
+    private var addedAttributes = mutableListOf<SpanAttributeData>()
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
     }
@@ -45,4 +45,8 @@ internal class FakeCurrentSessionSpan : CurrentSessionSpan {
     override fun getSessionId(): String {
         return "testSessionId"
     }
+
+    fun getAttribute(key: String): String? = addedAttributes.find { it.key == key }?.value
+
+    fun attributeCount(): Int = addedAttributes.size
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -22,6 +22,7 @@ import io.embrace.android.embracesdk.fakes.fakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
@@ -223,8 +224,8 @@ internal class EmbraceLogServiceTest {
         logService.log("Hello world", Severity.INFO, null)
 
         val log = logWriter.logEvents.single()
-        assertEquals("session_val_1", log.schemaType.attributes()["emb.properties.session_prop_1"])
-        assertEquals("session_val_2", log.schemaType.attributes()["emb.properties.session_prop_2"])
+        assertEquals("session_val_1", log.schemaType.attributes().getSessionProperty("session_prop_1"))
+        assertEquals("session_val_2", log.schemaType.attributes().getSessionProperty("session_prop_2"))
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.session.properties
 
 import io.embrace.android.embracesdk.FakeNdkService
-import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.capture.session.SessionPropertiesDataSource
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
@@ -43,21 +42,21 @@ internal class EmbraceSessionPropertiesServiceTest {
         assertEquals(expected, props.get())
         assertEquals(expected, ndkService.propUpdates.single())
         assertEquals(expected, service.getProperties())
-        assertEquals(SpanAttributeData("key", "value"), fakeCurrentSessionSpan.addedAttributes.first())
+        assertEquals(1, fakeCurrentSessionSpan.attributeCount())
 
         service.removeProperty("key")
         assertEquals(emptyMap<String, String>(), props.get())
         assertEquals(emptyMap<String, String>(), ndkService.propUpdates.last())
-        assertTrue(fakeCurrentSessionSpan.addedAttributes.isEmpty())
+        assertEquals(0, fakeCurrentSessionSpan.attributeCount())
     }
 
     @Test
     fun `populate session span with all set properties`() {
         props.add("key", "value", true)
         props.add("tempKey", "tempValue", false)
-        assertTrue(fakeCurrentSessionSpan.addedAttributes.isEmpty())
+        assertEquals(0, fakeCurrentSessionSpan.attributeCount())
         assertTrue(service.populateCurrentSession())
-        assertEquals(2, fakeCurrentSessionSpan.addedAttributes.size)
+        assertEquals(2, fakeCurrentSessionSpan.attributeCount())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Apply the attribute prefix `emb.properties.` whenever we write session properties to OTel signals via the SessionSpanWriter or population via the `SchemaType` (only applicable for logs). While the properties will be stored by the value the customer has defined, when applied to OTel signals as attributes, we use the prefix to namespace them and make them distinct from attributes that customers set themselves.

