### PR TITLE
Fix RN crash attribute serialization.

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -80,9 +80,9 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
 
         internal object ReactNativeCrash : System("android.react_native_crash", true) {
             /**
-             * The list JavaScript exceptions from the ReactNative layer
+             * The JavaScript unhandled exception from the ReactNative layer
              */
-            val embAndroidReactNativeCrashJsExceptions = EmbraceAttributeKey("android.react_native_crash.js_exceptions")
+            val embAndroidReactNativeCrashJsException = EmbraceAttributeKey("android.react_native_crash.js_exception")
         }
 
         internal object NativeCrash : System("android.native_crash", true) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.opentelemetry
 
 import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
+import io.embrace.android.embracesdk.payload.ThreadInfo
 
 /**
  * A snapshot of the current call stack of the threads running in the app process per [ThreadInfo]
@@ -8,14 +9,9 @@ import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 internal val embAndroidThreads = EmbraceAttributeKey("android.threads")
 
 /**
- * Attribute name for the app framework for which the telemetry is being logged
- */
-internal val embAppFramework = EmbraceAttributeKey("app_framework")
-
-/**
  * Sequence number for the number of crashes captured by Embrace on the device, reported on every crash
  */
-internal val embCrashNumber = EmbraceAttributeKey("crash_number")
+internal val embCrashNumber = EmbraceAttributeKey("android.crash_number")
 
 /**
  * Attribute name for the exception handling type - whether it's handled or unhandled


### PR DESCRIPTION
## Goal

- Fix RN crash attribute serialization.
- Updated key `emb.crash_number` to `emb.android.crash_number`
- Made `android.react_native_crash.js_exception` singular, as we were always sending only one `JsException`.

## Testing

Added unit test.

