### PR TITLE
Add internal start method to enable the passing of a faked config service

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -1,6 +1,9 @@
 package io.embrace.android.embracesdk
 
+import android.content.Context
+import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.IntegrationTestRule.Harness
+import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.local.NetworkLocalConfig
 import io.embrace.android.embracesdk.config.local.SdkLocalConfig
@@ -117,7 +120,7 @@ internal class IntegrationTestRule(
             )
             Embrace.setImpl(embraceImpl)
             if (startImmediately) {
-                embrace.start(overriddenCoreModule.context, enableIntegrationTesting, appFramework)
+                embraceImpl.startInternal(overriddenCoreModule.context, enableIntegrationTesting, appFramework) { overriddenConfigService }
             }
         }
     }
@@ -127,6 +130,14 @@ internal class IntegrationTestRule(
      */
     override fun after() {
         Embrace.getImpl().stop()
+    }
+
+    fun startSdk(
+        context: Context = harness.overriddenCoreModule.context,
+        appFramework: AppFramework = harness.appFramework,
+        configServiceProvider: Provider<ConfigService> = { harness.overriddenConfigService }
+    ) {
+        Embrace.getImpl().startInternal(context, false, appFramework, configServiceProvider)
     }
 
     /**

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AeiFeatureTest.kt
@@ -34,7 +34,7 @@ internal class AeiFeatureTest {
         setupFakeAeiData()
 
         with(testRule) {
-            testRule.embrace.start(ApplicationProvider.getApplicationContext())
+            testRule.startSdk(context = ApplicationProvider.getApplicationContext())
             val message = harness.recordSession()
             val deliveryService = harness.overriddenDeliveryModule.deliveryService
             val blobRecord = checkNotNull(deliveryService.blobMessages.single().applicationExits.single())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/PersonaFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/PersonaFeaturesTest.kt
@@ -24,7 +24,7 @@ internal class PersonaFeaturesTest {
     fun `personas found in metadata`() {
         with(testRule) {
             harness.androidServicesModule.preferencesService.userPersonas = setOf("preloaded")
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             embrace.setUserAsPayer()
             with(checkNotNull(harness.recordSession { embrace.addUserPersona("test") })) {
                 assertPersonaExists("preloaded")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/UserFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/UserFeaturesTest.kt
@@ -30,7 +30,7 @@ internal class UserFeaturesTest {
                 userEmailAddress = "custom@domain.com"
             }
 
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(harness.overriddenCoreModule.context)
             with(checkNotNull(harness.recordSession { })) {
                 assertUserInfo(preferenceService, "customId", "customUserName", "custom@domain.com")
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -115,7 +115,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `internal logging methods work as expected`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             val expectedProperties = mapOf(Pair("key", "value"))
             harness.recordSession {
                 embrace.internalInterface.logInfo("info", expectedProperties)
@@ -155,7 +155,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `network recording methods work as expected`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             val session = harness.recordSession {
                 harness.overriddenClock.tick()
                 harness.overriddenConfigService.updateListeners()
@@ -224,7 +224,7 @@ internal class EmbraceInternalInterfaceTest {
         val expectedElementName = "button"
 
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             val session = checkNotNull( harness.recordSession {
                 embrace.internalInterface.logComposeTap(Pair(expectedX, expectedY), expectedElementName)
             })
@@ -239,7 +239,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `access check methods work as expected`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             harness.recordSession {
                 assertTrue(embrace.internalInterface.shouldCaptureNetworkBody("capture.me", "GET"))
                 assertFalse(embrace.internalInterface.shouldCaptureNetworkBody("capture.me", "POST"))
@@ -252,7 +252,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `set process as started by notification works as expected`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             embrace.internalInterface.setProcessStartedByNotification()
             harness.recordSession(simulateAppStartup = true) { }
             assertEquals(EventType.START, harness.overriddenDeliveryModule.deliveryService.lastEventSentAsync?.event?.type)
@@ -262,7 +262,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `test sdk time`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             assertEquals(harness.overriddenClock.now(), embrace.internalInterface.getSdkCurrentTime())
             harness.overriddenClock.tick()
             assertEquals(harness.overriddenClock.now(), embrace.internalInterface.getSdkCurrentTime())
@@ -274,7 +274,7 @@ internal class EmbraceInternalInterfaceTest {
         ApkToolsConfig.IS_NETWORK_CAPTURE_DISABLED = true
         with(testRule) {
             assertFalse(embrace.internalInterface.isInternalNetworkCaptureDisabled())
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             assertTrue(embrace.internalInterface.isInternalNetworkCaptureDisabled())
         }
     }
@@ -282,7 +282,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `internal tracing APIs work as expected`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             val sessionPayload = harness.recordSession {
                 with(embrace.internalInterface) {
                     val parentSpanId = checkNotNull(startSpan(name = "tz-parent-span"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -42,7 +42,7 @@ internal class PublicApiTest {
     fun `SDK can start`() {
         with(testRule) {
             assertFalse(embrace.isStarted)
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             assertEquals(AppFramework.NATIVE, harness.appFramework)
             assertFalse(harness.essentialServiceModule.configService.isSdkDisabled())
             assertTrue(embrace.isStarted)
@@ -53,7 +53,7 @@ internal class PublicApiTest {
     fun `SDK start defaults to native app framework`() {
         with(testRule) {
             assertFalse(embrace.isStarted)
-            embrace.start(harness.overriddenCoreModule.context, false)
+            startSdk(context = harness.overriddenCoreModule.context)
             assertEquals(AppFramework.NATIVE, harness.appFramework)
             assertTrue(embrace.isStarted)
         }
@@ -63,7 +63,7 @@ internal class PublicApiTest {
     fun `SDK disabled via the binary cannot start`() {
         with(testRule) {
             ApkToolsConfig.IS_SDK_DISABLED = true
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             assertFalse(embrace.isStarted)
         }
     }
@@ -72,7 +72,7 @@ internal class PublicApiTest {
     fun `SDK disabled via config cannot start`() {
         with(testRule) {
             harness.overriddenConfigService.sdkDisabled = true
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             assertFalse(embrace.isStarted)
         }
     }
@@ -90,7 +90,7 @@ internal class PublicApiTest {
     @Test
     fun `custom appId cannot be set after start`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             assertTrue(embrace.isStarted)
             assertFalse(embrace.setAppId("xyz12"))
         }
@@ -106,7 +106,7 @@ internal class PublicApiTest {
     @Test
     fun `getCurrentSessionId returns sessionId when SDK is started and foreground session is active`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             harness.recordSession {
                 assertEquals(embrace.currentSessionId, harness.essentialServiceModule.sessionIdTracker.getActiveSessionId())
                 assertNotNull(embrace.currentSessionId)
@@ -117,7 +117,7 @@ internal class PublicApiTest {
     @Test
     fun `getCurrentSessionId returns sessionId when SDK is started and background session is active`() {
         with(testRule) {
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             var foregroundSessionId: String? = null
             harness.recordSession {
                 foregroundSessionId = embrace.currentSessionId

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -32,7 +32,7 @@ internal class SpanTest {
         with(testRule) {
             val fakeSpanExporter = FakeSpanExporter()
             embrace.addSpanExporter(fakeSpanExporter)
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             embrace.startSpan("test")?.stop()
             assertTrue(
                 "Timed out waiting for the span to be exported: ${fakeSpanExporter.exportedSpans.map { it.name }}",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -51,7 +51,7 @@ internal class TracingApiTest {
         with(testRule) {
             harness.overriddenClock.tick(100L)
             embrace.addSpanExporter(spanExporter)
-            embrace.start(harness.overriddenCoreModule.context)
+            startSdk(context = harness.overriddenCoreModule.context)
             results.add("\nSpans exported before session starts: ${spanExporter.exportedSpans.toList().map { it.name }}")
             val sessionMessage = harness.recordSession {
                 val parentSpan = checkNotNull(embrace.createSpan(name = "test-trace-root"))

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -213,9 +213,9 @@ final class EmbraceImpl {
         internalEmbraceLogger = moduleInitBootstrapper.getInitModule().getLogger();
         tracer = moduleInitBootstrapper.getOpenTelemetryModule().getEmbraceTracer();
         uninitializedSdkInternalInterface =
-                LazyKt.lazy(
-                        () -> new UninitializedSdkInternalInterfaceImpl(moduleInitBootstrapper.getOpenTelemetryModule().getInternalTracer())
-                );
+            LazyKt.lazy(
+                () -> new UninitializedSdkInternalInterfaceImpl(moduleInitBootstrapper.getOpenTelemetryModule().getInternalTracer())
+            );
     }
 
     EmbraceImpl() {
@@ -252,7 +252,7 @@ final class EmbraceImpl {
             Systrace.endSynchronous();
         } catch (Throwable t) {
             internalEmbraceLogger.logError(
-                    "Error occurred while initializing the Embrace SDK. Instrumentation may be disabled.", t, true);
+                "Error occurred while initializing the Embrace SDK. Instrumentation may be disabled.", t, true);
         }
     }
 
@@ -337,8 +337,8 @@ final class EmbraceImpl {
         Systrace.startSynchronous("send-cached-sessions");
         // Send any sessions that were cached and not yet sent.
         deliveryModule.getDeliveryService().sendCachedSessions(
-                nativeModule.getNdkService(),
-                essentialServiceModule.getSessionIdTracker()
+            nativeModule.getNdkService(),
+            essentialServiceModule.getSessionIdTracker()
         );
         Systrace.endSynchronous();
 
@@ -346,12 +346,12 @@ final class EmbraceImpl {
         loadCrashVerifier(crashModule, moduleInitBootstrapper.getWorkerThreadModule());
 
         internalInterfaceModule = new InternalInterfaceModuleImpl(
-                moduleInitBootstrapper.getInitModule(),
-                moduleInitBootstrapper.getOpenTelemetryModule(),
-                coreModule,
-                essentialServiceModule,
-                this,
-                crashModule
+            moduleInitBootstrapper.getInitModule(),
+            moduleInitBootstrapper.getOpenTelemetryModule(),
+            coreModule,
+            essentialServiceModule,
+            this,
+            crashModule
         );
 
         embraceInternalInterface = internalInterfaceModule.getEmbraceInternalInterface();
@@ -373,7 +373,7 @@ final class EmbraceImpl {
 
 
         final String startMsg = "Embrace SDK started. App ID: " +
-                essentialServiceModule.getConfigService().getSdkModeBehavior().getAppId() + " Version: " + BuildConfig.VERSION_NAME;
+            essentialServiceModule.getConfigService().getSdkModeBehavior().getAppId() + " Version: " + BuildConfig.VERSION_NAME;
         internalEmbraceLogger.logInfo(startMsg);
 
         final long endTimeMs = sdkClock.now();
@@ -405,7 +405,7 @@ final class EmbraceImpl {
     private void loadCrashVerifier(CrashModule crashModule, WorkerThreadModule workerThreadModule) {
         crashVerifier = crashModule.getLastRunCrashVerifier();
         crashVerifier.readAndCleanMarkerAsync(
-                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
+            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
         );
     }
 
@@ -464,7 +464,7 @@ final class EmbraceImpl {
         }
         if (!appIdPattern.matcher(appId).find()) {
             internalEmbraceLogger.logError("Invalid app ID. Must be a 5-character string with " +
-                    "characters from the set [A-Za-z0-9], but it was \"" + appId + "\".");
+                "characters from the set [A-Za-z0-9], but it was \"" + appId + "\".");
             return false;
         }
 
@@ -724,19 +724,19 @@ final class EmbraceImpl {
     void recordAndDeduplicateNetworkRequest(@NonNull String callId, @NonNull EmbraceNetworkRequest request) {
         if (checkSdkStartedAndLogPublicApiUsage("record_network_request")) {
             logNetworkRequestImpl(
-                    callId,
-                    request.getNetworkCaptureData(),
-                    request.getUrl(),
-                    request.getHttpMethod(),
-                    request.getStartTime(),
-                    request.getResponseCode(),
-                    request.getEndTime(),
-                    request.getErrorType(),
-                    request.getErrorMessage(),
-                    request.getTraceId(),
-                    request.getW3cTraceparent(),
-                    request.getBytesOut(),
-                    request.getBytesIn()
+                callId,
+                request.getNetworkCaptureData(),
+                request.getUrl(),
+                request.getHttpMethod(),
+                request.getStartTime(),
+                request.getResponseCode(),
+                request.getEndTime(),
+                request.getErrorType(),
+                request.getErrorMessage(),
+                request.getTraceId(),
+                request.getW3cTraceparent(),
+                request.getBytesOut(),
+                request.getBytesIn()
             );
         }
     }
@@ -756,33 +756,33 @@ final class EmbraceImpl {
                                        Long bytesIn) {
         if (configService.getNetworkBehavior().isUrlEnabled(url)) {
             if (errorType != null &&
-                    errorMessage != null &&
-                    !errorType.isEmpty() &&
-                    !errorMessage.isEmpty()) {
+                errorMessage != null &&
+                !errorType.isEmpty() &&
+                !errorMessage.isEmpty()) {
                 networkLoggingService.logNetworkError(
-                        callId,
-                        url,
-                        httpMethod,
-                        startTime,
-                        endTime != null ? endTime : 0,
-                        errorType,
-                        errorMessage,
-                        traceId,
-                        w3cTraceparent,
-                        networkCaptureData);
+                    callId,
+                    url,
+                    httpMethod,
+                    startTime,
+                    endTime != null ? endTime : 0,
+                    errorType,
+                    errorMessage,
+                    traceId,
+                    w3cTraceparent,
+                    networkCaptureData);
             } else {
                 networkLoggingService.logNetworkCall(
-                        callId,
-                        url,
-                        httpMethod,
-                        responseCode != null ? responseCode : 0,
-                        startTime,
-                        endTime != null ? endTime : 0,
-                        bytesOut,
-                        bytesIn,
-                        traceId,
-                        w3cTraceparent,
-                        networkCaptureData);
+                    callId,
+                    url,
+                    httpMethod,
+                    responseCode != null ? responseCode : 0,
+                    startTime,
+                    endTime != null ? endTime : 0,
+                    bytesOut,
+                    bytesIn,
+                    traceId,
+                    w3cTraceparent,
+                    networkCaptureData);
             }
             onActivityReported();
         }
@@ -792,14 +792,14 @@ final class EmbraceImpl {
                     @NonNull Severity severity,
                     @Nullable Map<String, ?> properties) {
         logMessage(
-                EventType.Companion.fromSeverity(severity),
-                message,
-                properties,
-                null,
-                null,
-                LogExceptionType.NONE,
-                null,
-                null
+            EventType.Companion.fromSeverity(severity),
+            message,
+            properties,
+            null,
+            null,
+            LogExceptionType.NONE,
+            null,
+            null
         );
     }
 
@@ -809,16 +809,16 @@ final class EmbraceImpl {
                       @Nullable String message) {
         String exceptionMessage = throwable.getMessage() != null ? throwable.getMessage() : "";
         logMessage(
-                EventType.Companion.fromSeverity(severity),
-                message != null ? message : exceptionMessage,
-                properties,
-                ThrowableUtilsKt.getSafeStackTrace(throwable),
-                null,
-                LogExceptionType.HANDLED,
-                null,
-                null,
-                throwable.getClass().getSimpleName(),
-                exceptionMessage);
+            EventType.Companion.fromSeverity(severity),
+            message != null ? message : exceptionMessage,
+            properties,
+            ThrowableUtilsKt.getSafeStackTrace(throwable),
+            null,
+            LogExceptionType.HANDLED,
+            null,
+            null,
+            throwable.getClass().getSimpleName(),
+            exceptionMessage);
     }
 
     void logCustomStacktrace(@NonNull StackTraceElement[] stacktraceElements,
@@ -826,64 +826,64 @@ final class EmbraceImpl {
                              @Nullable Map<String, ?> properties,
                              @Nullable String message) {
         logMessage(
-                EventType.Companion.fromSeverity(severity),
-                message != null ? message : "",
-                properties,
-                stacktraceElements,
-                null,
-                LogExceptionType.HANDLED,
-                null,
-                null,
-                null,
-                message);
+            EventType.Companion.fromSeverity(severity),
+            message != null ? message : "",
+            properties,
+            stacktraceElements,
+            null,
+            LogExceptionType.HANDLED,
+            null,
+            null,
+            null,
+            message);
     }
 
     void logMessage(
-            @NonNull EventType type,
-            @NonNull String message,
-            @Nullable Map<String, ?> properties,
-            @Nullable StackTraceElement[] stackTraceElements,
-            @Nullable String customStackTrace,
-            @NonNull LogExceptionType logExceptionType,
-            @Nullable String context,
-            @Nullable String library) {
+        @NonNull EventType type,
+        @NonNull String message,
+        @Nullable Map<String, ?> properties,
+        @Nullable StackTraceElement[] stackTraceElements,
+        @Nullable String customStackTrace,
+        @NonNull LogExceptionType logExceptionType,
+        @Nullable String context,
+        @Nullable String library) {
         logMessage(type,
-                message,
-                properties,
-                stackTraceElements,
-                customStackTrace,
-                logExceptionType,
-                context,
-                library,
-                null,
-                null);
+            message,
+            properties,
+            stackTraceElements,
+            customStackTrace,
+            logExceptionType,
+            context,
+            library,
+            null,
+            null);
     }
 
     void logMessage(
-            @NonNull EventType type,
-            @NonNull String message,
-            @Nullable Map<String, ?> properties,
-            @Nullable StackTraceElement[] stackTraceElements,
-            @Nullable String customStackTrace,
-            @NonNull LogExceptionType logExceptionType,
-            @Nullable String context,
-            @Nullable String library,
-            @Nullable String exceptionName,
-            @Nullable String exceptionMessage) {
+        @NonNull EventType type,
+        @NonNull String message,
+        @Nullable Map<String, ?> properties,
+        @Nullable StackTraceElement[] stackTraceElements,
+        @Nullable String customStackTrace,
+        @NonNull LogExceptionType logExceptionType,
+        @Nullable String context,
+        @Nullable String library,
+        @Nullable String exceptionName,
+        @Nullable String exceptionMessage) {
         if (checkSdkStartedAndLogPublicApiUsage("log_message")) {
             try {
                 logMessageService.log(
-                        message,
-                        type,
-                        logExceptionType,
-                        normalizeProperties(properties, internalEmbraceLogger),
-                        stackTraceElements,
-                        customStackTrace,
-                        appFramework,
-                        context,
-                        library,
-                        exceptionName,
-                        exceptionMessage);
+                    message,
+                    type,
+                    logExceptionType,
+                    normalizeProperties(properties, internalEmbraceLogger),
+                    stackTraceElements,
+                    customStackTrace,
+                    appFramework,
+                    context,
+                    library,
+                    exceptionName,
+                    exceptionMessage);
                 onActivityReported();
             } catch (Exception ex) {
                 internalEmbraceLogger.logDebug("Failed to log message using Embrace SDK.", ex);
@@ -997,23 +997,23 @@ final class EmbraceImpl {
      * @param messageDeliveredPriority the priority of the message (as resolved on the server)
      */
     void logPushNotification(
-            @Nullable String title,
-            @Nullable String body,
-            @Nullable String topic,
-            @Nullable String id,
-            @Nullable Integer notificationPriority,
-            Integer messageDeliveredPriority,
-            PushNotificationBreadcrumb.NotificationType type) {
+        @Nullable String title,
+        @Nullable String body,
+        @Nullable String topic,
+        @Nullable String id,
+        @Nullable Integer notificationPriority,
+        Integer messageDeliveredPriority,
+        PushNotificationBreadcrumb.NotificationType type) {
 
         if (checkSdkStartedAndLogPublicApiUsage("log_push_notification")) {
             pushNotificationService.logPushNotification(
-                    title,
-                    body,
-                    topic,
-                    id,
-                    notificationPriority,
-                    messageDeliveredPriority,
-                    type
+                title,
+                body,
+                topic,
+                id,
+                notificationPriority,
+                messageDeliveredPriority,
+                type
             );
             onActivityReported();
         }
@@ -1215,9 +1215,9 @@ final class EmbraceImpl {
             AnrService service = anrService;
             if (service != null && nativeThreadSamplerInstaller != null) {
                 nativeThreadSamplerInstaller.monitorCurrentThread(
-                        nativeThreadSampler,
-                        configService,
-                        service
+                    nativeThreadSampler,
+                    configService,
+                    service
                 );
             } else {
                 internalEmbraceLogger.logWarning("nativeThreadSamplerInstaller not started, cannot sample current thread");


### PR DESCRIPTION
## Goal

Much of the module overriding needed in the test harness is so a fake config service can be provided that is universally used. 

To simplify this, I've added a new internal method in `EmbraceImpl` that allows the passing of a ConfigService provider so that we can feed through one and get ModuleInitBootstrapper to initialize modules with a with it during integration tests.

It doesn't change the production code path for initialization, but I'm not super happy with having to do this. But ah well.