### PR TITLE
Convert internal error service to implement data capture service

### DIFF
--- a/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
+++ b/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/NullParametersTest.java
@@ -359,11 +359,11 @@ public class NullParametersTest {
 
     private void assertError(@NonNull String functionName) {
         assertInternalErrorLogged(
-            IntegrationTestRuleExtensionsKt.internalErrorService().getCurrentExceptionError(),
+            IntegrationTestRuleExtensionsKt.internalErrorService().getCapturedData(),
             IllegalArgumentException.class.getCanonicalName(),
             functionName + NULL_PARAMETER_ERROR_MESSAGE_TEMPLATE,
             IntegrationTestRule.DEFAULT_SDK_START_TIME_MS
         );
-        IntegrationTestRuleExtensionsKt.internalErrorService().resetExceptionErrorObject();
+        IntegrationTestRuleExtensionsKt.internalErrorService().getCapturedData();
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
@@ -29,7 +29,7 @@ internal class SessionPayloadSourceImpl(
 
     override fun getSessionPayload(endType: SessionSnapshotType): SessionPayload {
         val sharedLibSymbolMapping = captureDataSafely(logger) { nativeThreadSamplerService?.getNativeSymbols() }
-        val internalErrors = captureDataSafely(logger) { internalErrorService.currentExceptionError?.toNewPayload() }
+        val internalErrors = captureDataSafely(logger) { internalErrorService.getCapturedData()?.toNewPayload() }
         val snapshots = retrieveSpanSnapshotData()
 
         // Ensure the span retrieving is last as that potentially ends the session span, which effectively ends the session

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -118,7 +118,6 @@ internal class SessionModuleImpl(
             essentialServiceModule.userService,
             ndkService,
             essentialServiceModule.sessionProperties,
-            sdkObservabilityModule.internalErrorService,
             essentialServiceModule.networkConnectivityService
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbraceInternalErrorService.kt
@@ -4,16 +4,6 @@ import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
-import java.net.BindException
-import java.net.ConnectException
-import java.net.HttpRetryException
-import java.net.NoRouteToHostException
-import java.net.PortUnreachableException
-import java.net.ProtocolException
-import java.net.SocketException
-import java.net.SocketTimeoutException
-import java.net.UnknownHostException
-import java.net.UnknownServiceException
 
 /**
  * Intercepts Embrace SDK's exceptions errors and forwards them to the Embrace API.
@@ -22,84 +12,13 @@ internal class EmbraceInternalErrorService(
     private val processStateService: ProcessStateService,
     private val clock: Clock
 ) : InternalErrorService {
-    private var configService: ConfigService? = null
-    private var err: LegacyExceptionError? = null
 
-    override val currentExceptionError: LegacyExceptionError?
-        get() = err
+    private var err: LegacyExceptionError = LegacyExceptionError()
 
-    // ignore network-related exceptions since they are expected
-    private val ignoredExceptionClasses by lazy {
-        setOf<Class<*>>(
-            BindException::class.java,
-            ConnectException::class.java,
-            HttpRetryException::class.java,
-            NoRouteToHostException::class.java,
-            PortUnreachableException::class.java,
-            ProtocolException::class.java,
-            SocketException::class.java,
-            SocketTimeoutException::class.java,
-            UnknownHostException::class.java,
-            UnknownServiceException::class.java
-        )
-    }
-
-    private val ignoredExceptionStrings by lazy {
-        ignoredExceptionClasses.map { it.name }
-    }
-
-    override fun setConfigService(configService: ConfigService?) {
-        this.configService = configService
-    }
-
-    private fun ignoreThrowableCause(
-        throwable: Throwable?,
-        capturedThrowable: HashSet<Throwable>
-    ): Boolean {
-        return if (throwable != null) {
-            if (ignoredExceptionClasses.contains(throwable.javaClass)) {
-                true
-            } else {
-                /* if Hashset#add returns true means that the throwable was properly added,
-                if it returns false, the object already exists in the set so we return false
-                because we are in presence of a cycle in the Throwable cause */
-                val addResult = capturedThrowable.add(throwable)
-                addResult && ignoreThrowableCause(throwable.cause, capturedThrowable)
-            }
-        } else {
-            false
-        }
-    }
-
-    @Synchronized
     override fun handleInternalError(throwable: Throwable) {
-        if (ignoredExceptionClasses.contains(throwable.javaClass)) {
-            return
-        } else {
-            val capturedThrowable = HashSet<Throwable>()
-            if (ignoreThrowableCause(throwable.cause, capturedThrowable)) {
-                return
-            }
-        }
-
-        // If the exception has been wrapped in another exception, the ignored exception name will
-        // show up as the start of the message, delimited by a semicolon.
-        val message = throwable.message
-
-        if (message != null && ignoredExceptionStrings.contains(
-                message.split(":".toRegex()).dropLastWhile { it.isEmpty() }
-                    .toTypedArray()[0]
-            )
-        ) {
-            return
-        }
-        if (err == null) {
-            err = LegacyExceptionError()
-        }
-
         // if the config service has not been set yet, capture the exception
         if (configService == null || configService?.dataCaptureEventBehavior?.isInternalExceptionCaptureEnabled() == true) {
-            err?.addException(
+            err.addException(
                 throwable,
                 getApplicationState(),
                 clock
@@ -107,14 +26,20 @@ internal class EmbraceInternalErrorService(
         }
     }
 
+    override var configService: ConfigService? = null
+
+    override fun getCapturedData(): LegacyExceptionError? = when {
+        err.occurrences > 0 -> err
+        else -> null
+    }
+
+    override fun cleanCollections() {
+        err = LegacyExceptionError()
+    }
+
     private fun getApplicationState(): String = when {
         processStateService.isInBackground -> APPLICATION_STATE_BACKGROUND
         else -> APPLICATION_STATE_FOREGROUND
-    }
-
-    @Synchronized
-    override fun resetExceptionErrorObject() {
-        err = null
     }
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/InternalErrorService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.logging
 
+import io.embrace.android.embracesdk.arch.DataCaptureService
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 
@@ -7,9 +8,7 @@ import io.embrace.android.embracesdk.payload.LegacyExceptionError
  * Reports an internal error to Embrace. An internal error is defined as an exception that was
  * caught within Embrace code & logged to [EmbLogger].
  */
-internal interface InternalErrorService {
-    fun setConfigService(configService: ConfigService?)
+internal interface InternalErrorService : DataCaptureService<LegacyExceptionError?> {
+    var configService: ConfigService?
     fun handleInternalError(throwable: Throwable)
-    fun resetExceptionErrorObject()
-    val currentExceptionError: LegacyExceptionError?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.session
 
 import io.embrace.android.embracesdk.logging.EmbLogger
-import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.logging.InternalErrorType
 import io.embrace.android.embracesdk.utils.stream
 import java.util.concurrent.CopyOnWriteArrayList
@@ -14,9 +13,7 @@ internal class EmbraceMemoryCleanerService(private val logger: EmbLogger) : Memo
 
     val listeners = CopyOnWriteArrayList<MemoryCleanerListener>()
 
-    override fun cleanServicesCollections(
-        internalErrorService: InternalErrorService
-    ) {
+    override fun cleanServicesCollections() {
         stream(listeners) { listener: MemoryCleanerListener ->
             try {
                 listener.cleanCollections()
@@ -25,7 +22,6 @@ internal class EmbraceMemoryCleanerService(private val logger: EmbLogger) : Memo
                 logger.trackInternalError(InternalErrorType.MEMORY_CLEAN_LISTENER_FAIL, ex)
             }
         }
-        internalErrorService.resetExceptionErrorObject()
     }
 
     override fun addListener(listener: MemoryCleanerListener) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/MemoryCleanerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/MemoryCleanerService.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.logging.InternalErrorService
-
 internal interface MemoryCleanerService {
 
     /**
@@ -14,7 +12,5 @@ internal interface MemoryCleanerService {
     /**
      * Flush collections from each service which has collections in memory.
      */
-    fun cleanServicesCollections(
-        internalErrorService: InternalErrorService
-    )
+    fun cleanServicesCollections()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/V1PayloadMessageCollator.kt
@@ -139,7 +139,7 @@ internal class V1PayloadMessageCollator(
             infoLogsAttemptedToSend = captureDataSafely(logger, logMessageService::getInfoLogsAttemptedToSend),
             warnLogsAttemptedToSend = captureDataSafely(logger, logMessageService::getWarnLogsAttemptedToSend),
             errorLogsAttemptedToSend = captureDataSafely(logger, logMessageService::getErrorLogsAttemptedToSend),
-            exceptionError = captureDataSafely(logger, internalErrorService::currentExceptionError),
+            exceptionError = captureDataSafely(logger, internalErrorService::getCapturedData),
             lastHeartbeatTime = endTime,
             endType = lifeEventType,
             unhandledExceptions = captureDataSafely(logger, logMessageService::getUnhandledExceptionsSent),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegate.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.session.orchestrator
 
 import io.embrace.android.embracesdk.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.capture.user.UserService
-import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.ndk.NdkService
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
@@ -20,7 +19,6 @@ internal class OrchestratorBoundaryDelegate(
     private val userService: UserService,
     private val ndkService: NdkService?,
     private val sessionProperties: EmbraceSessionProperties,
-    private val internalErrorService: InternalErrorService,
     private val networkConnectivityService: NetworkConnectivityService
 ) {
 
@@ -29,7 +27,7 @@ internal class OrchestratorBoundaryDelegate(
      * resetting collections in services etc.
      */
     fun prepareForNewSession(clearUserInfo: Boolean = false) {
-        memoryCleanerService.cleanServicesCollections(internalErrorService)
+        memoryCleanerService.cleanServicesCollections()
         sessionProperties.clearTemporary()
 
         if (clearUserInfo) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
@@ -30,7 +30,7 @@ internal class SessionPayloadSourceImplTest {
     @Before
     fun setUp() {
         val errorService = FakeInternalErrorService().apply {
-            currentExceptionError = LegacyExceptionError().apply {
+            data = LegacyExceptionError().apply {
                 addException(RuntimeException(), "test", FakeClock())
             }
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalErrorService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalErrorService.kt
@@ -6,21 +6,20 @@ import io.embrace.android.embracesdk.payload.LegacyExceptionError
 
 internal class FakeInternalErrorService : InternalErrorService {
 
-    var lastConfigService: ConfigService? = null
+    override var configService: ConfigService? = null
     var throwables: MutableList<Throwable> = mutableListOf()
     var resetCallCount: Int = 0
-
-    override fun setConfigService(configService: ConfigService?) {
-        this.lastConfigService = configService
-    }
+    var data: LegacyExceptionError? = null
 
     override fun handleInternalError(throwable: Throwable) {
         throwables.add(throwable)
     }
 
-    override fun resetExceptionErrorObject() {
-        resetCallCount++
+    override fun getCapturedData(): LegacyExceptionError? {
+        return data
     }
 
-    override var currentExceptionError: LegacyExceptionError? = null
+    override fun cleanCollections() {
+        resetCallCount++
+    }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMemoryCleanerService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeMemoryCleanerService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.logging.InternalErrorService
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.MemoryCleanerService
 
@@ -13,9 +12,7 @@ internal class FakeMemoryCleanerService : MemoryCleanerService {
         listeners.add(listener)
     }
 
-    override fun cleanServicesCollections(
-        internalErrorService: InternalErrorService
-    ) {
+    override fun cleanServicesCollections() {
         callCount++
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerServiceTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerListener
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.utils.at
@@ -10,12 +9,10 @@ import org.junit.Test
 
 internal class EmbraceMemoryCleanerServiceTest {
 
-    private lateinit var internalErrorService: FakeInternalErrorService
     private lateinit var service: EmbraceMemoryCleanerService
 
     @Before
     fun setUp() {
-        internalErrorService = FakeInternalErrorService()
         service = EmbraceMemoryCleanerService(EmbLoggerImpl())
     }
 
@@ -27,7 +24,7 @@ internal class EmbraceMemoryCleanerServiceTest {
         service.addListener(listener)
         service.addListener(listener2)
 
-        service.cleanServicesCollections(internalErrorService)
+        service.cleanServicesCollections()
 
         assertEquals(1, listener.callCount)
         assertEquals(1, listener2.callCount)
@@ -45,16 +42,10 @@ internal class EmbraceMemoryCleanerServiceTest {
         service.addListener(listener2)
         service.addListener(listener3)
 
-        service.cleanServicesCollections(internalErrorService)
+        service.cleanServicesCollections()
 
         assertEquals(1, listener1.callCount)
         assertEquals(1, listener3.callCount)
-    }
-
-    @Test
-    fun `test cleanServicesCollections clears Embrace public API`() {
-        service.cleanServicesCollections(internalErrorService)
-        assertEquals(1, internalErrorService.resetCallCount)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -67,7 +67,7 @@ internal class V1PayloadMessageCollatorTest {
             eventService = FakeEventService(),
             logMessageService = FakeLogMessageService(),
             internalErrorService = FakeInternalErrorService().apply {
-                currentExceptionError = LegacyExceptionError()
+                data = LegacyExceptionError()
             },
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -57,7 +57,7 @@ internal class PayloadFactoryImplTest {
             eventService = FakeEventService(),
             logMessageService = FakeLogMessageService(),
             internalErrorService = FakeInternalErrorService().apply {
-                currentExceptionError = LegacyExceptionError()
+                data = LegacyExceptionError()
             },
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -59,7 +59,7 @@ internal class V2PayloadMessageCollatorTest {
             preferencesService = FakePreferenceService(),
             eventService = FakeEventService(),
             logMessageService = FakeLogMessageService(),
-            internalErrorService = FakeInternalErrorService().apply { currentExceptionError = LegacyExceptionError() },
+            internalErrorService = FakeInternalErrorService().apply { data = LegacyExceptionError() },
             breadcrumbService = FakeBreadcrumbService(),
             metadataService = FakeMetadataService(),
             performanceInfoService = FakePerformanceInfoService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.session.orchestrator
 
 import io.embrace.android.embracesdk.FakeNdkService
-import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeUserService
@@ -18,7 +17,6 @@ internal class OrchestratorBoundaryDelegateTest {
     private lateinit var userService: FakeUserService
     private lateinit var ndkService: FakeNdkService
     private lateinit var sessionProperties: EmbraceSessionProperties
-    private lateinit var internalErrorService: FakeInternalErrorService
     private lateinit var networkConnectivityService: FakeNetworkConnectivityService
 
     @Before
@@ -29,14 +27,12 @@ internal class OrchestratorBoundaryDelegateTest {
         sessionProperties = fakeEmbraceSessionProperties().apply {
             add("key", "value", false)
         }
-        internalErrorService = FakeInternalErrorService()
         networkConnectivityService = FakeNetworkConnectivityService()
         delegate = OrchestratorBoundaryDelegate(
             memoryCleanerService,
             userService,
             ndkService,
             sessionProperties,
-            internalErrorService,
             networkConnectivityService
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeDataSource
-import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
@@ -44,7 +43,6 @@ internal class SessionOrchestratorTest {
     private lateinit var clock: FakeClock
     private lateinit var configService: FakeConfigService
     private lateinit var memoryCleanerService: FakeMemoryCleanerService
-    private lateinit var internalErrorService: FakeInternalErrorService
     private lateinit var userService: FakeUserService
     private lateinit var ndkService: FakeNdkService
     private lateinit var deliveryService: FakeDeliveryService
@@ -67,7 +65,6 @@ internal class SessionOrchestratorTest {
         clock = FakeClock()
         configService = FakeConfigService(backgroundActivityCaptureEnabled = true)
         memoryCleanerService = FakeMemoryCleanerService()
-        internalErrorService = FakeInternalErrorService()
         sessionProperties = fakeEmbraceSessionProperties()
         userService = FakeUserService()
         ndkService = FakeNdkService()
@@ -102,7 +99,6 @@ internal class SessionOrchestratorTest {
                 userService,
                 ndkService,
                 sessionProperties,
-                internalErrorService,
                 FakeNetworkConnectivityService()
             ),
             deliveryService,
@@ -372,7 +368,6 @@ internal class SessionOrchestratorTest {
                 userService,
                 ndkService,
                 sessionProperties,
-                internalErrorService,
                 FakeNetworkConnectivityService()
             ),
             deliveryService,


### PR DESCRIPTION
## Goal

Converts the internal error service to implement the data capture service interface. This standardises how data is cleared between sessions & reduces the complexity of the previous implementation.

I have also removed logic for ignoring throwables as part of this changeset. Originally we searched the `Throwable` chain to see if any exceptions were network-connectivity errors, and skipped sending them if so. As we manually curate the exceptions we deliver to the backend now, this is not necessary anymore.

## Testing

Updated existing test coverage.
