### PR TITLE
Delete the span we log for the startup moment

### DIFF
--- a/embrace-android-sdk/src/androidTest/assets/golden-files/session-end-v2.json
+++ b/embrace-android-sdk/src/androidTest/assets/golden-files/session-end-v2.json
@@ -59,34 +59,6 @@
       {
         "attributes": [
           {
-            "key": "emb.key",
-            "value": "true"
-          },
-          {
-            "key": "emb.process_identifier",
-            "value": "__EMBRACE_TEST_IGNORE__"
-          },
-          {
-            "key": "emb.type",
-            "value": "perf"
-          },
-          {
-            "key": "emb.private.sequence_id",
-            "value": "3"
-          }
-        ],
-        "end_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
-        "events": "__EMBRACE_TEST_IGNORE__",
-        "name": "emb-startup-moment",
-        "parent_span_id": "0000000000000000",
-        "span_id": "__EMBRACE_TEST_IGNORE__",
-        "start_time_unix_nano": "__EMBRACE_TEST_IGNORE__",
-        "status": "Ok",
-        "trace_id": "__EMBRACE_TEST_IGNORE__"
-      },
-      {
-        "attributes": [
-          {
             "key": "emb.process_identifier",
             "value": "__EMBRACE_TEST_IGNORE__"
           },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataContainerModule.kt
@@ -25,6 +25,7 @@ internal interface DataContainerModule {
 
 internal class DataContainerModuleImpl(
     initModule: InitModule,
+    @Suppress("UNUSED_PARAMETER")
     openTelemetryModule: OpenTelemetryModule,
     workerThreadModule: WorkerThreadModule,
     systemServiceModule: SystemServiceModule,
@@ -84,8 +85,7 @@ internal class DataContainerModuleImpl(
             essentialServiceModule.sessionProperties,
             initModule.logger,
             workerThreadModule,
-            initModule.clock,
-            openTelemetryModule.spanService
+            initModule.clock
         )
     }
 }


### PR DESCRIPTION
## Goal

Don't log a span analog for the startup moment. The data we get is confusing given it exposes some of the quirks of the Moments implementation, so we'll replace this with something better instead.

