### PR TITLE
Changed ERROR to WARN for sdk not initialized

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalEmbraceLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalEmbraceLogger.kt
@@ -57,7 +57,7 @@ internal class InternalEmbraceLogger {
         val msg = "Embrace SDK is not initialized yet, cannot $action."
         log(
             msg,
-            Severity.ERROR,
+            Severity.WARNING,
             Throwable(msg),
             true
         )


### PR DESCRIPTION
## Goal

now logging sdk not initialized as warning, because it was way too invasive

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>

