### PR TITLE
Use non deprecated api for lifecycle callbacks

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ProcessStateService.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.session.lifecycle
 
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleEventObserver
 import java.io.Closeable
 
 /**
  * Service which handles Android process lifecycle callbacks.
  */
-internal interface ProcessStateService : LifecycleObserver, Closeable {
+internal interface ProcessStateService : LifecycleEventObserver, Closeable {
 
     /**
      * Whether the application is in the background.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeProcessStateService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeProcessStateService.kt
@@ -1,12 +1,17 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.content.res.Configuration
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
 
 internal class FakeProcessStateService(
     override var isInBackground: Boolean = false,
 ) : ProcessStateService {
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+    }
 
     val listeners: MutableList<ProcessStateListener> = mutableListOf()
     var config: Configuration? = null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/EmbraceProcessStateServiceTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.session
 
 import android.app.Application
 import android.os.Looper
+import androidx.lifecycle.Lifecycle
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeProcessStateListener
@@ -215,6 +216,34 @@ internal class EmbraceProcessStateServiceTest {
 
         val messages = fakeEmbLogger.internalErrorMessages
         assertTrue(messages.isEmpty())
+    }
+
+    @Test
+    fun `launched in background`() {
+        stateService = EmbraceProcessStateService(
+            fakeClock,
+            fakeEmbLogger,
+            mockk {
+                every { lifecycle } returns mockk<Lifecycle> {
+                    every { currentState } returns Lifecycle.State.INITIALIZED
+                }
+            }
+        )
+        assertTrue(stateService.isInBackground)
+    }
+
+    @Test
+    fun `launched in foreground`() {
+        stateService = EmbraceProcessStateService(
+            fakeClock,
+            fakeEmbLogger,
+            mockk {
+                every { lifecycle } returns mockk<Lifecycle> {
+                    every { currentState } returns Lifecycle.State.STARTED
+                }
+            }
+        )
+        assertFalse(stateService.isInBackground)
     }
 
     private class DecoratedListener(


### PR DESCRIPTION
## Goal

Avoids using a deprecated API in the [androidx lifecycle library](https://developer.android.com/jetpack/androidx/releases/lifecycle) that we rely upon to start sessions & background activities. I have used `LifecycleEventObserver` rather than `DefaultLifecycleObserver` as this is available since 2.1.0 rather than 2.4.0 of the library.

## Testing

Added unit test coverage & confirmed that sessions + background activities are reported to the dashboard.

## Release Notes

<!-- Notes to add in the next Release. Ignore if the changes are internal. -->

**WHAT**: Updated implementation of androidx lifecycle callbacks to use non-deprecated APIs<br>
**WHY**: Avoids use of a deprecated API<br>
**WHO**: Everyone<br>

