### PR TITLE
WIP for recording network requests as spans

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -100,7 +100,7 @@ internal class EmbraceInternalInterfaceTest {
                     0L,
                     200,
                     null
-                )
+                ),
             )
 
             logComposeTap(Pair(0.0f, 0.0f), "")
@@ -204,7 +204,7 @@ internal class EmbraceInternalInterfaceTest {
                         301L,
                         200,
                         null
-                    )
+                    ),
                 )
             }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -223,7 +223,7 @@ internal class NetworkRequestApiTest {
                         BYTES_SENT,
                         BYTES_RECEIVED,
                         200
-                    )
+                    ),
                 )
                 embrace.internalInterface.recordAndDeduplicateNetworkRequest(
                     callId,
@@ -235,7 +235,7 @@ internal class NetworkRequestApiTest {
                         BYTES_SENT,
                         BYTES_RECEIVED,
                         200
-                    )
+                    ),
                 )
             }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -717,11 +717,11 @@ final class EmbraceImpl {
 
     void recordNetworkRequest(@NonNull EmbraceNetworkRequest request) {
         if (embraceInternalInterface != null && checkSdkStartedAndLogPublicApiUsage("record_network_request")) {
-            embraceInternalInterface.recordAndDeduplicateNetworkRequest(UUID.randomUUID().toString(), request);
+            embraceInternalInterface.recordAndDeduplicateNetworkRequest(UUID.randomUUID().toString(), request, false);
         }
     }
 
-    void recordAndDeduplicateNetworkRequest(@NonNull String callId, @NonNull EmbraceNetworkRequest request) {
+    void recordAndDeduplicateNetworkRequest(@NonNull String callId, @NonNull EmbraceNetworkRequest request, boolean isStart) {
         if (checkSdkStartedAndLogPublicApiUsage("record_network_request")) {
             logNetworkRequestImpl(
                 callId,
@@ -759,29 +759,19 @@ final class EmbraceImpl {
                 errorMessage != null &&
                 !errorType.isEmpty() &&
                 !errorMessage.isEmpty()) {
-                networkLoggingService.logNetworkError(
+                networkLoggingService.endNetworkRequestWithError(
                     callId,
-                    url,
-                    httpMethod,
-                    startTime,
                     endTime != null ? endTime : 0,
                     errorType,
                     errorMessage,
-                    traceId,
-                    w3cTraceparent,
                     networkCaptureData);
             } else {
-                networkLoggingService.logNetworkCall(
+                networkLoggingService.endNetworkRequest(
                     callId,
-                    url,
-                    httpMethod,
                     responseCode != null ? responseCode : 0,
-                    startTime,
                     endTime != null ? endTime : 0,
                     bytesOut,
                     bytesIn,
-                    traceId,
-                    w3cTraceparent,
                     networkCaptureData);
             }
             onActivityReported();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
@@ -169,9 +169,10 @@ internal class EmbraceInternalInterfaceImpl(
 
     override fun recordAndDeduplicateNetworkRequest(
         callId: String,
-        embraceNetworkRequest: EmbraceNetworkRequest
+        embraceNetworkRequest: EmbraceNetworkRequest,
+        isStart: Boolean
     ) {
-        embraceImpl.recordAndDeduplicateNetworkRequest(callId, embraceNetworkRequest)
+        embraceImpl.recordAndDeduplicateNetworkRequest(callId, embraceNetworkRequest, isStart)
     }
 
     override fun shouldCaptureNetworkBody(url: String, method: String): Boolean = embraceImpl.shouldCaptureNetworkCall(url, method)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImpl.kt
@@ -62,7 +62,7 @@ internal class UninitializedSdkInternalInterfaceImpl(
     ) {
     }
 
-    override fun recordAndDeduplicateNetworkRequest(callId: String, embraceNetworkRequest: EmbraceNetworkRequest) {}
+    override fun recordAndDeduplicateNetworkRequest(callId: String, embraceNetworkRequest: EmbraceNetworkRequest, isStart: Boolean) {}
 
     override fun logComposeTap(point: Pair<Float, Float>, elementName: String) {}
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -50,7 +50,8 @@ internal class CustomerLogModuleImpl(
         EmbraceNetworkLoggingService(
             essentialServiceModule.configService,
             initModule.logger,
-            networkCaptureService
+            networkCaptureService,
+            openTelemetryModule.spanService
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
@@ -102,7 +102,8 @@ public interface EmbraceInternalInterface : InternalTracingApi {
      */
     public fun recordAndDeduplicateNetworkRequest(
         callId: String,
-        embraceNetworkRequest: EmbraceNetworkRequest
+        embraceNetworkRequest: EmbraceNetworkRequest,
+        isStart: Boolean = false
     )
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
@@ -586,7 +586,8 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
                             traceId,
                             traceparent,
                             networkCaptureData.get()
-                        )
+                        ),
+                        false
                     );
                 } else {
                     String exceptionClass = null;
@@ -616,7 +617,8 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
                             traceId,
                             traceparent,
                             networkCaptureData.get()
-                        )
+                        ),
+                        false
                     );
                 }
             } catch (Exception e) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkLoggingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkLoggingService.kt
@@ -20,29 +20,18 @@ internal interface NetworkLoggingService {
      * Logs a HTTP network call.
      *
      * @param callId             the unique ID of the call used for deduplication purposes
-     * @param url                the URL being called
-     * @param httpMethod         the HTTP method
      * @param statusCode         the status code from the response
-     * @param startTime          the start time of the request
      * @param endTime            the end time of the request
      * @param bytesSent          the number of bytes sent
      * @param bytesReceived      the number of bytes received
-     * @param traceId            optional trace ID that can be used to trace a particular request
-     * @param w3cTraceparent     optional W3C-compliant traceparent representing the network call that is being recorded
      * @param networkCaptureData the additional data captured if network body capture is enabled for the URL
      */
-    @Suppress("LongParameterList")
-    fun logNetworkCall(
+    fun endNetworkRequest(
         callId: String,
-        url: String,
-        httpMethod: String,
         statusCode: Int,
-        startTime: Long,
         endTime: Long,
         bytesSent: Long,
         bytesReceived: Long,
-        traceId: String?,
-        w3cTraceparent: String?,
         networkCaptureData: NetworkCaptureData?
     )
 
@@ -50,26 +39,26 @@ internal interface NetworkLoggingService {
      * Logs an exception which occurred when attempting to make a network call.
      *
      * @param callId             the unique ID of the call used for deduplication purposes
-     * @param url                the URL being called
-     * @param httpMethod         the HTTP method
-     * @param startTime          the start time of the request
      * @param endTime            the end time of the request
      * @param errorType          the type of error being thrown
      * @param errorMessage       the error message
-     * @param traceId            optional trace ID that can be used to trace a particular request
-     * @param w3cTraceparent     optional W3C-compliant traceparent representing the network call that is being recorded
      * @param networkCaptureData the additional data captured if network body capture is enabled for the URL
      */
-    fun logNetworkError(
+    fun endNetworkRequestWithError(
         callId: String,
-        url: String,
-        httpMethod: String,
-        startTime: Long,
         endTime: Long,
         errorType: String?,
         errorMessage: String?,
+        networkCaptureData: NetworkCaptureData?
+    )
+
+    fun startNetworkCall(
+        callId: String,
+        url: String,
+        httpMethod: String,
+        statusCode: Int,
+        startTime: Long,
         traceId: String?,
         w3cTraceparent: String?,
-        networkCaptureData: NetworkCaptureData?
     )
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
@@ -202,9 +202,9 @@ internal class EmbraceInternalInterfaceImplTest {
             200
         )
 
-        internalImpl.recordAndDeduplicateNetworkRequest(callId, networkRequest)
+        internalImpl.recordAndDeduplicateNetworkRequest(callId, networkRequest, true)
         verify(exactly = 1) {
-            embraceImpl.recordAndDeduplicateNetworkRequest(callId, capture(captor))
+            embraceImpl.recordAndDeduplicateNetworkRequest(callId, capture(captor), true)
         }
 
         assertEquals(url, captor.captured.url)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
@@ -57,7 +57,7 @@ internal class UninitializedSdkInternalInterfaceImplTest {
             2509L,
             200
         )
-        impl.recordAndDeduplicateNetworkRequest("testID", request)
+        impl.recordAndDeduplicateNetworkRequest("testID", request,)
         impl.recordIncompleteNetworkRequest(
             "https://google.com",
             "get",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
@@ -11,33 +11,35 @@ internal class FakeNetworkLoggingService : NetworkLoggingService {
     override fun getNetworkCallsSnapshot(): NetworkSessionV2 =
         data
 
-    override fun logNetworkCall(
+    override fun endNetworkRequest(
         callId: String,
-        url: String,
-        httpMethod: String,
         statusCode: Int,
-        startTime: Long,
         endTime: Long,
         bytesSent: Long,
         bytesReceived: Long,
-        traceId: String?,
-        w3cTraceparent: String?,
         networkCaptureData: NetworkCaptureData?
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun logNetworkError(
+    override fun endNetworkRequestWithError(
         callId: String,
-        url: String,
-        httpMethod: String,
-        startTime: Long,
         endTime: Long,
         errorType: String?,
         errorMessage: String?,
-        traceId: String?,
-        w3cTraceparent: String?,
         networkCaptureData: NetworkCaptureData?
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun startNetworkCall(
+        callId: String,
+        url: String,
+        httpMethod: String,
+        statusCode: Int,
+        startTime: Long,
+        traceId: String?,
+        w3cTraceparent: String?
     ) {
         TODO("Not yet implemented")
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
@@ -57,7 +57,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         mockInternalInterface = mockk(relaxed = true)
         every { mockInternalInterface.shouldCaptureNetworkBody(any(), any()) } answers { shouldCaptureNetworkBody }
         every {
-            mockInternalInterface.recordAndDeduplicateNetworkRequest(capture(capturedCallId), capture(capturedEmbraceNetworkRequest))
+            mockInternalInterface.recordAndDeduplicateNetworkRequest(capture(capturedCallId), capture(capturedEmbraceNetworkRequest),)
         } answers { }
         every { mockInternalInterface.isNetworkSpanForwardingEnabled() } answers { isNetworkSpanForwardingEnabled }
         every { mockInternalInterface.getSdkCurrentTime() } answers { fakeTimeMs }
@@ -280,7 +280,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             connection = createMockGzipConnection(),
             wrappedIoStream = true
         )
-        verify(exactly = 0) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 0) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any(),) }
     }
 
     @Test
@@ -291,7 +291,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        verify(exactly = 0) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 0) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any(),) }
     }
 
     @Test
@@ -309,7 +309,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             connection = createMockUncompressedConnection(),
             wrappedIoStream = false
         )
-        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any(),) }
         assertTrue(capturedCallId[0].isNotBlank())
     }
 
@@ -320,7 +320,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any(),) }
     }
 
     @Test
