### PR TITLE
Moved the logic for counting domain limits to a new class

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CustomerLogModule.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.network.logging.EmbraceNetworkLoggingServic
 import io.embrace.android.embracesdk.network.logging.NetworkCaptureDataSource
 import io.embrace.android.embracesdk.network.logging.NetworkCaptureDataSourceImpl
 import io.embrace.android.embracesdk.network.logging.NetworkCaptureService
+import io.embrace.android.embracesdk.network.logging.NetworkLoggingDomainCountLimiter
 import io.embrace.android.embracesdk.network.logging.NetworkLoggingService
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
@@ -57,10 +58,16 @@ internal class CustomerLogModuleImpl(
         )
     }
 
+    private val networkLoggingDomainCountLimiter: NetworkLoggingDomainCountLimiter by singleton {
+        NetworkLoggingDomainCountLimiter(
+            essentialServiceModule.configService,
+            initModule.logger
+        )
+    }
+
     override val networkLoggingService: NetworkLoggingService by singleton {
         EmbraceNetworkLoggingService(
-            essentialServiceModule.configService,
-            initModule.logger,
+            networkLoggingDomainCountLimiter,
             networkCaptureService,
             openTelemetryModule.spanService
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
@@ -2,19 +2,12 @@ package io.embrace.android.embracesdk.network.logging
 
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.SchemaType
-import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.spans.SpanService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.logging.EmbraceNetworkCaptureService.Companion.NETWORK_ERROR_CODE
-import io.embrace.android.embracesdk.payload.NetworkSessionV2.DomainCount
-import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.utils.NetworkUtils.getDomain
 import io.embrace.android.embracesdk.utils.NetworkUtils.getUrlPath
-import io.embrace.android.embracesdk.utils.NetworkUtils.isIpAddress
 import io.embrace.android.embracesdk.utils.NetworkUtils.stripUrl
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Logs network calls according to defined limits per domain.
@@ -25,29 +18,14 @@ import java.util.concurrent.atomic.AtomicInteger
  * and the number of calls is also captured if the limit is exceeded.
  */
 internal class EmbraceNetworkLoggingService(
-    private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger,
+    private val networkLoggingDomainCountLimiter: NetworkLoggingDomainCountLimiter,
     private val networkCaptureService: NetworkCaptureService,
     private val spanService: SpanService
-) : NetworkLoggingService, MemoryCleanerListener {
-
-    private val callsStorageLastUpdate = AtomicInteger(0)
-
-    private val domainSetting = ConcurrentHashMap<String, DomainSettings>()
-
-    private val callsPerDomainSuffix = hashMapOf<String, DomainCount>()
-
-    private val ipAddressNetworkCallCount = AtomicInteger(0)
-
-    private val untrackedNetworkCallCount = AtomicInteger(0)
-
-    private var defaultPerDomainSuffixCallLimit = configService.networkBehavior.getNetworkCaptureLimit()
-
-    private var domainSuffixCallLimits = configService.networkBehavior.getNetworkCallLimitsPerDomainSuffix()
+) : NetworkLoggingService {
 
     override fun logNetworkRequest(networkRequest: EmbraceNetworkRequest) {
         logNetworkCaptureData(networkRequest)
-        processNetworkRequest(networkRequest)
+        recordNetworkRequest(networkRequest)
     }
 
     private fun logNetworkCaptureData(networkRequest: EmbraceNetworkRequest) {
@@ -65,103 +43,33 @@ internal class EmbraceNetworkLoggingService(
     }
 
     /**
-     * Process network calls to assert that no limits are exceeded.
+     * Records network calls as spans if their domain can be parsed and is within the limits.
      *
-     * @param networkRequest the network request to process
+     * @param networkRequest the network request to record
      */
-    private fun processNetworkRequest(networkRequest: EmbraceNetworkRequest) {
+    private fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest) {
+        // TODO: Shouldn't we ignore domains that can't be parsed for networkCapturedData too?
+        // Shouldn't we also track limits for networkCapturedData?
+
         // Get the domain, if it can be successfully parsed. If not, don't log this call.
         val domain = getDomain(
             stripUrl(networkRequest.url)
         ) ?: return
 
-        synchronized(callsStorageLastUpdate) {
-            if (isIpAddress(domain)) {
-                if (ipAddressNetworkCallCount.getAndIncrement() < defaultPerDomainSuffixCallLimit) {
-                    storeNetworkRequest(networkRequest)
-                }
-                return
-            } else if (!domainSetting.containsKey(domain)) {
-                createLimitForDomain(domain)
-            }
+        if (networkLoggingDomainCountLimiter.canLogNetworkRequest(domain)) {
+            val strippedUrl = stripUrl(networkRequest.url)
 
-            val settings = domainSetting[domain]
-            if (settings == null) {
-                // Not sure how this is possible, but in case it is, limit logged logs where we can't figure out the settings to apply
-                if (untrackedNetworkCallCount.getAndIncrement() < defaultPerDomainSuffixCallLimit) {
-                    storeNetworkRequest(networkRequest)
-                }
-                return
-            } else {
-                val suffix = settings.suffix
-                val limit = settings.limit
-                var countPerSuffix = callsPerDomainSuffix[suffix]
-
-                if (countPerSuffix == null) {
-                    countPerSuffix = DomainCount(0, limit)
-                }
-
-                // Exclude if the network call exceeds the limit
-                if (countPerSuffix.requestCount < limit) {
-                    storeNetworkRequest(networkRequest)
-                }
-
-                // Track the number of calls for each domain (or configured suffix)
-                suffix?.let {
-                    callsPerDomainSuffix[it] = DomainCount(countPerSuffix.requestCount + 1, limit)
-                }
-            }
+            val networkRequestSchemaType = SchemaType.NetworkRequest(networkRequest)
+            spanService.recordCompletedSpan(
+                name = "${networkRequest.httpMethod} ${getUrlPath(strippedUrl)}",
+                startTimeMs = networkRequest.startTime,
+                endTimeMs = networkRequest.endTime,
+                errorCode = null,
+                parent = null,
+                attributes = networkRequestSchemaType.attributes(),
+                type = EmbType.Performance.Network,
+            )
         }
     }
 
-    private fun createLimitForDomain(domain: String) {
-        try {
-            for ((key, value) in domainSuffixCallLimits) {
-                if (domain.endsWith(key)) {
-                    domainSetting[domain] = DomainSettings(value, key)
-                }
-            }
-
-            if (!domainSetting.containsKey(domain)) {
-                domainSetting[domain] = DomainSettings(defaultPerDomainSuffixCallLimit, domain)
-            }
-        } catch (ex: Exception) {
-            logger.logDebug("Failed to determine limits for domain: $domain", ex)
-        }
-    }
-
-    private fun storeNetworkRequest(networkRequest: EmbraceNetworkRequest) {
-        callsStorageLastUpdate.incrementAndGet()
-
-        //TODO: Why do we want to strip the URL?
-        val strippedUrl = stripUrl(networkRequest.url)
-
-        val networkRequestSchemaType = SchemaType.NetworkRequest(networkRequest)
-        spanService.recordCompletedSpan(
-            name = "${networkRequest.httpMethod} ${getUrlPath(strippedUrl)}",
-            startTimeMs = networkRequest.startTime,
-            endTimeMs = networkRequest.endTime,
-            errorCode = null,
-            parent = null,
-            attributes = networkRequestSchemaType.attributes(),
-            type = EmbType.Performance.Network,
-        )
-    }
-
-    override fun cleanCollections() {
-        clearNetworkCalls()
-        // re-fetch limits in case they changed since they last time they were fetched
-        defaultPerDomainSuffixCallLimit = configService.networkBehavior.getNetworkCaptureLimit()
-        domainSuffixCallLimits = configService.networkBehavior.getNetworkCallLimitsPerDomainSuffix()
-    }
-
-    private fun clearNetworkCalls() {
-        synchronized(callsStorageLastUpdate) {
-            domainSetting.clear()
-            callsPerDomainSuffix.clear()
-            ipAddressNetworkCallCount.set(0)
-            untrackedNetworkCallCount.set(0)
-            callsStorageLastUpdate.set(0)
-        }
-    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkLoggingDomainCountLimiter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkLoggingDomainCountLimiter.kt
@@ -1,0 +1,89 @@
+package io.embrace.android.embracesdk.network.logging
+
+import io.embrace.android.embracesdk.config.ConfigService
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.payload.NetworkSessionV2
+import io.embrace.android.embracesdk.session.MemoryCleanerListener
+import io.embrace.android.embracesdk.utils.NetworkUtils
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class NetworkLoggingDomainCountLimiter(
+    private val configService: ConfigService,
+    private val logger: InternalEmbraceLogger,
+) : MemoryCleanerListener {
+
+    private val domainSetting = ConcurrentHashMap<String, DomainSettings>()
+    private val callsPerDomainSuffix = hashMapOf<String, NetworkSessionV2.DomainCount>()
+    private val ipAddressNetworkCallCount = AtomicInteger(0)
+    private val untrackedNetworkCallCount = AtomicInteger(0)
+    private var defaultPerDomainSuffixCallLimit = configService.networkBehavior.getNetworkCaptureLimit()
+    private var domainSuffixCallLimits = configService.networkBehavior.getNetworkCallLimitsPerDomainSuffix()
+
+    fun canLogNetworkRequest(domain: String): Boolean {
+        // TODO: Should we synchronize on another object now that we don't use callsStorageLastUpdate?
+        if (NetworkUtils.isIpAddress(domain)) {
+            // TODO: All of the IP address domains fall under the same limit? Is that correct?
+            return ipAddressNetworkCallCount.getAndIncrement() < defaultPerDomainSuffixCallLimit
+        }
+
+        if (!domainSetting.containsKey(domain))
+            createLimitForDomain(domain)
+
+        val settings = domainSetting[domain]
+        if (settings == null) {
+            // Not sure how this is possible, but in case it is, limit logged logs where we can't figure out the settings to apply
+            return untrackedNetworkCallCount.getAndIncrement() < defaultPerDomainSuffixCallLimit
+        } else {
+            val suffix = settings.suffix
+            val limit = settings.limit
+            var countPerSuffix = callsPerDomainSuffix[suffix]
+
+            if (countPerSuffix == null) {
+                countPerSuffix = NetworkSessionV2.DomainCount(0, limit)
+            }
+
+            // Exclude if the network call exceeds the limit
+            if (countPerSuffix.requestCount < limit) {
+                return true
+            }
+
+            // Track the number of calls for each domain (or configured suffix)
+            suffix?.let {
+                callsPerDomainSuffix[it] = NetworkSessionV2.DomainCount(countPerSuffix.requestCount + 1, limit)
+            }
+        }
+        return false
+    }
+
+    private fun createLimitForDomain(domain: String) {
+        try {
+            for ((key, value) in domainSuffixCallLimits) {
+                if (domain.endsWith(key)) {
+                    domainSetting[domain] = DomainSettings(value, key)
+                }
+            }
+
+            if (!domainSetting.containsKey(domain)) {
+                domainSetting[domain] = DomainSettings(defaultPerDomainSuffixCallLimit, domain)
+            }
+        } catch (ex: Exception) {
+            logger.logDebug("Failed to determine limits for domain: $domain", ex)
+        }
+    }
+
+    override fun cleanCollections() {
+        clearNetworkCalls()
+        // re-fetch limits in case they changed since they last time they were fetched
+        defaultPerDomainSuffixCallLimit = configService.networkBehavior.getNetworkCaptureLimit()
+        domainSuffixCallLimits = configService.networkBehavior.getNetworkCallLimitsPerDomainSuffix()
+    }
+
+    private fun clearNetworkCalls() {
+        domainSetting.clear()
+        callsPerDomainSuffix.clear()
+        ipAddressNetworkCallCount.set(0)
+        untrackedNetworkCallCount.set(0)
+    }
+
+}


### PR DESCRIPTION
## Goal

Extracted the logic for counting domain limits to another class. This will allow us to test it more thoroughly in the future, as we detected some inconsistencies. It also keeps the NetworkLogging service cleaner. 

### Questions: 
- Shouldn't we ignore domains that can't be parsed for networkCapturedData too?
- Shouldn't we also track limits for networkCapturedData?
- Should we synchronize on another object now that we don't use callsStorageLastUpdate?
- All of the IP address domains fall under the same limit? Is that correct?