### PR TITLE
Write session-related attributes to session span

### DIFF
--- a/embrace-android-sdk/src/androidTest/assets/golden-files/session-end-v2.json
+++ b/embrace-android-sdk/src/androidTest/assets/golden-files/session-end-v2.json
@@ -11,7 +11,23 @@
             "value": "true"
           },
           {
+            "key": "emb.state",
+            "value": "foreground"
+          },
+          {
+            "key": "emb.clean_exit",
+            "value": "true"
+          },
+          {
             "key": "emb.session_id",
+            "value": "__EMBRACE_TEST_IGNORE__"
+          },
+          {
+            "key": "emb.heartbeat_time_unix_nano",
+            "value": "__EMBRACE_TEST_IGNORE__"
+          },
+          {
+            "key": "emb.session_number",
             "value": "__EMBRACE_TEST_IGNORE__"
           },
           {
@@ -85,60 +101,76 @@
       {
         "attributes": [
           {
-            "key": "emb.process_identifier",
-            "value": "__EMBRACE_TEST_IGNORE__"
+            "key":"emb.usage.add_user_persona",
+            "value":"1"
           },
           {
-            "key": "emb.usage.set_user_email",
-            "value": "1"
+            "key":"emb.heartbeat_time_unix_nano",
+            "value":"__EMBRACE_TEST_IGNORE__"
           },
           {
-            "key": "emb.type",
-            "value": "ux.session"
+            "key":"emb.usage.set_user_identifier",
+            "value":"1"
           },
           {
-            "key": "emb.okhttp3",
-            "value": "true"
+            "key":"emb.session_id",
+            "value":"__EMBRACE_TEST_IGNORE__"
           },
           {
-            "key": "emb.is_emulator",
-            "value": "__EMBRACE_TEST_IGNORE__"
+            "key":"emb.kotlin_on_classpath",
+            "value":"1.4.32"
           },
           {
-            "key": "emb.usage.set_username",
-            "value": "1"
+            "key":"emb.usage.add_breadcrumb",
+            "value":"1"
           },
           {
-            "key": "emb.okhttp3_on_classpath",
-            "value": "4.9.3"
+            "key":"emb.private.sequence_id",
+            "value":"1"
           },
           {
-            "key": "emb.cold_start",
-            "value": "true"
+            "key":"emb.clean_exit",
+            "value":"true"
           },
           {
-            "key": "emb.private.sequence_id",
-            "value": "1"
+            "key":"emb.usage.set_username",
+            "value":"1"
           },
           {
-            "key": "emb.usage.add_breadcrumb",
-            "value": "1"
+            "key":"emb.okhttp3_on_classpath",
+            "value":"4.9.3"
           },
           {
-            "key": "emb.session_id",
-            "value": "__EMBRACE_TEST_IGNORE__"
+            "key":"emb.state",
+            "value":"foreground"
           },
           {
-            "key": "emb.usage.set_user_identifier",
-            "value": "1"
+            "key":"emb.cold_start",
+            "value":"true"
           },
           {
-            "key": "emb.kotlin_on_classpath",
-            "value": "1.4.32"
+            "key":"emb.session_number",
+            "value":"__EMBRACE_TEST_IGNORE__"
           },
           {
-            "key": "emb.usage.add_user_persona",
-            "value": "1"
+            "key":"emb.is_emulator",
+            "value":"__EMBRACE_TEST_IGNORE__"
+          },
+          {
+            "key":"emb.process_identifier",
+            "value":"__EMBRACE_TEST_IGNORE__"
+          },
+          {
+            "key":"emb.usage.set_user_email",
+            "value":"1"
+          },
+          {
+            "key":"emb.type",
+            "value":"ux.session"
+          },
+          {
+            "key":"emb.okhttp3",
+            "value":"true"
           }
         ],
         "end_time_unix_nano": "__EMBRACE_TEST_IGNORE__",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -143,6 +143,7 @@ internal class SessionModuleImpl(
             periodicSessionCacher,
             periodicBackgroundActivityCacher,
             dataCaptureOrchestrator,
+            openTelemetryModule.currentSessionSpan,
             initModule.logger
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setFixedAttribute
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.opentelemetry.embColdStart
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -39,7 +38,7 @@ internal class CurrentSessionSpanImpl(
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
         synchronized(sessionSpan) {
-            sessionSpan.set(startSessionSpan(sdkInitStartTimeMs, true))
+            sessionSpan.set(startSessionSpan(sdkInitStartTimeMs))
         }
     }
 
@@ -88,7 +87,7 @@ internal class CurrentSessionSpanImpl(
             if (appTerminationCause == null) {
                 endingSessionSpan.stop()
                 spanRepository.clearCompletedSpans()
-                sessionSpan.set(startSessionSpan(openTelemetryClock.now().nanosToMillis(), false))
+                sessionSpan.set(startSessionSpan(openTelemetryClock.now().nanosToMillis()))
             } else {
                 val crashTime = openTelemetryClock.now().nanosToMillis()
                 spanRepository.failActiveSpans(crashTime)
@@ -122,10 +121,7 @@ internal class CurrentSessionSpanImpl(
     /**
      * This method should always be used when starting a new session span
      */
-    private fun startSessionSpan(
-        startTimeMs: Long,
-        coldStart: Boolean
-    ): PersistableEmbraceSpan {
+    private fun startSessionSpan(startTimeMs: Long): PersistableEmbraceSpan {
         traceCount.set(0)
 
         return embraceSpanFactorySupplier().create(
@@ -136,7 +132,6 @@ internal class CurrentSessionSpanImpl(
         ).apply {
             start(startTimeMs = startTimeMs)
             addAttribute(embSessionId.name, Uuid.getEmbUuid())
-            addAttribute(embColdStart.name, coldStart.toString())
         }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -46,7 +46,7 @@ internal class FakeCurrentSessionSpan : CurrentSessionSpan {
         return "testSessionId"
     }
 
-    fun getAttribute(key: String): String? = addedAttributes.find { it.key == key }?.value
+    fun getAttribute(key: String): String? = addedAttributes.lastOrNull { it.key == key }?.value
 
     fun attributeCount(): Int = addedAttributes.size
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
@@ -33,7 +33,6 @@ internal class CurrentSessionSpanAttributeTests {
 
         // assert attributes added by default
         span.assertCommonSessionSpanAttrs()
-        assertEquals("true", span.findSpanAttribute("emb.cold_start"))
     }
 
     @Test
@@ -45,7 +44,6 @@ internal class CurrentSessionSpanAttributeTests {
 
         // assert attributes added by default
         span.assertCommonSessionSpanAttrs()
-        assertEquals("false", span.findSpanAttribute("emb.cold_start"))
     }
 
     private fun EmbraceSpanData.assertCommonSessionSpanAttrs() {


### PR DESCRIPTION
## Goal

Updates the session orchestration so that session-related attributes are written to the session span. This will allow the old session object to be removed from the payload eventually. I've implemented the following in this changeset:

- `emb.cold_start`
- `emb.session_number`
- `emb.state`
- `emb.clean_exit`
- `emb.heartbeat_time_unix_nano`
- `emb.crash_id`

## Testing

Added unit test coverage & updated functional tests.

