### PR TITLE
Refactor the SessionOrchestrator tests to use a real PayloadFactory

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal class PayloadFactoryImpl(
-    private val v1payloadMessageCollator: V1PayloadMessageCollator,
-    private val v2payloadMessageCollator: V2PayloadMessageCollator,
+    private val v1payloadMessageCollator: PayloadMessageCollator,
+    private val v2payloadMessageCollator: PayloadMessageCollator,
     private val configService: ConfigService,
     private val logger: EmbLogger
 ) : PayloadFactory {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
@@ -8,13 +8,13 @@ import io.embrace.android.embracesdk.fakes.FakeNativeThreadSamplerService
 import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 
@@ -38,7 +38,7 @@ internal class SessionPayloadSourceImplTest {
             storeCompletedSpans(listOf(cacheSpan))
         }
         currentSessionSpan = FakeCurrentSessionSpan().apply {
-            spanData = listOf(EmbraceSpanData(FakeSpanData("my-span")))
+            initializeService(1000L)
         }
         activeSpan = FakePersistableEmbraceSpan.started()
         spanRepository = SpanRepository()
@@ -57,8 +57,7 @@ internal class SessionPayloadSourceImplTest {
     fun `session crash`() {
         val payload = impl.getSessionPayload(SessionSnapshotType.JVM_CRASH)
         assertPayloadPopulated(payload)
-        val span = checkNotNull(payload.spans?.single())
-        assertEquals("my-span", span.name)
+        assertNotNull(payload.spans?.single())
     }
 
     @Test
@@ -73,8 +72,7 @@ internal class SessionPayloadSourceImplTest {
     fun `session lifecycle change`() {
         val payload = impl.getSessionPayload(SessionSnapshotType.NORMAL_END)
         assertPayloadPopulated(payload)
-        val span = checkNotNull(payload.spans?.single())
-        assertEquals("my-span", span.name)
+        assertNotNull(payload.spans?.single())
     }
 
     private fun assertPayloadPopulated(payload: SessionPayload) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams
+import io.embrace.android.embracesdk.session.message.InitialEnvelopeParams
+import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
+
+internal class FakePayloadCollator : PayloadMessageCollator {
+    override fun buildInitialSession(params: InitialEnvelopeParams): Session {
+        TODO("Not yet implemented")
+    }
+
+    override fun buildFinalSessionMessage(params: FinalEnvelopeParams.SessionParams): SessionMessage {
+        TODO("Not yet implemented")
+    }
+
+    override fun buildFinalBackgroundActivityMessage(params: FinalEnvelopeParams.BackgroundActivityParams): SessionMessage {
+        TODO("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.toOldPayload
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.Companion.APPLICATION_STATE_FOREGROUND
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -25,14 +26,18 @@ internal fun fakeSession(
     messageType = Session.MESSAGE_TYPE_END
 )
 
-internal fun fakeV1SessionMessage(): SessionMessage = SessionMessage(
-    session = fakeSession()
+internal fun fakeV1SessionMessage(session: Session = fakeSession()): SessionMessage = SessionMessage(
+    session = session
 )
 
-internal fun fakeV1EndedSessionMessage(): SessionMessage = SessionMessage(
-    session = fakeSession().copy(endTime = 160000500000L),
-    spans = listOfNotNull(testSpan),
-    spanSnapshots = listOfNotNull(),
+internal fun fakeV1EndedSessionMessage(
+    session: Session = fakeSession(),
+    spans: List<EmbraceSpanData> = listOfNotNull(testSpan),
+    spanSnapshots: List<EmbraceSpanData> = listOfNotNull(),
+): SessionMessage = SessionMessage(
+    session = session.copy(endTime = 160000500000L),
+    spans = spans,
+    spanSnapshots = spanSnapshots,
 )
 
 internal fun fakeV1EndedSessionMessageWithSnapshot(): SessionMessage = SessionMessage(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -26,7 +26,6 @@ internal class FakeSpanData(
     private var kind: SpanKind = SpanKind.INTERNAL,
     private var spanContext: SpanContext = newTraceRootContext(),
     private var parentSpanContext: SpanContext = SpanContext.getInvalid(),
-    private var status: StatusData = StatusData.unset(),
     private var startEpochNanos: Long = DEFAULT_START_TIME_MS.millisToNanos(),
     private var attributes: Attributes =
         Attributes.builder().fromMap(
@@ -44,21 +43,21 @@ internal class FakeSpanData(
         )
     ),
     private var links: MutableList<LinkData> = mutableListOf(),
-    private var endEpochNanos: Long = 0L,
-    private var hasEnded: Boolean = false,
-    private var resource: Resource = Resource.empty()
+    private var resource: Resource = Resource.empty(),
+    var spanStatus: StatusData = StatusData.unset(),
+    var endTimeNanos: Long = 0L
 ) : SpanData {
     override fun getName(): String = name
     override fun getKind(): SpanKind = kind
     override fun getSpanContext(): SpanContext = spanContext
     override fun getParentSpanContext(): SpanContext = parentSpanContext
-    override fun getStatus(): StatusData = status
+    override fun getStatus(): StatusData = spanStatus
     override fun getStartEpochNanos(): Long = startEpochNanos
     override fun getAttributes(): Attributes = attributes
     override fun getEvents(): MutableList<EventData> = events
     override fun getLinks(): MutableList<LinkData> = links
-    override fun getEndEpochNanos(): Long = endEpochNanos
-    override fun hasEnded(): Boolean = hasEnded
+    override fun getEndEpochNanos(): Long = endTimeNanos
+    override fun hasEnded(): Boolean = status != StatusData.unset()
     override fun getTotalRecordedEvents(): Int = events.size
     override fun getTotalRecordedLinks(): Int = links.size
     override fun getTotalAttributeCount(): Int = attributes.size()
@@ -73,8 +72,8 @@ internal class FakeSpanData(
         val perfSpanCompleted =
             FakeSpanData(
                 name = "completed-perf-span",
-                status = StatusData.ok(),
-                endEpochNanos = (DEFAULT_START_TIME_MS + 60000L).millisToNanos()
+                spanStatus = StatusData.ok(),
+                endTimeNanos = (DEFAULT_START_TIME_MS + 60000L).millisToNanos()
             )
 
         private fun newTraceRootContext() = SpanContext.create(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV1PayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV1PayloadCollator.kt
@@ -1,0 +1,107 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams
+import io.embrace.android.embracesdk.session.message.InitialEnvelopeParams
+import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class FakeV1PayloadCollator(
+    val currentSessionSpan: FakeCurrentSessionSpan = FakeCurrentSessionSpan()
+) : PayloadMessageCollator {
+
+    val sessionCount = AtomicInteger(0)
+    val baCount = AtomicInteger(0)
+
+    override fun buildInitialSession(params: InitialEnvelopeParams) = with(params) {
+        val sessionNumber = when (appState) {
+            Session.APPLICATION_STATE_FOREGROUND -> {
+                sessionCount.incrementAndGet()
+            }
+            Session.APPLICATION_STATE_BACKGROUND -> {
+                baCount.incrementAndGet()
+            }
+            else -> {
+                error("Unknown appState")
+            }
+        }
+        Session(
+            sessionId = currentSessionSpan.getSessionId(),
+            startTime = startTime,
+            isColdStart = coldStart,
+            messageType = Session.MESSAGE_TYPE_END,
+            appState = appState,
+            startType = startType,
+            number = sessionNumber,
+        )
+    }
+
+    /**
+     * Builds a fully populated session message. This can be sent to the backend (or stored
+     * on disk).
+     */
+    override fun buildFinalSessionMessage(
+        params: FinalEnvelopeParams.SessionParams
+    ): SessionMessage = with(params) {
+        val endSession = buildFinalBackgroundActivity(params).copy(
+            isEndedCleanly = endType.endedCleanly,
+            terminationTime = terminationTime,
+            isReceivedTermination = receivedTermination,
+            endTime = endTimeVal,
+            sdkStartupDuration = if (initial.isColdStart) 100L else null,
+            startupDuration = if (initial.isColdStart) 1000L else null,
+            startupThreshold = if (initial.isColdStart) 5000L else null,
+        )
+        return buildWrapperEnvelope(params, endSession)
+    }
+
+    override fun buildFinalBackgroundActivityMessage(
+        params: FinalEnvelopeParams.BackgroundActivityParams
+    ): SessionMessage = buildWrapperEnvelope(params, buildFinalBackgroundActivity(params))
+
+    /**
+     * Creates a background activity stop message.
+     */
+    private fun buildFinalBackgroundActivity(
+        params: FinalEnvelopeParams
+    ): Session = with(params) {
+        return initial.copy(
+            endTime = endTime,
+            lastHeartbeatTime = endTime,
+            endType = lifeEventType,
+            crashReportId = crashId
+        )
+    }
+
+    private fun buildWrapperEnvelope(
+        params: FinalEnvelopeParams,
+        finalPayload: Session,
+    ): SessionMessage {
+        val spans: List<EmbraceSpanData>? =
+            when {
+                !params.captureSpans -> null
+                !params.isCacheAttempt -> {
+                    val appTerminationCause = when {
+                        finalPayload.crashReportId != null -> AppTerminationCause.Crash
+                        else -> null
+                    }
+                    currentSessionSpan.endSession(appTerminationCause)
+                }
+
+                else -> null
+            }
+
+        val spanSnapshots = currentSessionSpan.sessionSpan?.let { span ->
+            listOf(EmbraceSpanData(spanData = span))
+        } ?: listOf()
+
+        return SessionMessage(
+            session = finalPayload,
+            spans = spans,
+            spanSnapshots = spanSnapshots,
+        )
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -114,7 +114,7 @@ internal class PayloadFactoryBaTest {
     fun `background activity is not started whn the service initializes in the foreground`() {
         activityService.isInBackground = false
         this.service = createService(false)
-        assertTrue(deliveryService.lastSavedSessionMessages.isEmpty())
+        assertTrue(deliveryService.savedSessionMessages.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Goal

There was too much logic in PayloadFactoryImpl for us to faithfully test SessionOrchestratorImpl without a really complex FakePayloadFactory. As such, we'll use a real one, and do the faking at the `PayloadMessageCollator` level so we can validate the whole `SessionMessage` to ensure they match.
