### PR TITLE
Create interface for internal logging

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/OtelSessionGatingTest.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.getSentSessionMessages
 import io.embrace.android.embracesdk.hasEventOfType
 import io.embrace.android.embracesdk.hasSpanOfType
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -50,7 +50,7 @@ internal class OtelSessionGatingTest {
                 RemoteConfig(sessionConfig = gatingConfig)
             },
         ),
-        InternalEmbraceLogger()
+        EmbLoggerImpl()
     )
 
     @Rule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterfaceImpl.kt
@@ -2,13 +2,13 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.capture.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 internal class FlutterInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
     private val impl: EmbraceInternalInterface,
     private val hostedSdkVersionInfo: HostedSdkVersionInfo,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : EmbraceInternalInterface by impl, FlutterInternalInterface {
 
     override fun setEmbraceFlutterSdkVersion(version: String?) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImpl.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.capture.crash.CrashService
 import io.embrace.android.embracesdk.capture.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.JsException
 
 internal class ReactNativeInternalInterfaceImpl(
@@ -16,7 +16,7 @@ internal class ReactNativeInternalInterfaceImpl(
     private val crashService: CrashService,
     private val metadataService: MetadataService,
     private val hostedSdkVersionInfo: HostedSdkVersionInfo,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : EmbraceInternalInterface by impl, ReactNativeInternalInterface {
 
     override fun logUnhandledJsException(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterfaceImpl.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.capture.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 
@@ -10,7 +10,7 @@ internal class UnityInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
     private val impl: EmbraceInternalInterface,
     private val hostedSdkVersionInfo: HostedSdkVersionInfo,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : EmbraceInternalInterface by impl, UnityInternalInterface {
 
     override fun setUnityMetaData(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.anr.detection.UnbalancedCallDetector
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicReference
 internal class EmbraceAnrService(
     var configService: ConfigService,
     looper: Looper,
-    logger: InternalEmbraceLogger,
+    logger: EmbLogger,
     livenessCheckScheduler: LivenessCheckScheduler,
     private val anrMonitorWorker: ScheduledWorker,
     state: ThreadMonitoringState,
@@ -39,7 +39,7 @@ internal class EmbraceAnrService(
     private val state: ThreadMonitoringState
     private val targetThread: Thread
     val stacktraceSampler: AnrStacktraceSampler
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
     private val targetThreadHeartbeatScheduler: LivenessCheckScheduler
 
     val listeners = CopyOnWriteArrayList<BlockedThreadListener>()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetector.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.anr.BlockedThreadListener
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.ResponsivenessSnapshot
 import java.util.concurrent.atomic.AtomicReference
 
@@ -37,7 +37,7 @@ internal class BlockedThreadDetector(
     var listener: BlockedThreadListener? = null,
     private val state: ThreadMonitoringState,
     private val targetThread: Thread,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val anrMonitorThread: AtomicReference<Thread>
 ) {
     private val heartbeatResponseMonitor = ResponsivenessMonitor(clock = clock, name = "heartbeatResponse")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.anr.detection.TargetThreadHandler.Companion
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.ResponsivenessSnapshot
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
@@ -29,7 +29,7 @@ internal class LivenessCheckScheduler internal constructor(
     private val state: ThreadMonitoringState,
     private val targetThreadHandler: TargetThreadHandler,
     private val blockedThreadDetector: BlockedThreadDetector,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val anrMonitorThread: AtomicReference<Thread>
 ) {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
@@ -7,7 +7,7 @@ import android.os.MessageQueue
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.enforceThread
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicReference
@@ -30,7 +30,7 @@ internal class TargetThreadHandler(
     private val anrMonitorThread: AtomicReference<Thread>,
     private val configService: ConfigService,
     private val messageQueue: MessageQueue? = LooperCompat.getMessageQueue(looper),
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val clock: Clock,
 ) : Handler(looper) {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.anr.detection
 
 import io.embrace.android.embracesdk.anr.BlockedThreadListener
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 internal class UnbalancedCallDetector(
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : BlockedThreadListener {
 
     @Volatile

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/EmbraceNativeThreadSamplerService.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.config.behavior.AnrBehavior
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.embrace.android.embracesdk.payload.mapThreadState
@@ -22,7 +22,7 @@ internal class EmbraceNativeThreadSamplerService @JvmOverloads constructor(
     private val configService: ConfigService,
     private val symbols: Lazy<Map<String, String>?>,
     private val random: Random = Random(),
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val delegate: NdkDelegate = NativeThreadSamplerNdkDelegate(),
     private val scheduledWorker: ScheduledWorker,
     private val deviceArchitecture: DeviceArchitecture,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadSamplerInstaller.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeThreadSamplerInstaller.kt
@@ -5,7 +5,7 @@ import android.os.Looper
 import io.embrace.android.embracesdk.anr.AnrService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -18,7 +18,7 @@ internal class NativeThreadSamplerNdkDelegate : EmbraceNativeThreadSamplerServic
 
 internal class NativeThreadSamplerInstaller(
     private val sharedObjectLoader: SharedObjectLoader,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
 ) {
     private val isMonitoring = AtomicBoolean(false)
     private var targetHandler: Handler? = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/AnrThreadIdDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/AnrThreadIdDelegate.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.anr.sigquit
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import java.io.File
 
 internal class AnrThreadIdDelegate(
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSource.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.AnrBehavior
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.utils.ThreadUtils
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -18,7 +18,7 @@ internal class SigquitDataSource(
     private val sharedObjectLoader: SharedObjectLoader,
     private val anrThreadIdDelegate: AnrThreadIdDelegate,
     private val anrBehavior: AnrBehavior,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     writer: SessionSpanWriter
 ) : SpanEventMapper<Long>, DataSourceImpl<SessionSpanWriter>(
     writer,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Orchestrates all data sources that could potentially be used in the SDK. This is a convenient
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
  */
 internal class DataCaptureOrchestrator(
     private val dataSourceState: List<DataSourceState<*>>,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     configService: ConfigService
 ) {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
@@ -1,14 +1,14 @@
 package io.embrace.android.embracesdk.arch.datasource
 
 import io.embrace.android.embracesdk.arch.limits.LimitStrategy
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Base class for data sources.
  */
 internal abstract class DataSourceImpl<T>(
     private val destination: T,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val limitStrategy: LimitStrategy,
 ) : DataSource<T> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSourceImpl.kt
@@ -2,14 +2,14 @@ package io.embrace.android.embracesdk.arch.datasource
 
 import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.internal.spans.SpanService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Base class for data sources.
  */
 internal abstract class SpanDataSourceImpl(
     destination: SpanService,
-    logger: InternalEmbraceLogger,
+    logger: EmbLogger,
     limitStrategy: LimitStrategy
 ) : SpanDataSource, DataSourceImpl<SpanService>(
     destination = destination,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.arch.limits
 
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Allows capturing data up until a limit, then stops capturing.
  */
 internal class UpToLimitStrategy(
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val limitProvider: Provider<Int>,
 ) : LimitStrategy {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/EmbracePerformanceInfoService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/EmbracePerformanceInfoService.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.capture
 
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.PerformanceInfo
 import io.embrace.android.embracesdk.session.captureDataSafely
 
 internal class EmbracePerformanceInfoService(
     private val metadataService: MetadataService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : PerformanceInfoService {
 
     override fun getSessionPerformanceInfo(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.config.behavior.AppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.BlobSession
@@ -38,7 +38,7 @@ internal class AeiDataSourceImpl(
     private val sessionIdTracker: SessionIdTracker,
     private val userService: UserService,
     logWriter: LogWriter,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val buildVersionChecker: VersionChecker = BuildVersionChecker,
 ) : AeiDataSource, LogEventMapper<BlobMessage>, LogDataSourceImpl(
     logWriter,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.injection.DataSourceModule
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.net.Inet4Address
 import java.net.NetworkInterface
@@ -19,7 +19,7 @@ internal class EmbraceNetworkConnectivityService(
     private val context: Context,
     private val clock: Clock,
     private val backgroundWorker: BackgroundWorker,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val connectivityManager: ConnectivityManager?,
     private val dataSourceModuleProvider: Provider<DataSourceModule?>,
 ) : BroadcastReceiver(), NetworkConnectivityService {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NetworkStatusDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NetworkStatusDataSource.kt
@@ -9,12 +9,12 @@ import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.spans.SpanService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 internal class NetworkStatusDataSource(
     spanService: SpanService,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : StartSpanMapper<NetworkStatusData>, SpanDataSourceImpl(
     destination = spanService,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.capture.cpu
 
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 internal class EmbraceCpuInfoDelegate(
     private val sharedObjectLoader: SharedObjectLoader,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : CpuInfoDelegate {
 
     override fun getCpuName(): String? {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CompositeCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CompositeCrashService.kt
@@ -3,14 +3,14 @@ package io.embrace.android.embracesdk.capture.crash
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.JsException
 
 internal class CompositeCrashService(
     private val crashServiceProvider: Provider<CrashService>,
     private val crashDataSourceProvider: Provider<CrashDataSource>,
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
 ) : CrashService {
 
     private val useCrashDataSource: Boolean

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
@@ -16,7 +16,7 @@ import io.embrace.android.embracesdk.internal.logs.LogOrchestrator
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.opentelemetry.embAndroidThreads
 import io.embrace.android.embracesdk.opentelemetry.embCrashNumber
@@ -45,7 +45,7 @@ internal class CrashDataSourceImpl(
     private val logWriter: LogWriter,
     private val configService: ConfigService,
     private val serializer: EmbraceSerializer,
-    logger: InternalEmbraceLogger,
+    logger: EmbLogger,
 ) : CrashDataSource,
     LogDataSourceImpl(
         destination = logWriter,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceCrashService.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarker
 import io.embrace.android.embracesdk.internal.logs.LogOrchestrator
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -41,7 +41,7 @@ internal class EmbraceCrashService(
     private val preferencesService: PreferencesService,
     private val crashMarker: CrashFileMarker,
     private val clock: Clock,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : CrashService {
 
     private var mainCrashHandled = false

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.capture.crash
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Intercepts uncaught exceptions from the JVM and forwards them to the Embrace API. Once handled,
@@ -17,7 +17,7 @@ internal class EmbraceUncaughtExceptionHandler(
      * The crash service which will submit the exception to the API as a crash
      */
     private val crashService: CrashService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : Thread.UncaughtExceptionHandler {
 
     init {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.CustomBreadcrumb
 
 /**
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.payload.CustomBreadcrumb
 internal class BreadcrumbDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
     writer: SessionSpanWriter,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.injection.DataSourceModule
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Breadcrumbs
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb.NotificationType
 import io.embrace.android.embracesdk.payload.TapBreadcrumb.TapBreadcrumbType
@@ -28,7 +28,7 @@ internal class EmbraceBreadcrumbService(
     private val clock: Clock,
     private val configService: ConfigService,
     private val dataSourceModuleProvider: Provider<DataSourceModule?>,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : BreadcrumbService, ActivityLifecycleListener, MemoryCleanerListener {
 
     private val rnBreadcrumbDataSource = RnBreadcrumbDataSource(configService, logger)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.capture.crumbs
 
 import android.app.Activity
 import android.os.Bundle
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb.NotificationType
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
  */
 internal class PushNotificationCaptureService(
     private val breadCrumbService: BreadcrumbService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : ActivityLifecycleListener {
 
     companion object Utils {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationDataSource.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 
 /**
@@ -19,7 +19,7 @@ internal class PushNotificationDataSource(
     private val breadcrumbBehavior: BreadcrumbBehavior,
     private val clock: Clock,
     writer: SessionSpanWriter,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnBreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnBreadcrumbDataSource.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.capture.crumbs
 import android.text.TextUtils
 import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.RnActionBreadcrumb
 
 /**
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.payload.RnActionBreadcrumb
  */
 internal class RnBreadcrumbDataSource(
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val store: BreadcrumbDataStore<RnActionBreadcrumb> = BreadcrumbDataStore {
         configService.breadcrumbBehavior.getCustomBreadcrumbLimit()
     },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapDataSource.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.TapBreadcrumb
 
 /**
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.payload.TapBreadcrumb
 internal class TapDataSource(
     private val breadcrumbBehavior: BreadcrumbBehavior,
     writer: SessionSpanWriter,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.SpanService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.FragmentBreadcrumb
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
@@ -21,7 +21,7 @@ internal class ViewDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
     private val clock: Clock,
     spanService: SpanService,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : SpanDataSourceImpl(
     spanService,
     logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSource.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
 
 /**
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.payload.WebViewBreadcrumb
 internal class WebViewUrlDataSource(
     private val breadcrumbBehavior: BreadcrumbBehavior,
     writer: SessionSpanWriter,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
@@ -7,7 +7,7 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import io.embrace.android.embracesdk.capture.cpu.CpuInfoDelegate
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.io.File
@@ -72,7 +72,7 @@ internal class DeviceImpl(
     private val backgroundWorker: BackgroundWorker,
     override val systemInfo: SystemInfo,
     cpuInfoDelegate: CpuInfoDelegate,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : Device {
     override var isJailbroken: Boolean? = null
     override var screenResolution: String = ""

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -23,7 +23,7 @@ internal class SessionPayloadSourceImpl(
     private val spanSink: SpanSink,
     private val currentSessionSpan: CurrentSessionSpan,
     private val spanRepository: SpanRepository,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val sessionPropertiesServiceProvider: Provider<SessionPropertiesService>
 ) : SessionPayloadSource {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackService.kt
@@ -3,13 +3,13 @@ package io.embrace.android.embracesdk.capture.memory
 import android.app.Application
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import java.io.Closeable
 
 internal class ComponentCallbackService(
     private val application: Application,
     private val memoryService: MemoryService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : ComponentCallbacks2, Closeable {
 
     init {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/MemoryWarningDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/MemoryWarningDataSource.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.arch.destination.SpanEventMapper
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.MemoryWarning
 
 /**
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.payload.MemoryWarning
  */
 internal class MemoryWarningDataSource(
     sessionSpanWriter: SessionSpanWriter,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = sessionSpanWriter,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -19,7 +19,7 @@ import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.AppInfo
 import io.embrace.android.embracesdk.payload.DeviceInfo
 import io.embrace.android.embracesdk.payload.DiskUsage
@@ -65,7 +65,7 @@ internal class EmbraceMetadataService private constructor(
     private val clock: Clock,
     private val embraceCpuInfoDelegate: CpuInfoDelegate,
     private val deviceArchitecture: DeviceArchitecture,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : MetadataService, ActivityLifecycleListener {
 
     private val statFs = lazy { StatFs(Environment.getDataDirectory().path) }
@@ -407,7 +407,7 @@ internal class EmbraceMetadataService private constructor(
             lazyAppVersionName: Lazy<String>,
             lazyAppVersionCode: Lazy<String>,
             hostedSdkVersionInfo: HostedSdkVersionInfo,
-            logger: InternalEmbraceLogger
+            logger: EmbLogger
         ): EmbraceMetadataService {
             val isAppUpdated = lazy {
                 val lastKnownAppVersion = preferencesService.appVersion
@@ -482,7 +482,7 @@ internal class EmbraceMetadataService private constructor(
             return bundleUrl.substring(bundleUrl.indexOf("://") + 3)
         }
 
-        private fun getBundleAsset(context: Context, bundleUrl: String, logger: InternalEmbraceLogger): InputStream? {
+        private fun getBundleAsset(context: Context, bundleUrl: String, logger: EmbLogger): InputStream? {
             try {
                 return context.assets.open(getBundleAssetName(bundleUrl))
             } catch (e: Exception) {
@@ -491,7 +491,7 @@ internal class EmbraceMetadataService private constructor(
             return null
         }
 
-        private fun getCustomBundleStream(bundleUrl: String, logger: InternalEmbraceLogger): InputStream? {
+        private fun getCustomBundleStream(bundleUrl: String, logger: EmbLogger): InputStream? {
             try {
                 return FileInputStream(bundleUrl)
             } catch (e: NullPointerException) {
@@ -506,7 +506,7 @@ internal class EmbraceMetadataService private constructor(
             context: Context,
             bundleUrl: String?,
             defaultBundleId: String?,
-            logger: InternalEmbraceLogger
+            logger: EmbLogger
         ): String? {
             if (bundleUrl == null) {
                 // If JS bundle URL is null, we set React Native bundle ID to the defaultBundleId.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSource.kt
@@ -12,14 +12,14 @@ import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 
 internal class LowPowerDataSource(
     private val context: Context,
     spanService: SpanService,
-    logger: InternalEmbraceLogger,
+    logger: EmbLogger,
     private val backgroundWorker: BackgroundWorker,
     private val clock: Clock,
     provider: Provider<PowerManager?>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/PowerSaveModeReceiver.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/PowerSaveModeReceiver.kt
@@ -7,11 +7,11 @@ import android.content.IntentFilter
 import android.os.PowerManager
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 
 internal class PowerSaveModeReceiver(
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val powerManagerProvider: Provider<PowerManager?>,
     private val callback: (powerSaveMode: Boolean) -> Unit
 ) : BroadcastReceiver() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
@@ -6,12 +6,12 @@ import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 internal class SessionPropertiesDataSource(
     sessionBehavior: SessionBehavior,
     writer: SessionSpanWriter,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.opentelemetry.sdk.common.Clock
@@ -40,7 +40,7 @@ internal class AppStartupTraceEmitter(
     private val spanService: SpanService,
     private val backgroundWorker: BackgroundWorker,
     private val versionChecker: VersionChecker,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
     private val processCreateRequestedMs: Long?
     private val processCreatedMs: Long?

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupTracker.kt
@@ -11,7 +11,7 @@ import android.view.ViewTreeObserver
 import android.view.Window
 import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Component that captures various timestamps throughout the startup process and uses that information to log spans that approximates to
@@ -37,7 +37,7 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
  */
 internal class StartupTracker(
     private val appStartupTraceEmitter: AppStartupTraceEmitter,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val versionChecker: VersionChecker,
 ) : Application.ActivityLifecycleCallbacks {
     private var isFirstDraw = false

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.capture.user
 
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.UserInfo
 import io.embrace.android.embracesdk.payload.UserInfo.Companion.ofStored
 import io.embrace.android.embracesdk.prefs.PreferencesService
@@ -10,7 +10,7 @@ import java.util.regex.Pattern
 
 internal class EmbraceUserService(
     private val preferencesService: PreferencesService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : UserService {
     /**
      * Do not access this directly - use [userInfo] and [modifyUserInfo] to get and set this

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/EmbraceWebViewService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/EmbraceWebViewService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.capture.webview
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.WebViewInfo
 import io.embrace.android.embracesdk.payload.WebVitalType
 import java.util.EnumMap
@@ -10,7 +10,7 @@ import java.util.EnumMap
 internal class EmbraceWebViewService(
     val configService: ConfigService,
     private val serializer: EmbraceSerializer,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : WebViewService {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiClientImpl.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.NO_HTTP_RESPO
 import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.TOO_MANY_REQUESTS
 import io.embrace.android.embracesdk.comms.api.ApiClient.Companion.defaultTimeoutMs
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -23,7 +23,7 @@ import java.net.HttpURLConnection.HTTP_OK
  * testing is enabled when calling [Embrace.start()].
  */
 internal class ApiClientImpl(
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : ApiClient {
 
     override fun executeGet(request: ApiRequest): ApiResponse {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/ApiResponseCache.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.comms.api
 import android.net.http.HttpResponseCache
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.storage.StorageService
 import java.io.Closeable
 import java.io.IOException
@@ -22,7 +22,7 @@ import java.net.URI
 internal class ApiResponseCache(
     private val serializer: EmbraceSerializer,
     private val storageService: StorageService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : Closeable {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.BlobMessage
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -28,7 +28,7 @@ internal class EmbraceApiService(
     private val apiClient: ApiClient,
     private val serializer: EmbraceSerializer,
     private val cachedConfigProvider: (url: String, request: ApiRequest) -> CachedConfig,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val backgroundWorker: BackgroundWorker,
     private val cacheManager: DeliveryCacheManager,
     private val pendingApiCallsSender: PendingApiCallsSender,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheService.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Types
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.storage.StorageService
 import java.io.File
@@ -20,7 +20,7 @@ import kotlin.concurrent.write
 internal class EmbraceCacheService(
     private val storageService: StorageService,
     private val serializer: PlatformSerializer,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : CacheService {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryCacheManager.
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.isV2Payload
@@ -16,7 +16,7 @@ import java.io.Closeable
 internal class EmbraceDeliveryCacheManager(
     private val cacheService: CacheService,
     private val backgroundWorker: BackgroundWorker,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : Closeable, DeliveryCacheManager {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.toFailedSpan
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.ndk.NativeCrashService
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NativeCrashData
@@ -25,7 +25,7 @@ internal class EmbraceDeliveryService(
     private val apiService: ApiService,
     private val backgroundWorker: BackgroundWorker,
     private val serializer: PlatformSerializer,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : DeliveryService {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSender.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSender.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.comms.api.ApiResponse
 import io.embrace.android.embracesdk.comms.api.Endpoint
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -18,7 +18,7 @@ internal class EmbracePendingApiCallsSender(
     private val scheduledWorker: ScheduledWorker,
     private val cacheManager: DeliveryCacheManager,
     private val clock: Clock,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : PendingApiCallsSender, NetworkConnectivityListener {
 
     private val pendingApiCalls: PendingApiCalls by lazy {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.utils.stream
@@ -38,7 +38,7 @@ internal class EmbraceConfigService @JvmOverloads constructor(
     private val apiService: ApiService,
     private val preferencesService: PreferencesService,
     private val clock: Clock,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val backgroundWorker: BackgroundWorker,
     isDebug: Boolean,
     internal val thresholdCheck: BehaviorThresholdCheck =

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/LocalConfigParser.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/LocalConfigParser.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.AndroidResourcesService
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 internal object LocalConfigParser {
 
@@ -42,7 +42,7 @@ internal object LocalConfigParser {
         packageName: String,
         customAppId: String?,
         serializer: EmbraceSerializer,
-        logger: InternalEmbraceLogger
+        logger: EmbLogger
     ): LocalConfig {
         return try {
             val appId: String = customAppId ?: resources.getString(
@@ -85,7 +85,7 @@ internal object LocalConfigParser {
         ndkEnabled: Boolean,
         sdkConfigs: String?,
         serializer: EmbraceSerializer,
-        logger: InternalEmbraceLogger
+        logger: EmbLogger
     ): LocalConfig {
         require(!appId.isNullOrEmpty()) { "Embrace AppId cannot be null or empty." }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.EventDescription
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
@@ -39,7 +39,7 @@ internal class EmbraceEventService(
     performanceInfoService: PerformanceInfoService,
     userService: UserService,
     private val sessionProperties: EmbraceSessionProperties,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     workerThreadModule: WorkerThreadModule,
     private val clock: Clock
 ) : EventService, ActivityLifecycleListener, ProcessStateListener, MemoryCleanerListener {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceLogMessageService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceLogMessageService.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.CacheableValue
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
@@ -38,7 +38,7 @@ internal class EmbraceLogMessageService(
     private val userService: UserService,
     private val configService: ConfigService,
     private val sessionProperties: EmbraceSessionProperties,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val clock: Clock,
     private val backgroundWorker: BackgroundWorker,
     private val gatingService: GatingService,
@@ -66,7 +66,7 @@ internal class EmbraceLogMessageService(
         userService: UserService,
         configService: ConfigService,
         sessionProperties: EmbraceSessionProperties,
-        logger: InternalEmbraceLogger,
+        logger: EmbLogger,
         clock: Clock,
         sessionGatingService: GatingService,
         networkConnectivityService: NetworkConnectivityService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EventHandler.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.EventDescription
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
@@ -32,7 +32,7 @@ internal class EventHandler(
     private val userService: UserService,
     private val performanceInfoService: PerformanceInfoService,
     private val deliveryService: DeliveryService,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val clock: Clock,
     private val scheduledWorker: ScheduledWorker
 ) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.gating.v2.EnvelopeSanitizerFacade
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 
@@ -18,7 +18,7 @@ import io.embrace.android.embracesdk.payload.SessionMessage
  */
 internal class EmbraceGatingService(
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : GatingService {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CoreModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/CoreModule.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.BuildInfo.Companion.fromResources
 import io.embrace.android.embracesdk.internal.EmbraceAndroidResourcesService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.registry.ServiceRegistry
 
 /**
@@ -62,7 +62,7 @@ internal interface CoreModule {
 internal class CoreModuleImpl(
     ctx: Context,
     override val appFramework: AppFramework,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : CoreModule {
 
     override val context: Context by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/InitModule.kt
@@ -5,7 +5,8 @@ import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.telemetry.EmbraceTelemetryService
 import io.embrace.android.embracesdk.telemetry.TelemetryService
 
@@ -31,7 +32,7 @@ internal interface InitModule {
     /**
      * Logger used by the SDK
      */
-    val logger: InternalEmbraceLogger
+    val logger: EmbLogger
 
     /**
      * Info about the system available at startup time without expensive disk or API calls
@@ -50,7 +51,7 @@ internal class InitModuleImpl(
     override val clock: io.embrace.android.embracesdk.internal.clock.Clock =
         NormalizedIntervalClock(systemClock = SystemClock()),
     override val openTelemetryClock: io.opentelemetry.sdk.common.Clock = OpenTelemetryClock(embraceClock = clock),
-    override val logger: InternalEmbraceLogger = InternalEmbraceLogger(),
+    override val logger: EmbLogger = EmbLoggerImpl(),
     override val systemInfo: SystemInfo = SystemInfo()
 ) : InitModule {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -26,7 +26,8 @@ import io.embrace.android.embracesdk.internal.utils.StorageModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.SystemServiceModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.utils.WorkerThreadModuleSupplier
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.ndk.NativeModule
 import io.embrace.android.embracesdk.ndk.NativeModuleImpl
 import io.embrace.android.embracesdk.worker.TaskPriority
@@ -44,7 +45,7 @@ import kotlin.reflect.KClass
  * A class that wires together and initializes modules in a manner that makes them work as a cohesive whole.
  */
 internal class ModuleInitBootstrapper(
-    val logger: InternalEmbraceLogger = InternalEmbraceLogger(),
+    val logger: EmbLogger = EmbLoggerImpl(),
     val initModule: InitModule = InitModuleImpl(logger = logger),
     val openTelemetryModule: OpenTelemetryModule = OpenTelemetryModuleImpl(initModule),
     private val coreModuleSupplier: CoreModuleSupplier = ::CoreModuleImpl,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/SharedObjectLoader.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/SharedObjectLoader.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.internal
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Component to load native binaries
  */
 internal class SharedObjectLoader(
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
     val loaded = AtomicBoolean(false)
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarkerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarkerImpl.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.crash
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import java.io.File
 
 /**
@@ -9,7 +9,7 @@ import java.io.File
  */
 internal class CrashFileMarkerImpl(
     private val markerFile: Lazy<File>,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : CrashFileMarker {
 
     private val lock = Any()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifier.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifier.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.crash
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
  */
 internal class LastRunCrashVerifier(
     private val crashFileMarker: CrashFileMarker,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
 
     private var didLastRunCrashFuture: Future<Boolean>? = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/CompositeLogService.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.network.logging.NetworkCaptureDataSource
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 
@@ -22,7 +22,7 @@ internal class CompositeLogService(
     private val v2LogService: Provider<LogService>,
     private val networkCaptureDataSource: Provider<NetworkCaptureDataSource>,
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val serializer: EmbraceSerializer
 ) : LogMessageService {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.config.behavior.LogMessageBehavior
 import io.embrace.android.embracesdk.internal.CacheableValue
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.opentelemetry.exceptionMessage
 import io.embrace.android.embracesdk.opentelemetry.exceptionStacktrace
@@ -38,7 +38,7 @@ internal class EmbraceLogService(
     private val appFramework: AppFramework,
     private val sessionProperties: EmbraceSessionProperties,
     private val backgroundWorker: BackgroundWorker,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     clock: Clock,
 ) : LogService {
 
@@ -285,7 +285,7 @@ internal class LogCounter(
     private val name: String,
     private val clock: Clock,
     private val getConfigLogLimit: (() -> Int),
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
     private val count = AtomicInteger(0)
     private val logIds: NavigableMap<Long, String> = ConcurrentSkipListMap()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.injection.SdkObservabilityModule
 import io.embrace.android.embracesdk.injection.SessionModule
 import io.embrace.android.embracesdk.injection.StorageModule
 import io.embrace.android.embracesdk.injection.SystemServiceModule
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.ndk.NativeModule
 import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
@@ -43,7 +43,7 @@ internal typealias UnimplementedConfig = Unit?
 internal typealias CoreModuleSupplier = (
     context: Context,
     appFramework: Embrace.AppFramework,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) -> CoreModule
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLogger.kt
@@ -1,0 +1,34 @@
+package io.embrace.android.embracesdk.logging
+
+/**
+ * A simple interface that is used within the Embrace SDK for logging.
+ */
+internal interface EmbLogger {
+
+    fun addLoggerAction(action: EmbLoggerImpl.LogAction)
+
+    /**
+     * Logs a debug message with an optional throwable.
+     */
+    fun logDebug(msg: String, throwable: Throwable? = null)
+
+    /**
+     * Logs an informational message.
+     */
+    fun logInfo(msg: String)
+
+    /**
+     * Logs a warning message with an optional throwable.
+     */
+    fun logWarning(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false)
+
+    /**
+     * Logs a warning message with an optional error.
+     */
+    fun logError(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false)
+
+    /**
+     * Logs a warning message that the SDK is not yet initialized for the given action.
+     */
+    fun logSdkNotInitialized(action: String)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLoggerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLoggerImpl.kt
@@ -13,37 +13,34 @@ internal const val EMBRACE_TAG = "[Embrace]"
 
 // Suppressing "Nothing to inline". These functions are used all around the codebase, pretty often, so we want them to
 // perform as fast as possible.
-internal class InternalEmbraceLogger {
+internal class EmbLoggerImpl : EmbLogger {
     private val logActions = CopyOnWriteArrayList<LogAction>(listOf())
 
     internal fun interface LogAction {
         fun log(msg: String, severity: Severity, throwable: Throwable?, logStacktrace: Boolean)
     }
 
-    fun addLoggerAction(action: LogAction) {
+    override fun addLoggerAction(action: LogAction) {
         logActions.add(action)
     }
 
-    @JvmOverloads
-    fun logDebug(msg: String, throwable: Throwable? = null) {
+    override fun logDebug(msg: String, throwable: Throwable?) {
         log(msg, Severity.DEBUG, throwable, true)
     }
 
-    fun logInfo(msg: String) {
-        log(msg, Severity.INFO, null, true)
+    override fun logInfo(msg: String) {
+        log(msg, Severity.INFO, null, false)
     }
 
-    @JvmOverloads
-    fun logWarning(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false) {
+    override fun logWarning(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
         log(msg, Severity.WARNING, throwable, logStacktrace)
     }
 
-    @JvmOverloads
-    fun logError(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false) {
+    override fun logError(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
         log(msg, Severity.ERROR, throwable, logStacktrace)
     }
 
-    fun logSdkNotInitialized(action: String) {
+    override fun logSdkNotInitialized(action: String) {
         val msg = "Embrace SDK is not initialized yet, cannot $action."
         log(msg, Severity.WARNING, Throwable(msg), true)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorService.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.payload.LegacyExceptionError
 
 /**
  * Reports an internal error to Embrace. An internal error is defined as an exception that was
- * caught within Embrace code & logged to [InternalEmbraceLogger].
+ * caught within Embrace code & logged to [EmbLogger].
  */
 internal interface InternalErrorService {
     fun setConfigService(configService: ConfigService?)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorServiceAction.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorServiceAction.kt
@@ -8,11 +8,11 @@ import android.util.Log
  */
 internal class InternalErrorServiceAction(
     private val internalErrorService: InternalErrorService
-) : InternalEmbraceLogger.LogAction {
+) : EmbLoggerImpl.LogAction {
 
     override fun log(
         msg: String,
-        severity: InternalEmbraceLogger.Severity,
+        severity: EmbLoggerImpl.Severity,
         throwable: Throwable?,
         logStacktrace: Boolean
     ) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NativeCrashData
@@ -55,7 +55,7 @@ internal class EmbraceNdkService(
     private val sessionProperties: EmbraceSessionProperties,
     appFramework: AppFramework,
     private val sharedObjectLoader: SharedObjectLoader,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
     private val repository: EmbraceNdkServiceRepository,
     private val delegate: NdkServiceDelegate.NdkDelegate,
     private val backgroundWorker: BackgroundWorker,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepository.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepository.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.ndk
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.embrace.android.embracesdk.storage.NATIVE_CRASH_FILE_FOLDER
 import io.embrace.android.embracesdk.storage.StorageService
@@ -17,7 +17,7 @@ private const val NATIVE_CRASH_MAP_FILE_SUFFIX = ".map"
  */
 internal class EmbraceNdkServiceRepository(
     private val storageService: StorageService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
 
     fun sortNativeCrashes(byOldest: Boolean): List<File> {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSource.kt
@@ -16,7 +16,7 @@ import io.embrace.android.embracesdk.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.opentelemetry.embCrashNumber
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.payload.NativeCrashData
@@ -33,7 +33,7 @@ internal class NativeCrashDataSourceImpl(
     private val logWriter: LogWriter,
     private val configService: ConfigService,
     private val serializer: EmbraceSerializer,
-    logger: InternalEmbraceLogger,
+    logger: EmbLogger,
 ) : NativeCrashDataSource, LogDataSourceImpl(
     destination = logWriter,
     logger = logger,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceDomainCountLimiter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceDomainCountLimiter.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.network.logging
 
 import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.NetworkSessionV2
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.utils.NetworkUtils
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 internal class EmbraceDomainCountLimiter(
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
 ) : MemoryCleanerListener, DomainCountLimiter {
 
     private val domainSetting = ConcurrentHashMap<String, DomainSettings>()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureService.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.config.remote.NetworkCaptureRuleRemoteConfi
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
@@ -22,7 +22,7 @@ internal class EmbraceNetworkCaptureService(
     private val logMessageService: LogMessageService,
     private val configService: ConfigService,
     private val serializer: EmbraceSerializer,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : NetworkCaptureService {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureDataSourceImpl.kt
@@ -7,12 +7,12 @@ import io.embrace.android.embracesdk.arch.destination.LogEventMapper
 import io.embrace.android.embracesdk.arch.destination.LogWriter
 import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.arch.schema.SchemaType
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 
 internal class NetworkCaptureDataSourceImpl(
     private val logWriter: LogWriter,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ) : NetworkCaptureDataSource,
     LogEventMapper<NetworkCapturedCall>, LogDataSourceImpl(
         destination = logWriter,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManager.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManager.java
@@ -19,7 +19,7 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger;
+import io.embrace.android.embracesdk.logging.EmbLogger;
 
 /**
  * API to encrypt/decrypt data
@@ -32,9 +32,9 @@ class NetworkCaptureEncryptionManager {
     private static final int mDecryptionBlockSize = 256;
 
     @NonNull
-    private final InternalEmbraceLogger logger;
+    private final EmbLogger logger;
 
-    NetworkCaptureEncryptionManager(@NonNull InternalEmbraceLogger logger) {
+    NetworkCaptureEncryptionManager(@NonNull EmbLogger logger) {
         this.logger = logger;
     }
 
@@ -48,11 +48,11 @@ class NetworkCaptureEncryptionManager {
             if (publicKey != null) {
                 return encrypt(data, publicKey);
             } else {
-                logger.logError("wrong public key");
+                logger.logError("wrong public key", null, false);
                 return null;
             }
         } catch (Exception e) {
-            logger.logError("data cannot be encrypted", e);
+            logger.logError("data cannot be encrypted", e, false);
             return null;
         }
     }
@@ -74,7 +74,7 @@ class NetworkCaptureEncryptionManager {
             result += encodedString;
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | BadPaddingException |
                  IllegalBlockSizeException | IOException e) {
-            logger.logError("data cannot be encrypted", e);
+            logger.logError("data cannot be encrypted", e, false);
         }
         return result;
     }
@@ -97,7 +97,7 @@ class NetworkCaptureEncryptionManager {
             result = new String(decodedData, UTF_8);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
                  BadPaddingException | IllegalBlockSizeException | IOException e) {
-            logger.logError("data cannot be encrypted", e);
+            logger.logError("data cannot be encrypted", e, false);
         }
         return result;
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.payload.extensions
 import android.util.Base64
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Crash
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
@@ -23,7 +23,7 @@ internal object CrashFactory {
      * @return a crash
      */
     fun ofThrowable(
-        logger: InternalEmbraceLogger,
+        logger: EmbLogger,
         throwable: Throwable?,
         jsException: JsException?,
         crashNumber: Int,
@@ -67,7 +67,7 @@ internal object CrashFactory {
      * @return a list of [String] representing the javascript stacktrace of the crash.
      */
     @JvmStatic
-    private fun jsExceptions(jsException: JsException?, logger: InternalEmbraceLogger): List<String>? {
+    private fun jsExceptions(jsException: JsException?, logger: EmbLogger): List<String>? {
         var jsExceptions: List<String>? = null
         if (jsException != null) {
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.registry
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * to remember to set callbacks & close resources when creating a new service.
  */
 internal class ServiceRegistry(
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : Closeable {
 
     private val registry = mutableListOf<Any>()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationExceptionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/AutomaticVerificationExceptionHandler.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.samples
 
 import io.embrace.android.embracesdk.EmbraceAutomaticVerification
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Exception Handler that verifies if a VerifyIntegrationException was received,
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
  */
 internal class AutomaticVerificationExceptionHandler(
     private val defaultHandler: Thread.UncaughtExceptionHandler?,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) :
 
     Thread.UncaughtExceptionHandler {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamples.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/samples/EmbraceCrashSamples.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.samples
 
 import io.embrace.android.embracesdk.Embrace
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 
 /**
  * Encapsulates the logic to trigger different type of crashes for testing purpose.
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
  */
 internal object EmbraceCrashSamples {
 
-    private val logger = InternalEmbraceLogger()
+    private val logger = EmbLoggerImpl()
 
     private val ndkCrashSamplesNdkDelegate = EmbraceCrashSamplesNdkDelegateImpl()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.utils.stream
 import java.util.concurrent.CopyOnWriteArrayList
 
-internal class EmbraceMemoryCleanerService(private val logger: InternalEmbraceLogger) : MemoryCleanerService {
+internal class EmbraceMemoryCleanerService(private val logger: EmbLogger) : MemoryCleanerService {
 
     /**
      * List of listeners that subscribe to clean services collections.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
@@ -1,14 +1,14 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Captures a block of data safely, logging any exceptions that occur as an internal error.
  * This is intended for use when building the session/background activity payloads. If an
  * exception is thrown during capture, then we still want to send the request.
  */
-internal inline fun <R> captureDataSafely(logger: InternalEmbraceLogger, result: Provider<R>): R? {
+internal inline fun <R> captureDataSafely(logger: EmbLogger, result: Provider<R>): R? {
     return try {
         result()
     } catch (exc: Throwable) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session.caching
 
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
@@ -12,7 +12,7 @@ import kotlin.math.max
 internal class PeriodicBackgroundActivityCacher(
     private val clock: Clock,
     private val scheduledWorker: ScheduledWorker,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session.caching
 
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 
 internal class PeriodicSessionCacher(
     private val sessionPeriodicCacheScheduledWorker: ScheduledWorker,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
@@ -2,12 +2,12 @@ package io.embrace.android.embracesdk.session.id
 
 import android.app.ActivityManager
 import android.os.Build
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.ndk.NdkService
 
 internal class SessionIdTrackerImpl(
     private val activityManager: ActivityManager?,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : SessionIdTracker {
 
     @Volatile

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
@@ -5,7 +5,7 @@ import android.app.Application
 import android.os.Bundle
 import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.capture.orientation.OrientationService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.utils.stream
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
@@ -16,7 +16,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 internal class ActivityLifecycleTracker(
     private val application: Application,
     private val orientationService: OrientationService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : ActivityTracker {
 
     init {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.utils.ThreadUtils
 import io.embrace.android.embracesdk.utils.stream
@@ -18,7 +18,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 internal class EmbraceProcessStateService(
     private val clock: Clock,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : ProcessStateService {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.internal.StartupEventInfo
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -19,7 +19,7 @@ internal sealed class FinalEnvelopeParams(
     val endType: SessionSnapshotType,
     val isCacheAttempt: Boolean,
     val captureSpans: Boolean,
-    val logger: InternalEmbraceLogger
+    val logger: EmbLogger
 ) {
 
     val crashId: String? = when {
@@ -40,7 +40,7 @@ internal sealed class FinalEnvelopeParams(
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,
-        logger: InternalEmbraceLogger,
+        logger: EmbLogger,
         captureSpans: Boolean = true,
         crashId: String? = null,
     ) : FinalEnvelopeParams(
@@ -67,7 +67,7 @@ internal sealed class FinalEnvelopeParams(
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,
-        logger: InternalEmbraceLogger,
+        logger: EmbLogger,
         captureSpans: Boolean = true,
         crashId: String? = null,
     ) : FinalEnvelopeParams(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.config.ConfigService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -12,7 +12,7 @@ internal class PayloadFactoryImpl(
     private val v1payloadMessageCollator: V1PayloadMessageCollator,
     private val v2payloadMessageCollator: V2PayloadMessageCollator,
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : PayloadFactory {
 
     private val collator: PayloadMessageCollator

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -21,7 +21,7 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanSink
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.payload.BetaFeatures
 import io.embrace.android.embracesdk.payload.Session
@@ -51,7 +51,7 @@ internal class V1PayloadMessageCollator(
     private val startupService: StartupService,
     private val anrOtelMapper: AnrOtelMapper,
     private val nativeAnrOtelMapper: NativeAnrOtelMapper,
-    private val logger: InternalEmbraceLogger,
+    private val logger: EmbLogger,
 ) : PayloadMessageCollator {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollator.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.gating.GatingService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -15,7 +15,7 @@ internal class V2PayloadMessageCollator(
     private val gatingService: GatingService,
     private val v1Collator: V1PayloadMessageCollator,
     private val sessionEnvelopeSource: SessionEnvelopeSource,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : PayloadMessageCollator {
 
     override fun buildInitialSession(params: InitialEnvelopeParams): Session {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session.orchestrator
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 
@@ -18,7 +18,7 @@ internal fun shouldEndManualSession(
     clock: Clock,
     activeSession: Session?,
     state: ProcessState,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ): Boolean {
     if (state == ProcessState.BACKGROUND) {
         logger.logWarning("Cannot manually end session while in background.")
@@ -44,7 +44,7 @@ internal fun shouldEndManualSession(
 
 internal fun shouldRunOnBackground(
     state: ProcessState,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ): Boolean {
     return if (state == ProcessState.BACKGROUND) {
         logger.logWarning("Detected unbalanced call to onBackground. Ignoring..")
@@ -56,7 +56,7 @@ internal fun shouldRunOnBackground(
 
 internal fun shouldRunOnForeground(
     state: ProcessState,
-    logger: InternalEmbraceLogger
+    logger: EmbLogger
 ): Boolean {
     return if (state == ProcessState.FOREGROUND) {
         logger.logWarning("Detected unbalanced call to onForeground. Ignoring..")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.opentelemetry.embCleanExit
 import io.embrace.android.embracesdk.opentelemetry.embColdStart
 import io.embrace.android.embracesdk.opentelemetry.embCrashId
@@ -42,7 +42,7 @@ internal class SessionOrchestratorImpl(
     private val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher,
     private val dataCaptureOrchestrator: DataCaptureOrchestrator,
     private val sessionSpanWriter: SessionSpanWriter,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) : SessionOrchestrator {
 
     private val lock = Any()
@@ -321,7 +321,7 @@ internal class SessionOrchestratorImpl(
         timestamp: Long,
         inBackground: Boolean,
         stateChange: String,
-        logger: InternalEmbraceLogger
+        logger: EmbLogger
     ) {
         val type = when {
             inBackground -> "background"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionProperties.kt
@@ -2,14 +2,14 @@ package io.embrace.android.embracesdk.session.properties
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import java.util.concurrent.atomic.AtomicReference
 
 internal class EmbraceSessionProperties(
     private val preferencesService: PreferencesService,
     private val configService: ConfigService,
-    private val logger: InternalEmbraceLogger
+    private val logger: EmbLogger
 ) {
     private val temporary: MutableMap<String, String> = HashMap()
     private val permanentPropertiesReference = AtomicReference(NOT_LOADED)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/PropertyUtils.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/PropertyUtils.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.utils
 
 import android.os.Parcelable
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import java.io.Serializable
 
 /**
@@ -22,7 +22,7 @@ internal object PropertyUtils {
      * @return a normalized Map of the provided properties.
      */
     @JvmStatic
-    fun sanitizeProperties(properties: Map<String?, Any?>?, logger: InternalEmbraceLogger): Map<String, Any> {
+    fun sanitizeProperties(properties: Map<String?, Any?>?, logger: EmbLogger): Map<String, Any> {
         properties ?: return emptyMap()
 
         if (properties.size > MAX_PROPERTY_SIZE) {
@@ -34,7 +34,7 @@ internal object PropertyUtils {
             .associate { Pair(it.key ?: "null", checkIfSerializable(it.key ?: "", it.value, logger)) }
     }
 
-    private fun checkIfSerializable(key: String, value: Any?, logger: InternalEmbraceLogger): Any {
+    private fun checkIfSerializable(key: String, value: Any?, logger: EmbLogger): Any {
         if (value == null) {
             return "null"
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/ThreadUtils.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/utils/ThreadUtils.kt
@@ -2,14 +2,14 @@ package io.embrace.android.embracesdk.utils
 
 import android.os.Handler
 import android.os.Looper
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 
 internal object ThreadUtils {
 
     private val mainLooper = Looper.getMainLooper()
     private val mainThread = mainLooper.thread
 
-    fun runOnMainThread(logger: InternalEmbraceLogger, runnable: Runnable) {
+    fun runOnMainThread(logger: EmbLogger, runnable: Runnable) {
         val wrappedRunnable = Runnable {
             try {
                 runnable.run()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/AeiDataSourceImplTest.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
@@ -91,7 +91,7 @@ internal class AeiDataSourceImplTest {
             sessionIdTracker,
             userService,
             logWriter,
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         ).apply(AeiDataSourceImpl::enableDataCapture)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCacheServiceTest.kt
@@ -18,7 +18,7 @@ import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fixtures.testSessionMessage
 import io.embrace.android.embracesdk.fixtures.testSessionMessage2
 import io.embrace.android.embracesdk.fixtures.testSessionMessageOneMinuteLater
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -39,14 +39,14 @@ internal class EmbraceCacheServiceTest {
     private lateinit var service: CacheService
     private lateinit var storageManager: FakeStorageService
     private lateinit var loggerAction: FakeLogAction
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLoggerImpl
     private val serializer = TestPlatformSerializer()
 
     @Before
     fun setUp() {
         storageManager = FakeStorageService()
         loggerAction = FakeLogAction()
-        logger = InternalEmbraceLogger().apply { addLoggerAction(loggerAction) }
+        logger = EmbLoggerImpl().apply { addLoggerAction(loggerAction) }
         service = EmbraceCacheService(
             storageManager,
             serializer,
@@ -359,7 +359,7 @@ internal class EmbraceCacheServiceTest {
         assertEquals(1, filesAgain.size)
         assertEquals(files[0], filesAgain[0])
 
-        val errors = loggerAction.msgQueue.filter { it.severity == InternalEmbraceLogger.Severity.ERROR }
+        val errors = loggerAction.msgQueue.filter { it.severity == EmbLoggerImpl.Severity.ERROR }
         assertEquals("The following errors were logged: $errors", 0, errors.size)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
@@ -14,7 +14,8 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -47,7 +48,7 @@ internal class EmbraceConfigServiceTest {
         private lateinit var mockApiService: ApiService
         private lateinit var processStateService: ProcessStateService
         private lateinit var mockCacheService: CacheService
-        private lateinit var logger: InternalEmbraceLogger
+        private lateinit var logger: EmbLogger
         private lateinit var fakeClock: FakeClock
         private lateinit var mockConfigListener: () -> Unit
         private lateinit var fakeCachedConfig: RemoteConfig
@@ -66,7 +67,7 @@ internal class EmbraceConfigServiceTest {
             processStateService = FakeProcessStateService()
             mockCacheService = mockk(relaxed = true)
             fakeClock = FakeClock()
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
             configListenerTriggered = false
             mockConfigListener = { configListenerTriggered = true }
             fakeCachedConfig = RemoteConfig( // alter config to trigger listener

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceCrashServiceTest.kt
@@ -13,7 +13,8 @@ import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.Crash
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
@@ -48,7 +49,7 @@ internal class EmbraceCrashServiceTest {
     private lateinit var anrService: FakeAnrService
     private lateinit var ndkService: FakeNdkService
     private lateinit var preferencesService: FakePreferenceService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
 
     private lateinit var crash: Crash
     private lateinit var localJsException: JsException
@@ -73,7 +74,7 @@ internal class EmbraceCrashServiceTest {
         ndkService = FakeNdkService()
         preferencesService = FakePreferenceService()
         crashMarker = mockk(relaxUnitFun = true)
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
 
         localJsException = JsException("jsException", "Error", "Error", "")
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheCurrentAccessTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheCurrentAccessTest.kt
@@ -7,7 +7,8 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fixtures.testSessionMessage
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.storage.StorageService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -26,13 +27,13 @@ internal class EmbraceDeliveryCacheCurrentAccessTest {
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var fakeClock: FakeClock
 
     @Before
     fun before() {
         fakeClock = FakeClock(clockInit)
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         storageService = FakeStorageService()
         worker = BackgroundWorker(SingleThreadTestScheduledExecutor())
         cacheService = spyk(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceDeliveryCacheManagerTest.kt
@@ -16,7 +16,7 @@ import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fixtures.testSessionMessage
 import io.embrace.android.embracesdk.fixtures.testSessionMessageOneMinuteLater
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.JVM_CRASH
@@ -51,7 +51,7 @@ internal class EmbraceDeliveryCacheManagerTest {
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService
     private lateinit var loggerAction: FakeLogAction
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLoggerImpl
     private lateinit var fakeClock: FakeClock
 
     companion object {
@@ -62,7 +62,7 @@ internal class EmbraceDeliveryCacheManagerTest {
     fun before() {
         fakeClock = FakeClock(clockInit)
         loggerAction = FakeLogAction()
-        logger = InternalEmbraceLogger().apply { addLoggerAction(loggerAction) }
+        logger = EmbLoggerImpl().apply { addLoggerAction(loggerAction) }
         storageService = FakeStorageService()
         cacheService = spyk(
             EmbraceCacheService(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
@@ -34,7 +34,8 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys.STARTUP_MOMENT
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.USER_PERSONAS
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.DiskUsage
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -58,7 +59,7 @@ internal class EmbraceGatingServiceV1PayloadTest {
     private lateinit var localConfig: LocalConfig
     private lateinit var gatingService: EmbraceGatingService
     private lateinit var configService: ConfigService
-    private lateinit var internalEmbraceLogger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
 
     private val enabledComponentsFull = setOf(
         BREADCRUMBS_TAPS,
@@ -90,10 +91,10 @@ internal class EmbraceGatingServiceV1PayloadTest {
         localConfig = LocalConfig("default test app Id", false, SdkLocalConfig())
         sessionBehavior = fakeSessionBehavior { cfg }
         configService = FakeConfigService(sessionBehavior = fakeSessionBehavior { cfg })
-        internalEmbraceLogger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         gatingService = EmbraceGatingService(
             configService,
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
     }
 
@@ -177,7 +178,7 @@ internal class EmbraceGatingServiceV1PayloadTest {
                 "]" +
                 "}}",
             EmbraceSerializer(),
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
 
         cfg = buildCustomRemoteConfig(
@@ -187,7 +188,7 @@ internal class EmbraceGatingServiceV1PayloadTest {
 
         gatingService = EmbraceGatingService(
             configService,
-            internalEmbraceLogger
+            logger
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV2PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV2PayloadTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.SessionMessage
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -37,7 +37,7 @@ internal class EmbraceGatingServiceV2PayloadTest {
     fun setUp() {
         sessionBehavior = fakeSessionBehavior { cfg }
         configService = FakeConfigService(sessionBehavior = fakeSessionBehavior { cfg })
-        gatingService = EmbraceGatingService(configService, InternalEmbraceLogger())
+        gatingService = EmbraceGatingService(configService, EmbLoggerImpl())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNativeThreadSamplerServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNativeThreadSamplerServiceTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe
@@ -50,7 +50,7 @@ internal class EmbraceNativeThreadSamplerServiceTest {
         configService = FakeConfigService(anrBehavior = anrBehavior)
         sharedObjectLoader = mockk(relaxed = true)
         delegate = mockk(relaxed = true)
-        val logger = InternalEmbraceLogger()
+        val logger = EmbLoggerImpl()
         random = mockk(relaxed = true)
         executorService = BlockingScheduledExecutorService()
         sampler =

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNetworkConnectivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNetworkConnectivityServiceTest.kt
@@ -11,7 +11,8 @@ import io.embrace.android.embracesdk.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.fakeDataSourceModule
 import io.embrace.android.embracesdk.fakes.system.mockContext
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -31,7 +32,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
 
     companion object {
         private lateinit var context: Context
-        private lateinit var logger: InternalEmbraceLogger
+        private lateinit var logger: EmbLogger
         private lateinit var mockConnectivityManager: ConnectivityManager
         private lateinit var worker: BackgroundWorker
         private lateinit var fakeClock: FakeClock
@@ -43,7 +44,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
         @JvmStatic
         fun setupBeforeAll() {
             context = mockContext()
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
             mockConnectivityManager = mockk()
             fakeClock = FakeClock()
             worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbracePerformanceInfoServiceTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.capture.EmbracePerformanceInfoService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.PerformanceInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
@@ -21,7 +21,7 @@ internal class EmbracePerformanceInfoServiceTest {
     fun setUp() {
         service = EmbracePerformanceInfoService(
             metadataService,
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceSessionPropertiesTest.kt
@@ -12,7 +12,8 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -39,7 +40,7 @@ internal class EmbraceSessionPropertiesTest {
     private lateinit var preferencesService: PreferencesService
     private lateinit var sessionProperties: EmbraceSessionProperties
     private lateinit var context: Context
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var configService: ConfigService
     private lateinit var config: RemoteConfig
 
@@ -47,7 +48,7 @@ internal class EmbraceSessionPropertiesTest {
     fun setUp() {
         val worker = BackgroundWorker(Executors.newSingleThreadExecutor())
         context = ApplicationProvider.getApplicationContext()
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         val prefs = lazy { PreferenceManager.getDefaultSharedPreferences(context) }
         preferencesService =
             EmbracePreferencesService(worker, prefs, fakeClock, EmbraceSerializer())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceUncaughtExceptionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceUncaughtExceptionHandlerTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.capture.crash.CrashService
 import io.embrace.android.embracesdk.capture.crash.EmbraceUncaughtExceptionHandler
 import io.embrace.android.embracesdk.fakes.FakeCrashService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.JsException
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -25,7 +25,7 @@ internal class EmbraceUncaughtExceptionHandlerTest {
      */
     @Test
     fun testNullArg1() {
-        EmbraceUncaughtExceptionHandler(null, FakeCrashService(), InternalEmbraceLogger())
+        EmbraceUncaughtExceptionHandler(null, FakeCrashService(), EmbLoggerImpl())
     }
 
     /**
@@ -36,7 +36,7 @@ internal class EmbraceUncaughtExceptionHandlerTest {
     fun testExceptionHandler() {
         val defaultHandler = TestUncaughtExceptionHandler()
         val fakeCrashService = FakeCrashService()
-        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, fakeCrashService, InternalEmbraceLogger())
+        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, fakeCrashService, EmbLoggerImpl())
 
         val testException = RuntimeException("Test exception")
         handler.uncaughtException(Thread.currentThread(), testException)
@@ -58,7 +58,7 @@ internal class EmbraceUncaughtExceptionHandlerTest {
     fun testCrashingExceptionHandler() {
         val defaultHandler = TestUncaughtExceptionHandler()
         val crashingCrashService = CrashingCrashService()
-        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, crashingCrashService, InternalEmbraceLogger())
+        val handler = EmbraceUncaughtExceptionHandler(defaultHandler, crashingCrashService, EmbLoggerImpl())
         val testException = RuntimeException("Test exception")
         handler.uncaughtException(Thread.currentThread(), testException)
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceUserServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceUserServiceTest.kt
@@ -2,7 +2,8 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.capture.user.EmbraceUserService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.UserInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -38,11 +39,11 @@ internal class EmbraceUserServiceTest {
 
     private lateinit var service: EmbraceUserService
     private lateinit var preferencesService: FakePreferenceService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
 
     @Before
     fun setUp() {
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         preferencesService = FakePreferenceService()
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.config.remote.WebViewVitals
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeWebViewVitalsBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.WebVitalType
 import io.embrace.android.embracesdk.utils.at
 import org.junit.Assert.assertEquals
@@ -41,7 +41,7 @@ internal class EmbraceWebViewServiceTest {
     fun setup() {
         cfg = RemoteConfig(webViewVitals = WebViewVitals(100f, 50))
         configService = FakeConfigService(webViewVitalsBehavior = fakeWebViewVitalsBehavior { cfg })
-        embraceWebViewService = EmbraceWebViewService(configService, EmbraceSerializer(), InternalEmbraceLogger())
+        embraceWebViewService = EmbraceWebViewService(configService, EmbraceSerializer(), EmbLoggerImpl())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FlutterInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FlutterInternalInterfaceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.capture.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -13,7 +13,7 @@ internal class FlutterInternalInterfaceImplTest {
 
     private lateinit var impl: FlutterInternalInterfaceImpl
     private lateinit var embrace: EmbraceImpl
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var hostedSdkVersionInfo: HostedSdkVersionInfo
     private lateinit var fakePreferencesService: FakePreferenceService
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/LocalConfigTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.config.LocalConfigParser
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -13,7 +13,7 @@ import org.junit.Test
 internal class LocalConfigTest {
 
     private val serializer = EmbraceSerializer()
-    private val logger = InternalEmbraceLogger()
+    private val logger = EmbLoggerImpl()
 
     @Test
     fun testEmptyConfig() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PropertiesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/PropertiesTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.utils.PropertyUtils
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -18,7 +18,7 @@ internal class PropertiesTest {
         for (i in 1..9) {
             sourceMap["Key$i"] = "Value$i"
         }
-        val resultMap = PropertyUtils.sanitizeProperties(sourceMap, InternalEmbraceLogger())
+        val resultMap = PropertyUtils.sanitizeProperties(sourceMap, EmbLoggerImpl())
         assertTrue(
             "Unexpected normalized map size.",
             resultMap.size <= PropertyUtils.MAX_PROPERTY_SIZE

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ReactNativeInternalInterfaceImplTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.capture.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.system.mockContext
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.mockk.every
@@ -26,7 +26,7 @@ internal class ReactNativeInternalInterfaceImplTest {
     private lateinit var preferencesService: PreferencesService
     private lateinit var crashService: CrashService
     private lateinit var metadataService: FakeMetadataService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var context: Context
     private lateinit var hostedSdkVersionInfo: HostedSdkVersionInfo
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UnityInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/UnityInternalInterfaceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import io.embrace.android.embracesdk.capture.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.mockk.every
 import io.mockk.mockk
@@ -17,7 +17,7 @@ internal class UnityInternalInterfaceImplTest {
     private lateinit var impl: UnityInternalInterfaceImpl
     private lateinit var embrace: EmbraceImpl
     private lateinit var preferencesService: PreferencesService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
 
     @Before
     fun setUp() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/EmbraceAnrServiceRule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/EmbraceAnrServiceRule.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import org.junit.rules.ExternalResource
 import java.util.concurrent.ScheduledExecutorService
@@ -27,7 +27,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
     val clock: FakeClock = FakeClock(),
     private val scheduledExecutorSupplier: Provider<T>
 ) : ExternalResource() {
-    val logger = InternalEmbraceLogger()
+    val logger = EmbLoggerImpl()
 
     lateinit var fakeConfigService: FakeConfigService
     lateinit var anrService: EmbraceAnrService

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetectorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/BlockedThreadDetectorTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.fakes.FakeBlockedThreadListener
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -37,7 +37,7 @@ internal class BlockedThreadDetectorTest {
             state,
             Thread.currentThread(),
             anrMonitorThread = anrMonitorThread,
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckSchedulerTest.kt
@@ -7,7 +7,8 @@ import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.every
 import io.mockk.mockk
@@ -29,7 +30,7 @@ internal class LivenessCheckSchedulerTest {
 
     private lateinit var configService: ConfigService
     private lateinit var anrExecutorService: BlockingScheduledExecutorService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var looper: Looper
     private lateinit var fakeClock: FakeClock
     private lateinit var fakeTargetThreadHandler: TargetThreadHandler
@@ -47,7 +48,7 @@ internal class LivenessCheckSchedulerTest {
         fakeClock = FakeClock(160982340900)
         configService = FakeConfigService(anrBehavior = fakeAnrBehavior { cfg })
         anrExecutorService = BlockingScheduledExecutorService(fakeClock)
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         looper = mockk {
             every { thread } returns Thread.currentThread()
         }
@@ -58,7 +59,7 @@ internal class LivenessCheckSchedulerTest {
             state = state,
             targetThread = Thread.currentThread(),
             anrMonitorThread = anrMonitorThread,
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
         )
         fakeTargetThreadHandler = mockk(relaxUnitFun = true) {
             every { action = any() } returns Unit

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandlerTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.system.mockLooper
 import io.embrace.android.embracesdk.fakes.system.mockMessage
 import io.embrace.android.embracesdk.fakes.system.mockMessageQueue
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import io.mockk.mockk
 import io.mockk.verify
@@ -52,7 +52,7 @@ internal class TargetThreadHandlerTest {
             anrMonitorThread = anrMonitorThread,
             configService,
             messageQueue,
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
         ) { FAKE_TIME_MS }.apply {
             action = {}
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetectorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetectorTest.kt
@@ -1,14 +1,14 @@
 package io.embrace.android.embracesdk.anr.detection
 
 import io.embrace.android.embracesdk.fakes.FakeLogAction
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
 internal class UnbalancedCallDetectorTest {
 
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLoggerImpl
     private lateinit var detector: UnbalancedCallDetector
     private lateinit var action: FakeLogAction
     private val thread = Thread.currentThread()
@@ -16,7 +16,7 @@ internal class UnbalancedCallDetectorTest {
     @Before
     fun setUp() {
         action = FakeLogAction()
-        logger = InternalEmbraceLogger().apply { addLoggerAction(action) }
+        logger = EmbLoggerImpl().apply { addLoggerAction(action) }
         detector = UnbalancedCallDetector(logger)
     }
 
@@ -76,7 +76,7 @@ internal class UnbalancedCallDetectorTest {
 
     private fun verifyInternalErrorLogs(expectedCount: Int) {
         val messages = action.msgQueue.filter { msg ->
-            msg.severity == InternalEmbraceLogger.Severity.ERROR && msg.logStacktrace
+            msg.severity == EmbLoggerImpl.Severity.ERROR && msg.logStacktrace
         }
         assertEquals(expectedCount, messages.size)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/sigquit/AnrThreadIdDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/sigquit/AnrThreadIdDelegateTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.anr.sigquit
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -8,7 +8,7 @@ internal class AnrThreadIdDelegateTest {
 
     @Test
     fun findGoogleAnrThread() {
-        val delegate = AnrThreadIdDelegate(InternalEmbraceLogger())
+        val delegate = AnrThreadIdDelegate(EmbLoggerImpl())
         val threadId = delegate.findGoogleAnrThread()
         assertEquals(0, threadId)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSourceTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -18,7 +18,7 @@ internal class SigquitDataSourceTest {
 
     @Before
     fun setUp() {
-        val logger = InternalEmbraceLogger()
+        val logger = EmbLoggerImpl()
         sessionSpan = FakeCurrentSessionSpan()
         config = AnrRemoteConfig()
         dataSource = SigquitDataSource(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.system.mockContext
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -28,7 +28,7 @@ internal class DataCaptureOrchestratorTest {
                     currentSessionType = null
                 )
             ),
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
             configService
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -38,7 +38,7 @@ internal class DataSourceImplTest {
     @Test
     fun `capture data respects limits`() {
         val dst = FakeCurrentSessionSpan()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -52,7 +52,7 @@ internal class DataSourceImplTest {
     @Test
     fun `capture data respects validation`() {
         val dst = FakeCurrentSessionSpan()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -67,7 +67,7 @@ internal class DataSourceImplTest {
         dst: FakeCurrentSessionSpan,
         limitStrategy: LimitStrategy = NoopLimitStrategy
     ) :
-        DataSourceImpl<FakeCurrentSessionSpan>(dst, InternalEmbraceLogger(), limitStrategy) {
+        DataSourceImpl<FakeCurrentSessionSpan>(dst, EmbLoggerImpl(), limitStrategy) {
 
         override fun enableDataCapture() {
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.fakes.FakeSpanService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -38,7 +38,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `capture data respects limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -52,7 +52,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `capture data respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -88,7 +88,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `start span respects limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -102,7 +102,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `start span respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -138,7 +138,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `stop span does not increment limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -152,7 +152,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `stop span respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(InternalEmbraceLogger()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
 
         var count = 0
         repeat(4) {
@@ -166,5 +166,5 @@ internal class SpanDataSourceImplTest {
     private class FakeDataSourceImpl(
         dst: FakeSpanService,
         limitStrategy: LimitStrategy = NoopLimitStrategy
-    ) : SpanDataSourceImpl(dst, InternalEmbraceLogger(), limitStrategy)
+    ) : SpanDataSourceImpl(dst, EmbLoggerImpl(), limitStrategy)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.arch.limits
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,7 +11,7 @@ internal class UpToLimitStrategyTest {
 
     @Test
     fun shouldCapture() {
-        val strategy = UpToLimitStrategy(InternalEmbraceLogger(), provider)
+        val strategy = UpToLimitStrategy(EmbLoggerImpl(), provider)
         repeat(10) {
             assertTrue(strategy.shouldCapture())
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.opentelemetry.exceptionType
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -30,7 +30,7 @@ internal class TelemetryAttributesTest {
         sessionProperties = EmbraceSessionProperties(
             FakePreferenceService(),
             FakeConfigService(),
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
         sessionId = Uuid.getEmbUuid()
         configService = FakeConfigService()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImplTest.kt
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
@@ -56,7 +56,7 @@ internal class AeiDataSourceImplTest {
     private val metadataService = FakeMetadataService()
     private val sessionIdTracker = FakeSessionIdTracker()
     private val userService = FakeUserService()
-    private val logger = InternalEmbraceLogger()
+    private val logger = EmbLoggerImpl()
 
     private val mockActivityManager: ActivityManager = mockk {
         every { getHistoricalProcessExitReasons(any(), any(), any()) } returns emptyList()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/aei/AeiNdkCrashProtobufSendTest.kt
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
@@ -153,7 +153,7 @@ internal class AeiNdkCrashProtobufSendTest {
             sessionIdTracker,
             FakeUserService(),
             logWriter,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
             VersionChecker { ndkTraceFile }
         ).enableDataCapture()
         return logWriter

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegateTest.kt
@@ -1,7 +1,8 @@
 package io.embrace.android.embracesdk.capture.cpu
 
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -13,12 +14,12 @@ import org.junit.Test
 internal class EmbraceCpuInfoDelegateTest {
 
     private val mockSharedObjectLoader: SharedObjectLoader = mockk(relaxed = true)
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var cpuInfoDelegate: EmbraceCpuInfoDelegate
 
     @Before
     fun before() {
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         cpuInfoDelegate = EmbraceCpuInfoDelegate(mockSharedObjectLoader, logger)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/CompositeCrashServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/CompositeCrashServiceTest.kt
@@ -10,7 +10,8 @@ import io.embrace.android.embracesdk.fakes.FakeCrashDataSource
 import io.embrace.android.embracesdk.fakes.FakeCrashService
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeOTelBehavior
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.JsException
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -20,14 +21,14 @@ internal class CompositeCrashServiceTest {
 
     private lateinit var compositeCrashService: CompositeCrashService
     private lateinit var configService: FakeConfigService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var crashServiceV1: FakeCrashService
     private lateinit var crashServiceV2: FakeCrashDataSource
     private lateinit var oTelConfig: OTelRemoteConfig
 
     @Before
     fun setUp() {
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         crashServiceV1 = FakeCrashService()
         crashServiceV2 = FakeCrashDataSource()
         oTelConfig = OTelRemoteConfig(isBetaEnabled = false)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImplTest.kt
@@ -10,7 +10,8 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import org.junit.Assert.assertEquals
@@ -33,7 +34,7 @@ internal class CrashDataSourceImplTest {
     private lateinit var configService: FakeConfigService
     private lateinit var serializer: EmbraceSerializer
     private lateinit var logWriter: FakeLogWriter
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var localJsException: JsException
     private lateinit var testException: Exception
 
@@ -49,7 +50,7 @@ internal class CrashDataSourceImplTest {
         logWriter = FakeLogWriter()
         configService = FakeConfigService()
         serializer = EmbraceSerializer()
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         localJsException = JsException(
             "NullPointerException",
             "Null pointer exception occurred",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSourceTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -20,7 +20,7 @@ internal class BreadcrumbDataSourceTest {
         source = BreadcrumbDataSource(
             FakeConfigService().breadcrumbBehavior,
             writer,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbServiceTest.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.fakes.injection.fakeDataSourceModule
 import io.embrace.android.embracesdk.fakes.system.mockActivity
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.EmbraceMemoryCleanerService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import org.junit.Assert.assertEquals
@@ -47,7 +47,7 @@ internal class EmbraceBreadcrumbServiceTest {
         )
         processStateService = FakeProcessStateService()
         activity = mockActivity()
-        memoryCleanerService = EmbraceMemoryCleanerService(InternalEmbraceLogger())
+        memoryCleanerService = EmbraceMemoryCleanerService(EmbLoggerImpl())
         clock.setCurrentTime(MILLIS_FOR_2020_01_01)
         clock.tickSecond()
     }
@@ -84,7 +84,7 @@ internal class EmbraceBreadcrumbServiceTest {
         clock,
         configService,
         { fakeDataSourceModule() },
-        InternalEmbraceLogger(),
+        EmbLoggerImpl(),
     )
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentViewDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/FragmentViewDataSourceTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeSpanService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -27,7 +27,7 @@ internal class FragmentViewDataSourceTest {
             configService.breadcrumbBehavior,
             clock,
             spanService,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationCaptureServiceTest.kt
@@ -5,7 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import io.embrace.android.embracesdk.FakeBreadcrumbService
 import io.embrace.android.embracesdk.fakes.system.mockBundle
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.PushNotificationBreadcrumb
 import io.mockk.clearAllMocks
 import io.mockk.clearMocks
@@ -23,7 +24,7 @@ internal class PushNotificationCaptureServiceTest {
     private lateinit var breadcrumbService: FakeBreadcrumbService
 
     companion object {
-        private val logger: InternalEmbraceLogger = InternalEmbraceLogger()
+        private val logger: EmbLogger = EmbLoggerImpl()
         private val mockBundle: Bundle = mockBundle()
         private val mockIntent: Intent = mockk {
             every { extras } returns mockBundle

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/TapBreadcrumbDataSourceTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.TapBreadcrumb
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -22,7 +22,7 @@ internal class TapBreadcrumbDataSourceTest {
         source = TapDataSource(
             FakeConfigService().breadcrumbBehavior,
             writer,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSourceTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -41,7 +41,7 @@ internal class WebViewUrlDataSourceTest {
         source = WebViewUrlDataSource(
             configService.breadcrumbBehavior,
             writer,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
         source.logWebView(
             "http://www.google.com?query=123",
@@ -77,7 +77,7 @@ internal class WebViewUrlDataSourceTest {
         source = WebViewUrlDataSource(
             configService.breadcrumbBehavior,
             writer,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
         source.logWebView(
             "http://www.google.com?query=123",
@@ -113,7 +113,7 @@ internal class WebViewUrlDataSourceTest {
         source = WebViewUrlDataSource(
             configService.breadcrumbBehavior,
             writer,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
         repeat(150) { k ->
             source.logWebView(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/DeviceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/resource/DeviceImplTest.kt
@@ -5,7 +5,7 @@ import android.view.WindowManager
 import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.clearAllMocks
@@ -65,7 +65,7 @@ internal class DeviceImplTest {
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
             SystemInfo(),
             cpuInfoDelegate,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
 
         assertEquals("200x300", device.screenResolution)
@@ -79,7 +79,7 @@ internal class DeviceImplTest {
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
             SystemInfo(),
             cpuInfoDelegate,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
 
         assertEquals("fake_cpu", device.cpuName)
@@ -93,7 +93,7 @@ internal class DeviceImplTest {
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
             SystemInfo(),
             cpuInfoDelegate,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
 
         assertEquals("fake_egl", device.eglInfo)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
@@ -49,7 +49,7 @@ internal class SessionPayloadSourceImplTest {
             sink,
             currentSessionSpan,
             spanRepository,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         ) { FakeSessionPropertiesService() }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/memory/ComponentCallbackServiceTest.kt
@@ -5,7 +5,7 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import io.embrace.android.embracesdk.fakes.FakeMemoryService
 import io.embrace.android.embracesdk.fakes.system.mockContext
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -43,7 +43,7 @@ internal class ComponentCallbackServiceTest {
         service = ComponentCallbackService(
             application,
             memoryService,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataReactNativeTest.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.fakes.system.mockWindowManager
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -62,7 +62,7 @@ internal class EmbraceMetadataReactNativeTest {
         preferencesService.javaScriptPatchNumber = "patch-number"
         preferencesService.reactNativeVersionNumber = "rn-version-number"
         mockSharedObjectLoader = mockk(relaxed = true)
-        cpuInfoDelegate = EmbraceCpuInfoDelegate(mockSharedObjectLoader, InternalEmbraceLogger())
+        cpuInfoDelegate = EmbraceCpuInfoDelegate(mockSharedObjectLoader, EmbLoggerImpl())
         hostedSdkVersionInfo = HostedSdkVersionInfo(
             preferencesService,
             Embrace.AppFramework.REACT_NATIVE
@@ -87,7 +87,7 @@ internal class EmbraceMetadataReactNativeTest {
         lazy { "" },
         lazy { "" },
         hostedSdkVersionInfo,
-        InternalEmbraceLogger(),
+        EmbLoggerImpl(),
     )
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -25,7 +25,7 @@ import io.embrace.android.embracesdk.fakes.system.mockWindowManager
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.mockk.clearAllMocks
@@ -56,7 +56,7 @@ internal class EmbraceMetadataServiceTest {
         private val fakeArchitecture = FakeDeviceArchitecture()
         private val storageStatsManager = mockk<StorageStatsManager>()
         private val windowManager = mockk<WindowManager>()
-        private val logger = InternalEmbraceLogger()
+        private val logger = EmbLoggerImpl()
 
         @BeforeClass
         @JvmStatic
@@ -147,7 +147,7 @@ internal class EmbraceMetadataServiceTest {
             lazy { packageInfo.versionName },
             lazy { packageInfo.versionCode.toString() },
             hostedSdkVersionInfo,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         ).apply { precomputeValues() }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSourceTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.system.mockPowerManager
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -30,7 +30,7 @@ internal class LowPowerDataSourceTest {
         dataSource = LowPowerDataSource(
             ApplicationProvider.getApplicationContext(),
             spanService,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
             FakeClock()
         ) { mockPowerManager() }.apply {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSourceTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.capture.session
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -20,7 +20,7 @@ internal class SessionPropertiesDataSourceTest {
         dataSource = SessionPropertiesDataSource(
             FakeConfigService().sessionBehavior,
             fakeCurrentSessionSpan,
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitterTest.kt
@@ -16,7 +16,7 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -39,7 +39,7 @@ internal class AppStartupTraceEmitterTest {
     private lateinit var spanSink: SpanSink
     private lateinit var spanService: SpanService
     private lateinit var loggerAction: FakeLogAction
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLoggerImpl
     private lateinit var backgroundWorker: BackgroundWorker
     private lateinit var appStartupTraceEmitter: AppStartupTraceEmitter
 
@@ -57,7 +57,7 @@ internal class AppStartupTraceEmitterTest {
         )
         clock.tick(100L)
         loggerAction = FakeLogAction()
-        logger = InternalEmbraceLogger().apply { addLoggerAction(loggerAction) }
+        logger = EmbLoggerImpl().apply { addLoggerAction(loggerAction) }
         appStartupTraceEmitter = AppStartupTraceEmitter(
             clock = initModule.openTelemetryClock,
             startupServiceProvider = { startupService },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/ApiClientImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.comms.api
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.mockk.every
 import io.mockk.mockk
@@ -33,7 +33,7 @@ internal class ApiClientImplTest {
 
     @Before
     fun setUp() {
-        apiClient = ApiClientImpl(InternalEmbraceLogger())
+        apiClient = ApiClientImpl(EmbLoggerImpl())
         server = MockWebServer()
         server.start()
         baseUrl = server.url("test").toString()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/api/EmbraceApiServiceTest.kt
@@ -18,7 +18,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.payload.AppInfo
 import io.embrace.android.embracesdk.payload.BlobMessage
@@ -611,7 +611,7 @@ internal class EmbraceApiServiceTest {
             apiClient = fakeApiClient,
             serializer = serializer,
             cachedConfigProvider = { _, _ -> cachedConfig },
-            logger = InternalEmbraceLogger(),
+            logger = EmbLoggerImpl(),
             backgroundWorker = BackgroundWorker(testScheduledExecutor),
             cacheManager = fakeCacheManager,
             lazyDeviceId = lazy { fakeDeviceId },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheServiceConcurrentAccessTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceCacheServiceConcurrentAccessTest.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fixtures.testSessionMessage
 import io.embrace.android.embracesdk.fixtures.testSessionMessage2
 import io.embrace.android.embracesdk.fixtures.testSessionMessageOneMinuteLater
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.SessionMessage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -19,7 +19,7 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
     private lateinit var storageService: FakeStorageService
     private lateinit var serializer: TestPlatformSerializer
     private lateinit var loggerAction: FakeLogAction
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLoggerImpl
     private lateinit var executionCoordinator: ExecutionCoordinator
 
     @Before
@@ -27,7 +27,7 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
         storageService = FakeStorageService()
         serializer = TestPlatformSerializer()
         loggerAction = FakeLogAction()
-        logger = InternalEmbraceLogger().apply { addLoggerAction(loggerAction) }
+        logger = EmbLoggerImpl().apply { addLoggerAction(loggerAction) }
         embraceCacheService = EmbraceCacheService(
             storageService,
             serializer,
@@ -152,7 +152,7 @@ internal class EmbraceCacheServiceConcurrentAccessTest {
 
     private fun getErrorLogs() = loggerAction
         .msgQueue
-        .filter { it.severity == InternalEmbraceLogger.Severity.ERROR }
+        .filter { it.severity == EmbLoggerImpl.Severity.ERROR }
         .toList()
 
     companion object {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -22,7 +22,8 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -50,7 +51,7 @@ internal class EmbraceDeliveryServiceTest {
     private lateinit var testPlatformSerializer: TestPlatformSerializer
     private lateinit var fakeStorageService: FakeStorageService
     private lateinit var cacheService: EmbraceCacheService
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var deliveryService: EmbraceDeliveryService
     private lateinit var sessionIdTracker: FakeSessionIdTracker
 
@@ -61,7 +62,7 @@ internal class EmbraceDeliveryServiceTest {
         apiService = FakeApiService()
         fakeNativeCrashService = FakeNativeCrashService()
         gatingService = FakeGatingService()
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         sessionIdTracker = FakeSessionIdTracker()
         fakeStorageService = FakeStorageService()
         testPlatformSerializer = TestPlatformSerializer()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.comms.api.Endpoint
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.internal.utils.SerializationAction
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.worker.ScheduledWorker
@@ -315,7 +315,7 @@ internal class EmbracePendingApiCallsSenderTest {
             scheduledWorker = worker,
             networkConnectivityService = networkConnectivityService,
             cacheManager = mockCacheManager,
-            logger = InternalEmbraceLogger(),
+            logger = EmbLoggerImpl(),
             clock = FakeClock()
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -147,7 +147,7 @@ internal class NetworkBehaviorTest {
     @Test
     fun testGetCapturePublicKey() {
         val json = ResourceReader.readResourceAsText("public_key_config.json")
-        val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), InternalEmbraceLogger())
+        val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), EmbLoggerImpl())
         val behavior = fakeNetworkBehavior(localCfg = localConfig::sdkConfig)
         assertEquals(testCleanPublicKey, behavior.getCapturePublicKey())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceEventServiceTest.kt
@@ -22,7 +22,8 @@ import io.embrace.android.embracesdk.fakes.fakeStartupBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.gating.GatingService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -60,7 +61,7 @@ internal class EmbraceEventServiceTest {
         private lateinit var performanceInfoService: PerformanceInfoService
         private lateinit var userService: UserService
         private lateinit var processStateService: ProcessStateService
-        private lateinit var logger: InternalEmbraceLogger
+        private lateinit var logger: EmbLogger
 
         @BeforeClass
         @JvmStatic
@@ -70,7 +71,7 @@ internal class EmbraceEventServiceTest {
             preferenceService = FakePreferenceService()
             performanceInfoService = FakePerformanceInfoService()
             processStateService = FakeProcessStateService()
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
             userService = EmbraceUserService(
                 preferencesService = preferenceService,
                 logger = logger

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EmbraceLogMessageServiceTest.kt
@@ -23,7 +23,8 @@ import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -56,7 +57,7 @@ internal class EmbraceLogMessageServiceTest {
         private lateinit var configService: ConfigService
         private lateinit var sessionProperties: EmbraceSessionProperties
         private lateinit var gatingService: EmbraceGatingService
-        private lateinit var logcat: InternalEmbraceLogger
+        private lateinit var logcat: EmbLogger
         private lateinit var executor: ExecutorService
         private lateinit var tick: AtomicLong
         private lateinit var clock: Clock
@@ -67,7 +68,7 @@ internal class EmbraceLogMessageServiceTest {
             metadataService = FakeMetadataService()
             sessionIdTracker = FakeSessionIdTracker()
             userService = FakeUserService()
-            logcat = InternalEmbraceLogger()
+            logcat = EmbLoggerImpl()
             executor = Executors.newSingleThreadExecutor()
             tick = AtomicLong(1609823408L)
             clock = Clock { tick.incrementAndGet() }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
@@ -21,7 +21,8 @@ import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.EventDescription
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.UserInfo
@@ -54,7 +55,7 @@ internal class EventHandlerTest {
         private lateinit var userService: UserService
         private lateinit var gatingService: GatingService
         private lateinit var sessionProperties: EmbraceSessionProperties
-        private lateinit var logger: InternalEmbraceLogger
+        private lateinit var logger: EmbLogger
         private lateinit var mockStartup: StartupEventInfo
         private lateinit var mockLateTimer: ScheduledFuture<*>
         private lateinit var userInfo: UserInfo
@@ -69,7 +70,7 @@ internal class EventHandlerTest {
             performanceService = FakePerformanceInfoService()
             userService = FakeUserService()
             gatingService = FakeGatingService()
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
             mockStartup = StartupEventInfo()
             mockLateTimer = mockk(relaxed = true)
             userInfo = UserInfo()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+
+internal class FakeEmbLogger : EmbLogger {
+
+    override fun addLoggerAction(action: EmbLoggerImpl.LogAction) {
+    }
+
+    override fun logDebug(msg: String, throwable: Throwable?) {
+    }
+
+    override fun logInfo(msg: String) {
+    }
+
+    override fun logWarning(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
+    }
+
+    override fun logError(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
+    }
+
+    override fun logSdkNotInitialized(action: String) {
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.SessionMessage
 
@@ -18,7 +18,7 @@ internal class FakeGatingService(configService: ConfigService = FakeConfigServic
     val envelopesFiltered = mutableListOf<Envelope<SessionPayload>>()
     val eventMessagesFiltered = mutableListOf<EventMessage>()
 
-    private val realGatingService = EmbraceGatingService(configService, InternalEmbraceLogger())
+    private val realGatingService = EmbraceGatingService(configService, EmbLoggerImpl())
 
     override fun gateSessionMessage(sessionMessage: SessionMessage): SessionMessage {
         val filteredMessage = realGatingService.gateSessionMessage(sessionMessage)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogAction.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogAction.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger.Severity
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl.Severity
 import java.util.LinkedList
 
-internal class FakeLogAction : InternalEmbraceLogger.LogAction {
+internal class FakeLogAction : EmbLoggerImpl.LogAction {
 
     val msgQueue = LinkedList<LogMessage>()
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionProperties.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionProperties.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 
 internal fun fakeEmbraceSessionProperties() = EmbraceSessionProperties(
     FakePreferenceService(),
     FakeConfigService(),
-    InternalEmbraceLogger()
+    EmbLoggerImpl()
 )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
@@ -11,17 +11,17 @@ import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.injection.AnrModule
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 
 internal class FakeAnrModule(
     override val anrService: AnrService = FakeAnrService(),
     override val anrOtelMapper: AnrOtelMapper = AnrOtelMapper(anrService),
     override val responsivenessMonitorService: ResponsivenessMonitorService = NoOpResponsivenessMonitorService(),
     override val sigquitDataSource: SigquitDataSource = SigquitDataSource(
-        SharedObjectLoader(InternalEmbraceLogger()),
-        AnrThreadIdDelegate(InternalEmbraceLogger()),
+        SharedObjectLoader(EmbLoggerImpl()),
+        AnrThreadIdDelegate(EmbLoggerImpl()),
         fakeAnrBehavior(),
-        InternalEmbraceLogger(),
+        EmbLoggerImpl(),
         FakeCurrentSessionSpan()
     )
 ) : AnrModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -10,7 +10,8 @@ import io.embrace.android.embracesdk.fakes.system.mockApplication
 import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.registry.ServiceRegistry
 import io.mockk.every
 import io.mockk.isMockKMock
@@ -21,7 +22,7 @@ import org.robolectric.RuntimeEnvironment
  * If used in a Robolectric test, [application] and [context] will be fakes supplied by the Robolectric framework
  */
 internal class FakeCoreModule(
-    val logger: InternalEmbraceLogger = InternalEmbraceLogger(),
+    val logger: EmbLogger = EmbLoggerImpl(),
     override val application: Application =
         if (RuntimeEnvironment.getApplication() == null) mockApplication() else RuntimeEnvironment.getApplication(),
     override val context: Context =

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCustomerLogModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCustomerLogModule.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.injection.CustomerLogModule
 import io.embrace.android.embracesdk.internal.logs.LogOrchestrator
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.network.logging.NetworkCaptureDataSource
 import io.embrace.android.embracesdk.network.logging.NetworkCaptureService
 import io.embrace.android.embracesdk.network.logging.NetworkLoggingService
@@ -33,7 +33,7 @@ internal class FakeCustomerLogModule(
         FakeUserService(),
         FakeConfigService(),
         fakeEmbraceSessionProperties(),
-        InternalEmbraceLogger(),
+        EmbLoggerImpl(),
         FakeClock(),
         BackgroundWorker(MoreExecutors.newDirectExecutorService()),
         FakeGatingService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeDataCaptureServiceModule.kt
@@ -17,14 +17,14 @@ import io.embrace.android.embracesdk.fakes.FakeMemoryService
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.injection.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 
 internal class FakeDataCaptureServiceModule(
     override val thermalStatusService: ThermalStatusService = NoOpThermalStatusService(),
     override val memoryService: MemoryService = FakeMemoryService(),
     override val breadcrumbService: BreadcrumbService = FakeBreadcrumbService(),
     override val webviewService: WebViewService =
-        EmbraceWebViewService(FakeConfigService(), EmbraceSerializer(), InternalEmbraceLogger()),
+        EmbraceWebViewService(FakeConfigService(), EmbraceSerializer(), EmbLoggerImpl()),
 ) : DataCaptureServiceModule {
 
     override val pushNotificationService: PushNotificationCaptureService

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -35,7 +35,7 @@ import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
@@ -53,7 +53,7 @@ internal class FakeEssentialServiceModule(
     override val orientationService: OrientationService = NoOpOrientationService(),
     override val apiClient: ApiClient = FakeApiClient(),
     override val userService: UserService = FakeUserService(),
-    override val sharedObjectLoader: SharedObjectLoader = SharedObjectLoader(InternalEmbraceLogger()),
+    override val sharedObjectLoader: SharedObjectLoader = SharedObjectLoader(EmbLoggerImpl()),
     override val deviceArchitecture: DeviceArchitecture = FakeDeviceArchitecture(),
     override val apiService: ApiService = FakeApiService(),
     override val networkConnectivityService: NetworkConnectivityService = NoOpNetworkConnectivityService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -10,12 +10,12 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 
 internal class FakeInitModule(
     clock: Clock = NormalizedIntervalClock(systemClock = SystemClock()),
     openTelemetryClock: io.opentelemetry.sdk.common.Clock = FakeOpenTelemetryClock(clock),
-    logger: InternalEmbraceLogger = InternalEmbraceLogger(),
+    logger: EmbLoggerImpl = EmbLoggerImpl(),
     systemInfo: SystemInfo = SystemInfo(
         osVersion = "99.0.0",
         deviceManufacturer = "Fake Manufacturer",

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.injection.SessionModule
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.message.PayloadFactory
@@ -34,5 +34,5 @@ internal class FakeSessionModule(
         get() = TODO("Not yet implemented")
 
     override val dataCaptureOrchestrator: DataCaptureOrchestrator =
-        DataCaptureOrchestrator(emptyList(), InternalEmbraceLogger(), FakeConfigService())
+        DataCaptureOrchestrator(emptyList(), EmbLoggerImpl(), FakeConfigService())
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CoreModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/CoreModuleImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.injection
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.capture.metadata.AppEnvironment
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
@@ -17,7 +17,7 @@ internal class CoreModuleImplTest {
     @Test
     fun testApplicationObject() {
         val ctx = RuntimeEnvironment.getApplication().applicationContext
-        val logger = InternalEmbraceLogger()
+        val logger = EmbLoggerImpl()
         val module = CoreModuleImpl(ctx, Embrace.AppFramework.NATIVE, logger)
         assertSame(ctx, module.context)
         assertSame(ctx, module.application)
@@ -30,7 +30,7 @@ internal class CoreModuleImplTest {
         val application = RuntimeEnvironment.getApplication()
         val isDebug = AppEnvironment(application.applicationInfo).isDebug
         val ctx = application.applicationContext
-        val module = CoreModuleImpl(ctx, Embrace.AppFramework.NATIVE, InternalEmbraceLogger())
+        val module = CoreModuleImpl(ctx, Embrace.AppFramework.NATIVE, EmbLoggerImpl())
         assertSame(application, module.application)
         assertEquals(isDebug, module.isDebug)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -7,7 +7,8 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModuleImpl
 import org.junit.Assert.assertFalse
@@ -24,13 +25,13 @@ import java.util.concurrent.TimeoutException
 internal class ModuleInitBootstrapperTest {
 
     private lateinit var moduleInitBootstrapper: ModuleInitBootstrapper
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var coreModule: FakeCoreModule
     private lateinit var context: Context
 
     @Before
     fun setup() {
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         coreModule = FakeCoreModule(logger = logger)
         moduleInitBootstrapper = ModuleInitBootstrapper(coreModuleSupplier = { _, _, _ -> coreModule }, logger = logger)
         context = RuntimeEnvironment.getApplication().applicationContext
@@ -40,7 +41,7 @@ internal class ModuleInitBootstrapperTest {
     fun `test default implementation`() {
         val moduleInitBootstrapper = ModuleInitBootstrapper(
             coreModuleSupplier = { _, _, _ -> coreModule },
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
         )
         with(moduleInitBootstrapper) {
             assertTrue(
@@ -109,7 +110,7 @@ internal class ModuleInitBootstrapperTest {
             initModule = fakeInitModule,
             coreModuleSupplier = { _, _, _ -> fakeCoreModule },
             workerThreadModuleSupplier = { _, -> fakeWorkerThreadModule },
-            logger = InternalEmbraceLogger()
+            logger = EmbLoggerImpl()
         )
         assertTrue(
             bootstrapper.init(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarkerImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/CrashFileMarkerImplTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.crash
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -38,7 +38,7 @@ internal class CrashFileMarkerImplTest {
         testFile = File(tempFolder.root.path, CrashFileMarkerImpl.CRASH_MARKER_FILE_NAME)
         mockFile = testFile
         markerLazyFile = lazy { mockFile }
-        crashMarker = CrashFileMarkerImpl(markerLazyFile, InternalEmbraceLogger())
+        crashMarker = CrashFileMarkerImpl(markerLazyFile, EmbLoggerImpl())
     }
 
     @After

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.crash
 
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.mockk.every
@@ -24,7 +24,7 @@ internal class LastRunCrashVerifierTest {
     @Before
     fun setUp() {
         mockCrashFileMarker = mockk()
-        lastRunCrashVerifier = LastRunCrashVerifier(mockCrashFileMarker, InternalEmbraceLogger())
+        lastRunCrashVerifier = LastRunCrashVerifier(mockCrashFileMarker, EmbLoggerImpl())
         fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), name = WorkerName.BACKGROUND_REGISTRATION)
         worker = fakeWorkerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/CompositeLogServiceTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureDataSource
 import io.embrace.android.embracesdk.fakes.fakeNetworkCapturedCall
 import io.embrace.android.embracesdk.fakes.fakeOTelBehavior
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -43,7 +43,7 @@ internal class CompositeLogServiceTest {
             v2LogService = { v2LogService },
             networkCaptureDataSource = { networkCaptureDataSource },
             configService = configService,
-            logger = InternalEmbraceLogger(),
+            logger = EmbLoggerImpl(),
             serializer = EmbraceSerializer()
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -23,7 +23,7 @@ import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.opentelemetry.exceptionMessage
 import io.embrace.android.embracesdk.opentelemetry.exceptionStacktrace
@@ -71,7 +71,7 @@ internal class EmbraceLogServiceTest {
         sessionProperties = EmbraceSessionProperties(
             FakePreferenceService(),
             FakeConfigService(),
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
         cfg = RemoteConfig()
         configService = FakeConfigService(
@@ -410,7 +410,7 @@ internal class EmbraceLogServiceTest {
             appFramework,
             sessionProperties,
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
-            InternalEmbraceLogger(),
+            EmbLoggerImpl(),
             clock,
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/EmbLoggerImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/EmbLoggerImplTest.kt
@@ -2,15 +2,15 @@ package io.embrace.android.embracesdk.logging
 
 import io.embrace.android.embracesdk.fakes.FakeLogAction
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger.Severity
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl.Severity
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-internal class InternalEmbraceLoggerTest {
+internal class EmbLoggerImplTest {
 
     private val action = FakeLogAction()
-    private var logger = InternalEmbraceLogger().apply {
+    private var logger = EmbLoggerImpl().apply {
         addLoggerAction(action)
     }
 
@@ -26,7 +26,7 @@ internal class InternalEmbraceLoggerTest {
 
         // then logger actions are triggered
         val msg = action.msgQueue.single()
-        val expected = FakeLogAction.LogMessage("test", Severity.INFO, null, true)
+        val expected = FakeLogAction.LogMessage("test", Severity.INFO, null, false)
         assertEquals(expected, msg)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalErrorServiceActionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/InternalErrorServiceActionTest.kt
@@ -29,7 +29,7 @@ internal class InternalErrorServiceActionTest {
     @Test
     fun `do not report error if no throwable available`() {
         setupService()
-        reportingLoggerAction.log(errorMsg, InternalEmbraceLogger.Severity.DEBUG, null, true)
+        reportingLoggerAction.log(errorMsg, EmbLoggerImpl.Severity.DEBUG, null, true)
 
         verify { internalErrorService wasNot Called }
     }
@@ -37,7 +37,7 @@ internal class InternalErrorServiceActionTest {
     @Test
     fun `report error if throwable available`() {
         setupService()
-        reportingLoggerAction.log(errorMsg, InternalEmbraceLogger.Severity.DEBUG, exception, true)
+        reportingLoggerAction.log(errorMsg, EmbLoggerImpl.Severity.DEBUG, exception, true)
 
         verify(exactly = 1) { internalErrorService.handleInternalError(exception) }
     }
@@ -46,21 +46,21 @@ internal class InternalErrorServiceActionTest {
     fun `if an exception is thrown reporting error, swallow it`() {
         setupService()
         every { internalErrorService.handleInternalError(exception) } throws RuntimeException()
-        reportingLoggerAction.log(errorMsg, InternalEmbraceLogger.Severity.DEBUG, exception, true)
+        reportingLoggerAction.log(errorMsg, EmbLoggerImpl.Severity.DEBUG, exception, true)
         verify(exactly = 1) { internalErrorService.handleInternalError(exception) }
     }
 
     @Test
     fun `if a throwable is not available with INFO severity then dont handle exception`() {
         setupService()
-        reportingLoggerAction.log(errorMsg, InternalEmbraceLogger.Severity.INFO, null, true)
+        reportingLoggerAction.log(errorMsg, EmbLoggerImpl.Severity.INFO, null, true)
         verify(exactly = 0) { internalErrorService.handleInternalError(any() as Exception) }
     }
 
     @Test
     fun `if a throwable is available with ERROR severity`() {
         setupService()
-        reportingLoggerAction.log(errorMsg, InternalEmbraceLogger.Severity.ERROR, exception, true)
+        reportingLoggerAction.log(errorMsg, EmbLoggerImpl.Severity.ERROR, exception, true)
         verify(exactly = 1) { internalErrorService.handleInternalError(exception) }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepositoryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceRepositoryTest.kt
@@ -1,7 +1,8 @@
 package io.embrace.android.embracesdk.ndk
 
 import io.embrace.android.embracesdk.fakes.FakeStorageService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.mockk.every
 import io.mockk.mockk
@@ -21,12 +22,12 @@ internal class EmbraceNdkServiceRepositoryTest {
     companion object {
         private lateinit var repository: EmbraceNdkServiceRepository
         private lateinit var storageManager: FakeStorageService
-        private lateinit var logger: InternalEmbraceLogger
+        private lateinit var logger: EmbLogger
 
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
-            mockkStatic(InternalEmbraceLogger::class)
+            mockkStatic(EmbLoggerImpl::class)
             storageManager = FakeStorageService()
             logger = mockk(relaxed = true)
             repository = EmbraceNdkServiceRepository(storageManager, logger)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/EmbraceNdkServiceTest.kt
@@ -31,7 +31,8 @@ import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.embrace.android.embracesdk.payload.NativeCrashMetadata
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -88,7 +89,7 @@ internal class EmbraceNdkServiceTest {
     private lateinit var sessionProperties: EmbraceSessionProperties
     private lateinit var appFramework: Embrace.AppFramework
     private lateinit var sharedObjectLoader: SharedObjectLoader
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var delegate: NdkServiceDelegate.NdkDelegate
     private lateinit var repository: EmbraceNdkServiceRepository
     private lateinit var resources: Resources
@@ -116,10 +117,10 @@ internal class EmbraceNdkServiceTest {
         deliveryService = FakeDeliveryService()
         userService = FakeUserService()
         preferencesService = FakePreferenceService()
-        sessionProperties = EmbraceSessionProperties(preferencesService, configService, InternalEmbraceLogger())
+        sessionProperties = EmbraceSessionProperties(preferencesService, configService, EmbLoggerImpl())
         appFramework = Embrace.AppFramework.NATIVE
         sharedObjectLoader = mockk()
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         delegate = mockk(relaxed = true)
         repository = mockk(relaxUnitFun = true)
         resources = mockResources()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
@@ -20,7 +20,8 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.getAttribute
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.opentelemetry.embCrashNumber
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.opentelemetry.logRecordUid
@@ -41,7 +42,7 @@ internal class NativeCrashDataSourceImplTest {
     private lateinit var configService: FakeConfigService
     private lateinit var serializer: EmbraceSerializer
     private lateinit var logWriter: LogWriter
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var otelLogger: FakeOpenTelemetryLogger
     private lateinit var sessionIdTracker: SessionIdTracker
     private lateinit var metadataService: FakeMetadataService
@@ -52,7 +53,7 @@ internal class NativeCrashDataSourceImplTest {
         sessionProperties = fakeEmbraceSessionProperties()
         fakeNdkService = FakeNdkService()
         preferencesService = FakePreferenceService()
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         sessionIdTracker = FakeSessionIdTracker().apply { setActiveSessionId("currentSessionId", true) }
         metadataService = FakeMetadataService()
         otelLogger = FakeOpenTelemetryLogger()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceDomainCountLimiterTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceDomainCountLimiterTest.kt
@@ -8,14 +8,15 @@ import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 internal class EmbraceDomainCountLimiterTest {
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var configService: ConfigService
     private lateinit var sdkLocalConfig: SdkLocalConfig
     private lateinit var remoteConfig: RemoteConfig
@@ -24,7 +25,7 @@ internal class EmbraceDomainCountLimiterTest {
 
     @Before
     fun setUp() {
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         configService = FakeConfigService(
             networkBehavior = fakeNetworkBehavior(
                 localCfg = { sdkLocalConfig },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.fakes.fakeSdkEndpointBehavior
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.mockk.clearAllMocks
 import io.mockk.unmockkAll
 import org.junit.AfterClass
@@ -56,7 +56,7 @@ internal class EmbraceNetworkCaptureServiceTest {
                     false,
                     "{\"base_urls\": {\"data\": \"https://data.emb-api.com\"}}",
                     EmbraceSerializer(),
-                    InternalEmbraceLogger()
+                    EmbLoggerImpl()
                 )
         }
 
@@ -229,7 +229,7 @@ internal class EmbraceNetworkCaptureServiceTest {
         logMessageService,
         configService,
         EmbraceSerializer(),
-        InternalEmbraceLogger()
+        EmbLoggerImpl()
     )
 
     private fun getDefaultRule(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureDataSourceTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.network.logging
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.fakeNetworkCapturedCall
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -14,7 +14,7 @@ internal class NetworkCaptureDataSourceTest {
         val logWriter = FakeLogWriter()
         val dataSource = NetworkCaptureDataSourceImpl(
             logWriter,
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
         val capturedCall = fakeNetworkCapturedCall()
         dataSource.logNetworkCapturedCall(capturedCall)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManagerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManagerTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.network.logging
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -18,7 +18,7 @@ internal class NetworkCaptureEncryptionManagerTest {
 
     @Before
     fun setup() {
-        networkCaptureEncryptionManager = NetworkCaptureEncryptionManager(InternalEmbraceLogger())
+        networkCaptureEncryptionManager = NetworkCaptureEncryptionManager(EmbLoggerImpl())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/registry/ServiceRegistryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/registry/ServiceRegistryTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.registry
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
@@ -17,7 +17,7 @@ internal class ServiceRegistryTest {
 
     @Test
     fun testServiceRegistration() {
-        val registry = ServiceRegistry(InternalEmbraceLogger())
+        val registry = ServiceRegistry(EmbLoggerImpl())
         val service = FakeService()
         val obj = "test_obj"
         registry.registerServices(service, obj)
@@ -31,7 +31,7 @@ internal class ServiceRegistryTest {
 
     @Test
     fun testListeners() {
-        val registry = ServiceRegistry(InternalEmbraceLogger())
+        val registry = ServiceRegistry(EmbLoggerImpl())
         val service = FakeService()
         registry.registerService(service)
         val expected = listOf(service)
@@ -55,7 +55,7 @@ internal class ServiceRegistryTest {
 
     @Test(expected = IllegalStateException::class)
     fun testClosedRegistration() {
-        val registry = ServiceRegistry(InternalEmbraceLogger())
+        val registry = ServiceRegistry(EmbLoggerImpl())
         registry.closeRegistration()
         registry.registerService(FakeService())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ActivityLifecycleTrackerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ActivityLifecycleTrackerTest.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeOrientationService
 import io.embrace.android.embracesdk.fakes.system.mockApplication
 import io.embrace.android.embracesdk.fakes.system.mockLooper
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleTracker
 import io.mockk.Called
@@ -81,7 +81,7 @@ internal class ActivityLifecycleTrackerTest {
         activityLifecycleTracker = ActivityLifecycleTracker(
             application,
             orientationService,
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerServiceTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerListener
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.utils.at
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -16,7 +16,7 @@ internal class EmbraceMemoryCleanerServiceTest {
     @Before
     fun setUp() {
         internalErrorService = FakeInternalErrorService()
-        service = EmbraceMemoryCleanerService(InternalEmbraceLogger())
+        service = EmbraceMemoryCleanerService(EmbLoggerImpl())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogAction
 import io.embrace.android.embracesdk.fakes.FakeProcessStateListener
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.system.mockLooper
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.lifecycle.EmbraceProcessStateService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
@@ -76,7 +76,7 @@ internal class EmbraceProcessStateServiceTest {
         logger = FakeLogAction()
         stateService = EmbraceProcessStateService(
             fakeClock,
-            InternalEmbraceLogger().apply { addLoggerAction(logger) }
+            EmbLoggerImpl().apply { addLoggerAction(logger) }
         )
     }
 
@@ -237,7 +237,7 @@ internal class EmbraceProcessStateServiceTest {
     }
 
     private fun fetchLogMessages() = logger.msgQueue.filter {
-        it.severity >= InternalEmbraceLogger.Severity.ERROR
+        it.severity >= EmbLoggerImpl.Severity.ERROR
     }
 
     private class DecoratedListener(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -40,7 +40,7 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
@@ -105,7 +105,7 @@ internal class PayloadFactoryBaTest {
             false,
             "{\"background_activity\": {\"max_background_activity_seconds\": 3600}}",
             EmbraceSerializer(),
-            InternalEmbraceLogger()
+            EmbLoggerImpl()
         )
 
         blockingExecutorService = BlockingScheduledExecutorService(blockingMode = false)
@@ -168,7 +168,7 @@ internal class PayloadFactoryBaTest {
 
     private fun createService(createInitialSession: Boolean = true): PayloadFactoryImpl {
         val gatingService = FakeGatingService()
-        val logger = InternalEmbraceLogger()
+        val logger = EmbLoggerImpl()
         val collator = V1PayloadMessageCollator(
             gatingService,
             configService,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.spans.SpanSink
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
@@ -98,7 +98,7 @@ internal class PayloadFactorySessionTest {
             resourceSource = FakeEnvelopeResourceSource(),
             sessionPayloadSource = FakeSessionPayloadSource()
         )
-        val logger = InternalEmbraceLogger()
+        val logger = EmbLoggerImpl()
         val v1Collator = mockk<V1PayloadMessageCollator>(relaxed = true)
         val v2Collator = V2PayloadMessageCollator(FakeGatingService(), v1Collator, sessionEnvelopeSource, logger)
         service = PayloadFactoryImpl(v1Collator, v2Collator, FakeConfigService(), logger)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -44,8 +44,9 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.logging.EmbraceInternalErrorService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
@@ -104,13 +105,13 @@ internal class SessionHandlerTest {
     private lateinit var payloadFactory: PayloadFactory
     private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var scheduledWorker: ScheduledWorker
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
 
     @Before
     fun before() {
         executorService = BlockingScheduledExecutorService()
         scheduledWorker = ScheduledWorker(executorService)
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         clock.setCurrentTime(now)
         activeSession = fakeSession()
         every { sessionProperties.get() } returns emptyMapSessionProperties

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImplTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.session.id
 
 import io.embrace.android.embracesdk.FakeNdkService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -14,7 +14,7 @@ internal class SessionIdTrackerImplTest {
 
     @Before
     fun setUp() {
-        tracker = SessionIdTrackerImpl(null, InternalEmbraceLogger())
+        tracker = SessionIdTrackerImpl(null, EmbLoggerImpl())
         ndkService = FakeNdkService()
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -22,7 +22,8 @@ import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.fakes.system.mockContext
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -55,7 +56,7 @@ internal class SessionOrchestratorTest {
     private lateinit var baCacheExecutor: BlockingScheduledExecutorService
     private lateinit var dataCaptureOrchestrator: DataCaptureOrchestrator
     private lateinit var fakeDataSource: FakeDataSource
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLogger
     private lateinit var sessionSpan: FakeCurrentSessionSpan
 
     @Before
@@ -73,7 +74,7 @@ internal class SessionOrchestratorTest {
         sessionIdTracker = FakeSessionIdTracker()
         sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)
         baCacheExecutor = BlockingScheduledExecutorService(clock, true)
-        logger = InternalEmbraceLogger()
+        logger = EmbLoggerImpl()
         periodicSessionCacher = PeriodicSessionCacher(ScheduledWorker(sessionCacheExecutor), logger)
         periodicBackgroundActivityCacher = PeriodicBackgroundActivityCacher(clock, ScheduledWorker(baCacheExecutor), logger)
         fakeDataSource = FakeDataSource(mockContext())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/properties/EmbraceSessionPropertiesServiceTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.capture.session.SessionPropertiesDataSource
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -22,7 +22,7 @@ internal class EmbraceSessionPropertiesServiceTest {
 
     @Before
     fun setUp() {
-        val logger = InternalEmbraceLogger()
+        val logger = EmbLoggerImpl()
         val fakeConfigService = FakeConfigService()
         props = EmbraceSessionProperties(FakePreferenceService(), fakeConfigService, logger)
         ndkService = FakeNdkService()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/utils/PropertyUtilsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/utils/PropertyUtilsTest.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.utils
 
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.utils.PropertyUtils.sanitizeProperties
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class PropertyUtilsTest {
 
-    private val logger = InternalEmbraceLogger()
+    private val logger = EmbLoggerImpl()
 
     @Test
     fun testEmptyCase() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/worker/WorkerThreadModuleImplTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.injection.CoreModule
 import io.embrace.android.embracesdk.injection.InitModule
 import io.embrace.android.embracesdk.injection.InitModuleImpl
-import io.embrace.android.embracesdk.logging.InternalEmbraceLogger
+import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -15,14 +15,14 @@ import org.junit.Test
 internal class WorkerThreadModuleImplTest {
 
     private lateinit var action: FakeLogAction
-    private lateinit var logger: InternalEmbraceLogger
+    private lateinit var logger: EmbLoggerImpl
     private lateinit var initModule: InitModule
     private lateinit var coreModule: CoreModule
 
     @Before
     fun setup() {
         action = FakeLogAction()
-        logger = InternalEmbraceLogger().apply { addLoggerAction(action) }
+        logger = EmbLoggerImpl().apply { addLoggerAction(action) }
         initModule = InitModuleImpl(logger = logger)
         coreModule = FakeCoreModule(logger = logger)
     }


### PR DESCRIPTION
## Goal

Extracts an interface named `EmbLogger` that will be used for internal logging. I have renamed `InternalEmbraceLogger` as `EmbLoggerImpl` for now but am open to naming suggestions. Extracting this code to an interface will make it easier to verify that specific messages are logged during testing. It also opens up the possibility of using a no-op implementation in production builds to save CPU time.

## Testing

Relied on existing test coverage.

