### PR TITLE
Record logged network requests as completed spans

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -61,7 +61,8 @@ internal class CustomerLogModuleImpl(
         EmbraceNetworkLoggingService(
             essentialServiceModule.configService,
             initModule.logger,
-            networkCaptureService
+            networkCaptureService,
+            openTelemetryModule.spanService
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/NetworkUtils.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/NetworkUtils.kt
@@ -74,11 +74,7 @@ internal object NetworkUtils {
      * @return the URL with the hash fragment and query string parameters removed
      */
     @JvmStatic
-    fun stripUrl(url: String?): String? {
-        if (url == null) {
-            return null
-        }
-
+    fun stripUrl(url: String): String {
         val pathPos: Int = url.lastIndexOf('/')
         val suffix: String = if (pathPos < 0) url else url.substring(pathPos)
 
@@ -94,5 +90,12 @@ internal object NetworkUtils {
             0,
             (if (pathPos < 0) 0 else pathPos) + suffix.length.coerceAtMost(terminalPos)
         )
+    }
+
+    @JvmStatic
+    fun getUrlPath(url: String?): String? = try {
+        URL(url).path
+    } catch (exception: Exception) {
+        ""
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/NetworkUtilsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/NetworkUtilsTest.kt
@@ -140,7 +140,7 @@ internal class NetworkUtilsTest {
 
     @Test
     fun stripUrl() {
-        assertNull(stripUrl(null))
+        assertEquals("", stripUrl(""))
 
         for (pairs in urlsToStrip) {
             val url = pairs[0]


### PR DESCRIPTION
- Record network requests as spans.

- Consolidate logNetworkCall and logNetworkError methods

EmbraceNetworkLoggingService had two methods: logNetworkCall and logNetworkError. They were both doing essentially the same, but with a different NetworkCallV2 object: strip the URL, sanitize the TraceId, logging the networkCapturedData, and processing the network call.

We don't need a NetworkCallV2 object anymore, and the EmbraceNetworkRequest is the same for both network call and network error, so we can just use one method.

- Remove unused methods.

### Questions:
- Why do we need to strip the URL? 
- Why are we stripping the URL for the span, but not for the networkCapturedData?

