### PR TITLE
Wait for logs to appear in integration test

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -1,16 +1,18 @@
 package io.embrace.android.embracesdk
 
 import android.app.Activity
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.robolectric.Robolectric
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import org.junit.Assert.assertNotNull
 
 /*** Extension functions that are syntactic sugar for retrieving information from the SDK. ***/
 
@@ -26,6 +28,19 @@ internal fun IntegrationTestRule.Harness.getSentLogMessages(expectedSize: Int? =
         null -> logs
         else -> returnIfConditionMet({ logs }) {
             logs.size == expectedSize
+        }
+    }
+}
+
+/**
+ * Wait for there to at least be [minSize] number of log envelopes to be sent and return all the ones sent. Times out at 1 second.
+ */
+internal fun IntegrationTestRule.Harness.getSentLogPayloads(minSize: Int? = null): List<Envelope<LogPayload>> {
+    val logs = overriddenDeliveryModule.deliveryService.lastSentLogPayloads
+    return when (minSize) {
+        null -> logs
+        else -> returnIfConditionMet({ logs }) {
+            logs.size >= minSize
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AeiFeatureTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.findLogAttribute
+import io.embrace.android.embracesdk.getSentLogPayloads
 import io.embrace.android.embracesdk.recordSession
 import io.mockk.every
 import io.mockk.mockk
@@ -38,8 +39,7 @@ internal class AeiFeatureTest {
             testRule.startSdk(context = ApplicationProvider.getApplicationContext())
             harness.recordSession()
 
-            val deliveryService = harness.overriddenDeliveryModule.deliveryService
-            val payload = deliveryService.lastSentLogPayloads.single()
+            val payload = harness.getSentLogPayloads(1).single()
             val log = checkNotNull(payload.data.logs?.single())
 
             // assert AEI fields populated


### PR DESCRIPTION
## Goal

Since logs are sent in the background now, integration tests should wait for them to be sent to to the DeliveryService before validating. Otherwise, flakiness.

