### PR TITLE
Convert stacktrace elements to String before serialization

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
@@ -66,7 +66,7 @@ internal class CompositeLogService(
                 )
             } else {
                 val stacktrace = if (stackTraceElements != null) {
-                    serializer.toJson(stackTraceElements)
+                    serializer.toJson(stackTraceElements.map(StackTraceElement::toString).take(200).toString())
                 } else {
                     customStackTrace
                 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
@@ -66,7 +66,8 @@ internal class CompositeLogService(
                 )
             } else {
                 val stacktrace = if (stackTraceElements != null) {
-                    serializer.toJson(stackTraceElements.map(StackTraceElement::toString).take(200).toString())
+                    val stackString = stackTraceElements.map(StackTraceElement::toString).take(200).toList()
+                    serializer.toJson(stackString, List::class.java)
                 } else {
                     customStackTrace
                 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -25,7 +25,7 @@ internal class FakeLogService : LogService {
         exceptionName: String?,
         exceptionMessage: String?
     ) {
-        exceptions.add(message)
+        exceptions.add("$exceptionName $exceptionMessage $stackTrace")
     }
 
     override fun logFlutterException(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
@@ -182,4 +182,25 @@ internal class CompositeLogServiceTest {
         assertEquals(0, v2LogService.logs.size)
         assertEquals(0, v2LogService.exceptions.size)
     }
+
+    @Test
+    fun `exception properly in v2`() {
+        val exception = IllegalArgumentException("bad arg")
+        oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
+        compositeLogService.log(
+            message = "log",
+            type = EventType.ERROR_LOG,
+            logExceptionType = LogExceptionType.UNHANDLED,
+            properties = null,
+            stackTraceElements = exception.stackTrace,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.NATIVE,
+            context = null,
+            library = null,
+            exceptionName = exception.javaClass.name,
+            exceptionMessage = exception.message
+        )
+        assertEquals(0, v1LogService.loggedMessages.size)
+        v2LogService.exceptions.single().contains("IllegalArgumentException")
+    }
 }


### PR DESCRIPTION
## Goal

Moshi can't serialize StackTraceElement without a custom adaptor, so stringify the array before sending it down if that's the way the data is coming in

## Testing
Add test case that breaks before is works after
