### PR TITLE
addLogRecordExporter api

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -9,6 +9,7 @@ public final class io/embrace/android/embracesdk/BuildConfig {
 
 public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/embracesdk/EmbraceAndroidApi {
 	public fun addBreadcrumb (Ljava/lang/String;)V
+	public fun addLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
 	public fun addSessionProperty (Ljava/lang/String;Ljava/lang/String;Z)Z
 	public fun addSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
 	public fun addUserPersona (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
@@ -5,6 +5,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
+import io.embrace.android.embracesdk.fakes.FakeLoggerAction
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert
 import org.junit.Rule
@@ -40,6 +42,29 @@ internal class LogRecordExporterTest {
             }
             Assert.assertTrue((fakeLogRecordExporter.exportedLogs?.size ?: 0) > 0)
             Assert.assertEquals("test message", fakeLogRecordExporter.exportedLogs?.first()?.body?.asString())
+        }
+    }
+
+    @Test
+    fun `a LogRecordExporter added after initialization won't be used`() {
+        with(testRule) {
+
+            val fake = FakeLoggerAction()
+            harness.overriddenInitModule.logger.apply { addLoggerAction(fake) }
+
+            val fakeLogRecordExporter = FakeLogRecordExporter()
+            embrace.start(harness.overriddenCoreModule.context)
+            embrace.addLogRecordExporter(fakeLogRecordExporter)
+
+            harness.recordSession {
+                embrace.logMessage("test message", Severity.INFO)
+
+                sleep(3000)
+            }
+            Assert.assertTrue((fakeLogRecordExporter.exportedLogs?.size ?: 0) == 0)
+            Assert.assertTrue(fake.msgQueue.any {
+                it.msg == "A LogRecordExporter can only be added before the SDK is started."
+            })
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
@@ -1,0 +1,49 @@
+package io.embrace.android.embracesdk.testcases
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
+import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.recordSession
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.lang.Thread.sleep
+
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+@RunWith(AndroidJUnit4::class)
+internal class LogRecordExporterTest {
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule(
+        harnessSupplier = {
+            IntegrationTestRule.newHarness(startImmediately = false)
+        }
+    )
+
+    @Test
+    fun `SDK can receive a LogRecordExporter`() {
+        with(testRule) {
+
+            val fakeLogRecordExporter = FakeLogRecordExporter()
+            embrace.addLogRecordExporter(fakeLogRecordExporter)
+            embrace.start(harness.fakeCoreModule.context)
+
+            harness.recordSession {
+                embrace.logMessage("test message", Severity.INFO)
+
+                sleep(3000)
+            }
+            Assert.assertTrue((fakeLogRecordExporter.exportedLogs?.size ?: 0) > 0)
+            Assert.assertEquals("test message", fakeLogRecordExporter.exportedLogs?.first()?.body)
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
@@ -4,11 +4,7 @@ import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
-import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert
 import org.junit.Rule
@@ -35,7 +31,7 @@ internal class LogRecordExporterTest {
 
             val fakeLogRecordExporter = FakeLogRecordExporter()
             embrace.addLogRecordExporter(fakeLogRecordExporter)
-            embrace.start(harness.fakeCoreModule.context)
+            embrace.start(harness.overriddenCoreModule.context)
 
             harness.recordSession {
                 embrace.logMessage("test message", Severity.INFO)
@@ -43,7 +39,7 @@ internal class LogRecordExporterTest {
                 sleep(3000)
             }
             Assert.assertTrue((fakeLogRecordExporter.exportedLogs?.size ?: 0) > 0)
-            Assert.assertEquals("test message", fakeLogRecordExporter.exportedLogs?.first()?.body)
+            Assert.assertEquals("test message", fakeLogRecordExporter.exportedLogs?.first()?.body?.asString())
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -18,6 +18,7 @@ import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb;
 import io.embrace.android.embracesdk.spans.EmbraceSpan;
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent;
 import io.embrace.android.embracesdk.spans.ErrorCode;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import kotlin.jvm.functions.Function0;
 
@@ -539,6 +540,18 @@ public final class Embrace implements EmbraceAndroidApi {
     public void addSpanExporter(@NonNull SpanExporter spanExporter) {
         if (verifyNonNullParameters("addSpanExporter", spanExporter)) {
             impl.addSpanExporter(spanExporter);
+        }
+    }
+
+    /**
+     * Adds a [LogRecordExporter] to the open telemetry logger.
+     *
+     * @param logRecordExporter the LogRecord exporter to add
+     */
+    @Override
+    public void addLogRecordExporter(@NonNull LogRecordExporter logRecordExporter) {
+        if (verifyNonNullParameters("addLogRecordExporter", logRecordExporter)) {
+            impl.addLogRecordExporter(logRecordExporter);
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceApi.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceApi.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import io.embrace.android.embracesdk.spans.TracingApi;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 /**
@@ -95,4 +96,11 @@ interface EmbraceApi extends LogsApi, MomentsApi, NetworkRequestApi, SessionApi,
      * @param spanExporter the span exporter to add
      */
     void addSpanExporter(@NonNull SpanExporter spanExporter);
+
+    /**
+     * Adds a [LogRecordExporter] to the open telemetry logger.
+     *
+     * @param logRecordExporter the LogRecord exporter to add
+     */
+    void addLogRecordExporter(@NonNull LogRecordExporter logRecordExporter);
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -66,6 +66,7 @@ import io.embrace.android.embracesdk.telemetry.TelemetryService;
 import io.embrace.android.embracesdk.utils.PropertyUtils;
 import io.embrace.android.embracesdk.worker.WorkerName;
 import io.embrace.android.embracesdk.worker.WorkerThreadModule;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import kotlin.Lazy;
 import kotlin.LazyKt;
@@ -1204,5 +1205,9 @@ final class EmbraceImpl {
 
     public void addSpanExporter(@NonNull SpanExporter spanExporter) {
         moduleInitBootstrapper.getOpenTelemetryModule().getOpenTelemetryConfiguration().addSpanExporter(spanExporter);
+    }
+
+    public void addLogRecordExporter(@NonNull LogRecordExporter logRecordExporter) {
+        moduleInitBootstrapper.getOpenTelemetryModule().getOpenTelemetryConfiguration().addLogExporter(logRecordExporter);
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -1204,10 +1204,18 @@ final class EmbraceImpl {
     }
 
     public void addSpanExporter(@NonNull SpanExporter spanExporter) {
+        if (isStarted()) {
+            internalEmbraceLogger.logError("A SpanExporter can only be added before the SDK is started.");
+            return;
+        }
         moduleInitBootstrapper.getOpenTelemetryModule().getOpenTelemetryConfiguration().addSpanExporter(spanExporter);
     }
 
     public void addLogRecordExporter(@NonNull LogRecordExporter logRecordExporter) {
+        if (isStarted()) {
+            internalEmbraceLogger.logError("A LogRecordExporter can only be added before the SDK is started.");
+            return;
+        }
         moduleInitBootstrapper.getOpenTelemetryModule().getOpenTelemetryConfiguration().addLogExporter(logRecordExporter);
     }
 }


### PR DESCRIPTION
## Goal

Adds a public api that allows a client app to add a LogRecordExporter at runtime, through a OpenTelemetryConfiguration class.

## Testing

Added instrumentation tests to LogsTest class.

## Release Notes

New addLogRecordExporter public api, to add many LogRecordExporter to the OTel SDK.

WHAT:We have created an api to add LogRecordExporter to the OTel SDK
WHY:To allow customers to export their data to any OTel Collector.
WHO:Any customer with an OTel collector.

