### PR TITLE
Modify interfaces of services and modules that touches the native crash workflow

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -337,7 +337,7 @@ final class EmbraceImpl {
         Systrace.startSynchronous("send-cached-sessions");
         // Send any sessions that were cached and not yet sent.
         deliveryModule.getDeliveryService().sendCachedSessions(
-            nativeModule.getNdkService(),
+            nativeModule::getNdkService,
             essentialServiceModule.getSessionIdTracker()
         );
         Systrace.endSynchronous();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/DeliveryService.kt
@@ -2,7 +2,8 @@ package io.embrace.android.embracesdk.comms.delivery
 
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.ndk.NdkService
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.ndk.NativeCrashService
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -11,7 +12,10 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal interface DeliveryService {
     fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType)
-    fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker)
+    fun sendCachedSessions(
+        nativeCrashServiceProvider: Provider<NativeCrashService?>,
+        sessionIdTracker: SessionIdTracker
+    )
     fun sendLog(eventMessage: EventMessage)
     fun sendLogs(logEnvelope: Envelope<LogPayload>)
     fun saveLogs(logEnvelope: Envelope<LogPayload>)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -290,7 +290,11 @@ internal class EmbraceNdkService(
      *
      * @return Crash data, if a native crash file was found
      */
-    override fun checkForNativeCrash(): NativeCrashData? {
+    override fun getAndSendNativeCrash(): NativeCrashData? {
+        return getNativeCrash()?.apply { sendNativeCrash(this) }
+    }
+
+    override fun getNativeCrash(): NativeCrashData? {
         var nativeCrash: NativeCrashData? = null
         val matchingFiles = repository.sortNativeCrashes(false)
         for (crashFile in matchingFiles) {
@@ -322,7 +326,6 @@ internal class EmbraceNdkService(
                     } else {
                         nativeCrash.symbols = symbols.toMap()
                     }
-                    sendNativeCrash(nativeCrash)
                 }
                 repository.deleteFiles(crashFile, errorFile, mapFile, nativeCrash)
             } catch (ex: Exception) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashService.kt
@@ -3,5 +3,5 @@ package io.embrace.android.embracesdk.ndk
 import io.embrace.android.embracesdk.payload.NativeCrashData
 
 internal interface NativeCrashService {
-    fun checkForNativeCrash(): NativeCrashData?
+    fun getAndSendNativeCrash(): NativeCrashData?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NdkService.kt
@@ -1,10 +1,20 @@
 package io.embrace.android.embracesdk.ndk
 
+import io.embrace.android.embracesdk.payload.NativeCrashData
+
 internal interface NdkService : NativeCrashService {
     fun updateSessionId(newSessionId: String)
+
     fun onSessionPropertiesUpdate(properties: Map<String, String>)
+
     fun onUserInfoUpdate()
+
     fun getUnityCrashId(): String?
+
+    /**
+     * Get and delete the stored [NativeCrashData] from a previous instance of the app that ended in a native crash if it exists
+     */
+    fun getNativeCrash(): NativeCrashData?
 
     /**
      * Retrieves symbol information for the current architecture.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -3,7 +3,8 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.ndk.NdkService
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.ndk.NativeCrashService
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -42,7 +43,10 @@ internal open class FakeDeliveryService : DeliveryService {
         lastSnapshotType = snapshotType
     }
 
-    override fun sendCachedSessions(ndkService: NdkService?, sessionIdTracker: SessionIdTracker) {
+    override fun sendCachedSessions(
+        nativeCrashServiceProvider: Provider<NativeCrashService?>,
+        sessionIdTracker: SessionIdTracker
+    ) {
         lastSentCachedSession = sessionIdTracker.getActiveSessionId()
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeNdkService.kt
@@ -27,7 +27,9 @@ internal class FakeNdkService : NdkService {
         return lastUnityCrashId
     }
 
-    override fun checkForNativeCrash(): NativeCrashData? {
+    override fun getNativeCrash(): NativeCrashData? = null
+
+    override fun getAndSendNativeCrash(): NativeCrashData? {
         checkForNativeCrashCount++
         return null
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.ndk.NativeCrashService
+import io.embrace.android.embracesdk.payload.NativeCrashData
+
+internal class FakeNativeCrashService : NativeCrashService {
+
+    var checkAndSendNativeCrashInvocation = 0
+
+    override fun getAndSendNativeCrash(): NativeCrashData? {
+        checkAndSendNativeCrashInvocation++
+        return null
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -400,7 +400,7 @@ internal class EmbraceNdkServiceTest {
     fun `test checkForNativeCrash does nothing if there are no matchingFiles`() {
         every { repository.sortNativeCrashes(false) } returns listOf()
         initializeService()
-        val result = embraceNdkService.checkForNativeCrash()
+        val result = embraceNdkService.getAndSendNativeCrash()
         assertNull(result)
         verify { repository.sortNativeCrashes(false) }
         verify(exactly = 0) { delegate._getCrashReport(any()) }
@@ -455,7 +455,7 @@ internal class EmbraceNdkServiceTest {
         every { repository.sortNativeCrashes(false) } returns listOf(crashFile)
         every { delegate._getCrashReport(any()) } returns ""
         initializeService()
-        val crashData = embraceNdkService.checkForNativeCrash()
+        val crashData = embraceNdkService.getAndSendNativeCrash()
         assertNull(crashData)
     }
 
@@ -475,7 +475,7 @@ internal class EmbraceNdkServiceTest {
         every { delegate._getCrashReport(any()) } returns json
 
         initializeService()
-        val crashData = embraceNdkService.checkForNativeCrash()
+        val crashData = embraceNdkService.getAndSendNativeCrash()
         assertNull(crashData)
     }
 
@@ -498,7 +498,7 @@ internal class EmbraceNdkServiceTest {
         initializeService()
         every { embraceNdkService.getSymbolsForCurrentArch() } returns mockk()
 
-        val result = embraceNdkService.checkForNativeCrash()
+        val result = embraceNdkService.getAndSendNativeCrash()
         assertNotNull(result)
 
         verify { embraceNdkService["getNativeCrashErrors"](any() as NativeCrashData, errorFile) }
@@ -515,7 +515,7 @@ internal class EmbraceNdkServiceTest {
         appFramework = Embrace.AppFramework.UNITY
         initializeService()
 
-        val result = embraceNdkService.checkForNativeCrash()
+        val result = embraceNdkService.getAndSendNativeCrash()
         assertNull(result)
 
         verify(exactly = 1) { repository.sortNativeCrashes(false) }


### PR DESCRIPTION
## Goal

Prep the SDK to receive an alternative implementation of native crash handling. Split out native crash interface from uber NDK interface and provide that narrow interface to when we handle sending native crashes.

## Testing

Add tests and fakes to make testing this stuff easier

