### PR TITLE
Remove logStacktrace parameter from EmbLogger

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.java
@@ -248,7 +248,7 @@ final class EmbraceImpl {
             Systrace.endSynchronous();
         } catch (Throwable t) {
             logger.logError(
-                "Error occurred while initializing the Embrace SDK. Instrumentation may be disabled.", t, true);
+                "Error occurred while initializing the Embrace SDK. Instrumentation may be disabled.", t);
         }
     }
 
@@ -258,7 +258,7 @@ final class EmbraceImpl {
                            @NonNull Function0<ConfigService> configServiceProvider) {
         if (application != null) {
             // We don't hard fail if the SDK has been already initialized.
-            logger.logWarning("Embrace SDK has already been initialized", null, false);
+            logger.logWarning("Embrace SDK has already been initialized", null);
             return;
         }
 
@@ -417,7 +417,7 @@ final class EmbraceImpl {
             composeActivityListenerInstance = composeActivityListener.newInstance();
             coreModule.getApplication().registerActivityLifecycleCallbacks((Application.ActivityLifecycleCallbacks) composeActivityListenerInstance);
         } catch (Throwable e) {
-            logger.logError("registerComposeActivityListener error", e, false);
+            logger.logError("registerComposeActivityListener error", e);
         }
     }
 
@@ -430,7 +430,7 @@ final class EmbraceImpl {
         try {
             app.unregisterActivityLifecycleCallbacks((Application.ActivityLifecycleCallbacks) composeActivityListenerInstance);
         } catch (Throwable e) {
-            logger.logError("Instantiation error for ComposeActivityListener", e, false);
+            logger.logError("Instantiation error for ComposeActivityListener", e);
         }
     }
 
@@ -452,16 +452,16 @@ final class EmbraceImpl {
      */
     boolean setAppId(@NonNull String appId) {
         if (isStarted()) {
-            logger.logError("You must set the custom app ID before the SDK is started.", null, false);
+            logger.logError("You must set the custom app ID before the SDK is started.", null);
             return false;
         }
         if (appId.isEmpty()) {
-            logger.logError("App ID cannot be null or empty.", null, false);
+            logger.logError("App ID cannot be null or empty.", null);
             return false;
         }
         if (!appIdPattern.matcher(appId).find()) {
             logger.logError("Invalid app ID. Must be a 5-character string with " +
-                "characters from the set [A-Za-z0-9], but it was \"" + appId + "\".", null, false);
+                "characters from the set [A-Za-z0-9], but it was \"" + appId + "\".", null);
             return false;
         }
 
@@ -483,7 +483,7 @@ final class EmbraceImpl {
                 application = null;
                 moduleInitBootstrapper.stopServices();
             } catch (Exception ex) {
-                logger.logError("Error while shutting down Embrace SDK", ex, false);
+                logger.logError("Error while shutting down Embrace SDK", ex);
             }
         }
     }
@@ -1106,7 +1106,7 @@ final class EmbraceImpl {
      */
     void logRnView(@NonNull String screen) {
         if (appFramework != Embrace.AppFramework.REACT_NATIVE) {
-            logger.logWarning("[Embrace] logRnView is only available on React Native", null, false);
+            logger.logWarning("[Embrace] logRnView is only available on React Native", null);
             return;
         }
 
@@ -1157,10 +1157,10 @@ final class EmbraceImpl {
                     service
                 );
             } else {
-                logger.logWarning("nativeThreadSamplerInstaller not started, cannot sample current thread", null, false);
+                logger.logWarning("nativeThreadSamplerInstaller not started, cannot sample current thread", null);
             }
         } catch (Exception exc) {
-            logger.logError("Failed to sample current thread during ANRs", exc, false);
+            logger.logError("Failed to sample current thread during ANRs", exc);
         }
     }
 
