### PR TITLE
Replace emb.state with android.state

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -19,9 +19,9 @@ import io.embrace.android.embracesdk.internal.CacheableValue
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.opentelemetry.androidState
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
-import io.embrace.android.embracesdk.opentelemetry.embState
 import io.embrace.android.embracesdk.opentelemetry.exceptionMessage
 import io.embrace.android.embracesdk.opentelemetry.exceptionStacktrace
 import io.embrace.android.embracesdk.opentelemetry.exceptionType
@@ -199,7 +199,7 @@ internal class EmbraceLogService(
 
         attributes.setAttribute(logRecordUid, Uuid.getEmbUuid())
         sessionIdTracker.getActiveSessionId()?.let { attributes.setAttribute(embSessionId, it) }
-        metadataService.getAppState()?.let { attributes.setAttribute(embState, it) }
+        metadataService.getAppState()?.let { attributes.setAttribute(androidState, it) }
 
         return attributes
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -26,4 +26,3 @@ internal val embSequenceId: EmbraceAttributeKey = EmbraceAttributeKey(id = "sequ
  * Attribute name for the Embrace Sesssion
  */
 internal val embSessionId: EmbraceAttributeKey = EmbraceAttributeKey("session_id")
-

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -27,7 +27,3 @@ internal val embSequenceId: EmbraceAttributeKey = EmbraceAttributeKey(id = "sequ
  */
 internal val embSessionId: EmbraceAttributeKey = EmbraceAttributeKey("session_id")
 
-/**
- * Attribute name for the application state (foreground/background) at the time the log was recorded
- */
-internal val embState = EmbraceAttributeKey("state")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryAttributeKeys.kt
@@ -28,3 +28,5 @@ internal val serviceVersion: AttributeKey<String> = AttributeKey.stringKey("serv
 internal val exceptionMessage: AttributeKey<String> = AttributeKey.stringKey("exception.message")
 internal val exceptionStacktrace: AttributeKey<String> = AttributeKey.stringKey("exception.stacktrace")
 internal val exceptionType: AttributeKey<String> = AttributeKey.stringKey("exception.type")
+
+internal val androidState: AttributeKey<String> = AttributeKey.stringKey("android.state")


### PR DESCRIPTION
## Goal

- Replaced `emb.state` with `android.state` that is what the Opentelemetry documentation specifies that should be used. 

## Testing

Rely on existing unit tests. 
