### PR TITLE
Change beta OTel feature flag to default to on

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -9,6 +9,9 @@ import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.LogType
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.assertions.assertLogMessageReceived
+import io.embrace.android.embracesdk.config.remote.OTelRemoteConfig
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.fakes.fakeOTelBehavior
 import io.embrace.android.embracesdk.findEventOfType
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getSentLogMessages
@@ -46,6 +49,9 @@ internal class EmbraceInternalInterfaceTest {
     @Before
     fun setup() {
         ApkToolsConfig.IS_NETWORK_CAPTURE_DISABLED = false
+        testRule.harness.overriddenConfigService.oTelBehavior = fakeOTelBehavior {
+            RemoteConfig(oTelConfig = OTelRemoteConfig(isStableEnabled = false))
+        }
     }
 
     @Test
@@ -112,7 +118,7 @@ internal class EmbraceInternalInterfaceTest {
     }
 
     @Test
-    fun `internal logging methods work as expected`() {
+    fun `internal logging methods work as expected in v1`() {
         with(testRule) {
             startSdk(context = harness.overriddenCoreModule.context)
             val expectedProperties = mapOf(Pair("key", "value"))
@@ -223,7 +229,7 @@ internal class EmbraceInternalInterfaceTest {
 
         with(testRule) {
             startSdk(context = harness.overriddenCoreModule.context)
-            val session = checkNotNull( harness.recordSession {
+            val session = checkNotNull(harness.recordSession {
                 embrace.internalInterface.logComposeTap(Pair(expectedX, expectedY), expectedElementName)
             })
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LoggingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LoggingApiTest.kt
@@ -6,17 +6,27 @@ import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.assertions.assertLogMessageReceived
+import io.embrace.android.embracesdk.config.remote.OTelRemoteConfig
+import io.embrace.android.embracesdk.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.fakes.fakeOTelBehavior
 import io.embrace.android.embracesdk.getLastSentLogMessage
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.IllegalArgumentException
 
 @RunWith(AndroidJUnit4::class)
 internal class LoggingApiTest {
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
+
+    @Before
+    fun setup() {
+        testRule.harness.overriddenConfigService.oTelBehavior = fakeOTelBehavior {
+            RemoteConfig(oTelConfig = OTelRemoteConfig(isStableEnabled = false))
+        }
+    }
 
     @Test
     fun `log info message sent`() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.arch.destination
 
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.internal.spans.toOtelSeverity
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.opentelemetry.embState
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.api.logs.Severity
 
 internal class LogWriterImpl(
     private val logger: Logger,
@@ -41,11 +41,5 @@ internal class LogWriterImpl(
         }
 
         builder.emit()
-    }
-
-    private fun io.embrace.android.embracesdk.Severity.toOtelSeverity(): Severity = when (this) {
-        io.embrace.android.embracesdk.Severity.INFO -> Severity.INFO
-        io.embrace.android.embracesdk.Severity.WARNING -> Severity.WARN
-        io.embrace.android.embracesdk.Severity.ERROR -> Severity.ERROR
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/OTelBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/OTelBehavior.kt
@@ -23,7 +23,7 @@ internal class OTelBehavior(
     /**
      * Returns whether OTel Beta is enabled.
      */
-    fun isBetaEnabled() = remote?.oTelConfig?.isBetaEnabled ?: false
+    fun isBetaEnabled() = remote?.oTelConfig?.isBetaEnabled ?: true
 
     /**
      * Returns whether OTel Dev is enabled.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
@@ -27,7 +27,7 @@ internal class CompositeLogService(
 ) : LogMessageService {
 
     private val useV2LogService: Boolean
-        get() = configService.oTelBehavior.isBetaEnabled()
+        get() = configService.oTelBehavior.isStableEnabled()
 
     private val baseLogService: BaseLogService
         get() = if (useV2LogService) v2LogService() else v1LogService()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
+import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.StatusCode
@@ -172,3 +173,9 @@ internal fun Map<String, String>.getSessionProperty(key: String): String? = this
 internal fun Map<String, String>.getAttribute(key: AttributeKey<String>): String? = this[key.key]
 
 internal fun Map<String, String>.getAttribute(key: EmbraceAttributeKey): String? = getAttribute(key.attributeKey)
+
+internal fun io.embrace.android.embracesdk.Severity.toOtelSeverity(): Severity = when (this) {
+    io.embrace.android.embracesdk.Severity.INFO -> Severity.INFO
+    io.embrace.android.embracesdk.Severity.WARNING -> Severity.WARN
+    io.embrace.android.embracesdk.Severity.ERROR -> Severity.ERROR
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/OTelBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/OTelBehaviorTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 internal class OTelBehaviorTest {
 
-    private val remote = RemoteConfig(
+    private val remoteAllOn = RemoteConfig(
         oTelConfig = OTelRemoteConfig(
             isStableEnabled = true,
             isBetaEnabled = true,
@@ -17,21 +17,38 @@ internal class OTelBehaviorTest {
         ),
     )
 
+    private val remoteAllOff = RemoteConfig(
+        oTelConfig = OTelRemoteConfig(
+            isStableEnabled = false,
+            isBetaEnabled = false,
+            isDevEnabled = false
+        ),
+    )
+
     @Test
     fun testDefaults() {
         with(fakeOTelBehavior()) {
             assertTrue(isStableEnabled())
-            assertFalse(isBetaEnabled())
+            assertTrue(isBetaEnabled())
             assertFalse(isDevEnabled())
         }
     }
 
     @Test
-    fun testRemote() {
-        with(fakeOTelBehavior(remoteCfg = { remote })) {
+    fun `flags can be turned on remotely`() {
+        with(fakeOTelBehavior(remoteCfg = { remoteAllOn })) {
             assertTrue(isStableEnabled())
             assertTrue(isBetaEnabled())
             assertTrue(isDevEnabled())
+        }
+    }
+
+    @Test
+    fun `flags can be turned off remotely`() {
+        with(fakeOTelBehavior(remoteCfg = { remoteAllOff })) {
+            assertFalse(isStableEnabled())
+            assertFalse(isBetaEnabled())
+            assertFalse(isDevEnabled())
         }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CrashModuleImplTest.kt
@@ -30,10 +30,10 @@ internal class CrashModuleImplTest {
         localCfg = { LocalConfig(appId = "xYxYx", ndkEnabled = true, sdkConfig = SdkLocalConfig()) }
     )
 
-    private val oTelBehaviorWithBetaFeatureEnabled = fakeOTelBehavior(
+    private val oTelBehaviorWithBetaFeatureDisabled = fakeOTelBehavior(
         remoteCfg = {
             RemoteConfig(
-                oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
+                oTelConfig = OTelRemoteConfig(isBetaEnabled = false)
             )
         }
     )
@@ -60,14 +60,15 @@ internal class CrashModuleImplTest {
     }
 
     @Test
-    fun `NdkService used as NativeCrashService if NDK feature is on`() {
+    fun `NdkService used as NativeCrashService if NDK feature is on and beta flag is off`() {
         val module = CrashModuleImpl(
             InitModuleImpl(),
             FakeCoreModule(),
             FakeStorageModule(),
             FakeEssentialServiceModule(
                 configService = FakeConfigService(
-                    autoDataCaptureBehavior = autoDataCaptureBehaviorWithNdkEnabled
+                    autoDataCaptureBehavior = autoDataCaptureBehaviorWithNdkEnabled,
+                    oTelBehavior = oTelBehaviorWithBetaFeatureDisabled
                 )
             ),
             FakeDeliveryModule(),
@@ -85,15 +86,14 @@ internal class CrashModuleImplTest {
     }
 
     @Test
-    fun `beta feature flag turns on v2 native crash service`() {
+    fun `default config turns on v2 native crash service`() {
         val module = CrashModuleImpl(
             InitModuleImpl(),
             FakeCoreModule(),
             FakeStorageModule(),
             FakeEssentialServiceModule(
                 configService = FakeConfigService(
-                    autoDataCaptureBehavior = autoDataCaptureBehaviorWithNdkEnabled,
-                    oTelBehavior = oTelBehaviorWithBetaFeatureEnabled
+                    autoDataCaptureBehavior = autoDataCaptureBehaviorWithNdkEnabled
                 )
             ),
             FakeDeliveryModule(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
 
 internal class CompositeLogServiceTest {
 
-    private var oTelConfig = OTelRemoteConfig()
+    private lateinit var otelConfig: OTelRemoteConfig
     private lateinit var compositeLogService: CompositeLogService
     private lateinit var v1LogService: FakeLogMessageService
     private lateinit var v2LogService: FakeLogService
@@ -27,10 +27,11 @@ internal class CompositeLogServiceTest {
 
     @Before
     fun setUp() {
+        otelConfig = defaultOTelConfig
         val configService = FakeConfigService(
             oTelBehavior = fakeOTelBehavior(
                 remoteCfg = {
-                    RemoteConfig(oTelConfig = oTelConfig)
+                    RemoteConfig(oTelConfig = otelConfig)
                 }
             )
         )
@@ -48,47 +49,31 @@ internal class CompositeLogServiceTest {
     }
 
     @Test
-    fun testLogV1() {
-        compositeLogService.log(
-            message = "simple log",
-            type = EventType.INFO_LOG,
-            logExceptionType = LogExceptionType.NONE,
-            properties = null,
-            stackTraceElements = null,
-            customStackTrace = null,
-            framework = Embrace.AppFramework.NATIVE,
-            context = null,
-            library = null,
-            exceptionName = null,
-            exceptionMessage = null
-        )
+    fun `default logs to v1`() {
+        logEmbraceLog()
+        assertEquals(0, v1LogService.loggedMessages.size)
+        assertEquals(1, v2LogService.logs.size)
+    }
+
+    @Test
+    fun `stable flag off logs to v1`() {
+        otelConfig = stableOffOTelConfig
+        logEmbraceLog()
         assertEquals(1, v1LogService.loggedMessages.size)
         assertEquals(0, v2LogService.logs.size)
     }
 
     @Test
-    fun testLogV2() {
-        oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
-        compositeLogService.log(
-            message = "simple log",
-            type = EventType.INFO_LOG,
-            logExceptionType = LogExceptionType.NONE,
-            properties = null,
-            stackTraceElements = null,
-            customStackTrace = null,
-            framework = Embrace.AppFramework.NATIVE,
-            context = null,
-            library = null,
-            exceptionName = null,
-            exceptionMessage = null
-        )
+    fun `stable flag on logs to v2`() {
+        otelConfig = stableOnOTelConfig
+        logEmbraceLog()
         assertEquals(0, v1LogService.loggedMessages.size)
         assertEquals(1, v2LogService.logs.size)
     }
 
     @Test
     fun testNetworkCaptureV1() {
-        oTelConfig = OTelRemoteConfig(isBetaEnabled = false)
+        otelConfig = stableOffOTelConfig
         compositeLogService.logNetwork(
             fakeNetworkCapturedCall()
         )
@@ -98,7 +83,7 @@ internal class CompositeLogServiceTest {
 
     @Test
     fun testNetworkCaptureV2() {
-        oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
+        otelConfig = stableOnOTelConfig
         compositeLogService.logNetwork(
             fakeNetworkCapturedCall()
         )
@@ -108,78 +93,34 @@ internal class CompositeLogServiceTest {
 
     @Test
     fun testLogExceptionV1() {
-        compositeLogService.log(
-            message = "simple log",
-            type = EventType.INFO_LOG,
-            logExceptionType = LogExceptionType.HANDLED,
-            properties = null,
-            stackTraceElements = null,
-            customStackTrace = null,
-            framework = Embrace.AppFramework.NATIVE,
-            context = null,
-            library = null,
-            exceptionName = null,
-            exceptionMessage = null
-        )
+        otelConfig = stableOffOTelConfig
+        logTestException()
         assertEquals(1, v1LogService.loggedMessages.size)
         assertEquals(0, v2LogService.exceptions.size)
+        v1LogService.loggedMessages.single().contains("IllegalArgumentException")
     }
 
     @Test
     fun testLogExceptionV2() {
-        oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
-        compositeLogService.log(
-            message = "simple log",
-            type = EventType.INFO_LOG,
-            logExceptionType = LogExceptionType.HANDLED,
-            properties = null,
-            stackTraceElements = null,
-            customStackTrace = null,
-            framework = Embrace.AppFramework.NATIVE,
-            context = null,
-            library = null,
-            exceptionName = null,
-            exceptionMessage = null
-        )
+        otelConfig = stableOnOTelConfig
+        logTestException()
         assertEquals(0, v1LogService.loggedMessages.size)
         assertEquals(1, v2LogService.exceptions.size)
+        v2LogService.exceptions.single().contains("IllegalArgumentException")
     }
 
     @Test
     fun testFlutterExceptionV1() {
-        compositeLogService.log(
-            message = "Dart error",
-            type = EventType.ERROR_LOG,
-            logExceptionType = LogExceptionType.HANDLED,
-            properties = null,
-            stackTraceElements = null,
-            customStackTrace = null,
-            framework = Embrace.AppFramework.FLUTTER,
-            context = "exception context",
-            library = "exception library",
-            exceptionName = null,
-            exceptionMessage = null
-        )
+        otelConfig = stableOffOTelConfig
+        logFlutterException()
         assertEquals(1, v1LogService.loggedMessages.size)
         assertEquals(0, v2LogService.logs.size)
     }
 
     @Test
     fun testFlutterExceptionV2() {
-        oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
-        compositeLogService.log(
-            message = "Dart error",
-            type = EventType.ERROR_LOG,
-            logExceptionType = LogExceptionType.HANDLED,
-            properties = null,
-            stackTraceElements = null,
-            customStackTrace = null,
-            framework = Embrace.AppFramework.FLUTTER,
-            context = "exception context",
-            library = "exception library",
-            exceptionName = null,
-            exceptionMessage = null
-        )
+        otelConfig = stableOnOTelConfig
+        logFlutterException()
         assertEquals(0, v1LogService.loggedMessages.size)
         assertEquals(0, v2LogService.logs.size)
         assertEquals(0, v2LogService.exceptions.size)
@@ -189,7 +130,6 @@ internal class CompositeLogServiceTest {
     @Test
     fun testWrongEventType() {
         // The log service can handle only INFO_LOG, WARNING_LOG and ERROR_LOG event types
-        oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
         compositeLogService.log(
             message = "simple log",
             type = EventType.CRASH,
@@ -208,10 +148,24 @@ internal class CompositeLogServiceTest {
         assertEquals(0, v2LogService.exceptions.size)
     }
 
-    @Test
-    fun `exception properly in v2`() {
+    private fun logEmbraceLog() {
+        compositeLogService.log(
+            message = "simple log",
+            type = EventType.INFO_LOG,
+            logExceptionType = LogExceptionType.NONE,
+            properties = mapOf("key" to "value"),
+            stackTraceElements = null,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.NATIVE,
+            context = null,
+            library = null,
+            exceptionName = null,
+            exceptionMessage = null
+        )
+    }
+
+    private fun logTestException() {
         val exception = IllegalArgumentException("bad arg")
-        oTelConfig = OTelRemoteConfig(isBetaEnabled = true)
         compositeLogService.log(
             message = "log",
             type = EventType.ERROR_LOG,
@@ -225,7 +179,27 @@ internal class CompositeLogServiceTest {
             exceptionName = exception.javaClass.name,
             exceptionMessage = exception.message
         )
-        assertEquals(0, v1LogService.loggedMessages.size)
-        v2LogService.exceptions.single().contains("IllegalArgumentException")
+    }
+
+    private fun logFlutterException() {
+        compositeLogService.log(
+            message = "Dart error",
+            type = EventType.ERROR_LOG,
+            logExceptionType = LogExceptionType.HANDLED,
+            properties = null,
+            stackTraceElements = null,
+            customStackTrace = null,
+            framework = Embrace.AppFramework.FLUTTER,
+            context = "exception context",
+            library = "exception library",
+            exceptionName = null,
+            exceptionMessage = null
+        )
+    }
+
+    companion object {
+        private val defaultOTelConfig = OTelRemoteConfig()
+        private val stableOnOTelConfig = OTelRemoteConfig(isStableEnabled = true)
+        private val stableOffOTelConfig = OTelRemoteConfig(isStableEnabled = false)
     }
 }


### PR DESCRIPTION
## Goal

For the next release, we will put crashes behind the beta feature flag, and logs/exceptions/network-capture behind the stable one - both will default to on, but it means we can disable each group individually.

## Testing
Fixes tests to expect v2 defaults