@@ -1171,7 +1171,7 @@ final class EmbraceImpl {
             try {
                 normalizedProperties = PropertyUtils.sanitizeProperties(properties, logger);
             } catch (Exception e) {
-                this.logger.logError("Exception occurred while normalizing the properties.", e, false);
+                this.logger.logError("Exception occurred while normalizing the properties.", e);
             }
             return normalizedProperties;
         } else {
@@ -1202,7 +1202,7 @@ final class EmbraceImpl {
 
     public void addSpanExporter(@NonNull SpanExporter spanExporter) {
         if (isStarted()) {
-            logger.logError("A SpanExporter can only be added before the SDK is started.", null, false);
+            logger.logError("A SpanExporter can only be added before the SDK is started.", null);
             return;
         }
         moduleInitBootstrapper.getOpenTelemetryModule().getOpenTelemetryConfiguration().addSpanExporter(spanExporter);
@@ -1210,7 +1210,7 @@ final class EmbraceImpl {
 
     public void addLogRecordExporter(@NonNull LogRecordExporter logRecordExporter) {
         if (isStarted()) {
-            logger.logError("A LogRecordExporter can only be added before the SDK is started.", null, false);
+            logger.logError("A LogRecordExporter can only be added before the SDK is started.", null);
             return;
         }
         moduleInitBootstrapper.getOpenTelemetryModule().getOpenTelemetryConfiguration().addLogExporter(logRecordExporter);

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
@@ -92,7 +92,7 @@ internal class EmbraceAnrService(
             }
             anrMonitorWorker.submit(callable).get(MAX_DATA_WAIT_MS, TimeUnit.MILLISECONDS)
         } catch (exc: Exception) {
-            logger.logWarning("Failed to getAnrIntervals()", exc, true)
+            logger.logWarning("Failed to getAnrIntervals()", exc)
             logger.trackInternalError(InternalErrorType.ANR_DATA_FETCH, exc)
             emptyList()
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
@@ -99,7 +99,7 @@ internal class LivenessCheckScheduler internal constructor(
         } catch (exc: Exception) {
             // ignore any RejectedExecution - ScheduledExecutorService only throws when shutting down.
             val message = "ANR capture initialization failed"
-            logger.logWarning(message, exc, true)
+            logger.logWarning(message, exc)
         }
     }
 
@@ -150,7 +150,7 @@ internal class LivenessCheckScheduler internal constructor(
                 blockedThreadDetector.updateAnrTracking(now)
             }
         } catch (exc: Exception) {
-            logger.logError("Failed to process ANR monitor thread heartbeat", exc, true)
+            logger.logError("Failed to process ANR monitor thread heartbeat", exc)
             logger.trackInternalError(InternalErrorType.ANR_HEARTBEAT_CHECK_FAIL, exc)
         }
     }
@@ -160,8 +160,7 @@ internal class LivenessCheckScheduler internal constructor(
         if (!targetThreadHandler.sendMessage(heartbeatMessage)) {
             logger.logWarning(
                 "Failed to send message to targetHandler, main thread likely shutting down.",
-                IllegalStateException("Failed to send message to targetHandler"),
-                true
+                IllegalStateException("Failed to send message to targetHandler")
             )
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/TargetThreadHandler.kt
@@ -66,7 +66,7 @@ internal class TargetThreadHandler(
                 }
             }
         } catch (ex: Exception) {
-            logger.logError("ANR healthcheck failed in main (monitored) thread", ex, true)
+            logger.logError("ANR healthcheck failed in main (monitored) thread", ex)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
@@ -34,7 +34,7 @@ internal class UnbalancedCallDetector(
     private fun checkTimeTravel(name: String, timestamp: Long) {
         if (lastTimestamp > timestamp) {
             val msg = "Time travel in $name. $lastTimestamp to $timestamp"
-            logger.logWarning(msg, IllegalStateException(msg), true)
+            logger.logWarning(msg)
             logger.trackInternalError(InternalErrorType.TIME_TRAVEL, IllegalStateException("Time Travel"))
         }
         lastTimestamp = timestamp
@@ -44,7 +44,7 @@ internal class UnbalancedCallDetector(
         if (blocked != expected) {
             val threadName = Thread.currentThread().name
             val msg = "Unbalanced call to $name in ANR detection. Thread=$threadName"
-            logger.logWarning(msg, IllegalStateException(msg), true)
+            logger.logWarning(msg)
             logger.trackInternalError(InternalErrorType.UNBALANCED_CALL, IllegalStateException("Unbalanced call"))
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -66,8 +66,7 @@ internal class AeiDataSourceImpl(
             } catch (exc: Throwable) {
                 logger.logWarning(
                     "AEI - Failed to process AEIs due to unexpected error",
-                    exc,
-                    true
+                    exc
                 )
                 logger.trackInternalError(InternalErrorType.ENABLE_DATA_CAPTURE, exc)
             }
@@ -234,13 +233,13 @@ internal class AeiDataSourceImpl(
 
             return AppExitInfoBehavior.CollectTracesResult.Success(trace)
         } catch (e: IOException) {
-            logger.logWarning("AEI - IOException: ${e.message}", e, true)
+            logger.logWarning("AEI - IOException", e)
             return AppExitInfoBehavior.CollectTracesResult.TraceException(("ioexception: ${e.message}"))
         } catch (e: OutOfMemoryError) {
-            logger.logWarning("AEI - Out of Memory: ${e.message}", e, true)
+            logger.logWarning("AEI - Out of Memory", e)
             return AppExitInfoBehavior.CollectTracesResult.TraceException(("oom: ${e.message}"))
         } catch (tr: Throwable) {
-            logger.logWarning("AEI - An error occurred: ${tr.message}", tr, true)
+            logger.logWarning("AEI - An error occurred", tr)
             return AppExitInfoBehavior.CollectTracesResult.TraceException(("error: ${tr.message}"))
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/cpu/EmbraceCpuInfoDelegate.kt
@@ -13,7 +13,7 @@ internal class EmbraceCpuInfoDelegate(
             try {
                 getNativeCpuName()
             } catch (exception: LinkageError) {
-                logger.logWarning("Could not get the CPU name. Exception: $exception", exception)
+                logger.logWarning("Could not get the CPU name.", exception)
                 null
             }
         } else {
@@ -26,7 +26,7 @@ internal class EmbraceCpuInfoDelegate(
             try {
                 getNativeEgl()
             } catch (exception: LinkageError) {
-                logger.logWarning("Could not get the EGL name. Exception: $exception", exception)
+                logger.logWarning("Could not get the EGL name.", exception)
                 null
             }
         } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
@@ -32,7 +32,7 @@ internal class EmbraceUncaughtExceptionHandler(
             logger.logError("Error occurred in the uncaught exception handler", ex)
             logger.trackInternalError(InternalErrorType.UNCAUGHT_EXC_HANDLER, ex)
         } finally {
-            logger.logDebug("Finished handling exception. Delegating to default handler.", exception)
+            logger.logDebug("Finished handling exception. Delegating to default handler.")
             defaultHandler?.uncaughtException(thread, exception)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
@@ -23,7 +23,7 @@ internal class EmbraceUserService(
         return try {
             ofStored(preferencesService)
         } catch (ex: Exception) {
-            logger.logError("Failed to load user info from persistent storage.", ex, true)
+            logger.logError("Failed to load user info from persistent storage.", ex)
             logger.trackInternalError(InternalErrorType.USER_LOAD_FAIL, ex)
             null
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -62,7 +62,7 @@ internal class EmbraceDeliveryCacheManager(
                 }
             }
         } catch (exc: Throwable) {
-            logger.logError("Save session failed", exc, true)
+            logger.logError("Save session failed", exc)
             throw exc
         }
     }
@@ -243,7 +243,7 @@ internal class EmbraceDeliveryCacheManager(
                 }
             }
         } catch (ex: Throwable) {
-            logger.logError("Failed to cache current active session", ex, true)
+            logger.logError("Failed to cache current active session", ex)
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryService.kt
@@ -170,7 +170,7 @@ internal class EmbraceDeliveryService(
                     logger.logError("Session $sessionId not found")
                 }
             } catch (ex: Throwable) {
-                logger.logError("Could not send cached session", ex, true)
+                logger.logError("Could not send cached session", ex)
             }
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -165,8 +165,7 @@ internal class EmbraceEventService(
         } catch (ex: Exception) {
             logger.logError(
                 "Cannot start event with name: $name, identifier: $identifier due to an exception",
-                ex,
-                false
+                ex
             )
             logger.trackInternalError(InternalErrorType.START_EVENT_FAIL, ex)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLogger.kt
@@ -24,12 +24,12 @@ internal interface EmbLogger {
     /**
      * Logs a warning message with an optional throwable.
      */
-    fun logWarning(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false)
+    fun logWarning(msg: String, throwable: Throwable? = null)
 
     /**
      * Logs a warning message with an optional error.
      */
-    fun logError(msg: String, throwable: Throwable? = null, logStacktrace: Boolean = false)
+    fun logError(msg: String, throwable: Throwable? = null)
 
     /**
      * Logs a warning message that the SDK is not yet initialized for the given action.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLoggerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLoggerImpl.kt
@@ -15,24 +15,24 @@ internal class EmbLoggerImpl : EmbLogger {
     override var internalErrorService: InternalErrorService? = null
 
     override fun logDebug(msg: String, throwable: Throwable?) {
-        log(msg, Severity.DEBUG, throwable, true)
+        log(msg, Severity.DEBUG, throwable)
     }
 
     override fun logInfo(msg: String, throwable: Throwable?) {
-        log(msg, Severity.INFO, throwable, false)
+        log(msg, Severity.INFO, throwable)
     }
 
-    override fun logWarning(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
-        log(msg, Severity.WARNING, throwable, logStacktrace)
+    override fun logWarning(msg: String, throwable: Throwable?) {
+        log(msg, Severity.WARNING, throwable)
     }
 
-    override fun logError(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
-        log(msg, Severity.ERROR, throwable, logStacktrace)
+    override fun logError(msg: String, throwable: Throwable?) {
+        log(msg, Severity.ERROR, throwable)
     }
 
     override fun logSdkNotInitialized(action: String) {
         val msg = "Embrace SDK is not initialized yet, cannot $action."
-        log(msg, Severity.WARNING, Throwable(msg), true)
+        log(msg, Severity.WARNING, Throwable(msg))
     }
 
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {
@@ -50,12 +50,11 @@ internal class EmbLoggerImpl : EmbLogger {
      * @param msg the message to log.
      * @param severity how severe the log is. If it's lower than the threshold, the message will not be logged.
      * @param throwable exception, if any.
-     * @param logStacktrace should add the throwable to the logging
      */
     @Suppress("NOTHING_TO_INLINE") // hot path - optimize by inlining
-    private inline fun log(msg: String, severity: Severity, throwable: Throwable?, logStacktrace: Boolean) {
+    private inline fun log(msg: String, severity: Severity, throwable: Throwable?) {
         if (severity >= Severity.INFO || ApkToolsConfig.IS_DEVELOPER_LOGGING_ENABLED) {
-            logcatImpl(throwable, logStacktrace, severity, msg)
+            logcatImpl(throwable, severity, msg)
         }
     }
 
@@ -65,16 +64,14 @@ internal class EmbLoggerImpl : EmbLogger {
     @Suppress("NOTHING_TO_INLINE") // hot path - optimize by inlining
     private inline fun logcatImpl(
         throwable: Throwable?,
-        logStacktrace: Boolean,
         severity: Severity,
         msg: String
     ) {
-        val exception = throwable?.takeIf { logStacktrace }
         when (severity) {
-            Severity.DEBUG -> Log.d(EMBRACE_TAG, msg, exception)
-            Severity.INFO -> Log.i(EMBRACE_TAG, msg, exception)
-            Severity.WARNING -> Log.w(EMBRACE_TAG, msg, exception)
-            Severity.ERROR -> Log.e(EMBRACE_TAG, msg, exception)
+            Severity.DEBUG -> Log.d(EMBRACE_TAG, msg, throwable)
+            Severity.INFO -> Log.i(EMBRACE_TAG, msg, throwable)
+            Severity.WARNING -> Log.w(EMBRACE_TAG, msg, throwable)
+            Severity.ERROR -> Log.e(EMBRACE_TAG, msg, throwable)
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -179,7 +179,7 @@ internal class EmbraceNdkService(
                 """.trimIndent()
                 val exc = RuntimeException(errMsg)
                 exc.stackTrace = arrayOfNulls(0)
-                logger.logWarning(errMsg, exc, false)
+                logger.logWarning(errMsg, exc)
                 delegate._reinstallSignalHandlers()
             }
         }
@@ -334,8 +334,7 @@ internal class EmbraceNdkService(
                 crashFile.delete()
                 logger.logError(
                     "Failed to read native crash file {crashFilePath=" + crashFile.absolutePath + "}.",
-                    ex,
-                    true
+                    ex
                 )
                 logger.trackInternalError(InternalErrorType.NATIVE_CRASH_LOAD_FAIL, ex)
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManager.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureEncryptionManager.java
@@ -48,11 +48,11 @@ class NetworkCaptureEncryptionManager {
             if (publicKey != null) {
                 return encrypt(data, publicKey);
             } else {
-                logger.logError("wrong public key", null, false);
+                logger.logError("wrong public key", null);
                 return null;
             }
         } catch (Exception e) {
-            logger.logError("data cannot be encrypted", e, false);
+            logger.logError("data cannot be encrypted", e);
             return null;
         }
     }
@@ -74,7 +74,7 @@ class NetworkCaptureEncryptionManager {
             result += encodedString;
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | BadPaddingException |
                  IllegalBlockSizeException | IOException e) {
-            logger.logError("data cannot be encrypted", e, false);
+            logger.logError("data cannot be encrypted", e);
         }
         return result;
     }
@@ -97,7 +97,7 @@ class NetworkCaptureEncryptionManager {
             result = new String(decodedData, UTF_8);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
                  BadPaddingException | IllegalBlockSizeException | IOException e) {
-            logger.logError("data cannot be encrypted", e, false);
+            logger.logError("data cannot be encrypted", e);
         }
         return result;
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/extensions/CrashFactory.kt
@@ -78,8 +78,7 @@ internal object CrashFactory {
             } catch (ex: Exception) {
                 logger.logError(
                     "Failed to parse javascript exception",
-                    ex,
-                    true
+                    ex
                 )
                 logger.trackInternalError(InternalErrorType.INVALID_JS_EXCEPTION, ex)
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
@@ -71,7 +71,7 @@ internal class ServiceRegistry(
             try {
                 action(it)
             } catch (exc: Throwable) {
-                logger.logError(msg, exc, true)
+                logger.logError(msg, exc)
             }
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
@@ -68,7 +68,7 @@ internal class ActivityLifecycleTracker(
         try {
             orientationService.onOrientationChanged(activity.resources.configuration.orientation)
         } catch (ex: Exception) {
-            logger.logWarning("Failed to register an orientation change", ex)
+            logger.logWarning("Failed to register an orientation change")
             logger.trackInternalError(InternalErrorType.ORIENTATION_CAPTURE_FAIL, ex)
         }
     }
@@ -80,7 +80,7 @@ internal class ActivityLifecycleTracker(
             try {
                 listener.onActivityCreated(activity, bundle)
             } catch (ex: Exception) {
-                logger.logWarning(ERROR_FAILED_TO_NOTIFY, ex)
+                logger.logWarning(ERROR_FAILED_TO_NOTIFY)
                 logger.trackInternalError(InternalErrorType.ACTIVITY_LISTENER_FAIL, ex)
             }
         }
@@ -92,7 +92,7 @@ internal class ActivityLifecycleTracker(
             try {
                 listener.onView(activity)
             } catch (ex: Exception) {
-                logger.logWarning(ERROR_FAILED_TO_NOTIFY, ex)
+                logger.logWarning(ERROR_FAILED_TO_NOTIFY)
                 logger.trackInternalError(InternalErrorType.ACTIVITY_LISTENER_FAIL, ex)
             }
         }
@@ -106,7 +106,7 @@ internal class ActivityLifecycleTracker(
                 try {
                     listener.applicationStartupComplete()
                 } catch (ex: Exception) {
-                    logger.logWarning(ERROR_FAILED_TO_NOTIFY, ex)
+                    logger.logWarning(ERROR_FAILED_TO_NOTIFY)
                     logger.trackInternalError(InternalErrorType.ACTIVITY_LISTENER_FAIL, ex)
                 }
             }
@@ -119,7 +119,7 @@ internal class ActivityLifecycleTracker(
             try {
                 listener.onViewClose(activity)
             } catch (ex: Exception) {
-                logger.logWarning(ERROR_FAILED_TO_NOTIFY, ex)
+                logger.logWarning(ERROR_FAILED_TO_NOTIFY)
                 logger.trackInternalError(InternalErrorType.ACTIVITY_LISTENER_FAIL, ex)
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -102,7 +102,7 @@ internal class EmbraceProcessStateService(
         try {
             action()
         } catch (ex: Exception) {
-            logger.logWarning(ERROR_FAILED_TO_NOTIFY, ex)
+            logger.logWarning(ERROR_FAILED_TO_NOTIFY)
             logger.trackInternalError(InternalErrorType.PROCESS_STATE_CALLBACK_FAIL, ex)
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetectorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetectorTest.kt
@@ -72,7 +72,6 @@ internal class UnbalancedCallDetectorTest {
     }
 
     private fun verifyInternalErrorLogs(expectedCount: Int) {
-        val messages = logger.warningMessages.filter { msg -> msg.logStacktrace }
-        assertEquals(expectedCount, messages.size)
+        assertEquals(expectedCount, logger.warningMessages.size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -8,8 +8,7 @@ internal class FakeEmbLogger : EmbLogger {
 
     data class LogMessage(
         val msg: String,
-        val throwable: Throwable?,
-        val logStacktrace: Boolean
+        val throwable: Throwable?
     )
 
     var debugMessages: MutableList<LogMessage> = mutableListOf()
@@ -22,26 +21,26 @@ internal class FakeEmbLogger : EmbLogger {
     override var internalErrorService: InternalErrorService? = null
 
     override fun logDebug(msg: String, throwable: Throwable?) {
-        debugMessages.add(LogMessage(msg, throwable, false))
+        debugMessages.add(LogMessage(msg, throwable))
     }
 
     override fun logInfo(msg: String, throwable: Throwable?) {
-        infoMessages.add(LogMessage(msg, throwable, false))
+        infoMessages.add(LogMessage(msg, throwable))
     }
 
-    override fun logWarning(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
-        warningMessages.add(LogMessage(msg, throwable, logStacktrace))
+    override fun logWarning(msg: String, throwable: Throwable?) {
+        warningMessages.add(LogMessage(msg, throwable))
     }
 
-    override fun logError(msg: String, throwable: Throwable?, logStacktrace: Boolean) {
-        errorMessages.add(LogMessage(msg, throwable, logStacktrace))
+    override fun logError(msg: String, throwable: Throwable?) {
+        errorMessages.add(LogMessage(msg, throwable))
     }
 
     override fun logSdkNotInitialized(action: String) {
-        sdkNotInitializedMessages.add(LogMessage(action, null, false))
+        sdkNotInitializedMessages.add(LogMessage(action, null))
     }
 
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {
-        internalErrorMessages.add(LogMessage(type.toString(), throwable, false))
+        internalErrorMessages.add(LogMessage(type.toString(), throwable))
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/EmbLoggerImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/logging/EmbLoggerImplTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.logging
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -27,20 +26,18 @@ internal class EmbLoggerImplTest {
         val msg = logger.infoMessages.single()
         assertEquals("test", msg.msg)
         assertNull(msg.throwable)
-        assertFalse(msg.logStacktrace)
     }
 
     @Test
     fun `a log with a higher severity than the threshold triggers logging actions`() {
         // when log is called with a higher severity
         val throwable = Exception()
-        logger.logWarning("test", throwable, false)
+        logger.logWarning("test", throwable)
 
         // then logger actions are triggered
         val msg = logger.warningMessages.single()
         assertEquals("test", msg.msg)
         assertEquals(throwable, msg.throwable)
-        assertFalse(msg.logStacktrace)
     }
 
     @Test
@@ -56,6 +53,5 @@ internal class EmbLoggerImplTest {
         val msg = logger.debugMessages.single()
         assertEquals("test", msg.msg)
         assertEquals(throwable, msg.throwable)
-        assertFalse(msg.logStacktrace)
     }
 }


### PR DESCRIPTION
## Goal

Removes the `logStacktrace` parameter from `EmbLogger` as it's confusing & not well-used throughout the codebase. This changes the SDK so that if a Throwable is passed into a log function, it gets logged out via logcat. As part of this change I removed log messages that could end up being noisy.

