### PR TITLE
Detect and convert nanosecond timestamps for all timestamp parameters

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -56,7 +56,7 @@ internal class EmbraceSpanImpl(
             false
         } else {
             var successful: Boolean
-            val attemptedStartTimeMs = startTimeMs ?: openTelemetryClock.now().nanosToMillis()
+            val attemptedStartTimeMs = startTimeMs?.normalizeTimestampAsMillis() ?: openTelemetryClock.now().nanosToMillis()
             synchronized(startedSpan) {
                 startedSpan.set(spanBuilder.startSpan(attemptedStartTimeMs))
                 successful = startedSpan.get() != null
@@ -74,7 +74,7 @@ internal class EmbraceSpanImpl(
             false
         } else {
             var successful = false
-            val attemptedEndTimeMs = endTimeMs ?: openTelemetryClock.now().nanosToMillis()
+            val attemptedEndTimeMs = endTimeMs?.normalizeTimestampAsMillis() ?: openTelemetryClock.now().nanosToMillis()
 
             synchronized(startedSpan) {
                 startedSpan.get()?.let { spanToStop ->

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -22,7 +22,7 @@ internal class EmbraceTracer(
         spanService.startSpan(
             name = name,
             parent = parent,
-            startTimeMs = startTimeMs,
+            startTimeMs = startTimeMs?.normalizeTimestampAsMillis(),
             internal = false
         )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -26,7 +26,10 @@ internal class InternalTracer(
     }
 
     override fun stopSpan(spanId: String, errorCode: ErrorCode?, endTimeMs: Long?): Boolean =
-        spanRepository.getSpan(spanId = spanId)?.stop(errorCode = errorCode, endTimeMs = endTimeMs) ?: false
+        spanRepository.getSpan(spanId = spanId)?.stop(
+            errorCode = errorCode,
+            endTimeMs = endTimeMs?.normalizeTimestampAsMillis()
+        ) ?: false
 
     override fun <T> recordSpan(
         name: String,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -121,6 +121,22 @@ internal class EmbraceSpanImplTest {
     }
 
     @Test
+    fun `starting and stopping span with nanosecond timestamps`() {
+        with(embraceSpan) {
+            val expectedStartTimeMs = fakeClock.now() + 99
+            val expectedEndTimeMs = fakeClock.now() + 505
+            assertTrue(start(startTimeMs = expectedStartTimeMs.millisToNanos()))
+            assertTrue(stop(errorCode = ErrorCode.FAILURE, endTimeMs = expectedEndTimeMs.millisToNanos()))
+            assertSnapshot(
+                expectedStartTimeMs = expectedStartTimeMs,
+                expectedEndTimeMs = expectedEndTimeMs,
+                expectedStatus = Span.Status.ERROR
+            )
+            validateStoppedSpan()
+        }
+    }
+
+    @Test
     fun `check adding events`() {
         with(embraceSpan) {
             assertTrue(start())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -81,8 +81,13 @@ internal class EmbraceTracerTest {
         val parent = checkNotNull(embraceTracer.startSpan(name = "test-span"))
         clock.tick(20L)
         val childStartTimeMs = clock.now() - 10L
-        val child =
-            checkNotNull(embraceTracer.startSpan(name = "child-span", parent = parent, startTimeMs = childStartTimeMs))
+        val child = checkNotNull(
+            embraceTracer.startSpan(
+                name = "child-span",
+                parent = parent,
+                startTimeMs = childStartTimeMs,
+            )
+        )
         assertTrue(parent.stop())
         assertTrue(child.stop())
         val spans = spanSink.flushSpans()
@@ -291,6 +296,26 @@ internal class EmbraceTracerTest {
             assertEquals(2, events.size)
             assertEquals(eventTimeNanos, events[0].timestampNanos)
             assertEquals(eventTimeNanos, events[1].timestampNanos)
+        }
+    }
+
+    @Test
+    fun `start and stop span with nanosecond timestamp`() {
+        spanSink.flushSpans()
+        val expectedStartTimeNanos = clock.nowInNanos()
+        val span = checkNotNull(
+            embraceTracer.startSpan(
+                name = "fallback-span",
+                parent = null,
+                startTimeMs = expectedStartTimeNanos
+            )
+        )
+        clock.tick(10L)
+        val expectedEndTimeNanos = clock.nowInNanos()
+        assertTrue(span.stop(endTimeMs = expectedEndTimeNanos))
+        with(verifyPublicSpan("fallback-span")) {
+            assertEquals(expectedStartTimeNanos, startTimeNanos)
+            assertEquals(expectedEndTimeNanos, endTimeNanos)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
@@ -77,6 +77,20 @@ internal class InternalTracerTest {
     }
 
     @Test
+    fun `start and stop span with nanosecond timestamp`() {
+        spanSink.flushSpans()
+        val expectedStartTimeNanos = clock.nowInNanos()
+        val spanId = checkNotNull(internalTracer.startSpan(name = "my-span", startTimeMs = expectedStartTimeNanos))
+        clock.tick(10L)
+        val expectedEndTimeNanos = clock.nowInNanos()
+        assertTrue(internalTracer.stopSpan(spanId = spanId, endTimeMs = expectedEndTimeNanos))
+        with(verifyPublicSpan("my-span")) {
+            assertEquals(expectedStartTimeNanos, startTimeNanos)
+            assertEquals(expectedEndTimeNanos, endTimeNanos)
+        }
+    }
+
+    @Test
     fun `verify event timestamp fallback`() {
         spanSink.flushSpans()
         val spanId = checkNotNull(internalTracer.startSpan(name = "my-span"))


### PR DESCRIPTION
## Goal

Use nanosecond fallback for all timestamp parameters. This is because the hosted SDKs are passing in nanosecond time because that's what iOS expects, so we'll just support it on every parameter, rather than just the ones that had previously been in nanoseconds so customers might be using it.

## Testing

Added tests in every layer