### PR TITLE
Do not wrap UrlConnection is embrace is not started

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlStreamHandler.java
@@ -48,7 +48,7 @@ final class EmbraceHttpUrlStreamHandler extends EmbraceUrlStreamHandler {
     }
 
     @Override
-    protected URLConnection newEmbraceUrlConnection(URLConnection connection) {
+    protected URLConnection wrapUrlConnection(URLConnection connection) {
         if (!(connection instanceof HttpURLConnection)) {
             return connection;
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpsUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpsUrlStreamHandler.java
@@ -49,7 +49,7 @@ final class EmbraceHttpsUrlStreamHandler extends EmbraceUrlStreamHandler {
     }
 
     @Override
-    protected URLConnection newEmbraceUrlConnection(URLConnection connection) {
+    protected URLConnection wrapUrlConnection(URLConnection connection) {
         if (!(connection instanceof HttpsURLConnection)) {
             return connection;
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandler.java
@@ -92,7 +92,7 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
     @Override
     protected URLConnection openConnection(URL url) throws IOException {
         try {
-            return newEmbraceUrlConnection((URLConnection) this.methodOpenConnection1.invoke(this.handler, url));
+            return newUrlConnection((URLConnection) this.methodOpenConnection1.invoke(this.handler, url));
         } catch (Exception e) {
             // We catch Exception here instead of the specific exceptions that can be thrown due to a change in the way some
             // of these exceptions are compiled on different OS versions.
@@ -104,7 +104,7 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
     @Override
     protected URLConnection openConnection(URL url, Proxy proxy) throws IOException {
         try {
-            return newEmbraceUrlConnection((URLConnection) this.methodOpenConnection2.invoke(this.handler, url, proxy));
+            return newUrlConnection((URLConnection) this.methodOpenConnection2.invoke(this.handler, url, proxy));
         } catch (Exception e) {
             // We catch Exception here instead of the specific exceptions that can be thrown due to a change in the way some
             // of these exceptions are compiled on different OS versions.
@@ -117,6 +117,19 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
         boolean networkSpanForwardingEnabled = embrace.getInternalInterface().isNetworkSpanForwardingEnabled();
         if (networkSpanForwardingEnabled && !connection.getRequestProperties().containsKey(TRACEPARENT_HEADER_NAME)) {
             connection.addRequestProperty(TRACEPARENT_HEADER_NAME, embrace.generateW3cTraceparent());
+        }
+    }
+
+    /**
+     * If sdk is not started we won't wrap url connection. Instead, we return the original connection.
+     * @param connection
+     * @return
+     */
+    private URLConnection newUrlConnection(URLConnection connection) {
+        if (embrace.isStarted()) {
+            return newEmbraceUrlConnection(connection);
+        } else {
+            return connection;
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandler.java
@@ -12,7 +12,6 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
 import io.embrace.android.embracesdk.Embrace;
-import io.embrace.android.embracesdk.utils.NetworkUtils;
 
 /**
  * Custom implementation of URLStreamHandler that wraps a base URLStreamHandler and provides a context for executing
@@ -87,7 +86,7 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
      * Given an instance of URLConnection, returns a new URLConnection that wraps the provided instance with additional
      * Embrace-specific logic.
      */
-    protected abstract URLConnection newEmbraceUrlConnection(URLConnection connection);
+    protected abstract URLConnection wrapUrlConnection(URLConnection connection);
 
     @Override
     protected URLConnection openConnection(URL url) throws IOException {
@@ -127,7 +126,7 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
      */
     private URLConnection newUrlConnection(URLConnection connection) {
         if (embrace.isStarted()) {
-            return newEmbraceUrlConnection(connection);
+            return wrapUrlConnection(connection);
         } else {
             return connection;
         }


### PR DESCRIPTION


## Goal

if embrace is not started then do not wrap it and return the original connection.

## Testing

Manual testing and unit tests.

## Release Notes

Bug fix when performing a network request with embrace sdk  not started.
**WHAT**: It fixes an issue when performing a network request while embrace sdk is not started or disabled
**WHY**: We could have responseCode=-1
**WHO**: anyone

