### PR TITLE
Map native anrs to OTel data structures

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
@@ -17,7 +17,7 @@ internal class AnrOtelMapper(
     private val anrService: AnrService
 ) : DataCaptureServiceOtelConverter {
 
-    override fun snapshot(): List<Span> {
+    override fun snapshot(isFinalPayload: Boolean): List<Span> {
         val intervals = anrService.getCapturedData()
 
         return intervals.map { interval ->

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
@@ -37,7 +37,7 @@ internal class EmbraceNativeThreadSamplerService @JvmOverloads constructor(
         fun setupNativeThreadSampler(is32Bit: Boolean): Boolean
         fun monitorCurrentThread(): Boolean
         fun startSampling(unwinderOrdinal: Int, intervalMs: Long)
-        fun finishSampling(): List<NativeThreadAnrSample>? // TODO: call this when entering bg!
+        fun finishSampling(): List<NativeThreadAnrSample>?
     }
 
     internal var ignored = true

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
@@ -1,0 +1,114 @@
+package io.embrace.android.embracesdk.anr.ndk
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Types
+import io.embrace.android.embracesdk.arch.DataCaptureServiceOtelConverter
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.payload.Attribute
+import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
+import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
+import io.opentelemetry.api.trace.SpanId
+import io.opentelemetry.sdk.trace.IdGenerator
+
+internal class NativeAnrOtelMapper(
+    private val nativeThreadSamplerService: NativeThreadSamplerService,
+    private val serializer: EmbraceSerializer
+) : DataCaptureServiceOtelConverter {
+
+    override fun snapshot(isFinalPayload: Boolean): List<Span> {
+        val intervals: List<NativeThreadAnrInterval> =
+            nativeThreadSamplerService.getCapturedIntervals(isFinalPayload) ?: emptyList()
+
+        return intervals.map { interval ->
+            val attrs = mapIntervalToSpanAttributes(interval)
+            val events = mapIntervalToSpanEvents(interval)
+            Span(
+                traceId = IdGenerator.random().generateTraceId(),
+                spanId = IdGenerator.random().generateSpanId(),
+                parentSpanId = SpanId.getInvalid(),
+                name = "emb_native_thread_blockage",
+                startTimeUnixNano = interval.threadBlockedTimestamp?.millisToNanos(),
+                status = Span.Status.OK,
+                attributes = attrs,
+                events = events
+            )
+        }
+    }
+
+    private fun mapIntervalToSpanAttributes(interval: NativeThreadAnrInterval): List<Attribute> {
+        val attrs = mutableListOf<Attribute>()
+        attrs.add(Attribute("emb.type", "perf.native_thread_blockage"))
+
+        interval.id?.let {
+            attrs.add(Attribute("thread_id", it.toString()))
+        }
+        interval.name?.let {
+            attrs.add(Attribute("thread_name", it))
+        }
+        interval.priority?.let {
+            attrs.add(Attribute("thread_priority", it.toString()))
+        }
+        interval.state?.let {
+            attrs.add(Attribute("thread_state", it.toString()))
+        }
+        interval.sampleOffsetMs?.let {
+            attrs.add(Attribute("sampling_offset_ms", it.toString()))
+        }
+        interval.unwinder?.let {
+            attrs.add(Attribute("stack_unwinder", it.toString()))
+        }
+        return attrs
+    }
+
+    private fun mapIntervalToSpanEvents(interval: NativeThreadAnrInterval): List<SpanEvent> {
+        return interval.samples?.map(::mapSampleToSpanEvent) ?: emptyList()
+    }
+
+    private fun mapSampleToSpanEvent(sample: NativeThreadAnrSample): SpanEvent {
+        val attrs = mutableListOf<Attribute>()
+        attrs.add(Attribute("emb.type", "perf.native_thread_blockage_sample"))
+
+        sample.result?.let {
+            attrs.add(Attribute("result", it.toString()))
+        }
+        sample.sampleDurationMs?.let {
+            attrs.add(Attribute("sample_overhead_ms", it.toString()))
+        }
+        val frames = sample.stackframes?.map { frame ->
+            NativeAnrSampleFrame(
+                programCounter = frame.pc,
+                soLoadAddr = frame.soLoadAddr,
+                soName = frame.soPath,
+                result = frame.result
+            )
+        }
+        frames?.let { stacktrace ->
+            val json = serializer.toJson(stacktrace, Types.newParameterizedType(List::class.java, NativeAnrSampleFrame::class.java))
+            attrs.add(Attribute("stacktrace", json))
+        }
+        return SpanEvent(
+            name = "emb_native_thread_blockage_sample",
+            timeUnixNano = sample.sampleTimestamp?.millisToNanos(),
+            attributes = attrs
+        )
+    }
+
+    @JsonClass(generateAdapter = true)
+    internal class NativeAnrSampleFrame(
+        @Json(name = "program_counter")
+        val programCounter: String? = null,
+
+        @Json(name = "so_load_addr")
+        val soLoadAddr: String? = null,
+
+        @Json(name = "so_name")
+        val soName: String? = null,
+
+        @Json(name = "result")
+        val result: Int? = null
+    )
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureServiceOtelConverter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureServiceOtelConverter.kt
@@ -18,5 +18,5 @@ internal fun interface DataCaptureServiceOtelConverter {
     /**
      * Returns a snapshot of the data captured by the service as a list of spans.
      */
-    fun snapshot(): List<Span>?
+    fun snapshot(isFinalPayload: Boolean): List<Span>?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -181,7 +181,7 @@ internal class V1PayloadMessageCollator(
                 else -> spanSink.completedSpans()
             }
             // add ANR spans if the payload is capturing spans.
-            result?.plus(anrOtelMapper.snapshot().map(Span::toOldPayload)) ?: result
+            result?.plus(anrOtelMapper.snapshot(!params.isCacheAttempt).map(Span::toOldPayload)) ?: result
         }
         val breadcrumbs = captureDataSafely(logger) {
             when {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
@@ -89,7 +89,7 @@ internal class AnrOtelMapperTest {
 
     @Test
     fun `empty intervals`() {
-        assertEquals(emptyList<Span>(), mapper.snapshot())
+        assertEquals(emptyList<Span>(), mapper.snapshot(false))
     }
 
     @Test
@@ -100,14 +100,14 @@ internal class AnrOtelMapperTest {
             clearedInterval,
             intervalWithLimitedSample
         )
-        val spans = mapper.snapshot()
+        val spans = mapper.snapshot(false)
         assertEquals(4, spans.size)
     }
 
     @Test
     fun `map completed interval`() {
         anrService.data = listOf(completedInterval)
-        val spans = mapper.snapshot()
+        val spans = mapper.snapshot(false)
         val span = spans.single()
         span.assertCommonOtelCharacteristics()
         assertEquals(END_TIME_MS, span.endTimeUnixNano?.nanosToMillis())
@@ -123,7 +123,7 @@ internal class AnrOtelMapperTest {
     @Test
     fun `map in progress interval`() {
         anrService.data = listOf(inProgressInterval)
-        val spans = mapper.snapshot()
+        val spans = mapper.snapshot(false)
         val span = spans.single()
         span.assertCommonOtelCharacteristics()
 
@@ -143,7 +143,7 @@ internal class AnrOtelMapperTest {
     @Test
     fun `map cleared interval`() {
         anrService.data = listOf(clearedInterval)
-        val spans = mapper.snapshot()
+        val spans = mapper.snapshot(false)
         val span = spans.single()
         span.assertCommonOtelCharacteristics()
         assertEquals("1", span.attributes?.findAttribute("interval_code")?.data)
@@ -153,7 +153,7 @@ internal class AnrOtelMapperTest {
     @Test
     fun `map limited sample`() {
         anrService.data = listOf(intervalWithLimitedSample)
-        val spans = mapper.snapshot()
+        val spans = mapper.snapshot(false)
         val span = spans.single()
         span.assertCommonOtelCharacteristics()
         assertEquals("0", span.attributes?.findAttribute("interval_code")?.data)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
@@ -1,0 +1,100 @@
+package io.embrace.android.embracesdk.anr.ndk
+
+import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeNativeThreadSamplerService
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.payload.Attribute
+import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
+import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
+import io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe
+import io.embrace.android.embracesdk.payload.ThreadState
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class NativeAnrOtelMapperTest {
+
+    private lateinit var mapper: NativeAnrOtelMapper
+    private lateinit var service: FakeNativeThreadSamplerService
+
+    @Before
+    fun setUp() {
+        service = FakeNativeThreadSamplerService()
+        mapper = NativeAnrOtelMapper(service, EmbraceSerializer())
+    }
+
+    @Test
+    fun `null intervals`() {
+        assertEquals(emptyList<Span>(), mapper.snapshot(false))
+    }
+
+    @Test
+    fun `empty intervals`() {
+        service.intervals = emptyList()
+        assertEquals(emptyList<Span>(), mapper.snapshot(false))
+    }
+
+    @Test
+    fun `has intervals`() {
+        service.intervals = listOf(
+            NativeThreadAnrInterval(
+                id = 1,
+                name = "main",
+                priority = 5,
+                threadState = ThreadState.BLOCKED,
+                sampleOffsetMs = 100,
+                unwinderType = AnrRemoteConfig.Unwinder.LIBUNWINDSTACK,
+                threadBlockedTimestamp = 1000L,
+                samples = mutableListOf(
+                    NativeThreadAnrSample(
+                        0,
+                        2000L,
+                        5,
+                        listOf(
+                            NativeThreadAnrStackframe(
+                                "0x8000050209",
+                                "0x500234500",
+                                "/data/app/lib.so",
+                                0
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val spans = mapper.snapshot(false)
+        val span = spans.single()
+
+        // assert span
+        assertEquals("emb_native_thread_blockage", span.name)
+        assertEquals(1000L.millisToNanos(), span.startTimeUnixNano)
+
+        // assert span attrs
+        val attrs = checkNotNull(span.attributes)
+        assertEquals("perf.native_thread_blockage", attrs.findAttribute("emb.type").data)
+        assertEquals("1", attrs.findAttribute("thread_id").data)
+        assertEquals("main", attrs.findAttribute("thread_name").data)
+        assertEquals("2", attrs.findAttribute("thread_state").data)
+        assertEquals("100", attrs.findAttribute("sampling_offset_ms").data)
+        assertEquals("1", attrs.findAttribute("stack_unwinder").data)
+
+        // assert span event
+        val event = checkNotNull(span.events?.single())
+        assertEquals("emb_native_thread_blockage_sample", event.name)
+        assertEquals(2000L.millisToNanos(), event.timeUnixNano)
+        val eventAttrs = checkNotNull(event.attributes)
+        assertEquals("0", eventAttrs.findAttribute("result").data)
+        assertEquals("5", eventAttrs.findAttribute("sample_overhead_ms").data)
+        assertEquals("perf.native_thread_blockage_sample", eventAttrs.findAttribute("emb.type").data)
+
+        val expectedStacktrace = "[{\"program_counter\":\"0x8000050209\",\"so_load_addr\":\"0x500234500\"," +
+            "\"so_name\":\"/data/app/lib.so\",\"result\":0}]"
+        assertEquals(expectedStacktrace, eventAttrs.findAttribute("stacktrace").data)
+    }
+
+    private fun List<Attribute>.findAttribute(key: String): Attribute {
+        return single { it.key == key }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 internal class FakeNativeThreadSamplerService : NativeThreadSamplerService {
 
     var symbols: Map<String, String>? = mapOf("armeabi-v7a" to "my-symbols")
+    var intervals: List<NativeThreadAnrInterval>? = null
 
     override fun onThreadBlocked(thread: Thread, timestamp: Long) {
         TODO("Not yet implemented")
@@ -30,7 +31,7 @@ internal class FakeNativeThreadSamplerService : NativeThreadSamplerService {
     override fun getNativeSymbols(): Map<String, String>? = symbols
 
     override fun getCapturedIntervals(receivedTermination: Boolean?): List<NativeThreadAnrInterval>? {
-        TODO("Not yet implemented")
+        return intervals
     }
 
     override fun cleanCollections() {


### PR DESCRIPTION
## Goal

Maps native ANRs to OTel data structures. This does not alter how data is captured or the payload that is sent to the backend at this stage - that will come in future PRs.

## Testing

Added unit tests.
