### PR TITLE
Allow schema attributes to overwrite common attributes set by LogWriterImpl

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -28,16 +28,16 @@ internal class LogWriterImpl(
             .setSeverity(logEventData.severity.toOtelSeverity())
             .setSeverityText(logEventData.severity.name)
 
-        logEventData.schemaType.attributes().forEach {
-            builder.setAttribute(AttributeKey.stringKey(it.key), it.value)
-        }
-
         sessionIdTracker.getActiveSessionId()?.let { sessionId ->
             builder.setAttribute(embSessionId.attributeKey, sessionId)
         }
 
         metadataService.getAppState()?.let { appState ->
             builder.setAttribute(embState.attributeKey, appState)
+        }
+
+        logEventData.schemaType.attributes().forEach {
+            builder.setAttribute(AttributeKey.stringKey(it.key), it.value)
         }
 
         builder.emit()


### PR DESCRIPTION
## Goal

Allow common attributes set by the LogWriter if the schema attributes decides to override it like we will have to for native crashes, as the session ID won't be that of the current session.

## Testing
No easy way to test this yet but will in the next PR when we have an overwrite happening