@@ -328,7 +328,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         val mockConnection = createMockUncompressedConnection()
         EmbraceUrlConnectionDelegate(mockConnection, true, mockEmbrace).disconnect()
         verifyIncompleteRequestLogged(mockConnection)
-        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any(),) }
         assertEquals(1, capturedCallId.size)
     }
 
@@ -611,7 +611,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     }
 
     private fun verifyTwoCallsRecordedWithSameCallId() {
-        verify(exactly = 2) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 2) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any(),) }
         assertEquals(2, capturedCallId.size)
         assertEquals(capturedCallId[0], capturedCallId[1])
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureService
+import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
@@ -338,16 +339,11 @@ internal class EmbraceNetworkLoggingServiceTest {
         val startTime = 10000L
         val endTime = 20000L
 
-        networkLoggingService.logNetworkError(
+        networkLoggingService.endNetworkRequestWithError(
             randomId(),
-            url,
-            httpMethod,
-            startTime,
             endTime,
             "test",
             "test",
-            null,
-            null,
             null
         )
 
@@ -359,17 +355,12 @@ internal class EmbraceNetworkLoggingServiceTest {
     @Test
     fun `test logNetworkCall sends the network body if necessary`() {
         val url = "www.example.com"
-        networkLoggingService.logNetworkCall(
+        networkLoggingService.endNetworkRequest(
             randomId(),
-            url,
-            "GET",
             200,
-            10000L,
             20000L,
             1000L,
             1000L,
-            null,
-            null,
             NetworkCaptureData(
                 null,
                 null,
@@ -384,17 +375,12 @@ internal class EmbraceNetworkLoggingServiceTest {
 
     @Test
     fun `test logNetworkCall doesn't send the network body if null`() {
-        networkLoggingService.logNetworkCall(
+        networkLoggingService.endNetworkRequest(
             randomId(),
-            "www.example.com",
-            "GET",
             200,
-            10000L,
             20000L,
             1000L,
             1000L,
-            null,
-            null,
             null
         )
         assertTrue(networkCaptureService.urls.isEmpty())
@@ -456,37 +442,28 @@ internal class EmbraceNetworkLoggingServiceTest {
             EmbraceNetworkLoggingService(
                 configService,
                 logger,
-                networkCaptureService
+                networkCaptureService,
+                FakeSpanService()
             )
     }
 
     private fun logNetworkCall(url: String, startTime: Long = 100, endTime: Long = 200, callId: String = randomId()) {
-        networkLoggingService.logNetworkCall(
+        networkLoggingService.endNetworkRequest(
             callId,
-            url,
-            "GET",
             200,
-            startTime,
             endTime,
             1000L,
             1000L,
-            null,
-            null,
             null
         )
     }
 
     private fun logNetworkError(url: String, startTime: Long = 100, callId: String = randomId()) {
-        networkLoggingService.logNetworkError(
+        networkLoggingService.endNetworkRequestWithError(
             callId,
-            url,
-            "GET",
-            startTime,
             0,
             NullPointerException::class.java.canonicalName,
             "NPE baby",
-            null,
-            null,
             null
         )
     }


### PR DESCRIPTION
Playing around with recording network requests as a trace by starting it when a network request begins and sending it when we used to record the full requet.

This does not work. Do not merge.
