### PR TITLE
Add gating for log and session properties in logs and crashes.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch.schema
 
+import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.opentelemetry.api.common.AttributeKey
@@ -8,6 +9,7 @@ import io.opentelemetry.api.common.AttributeKey
  * Object that aggregates various attributes and returns a [Map] that represents the values at the current state
  */
 internal class TelemetryAttributes(
+    private val configService: ConfigService,
     private val sessionProperties: EmbraceSessionProperties? = null,
     private val customAttributes: Map<String, String>? = null
 ) {
@@ -17,10 +19,25 @@ internal class TelemetryAttributes(
      * Return a snapshot of the current values of the attributes set on this as a [Map]. Schema keys will always overwrite any previous
      * entries set on the object.
      */
-    fun snapshot(): Map<String, String> =
-        (customAttributes ?: emptyMap())
-            .plus(sessionProperties?.get()?.mapKeys { it.key.toSessionPropertyAttributeName() } ?: emptyMap())
-            .plus(map.mapKeys { it.key.key })
+    fun snapshot(): Map<String, String> {
+        val shouldGateLogProperties = configService.sessionBehavior.shouldGateLogProperties()
+        val shouldGateSessionProperties = configService.sessionBehavior.shouldGateSessionProperties()
+        val result = mutableMapOf<String, String>()
+
+        if (!shouldGateLogProperties) {
+            customAttributes?.let { result.putAll(it) }
+        }
+
+        if (!shouldGateSessionProperties) {
+            sessionProperties?.get()?.let {
+                result.putAll(it.mapKeys { it.key.toSessionPropertyAttributeName() })
+            }
+        }
+
+        result.putAll(map.mapKeys { it.key.key })
+
+        return result
+    }
 
     fun setAttribute(key: EmbraceAttributeKey, value: String) {
         setAttribute(key.attributeKey, value)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.EmbType.System.ReactNativeCrash.embAndroidReactNativeCrashJsExceptions
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.arch.schema.TelemetryAttributes
-import io.embrace.android.embracesdk.gating.GatingService
+import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarker
 import io.embrace.android.embracesdk.internal.logs.LogOrchestrator
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
@@ -37,10 +37,10 @@ internal class CrashDataSourceImpl(
     private val sessionProperties: EmbraceSessionProperties,
     private val anrService: AnrService?,
     private val ndkService: NdkService,
-    @Suppress("UnusedPrivateMember") private val gatingService: GatingService,
     private val preferencesService: PreferencesService,
     private val crashMarker: CrashFileMarker,
     private val logWriter: LogWriter,
+    private val configService: ConfigService,
     logger: InternalEmbraceLogger,
 ) : CrashDataSource,
     LogDataSourceImpl(
@@ -72,6 +72,7 @@ internal class CrashDataSourceImpl(
             val crashId = ndkService.getUnityCrashId() ?: getEmbUuid()
             val crashNumber = preferencesService.incrementAndGetCrashNumber()
             val crashAttributes = TelemetryAttributes(
+                configService = configService,
                 sessionProperties = sessionProperties
             )
 
@@ -95,8 +96,6 @@ internal class CrashDataSourceImpl(
             )
 
             logWriter.addLog(logEventData)
-
-            // TODO: apply gating service logic
 
             // Attempt to send any logs that are still waiting in the sink
             logOrchestrator.flush(true)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SessionBehavior.kt
@@ -116,6 +116,18 @@ internal class SessionBehavior(
         getFullSessionEvents().contains(SessionGatingKeys.FULL_SESSION_ERROR_LOGS)
 
     /**
+     * Check if should gate Session Properties based on gating config.
+     */
+    fun shouldGateSessionProperties() =
+        shouldGateFeature(SessionGatingKeys.SESSION_PROPERTIES)
+
+    /**
+     * Check if should gate Log Properties based on gating config.
+     */
+    fun shouldGateLogProperties() =
+        shouldGateFeature(SessionGatingKeys.LOG_PROPERTIES)
+
+    /**
      * Checks whether a feature should be gated.
      * If [getSessionComponents] is null, this will return false.
      * If [getSessionComponents] is empty, this will return true.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CrashModule.kt
@@ -66,10 +66,10 @@ internal class CrashModuleImpl(
             essentialServiceModule.sessionProperties,
             anrModule.anrService,
             nativeModule.ndkService,
-            essentialServiceModule.gatingService,
             androidServicesModule.preferencesService,
             crashMarker,
             essentialServiceModule.logWriter,
+            essentialServiceModule.configService,
             initModule.logger,
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -187,6 +187,7 @@ internal class EmbraceLogService(
      */
     private fun createTelemetryAttributes(customProperties: Map<String, Any>?): TelemetryAttributes {
         val attributes = TelemetryAttributes(
+            configService = configService,
             sessionProperties = sessionProperties,
             customAttributes = customProperties?.mapValues { it.value.toString() } ?: emptyMap()
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
@@ -425,6 +425,8 @@ internal class EmbraceGatingServiceV1PayloadTest {
         assertTrue(sessionBehavior.shouldGateInfoLog())
         assertTrue(sessionBehavior.shouldGateWarnLog())
         assertTrue(sessionBehavior.shouldGateStartupMoment())
+        assertTrue(sessionBehavior.shouldGateLogProperties())
+        assertTrue(sessionBehavior.shouldGateSessionProperties())
     }
 
     private fun buildCustomRemoteConfig(components: Set<String>?, fullSessionEvents: Set<String>?) =

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.arch.destination
 import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.arch.schema.TelemetryAttributes
+import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
@@ -58,7 +59,10 @@ internal class LogWriterImplTest {
         sessionIdTracker.setActiveSessionId("session-id", true)
         val logEventData = LogEventData(
             schemaType = SchemaType.Log(
-                TelemetryAttributes(customAttributes = mapOf(PrivateSpan.toEmbraceKeyValuePair()))
+                TelemetryAttributes(
+                    configService = FakeConfigService(),
+                    customAttributes = mapOf(PrivateSpan.toEmbraceKeyValuePair())
+                )
             ),
             severity = io.embrace.android.embracesdk.Severity.ERROR,
             message = "test"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -13,11 +13,13 @@ import io.embrace.android.embracesdk.config.remote.LogRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
@@ -46,6 +48,7 @@ internal class EmbraceLogServiceTest {
     companion object {
         private lateinit var logWriter: FakeLogWriter
         private lateinit var configService: ConfigService
+        private lateinit var gatingService: GatingService
         private lateinit var sessionProperties: EmbraceSessionProperties
         private lateinit var executor: ExecutorService
         private lateinit var tick: AtomicLong
@@ -82,6 +85,7 @@ internal class EmbraceLogServiceTest {
                 cfg
             }
         )
+        gatingService = FakeGatingService(configService)
     }
 
     @Test


### PR DESCRIPTION
## Goal

- Added gating for log and session properties on crash events. 
- Added gating for log and session properties on log events. 

## Testing

Added unit tests. 


