### PR TITLE
Filter private logs out of external exporters

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriter.kt
@@ -4,5 +4,5 @@ package io.embrace.android.embracesdk.arch.destination
  * Declares functions for writing a [LogEventData] to the current session span.
  */
 internal interface LogWriter {
-    fun <T> addLog(log: T, mapper: (T.() -> LogEventData)? = null)
+    fun <T> addLog(log: T, mapper: (T.() -> LogEventData)? = null, isPrivate: Boolean = false)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.arch.destination
 
+import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.internal.spans.setFixedAttribute
 import io.embrace.android.embracesdk.internal.spans.toOtelSeverity
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
@@ -16,7 +18,7 @@ internal class LogWriterImpl(
     private val metadataService: MetadataService,
 ) : LogWriter {
 
-    override fun <T> addLog(log: T, mapper: (T.() -> LogEventData)?) {
+    override fun <T> addLog(log: T, mapper: (T.() -> LogEventData)?, isPrivate: Boolean) {
         val logEventData = if (log is LogEventData) {
             log
         } else if (mapper != null) {
@@ -38,6 +40,10 @@ internal class LogWriterImpl(
 
         metadataService.getAppState()?.let { appState ->
             builder.setAttribute(embState.attributeKey, appState)
+        }
+
+        if (isPrivate) {
+            builder.setFixedAttribute(PrivateSpan)
         }
 
         logEventData.schemaType.attributes().forEach {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporter.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.logs
 
+import io.embrace.android.embracesdk.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.logs.export.LogRecordExporter
@@ -7,9 +9,22 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter
 /**
  * Exports the given [LogRecordData] to a [LogSink]
  */
-internal class EmbraceLogRecordExporter(private val logSink: LogSink) : LogRecordExporter {
-    override fun export(logs: Collection<LogRecordData>): CompletableResultCode =
-        logSink.storeLogs(logs.toList())
+internal class EmbraceLogRecordExporter(
+    private val logSink: LogSink,
+    private val externalLogRecordExporter: LogRecordExporter
+) : LogRecordExporter {
+    override fun export(logs: Collection<LogRecordData>): CompletableResultCode {
+        val result = logSink.storeLogs(logs.toList())
+        if (result == CompletableResultCode.ofSuccess()) {
+            return externalLogRecordExporter.export(
+                logs.filterNot {
+                    it.hasFixedAttribute(PrivateSpan)
+                }
+            )
+        }
+
+        return result
+    }
 
     override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
+import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
@@ -90,6 +91,11 @@ internal fun Span.setEmbraceAttribute(key: EmbraceAttributeKey, value: String): 
 }
 
 internal fun Span.setFixedAttribute(fixedAttribute: FixedAttribute): Span = setEmbraceAttribute(fixedAttribute.key, fixedAttribute.value)
+
+internal fun LogRecordBuilder.setFixedAttribute(fixedAttribute: FixedAttribute): LogRecordBuilder {
+    setAttribute(fixedAttribute.key.attributeKey, fixedAttribute.value)
+    return this
+}
 
 /**
  * Ends the given [Span], and setting the correct properties per the optional [ErrorCode] passed in. If [errorCode]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
@@ -36,7 +36,7 @@ internal class OpenTelemetryConfiguration(
         .build()
 
     private val externalSpanExporters = mutableListOf<SpanExporter>()
-    private val logExporters = mutableListOf<LogRecordExporter>(EmbraceLogRecordExporter(logSink))
+    private val externalLogExporters = mutableListOf<LogRecordExporter>()
 
     val spanProcessor: SpanProcessor by lazy {
         EmbraceSpanProcessor(
@@ -49,7 +49,12 @@ internal class OpenTelemetryConfiguration(
     }
 
     val logProcessor: LogRecordProcessor by lazy {
-        EmbraceLogRecordProcessor(LogRecordExporter.composite(logExporters))
+        EmbraceLogRecordProcessor(
+            EmbraceLogRecordExporter(
+                logSink = logSink,
+                externalLogRecordExporter = LogRecordExporter.composite(externalLogExporters)
+            )
+        )
     }
 
     fun addSpanExporter(spanExporter: SpanExporter) {
@@ -57,6 +62,6 @@ internal class OpenTelemetryConfiguration(
     }
 
     fun addLogExporter(logExporter: LogRecordExporter) {
-        logExporters.add(logExporter)
+        externalLogExporters.add(logExporter)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.opentelemetry.api.logs.Severity
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -80,6 +81,27 @@ internal class LogWriterImplTest {
             assertNotNull(attributes.getAttribute(embState))
             assertNotNull(attributes.getAttribute(logRecordUid))
             assertTrue(attributes.hasFixedAttribute(PrivateSpan))
+        }
+    }
+
+    @Test
+    fun `check that private value is set`() {
+        val logEventData = LogEventData(
+            schemaType = SchemaType.Log(
+                TelemetryAttributes(
+                    configService = FakeConfigService()
+                )
+            ),
+            severity = io.embrace.android.embracesdk.Severity.ERROR,
+            message = "test"
+        )
+        logWriterImpl.addLog(logEventData, isPrivate = true)
+        with(logger.builders.single()) {
+            assertTrue(attributes.hasFixedAttribute(PrivateSpan))
+        }
+        logWriterImpl.addLog(logEventData, isPrivate = false)
+        with(logger.builders.last()) {
+            assertFalse(attributes.hasFixedAttribute(PrivateSpan))
         }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
@@ -7,7 +7,7 @@ internal class FakeLogWriter : LogWriter {
 
     val logEvents = mutableListOf<LogEventData>()
 
-    override fun <T> addLog(log: T, mapper: (T.() -> LogEventData)?) {
+    override fun <T> addLog(log: T, mapper: (T.() -> LogEventData)?, isPrivate: Boolean) {
         val logEvent = if (log is LogEventData) {
             log
         } else if (mapper != null) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporterTest.kt
@@ -1,7 +1,12 @@
 package io.embrace.android.embracesdk.internal.logs
 
+import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
+import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
+import io.embrace.android.embracesdk.fixtures.testLog
+import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.opentelemetry.sdk.logs.export.LogRecordExporter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
@@ -11,12 +16,34 @@ internal class EmbraceLogRecordExporterTest {
     @Test
     fun `export() should store logs in LogSink`() {
         val logSink: LogSink = LogSinkImpl()
-        val embraceLogRecordExporter = EmbraceLogRecordExporter(logSink)
+        val embraceLogRecordExporter = EmbraceLogRecordExporter(logSink, LogRecordExporter.composite(emptyList()))
         val logRecordData = FakeLogRecordData()
 
         embraceLogRecordExporter.export(listOf(logRecordData))
 
         assertFalse(logSink.completedLogs().isEmpty())
         assertEquals(logRecordData.toNewPayload(), logSink.completedLogs()[0])
+    }
+
+    @Test
+    fun `private logs should be filtered out from external exporters`() {
+        val logSink: LogSink = LogSinkImpl()
+        val externalExporter = FakeLogRecordExporter()
+        val embraceLogRecordExporter = EmbraceLogRecordExporter(logSink, LogRecordExporter.composite(externalExporter))
+        val logRecordData = FakeLogRecordData()
+        val privateLogRecordData = FakeLogRecordData(
+            log = testLog.copy(
+                attributes = logRecordData.log.attributes?.plus(Attribute(PrivateSpan.key.name, PrivateSpan.value))
+            )
+        )
+
+        embraceLogRecordExporter.export(listOf(logRecordData, privateLogRecordData))
+
+        assertEquals(2, logSink.completedLogs().size)
+        assertEquals(logRecordData.toNewPayload(), logSink.completedLogs()[0])
+        assertEquals(privateLogRecordData.toNewPayload(), logSink.completedLogs()[1])
+
+        assertEquals(1, externalExporter.exportedLogs?.size)
+        assertEquals(logRecordData, externalExporter.exportedLogs?.first())
     }
 }


### PR DESCRIPTION
## Goal

Filter out OTel logs with the "emb.private" attribute when exporting to a customer-provided log exporter.

## Testing

Modified unit tests. Note that currently there are no logs that are marked as private within the SDK.


