### PR TITLE
Define session span attribute keys

### DIFF
--- a/embrace-android-sdk/src/androidTest/assets/golden-files/session-end-v2.json
+++ b/embrace-android-sdk/src/androidTest/assets/golden-files/session-end-v2.json
@@ -7,6 +7,10 @@
       {
         "attributes": [
           {
+            "key": "emb.cold_start",
+            "value": "true"
+          },
+          {
             "key": "emb.session_id",
             "value": "__EMBRACE_TEST_IGNORE__"
           },
@@ -107,6 +111,10 @@
           {
             "key": "emb.okhttp3_on_classpath",
             "value": "4.9.3"
+          },
+          {
+            "key": "emb.cold_start",
+            "value": "true"
           },
           {
             "key": "emb.private.sequence_id",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -41,3 +41,28 @@ internal val embSessionId: EmbraceAttributeKey = EmbraceAttributeKey("session_id
  * Attribute name for the application state (foreground/background) at the time the log was recorded
  */
 internal val embState = EmbraceAttributeKey("state")
+
+/**
+ * Attribute name for whether the session is a cold start
+ */
+internal val embColdStart = EmbraceAttributeKey("cold_start")
+
+/**
+ * Attribute name for session number (integer sequence ID)
+ */
+internal val embSessionNumber = EmbraceAttributeKey("session_number")
+
+/**
+ * Attribute name that indicates whether the session was ended by the SDK or an unexpected termination
+ */
+internal val embCleanExit = EmbraceAttributeKey("clean_exit")
+
+/**
+ * Attribute name that represents last known time that the session existed (nanoseconds since epoch)
+ */
+internal val embHeartbeatTimeUnixNano = EmbraceAttributeKey("heartbeat_time_unix_nano")
+
+/**
+ * Attribute name that identifies the crash report tied to the session
+ */
+internal val embCrashId = EmbraceAttributeKey("crash_id")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.findSpanAttribute
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+internal class CurrentSessionSpanAttributeTests {
+
+    private lateinit var spanRepository: SpanRepository
+    private lateinit var spanSink: SpanSink
+    private lateinit var currentSessionSpan: CurrentSessionSpan
+    private lateinit var spanService: SpanService
+    private val clock = FakeClock(1000L)
+
+    @Before
+    fun setup() {
+        val initModule = FakeInitModule(clock = clock)
+        spanRepository = initModule.openTelemetryModule.spanRepository
+        spanSink = initModule.openTelemetryModule.spanSink
+        currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
+        spanService = initModule.openTelemetryModule.spanService
+        spanService.initializeService(clock.now())
+    }
+
+    @Test
+    fun `attributes added to cold start session span`() {
+        val span = currentSessionSpan.endSession(null).single()
+        assertEquals("emb-session", span.name)
+
+        // assert attributes added by default
+        span.assertCommonSessionSpanAttrs()
+        assertEquals("true", span.findSpanAttribute("emb.cold_start"))
+    }
+
+    @Test
+    fun `attributes added to hot session span`() {
+        // end the first session span then create another one
+        currentSessionSpan.endSession(null)
+        val span = currentSessionSpan.endSession(null).single()
+        assertEquals("emb-session", span.name)
+
+        // assert attributes added by default
+        span.assertCommonSessionSpanAttrs()
+        assertEquals("false", span.findSpanAttribute("emb.cold_start"))
+    }
+
+    private fun EmbraceSpanData.assertCommonSessionSpanAttrs() {
+        assertNotNull(findSpanAttribute("emb.session_id"))
+        assertEquals("ux.session", findSpanAttribute("emb.type"))
+    }
+}


### PR DESCRIPTION
## Goal

Defines keys that will be used on the session span. This populates the `emb.cold_start` attribute but leaves the others for now.

