### PR TITLE
Logic fix in LogOrchestrator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/LogOrchestrator.kt
@@ -100,11 +100,11 @@ internal class LogOrchestratorImpl(
         sink.completedLogs().size >= MAX_LOGS_PER_BATCH
 
     private fun isMaxInactivityTimeReached(now: Long): Boolean =
-        now - lastLogTime.get() > MAX_INACTIVITY_TIME
+        now - lastLogTime.get() >= MAX_INACTIVITY_TIME
 
     private fun isMaxBatchTimeReached(now: Long): Boolean {
         val firstLogInBatchTime = firstLogInBatchTime.get()
-        return firstLogInBatchTime != 0L && now - firstLogInBatchTime > MAX_BATCH_TIME
+        return firstLogInBatchTime != 0L && now - firstLogInBatchTime >= MAX_BATCH_TIME
     }
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
@@ -78,7 +78,7 @@ internal class LogOrchestratorTest {
     fun `logs are sent after inactivity time has passed`() {
         logSink.storeLogs(listOf(FakeLogRecordData()))
 
-        moveTimeAhead(2500L)
+        moveTimeAhead(2000L)
 
         // Verify the logs are sent
         assertTrue(logSink.completedLogs().isEmpty())
@@ -87,9 +87,9 @@ internal class LogOrchestratorTest {
 
     @Test
     fun `logs are sent after batch time has passed`() {
-        val timeStep = 1100L
+        val timeStep = 500L
 
-        repeat(4) {
+        repeat(9) {
             logSink.storeLogs(listOf(FakeLogRecordData()))
             moveTimeAhead(timeStep)
         }
@@ -98,11 +98,11 @@ internal class LogOrchestratorTest {
         assertFalse(logSink.completedLogs().isEmpty())
         verifyPayloadNotSent()
 
-        moveTimeAhead(700)
+        moveTimeAhead(500)
 
         // Verify the logs are sent
         assertTrue(logSink.completedLogs().isEmpty())
-        verifyPayload(4)
+        verifyPayload(9)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Flush the logs if the milliseconds difference is exact.

## Testing

Reproduced the case where logs were not flushed with the test suite, and verified the solution in the test suite as well.
