### PR TITLE
Tweak data source warning

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSource.kt
@@ -23,7 +23,7 @@ internal class SigquitDataSource(
 ) : SpanEventMapper<Long>, DataSourceImpl<SessionSpanWriter>(
     writer,
     logger,
-    UpToLimitStrategy(logger) { 50 }
+    UpToLimitStrategy { 50 }
 ) {
 
     private val googleAnrTrackerInstalled = AtomicBoolean(false)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
@@ -37,7 +37,10 @@ internal abstract class DataSourceImpl<T>(
     ): Boolean {
         try {
             if (enforceLimits && !limitStrategy.shouldCapture()) {
-                logger.logWarning("Data capture limit reached.")
+                logger.logInfo(
+                    "Data capture limit reached for ${this.javaClass.name}." +
+                        " Ignoring to keep payload size reasonable - other data types will still be captured normally."
+                )
                 return false
             }
             if (!inputValidation()) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
@@ -1,13 +1,11 @@
 package io.embrace.android.embracesdk.arch.limits
 
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.logging.EmbLogger
 
 /**
  * Allows capturing data up until a limit, then stops capturing.
  */
 internal class UpToLimitStrategy(
-    private val logger: EmbLogger,
     private val limitProvider: Provider<Int>,
 ) : LimitStrategy {
 
@@ -17,7 +15,6 @@ internal class UpToLimitStrategy(
     override fun shouldCapture(): Boolean {
         synchronized(lock) {
             if (count >= limitProvider()) {
-                logger.logWarning("Data capture limit reached.")
                 return false
             }
             count++

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -44,7 +44,7 @@ internal class AeiDataSourceImpl(
 ) : AeiDataSource, LogEventMapper<BlobMessage>, LogDataSourceImpl(
     logWriter,
     logger,
-    limitStrategy = UpToLimitStrategy(logger) { SDK_AEI_SEND_LIMIT }
+    limitStrategy = UpToLimitStrategy { SDK_AEI_SEND_LIMIT }
 ) {
 
     companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NetworkStatusDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NetworkStatusDataSource.kt
@@ -18,7 +18,7 @@ internal class NetworkStatusDataSource(
 ) : StartSpanMapper<NetworkStatusData>, SpanDataSourceImpl(
     destination = spanService,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger) { MAX_CAPTURED_NETWORK_STATUS }
+    limitStrategy = UpToLimitStrategy { MAX_CAPTURED_NETWORK_STATUS }
 ) {
     private companion object {
         private const val MAX_CAPTURED_NETWORK_STATUS = 100

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
@@ -21,7 +21,7 @@ internal class BreadcrumbDataSource(
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger, breadcrumbBehavior::getCustomBreadcrumbLimit)
+    limitStrategy = UpToLimitStrategy(breadcrumbBehavior::getCustomBreadcrumbLimit)
 ),
     SpanEventMapper<CustomBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationDataSource.kt
@@ -23,7 +23,7 @@ internal class PushNotificationDataSource(
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger, breadcrumbBehavior::getCustomBreadcrumbLimit)
+    limitStrategy = UpToLimitStrategy(breadcrumbBehavior::getCustomBreadcrumbLimit)
 ),
     SpanEventMapper<PushNotificationBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnActionDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/RnActionDataSource.kt
@@ -14,7 +14,7 @@ internal open class RnActionDataSource(
 ) : SpanDataSourceImpl(
     spanService,
     logger,
-    UpToLimitStrategy(logger) { breadcrumbBehavior.getCustomBreadcrumbLimit() }
+    UpToLimitStrategy { breadcrumbBehavior.getCustomBreadcrumbLimit() }
 ) {
     open fun logRnAction(
         name: String?,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapDataSource.kt
@@ -21,7 +21,7 @@ internal class TapDataSource(
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger, breadcrumbBehavior::getTapBreadcrumbLimit)
+    limitStrategy = UpToLimitStrategy(breadcrumbBehavior::getTapBreadcrumbLimit)
 ),
     SpanEventMapper<TapBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
@@ -25,7 +25,7 @@ internal class ViewDataSource(
 ) : SpanDataSourceImpl(
     spanService,
     logger,
-    UpToLimitStrategy(logger) { breadcrumbBehavior.getFragmentBreadcrumbLimit() }
+    UpToLimitStrategy { breadcrumbBehavior.getFragmentBreadcrumbLimit() }
 ),
     StartSpanMapper<FragmentBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSource.kt
@@ -21,7 +21,7 @@ internal class WebViewUrlDataSource(
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger, breadcrumbBehavior::getWebViewBreadcrumbLimit)
+    limitStrategy = UpToLimitStrategy(breadcrumbBehavior::getWebViewBreadcrumbLimit)
 ),
     SpanEventMapper<WebViewBreadcrumb> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/MemoryWarningDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/MemoryWarningDataSource.kt
@@ -19,7 +19,7 @@ internal class MemoryWarningDataSource(
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = sessionSpanWriter,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger) { EmbraceMemoryService.MAX_CAPTURED_MEMORY_WARNINGS }
+    limitStrategy = UpToLimitStrategy { EmbraceMemoryService.MAX_CAPTURED_MEMORY_WARNINGS }
 ),
     SpanEventMapper<MemoryWarning> {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSource.kt
@@ -26,7 +26,7 @@ internal class LowPowerDataSource(
 ) : StartSpanMapper<Long>, SpanDataSourceImpl(
     destination = spanService,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger) { MAX_CAPTURED_POWER_MODE_INTERVALS }
+    limitStrategy = UpToLimitStrategy { MAX_CAPTURED_POWER_MODE_INTERVALS }
 ) {
 
     private companion object {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
@@ -15,7 +15,7 @@ internal class SessionPropertiesDataSource(
 ) : DataSourceImpl<SessionSpanWriter>(
     destination = writer,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger) { sessionBehavior.getMaxSessionProperties() }
+    limitStrategy = UpToLimitStrategy { sessionBehavior.getMaxSessionProperties() }
 ) {
     /**
      * Assume input has already been sanitized

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/thermalstate/ThermalStateDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/thermalstate/ThermalStateDataSource.kt
@@ -30,7 +30,7 @@ internal class ThermalStateDataSource(
 ) : StartSpanMapper<ThermalState>, SpanDataSourceImpl(
     destination = spanService,
     logger = logger,
-    limitStrategy = UpToLimitStrategy(logger) { MAX_CAPTURED_THERMAL_STATES }
+    limitStrategy = UpToLimitStrategy { MAX_CAPTURED_THERMAL_STATES }
 ) {
     private companion object {
         private const val MAX_CAPTURED_THERMAL_STATES = 100

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -38,7 +38,7 @@ internal class DataSourceImplTest {
     @Test
     fun `capture data respects limits`() {
         val dst = FakeCurrentSessionSpan()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {
@@ -52,7 +52,7 @@ internal class DataSourceImplTest {
     @Test
     fun `capture data respects validation`() {
         val dst = FakeCurrentSessionSpan()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
@@ -38,7 +38,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `capture data respects limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {
@@ -52,7 +52,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `capture data respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {
@@ -88,7 +88,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `start span respects limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {
@@ -102,7 +102,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `start span respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {
@@ -138,7 +138,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `stop span does not increment limits`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {
@@ -152,7 +152,7 @@ internal class SpanDataSourceImplTest {
     @Test
     fun `stop span respects validation`() {
         val dst = FakeSpanService()
-        val source = FakeDataSourceImpl(dst, UpToLimitStrategy(EmbLoggerImpl()) { 2 })
+        val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
         repeat(4) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategyTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.arch.limits
 
-import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,7 +10,7 @@ internal class UpToLimitStrategyTest {
 
     @Test
     fun shouldCapture() {
-        val strategy = UpToLimitStrategy(EmbLoggerImpl(), provider)
+        val strategy = UpToLimitStrategy(provider)
         repeat(10) {
             assertTrue(strategy.shouldCapture())
         }


### PR DESCRIPTION
## Goal

Tweaks the log level & text shown when the data capture limit is reached in `DataSourceImpl`. This caused a bit of confusion so a lower severity level & clearer message is desirable. I've also altered the message to include the class name that has run into the limit.

## Testing

Relied on existing test coverage & also tested out message manually in the test app:

>Data capture limit reached for io.embrace.android.embracesdk.capture.crumbs.BreadcrumbDataSource. Ignoring to keep payload size reasonable - other data types will still be captured normally.

