### PR TITLE
Send network requests as spans

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -209,10 +209,10 @@ public abstract interface class io/embrace/android/embracesdk/internal/EmbraceIn
 	public abstract fun logInternalError (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun logInternalError (Ljava/lang/Throwable;)V
 	public abstract fun logWarning (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
-	public abstract fun recordAndDeduplicateNetworkRequest (Ljava/lang/String;Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 	public abstract fun recordCompletedNetworkRequest (Ljava/lang/String;Ljava/lang/String;JJJJILjava/lang/String;Lio/embrace/android/embracesdk/internal/network/http/NetworkCaptureData;)V
 	public abstract fun recordIncompleteNetworkRequest (Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/embrace/android/embracesdk/internal/network/http/NetworkCaptureData;)V
 	public abstract fun recordIncompleteNetworkRequest (Ljava/lang/String;Ljava/lang/String;JJLjava/lang/Throwable;Ljava/lang/String;Lio/embrace/android/embracesdk/internal/network/http/NetworkCaptureData;)V
+	public abstract fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 	public abstract fun setProcessStartedByNotification ()V
 	public abstract fun shouldCaptureNetworkBody (Ljava/lang/String;Ljava/lang/String;)Z
 	public abstract fun stopSdk ()V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -202,48 +202,6 @@ internal class NetworkRequestApiTest {
         }
     }
 
-//    @Ignore() //TODO: Fix this test
-//    @Test
-//    fun `ensure calls with same callId but different start times are deduped`() {
-//        val expectedStartTime = START_TIME + 1
-//        with(testRule) {
-//            harness.recordSession {
-//                harness.overriddenConfigService.updateListeners()
-//                harness.overriddenClock.tick(5)
-//
-//                val callId = UUID.randomUUID().toString()
-//                embrace.internalInterface.recordURLConnectionNetworkRequest(
-//                    callId,
-//                    EmbraceNetworkRequest.fromCompletedRequest(
-//                        "$URL/bad",
-//                        HttpMethod.GET,
-//                        START_TIME,
-//                        END_TIME,
-//                        BYTES_SENT,
-//                        BYTES_RECEIVED,
-//                        200
-//                    )
-//                )
-//                embrace.internalInterface.recordURLConnectionNetworkRequest(
-//                    callId,
-//                    EmbraceNetworkRequest.fromCompletedRequest(
-//                        URL,
-//                        HttpMethod.GET,
-//                        expectedStartTime,
-//                        expectedStartTime + 1,
-//                        BYTES_SENT,
-//                        BYTES_RECEIVED,
-//                        200
-//                    )
-//                )
-//            }
-//
-//            val networkSpan = validateAndReturnExpectedNetworkSpan()
-//            assertEquals(URL, networkSpan.attributes["url.full"])
-//            assertEquals(expectedStartTime, networkSpan.startTimeNanos)
-//        }
-//    }
-
     /**
      * This reproduces the bug that will be fixed. Uncomment when ready.
      */

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
@@ -17,7 +17,6 @@ import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream


### PR DESCRIPTION
EmbraceNetworkLoggingService now records spans when it receives a request. 
