### PR TITLE
Improve error message when desugaring not enabled

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/OpenTelemetryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/OpenTelemetryModule.kt
@@ -98,10 +98,19 @@ internal class OpenTelemetryModuleImpl(
 
     private val openTelemetrySdk: OpenTelemetrySdk by lazy {
         Systrace.traceSynchronous("otel-sdk-wrapper-init") {
-            OpenTelemetrySdk(
-                openTelemetryClock = initModule.openTelemetryClock,
-                configuration = openTelemetryConfiguration
-            )
+            try {
+                OpenTelemetrySdk(
+                    openTelemetryClock = initModule.openTelemetryClock,
+                    configuration = openTelemetryConfiguration
+                )
+            } catch (exc: NoClassDefFoundError) {
+                throw LinkageError(
+                    "Please enable library desugaring in your project to use the Embrace SDK. " +
+                        "This is required if you target API levels below 24. For instructions, please see " +
+                        "https://developer.android.com/studio/write/java8-support#library-desugaring",
+                    exc
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Goal

Improves the error message when desugaring has not been enabled in a project by catching a `NoClassDefError` thrown when initializing OTel. We then rethrow it with instructions on how to resolve the problem.

I've chosen `LinkageError` as we catch `Exception` but not `Error`, and it felt appropriate to rethrow with a similar type.

## Testing

Verified by running our test-suite on Android 6 & saw the following error message:

```
java.lang.LinkageError: Please enable library desugaring in your project to use the Embrace SDK. This is required if you target API levels below 24. For instructions, please see https://developer.android.com/studio/write/java8-support#library-desugaring
at io.embrace.android.embracesdk.injection.OpenTelemetryModuleImpl$openTelemetrySdk$2.invoke(OpenTelemetryModule.kt:107)
at io.embrace.android.embracesdk.injection.OpenTelemetryModuleImpl$openTelemetrySdk$2.invoke(OpenTelemetryModule.kt:78)
```
