### PR TITLE
Create a mechanism to not batch certain log telemetry types

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.arch.schema
 internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
     override val key = EmbraceAttributeKey(id = "type")
     override val value = type + (subtype?.run { ".$this" } ?: "")
+    override val sendImmediately: Boolean = false
 
     /**
      * Keys that track how fast a time interval is. Only applies to spans.
@@ -43,7 +44,10 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
      * Keys that track telemetry that is not explicitly tied to user behaviour and is not visual in nature.
      * Applies to spans, logs, and span events.
      */
-    internal sealed class System(subtype: String) : EmbType("sys", subtype) {
+    internal sealed class System(
+        subtype: String,
+        override val sendImmediately: Boolean = false
+    ) : EmbType("sys", subtype) {
 
         internal object Breadcrumb : System("breadcrumb")
 
@@ -63,25 +67,25 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
             val embFlutterExceptionLibrary = EmbraceAttributeKey("exception.library")
         }
 
-        internal object Exit : System("exit")
+        internal object Exit : System("exit", true)
 
         internal object PushNotification : System("push_notification")
 
-        internal object Crash : System("android.crash") {
+        internal object Crash : System("android.crash", true) {
             /**
              * The list of [Throwable] that caused the exception responsible for a crash
              */
             val embAndroidCrashExceptionCause = EmbraceAttributeKey("android.crash.exception_cause")
         }
 
-        internal object ReactNativeCrash : System("android.react_native_crash") {
+        internal object ReactNativeCrash : System("android.react_native_crash", true) {
             /**
              * The list JavaScript exceptions from the ReactNative layer
              */
             val embAndroidReactNativeCrashJsExceptions = EmbraceAttributeKey("android.react_native_crash.js_exceptions")
         }
 
-        internal object NativeCrash : System("android.native_crash") {
+        internal object NativeCrash : System("android.native_crash", true) {
             /**
              * Exception coming from the native layer
              */
@@ -117,4 +121,6 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
  * a visual event around a UI element. ux is the type, and view is the subtype. This tells the
  * backend that it can assume the data in the event follows a particular schema.
  */
-internal interface TelemetryType : FixedAttribute
+internal interface TelemetryType : FixedAttribute {
+    val sendImmediately: Boolean
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SendImmediately.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SendImmediately.kt
@@ -1,0 +1,7 @@
+import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
+import io.embrace.android.embracesdk.arch.schema.FixedAttribute
+
+internal object SendImmediately : FixedAttribute {
+    override val key = EmbraceAttributeKey(id = "send_immediately")
+    override val value: String = "true"
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSource.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.capture.envelope.log
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
-internal fun interface LogEnvelopeSource {
-    fun getEnvelope(): Envelope<LogPayload>
+internal interface LogEnvelopeSource {
+    fun getBatchedLogEnvelope(): Envelope<LogPayload>
+
+    fun getNonbatchedEnvelope(): List<Envelope<LogPayload>>
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.capture.envelope.log
 import io.embrace.android.embracesdk.capture.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.capture.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.LogPayload
 
 internal class LogEnvelopeSourceImpl(
     private val metadataSource: EnvelopeMetadataSource,
@@ -10,11 +11,22 @@ internal class LogEnvelopeSourceImpl(
     private val logPayloadSource: LogPayloadSource,
 ) : LogEnvelopeSource {
 
-    override fun getEnvelope() = Envelope(
+    override fun getBatchedLogEnvelope() = getLogEnvelope(logPayloadSource.getBatchedLogPayload())
+
+    override fun getNonbatchedEnvelope(): List<Envelope<LogPayload>> {
+        val payloads = logPayloadSource.getNonbatchedLogPayloads()
+        return if (payloads.isNotEmpty()) {
+            payloads.map { getLogEnvelope(it) }
+        } else {
+            emptyList()
+        }
+    }
+
+    private fun getLogEnvelope(payload: LogPayload) = Envelope(
         resourceSource.getEnvelopeResource(),
         metadataSource.getEnvelopeMetadata(),
         "0.1.0",
         "logs",
-        logPayloadSource.getLogPayload()
+        payload
     )
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSource.kt
@@ -4,5 +4,13 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 
 internal interface LogPayloadSource {
 
-    fun getLogPayload(): LogPayload
+    /**
+     * Returns a [LogPayload] containing the next batch of objects to be sent
+     */
+    fun getBatchedLogPayload(): LogPayload
+
+    /**
+     * Returns a list of [LogPayload] that each contain a single high priority log
+     */
+    fun getNonbatchedLogPayloads(): List<LogPayload>
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImpl.kt
@@ -7,9 +7,29 @@ internal class LogPayloadSourceImpl(
     private val logSink: LogSink
 ) : LogPayloadSource {
 
-    override fun getLogPayload(): LogPayload {
+    override fun getBatchedLogPayload(): LogPayload {
         return LogPayload(
             logs = logSink.flushLogs()
         )
+    }
+
+    override fun getNonbatchedLogPayloads(): List<LogPayload> {
+        val nonbatchedLogs = mutableListOf<LogPayload>()
+        var log = logSink.pollNonbatchedLog()
+
+        while (log != null) {
+            nonbatchedLogs.add(LogPayload(logs = listOf(log)))
+            log = if (nonbatchedLogs.size < MAX_PAYLOADS) {
+                logSink.pollNonbatchedLog()
+            } else {
+                null
+            }
+        }
+
+        return nonbatchedLogs
+    }
+
+    companion object {
+        private const val MAX_PAYLOADS = 10
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSink.kt
@@ -11,23 +11,28 @@ import io.opentelemetry.sdk.logs.data.LogRecordData
 internal interface LogSink {
 
     /**
-     * Stores Logs. Implementations must support concurrent invocations.
+     * Store [Log] objects to be sent in the nexdt batch. Implementations must support concurrent invocations.
      */
     fun storeLogs(logs: List<LogRecordData>): CompletableResultCode
 
     /**
-     * Returns the list of currently stored Logs.
+     * Returns the list of currently stored [Log] objects, waiting to be sent in the next batch
      */
     fun completedLogs(): List<Log>
 
     /**
-     * Returns and clears the currently stored Logs. Implementations of this method must make sure the clearing and returning is
-     * atomic, i.e. logs cannot be added during this operation.
+     * Returns and clears the currently stored [Log] objects, to be used when the next batch is to be sent.
+     * Implementations of this method must make sure the clearing and returning is atomic, i.e. logs cannot be added during this operation.
      */
     fun flushLogs(): List<Log>
 
     /**
-     * Registers a callback to be called when logs are stored.
+     * Return a [Log] that is to be sent immediately rather than batched
      */
-    fun callOnLogsStored(onLogsStored: () -> Unit)
+    fun pollNonbatchedLog(): Log?
+
+    /**
+     * Registers a callback to be called after new logs are stored.
+     */
+    fun registerLogStoredCallback(onLogsStored: () -> Unit)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -1,8 +1,10 @@
 package io.embrace.android.embracesdk.internal.logs
 
+import SendImmediately
 import io.embrace.android.embracesdk.internal.logs.LogOrchestratorImpl.Companion.MAX_LOGS_PER_BATCH
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.utils.threadSafeTake
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.data.LogRecordData
@@ -10,12 +12,19 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 internal class LogSinkImpl : LogSink {
     private val storedLogs: ConcurrentLinkedQueue<Log> = ConcurrentLinkedQueue()
+    private val nonbatchedLogs: ConcurrentLinkedQueue<Log> = ConcurrentLinkedQueue()
     private var onLogsStored: (() -> Unit)? = null
     private val flushLock = Any()
 
     override fun storeLogs(logs: List<LogRecordData>): CompletableResultCode {
         try {
-            storedLogs.addAll(logs.map { it.toNewPayload() })
+            logs.forEach { log ->
+                if (log.hasFixedAttribute(SendImmediately)) {
+                    nonbatchedLogs.add(log.toNewPayload())
+                } else {
+                    storedLogs.add(log.toNewPayload())
+                }
+            }
             onLogsStored?.invoke()
         } catch (t: Throwable) {
             return CompletableResultCode.ofFailure()
@@ -37,7 +46,9 @@ internal class LogSinkImpl : LogSink {
         }
     }
 
-    override fun callOnLogsStored(onLogsStored: () -> Unit) {
+    override fun pollNonbatchedLog(): Log? = nonbatchedLogs.poll()
+
+    override fun registerLogStoredCallback(onLogsStored: () -> Unit) {
         this.onLogsStored = onLogsStored
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.trace.data.SpanData
 import java.util.concurrent.TimeUnit
 
@@ -145,6 +146,9 @@ internal fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIB
 
 internal fun SpanData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
     attributes.asMap()[fixedAttribute.key.attributeKey] == fixedAttribute.value
+
+internal fun LogRecordData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
+    attributes[fixedAttribute.key.attributeKey] == fixedAttribute.value
 
 internal fun EmbraceSpanData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
     fixedAttribute.value == attributes[fixedAttribute.key.name]

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogEnvelopeSourceImplTest.kt
@@ -3,26 +3,57 @@ package io.embrace.android.embracesdk.capture.envelope.log
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeLogPayloadSource
+import io.embrace.android.embracesdk.fixtures.nonbatchableLog
+import io.embrace.android.embracesdk.internal.payload.LogPayload
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class LogEnvelopeSourceImplTest {
 
+    private val metadataSource = FakeEnvelopeMetadataSource()
+    private val resourceSource = FakeEnvelopeResourceSource()
+    private val logSource = FakeLogPayloadSource()
+    private val source = LogEnvelopeSourceImpl(
+        metadataSource,
+        resourceSource,
+        logSource,
+    )
+
     @Test
-    fun getEnvelope() {
-        val metadataSource = FakeEnvelopeMetadataSource()
-        val resourceSource = FakeEnvelopeResourceSource()
-        val logSource = FakeLogPayloadSource()
-        val source = LogEnvelopeSourceImpl(
-            metadataSource,
-            resourceSource,
-            logSource,
-        )
-        val payload = source.getEnvelope()
+    fun getBatchedLogEnvelope() {
+        val payload = source.getBatchedLogEnvelope()
         assertEquals(metadataSource.metadata, payload.metadata)
         assertEquals(resourceSource.resource, payload.resource)
         assertEquals(logSource.logs, payload.data)
         assertEquals("logs", payload.type)
         assertEquals("0.1.0", payload.version)
+    }
+
+    @Test
+    fun getNonbatchedLogEnvelopes() {
+        with(source.getNonbatchedEnvelope().single()) {
+            assertEquals(metadataSource.metadata, metadata)
+            assertEquals(resourceSource.resource, resource)
+            assertEquals(logSource.nonbatchedLogs.single(), data)
+            assertEquals("logs", type)
+            assertEquals("0.1.0", version)
+        }
+    }
+
+    @Test
+    fun `check maximum number of envelopes returned`() {
+        val fakeLogPayloadSource = FakeLogPayloadSource()
+        val nonbatchedLogs = mutableListOf<LogPayload>()
+        repeat(5) {
+            nonbatchedLogs.add(LogPayload(listOf(nonbatchableLog.copy(body = "$it"))))
+        }
+
+        fakeLogPayloadSource.nonbatchedLogs = nonbatchedLogs
+        val maxedOutSource = LogEnvelopeSourceImpl(
+            metadataSource,
+            resourceSource,
+            fakeLogPayloadSource,
+        )
+        assertEquals(5, maxedOutSource.getNonbatchedEnvelope().size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/log/LogPayloadSourceImplTest.kt
@@ -1,8 +1,13 @@
 package io.embrace.android.embracesdk.capture.envelope.log
 
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
+import io.embrace.android.embracesdk.fixtures.nonbatchableLog
+import io.embrace.android.embracesdk.fixtures.unbatchableLogRecordData
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
+import io.embrace.android.embracesdk.internal.payload.LogPayload
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 
@@ -16,13 +21,14 @@ internal class LogPayloadSourceImplTest {
     fun setUp() {
         sink = LogSinkImpl().apply {
             storeLogs(listOf(fakeLog))
+            storeLogs(listOf(unbatchableLogRecordData))
         }
         impl = LogPayloadSourceImpl(sink)
     }
 
     @Test
-    fun `test getLogPayload returns a correct payload`() {
-        val payload = impl.getLogPayload()
+    fun `getBatchedLogPayload returns a correct payload`() {
+        val payload = impl.getBatchedLogPayload()
         val log = checkNotNull(payload.logs?.single())
         assertEquals(0, sink.completedLogs().size)
         assertEquals(1, payload.logs?.size)
@@ -31,5 +37,25 @@ internal class LogPayloadSourceImplTest {
         assertEquals(fakeLog.severity.severityNumber, log.severityNumber)
         assertEquals(fakeLog.attributes.size(), log.attributes?.size)
         assertEquals(fakeLog.body.asString(), log.body)
+    }
+
+    @Test
+    fun `getNonbatchedLogPayloads returns the correct payload`() {
+        val payloads = impl.getNonbatchedLogPayloads()
+        val log = checkNotNull(payloads.single())
+        assertNull(sink.pollNonbatchedLog())
+        assertEquals(LogPayload(logs = listOf(nonbatchableLog)), log)
+    }
+
+    @Test
+    fun `getNonbatchedLogPayloads returns the maximum number of payloads`() {
+        repeat(10) {
+            sink.storeLogs(listOf(unbatchableLogRecordData))
+        }
+
+        val payloads = impl.getNonbatchedLogPayloads()
+        assertEquals(10, payloads.size)
+        assertNotNull(sink.pollNonbatchedLog())
+        assertNull(sink.pollNonbatchedLog())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogPayloadSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogPayloadSource.kt
@@ -1,11 +1,15 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.capture.envelope.log.LogPayloadSource
+import io.embrace.android.embracesdk.fixtures.nonbatchableLog
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
 internal class FakeLogPayloadSource : LogPayloadSource {
 
     var logs: LogPayload = LogPayload()
+    var nonbatchedLogs: List<LogPayload> = listOf(LogPayload(logs = listOf(nonbatchableLog)))
 
-    override fun getLogPayload(): LogPayload = logs
+    override fun getBatchedLogPayload(): LogPayload = logs
+
+    override fun getNonbatchedLogPayloads(): List<LogPayload> = nonbatchedLogs
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
@@ -10,7 +10,7 @@ internal class FakeReadWriteLogRecord : ReadWriteLogRecord {
 
     private val logRecordData = FakeLogRecordData()
 
-    override fun <T : Any?> setAttribute(key: AttributeKey<T>, value: T): ReadWriteLogRecord {
+    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T): ReadWriteLogRecord {
         attributes[key.key] = value.toString()
         return this
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.fixtures
 
+import SendImmediately
+import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Log
 
@@ -12,3 +14,15 @@ internal val testLog = Log(
     body = "test log message",
     attributes = listOf(Attribute(key = "test1", data = "value1"), Attribute(key = "test2", data = "value2"))
 )
+
+internal val nonbatchableLog = Log(
+    traceId = null,
+    spanId = null,
+    timeUnixNano = 1681972471806000000L,
+    severityNumber = 9,
+    severityText = "INFO",
+    body = "unbatchable",
+    attributes = listOf(SendImmediately.toPayload())
+)
+
+internal val unbatchableLogRecordData = FakeLogRecordData(log = nonbatchableLog)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
@@ -7,11 +7,13 @@ import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecut
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fakes.FakePayloadModule
+import io.embrace.android.embracesdk.fixtures.unbatchableLogRecordData
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -173,6 +175,14 @@ internal class LogOrchestratorTest {
 
         assertEquals("Too many payloads sent", 1, deliveryService.lastSentLogPayloads.size)
         assertEquals("Too many logs in payload", 50, deliveryService.lastSentLogPayloads[0].data.logs?.size)
+    }
+
+    @Test
+    fun `priority logs are sent immediately`() {
+        logSink.storeLogs(listOf(unbatchableLogRecordData))
+        // Verify the logs are sent
+        assertNull(logSink.pollNonbatchedLog())
+        verifyPayload(1)
     }
 
     private fun verifyPayload(numberOfLogs: Int) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogSinkImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogSinkImplTest.kt
@@ -1,10 +1,11 @@
 package io.embrace.android.embracesdk.internal.logs
 
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
+import io.embrace.android.embracesdk.fixtures.unbatchableLogRecordData
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
-import io.mockk.mockk
 import io.opentelemetry.sdk.common.CompletableResultCode
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
@@ -34,7 +35,7 @@ internal class LogSinkImplTest {
 
     @Test
     fun `flushing clears stored logs`() {
-        logSink.storeLogs(listOf(mockk(relaxed = true), mockk(relaxed = true)))
+        logSink.storeLogs(listOf(FakeLogRecordData(), FakeLogRecordData()))
         val snapshot = logSink.completedLogs()
         assertEquals(2, snapshot.size)
 
@@ -49,8 +50,17 @@ internal class LogSinkImplTest {
     @Test
     fun `onStore is called when logs are stored`() {
         var onStoreCalled = false
-        (logSink as LogSinkImpl).callOnLogsStored { onStoreCalled = true }
+        (logSink as LogSinkImpl).registerLogStoredCallback { onStoreCalled = true }
         logSink.storeLogs(listOf(FakeLogRecordData()))
         assertEquals(true, onStoreCalled)
+    }
+
+    @Test
+    fun `unbatchable logs are stored in priority log queue`() {
+        val resultCode = logSink.storeLogs(listOf(unbatchableLogRecordData))
+        assertEquals(CompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(0, logSink.completedLogs().size)
+        assertEquals(unbatchableLogRecordData.log, logSink.pollNonbatchedLog())
+        assertNull(logSink.pollNonbatchedLog())
     }
 }


### PR DESCRIPTION
## Goal

Allow a telemetry type to specify that it shouldn't be batched if it were a log being sent.

In the future, we will modify request priority too, but we'll just keep the current priority but ensure that crashes and AEIs aren't batched (the former because they're important, and the latter because it could be big)

## Testing

Unit tests added. Integration tests will be added tomorrow.