### PR TITLE
Set warm start delay heuristic to 2 seconds

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -404,10 +404,10 @@ internal class AppStartupTraceEmitter(
     companion object {
         /**
          * The gap between the end of the Embrace SDK initialization to when the first activity loaded after startup happens.
-         * If this gap is greater than 1 minute, it's likely that the app process was not created because the user tapped on the app icon,
+         * If this gap is greater than 2 seconds, it is assumed that the app process was not created because the user tapped on the app,
          * so we track this app launch as a warm start.
          */
-        const val SDK_AND_ACTIVITY_INIT_GAP = 60000L
+        const val SDK_AND_ACTIVITY_INIT_GAP = 2000L
 
         fun duration(start: Long?, end: Long?): Long? = if (start != null && end != null) {
             end - start

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -70,6 +70,9 @@ internal class AppStartupTraceEmitter(
     private var startupActivityName: String? = null
 
     @Volatile
+    private var firstActivityInitStartMs: Long? = null
+
+    @Volatile
     private var startupActivityPreCreatedMs: Long? = null
 
     @Volatile
@@ -109,7 +112,11 @@ internal class AppStartupTraceEmitter(
     }
 
     override fun startupActivityInitStart(timestampMs: Long?) {
-        startupActivityInitStartMs = timestampMs ?: nowMs()
+        startupActivityInitStartMs = (timestampMs ?: nowMs()).apply {
+            if (firstActivityInitStartMs == null) {
+                firstActivityInitStartMs = this
+            }
+        }
     }
 
     override fun startupActivityPostCreated(timestampMs: Long?) {
@@ -183,8 +190,8 @@ internal class AppStartupTraceEmitter(
         sdkInitEndedInForeground = startupService.endedInForeground()
         sdkInitThreadName = startupService.getInitThreadName()
 
-        if (processStartTimeMs != null && traceEndTimeMs != null) {
-            val gap = applicationActivityCreationGap() ?: duration(sdkInitEndMs, startupActivityInitStartMs)
+        if (processStartTimeMs != null && traceEndTimeMs != null && sdkInitEndMs != null) {
+            val gap = applicationActivityCreationGap(sdkInitEndMs)
             if (gap != null) {
                 val startupTrace: EmbraceSpan? = if (!spanService.initialized()) {
                     logger.logWarning("Startup trace not recorded because the spans service is not initialized")
@@ -195,14 +202,17 @@ internal class AppStartupTraceEmitter(
                         applicationInitEndMs = applicationInitEndMs,
                         sdkInitStartMs = sdkInitStartMs,
                         sdkInitEndMs = sdkInitEndMs,
+                        firstActivityInitMs = firstActivityInitStartMs,
                         activityInitStartMs = startupActivityInitStartMs,
                         activityInitEndMs = startupActivityInitEndMs,
-                        traceEndTimeMs = traceEndTimeMs,
+                        traceEndTimeMs = traceEndTimeMs
                     )
                 } else {
-                    startupActivityInitStartMs?.let { startTime ->
+                    val warmStartTimeMs = firstActivityInitStartMs ?: startupActivityInitStartMs
+                    warmStartTimeMs?.let { startTime ->
                         recordWarmTtid(
                             traceStartTimeMs = startTime,
+                            activityInitStartMs = startupActivityInitStartMs,
                             activityInitEndMs = startupActivityInitEndMs,
                             traceEndTimeMs = traceEndTimeMs,
                             processToActivityCreateGap = gap,
@@ -238,6 +248,7 @@ internal class AppStartupTraceEmitter(
         applicationInitEndMs: Long?,
         sdkInitStartMs: Long?,
         sdkInitEndMs: Long?,
+        firstActivityInitMs: Long?,
         activityInitStartMs: Long?,
         activityInitEndMs: Long?,
         traceEndTimeMs: Long,
@@ -273,12 +284,13 @@ internal class AppStartupTraceEmitter(
                     )
                 }
                 val lastEventBeforeActivityInit = applicationInitEndMs ?: sdkInitEndMs
-                if (lastEventBeforeActivityInit != null && activityInitStartMs != null) {
+                val firstActivityInit = firstActivityInitMs ?: activityInitStartMs
+                if (lastEventBeforeActivityInit != null && firstActivityInit != null) {
                     spanService.recordCompletedSpan(
                         name = "activity-init-gap",
                         parent = this,
                         startTimeMs = lastEventBeforeActivityInit,
-                        endTimeMs = activityInitStartMs,
+                        endTimeMs = firstActivityInit,
                         private = false,
                     )
                 }
@@ -313,6 +325,7 @@ internal class AppStartupTraceEmitter(
 
     private fun recordWarmTtid(
         traceStartTimeMs: Long,
+        activityInitStartMs: Long?,
         activityInitEndMs: Long?,
         traceEndTimeMs: Long,
         processToActivityCreateGap: Long?,
@@ -336,11 +349,11 @@ internal class AppStartupTraceEmitter(
                 if (stop(endTimeMs = traceEndTimeMs)) {
                     startupRecorded.set(true)
                 }
-                if (activityInitEndMs != null) {
+                if (activityInitStartMs != null && activityInitEndMs != null) {
                     spanService.recordCompletedSpan(
                         name = "activity-create",
                         parent = this,
-                        startTimeMs = traceStartTimeMs,
+                        startTimeMs = activityInitStartMs,
                         endTimeMs = activityInitEndMs,
                         private = false,
                     )
@@ -365,7 +378,8 @@ internal class AppStartupTraceEmitter(
 
     private fun processCreateDelay(): Long? = duration(processCreateRequestedMs, processCreatedMs)
 
-    private fun applicationActivityCreationGap(): Long? = duration(applicationInitEndMs, startupActivityInitStartMs)
+    private fun applicationActivityCreationGap(sdkInitEndMs: Long): Long? =
+        duration(applicationInitEndMs ?: sdkInitEndMs, firstActivityInitStartMs)
 
     private fun nowMs(): Long = clock.now().nanosToMillis()
 
@@ -388,6 +402,10 @@ internal class AppStartupTraceEmitter(
 
         sdkInitEndedInForeground?.let { inForeground ->
             addAttribute("embrace-init-in-foreground", inForeground.toString())
+        }
+
+        firstActivityInitStartMs?.let { timeMs ->
+            addAttribute("first-activity-init-ms", timeMs.toString())
         }
 
         sdkInitThreadName?.let { threadName ->


### PR DESCRIPTION
## Goal

At 60 seconds, the heuristic we are using to determine whether we are experiencing a warm start vs a cold start, which previously measured the time between the last event before activity onCreate is called to the activity onCreate of the Activity we consider to be the activity whose rendering  will end startup, is too generous, leaving too much time for background app startups followed by a user-invoked launcher startup to be considered a cold startup. 

As such, we are going to shrink that to a more reasonable 2 seconds, which is quite a bit of time already if that last even is the end of the Application onCreate. We are also counting the FIRST activity onCreate being invoked, event if it is not the startup activity, because that indicates the startup is happening.

Even with this fix, though, the implementation is still imperfect, because if we don't know when application onCreate finishes (which we don't know out of the box), we simply use the end of the Embrace SDK's init time as that. We should look to improve this heuristic by getting customers to set this information, much like how they call `reportFullyDrawn()` to sent the end of time startup for GPC. 

Ideally, we don't even use this heuristic, but that is a longer term goal that we can't quite do it without some major time investment.

While this is not perfect, p99 should be plenty good enough - with a few false negatives leading to an actual cold start being tracked as a warm start. But that would still be better than the state of the startup traces now.

## Testing

Added appropriate tests. I also did some consolidation so there is less repeats in the tests.