### PR TITLE
Add a name to the low memory warning telemetry type

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -185,7 +185,10 @@ internal sealed class SchemaType(
         ).toNonNullMap()
     }
 
-    internal class MemoryWarning : SchemaType(EmbType.Performance.MemoryWarning) {
+    internal class MemoryWarning : SchemaType(
+        telemetryType = EmbType.Performance.MemoryWarning,
+        fixedObjectName = "memory-warning"
+    ) {
         override val schemaAttributes = emptyMap<String, String>()
     }
 


### PR DESCRIPTION
## Goal

Add a default name for events created for the low memory warning telemetry type 