### PR TITLE
Move diagnostic child spans out of startup traces

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -38,8 +38,8 @@ internal class SpanTest {
                 "Timed out waiting for the span to be exported: ${fakeSpanExporter.exportedSpans.map { it.name }}",
                 fakeSpanExporter.awaitSpanExport(1)
             )
-            // Verify that 2 spans have been logged - the exported ones and the private not-exported emb-sdk-init
-            assertEquals(2, harness.overriddenOpenTelemetryModule.spanSink.completedSpans().size)
+            // Verify that 4 spans have been logged - the exported ones and 3 private diagnostic traces
+            assertEquals(4, harness.overriddenOpenTelemetryModule.spanSink.completedSpans().size)
 
             harness.recordSession {
                 assertTrue(
@@ -50,7 +50,7 @@ internal class SpanTest {
                 assertEquals(2, fakeSpanExporter.exportedSpans.size)
                 val exportedSpans = fakeSpanExporter.exportedSpans.associateBy { it.name }
                 val testSpan = checkNotNull(exportedSpans["test"])
-                testSpan.assertHasEmbraceAttribute(embSequenceId, "3")
+                testSpan.assertHasEmbraceAttribute(embSequenceId, "5")
                 testSpan.assertHasEmbraceAttribute(embProcessIdentifier, harness.overriddenInitModule.processIdentifier)
                 testSpan.resource.assertExpectedAttributes(
                     expectedServiceName = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceServiceName,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -312,11 +312,10 @@ internal class ModuleInitBootstrapper(
                         val ndkService = nativeModule.ndkService
                         val initWorkerTaskQueueTime = initModule.clock.now()
                         workerThreadModule.backgroundWorker(WorkerName.SERVICE_INIT).submit {
-                            val taskRuntimeMs = initModule.clock.now()
-                            dataCaptureServiceModule.appStartupTraceEmitter.addTrackedInterval(
+                            openTelemetryModule.spanService.recordCompletedSpan(
                                 name = "init-worker-schedule-delay",
                                 startTimeMs = initWorkerTaskQueueTime,
-                                endTimeMs = taskRuntimeMs
+                                endTimeMs = initModule.clock.now()
                             )
                         }
                         serviceRegistry.registerServices(
@@ -494,7 +493,7 @@ internal class ModuleInitBootstrapper(
             val delayStartMs = synchronousInitCompletionMs
             val delayEndMs = max(synchronousInitCompletionMs, asyncInitCompletionMs)
             if (delayStartMs > 0) {
-                dataCaptureServiceModule.appStartupTraceEmitter.addTrackedInterval(
+                openTelemetryModule.spanService.recordCompletedSpan(
                     name = "async-init-delay",
                     startTimeMs = delayStartMs,
                     endTimeMs = delayEndMs


### PR DESCRIPTION
## Goal

Moving two child spans of the startup trace to their own private traces as this is diagnostic info customers shouldn't care about

## Testing
Modified exporting tests to account for them

