### PR TITLE
Remove requirement for supplying appId

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -300,7 +300,7 @@ internal class EmbraceMetadataService private constructor(
 
     override fun getLightweightAppInfo(): AppInfo = getAppInfo(false)
 
-    override fun getAppId(): String {
+    override fun getAppId(): String? {
         return configService.sdkModeBehavior.appId
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/MetadataService.kt
@@ -33,7 +33,7 @@ internal interface MetadataService {
      *
      * @return the app ID.
      */
-    fun getAppId(): String
+    fun getAppId(): String?
 
     /**
      * Gets information and specifications of the current device. This is sent with the following

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/NoopDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/delivery/NoopDeliveryService.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.embracesdk.comms.delivery
+
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.LogPayload
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.ndk.NativeCrashService
+import io.embrace.android.embracesdk.payload.EventMessage
+import io.embrace.android.embracesdk.payload.NetworkEvent
+import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.session.id.SessionIdTracker
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
+
+internal class NoopDeliveryService : DeliveryService {
+
+    override fun sendSession(sessionMessage: SessionMessage, snapshotType: SessionSnapshotType) {
+    }
+
+    override fun sendCachedSessions(
+        nativeCrashServiceProvider: Provider<NativeCrashService?>,
+        sessionIdTracker: SessionIdTracker
+    ) {
+    }
+
+    override fun sendLog(eventMessage: EventMessage) {
+    }
+
+    override fun sendLogs(logEnvelope: Envelope<LogPayload>) {
+    }
+
+    override fun saveLogs(logEnvelope: Envelope<LogPayload>) {
+    }
+
+    override fun sendNetworkCall(networkEvent: NetworkEvent) {
+    }
+
+    override fun sendCrash(crash: EventMessage, processTerminating: Boolean) {
+    }
+
+    override fun sendMoment(eventMessage: EventMessage) {
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/EmbraceConfigService.kt
@@ -36,7 +36,7 @@ import kotlin.math.min
  */
 internal class EmbraceConfigService @JvmOverloads constructor(
     private val localConfig: LocalConfig,
-    private val apiService: ApiService,
+    private val apiService: ApiService?,
     private val preferencesService: PreferencesService,
     private val clock: Clock,
     private val logger: EmbLogger,
@@ -181,8 +181,8 @@ internal class EmbraceConfigService @JvmOverloads constructor(
      */
 
     fun loadConfigFromCache() {
-        val cachedConfig = apiService.getCachedConfig()
-        val obj = cachedConfig.remoteConfig
+        val cachedConfig = apiService?.getCachedConfig()
+        val obj = cachedConfig?.remoteConfig
 
         if (obj != null) {
             val oldConfig = configProp
@@ -214,7 +214,7 @@ internal class EmbraceConfigService @JvmOverloads constructor(
             if (configRequiresRefresh()) {
                 try {
                     lastRefreshConfigAttempt = clock.now()
-                    val newConfig = apiService.getConfig()
+                    val newConfig = apiService?.getConfig()
                     if (newConfig != null) {
                         updateConfig(previousConfig, newConfig)
                         lastUpdated = clock.now()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkEndpointBehavior.kt
@@ -23,10 +23,20 @@ internal class SdkEndpointBehavior(
     /**
      * Data base URL.
      */
-    fun getData(appId: String): String = local?.data ?: "https://a-$appId.$DATA_DEFAULT"
+    fun getData(appId: String?): String {
+        if (appId == null) {
+            return ""
+        }
+        return local?.data ?: "https://a-$appId.$DATA_DEFAULT"
+    }
 
     /**
      * Config base URL.
      */
-    fun getConfig(appId: String): String = local?.config ?: "https://a-$appId.$CONFIG_DEFAULT"
+    fun getConfig(appId: String?): String {
+        if (appId == null) {
+            return ""
+        }
+        return local?.config ?: "https://a-$appId.$CONFIG_DEFAULT"
+    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/SdkModeBehavior.kt
@@ -75,7 +75,7 @@ internal class SdkModeBehavior(
     /**
      * The Embrace app ID. This is used to identify the app within the database.
      */
-    val appId: String by lazy { local?.appId ?: error("App ID not supplied.") }
+    val appId: String? by lazy { local?.appId }
 
     /**
      * The % of devices that should be enabled.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/local/LocalConfig.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/local/LocalConfig.kt
@@ -9,7 +9,7 @@ internal class LocalConfig(
     /**
      * The Embrace app ID. This is used to identify the app within the database.
      */
-    val appId: String,
+    val appId: String?,
 
     /**
      * Control whether the Embrace SDK is able to capture native crashes.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DeliveryModule.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.comms.delivery.EmbraceDeliveryService
+import io.embrace.android.embracesdk.comms.delivery.NoopDeliveryService
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.embrace.android.embracesdk.worker.WorkerThreadModule
 
@@ -18,12 +19,17 @@ internal class DeliveryModuleImpl(
 ) : DeliveryModule {
 
     override val deliveryService: DeliveryService by singleton {
-        EmbraceDeliveryService(
-            storageModule.deliveryCacheManager,
-            essentialServiceModule.apiService,
-            workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
-            coreModule.jsonSerializer,
-            initModule.logger
-        )
+        val apiService = essentialServiceModule.apiService
+        if (apiService == null) {
+            NoopDeliveryService()
+        } else {
+            EmbraceDeliveryService(
+                storageModule.deliveryCacheManager,
+                apiService,
+                workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
+                coreModule.jsonSerializer,
+                initModule.logger
+            )
+        }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/EssentialServiceModule.kt
@@ -63,7 +63,7 @@ internal interface EssentialServiceModule {
     val userService: UserService
     val urlBuilder: ApiUrlBuilder
     val apiClient: ApiClient
-    val apiService: ApiService
+    val apiService: ApiService?
     val sharedObjectLoader: SharedObjectLoader
     val cpuInfoDelegate: CpuInfoDelegate
     val deviceArchitecture: DeviceArchitecture
@@ -95,6 +95,7 @@ internal class EssentialServiceModuleImpl(
             coreModule.context.packageName,
             customAppId,
             coreModule.jsonSerializer,
+            openTelemetryModule.openTelemetryConfiguration,
             initModule.logger
         )
     }
@@ -226,7 +227,7 @@ internal class EssentialServiceModuleImpl(
                 thresholdCheck = thresholdCheck,
                 localSupplier = localConfig.sdkConfig::baseUrls,
             )
-
+            checkNotNull(appId)
             val coreBaseUrl = sdkEndpointBehavior.getData(appId)
             val configBaseUrl = sdkEndpointBehavior.getConfig(appId)
 
@@ -278,7 +279,10 @@ internal class EssentialServiceModuleImpl(
         }
     }
 
-    override val apiService: ApiService by singleton {
+    override val apiService: ApiService? by singleton {
+        if (appId == null) {
+            return@singleton null
+        }
         Systrace.traceSynchronous("api-service-init") {
             EmbraceApiService(
                 apiClient = apiClient,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/BuildInfo.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/BuildInfo.kt
@@ -66,10 +66,7 @@ internal class BuildInfo internal constructor(
                     ex
                 )
             } catch (ex: Resources.NotFoundException) {
-                throw IllegalArgumentException(
-                    "No resource found for $buildProperty property. Failed to create build info.",
-                    ex
-                )
+                null
             }
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
@@ -64,4 +64,6 @@ internal class OpenTelemetryConfiguration(
     fun addLogExporter(logExporter: LogRecordExporter) {
         externalLogExporters.add(logExporter)
     }
+
+    fun hasConfiguredOtelExporters() = externalLogExporters.isNotEmpty() || externalSpanExporters.isNotEmpty()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/NetworkEvent.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/NetworkEvent.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 internal data class NetworkEvent(
     @Json(name = "app_id")
-    val appId: String,
+    val appId: String?,
 
     @Json(name = "a")
     val appInfo: AppInfo,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceGatingServiceV1PayloadTest.kt
@@ -32,10 +32,14 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_PROPERTIES
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_USER_TERMINATION
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.STARTUP_MOMENT
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.USER_PERSONAS
+import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.opentelemetry.OpenTelemetryConfiguration
 import io.embrace.android.embracesdk.payload.DiskUsage
 import io.embrace.android.embracesdk.payload.Event
 import io.embrace.android.embracesdk.payload.EventMessage
@@ -79,6 +83,13 @@ internal class EmbraceGatingServiceV1PayloadTest {
         LOG_PROPERTIES,
         LOGS_INFO,
         LOGS_WARN
+    )
+
+    private val otelCfg = OpenTelemetryConfiguration(
+        SpanSinkImpl(),
+        LogSinkImpl(),
+        SystemInfo(),
+        "my-id"
     )
 
     private lateinit var sessionBehavior: SessionBehavior
@@ -176,6 +187,7 @@ internal class EmbraceGatingServiceV1PayloadTest {
                 "]" +
                 "}}",
             EmbraceSerializer(),
+            otelCfg,
             EmbLoggerImpl()
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/NetworkBehaviorTest.kt
@@ -9,8 +9,12 @@ import io.embrace.android.embracesdk.config.remote.NetworkCaptureRuleRemoteConfi
 import io.embrace.android.embracesdk.config.remote.NetworkRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
+import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.opentelemetry.OpenTelemetryConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -146,8 +150,14 @@ internal class NetworkBehaviorTest {
 
     @Test
     fun testGetCapturePublicKey() {
+        val otelCfg = OpenTelemetryConfiguration(
+            SpanSinkImpl(),
+            LogSinkImpl(),
+            SystemInfo(),
+            "my-id"
+        )
         val json = ResourceReader.readResourceAsText("public_key_config.json")
-        val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), EmbLoggerImpl())
+        val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), otelCfg, EmbLoggerImpl())
         val behavior = fakeNetworkBehavior(localCfg = localConfig::sdkConfig)
         assertEquals(testCleanPublicKey, behavior.getCapturePublicKey())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -12,9 +12,13 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.fakes.fakeSdkEndpointBehavior
+import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.opentelemetry.OpenTelemetryConfiguration
 import io.mockk.clearAllMocks
 import io.mockk.unmockkAll
 import org.junit.AfterClass
@@ -50,12 +54,19 @@ internal class EmbraceNetworkCaptureServiceTest {
         @BeforeClass
         @JvmStatic
         fun beforeClass() {
+            val otelCfg = OpenTelemetryConfiguration(
+                SpanSinkImpl(),
+                LogSinkImpl(),
+                SystemInfo(),
+                "my-id"
+            )
             mockLocalConfig =
                 LocalConfigParser.buildConfig(
                     "GrCPU",
                     false,
                     "{\"base_urls\": {\"data\": \"https://data.emb-api.com\"}}",
                     EmbraceSerializer(),
+                    otelCfg,
                     EmbLoggerImpl()
                 )
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -34,12 +34,16 @@ import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.opentelemetry.OpenTelemetryConfiguration
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.session.message.V1PayloadMessageCollator
@@ -96,11 +100,18 @@ internal class PayloadFactoryBaTest {
             backgroundActivityCaptureEnabled = true
         )
         configService.updateListeners()
+        val otelCfg = OpenTelemetryConfiguration(
+            SpanSinkImpl(),
+            LogSinkImpl(),
+            SystemInfo(),
+            "my-id"
+        )
         localConfig = LocalConfigParser.buildConfig(
             "GrCPU",
             false,
             "{\"background_activity\": {\"max_background_activity_seconds\": 3600}}",
             EmbraceSerializer(),
+            otelCfg,
             EmbLoggerImpl()
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -32,12 +32,16 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.opentelemetry.OpenTelemetryConfiguration
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
@@ -119,11 +123,18 @@ internal class PayloadFactorySessionTest {
         currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan
         spanService = initModule.openTelemetryModule.spanService
         configService.updateListeners()
+        val otelCfg = OpenTelemetryConfiguration(
+            SpanSinkImpl(),
+            LogSinkImpl(),
+            SystemInfo(),
+            "my-id"
+        )
         localConfig = LocalConfigParser.buildConfig(
             "GrCPU",
             false,
             "{\"background_activity\": {\"max_background_activity_seconds\": 3600}}",
             EmbraceSerializer(),
+            otelCfg,
             EmbLoggerImpl()
         )
 


### PR DESCRIPTION
## Goal

Removes the requirement for supplying appId. This will allow folks to send data from Embrace to 3rd party OTel exporters without needing to send anything to Embrace's servers.

I have taken the approach of making the `DeliveryService` no-op if an appId is not supplied. There is probably some additional work that we could cancel (such as construction of payload messages etc), but I feel this is a good first approach. Perhaps ultimately we can aim to export as pure OTel & therefore kill a lot of SDK code.

I would appreciate in-depth reviews on this as it substantially changes how the SDK works & I want to be sure I haven't forgotten anything important.

