### PR TITLE
Use shutdown rather than shutdownNow

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/EmbraceAnrServiceTest.kt
@@ -101,7 +101,7 @@ internal class EmbraceAnrServiceTest {
 
             // the ANR interval should be removed here
             anrService.cleanCollections()
-            anrExecutorService.shutdownNow()
+            anrExecutorService.shutdown()
             anrExecutorService.awaitTermination(1, TimeUnit.SECONDS)
             assertEquals(1, anrIntervals.size)
             assertEquals(inProgressInterval, anrIntervals.single())


### PR DESCRIPTION
## Goal

Use `shutdown` rather than `shutdownNow`. This is because `shutdown` allows previously submitted tasks to complete, whereas `shutdownNow` attempts to shut everything down. I believe this was a cause of flaky behavior in the `cleanCollections` test case.

