### PR TITLE
Initial prep for sending network requests as spans

### DIFF
--- a/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
+++ b/embrace-android-sdk/src/androidTest/assets/golden-files/session-end.json
@@ -19,12 +19,6 @@
   },
   "d": "__EMBRACE_TEST_IGNORE__",
   "p": {
-    "nr": {
-      "v2": {
-        "c": {},
-        "r": []
-      }
-    },
     "ds": {
       "as": "__EMBRACE_TEST_IGNORE__",
       "fs": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -89,8 +89,7 @@ internal class EmbraceInternalInterfaceTest {
                 networkCaptureData = null
             )
 
-            recordAndDeduplicateNetworkRequest(
-                callId = "",
+            recordNetworkRequest(
                 embraceNetworkRequest = EmbraceNetworkRequest.fromCompletedRequest(
                     "",
                     HttpMethod.GET,
@@ -193,8 +192,7 @@ internal class EmbraceInternalInterfaceTest {
                     networkCaptureData = null
                 )
 
-                embrace.internalInterface.recordAndDeduplicateNetworkRequest(
-                    callId = "",
+                embrace.internalInterface.recordNetworkRequest(
                     embraceNetworkRequest = EmbraceNetworkRequest.fromCompletedRequest(
                         URL,
                         HttpMethod.POST,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -213,8 +213,7 @@ internal class NetworkRequestApiTest {
                 harness.overriddenClock.tick(5)
 
                 val callId = UUID.randomUUID().toString()
-                embrace.internalInterface.recordAndDeduplicateNetworkRequest(
-                    callId,
+                embrace.internalInterface.recordNetworkRequest(
                     EmbraceNetworkRequest.fromCompletedRequest(
                         "$URL/bad",
                         HttpMethod.GET,
@@ -225,8 +224,7 @@ internal class NetworkRequestApiTest {
                         200
                     )
                 )
-                embrace.internalInterface.recordAndDeduplicateNetworkRequest(
-                    callId,
+                embrace.internalInterface.recordNetworkRequest(
                     EmbraceNetworkRequest.fromCompletedRequest(
                         URL,
                         HttpMethod.GET,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -11,7 +11,6 @@ import androidx.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -45,7 +44,6 @@ import io.embrace.android.embracesdk.internal.IdGenerator;
 import io.embrace.android.embracesdk.internal.Systrace;
 import io.embrace.android.embracesdk.internal.clock.Clock;
 import io.embrace.android.embracesdk.internal.crash.LastRunCrashVerifier;
-import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData;
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer;
 import io.embrace.android.embracesdk.internal.utils.ThrowableUtilsKt;
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger;
@@ -717,74 +715,14 @@ final class EmbraceImpl {
     }
 
     void recordNetworkRequest(@NonNull EmbraceNetworkRequest request) {
-        if (embraceInternalInterface != null && checkSdkStartedAndLogPublicApiUsage("record_network_request")) {
-            embraceInternalInterface.recordAndDeduplicateNetworkRequest(UUID.randomUUID().toString(), request);
-        }
-    }
-
-    void recordAndDeduplicateNetworkRequest(@NonNull String callId, @NonNull EmbraceNetworkRequest request) {
         if (checkSdkStartedAndLogPublicApiUsage("record_network_request")) {
-            logNetworkRequestImpl(
-                callId,
-                request.getNetworkCaptureData(),
-                request.getUrl(),
-                request.getHttpMethod(),
-                request.getStartTime(),
-                request.getResponseCode(),
-                request.getEndTime(),
-                request.getErrorType(),
-                request.getErrorMessage(),
-                request.getTraceId(),
-                request.getW3cTraceparent(),
-                request.getBytesOut(),
-                request.getBytesIn()
-            );
+            logNetworkRequest(request);
         }
     }
 
-    private void logNetworkRequestImpl(@NonNull String callId,
-                                       @Nullable NetworkCaptureData networkCaptureData,
-                                       String url,
-                                       String httpMethod,
-                                       Long startTime,
-                                       Integer responseCode,
-                                       Long endTime,
-                                       String errorType,
-                                       String errorMessage,
-                                       String traceId,
-                                       @Nullable String w3cTraceparent,
-                                       Long bytesOut,
-                                       Long bytesIn) {
-        if (configService.getNetworkBehavior().isUrlEnabled(url)) {
-            if (errorType != null &&
-                errorMessage != null &&
-                !errorType.isEmpty() &&
-                !errorMessage.isEmpty()) {
-                networkLoggingService.logNetworkError(
-                    callId,
-                    url,
-                    httpMethod,
-                    startTime,
-                    endTime != null ? endTime : 0,
-                    errorType,
-                    errorMessage,
-                    traceId,
-                    w3cTraceparent,
-                    networkCaptureData);
-            } else {
-                networkLoggingService.logNetworkCall(
-                    callId,
-                    url,
-                    httpMethod,
-                    responseCode != null ? responseCode : 0,
-                    startTime,
-                    endTime != null ? endTime : 0,
-                    bytesOut,
-                    bytesIn,
-                    traceId,
-                    w3cTraceparent,
-                    networkCaptureData);
-            }
+    private void logNetworkRequest(@NonNull EmbraceNetworkRequest request) {
+        if (configService.getNetworkBehavior().isUrlEnabled(request.getUrl())) {
+            networkLoggingService.logNetworkRequest(request);
             onActivityReported();
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImpl.kt
@@ -167,11 +167,8 @@ internal class EmbraceInternalInterfaceImpl(
         )
     }
 
-    override fun recordAndDeduplicateNetworkRequest(
-        callId: String,
-        embraceNetworkRequest: EmbraceNetworkRequest
-    ) {
-        embraceImpl.recordAndDeduplicateNetworkRequest(callId, embraceNetworkRequest)
+    override fun recordNetworkRequest(embraceNetworkRequest: EmbraceNetworkRequest) {
+        embraceImpl.recordNetworkRequest(embraceNetworkRequest)
     }
 
     override fun shouldCaptureNetworkBody(url: String, method: String): Boolean = embraceImpl.shouldCaptureNetworkCall(url, method)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImpl.kt
@@ -62,7 +62,7 @@ internal class UninitializedSdkInternalInterfaceImpl(
     ) {
     }
 
-    override fun recordAndDeduplicateNetworkRequest(callId: String, embraceNetworkRequest: EmbraceNetworkRequest) {}
+    override fun recordNetworkRequest(embraceNetworkRequest: EmbraceNetworkRequest) {}
 
     override fun logComposeTap(point: Pair<Float, Float>, elementName: String) {}
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/EmbracePerformanceInfoService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/EmbracePerformanceInfoService.kt
@@ -30,7 +30,6 @@ internal class EmbracePerformanceInfoService(
         val info = getPerformanceInfo(sessionStart, sessionLastKnownTime, coldStart)
 
         return info.copy(
-            networkRequests = captureDataSafely(logger) { NetworkRequests(networkLoggingService.getNetworkCallsSnapshot()) },
             googleAnrTimestamps = captureDataSafely(logger) {
                 googleAnrTimestampRepository.getGoogleAnrTimestamps(
                     sessionStart,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
@@ -94,14 +94,11 @@ public interface EmbraceInternalInterface : InternalTracingApi {
     )
 
     /**
-     * Record a network request and overwrite any previously recorded request with the same callId
+     * Record a network request.
      *
-     * @param callId                the ID with which the request will be identified internally. The session will only contain one recorded
-     *                              request with a given ID - last writer wins.
      * @param embraceNetworkRequest the request to be recorded
      */
-    public fun recordAndDeduplicateNetworkRequest(
-        callId: String,
+    public fun recordNetworkRequest(
         embraceNetworkRequest: EmbraceNetworkRequest
     )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
@@ -573,8 +573,7 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
                 long contentLength = Math.max(0, responseSize.get());
 
                 if (inputStreamAccessException == null && lastConnectionAccessException == null && responseCode.get() != 0) {
-                    embrace.getInternalInterface().recordAndDeduplicateNetworkRequest(
-                        callId,
+                    embrace.recordNetworkRequest(
                         EmbraceNetworkRequest.fromCompletedRequest(
                             url,
                             HttpMethod.fromString(getRequestMethod()),
@@ -604,8 +603,7 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
                     String errorType = exceptionClass != null ? exceptionClass : "UnknownState";
                     String errorMessage = exceptionMessage != null ? exceptionMessage : "HTTP response state unknown";
 
-                    embrace.getInternalInterface().recordAndDeduplicateNetworkRequest(
-                        callId,
+                    embrace.recordNetworkRequest(
                         EmbraceNetworkRequest.fromIncompleteRequest(
                             url,
                             HttpMethod.fromString(getRequestMethod()),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.CacheableValue
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.logging.EmbraceNetworkCaptureService.Companion.NETWORK_ERROR_CODE
 import io.embrace.android.embracesdk.payload.NetworkCallV2
 import io.embrace.android.embracesdk.payload.NetworkSessionV2
@@ -52,7 +53,7 @@ internal class EmbraceNetworkLoggingService(
 
     private var domainSuffixCallLimits = configService.networkBehavior.getNetworkCallLimitsPerDomainSuffix()
 
-    override fun getNetworkCallsSnapshot(): NetworkSessionV2 {
+    fun getNetworkCallsSnapshot(): NetworkSessionV2 {
         var storedCallsSize: Int? = null
         var cachedCallsSize: Int? = null
 
@@ -82,7 +83,7 @@ internal class EmbraceNetworkLoggingService(
         }
     }
 
-    override fun logNetworkCall(
+    fun logNetworkCall(
         callId: String,
         url: String,
         httpMethod: String,
@@ -125,7 +126,7 @@ internal class EmbraceNetworkLoggingService(
         processNetworkCall(callId, networkCall)
     }
 
-    override fun logNetworkError(
+    fun logNetworkError(
         callId: String,
         url: String,
         httpMethod: String,
@@ -254,5 +255,9 @@ internal class EmbraceNetworkLoggingService(
             callsStorageLastUpdate.set(0)
             sessionNetworkCalls.clear()
         }
+    }
+
+    override fun logNetworkRequest(networkRequest: EmbraceNetworkRequest) {
+        // TODO("Not yet implemented")
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkLoggingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkLoggingService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.network.logging
 
-import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
-import io.embrace.android.embracesdk.payload.NetworkSessionV2
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 
 /**
  * Logs network calls made by the application. The Embrace SDK intercepts the calls and reports
@@ -10,66 +9,10 @@ import io.embrace.android.embracesdk.payload.NetworkSessionV2
 internal interface NetworkLoggingService {
 
     /**
-     * Get the calls and counts of network calls (which exceed the limit) that haven't been associated with a session or background activity
+     * Logs a network request.
+     * This network request is considered unique and finished, meaning that we will not receive additional data for it.
      *
-     * @return the network calls for the given session
+     * @param networkRequest the network request to log
      */
-    fun getNetworkCallsSnapshot(): NetworkSessionV2
-
-    /**
-     * Logs a HTTP network call.
-     *
-     * @param callId             the unique ID of the call used for deduplication purposes
-     * @param url                the URL being called
-     * @param httpMethod         the HTTP method
-     * @param statusCode         the status code from the response
-     * @param startTime          the start time of the request
-     * @param endTime            the end time of the request
-     * @param bytesSent          the number of bytes sent
-     * @param bytesReceived      the number of bytes received
-     * @param traceId            optional trace ID that can be used to trace a particular request
-     * @param w3cTraceparent     optional W3C-compliant traceparent representing the network call that is being recorded
-     * @param networkCaptureData the additional data captured if network body capture is enabled for the URL
-     */
-    @Suppress("LongParameterList")
-    fun logNetworkCall(
-        callId: String,
-        url: String,
-        httpMethod: String,
-        statusCode: Int,
-        startTime: Long,
-        endTime: Long,
-        bytesSent: Long,
-        bytesReceived: Long,
-        traceId: String?,
-        w3cTraceparent: String?,
-        networkCaptureData: NetworkCaptureData?
-    )
-
-    /**
-     * Logs an exception which occurred when attempting to make a network call.
-     *
-     * @param callId             the unique ID of the call used for deduplication purposes
-     * @param url                the URL being called
-     * @param httpMethod         the HTTP method
-     * @param startTime          the start time of the request
-     * @param endTime            the end time of the request
-     * @param errorType          the type of error being thrown
-     * @param errorMessage       the error message
-     * @param traceId            optional trace ID that can be used to trace a particular request
-     * @param w3cTraceparent     optional W3C-compliant traceparent representing the network call that is being recorded
-     * @param networkCaptureData the additional data captured if network body capture is enabled for the URL
-     */
-    fun logNetworkError(
-        callId: String,
-        url: String,
-        httpMethod: String,
-        startTime: Long,
-        endTime: Long,
-        errorType: String?,
-        errorMessage: String?,
-        traceId: String?,
-        w3cTraceparent: String?,
-        networkCaptureData: NetworkCaptureData?
-    )
+    fun logNetworkRequest(networkRequest: EmbraceNetworkRequest)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceInternalInterfaceImplTest.kt
@@ -190,7 +190,6 @@ internal class EmbraceInternalInterfaceImplTest {
     @Test
     fun testRecordAndDeduplicateNetworkRequest() {
         val url = "https://embrace.io"
-        val callId = "testID"
         val captor = slot<EmbraceNetworkRequest>()
         val networkRequest: EmbraceNetworkRequest = EmbraceNetworkRequest.fromCompletedRequest(
             url,
@@ -202,9 +201,9 @@ internal class EmbraceInternalInterfaceImplTest {
             200
         )
 
-        internalImpl.recordAndDeduplicateNetworkRequest(callId, networkRequest)
+        internalImpl.recordNetworkRequest(networkRequest)
         verify(exactly = 1) {
-            embraceImpl.recordAndDeduplicateNetworkRequest(callId, capture(captor))
+            embraceImpl.recordNetworkRequest(capture(captor))
         }
 
         assertEquals(url, captor.captured.url)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
@@ -69,7 +69,6 @@ internal class EmbracePerformanceInfoServiceTest {
     }
 
     private fun assertBasicSessionPerfInfoIncluded(info: PerformanceInfo) {
-        assertValueCopied(NetworkRequests(networkLoggingService.data), info.networkRequests)
         assertValueCopied(
             googleAnrTimestampRepository.getGoogleAnrTimestamps(0, SESSION_END_TIME_MS),
             info.googleAnrTimestamps

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UninitializedSdkInternalInterfaceImplTest.kt
@@ -57,7 +57,7 @@ internal class UninitializedSdkInternalInterfaceImplTest {
             2509L,
             200
         )
-        impl.recordAndDeduplicateNetworkRequest("testID", request)
+        impl.recordNetworkRequest(request)
         impl.recordIncompleteNetworkRequest(
             "https://google.com",
             "get",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
@@ -1,44 +1,13 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.logging.NetworkLoggingService
 import io.embrace.android.embracesdk.payload.NetworkSessionV2
 
 internal class FakeNetworkLoggingService : NetworkLoggingService {
-
-    var data: NetworkSessionV2 = NetworkSessionV2(emptyList(), emptyMap())
-
-    override fun getNetworkCallsSnapshot(): NetworkSessionV2 =
-        data
-
-    override fun logNetworkCall(
-        callId: String,
-        url: String,
-        httpMethod: String,
-        statusCode: Int,
-        startTime: Long,
-        endTime: Long,
-        bytesSent: Long,
-        bytesReceived: Long,
-        traceId: String?,
-        w3cTraceparent: String?,
-        networkCaptureData: NetworkCaptureData?
-    ) {
+    override fun logNetworkRequest(networkRequest: EmbraceNetworkRequest) {
         TODO("Not yet implemented")
     }
 
-    override fun logNetworkError(
-        callId: String,
-        url: String,
-        httpMethod: String,
-        startTime: Long,
-        endTime: Long,
-        errorType: String?,
-        errorMessage: String?,
-        traceId: String?,
-        w3cTraceparent: String?,
-        networkCaptureData: NetworkCaptureData?
-    ) {
-        TODO("Not yet implemented")
-    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
@@ -57,7 +57,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         mockInternalInterface = mockk(relaxed = true)
         every { mockInternalInterface.shouldCaptureNetworkBody(any(), any()) } answers { shouldCaptureNetworkBody }
         every {
-            mockInternalInterface.recordAndDeduplicateNetworkRequest(capture(capturedCallId), capture(capturedEmbraceNetworkRequest))
+            mockInternalInterface.recordNetworkRequest(capture(capturedEmbraceNetworkRequest))
         } answers { }
         every { mockInternalInterface.isNetworkSpanForwardingEnabled() } answers { isNetworkSpanForwardingEnabled }
         every { mockInternalInterface.getSdkCurrentTime() } answers { fakeTimeMs }
@@ -280,7 +280,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             connection = createMockGzipConnection(),
             wrappedIoStream = true
         )
-        verify(exactly = 0) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 0) { mockInternalInterface.recordNetworkRequest(any()) }
     }
 
     @Test
@@ -291,7 +291,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        verify(exactly = 0) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 0) { mockInternalInterface.recordNetworkRequest(any()) }
     }
 
     @Test
@@ -309,7 +309,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             connection = createMockUncompressedConnection(),
             wrappedIoStream = false
         )
-        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
         assertTrue(capturedCallId[0].isNotBlank())
     }
 
@@ -320,7 +320,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
     }
 
     @Test
@@ -328,7 +328,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         val mockConnection = createMockUncompressedConnection()
         EmbraceUrlConnectionDelegate(mockConnection, true, mockEmbrace).disconnect()
         verifyIncompleteRequestLogged(mockConnection)
-        verify(exactly = 1) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
         assertEquals(1, capturedCallId.size)
     }
 
@@ -611,7 +611,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     }
 
     private fun verifyTwoCallsRecordedWithSameCallId() {
-        verify(exactly = 2) { mockInternalInterface.recordAndDeduplicateNetworkRequest(any(), any()) }
+        verify(exactly = 2) { mockInternalInterface.recordNetworkRequest(any()) }
         assertEquals(2, capturedCallId.size)
         assertEquals(capturedCallId[0], capturedCallId[1])
     }


### PR DESCRIPTION
## Goal

This is the initial PR for sending network requests as spans. 

- Removed recordAndDeduplicateNetworkRequest. 

This was used in HttpURLConnectionDelegate to avoid logging network requests with the same call ID. It is still required, but we will address it differently in the following PRs. For now, we will use the same method as the rest of the requests.

- logNetworkError and logNetworkCall did essentially the same. We will move that logic to the logging service so we don't bloat EmbraceImpl

- getNetworkCallsSnapshot won't be used anymore, as we will record spans directly when they get to the logging service. We won't need to expose them when the session ends.

- Stop looking for network logs in PerformanceInfo. Removed "nr" from session-end.json. We won't be sending network requests there anymore.

- Updated tests to use the new APIs



