### PR TITLE
Set session ID on all OTel logs

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -1,10 +1,15 @@
 package io.embrace.android.embracesdk.arch.destination
 
+import io.embrace.android.embracesdk.opentelemetry.embSessionId
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.logs.Severity
 
-internal class LogWriterImpl(private val logger: Logger) : LogWriter {
+internal class LogWriterImpl(
+    private val logger: Logger,
+    private val sessionIdTracker: SessionIdTracker
+) : LogWriter {
 
     override fun <T> addLog(log: T, mapper: T.() -> LogEventData) {
         val logEventData = log.mapper()
@@ -18,6 +23,11 @@ internal class LogWriterImpl(private val logger: Logger) : LogWriter {
         logEventData.schemaType.attributes().forEach {
             builder.setAttribute(AttributeKey.stringKey(it.key), it.value)
         }
+
+        sessionIdTracker.getActiveSessionId()?.let { sessionId ->
+            builder.setAttribute(embSessionId.attributeKey, sessionId)
+        }
+
         builder.emit()
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -76,7 +76,6 @@ internal class CustomerLogModuleImpl(
             essentialServiceModule.metadataService,
             essentialServiceModule.configService,
             coreModule.appFramework,
-            essentialServiceModule.sessionIdTracker,
             essentialServiceModule.sessionProperties,
             workerThreadModule.backgroundWorker(WorkerName.REMOTE_LOGGING),
             initModule.logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -337,7 +337,10 @@ internal class EssentialServiceModuleImpl(
     }
 
     override val logWriter: LogWriter by singleton {
-        LogWriterImpl(openTelemetryModule.logger)
+        LogWriterImpl(
+            logger = openTelemetryModule.logger,
+            sessionIdTracker = sessionIdTracker,
+        )
     }
 }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -20,13 +20,11 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.opentelemetry.embState
 import io.embrace.android.embracesdk.opentelemetry.exceptionMessage
 import io.embrace.android.embracesdk.opentelemetry.exceptionStacktrace
 import io.embrace.android.embracesdk.opentelemetry.exceptionType
 import io.embrace.android.embracesdk.opentelemetry.logRecordUid
-import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.util.NavigableMap
@@ -41,7 +39,6 @@ internal class EmbraceLogService(
     private val metadataService: MetadataService,
     private val configService: ConfigService,
     private val appFramework: AppFramework,
-    private val sessionIdTracker: SessionIdTracker,
     private val sessionProperties: EmbraceSessionProperties,
     private val backgroundWorker: BackgroundWorker,
     private val logger: InternalEmbraceLogger,
@@ -198,7 +195,6 @@ internal class EmbraceLogService(
         )
 
         attributes.setAttribute(logRecordUid, Uuid.getEmbUuid())
-        sessionIdTracker.getActiveSessionId()?.let { attributes.setAttribute(embSessionId, it) }
         metadataService.getAppState()?.let { attributes.setAttribute(embState, it) }
 
         return attributes

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
@@ -1,0 +1,51 @@
+package io.embrace.android.embracesdk.arch.destination
+
+import io.embrace.android.embracesdk.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.arch.schema.SchemaType
+import io.embrace.android.embracesdk.arch.schema.TelemetryAttributes
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
+import io.embrace.android.embracesdk.opentelemetry.embSessionId
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.opentelemetry.api.logs.Severity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class LogWriterImplTest {
+    private lateinit var logger: FakeOpenTelemetryLogger
+    private lateinit var sessionIdTracker: SessionIdTracker
+    private lateinit var logWriterImpl: LogWriterImpl
+
+    @Before
+    fun setup() {
+        sessionIdTracker = FakeSessionIdTracker()
+        logger = FakeOpenTelemetryLogger()
+        logWriterImpl = LogWriterImpl(
+            logger = logger,
+            sessionIdTracker = sessionIdTracker
+        )
+    }
+
+    @Test
+    fun `check expected values added to every OTel log`() {
+        sessionIdTracker.setActiveSessionId("session-id", true)
+        val logEventData = LogEventData(
+            schemaType = SchemaType.Log(
+                TelemetryAttributes(customAttributes = mapOf(PrivateSpan.toEmbraceKeyValuePair()))
+            ),
+            severity = io.embrace.android.embracesdk.Severity.ERROR,
+            message = "test"
+        )
+        logWriterImpl.addLog(logEventData) { logEventData }
+        with(logger.builders.single()) {
+            assertEquals("test", body)
+            assertEquals(Severity.ERROR, severity)
+            assertEquals(Severity.ERROR.name, severity.name)
+            assertEquals("session-id", attributes[embSessionId.name])
+            assertTrue(attributes.hasFixedAttribute(PrivateSpan))
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Set session ID in one LogWriter since all OTel logs will need this.

## Testing

Add unit test to LogWriter and check for session ID there instead in the individual data sources.