### PR TITLE
[EMBR-3562] Fix data-dev URL

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehavior.kt
@@ -29,7 +29,7 @@ internal class SdkEndpointBehavior(
     /**
      * Data dev base URL.
      */
-    fun getDataDev(appId: String): String = local?.dataDev ?: "https://a-$appId.$DATA_DEV_DEFAULT"
+    fun getDataDev(): String = local?.dataDev ?: "https://$DATA_DEV_DEFAULT"
 
     /**
      * Config base URL.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -234,7 +234,7 @@ internal class EssentialServiceModuleImpl(
                 (Debug.isDebuggerConnected() || Debug.waitingForDebugger())
 
             val coreBaseUrl = if (isDebug) {
-                sdkEndpointBehavior.getDataDev(appId)
+                sdkEndpointBehavior.getDataDev()
             } else {
                 sdkEndpointBehavior.getData(appId)
             }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehaviorTest.kt
@@ -19,7 +19,7 @@ internal class SdkEndpointBehaviorTest {
         with(fakeSdkEndpointBehavior()) {
             assertEquals("https://a-12345.config.emb-api.com", getConfig("12345"))
             assertEquals("https://a-12345.data.emb-api.com", getData("12345"))
-            assertEquals("https://a-12345.data-dev.emb-api.com", getDataDev("12345"))
+            assertEquals("https://data-dev.emb-api.com", getDataDev())
         }
     }
 
@@ -28,7 +28,7 @@ internal class SdkEndpointBehaviorTest {
         with(fakeSdkEndpointBehavior(localCfg = { local })) {
             assertEquals("https://config.example.com", getConfig("12345"))
             assertEquals("https://data.example.com", getData("12345"))
-            assertEquals("https://data-dev.example.com", getDataDev("12345"))
+            assertEquals("https://data-dev.example.com", getDataDev())
         }
     }
 }


### PR DESCRIPTION
## Goal

- While trying to generate `development` sessions, we were using a URL with the following form:
    - `https://a-appid.data-dev.emb-api.com` 
- And we were getting the following error:
```
Hostname a-fuzhn.data-dev.emb-api.com not verified:
    certificate: sha1/y3meNG0B1bUGmOnP79GyLQ0avwY=
    DN: CN=*.emb-api.com,O=Embrace Mobile\, Inc,L=Culver City,ST=California,C=US
    subjectAltNames: [*.emb-api.com, emb-api.com, *.config.emb-api.com, *.data.emb-api.com, config.emb-api.com, data.emb-api.com]
```
- The problem was that instead of `https://a-appid.data-dev.emb-api.com`, the URL we should use is `https://data-dev.emb-api.com` (like iOS is doing [here](https://github.com/embrace-io/embrace-apple-sdk/blob/cabfc73ba2ac00bd4ee9ee11ed1eb3561c9da031/Sources/EmbraceCore/Options/Embrace%2BEndpoints.swift#L39-L42))
- After making this change, we can see that if we:
    - Call the `Embrace.getInstance().start()` method with `enableIntegrationTesting` in `true`
    - And generate a `debug` build.
The sessions in the dashboard will have `Environment: Development` instead of `Environment: Production`.

## Testing

Updated unit tests and tested manually.

## Release Notes

Fixed the ability to generate sessions in a development environment. 

**WHAT**: Fixed the ability to generate sessions in a development environment. 
**WHY**: We were using the wrong URL.
**WHO**: All customers. 

