### PR TITLE
Use macos to run the rc workflow

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   release:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     strategy:
       matrix:
         jdk-version: [ "17" ]


### PR DESCRIPTION
## Goal

Workflow failing inexplicably on tests that are passing in other environments. Change the OS the action runs on to see if that fixes this.