### PR TITLE
Fix services stopping logic

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -130,6 +130,10 @@ internal class IntegrationTestRule(
         Embrace.getImpl().startInternal(context, appFramework, configServiceProvider)
     }
 
+    fun stopSdk() {
+        Embrace.getImpl().stop()
+    }
+
     /**
      * Test harness for which an instance is generated each test run and provided to the test by the Rule
      */

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -136,4 +136,15 @@ internal class PublicApiTest {
             }
         }
     }
+
+    @Test
+    fun `SDK can be stopped`() {
+        with(testRule) {
+            assertFalse(embrace.isStarted)
+            startSdk(context = harness.overriddenCoreModule.context)
+            assertTrue(embrace.isStarted)
+            stopSdk()
+            assertFalse(embrace.isStarted)
+        }
+    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -478,7 +478,7 @@ internal class ModuleInitBootstrapper(
     }
 
     fun stopServices() {
-        if (isInitialized()) {
+        if (!isInitialized()) {
             return
         }
 
@@ -487,13 +487,12 @@ internal class ModuleInitBootstrapper(
                 coreModule.serviceRegistry.close()
                 workerThreadModule.close()
                 essentialServiceModule.processStateService.close()
-            } else {
                 asyncInitTask.set(null)
             }
         }
     }
 
-    private fun isInitialized(): Boolean = asyncInitTask.get() != null
+    fun isInitialized(): Boolean = asyncInitTask.get() != null
 
     private fun <T> init(module: KClass<*>, provider: Provider<T>): T =
         Systrace.traceSynchronous("${toSectionName(module)}-init") { provider() }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -119,4 +119,19 @@ internal class ModuleInitBootstrapperTest {
             bootstrapper.waitForAsyncInit(500L, TimeUnit.MILLISECONDS)
         }
     }
+
+    @Test
+    fun `stopping services makes bootstrapper not initialized`() {
+        assertTrue(
+            moduleInitBootstrapper.init(
+                context = context,
+                appFramework = Embrace.AppFramework.NATIVE,
+                sdkStartTimeMs = 0L,
+            )
+        )
+
+        assertTrue(moduleInitBootstrapper.isInitialized())
+        moduleInitBootstrapper.stopServices()
+        assertFalse(moduleInitBootstrapper.isInitialized())
+    }
 }


### PR DESCRIPTION
## Goal

Fix the logic to stopping registered services when the SDK is stopped.

## Testing

Add basic tests
