### PR TITLE
Renamed `enableIntegrationTesting` param to `isDevMode` in `Embrace.start()`

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -110,7 +110,7 @@ internal class IntegrationTestRule(
             val embraceImpl = EmbraceImpl(bootstrapper)
             Embrace.setImpl(embraceImpl)
             if (startImmediately) {
-                embraceImpl.startInternal(overriddenCoreModule.context, enableIntegrationTesting, appFramework) { overriddenConfigService }
+                embraceImpl.startInternal(overriddenCoreModule.context, isDevMode, appFramework) { overriddenConfigService }
             }
         }
     }
@@ -136,7 +136,7 @@ internal class IntegrationTestRule(
     internal class Harness(
         currentTimeMs: Long = DEFAULT_SDK_START_TIME_MS,
         val startImmediately: Boolean = true,
-        val enableIntegrationTesting: Boolean = false,
+        val isDevMode: Boolean = false,
         val appFramework: AppFramework = AppFramework.NATIVE,
         val overriddenClock: FakeClock = FakeClock(currentTime = currentTimeMs),
         val overriddenInitModule: FakeInitModule = FakeInitModule(clock = overriddenClock),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -75,16 +75,16 @@ public final class Embrace implements EmbraceAndroidApi {
     }
 
     @Override
-    public void start(@NonNull Context context, boolean enableIntegrationTesting) {
+    public void start(@NonNull Context context, boolean isDevMode) {
         if (verifyNonNullParameters("start", context)) {
-            start(context, enableIntegrationTesting, AppFramework.NATIVE);
+            start(context, isDevMode, AppFramework.NATIVE);
         }
     }
 
     @Override
-    public void start(@NonNull Context context, boolean enableIntegrationTesting, @NonNull AppFramework appFramework) {
+    public void start(@NonNull Context context, boolean isDevMode, @NonNull AppFramework appFramework) {
         if (verifyNonNullParameters("start", context, appFramework)) {
-            impl.start(context, enableIntegrationTesting, appFramework);
+            impl.start(context, isDevMode, appFramework);
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAndroidApi.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAndroidApi.java
@@ -33,13 +33,12 @@ interface EmbraceAndroidApi extends EmbraceApi {
      * the Embrace SDK must be initialized after any other SDK.
      *
      * @param context                  an instance of context
-     * @param enableIntegrationTesting if true, debug sessions (those which are not part of a
-     *                                 release APK) will go to the live integration testing tab
-     *                                 of the dashboard. If false, they will appear in 'recent
-     *                                 sessions'.
+     * @param isDevMode                if true, sets the environment for all sessions to 'Development',
+     *                                 similar to using a build type with debuggable set to true.
+     *
      */
     void start(@NonNull Context context,
-               boolean enableIntegrationTesting);
+               boolean isDevMode);
 
     /**
      * Starts instrumentation of the Android application using the Embrace SDK. This should be
@@ -50,13 +49,11 @@ interface EmbraceAndroidApi extends EmbraceApi {
      * the Embrace SDK must be initialized after any other SDK.
      *
      * @param context                  an instance of context
-     * @param enableIntegrationTesting if true, debug sessions (those which are not part of a
-     *                                 release APK) will go to the live integration testing tab
-     *                                 of the dashboard. If false, they will appear in 'recent
-     *                                 sessions'.
+     * @param isDevMode                if true, sets the environment for all sessions to 'Development',
+     *                                 similar to using a build type with debuggable set to true.
      */
     void start(@NonNull Context context,
-               boolean enableIntegrationTesting,
+               boolean isDevMode,
                @NonNull Embrace.AppFramework appFramework);
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAndroidApi.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAndroidApi.java
@@ -33,8 +33,8 @@ interface EmbraceAndroidApi extends EmbraceApi {
      * the Embrace SDK must be initialized after any other SDK.
      *
      * @param context                  an instance of context
-     * @param isDevMode                if true, sets the environment for all sessions to 'Development',
-     *                                 similar to using a build type with debuggable set to true.
+     * @param isDevMode                if true, and the build type is debuggable, it
+     *                                 sets the environment for all sessions to 'Development'.
      *
      */
     void start(@NonNull Context context,
@@ -49,8 +49,8 @@ interface EmbraceAndroidApi extends EmbraceApi {
      * the Embrace SDK must be initialized after any other SDK.
      *
      * @param context                  an instance of context
-     * @param isDevMode                if true, sets the environment for all sessions to 'Development',
-     *                                 similar to using a build type with debuggable set to true.
+     * @param isDevMode                if true, and the build type is debuggable, it
+     *                                 sets the environment for all sessions to 'Development'.
      */
     void start(@NonNull Context context,
                boolean isDevMode,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -230,24 +230,22 @@ final class EmbraceImpl {
      * the Embrace SDK must be initialized after any other SDK.
      *
      * @param context                  an instance of context
-     * @param enableIntegrationTesting if true, debug sessions (those which are not part of a
-     *                                 release APK) will go to the live integration testing tab
-     *                                 of the dashboard. If false, they will appear in 'recent
-     *                                 sessions'.
+     * @param isDevMode                if true, sets the environment for all sessions to 'Development',
+     *                                 similar to using a build type with debuggable set to true.
      */
     void start(@NonNull Context context,
-               boolean enableIntegrationTesting,
+               boolean isDevMode,
                @NonNull Embrace.AppFramework appFramework) {
-        startInternal(context, enableIntegrationTesting, appFramework, () -> null);
+        startInternal(context, isDevMode, appFramework, () -> null);
     }
 
     void startInternal(@NonNull Context context,
-                       boolean enableIntegrationTesting,
+                       boolean isDevMode,
                        @NonNull Embrace.AppFramework appFramework,
                        @NonNull Function0<ConfigService> configServiceProvider) {
         try {
             Systrace.startSynchronous("sdk-start");
-            startImpl(context, enableIntegrationTesting, appFramework, configServiceProvider);
+            startImpl(context, isDevMode, appFramework, configServiceProvider);
             Systrace.endSynchronous();
         } catch (Throwable t) {
             internalEmbraceLogger.logError(
@@ -256,7 +254,7 @@ final class EmbraceImpl {
     }
 
     private void startImpl(@NonNull Context context,
-                           boolean enableIntegrationTesting,
+                           boolean isDevMode,
                            @NonNull Embrace.AppFramework framework,
                            @NonNull Function0<ConfigService> configServiceProvider) {
         if (application != null) {
@@ -273,7 +271,7 @@ final class EmbraceImpl {
 
         final long startTimeMs = sdkClock.now();
         internalEmbraceLogger.logInfo("Starting SDK for framework " + framework.name());
-        moduleInitBootstrapper.init(context, enableIntegrationTesting, framework, startTimeMs, customAppId, configServiceProvider);
+        moduleInitBootstrapper.init(context, isDevMode, framework, startTimeMs, customAppId, configServiceProvider);
         Systrace.startSynchronous("post-services-setup");
         telemetryService = moduleInitBootstrapper.getInitModule().getTelemetryService();
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.injection
 
-import android.os.Debug
 import io.embrace.android.embracesdk.arch.destination.LogWriter
 import io.embrace.android.embracesdk.arch.destination.LogWriterImpl
 import io.embrace.android.embracesdk.capture.connectivity.EmbraceNetworkConnectivityService
@@ -84,7 +83,7 @@ internal class EssentialServiceModuleImpl(
     androidServicesModule: AndroidServicesModule,
     storageModule: StorageModule,
     customAppId: String?,
-    enableIntegrationTesting: Boolean,
+    isDevMode: Boolean,
     dataSourceModuleProvider: Provider<DataSourceModule>,
     private val configServiceProvider: Provider<ConfigService?> = { null }
 ) : EssentialServiceModule {
@@ -229,9 +228,7 @@ internal class EssentialServiceModuleImpl(
                 localSupplier = localConfig.sdkConfig::baseUrls,
             )
 
-            val isDebug = coreModule.isDebug &&
-                enableIntegrationTesting &&
-                (Debug.isDebuggerConnected() || Debug.waitingForDebugger())
+            val isDebug = coreModule.isDebug || isDevMode
 
             val coreBaseUrl = if (isDebug) {
                 sdkEndpointBehavior.getDataDev()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
+import android.os.Debug
 import io.embrace.android.embracesdk.arch.destination.LogWriter
 import io.embrace.android.embracesdk.arch.destination.LogWriterImpl
 import io.embrace.android.embracesdk.capture.connectivity.EmbraceNetworkConnectivityService
@@ -228,7 +229,9 @@ internal class EssentialServiceModuleImpl(
                 localSupplier = localConfig.sdkConfig::baseUrls,
             )
 
-            val isDebug = coreModule.isDebug || isDevMode
+            val isDebug = coreModule.isDebug &&
+                isDevMode &&
+                (Debug.isDebuggerConnected() || Debug.waitingForDebugger())
 
             val coreBaseUrl = if (isDebug) {
                 sdkEndpointBehavior.getDataDev()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -130,7 +130,7 @@ internal class ModuleInitBootstrapper(
     @JvmOverloads
     fun init(
         context: Context,
-        enableIntegrationTesting: Boolean,
+        isDevMode: Boolean,
         appFramework: AppFramework,
         sdkStartTimeMs: Long,
         customAppId: String? = null,
@@ -188,7 +188,7 @@ internal class ModuleInitBootstrapper(
                             androidServicesModule,
                             storageModule,
                             customAppId,
-                            enableIntegrationTesting,
+                            isDevMode,
                             { dataSourceModule },
                             configServiceProvider
                         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -89,7 +89,7 @@ internal typealias EssentialServiceModuleSupplier = (
     androidServicesModule: AndroidServicesModule,
     storageModule: StorageModule,
     customAppId: String?,
-    enableIntegrationTesting: Boolean,
+    isDevMode: Boolean,
     dataSourceModuleProvider: Provider<DataSourceModule>,
     configServiceProvider: Provider<ConfigService?>
 ) -> EssentialServiceModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
@@ -4,7 +4,6 @@ import android.os.Looper
 import io.embrace.android.embracesdk.arch.destination.LogWriterImpl
 import io.embrace.android.embracesdk.capture.connectivity.EmbraceNetworkConnectivityService
 import io.embrace.android.embracesdk.capture.cpu.EmbraceCpuInfoDelegate
-import io.embrace.android.embracesdk.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.capture.metadata.EmbraceMetadataService
 import io.embrace.android.embracesdk.capture.orientation.NoOpOrientationService
 import io.embrace.android.embracesdk.capture.user.EmbraceUserService
@@ -27,7 +26,6 @@ import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -95,91 +93,5 @@ internal class EssentialServiceModuleImplTest {
         ) { fakeConfigService }
 
         assertSame(fakeConfigService, module.configService)
-    }
-
-    @Test
-    fun `test data URL is returned when isDevMode and isDebug are false`() {
-        val fakeCoreModule = FakeCoreModule(isDebug = false)
-        val initModule = InitModuleImpl()
-        val module = EssentialServiceModuleImpl(
-            initModule = initModule,
-            openTelemetryModule = FakeOpenTelemetryModule(),
-            coreModule = fakeCoreModule,
-            workerThreadModule = WorkerThreadModuleImpl(initModule),
-            systemServiceModule = FakeSystemServiceModule(),
-            androidServicesModule = FakeAndroidServicesModule(),
-            storageModule = FakeStorageModule(),
-            customAppId = "abcde",
-            dataSourceModuleProvider = { fakeDataSourceModule() },
-            isDevMode = false,
-        ) { null }
-
-        assertFalse(AppEnvironment(fakeCoreModule.context.applicationInfo).isDebug)
-        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
-        assertTrue(dataUrl.startsWith("https://a-abcde.data.emb-api.com"))
-    }
-
-    @Test
-    fun `test data dev URL is returned when isDevMode is true and isDebug is false`() {
-        val fakeCoreModule = FakeCoreModule(isDebug = false)
-        val initModule = InitModuleImpl()
-        val module = EssentialServiceModuleImpl(
-            initModule = initModule,
-            openTelemetryModule = FakeOpenTelemetryModule(),
-            coreModule = fakeCoreModule,
-            workerThreadModule = WorkerThreadModuleImpl(initModule),
-            systemServiceModule = FakeSystemServiceModule(),
-            androidServicesModule = FakeAndroidServicesModule(),
-            storageModule = FakeStorageModule(),
-            customAppId = "abcde",
-            dataSourceModuleProvider = { fakeDataSourceModule() },
-            isDevMode = true,
-        ) { null }
-
-        assertFalse(AppEnvironment(fakeCoreModule.context.applicationInfo).isDebug)
-        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
-        assertTrue(dataUrl.startsWith("https://data-dev.emb-api.com"))
-    }
-
-    @Test
-    fun `test data dev URL is returned when isDevMode is false and isDebug is true`() {
-        val fakeCoreModule = FakeCoreModule(isDebug = true)
-        val initModule = InitModuleImpl()
-        val module = EssentialServiceModuleImpl(
-            initModule = initModule,
-            openTelemetryModule = FakeOpenTelemetryModule(),
-            coreModule = fakeCoreModule,
-            workerThreadModule = WorkerThreadModuleImpl(initModule),
-            systemServiceModule = FakeSystemServiceModule(),
-            androidServicesModule = FakeAndroidServicesModule(),
-            storageModule = FakeStorageModule(),
-            customAppId = "abcde",
-            dataSourceModuleProvider = { fakeDataSourceModule() },
-            isDevMode = false,
-        ) { null }
-
-        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
-        assertTrue(dataUrl.startsWith("https://data-dev.emb-api.com"))
-    }
-
-    @Test
-    fun `test data dev URL is returned when isDevMode and isDebug are true`() {
-        val fakeCoreModule = FakeCoreModule(isDebug = true)
-        val initModule = InitModuleImpl()
-        val module = EssentialServiceModuleImpl(
-            initModule = initModule,
-            openTelemetryModule = FakeOpenTelemetryModule(),
-            coreModule = fakeCoreModule,
-            workerThreadModule = WorkerThreadModuleImpl(initModule),
-            systemServiceModule = FakeSystemServiceModule(),
-            androidServicesModule = FakeAndroidServicesModule(),
-            storageModule = FakeStorageModule(),
-            customAppId = "abcde",
-            dataSourceModuleProvider = { fakeDataSourceModule() },
-            isDevMode = true,
-        ) { null }
-
-        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
-        assertTrue(dataUrl.startsWith("https://data-dev.emb-api.com"))
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EssentialServiceModuleImplTest.kt
@@ -4,6 +4,7 @@ import android.os.Looper
 import io.embrace.android.embracesdk.arch.destination.LogWriterImpl
 import io.embrace.android.embracesdk.capture.connectivity.EmbraceNetworkConnectivityService
 import io.embrace.android.embracesdk.capture.cpu.EmbraceCpuInfoDelegate
+import io.embrace.android.embracesdk.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.capture.metadata.EmbraceMetadataService
 import io.embrace.android.embracesdk.capture.orientation.NoOpOrientationService
 import io.embrace.android.embracesdk.capture.user.EmbraceUserService
@@ -26,6 +27,7 @@ import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -50,7 +52,7 @@ internal class EssentialServiceModuleImplTest {
             storageModule = FakeStorageModule(),
             customAppId = "abcde",
             dataSourceModuleProvider = { fakeDataSourceModule() },
-            enableIntegrationTesting = false,
+            isDevMode = false,
         ) { null }
 
         assertTrue(module.memoryCleanerService is EmbraceMemoryCleanerService)
@@ -89,9 +91,95 @@ internal class EssentialServiceModuleImplTest {
             storageModule = FakeStorageModule(),
             customAppId = null,
             dataSourceModuleProvider = { fakeDataSourceModule() },
-            enableIntegrationTesting = false,
+            isDevMode = false,
         ) { fakeConfigService }
 
         assertSame(fakeConfigService, module.configService)
+    }
+
+    @Test
+    fun `test data URL is returned when isDevMode and isDebug are false`() {
+        val fakeCoreModule = FakeCoreModule(isDebug = false)
+        val initModule = InitModuleImpl()
+        val module = EssentialServiceModuleImpl(
+            initModule = initModule,
+            openTelemetryModule = FakeOpenTelemetryModule(),
+            coreModule = fakeCoreModule,
+            workerThreadModule = WorkerThreadModuleImpl(initModule),
+            systemServiceModule = FakeSystemServiceModule(),
+            androidServicesModule = FakeAndroidServicesModule(),
+            storageModule = FakeStorageModule(),
+            customAppId = "abcde",
+            dataSourceModuleProvider = { fakeDataSourceModule() },
+            isDevMode = false,
+        ) { null }
+
+        assertFalse(AppEnvironment(fakeCoreModule.context.applicationInfo).isDebug)
+        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
+        assertTrue(dataUrl.startsWith("https://a-abcde.data.emb-api.com"))
+    }
+
+    @Test
+    fun `test data dev URL is returned when isDevMode is true and isDebug is false`() {
+        val fakeCoreModule = FakeCoreModule(isDebug = false)
+        val initModule = InitModuleImpl()
+        val module = EssentialServiceModuleImpl(
+            initModule = initModule,
+            openTelemetryModule = FakeOpenTelemetryModule(),
+            coreModule = fakeCoreModule,
+            workerThreadModule = WorkerThreadModuleImpl(initModule),
+            systemServiceModule = FakeSystemServiceModule(),
+            androidServicesModule = FakeAndroidServicesModule(),
+            storageModule = FakeStorageModule(),
+            customAppId = "abcde",
+            dataSourceModuleProvider = { fakeDataSourceModule() },
+            isDevMode = true,
+        ) { null }
+
+        assertFalse(AppEnvironment(fakeCoreModule.context.applicationInfo).isDebug)
+        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
+        assertTrue(dataUrl.startsWith("https://data-dev.emb-api.com"))
+    }
+
+    @Test
+    fun `test data dev URL is returned when isDevMode is false and isDebug is true`() {
+        val fakeCoreModule = FakeCoreModule(isDebug = true)
+        val initModule = InitModuleImpl()
+        val module = EssentialServiceModuleImpl(
+            initModule = initModule,
+            openTelemetryModule = FakeOpenTelemetryModule(),
+            coreModule = fakeCoreModule,
+            workerThreadModule = WorkerThreadModuleImpl(initModule),
+            systemServiceModule = FakeSystemServiceModule(),
+            androidServicesModule = FakeAndroidServicesModule(),
+            storageModule = FakeStorageModule(),
+            customAppId = "abcde",
+            dataSourceModuleProvider = { fakeDataSourceModule() },
+            isDevMode = false,
+        ) { null }
+
+        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
+        assertTrue(dataUrl.startsWith("https://data-dev.emb-api.com"))
+    }
+
+    @Test
+    fun `test data dev URL is returned when isDevMode and isDebug are true`() {
+        val fakeCoreModule = FakeCoreModule(isDebug = true)
+        val initModule = InitModuleImpl()
+        val module = EssentialServiceModuleImpl(
+            initModule = initModule,
+            openTelemetryModule = FakeOpenTelemetryModule(),
+            coreModule = fakeCoreModule,
+            workerThreadModule = WorkerThreadModuleImpl(initModule),
+            systemServiceModule = FakeSystemServiceModule(),
+            androidServicesModule = FakeAndroidServicesModule(),
+            storageModule = FakeStorageModule(),
+            customAppId = "abcde",
+            dataSourceModuleProvider = { fakeDataSourceModule() },
+            isDevMode = true,
+        ) { null }
+
+        val dataUrl = module.urlBuilder.getEmbraceUrlWithSuffix("v1", "log")
+        assertTrue(dataUrl.startsWith("https://data-dev.emb-api.com"))
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -46,7 +46,7 @@ internal class ModuleInitBootstrapperTest {
             assertTrue(
                 moduleInitBootstrapper.init(
                     context = context,
-                    enableIntegrationTesting = false,
+                    isDevMode = false,
                     appFramework = Embrace.AppFramework.NATIVE,
                     sdkStartTimeMs = 0L,
                 )
@@ -69,7 +69,7 @@ internal class ModuleInitBootstrapperTest {
         assertTrue(
             moduleInitBootstrapper.init(
                 context = context,
-                enableIntegrationTesting = false,
+                isDevMode = false,
                 appFramework = Embrace.AppFramework.NATIVE,
                 sdkStartTimeMs = 0L,
             )
@@ -77,7 +77,7 @@ internal class ModuleInitBootstrapperTest {
         assertFalse(
             moduleInitBootstrapper.init(
                 context = context,
-                enableIntegrationTesting = false,
+                isDevMode = false,
                 appFramework = Embrace.AppFramework.NATIVE,
                 sdkStartTimeMs = 0L,
             )
@@ -89,7 +89,7 @@ internal class ModuleInitBootstrapperTest {
         assertTrue(
             moduleInitBootstrapper.init(
                 context = context,
-                enableIntegrationTesting = false,
+                isDevMode = false,
                 appFramework = Embrace.AppFramework.NATIVE,
                 sdkStartTimeMs = 0L,
             )
@@ -114,7 +114,7 @@ internal class ModuleInitBootstrapperTest {
         assertTrue(
             bootstrapper.init(
                 context = context,
-                enableIntegrationTesting = false,
+                isDevMode = false,
                 appFramework = Embrace.AppFramework.NATIVE,
                 sdkStartTimeMs = 0L,
             )


### PR DESCRIPTION
## Goal

- Renamed `enableIntegrationTesting` param to `isDevMode` in `Embrace.start()`.

- [PR](https://github.com/embrace-io/embrace-docs/pull/464) updating embrace-docs. 

