### PR TITLE
Run on macOS 12

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 45
     strategy:
       matrix:


### PR DESCRIPTION
## Goal

Github [switching to macOS 14](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) by default seems to have broken the functional test workflow, so use macOS 12 for now.
