### PR TITLE
Use a threadsafe map to make getActiveSpans threadsafe

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * Allows the tracking of [EmbraceSpan] instances so that their references can be retrieved with its associated spanId
  */
 internal class SpanRepository {
-    private val activeSpans: MutableMap<String, PersistableEmbraceSpan> = mutableMapOf()
+    private val activeSpans: MutableMap<String, PersistableEmbraceSpan> = ConcurrentHashMap()
     private val completedSpans: MutableMap<String, EmbraceSpan> = mutableMapOf()
     private val spanIdsInProcess: MutableMap<String, AtomicInteger> = ConcurrentHashMap()
 


### PR DESCRIPTION
## Goal

The underlying snapshot taking operation isn't thread safe, so we have to use a thread safe data structure to ensure we can snapshot the current active spans while is being modified. This leaves room for some race conditions as to which session a span is started or stopped in, which is probably fine given the asynchronous nature of tracking spans anyway.

What I don't want is to lock everything every time a span is started or stopped, which could potentially result in some pretty bad performance. I can take a look to see if we can have some greater guarantees to reduce the aforementioned race condition, but this will work fine for now as long as we don't mind a bit of timestamp misalignment between span and session boundaries.