### PR TITLE
Handle null version name when building envelope

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -23,7 +23,7 @@ internal class EnvelopeResourceSourceImpl(
 
     override fun getEnvelopeResource(): EnvelopeResource {
         return EnvelopeResource(
-            appVersion = packageInfo.versionName.toString().trim { it <= ' ' },
+            appVersion = packageInfo.versionName?.toString()?.trim { it <= ' ' } ?: "",
             bundleVersion = packageInfo.versionCode.toString(),
             appEcosystemId = packageInfo.packageName,
             appFramework = mapFramework(appFramework),


### PR DESCRIPTION
## Goal

The roboletric runtime environment returns a null version name in packageInfo. Check for null and return empty string instead of assuming it's not. Oh Java platform APIs...

