### PR TITLE
[POC] Span links

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -39,7 +39,7 @@ object Versions {
     val ndk = "21.4.7075529"
 
     @JvmField
-    val openTelemetryCore = "1.35.0"
+    val openTelemetryCore = "1.37.0"
 
     @JvmField
     val moshi = "1.12.0"

--- a/embrace-android-sdk/config/detekt/baseline.xml
+++ b/embrace-android-sdk/config/detekt/baseline.xml
@@ -2,11 +2,10 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ArgumentListWrapping:LegacyExceptionInfoTest.kt$LegacyExceptionInfoTest$( "io.embrace.android.embracesdk.LegacyExceptionInfoTest.testOfThrowable(LegacyExceptionInfoTest.kt:45)", info.lines.first())</ID>
-    <ID>ArgumentListWrapping:LegacyExceptionInfoTest.kt$LegacyExceptionInfoTest$("io.embrace.android.embracesdk.LegacyExceptionInfoTest.testOfThrowable(LegacyExceptionInfoTest.kt:45)", info.lines.first())</ID>
     <ID>DataClassContainsFunctions:LegacyExceptionError.kt$LegacyExceptionError$fun addException(ex: Throwable?, appState: String?, clock: Clock)</ID>
     <ID>DataClassContainsFunctions:LegacyExceptionError.kt$LegacyExceptionError$private fun getExceptionInfo(ex: Throwable?): List&lt;LegacyExceptionInfo&gt;</ID>
     <ID>DataClassShouldBeImmutable:LegacyExceptionError.kt$LegacyExceptionError$@Json(name = "c") var occurrences = 0</ID>
     <ID>DataClassShouldBeImmutable:LegacyExceptionError.kt$LegacyExceptionError$@Json(name = "rep") var exceptionErrors = mutableListOf&lt;LegacyExceptionErrorInfo&gt;()</ID>
+    <ID>LongParameterList:SpanService.kt$SpanService$( name: String, startTimeMs: Long, endTimeMs: Long, parent: EmbraceSpan? = null, type: TelemetryType = EmbType.Performance.Default, internal: Boolean = true, private: Boolean = internal, attributes: Map&lt;String, String&gt; = emptyMap(), events: List&lt;EmbraceSpanEvent&gt; = emptyList(), links: List&lt;EmbraceSpanLink&gt; = emptyList(), errorCode: ErrorCode? = null )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Span.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Span.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.payload
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLink
 
 /**
  * A span represents a single unit of work done in the app. It can be a network request, a database
@@ -50,6 +51,9 @@ internal data class Span(
 
     @Json(name = "events")
     val events: List<SpanEvent>? = null,
+
+    @Json(name = "links")
+    val links: List<EmbraceSpanLink>? = null,
 
     @Json(name = "attributes")
     val attributes: List<Attribute>? = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
@@ -25,6 +25,7 @@ internal fun EmbraceSpanData.toNewPayload() = Span(
         else -> Span.Status.UNSET
     },
     events = events.map(EmbraceSpanEvent::toNewPayload),
+    links = spanLinks,
     attributes = attributes.toNewPayload()
 )
 
@@ -61,7 +62,8 @@ internal fun Span.toOldPayload(): EmbraceSpanData {
             else -> StatusCode.UNSET
         },
         events = events?.map { it.toOldPayload() } ?: emptyList(),
-        attributes = attributes?.toOldPayload() ?: emptyMap()
+        spanLinks = links ?: emptyList(),
+        attributes = attributes?.toOldPayload() ?: emptyMap(),
     )
 }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanContext.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanContext.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class EmbraceSpanContext(
+    @Json(name = "trace_id")
+    val traceId: String,
+
+    @Json(name = "span_id")
+    val spanId: String,
+
+    // TODO: Should we also add trace state and trace flags?
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
@@ -38,7 +38,11 @@ internal data class EmbraceSpanData(
     val events: List<EmbraceSpanEvent> = emptyList(),
 
     @Json(name = "attributes")
-    val attributes: Map<String, String> = emptyMap()
+    val attributes: Map<String, String> = emptyMap(),
+
+    @Json(name = "links")
+    val spanLinks: List<EmbraceSpanLink> = emptyList()
+
 ) {
     internal constructor(spanData: SpanData) : this(
         traceId = spanData.spanContext.traceId,
@@ -49,6 +53,12 @@ internal data class EmbraceSpanData(
         endTimeNanos = spanData.endEpochNanos,
         status = spanData.status.statusCode,
         events = fromEventData(eventDataList = spanData.events),
+        spanLinks = spanData.links.map { linkData ->
+            EmbraceSpanLink(
+                EmbraceSpanContext(linkData.spanContext.traceId, linkData.spanContext.spanId),
+                linkData.attributes.asMap().entries.associate { it.key.key to it.value.toString() }
+            )
+        },
         attributes = spanData.attributes.asMap().entries.associate { it.key.key to it.value.toString() }
     )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanLink.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanLink.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.internal.spans
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class EmbraceSpanLink(
+
+    @Json(name = "span_context")
+    val spanContext: EmbraceSpanContext,
+
+    @Json(name = "attributes")
+    val attributes: Map<String, String>
+)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -82,6 +82,7 @@ internal class EmbraceSpanService(
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        links: List<EmbraceSpanLink>,
         errorCode: ErrorCode?
     ): Boolean = currentDelegate.recordCompletedSpan(
         name = name,
@@ -93,8 +94,10 @@ internal class EmbraceSpanService(
         private = private,
         attributes = attributes,
         events = events,
+        links = links,
         errorCode = errorCode
     )
 
     override fun getSpan(spanId: String): EmbraceSpan? = currentDelegate.getSpan(spanId = spanId)
+    override fun getActiveSpans(): List<PersistableEmbraceSpan> = currentDelegate.getActiveSpans()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -79,6 +79,7 @@ internal interface SpanService : Initializable {
         private: Boolean = internal,
         attributes: Map<String, String> = emptyMap(),
         events: List<EmbraceSpanEvent> = emptyList(),
+        links: List<EmbraceSpanLink> = emptyList(),
         errorCode: ErrorCode? = null
     ): Boolean
 
@@ -86,4 +87,9 @@ internal interface SpanService : Initializable {
      * Return the [EmbraceSpan] corresponding to the given spanId if it is active or it has completed in the current session
      */
     fun getSpan(spanId: String): EmbraceSpan?
+
+    /**
+     * Get a list of active spans that are being tracked
+     */
+    fun getActiveSpans(): List<PersistableEmbraceSpan>
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -93,6 +93,7 @@ internal class SpanServiceImpl(
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        links: List<EmbraceSpanLink>,
         errorCode: ErrorCode?
     ): Boolean {
         if (startTimeMs > endTimeMs) {
@@ -108,6 +109,9 @@ internal class SpanServiceImpl(
                 events.forEach {
                     newSpan.addEvent(it.name, it.timestampNanos.nanosToMillis(), it.attributes)
                 }
+                links.forEach {
+                    newSpan.addLink(it.spanContext.spanId, it.spanContext.traceId, it.attributes)
+                }
                 return newSpan.stop(errorCode, endTimeMs)
             }
         }
@@ -116,6 +120,7 @@ internal class SpanServiceImpl(
     }
 
     override fun getSpan(spanId: String): EmbraceSpan? = spanRepository.getSpan(spanId = spanId)
+    override fun getActiveSpans(): List<PersistableEmbraceSpan> = spanRepository.getActiveSpans()
 
     private fun inputsValid(
         name: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
@@ -52,6 +52,7 @@ internal class UninitializedSdkSpanService : SpanService {
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        links: List<EmbraceSpanLink>,
         errorCode: ErrorCode?
     ): Boolean {
         return realSpanService.get()?.recordCompletedSpan(
@@ -91,6 +92,7 @@ internal class UninitializedSdkSpanService : SpanService {
     }
 
     override fun getSpan(spanId: String): EmbraceSpan? = null
+    override fun getActiveSpans(): List<PersistableEmbraceSpan> = emptyList()
 
     /**
      * Set the real [SpanService] to record completed spans and record the buffered instances

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -92,4 +92,12 @@ public interface EmbraceSpan {
      * if the validation at the Embrace Level has passed and the call to add the Attribute at the OpenTelemetry level was successful.
      */
     public fun addAttribute(key: String, value: String): Boolean
+
+    /**
+     * Add a Link to another Span. Returns false if the Link was not added. Returns true if the validation at the Embrace level
+     * has passed.
+     *
+     * TODO: Should we add trace state and flags?
+     */
+    public fun addLink(spanId: String, traceId: String, attributes: Map<String, String>): Boolean
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -89,6 +89,10 @@ internal class FakePersistableEmbraceSpan(
         return true
     }
 
+    override fun addLink(spanId: String, traceId: String, attributes: Map<String, String>): Boolean {
+        return false
+    }
+
     override fun snapshot(): Span? {
         return if (spanId == null) {
             null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLink
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -49,6 +50,7 @@ internal class FakeSpanService : SpanService {
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        links: List<EmbraceSpanLink>,
         errorCode: ErrorCode?
     ): Boolean {
         createdSpans.add(
@@ -65,4 +67,5 @@ internal class FakeSpanService : SpanService {
     }
 
     override fun getSpan(spanId: String): EmbraceSpan? = null
+    override fun getActiveSpans(): List<PersistableEmbraceSpan> = emptyList()
 }

--- a/embrace-android-sdk/src/test/resources/bg_activity_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/bg_activity_message_expected.json
@@ -35,6 +35,7 @@
       "end_time_unix_nano": 0,
       "status": "OK",
       "events": [],
+      "links": [],
       "attributes": {}
     }
   ],

--- a/embrace-android-sdk/src/test/resources/session_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_message_expected.json
@@ -36,6 +36,7 @@
       "end_time_unix_nano": 0,
       "status": "OK",
       "events": [],
+      "links": [],
       "attributes": {}
     }
   ],
@@ -49,6 +50,7 @@
       "end_time_unix_nano": 0,
       "status": "UNSET",
       "events": [],
+      "links": [],
       "attributes": {}
     }
   ],


### PR DESCRIPTION
## Goal

This quarter, one of the highlighter team's goals is to show NetworkRequests as spans in the dashboard, under the traces where they happen. [Link to ticket](https://www.notion.so/embraceio/Network-Requests-in-Traces-1a549b920f0d482ea0a8d8c00494bdb3)

A way of doing that is adding every ongoing span as a **Span Link** in the network request span.

This PR makes it possible to add span links to every span, and in particular, it adds every ongoing span that doesn't start with `"emb-"` to the network request spans as a span link.

It's a POC; I'm mainly uploading it to have a working sample of how we could add links, but some things might be wrong.

## Considerations

- We need to update the OTel dependency as links were added in the latest version of the SDK.
- We should probably add TraceState and TraceFlags to EmbraceSpanContext to be aligned with OTel.
- We might want to link only the deepest spans of a trace, without the parent spans.
- I exposed getActiveSpans in the SpanService so that we could get the active spans in the NetworkLoggingService. We might want to expose the active spans in a different way.
- We should think of a better way to ignore embrace spans than checking if they start with "emb-".
- We should add tests.



