### PR TITLE
Use onCreate invocation to denote Activity init start time

### DIFF
--- a/embrace-android-sdk/build.gradle
+++ b/embrace-android-sdk/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     testImplementation "io.mockk:mockk:1.12.2"
     testImplementation "androidx.test:core:1.4.0"
     testImplementation "androidx.test.ext:junit:1.1.3"
-    testImplementation "org.robolectric:robolectric:4.10.3"
+    testImplementation "org.robolectric:robolectric:4.12.1"
     testImplementation project(path: ":embrace-android-sdk")
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
     testImplementation("com.google.protobuf:protobuf-java:3.24.0")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupDataCollector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupDataCollector.kt
@@ -1,0 +1,54 @@
+package io.embrace.android.embracesdk.capture.startup
+
+/**
+ * Collects relevant information during app startup to be used to produce telemetry about the startup workflow.
+ *
+ * Due to differences in behaviour between platform versions and various startup scenarios, you cannot assume that these methods
+ * will be invoked in any order or at all. Implementations need to take into account that fact when using the underlying data.
+ */
+internal interface AppStartupDataCollector {
+    /**
+     *  Set the time when the application object initialization was started
+     */
+    fun applicationInitStart(timestampMs: Long? = null)
+
+    /**
+     *  Set the time when the application object initialization has finished
+     */
+    fun applicationInitEnd(timestampMs: Long? = null)
+
+    /**
+     * Set the time just prior to the creation of the Activity whose rendering will denote the end of the startup workflow
+     */
+    fun startupActivityPreCreated(timestampMs: Long? = null)
+
+    /**
+     * Set the time for the start of the initialization of the Activity whose rendering will denote the end of the startup workflow
+     */
+    fun startupActivityInitStart(timestampMs: Long? = null)
+
+    /**
+     * Set the time just after the creation of the Activity whose rendering will denote the end of the startup workflow
+     */
+    fun startupActivityPostCreated(timestampMs: Long? = null)
+
+    /**
+     * Set the time for the end of the initialization of the Activity whose rendering will denote the end of the startup workflow
+     */
+    fun startupActivityInitEnd(timestampMs: Long? = null)
+
+    /**
+     * Set the time for when the startup Activity begins to render as well as its name
+     */
+    fun startupActivityResumed(activityName: String, timestampMs: Long? = null)
+
+    /**
+     * Set the time for when the startup Activity has finished rendering its first frame as well as its name
+     */
+    fun firstFrameRendered(activityName: String, timestampMs: Long? = null)
+
+    /**
+     * Set an arbitrary time interval during startup that is of note
+     */
+    fun addTrackedInterval(name: String, startTimeMs: Long, endTimeMs: Long)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -41,7 +41,7 @@ internal class AppStartupTraceEmitter(
     private val backgroundWorker: BackgroundWorker,
     private val versionChecker: VersionChecker,
     private val logger: EmbLogger
-) {
+) : AppStartupDataCollector {
     private val processCreateRequestedMs: Long?
     private val processCreatedMs: Long?
     private val additionalTrackedIntervals = ConcurrentLinkedQueue<TrackedInterval>()
@@ -90,31 +90,31 @@ internal class AppStartupTraceEmitter(
     private val startupRecorded = AtomicBoolean(false)
     private val endWithFrameDraw: Boolean = versionChecker.isAtLeast(VERSION_CODES.Q)
 
-    fun applicationInitStart(timestampMs: Long? = null) {
+    override fun applicationInitStart(timestampMs: Long?) {
         applicationInitStartMs = timestampMs ?: nowMs()
     }
 
-    fun applicationInitEnd(timestampMs: Long? = null) {
+    override fun applicationInitEnd(timestampMs: Long?) {
         applicationInitEndMs = timestampMs ?: nowMs()
     }
 
-    fun startupActivityPreCreated(timestampMs: Long? = null) {
+    override fun startupActivityPreCreated(timestampMs: Long?) {
         startupActivityPreCreatedMs = timestampMs ?: nowMs()
     }
 
-    fun startupActivityInitStart(timestampMs: Long? = null) {
+    override fun startupActivityInitStart(timestampMs: Long?) {
         startupActivityInitStartMs = timestampMs ?: nowMs()
     }
 
-    fun startupActivityPostCreated(timestampMs: Long? = null) {
+    override fun startupActivityPostCreated(timestampMs: Long?) {
         startupActivityPostCreatedMs = timestampMs ?: nowMs()
     }
 
-    fun startupActivityInitEnd(timestampMs: Long? = null) {
+    override fun startupActivityInitEnd(timestampMs: Long?) {
         startupActivityInitEndMs = timestampMs ?: nowMs()
     }
 
-    fun startupActivityResumed(activityName: String, timestampMs: Long? = null) {
+    override fun startupActivityResumed(activityName: String, timestampMs: Long?) {
         startupActivityName = activityName
         startupActivityResumedMs = timestampMs ?: nowMs()
         if (!endWithFrameDraw) {
@@ -122,7 +122,7 @@ internal class AppStartupTraceEmitter(
         }
     }
 
-    fun firstFrameRendered(activityName: String, timestampMs: Long? = null) {
+    override fun firstFrameRendered(activityName: String, timestampMs: Long?) {
         startupActivityName = activityName
         firstFrameRenderedMs = timestampMs ?: nowMs()
         if (endWithFrameDraw) {
@@ -130,12 +130,15 @@ internal class AppStartupTraceEmitter(
         }
     }
 
-    fun addTrackedInterval(name: String, startTimeMs: Long, endTimeMs: Long) {
+    override fun addTrackedInterval(name: String, startTimeMs: Long, endTimeMs: Long) {
         additionalTrackedIntervals.add(
             TrackedInterval(name = name, startTimeMs = startTimeMs, endTimeMs = endTimeMs)
         )
     }
 
+    /**
+     * Called when app startup is considered complete, i.e. the data can be used and any additional updates can be ignored
+     */
     private fun dataCollectionComplete() {
         if (!startupRecorded.get()) {
             synchronized(startupRecorded) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupTracker.kt
@@ -36,7 +36,7 @@ import io.embrace.android.embracesdk.logging.EmbLogger
  * that can be found here: https://blog.p-y.wtf/tracking-android-app-launch-in-production. PY's code was adapted and tweaked for use here.
  */
 internal class StartupTracker(
-    private val appStartupTraceEmitter: AppStartupTraceEmitter,
+    private val appStartupDataCollector: AppStartupDataCollector,
     private val logger: EmbLogger,
     private val versionChecker: VersionChecker,
 ) : Application.ActivityLifecycleCallbacks {
@@ -46,14 +46,14 @@ internal class StartupTracker(
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (activity.useAsStartupActivity()) {
-            appStartupTraceEmitter.startupActivityPreCreated()
+            appStartupDataCollector.startupActivityPreCreated()
         }
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (activity.useAsStartupActivity()) {
             val activityName = activity.localClassName
-            appStartupTraceEmitter.startupActivityInitStart()
+            appStartupDataCollector.startupActivityInitStart()
             if (versionChecker.isAtLeast(Build.VERSION_CODES.Q)) {
                 if (!isFirstDraw) {
                     val window = activity.window
@@ -63,7 +63,7 @@ internal class StartupTracker(
                             decorView.onNextDraw {
                                 if (!isFirstDraw) {
                                     isFirstDraw = true
-                                    val callback = { appStartupTraceEmitter.firstFrameRendered(activityName = activityName) }
+                                    val callback = { appStartupDataCollector.firstFrameRendered(activityName = activityName) }
                                     decorView.viewTreeObserver.registerFrameCommitCallback(callback)
                                 }
                             }
@@ -79,19 +79,19 @@ internal class StartupTracker(
 
     override fun onActivityPostCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (activity.useAsStartupActivity()) {
-            appStartupTraceEmitter.startupActivityPostCreated()
+            appStartupDataCollector.startupActivityPostCreated()
         }
     }
 
     override fun onActivityStarted(activity: Activity) {
         if (activity.isStartupActivity()) {
-            appStartupTraceEmitter.startupActivityInitEnd()
+            appStartupDataCollector.startupActivityInitEnd()
         }
     }
 
     override fun onActivityResumed(activity: Activity) {
         if (activity.observeForStartup()) {
-            appStartupTraceEmitter.startupActivityResumed(activityName = activity.localClassName)
+            appStartupDataCollector.startupActivityResumed(activityName = activity.localClassName)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -159,7 +159,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
 
     override val startupTracker: StartupTracker by singleton {
         StartupTracker(
-            appStartupTraceEmitter = appStartupTraceEmitter,
+            appStartupDataCollector = appStartupTraceEmitter,
             logger = initModule.logger,
             versionChecker = versionChecker,
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModule.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.capture.memory.ComponentCallbackService
 import io.embrace.android.embracesdk.capture.memory.EmbraceMemoryService
 import io.embrace.android.embracesdk.capture.memory.MemoryService
 import io.embrace.android.embracesdk.capture.memory.NoOpMemoryService
+import io.embrace.android.embracesdk.capture.startup.AppStartupDataCollector
 import io.embrace.android.embracesdk.capture.startup.AppStartupTraceEmitter
 import io.embrace.android.embracesdk.capture.startup.StartupService
 import io.embrace.android.embracesdk.capture.startup.StartupServiceImpl
@@ -68,7 +69,7 @@ internal interface DataCaptureServiceModule {
 
     val startupTracker: StartupTracker
 
-    val appStartupTraceEmitter: AppStartupTraceEmitter
+    val appStartupDataCollector: AppStartupDataCollector
 }
 
 internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
@@ -146,7 +147,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         )
     }
 
-    override val appStartupTraceEmitter: AppStartupTraceEmitter by singleton {
+    override val appStartupDataCollector: AppStartupDataCollector by singleton {
         AppStartupTraceEmitter(
             clock = initModule.openTelemetryClock,
             startupServiceProvider = { startupService },
@@ -159,7 +160,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
 
     override val startupTracker: StartupTracker by singleton {
         StartupTracker(
-            appStartupDataCollector = appStartupTraceEmitter,
+            appStartupDataCollector = appStartupDataCollector,
             logger = initModule.logger,
             versionChecker = versionChecker,
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupTrackerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupTrackerTest.kt
@@ -1,0 +1,189 @@
+package io.embrace.android.embracesdk.capture.startup
+
+import android.app.Activity
+import android.app.Application
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeActivity
+import io.embrace.android.embracesdk.fakes.FakeAppStartupDataCollector
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+internal class StartupTrackerTest {
+    private lateinit var application: Application
+    private lateinit var clock: FakeClock
+    private lateinit var dataCollector: FakeAppStartupDataCollector
+    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var startupTracker: StartupTracker
+    private lateinit var defaultActivityController: ActivityController<Activity>
+
+    @Before
+    fun setUp() {
+        application = RuntimeEnvironment.getApplication()
+        clock = FakeClock()
+        logger = InternalEmbraceLogger()
+        dataCollector = FakeAppStartupDataCollector(clock = clock)
+        startupTracker = StartupTracker(
+            appStartupDataCollector = dataCollector,
+            logger = logger,
+            versionChecker = BuildVersionChecker
+        )
+        application.registerActivityLifecycleCallbacks(startupTracker)
+        defaultActivityController = Robolectric.buildActivity(Activity::class.java)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `cold start in U`() {
+        with(launchActivity()) {
+            assertEquals("android.app.Activity", dataCollector.startupActivityName)
+            verifyTiming(
+                preCreateTime = createTime,
+                createTime = createTime,
+                postCreateTime = createTime,
+                startTime = startTime,
+                resumeTime = resumeTime
+            )
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    @Test
+    fun `cold start in Q`() {
+        with(launchActivity()) {
+            verifyTiming(
+                preCreateTime = createTime,
+                createTime = createTime,
+                postCreateTime = createTime,
+                startTime = startTime,
+                resumeTime = resumeTime
+            )
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `cold start in P`() {
+        with(launchActivity()) {
+            verifyTiming(
+                createTime = createTime,
+                startTime = startTime,
+                resumeTime = resumeTime
+            )
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `cold start in L`() {
+        with(launchActivity()) {
+            verifyTiming(
+                createTime = createTime,
+                startTime = startTime,
+                resumeTime = resumeTime
+            )
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `cold start with activity instance recreated`() {
+        defaultActivityController.create()
+        clock.tick()
+        val recreateTime = clock.now()
+        defaultActivityController.recreate()
+        clock.tick()
+        val startTime = clock.now()
+        defaultActivityController.start()
+        clock.tick()
+        val resumeTime = clock.now()
+        defaultActivityController.resume()
+        clock.tick()
+
+        verifyTiming(
+            preCreateTime = recreateTime,
+            createTime = recreateTime,
+            postCreateTime = recreateTime,
+            startTime = startTime,
+            resumeTime = resumeTime
+        )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `cold start with different activities being created and foregrounded first`() {
+        defaultActivityController.create()
+        clock.tick()
+        with(launchActivity(Robolectric.buildActivity(FakeActivity::class.java))) {
+            assertEquals("io.embrace.android.embracesdk.fakes.FakeActivity", dataCollector.startupActivityName)
+            verifyTiming(
+                preCreateTime = createTime,
+                createTime = createTime,
+                postCreateTime = createTime,
+                startTime = startTime,
+                resumeTime = resumeTime
+            )
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `cold start initial activity not tracked will use the second for timing`() {
+        launchActivity(Robolectric.buildActivity(FakeSplashScreenActivity::class.java))
+        clock.tick()
+        with(launchActivity()) {
+            assertEquals("android.app.Activity", dataCollector.startupActivityName)
+            verifyTiming(
+                preCreateTime = createTime,
+                createTime = createTime,
+                postCreateTime = createTime,
+                startTime = startTime,
+                resumeTime = resumeTime
+            )
+        }
+    }
+
+    private fun launchActivity(controller: ActivityController<*> = defaultActivityController): ActivityTiming {
+        val createTime = clock.now()
+        controller.create()
+        clock.tick()
+        val startTime = clock.now()
+        controller.start()
+        clock.tick()
+        val resumeTime = clock.now()
+        controller.resume()
+        clock.tick()
+        return ActivityTiming(createTime, startTime, resumeTime)
+    }
+
+    private fun verifyTiming(
+        preCreateTime: Long? = null,
+        createTime: Long,
+        postCreateTime: Long? = null,
+        startTime: Long,
+        resumeTime: Long
+    ) {
+        assertEquals(preCreateTime, dataCollector.startupActivityPreCreatedMs)
+        assertEquals(createTime, dataCollector.startupActivityInitStartMs)
+        assertEquals(postCreateTime, dataCollector.startupActivityPostCreatedMs)
+        assertEquals(startTime, dataCollector.startupActivityInitEndMs)
+        assertEquals(resumeTime, dataCollector.startupActivityResumedMs)
+    }
+
+    private data class ActivityTiming(
+        val createTime: Long,
+        val startTime: Long,
+        val resumeTime: Long
+    )
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupTrackerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupTrackerTest.kt
@@ -7,9 +7,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeActivity
 import io.embrace.android.embracesdk.fakes.FakeAppStartupDataCollector
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -24,7 +25,7 @@ internal class StartupTrackerTest {
     private lateinit var application: Application
     private lateinit var clock: FakeClock
     private lateinit var dataCollector: FakeAppStartupDataCollector
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var startupTracker: StartupTracker
     private lateinit var defaultActivityController: ActivityController<Activity>
 
@@ -32,7 +33,7 @@ internal class StartupTrackerTest {
     fun setUp() {
         application = RuntimeEnvironment.getApplication()
         clock = FakeClock()
-        logger = InternalEmbraceLogger()
+        logger = FakeEmbLogger()
         dataCollector = FakeAppStartupDataCollector(clock = clock)
         startupTracker = StartupTracker(
             appStartupDataCollector = dataCollector,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeActivity.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeActivity.kt
@@ -1,0 +1,5 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+
+internal class FakeActivity : Activity()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.capture.startup.AppStartupDataCollector
+
+internal class FakeAppStartupDataCollector(
+    private val clock: FakeClock,
+) : AppStartupDataCollector {
+    var applicationInitStartMs: Long? = null
+    var applicationInitEndMs: Long? = null
+    var startupActivityName: String? = null
+    var startupActivityPreCreatedMs: Long? = null
+    var startupActivityInitStartMs: Long? = null
+    var startupActivityPostCreatedMs: Long? = null
+    var startupActivityInitEndMs: Long? = null
+    var startupActivityResumedMs: Long? = null
+    var firstFrameRenderedMs: Long? = null
+
+    override fun applicationInitStart(timestampMs: Long?) {
+        applicationInitStartMs = timestampMs ?: clock.now()
+    }
+
+    override fun applicationInitEnd(timestampMs: Long?) {
+        applicationInitEndMs = timestampMs ?: clock.now()
+    }
+
+    override fun startupActivityPreCreated(timestampMs: Long?) {
+        startupActivityPreCreatedMs = timestampMs ?: clock.now()
+    }
+
+    override fun startupActivityInitStart(timestampMs: Long?) {
+        startupActivityInitStartMs = timestampMs ?: clock.now()
+    }
+
+    override fun startupActivityPostCreated(timestampMs: Long?) {
+        startupActivityPostCreatedMs = timestampMs ?: clock.now()
+    }
+
+    override fun startupActivityInitEnd(timestampMs: Long?) {
+        startupActivityInitEndMs = timestampMs ?: clock.now()
+    }
+
+    override fun startupActivityResumed(activityName: String, timestampMs: Long?) {
+        startupActivityName = activityName
+        startupActivityResumedMs = timestampMs ?: clock.now()
+    }
+
+    override fun firstFrameRendered(activityName: String, timestampMs: Long?) {
+        startupActivityName = activityName
+        firstFrameRenderedMs = timestampMs ?: clock.now()
+    }
+
+    override fun addTrackedInterval(name: String, startTimeMs: Long, endTimeMs: Long) {
+        TODO("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSplashScreenActivity.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSplashScreenActivity.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import io.embrace.android.embracesdk.annotation.StartupActivity
+
+/**
+ * Activity that will not be used in recording the startup trace
+ */
+@StartupActivity
+internal class FakeSplashScreenActivity : Activity()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.capture.crumbs.BreadcrumbService
 import io.embrace.android.embracesdk.capture.crumbs.PushNotificationCaptureService
 import io.embrace.android.embracesdk.capture.memory.ComponentCallbackService
 import io.embrace.android.embracesdk.capture.memory.MemoryService
-import io.embrace.android.embracesdk.capture.startup.AppStartupTraceEmitter
+import io.embrace.android.embracesdk.capture.startup.AppStartupDataCollector
 import io.embrace.android.embracesdk.capture.startup.StartupService
 import io.embrace.android.embracesdk.capture.startup.StartupTracker
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
@@ -38,6 +38,6 @@ internal class FakeDataCaptureServiceModule(
     override val startupTracker: StartupTracker
         get() = TODO("Not yet implemented")
 
-    override val appStartupTraceEmitter: AppStartupTraceEmitter
+    override val appStartupDataCollector: AppStartupDataCollector
         get() = TODO("Not yet implemented")
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataCaptureServiceModuleImplTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.injection
 import io.embrace.android.embracesdk.capture.crumbs.EmbraceBreadcrumbService
 import io.embrace.android.embracesdk.capture.memory.EmbraceMemoryService
 import io.embrace.android.embracesdk.capture.memory.NoOpMemoryService
+import io.embrace.android.embracesdk.capture.startup.AppStartupTraceEmitter
 import io.embrace.android.embracesdk.capture.thermalstate.EmbraceThermalStatusService
 import io.embrace.android.embracesdk.capture.thermalstate.NoOpThermalStatusService
 import io.embrace.android.embracesdk.capture.webview.EmbraceWebViewService
@@ -50,6 +51,7 @@ internal class DataCaptureServiceModuleImplTest {
         assertTrue(module.webviewService is EmbraceWebViewService)
         assertTrue(module.breadcrumbService is EmbraceBreadcrumbService)
         assertTrue(module.thermalStatusService is EmbraceThermalStatusService)
+        assertTrue(module.appStartupDataCollector is AppStartupTraceEmitter)
         assertNotNull(module.pushNotificationService)
         assertNotNull(module.componentCallbackService)
         assertNotNull(module.startupService)


### PR DESCRIPTION
## Goal

In production, we are seeing a small minority of cases where there is a big gap between when onActivityPreCreated was invoked and when onActivityStart() was invoked. This could be a case of these being two separate activities or instances, or there are cases when the activity creation and starting stage can be paused.

In order to improve the trace and diagnose what's really going on, I changed the trace to use the onCreate time rather than the preCreate time, which is how it works on Android 9 or earlier, as preCreate is not a thing on those API versions. We also explicitly log the pre-create and post-create times as attributes for further debugging if this doesn't end up addressing the problem.

As well as the fix, I tweaked the implementation of the trace logging component (AppStartupTraceEmitter) so it's more streamlined, logs the name of the activity being displayed, removed the emb- prefix on attributes, and extracted the public interface into an interface so i can more easily test the StartupTracker by faking that.

In additional, I added more tests to verify the startup trace being logged properly as well as the `StartupTracker` consuming lifecycle events properly. I couldn't add test to verify the render due to the limitations of Roboletric, so I've left that alone for now. I've spent way too much time on this already....

## Testing

Updated Roboletric to the latest stable version so I can test with U as well as added the modified the appropriate tests.

