### PR TITLE
Make startup traces publically visible

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
@@ -41,8 +41,8 @@ internal fun <T> SpanService.startSpanCapture(obj: T, mapper: T.() -> StartSpanD
     val data = obj.mapper()
     return startSpan(
         name = data.schemaType.fixedObjectName,
-        type = data.schemaType.telemetryType,
-        startTimeMs = data.spanStartTimeMs
+        startTimeMs = data.spanStartTimeMs,
+        type = data.schemaType.telemetryType
     )?.apply {
         data.schemaType.attributes().forEach {
             addAttribute(it.key, it.value)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -43,14 +43,21 @@ internal class EmbraceSpanService(
 
     override fun initialized(): Boolean = currentDelegate is SpanServiceImpl
 
-    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): PersistableEmbraceSpan? =
-        currentDelegate.createSpan(name = name, parent = parent, type = type, internal = internal)
+    override fun createSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        type: TelemetryType,
+        internal: Boolean,
+        private: Boolean
+    ): PersistableEmbraceSpan? =
+        currentDelegate.createSpan(name = name, parent = parent, type = type, internal = internal, private = private)
 
     override fun <T> recordSpan(
         name: String,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         code: () -> T
@@ -59,6 +66,7 @@ internal class EmbraceSpanService(
         parent = parent,
         type = type,
         internal = internal,
+        private = private,
         attributes = attributes,
         events = events,
         code = code
@@ -71,6 +79,7 @@ internal class EmbraceSpanService(
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?
@@ -81,6 +90,7 @@ internal class EmbraceSpanService(
         parent = parent,
         type = type,
         internal = internal,
+        private = private,
         attributes = attributes,
         events = events,
         errorCode = errorCode

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -35,9 +35,9 @@ internal class EmbraceTracer(
     ): T = spanService.recordSpan(
         name = name,
         parent = parent,
+        internal = false,
         attributes = attributes ?: emptyMap(),
         events = events ?: emptyList(),
-        internal = false,
         code = code
     )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -20,7 +20,8 @@ internal interface SpanService : Initializable {
         name: String,
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
-        internal: Boolean = true
+        internal: Boolean = true,
+        private: Boolean = internal,
     ): PersistableEmbraceSpan?
 
     /**
@@ -31,13 +32,15 @@ internal interface SpanService : Initializable {
         parent: EmbraceSpan? = null,
         startTimeMs: Long? = null,
         type: TelemetryType = EmbType.Performance.Default,
-        internal: Boolean = true
+        internal: Boolean = true,
+        private: Boolean = internal
     ): PersistableEmbraceSpan? {
         createSpan(
             name = name,
             parent = parent,
             type = type,
-            internal = internal
+            internal = internal,
+            private = private,
         )?.let { newSpan ->
             if (newSpan.start(startTimeMs)) {
                 return newSpan
@@ -56,6 +59,7 @@ internal interface SpanService : Initializable {
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
+        private: Boolean = internal,
         attributes: Map<String, String> = emptyMap(),
         events: List<EmbraceSpanEvent> = emptyList(),
         code: () -> T
@@ -72,6 +76,7 @@ internal interface SpanService : Initializable {
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
+        private: Boolean = internal,
         attributes: Map<String, String> = emptyMap(),
         events: List<EmbraceSpanEvent> = emptyList(),
         errorCode: ErrorCode? = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -27,12 +27,19 @@ internal class SpanServiceImpl(
 
     override fun initialized(): Boolean = initialized.get()
 
-    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): PersistableEmbraceSpan? {
+    override fun createSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        type: TelemetryType,
+        internal: Boolean,
+        private: Boolean
+    ): PersistableEmbraceSpan? {
         return if (inputsValid(name) && currentSessionSpan.canStartNewSpan(parent, internal)) {
             embraceSpanFactory.create(
                 name = name,
                 type = type,
                 internal = internal,
+                private = private,
                 parent = parent
             )
         } else {
@@ -45,12 +52,13 @@ internal class SpanServiceImpl(
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         code: () -> T
     ): T {
         val returnValue: T
-        val span = createSpan(name = name, parent = parent, type = type, internal = internal)
+        val span = createSpan(name = name, parent = parent, type = type, internal = internal, private = private)
         try {
             val started = span?.start() ?: false
             if (started) {
@@ -82,6 +90,7 @@ internal class SpanServiceImpl(
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?
@@ -91,7 +100,7 @@ internal class SpanServiceImpl(
         }
 
         if (inputsValid(name, events, attributes) && currentSessionSpan.canStartNewSpan(parent, internal)) {
-            val newSpan = embraceSpanFactory.create(name = name, type = type, internal = internal, parent = parent)
+            val newSpan = embraceSpanFactory.create(name = name, type = type, internal = internal, private = private, parent = parent)
             if (newSpan.start(startTimeMs)) {
                 attributes.forEach {
                     newSpan.addAttribute(it.key, it.value)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
@@ -23,13 +23,20 @@ internal class UninitializedSdkSpanService : SpanService {
 
     override fun initialized(): Boolean = true
 
-    override fun createSpan(name: String, parent: EmbraceSpan?, type: TelemetryType, internal: Boolean): PersistableEmbraceSpan? = null
+    override fun createSpan(
+        name: String,
+        parent: EmbraceSpan?,
+        type: TelemetryType,
+        internal: Boolean,
+        private: Boolean
+    ): PersistableEmbraceSpan? = null
 
     override fun <T> recordSpan(
         name: String,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         code: () -> T
@@ -42,6 +49,7 @@ internal class UninitializedSdkSpanService : SpanService {
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?
@@ -53,6 +61,7 @@ internal class UninitializedSdkSpanService : SpanService {
             parent = parent,
             type = type,
             internal = internal,
+            private = private,
             attributes = attributes,
             events = events,
             errorCode = errorCode
@@ -68,6 +77,7 @@ internal class UninitializedSdkSpanService : SpanService {
                         parent = parent,
                         type = type,
                         internal = internal,
+                        private = private,
                         attributes = attributes,
                         events = events,
                         errorCode = errorCode
@@ -120,6 +130,7 @@ internal class UninitializedSdkSpanService : SpanService {
         val parent: EmbraceSpan?,
         val type: TelemetryType,
         val internal: Boolean,
+        val private: Boolean,
         val attributes: Map<String, String>,
         val events: List<EmbraceSpanEvent>,
         val errorCode: ErrorCode?,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -22,6 +22,7 @@ internal class FakePersistableEmbraceSpan(
     val name: String? = null,
     val type: TelemetryType = EmbType.Performance.Default,
     val internal: Boolean = false,
+    val private: Boolean = internal,
     private val fakeClock: FakeClock = FakeClock()
 ) : PersistableEmbraceSpan {
 
@@ -116,14 +117,14 @@ internal class FakePersistableEmbraceSpan(
     companion object {
         fun notStarted(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan =
             FakePersistableEmbraceSpan(
-                name = "not-started",
-                parent = parent
+                parent = parent,
+                name = "not-started"
             )
 
         fun started(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan {
             val span = FakePersistableEmbraceSpan(
-                name = "started",
-                parent = parent
+                parent = parent,
+                name = "started"
             )
             span.start()
             return span
@@ -131,8 +132,8 @@ internal class FakePersistableEmbraceSpan(
 
         fun stopped(parent: EmbraceSpan? = null): FakePersistableEmbraceSpan {
             val span = FakePersistableEmbraceSpan(
-                name = "stopped",
-                parent = parent
+                parent = parent,
+                name = "stopped"
             )
             span.start()
             span.stop()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -20,8 +20,9 @@ internal class FakeSpanService : SpanService {
         name: String,
         parent: EmbraceSpan?,
         type: TelemetryType,
-        internal: Boolean
-    ): PersistableEmbraceSpan = FakePersistableEmbraceSpan(null, name, type, internal).apply {
+        internal: Boolean,
+        private: Boolean
+    ): PersistableEmbraceSpan = FakePersistableEmbraceSpan(null, name, type, internal, private).apply {
         createdSpans.add(this)
     }
 
@@ -30,6 +31,7 @@ internal class FakeSpanService : SpanService {
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         code: () -> T
@@ -44,6 +46,7 @@ internal class FakeSpanService : SpanService {
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
+        private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -140,9 +140,9 @@ internal class EmbraceSpanServiceTest {
         assertTrue(
             spanService.recordCompletedSpan(
                 name = expectedName,
-                parent = parentSpan,
                 startTimeMs = expectedStartTimeMs,
-                endTimeMs = expectedEndTimeMs
+                endTimeMs = expectedEndTimeMs,
+                parent = parentSpan
             )
         )
         assertTrue(parentSpan.stop())


### PR DESCRIPTION
## Goal

Detach the notion of internal (logged by the SDK, so should have the `emb.` prefix in the span name) from private (hidden from customers) at the SpanService level. This will allow us to create internal spans that are also public, like the new startup traces.

## Testing

Added unit tests
