### PR TITLE
Make network capture not batch

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -109,7 +109,7 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
 
         internal object LowPower : System("low_power")
 
-        internal object NetworkCapturedRequest : System("network_captured_request")
+        internal object NetworkCapturedRequest : System("network_capture", true)
 
         internal object NetworkStatus : System("network_status")
     }


### PR DESCRIPTION
## Goal

Make network capture logs not batch and use the emb.type sys.network_capture
