### PR TITLE
Add log.record.uid to all logs generated

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -2,8 +2,10 @@ package io.embrace.android.embracesdk.arch.destination
 
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.spans.toOtelSeverity
+import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.opentelemetry.embState
+import io.embrace.android.embracesdk.opentelemetry.logRecordUid
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Logger
@@ -27,6 +29,8 @@ internal class LogWriterImpl(
             .setBody(logEventData.message)
             .setSeverity(logEventData.severity.toOtelSeverity())
             .setSeverityText(logEventData.severity.name)
+
+        builder.setAttribute(logRecordUid, Uuid.getEmbUuid())
 
         sessionIdTracker.getActiveSessionId()?.let { sessionId ->
             builder.setAttribute(embSessionId.attributeKey, sessionId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
@@ -7,12 +7,16 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.internal.spans.getAttribute
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
+import io.embrace.android.embracesdk.opentelemetry.embState
+import io.embrace.android.embracesdk.opentelemetry.logRecordUid
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.opentelemetry.api.logs.Severity
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -72,7 +76,9 @@ internal class LogWriterImplTest {
             assertEquals("test", body)
             assertEquals(Severity.ERROR, severity)
             assertEquals(Severity.ERROR.name, severity.name)
-            assertEquals("session-id", attributes[embSessionId.name])
+            assertEquals("session-id", attributes.getAttribute(embSessionId))
+            assertNotNull(attributes.getAttribute(embState))
+            assertNotNull(attributes.getAttribute(logRecordUid))
             assertTrue(attributes.hasFixedAttribute(PrivateSpan))
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
@@ -23,6 +23,7 @@ import io.embrace.android.embracesdk.internal.utils.toUTF8String
 import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.opentelemetry.embCrashNumber
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
+import io.embrace.android.embracesdk.opentelemetry.logRecordUid
 import io.embrace.android.embracesdk.payload.NativeCrashDataError
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -81,6 +82,7 @@ internal class NativeCrashDataSourceImplTest {
         with(otelLogger.builders.single()) {
             assertEquals(1, emitCalled)
             assertTrue(attributes.hasFixedAttribute(EmbType.System.NativeCrash))
+            assertNotNull(attributes.getAttribute(logRecordUid))
             assertEquals(testNativeCrashData.sessionId, attributes.getAttribute(embSessionId))
             assertEquals("1", attributes.getAttribute(embCrashNumber))
             assertEquals(testNativeCrashData.crash, attributes.getAttribute(embNativeCrashException))


### PR DESCRIPTION
## Goal

Add `log.record.uid` to every OTel log written that uses `LogWriterImpl`, similar to how we add other common attributes.

Kept the existing logic in JVM crashes and Embrace logs because of some extra things they are doing - limiting the size of the change and will consolidate that later.

## Testing
Add test to LogWriterImpl
