### PR TITLE
Delete useless methods and related tests and move the check for native crash method out

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -102,14 +102,6 @@ internal class EmbraceNdkService(
         }
     }
 
-    override fun testCrash(isCpp: Boolean) {
-        if (isCpp) {
-            testCrashCpp()
-        } else {
-            testCrashC()
-        }
-    }
-
     override fun updateSessionId(newSessionId: String) {
         if (isInstalled) {
             delegate._updateSessionId(newSessionId)
@@ -564,14 +556,6 @@ internal class EmbraceNdkService(
     @Suppress("UnusedPrivateMember")
     private fun uninstallSignals() {
         delegate._uninstallSignals()
-    }
-
-    private fun testCrashC() {
-        delegate._testNativeCrash_C()
-    }
-
-    private fun testCrashCpp() {
-        delegate._testNativeCrash_CPP()
     }
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashService.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.ndk
+
+import io.embrace.android.embracesdk.payload.NativeCrashData
+
+internal interface NativeCrashService {
+    fun checkForNativeCrash(): NativeCrashData?
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NdkService.kt
@@ -1,16 +1,10 @@
 package io.embrace.android.embracesdk.ndk
 
-import io.embrace.android.embracesdk.payload.NativeCrashData
-
-internal interface NdkService {
+internal interface NdkService : NativeCrashService {
     fun updateSessionId(newSessionId: String)
     fun onSessionPropertiesUpdate(properties: Map<String, String>)
     fun onUserInfoUpdate()
     fun getUnityCrashId(): String?
-
-    // TODO: remove this. Only for testing purposes.
-    fun testCrash(isCpp: Boolean)
-    fun checkForNativeCrash(): NativeCrashData?
 
     /**
      * Retrieves symbol information for the current architecture.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
@@ -27,10 +27,6 @@ internal class FakeNdkService : NdkService {
         return lastUnityCrashId
     }
 
-    override fun testCrash(isCpp: Boolean) {
-        TODO("Not yet implemented")
-    }
-
     override fun checkForNativeCrash(): NativeCrashData? {
         checkForNativeCrashCount++
         return null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -354,22 +354,6 @@ internal class EmbraceNdkServiceTest {
     }
 
     @Test
-    fun `test testCrash where isCpp is true`() {
-        initializeService()
-        embraceNdkService.testCrash(true)
-        verify { delegate._testNativeCrash_CPP() }
-        verify(exactly = 0) { delegate._testNativeCrash_C() }
-    }
-
-    @Test
-    fun `test testCrash where isCpp is false`() {
-        initializeService()
-        embraceNdkService.testCrash(false)
-        verify { delegate._testNativeCrash_C() }
-        verify(exactly = 0) { delegate._testNativeCrash_CPP() }
-    }
-
-    @Test
     fun `test onUserInfoUpdate where _updateMetaData was not executed and isInstalled false`() {
         enableNdk(false)
         initializeService()


### PR DESCRIPTION
## Goal

Remove methods that are invoked only in tests that seem to... only invoke test methods in the NDK? These don't seem like they are testing anything really.

The real change is to create a new interface for picking up and sending native crashes, but with the test method deletion, I thought I'd pull this out to its own review.