### PR TITLE
Hook up NativeCrashDataSource with crash module behind beta feature flag

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -334,15 +334,16 @@ final class EmbraceImpl {
         sessionOrchestrator = sessionModule.getSessionOrchestrator();
         sessionPropertiesService = sessionModule.getSessionPropertiesService();
 
+        final CrashModule crashModule = moduleInitBootstrapper.getCrashModule();
+
         Systrace.startSynchronous("send-cached-sessions");
         // Send any sessions that were cached and not yet sent.
         deliveryModule.getDeliveryService().sendCachedSessions(
-            nativeModule::getNdkService,
+            crashModule::getNativeCrashService,
             essentialServiceModule.getSessionIdTracker()
         );
         Systrace.endSynchronous();
 
-        final CrashModule crashModule = moduleInitBootstrapper.getCrashModule();
         loadCrashVerifier(crashModule, moduleInitBootstrapper.getWorkerThreadModule());
 
         internalInterfaceModule = new InternalInterfaceModuleImpl(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NoopNativeCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NoopNativeCrashService.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.ndk
+
+import io.embrace.android.embracesdk.payload.NativeCrashData
+
+/**
+ * [NativeCrashService] used when the native features are not enabled
+ */
+internal class NoopNativeCrashService : NativeCrashService {
+    override fun getAndSendNativeCrash(): NativeCrashData? = null
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCrashModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCrashModule.kt
@@ -1,9 +1,11 @@
 package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.fakes.FakeCrashService
+import io.embrace.android.embracesdk.fakes.FakeNativeCrashService
 import io.embrace.android.embracesdk.injection.CrashModule
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.crash.LastRunCrashVerifier
+import io.embrace.android.embracesdk.ndk.NativeCrashService
 import io.embrace.android.embracesdk.samples.AutomaticVerificationExceptionHandler
 import io.mockk.mockk
 
@@ -12,7 +14,11 @@ internal class FakeCrashModule : CrashModule {
         CrashFileMarkerImpl(mockk(relaxed = true), mockk(relaxed = true)),
         mockk(relaxed = true)
     )
+
     override val crashService = FakeCrashService()
+
     override val automaticVerificationExceptionHandler =
         AutomaticVerificationExceptionHandler(null, mockk(relaxed = true))
+
+    override val nativeCrashService: NativeCrashService = FakeNativeCrashService()
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
@@ -1,5 +1,12 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.config.local.LocalConfig
+import io.embrace.android.embracesdk.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.config.remote.OTelRemoteConfig
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.fakeOTelBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
@@ -10,10 +17,26 @@ import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSessionModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
+import io.embrace.android.embracesdk.ndk.NativeCrashDataSource
+import io.embrace.android.embracesdk.ndk.NdkService
+import io.embrace.android.embracesdk.ndk.NoopNativeCrashService
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class CrashModuleImplTest {
+
+    private val autoDataCaptureBehaviorWithNdkEnabled = fakeAutoDataCaptureBehavior(
+        localCfg = { LocalConfig(appId = "xYxYx", ndkEnabled = true, sdkConfig = SdkLocalConfig()) }
+    )
+
+    private val oTelBehaviorWithBetaFeatureEnabled = fakeOTelBehavior(
+        remoteCfg = {
+            RemoteConfig(
+                oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
+            )
+        }
+    )
 
     @Test
     fun testDefaultImplementations() {
@@ -33,5 +56,57 @@ internal class CrashModuleImplTest {
         assertNotNull(module.lastRunCrashVerifier)
         assertNotNull(module.crashService)
         assertNotNull(module.automaticVerificationExceptionHandler)
+        assertTrue(module.nativeCrashService is NoopNativeCrashService)
+    }
+
+    @Test
+    fun `NdkService used as NativeCrashService if NDK feature is on`() {
+        val module = CrashModuleImpl(
+            InitModuleImpl(),
+            FakeCoreModule(),
+            FakeStorageModule(),
+            FakeEssentialServiceModule(
+                configService = FakeConfigService(
+                    autoDataCaptureBehavior = autoDataCaptureBehaviorWithNdkEnabled
+                )
+            ),
+            FakeDeliveryModule(),
+            FakeNativeModule(),
+            FakeSessionModule(),
+            FakeAnrModule(),
+            FakeDataContainerModule(),
+            FakeAndroidServicesModule(),
+            FakeCustomerLogModule(),
+        )
+        assertNotNull(module.lastRunCrashVerifier)
+        assertNotNull(module.crashService)
+        assertNotNull(module.automaticVerificationExceptionHandler)
+        assertTrue(module.nativeCrashService is NdkService)
+    }
+
+    @Test
+    fun `beta feature flag turns on v2 native crash service`() {
+        val module = CrashModuleImpl(
+            InitModuleImpl(),
+            FakeCoreModule(),
+            FakeStorageModule(),
+            FakeEssentialServiceModule(
+                configService = FakeConfigService(
+                    autoDataCaptureBehavior = autoDataCaptureBehaviorWithNdkEnabled,
+                    oTelBehavior = oTelBehaviorWithBetaFeatureEnabled
+                )
+            ),
+            FakeDeliveryModule(),
+            FakeNativeModule(),
+            FakeSessionModule(),
+            FakeAnrModule(),
+            FakeDataContainerModule(),
+            FakeAndroidServicesModule(),
+            FakeCustomerLogModule(),
+        )
+        assertNotNull(module.lastRunCrashVerifier)
+        assertNotNull(module.crashService)
+        assertNotNull(module.automaticVerificationExceptionHandler)
+        assertTrue(module.nativeCrashService is NativeCrashDataSource)
     }
 }


### PR DESCRIPTION
## Goal

Initialize the NativeCrashDataSource in the CrashModule under the right conditions 

## Testing
Test the module init. Can't write integration tests right now because of issues with loading the NDK in that environment.
