### PR TITLE
Downgrade lifecycle library

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -45,5 +45,5 @@ object Versions {
     val moshi = "1.12.0"
 
     @JvmField
-    val lifecycle = "2.7.0"
+    val lifecycle = "2.5.0"
 }


### PR DESCRIPTION
## Goal

Downgrades the androidx lifecycle library to the previous version to avoid a compatibility warning on older JDK versions.
