### PR TITLE
Only log network request when getWrappedStream is called

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
@@ -347,8 +347,7 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
     @Override
     @Nullable
     public Map<String, List<String>> getHeaderFields() {
-        final long startTime = embrace.getInternalInterface().getSdkCurrentTime();
-        cacheAndLogNetworkCall(startTime);
+        cacheNetworkCallData();
         return headerFields.get();
     }
 
@@ -359,14 +358,13 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
         if (name == null) {
             return null;
         }
-        long startTime = embrace.getInternalInterface().getSdkCurrentTime();
         if (shouldInterceptHeaderRetrieval(name)) {
             // Strip the content encoding and length headers, as we transparently ungzip the content
             return defaultValue;
         }
 
         R result = action.invoke();
-        cacheAndLogNetworkCall(startTime);
+        cacheNetworkCallData();
 
         return result;
     }
@@ -461,8 +459,7 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
     @Override
     public int getResponseCode() {
         identifyTraceId();
-        long startTime = embrace.getInternalInterface().getSdkCurrentTime();
-        cacheAndLogNetworkCall(startTime);
+        cacheNetworkCallData();
         return responseCode.get();
     }
 
@@ -470,9 +467,8 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
     @Nullable
     public String getResponseMessage() throws IOException {
         identifyTraceId();
-        long startTime = embrace.getInternalInterface().getSdkCurrentTime();
         String responseMsg = this.connection.getResponseMessage();
-        cacheAndLogNetworkCall(startTime);
+        cacheNetworkCallData();
         return responseMsg;
     }
 


### PR DESCRIPTION
## Goal

We were prematurely trying to log a span for a request sent using HttpUrlConnection - we used to overwrite this but since we don't do that anymore, it got used.

Instead of relying on that, we streamline the logging - putting in the "cacheNetworkCall" to force request invocation down the path of calling getResponseCode(). This took care of some edge cases that we previously didn't cover.

If we are not wrapping the stream, we log the call after the request is executed. If we are wrapping the stream, we do the logging when the stream is read and the bytes are counted. If there's an error during the execution or if the request wasn't executed at all because of the lack of a network connection, the logging happens at disconnect.

HttpUrlConnection - you got me again!

## Testing

Existing unit tests pass. 

