### PR TITLE
Added EmbraceTracedConverterFactory

### DIFF
--- a/embrace-android-retrofit/CREDITS.md
+++ b/embrace-android-retrofit/CREDITS.md
@@ -1,0 +1,13 @@
+In an effort to provide fair attribution, the following list contains the names and licensing notices for all sources that have provided significant direct or indirect contributions to this project.
+
+--------------------------------------------------------------------------------
+
+The MIT License (MIT)
+Copyright (c) 2016 Raygun Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/embrace-android-retrofit/README.md
+++ b/embrace-android-retrofit/README.md
@@ -1,0 +1,3 @@
+# Embrace.io - Retrofit Networking Android SDK
+
+This optional add-on SDK exposes some additional networking related APIs that extends the functionality of the core Embrace.io Android SDK.

--- a/embrace-android-retrofit/api/embrace-android-retrofit.api
+++ b/embrace-android-retrofit/api/embrace-android-retrofit.api
@@ -1,0 +1,6 @@
+public final class io/embrace/android/embracesdk/retrofit/swazzle/callback/retrofit/EmbraceTracedConverterFactory : retrofit2/Converter$Factory {
+	public fun <init> (Lretrofit2/Converter$Factory;)V
+	public fun requestBodyConverter (Ljava/lang/reflect/Type;[Ljava/lang/annotation/Annotation;[Ljava/lang/annotation/Annotation;Lretrofit2/Retrofit;)Lretrofit2/Converter;
+	public fun responseBodyConverter (Ljava/lang/reflect/Type;[Ljava/lang/annotation/Annotation;Lretrofit2/Retrofit;)Lretrofit2/Converter;
+}
+

--- a/embrace-android-retrofit/build.gradle
+++ b/embrace-android-retrofit/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id("internal-embrace-plugin")
+}
+
+description = "Embrace Android SDK: Retrofit"
+
+android {
+    namespace = "io.embrace.android.embracesdk.retrofit"
+}
+
+dependencies {
+    compileOnly("com.squareup.retrofit2:retrofit:2.9.0")
+    compileOnly(project(":embrace-android-sdk"))
+    testImplementation(project(":embrace-android-sdk"))
+    testImplementation "io.mockk:mockk:1.12.2"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
+}

--- a/embrace-android-retrofit/lint-baseline.xml
+++ b/embrace-android-retrofit/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.3.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.3.2)" variant="all" version="8.3.2">
+
+</issues>

--- a/embrace-android-retrofit/src/main/AndroidManifest.xml
+++ b/embrace-android-retrofit/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/embrace-android-retrofit/src/main/java/io/embrace/android/embracesdk/retrofit/swazzle/callback/retrofit/EmbraceTracedConverterFactory.kt
+++ b/embrace-android-retrofit/src/main/java/io/embrace/android/embracesdk/retrofit/swazzle/callback/retrofit/EmbraceTracedConverterFactory.kt
@@ -1,0 +1,74 @@
+package io.embrace.android.embracesdk.retrofit.swazzle.callback.retrofit
+
+import io.embrace.android.embracesdk.Embrace
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import retrofit2.Converter
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+
+/**
+ * This class wraps a [Converter.Factory] and records spans around the
+ * serialization of retrofit request and response bodies.
+ */
+public class EmbraceTracedConverterFactory(
+    private val delegate: Converter.Factory
+) : Converter.Factory() {
+
+    private class ResponseBodyTracedConverter<T>(
+        private val delegate: Converter<ResponseBody, T>,
+        private val url: String
+    ) : Converter<ResponseBody, T> {
+
+        override fun convert(value: ResponseBody): T? {
+            var result: T? = null
+            Embrace.getInstance().internalInterface.recordSpan(
+                "Retrofit response body serialization",
+                attributes = mapOf("url.full" to url)
+            ) {
+                result = delegate.convert(value)
+            }
+            return result
+        }
+    }
+
+    private class RequestBodyTracedConverter<T>(
+        private val delegate: Converter<T, RequestBody>,
+        private val url: String
+    ) : Converter<T, RequestBody> {
+
+        override fun convert(value: T): RequestBody? {
+            var result: RequestBody? = null
+            Embrace.getInstance().internalInterface.recordSpan(
+                "Retrofit request body serialization",
+                attributes = mapOf("url.full" to url)
+            ) {
+                result = delegate.convert(value)
+            }
+            return result
+        }
+    }
+
+    override fun responseBodyConverter(
+        type: Type,
+        annotations: Array<Annotation>,
+        retrofit: Retrofit
+    ): Converter<ResponseBody, *>? {
+        val delegateConverter = delegate.responseBodyConverter(type, annotations, retrofit)
+            ?: return null
+        return ResponseBodyTracedConverter(delegateConverter, retrofit.baseUrl().toString())
+    }
+
+    override fun requestBodyConverter(
+        type: Type,
+        parameterAnnotations: Array<Annotation>,
+        methodAnnotations: Array<Annotation>,
+        retrofit: Retrofit
+    ): Converter<*, RequestBody>? {
+        val delegateConverter =
+            delegate.requestBodyConverter(type, parameterAnnotations, methodAnnotations, retrofit)
+                ?: return null
+
+        return RequestBodyTracedConverter(delegateConverter, retrofit.baseUrl().toString())
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ":embrace-android-sdk",
         ":embrace-android-okhttp3",
+        ":embrace-android-retrofit",
         ":embrace-android-fcm",
         ":embrace-android-compose",
         ":embrace-lint"


### PR DESCRIPTION
## Goal

This allows the user to wrap their Retrofit converter factories with our class, and generate spans that measure request and response body serialization.

For example, if a user is using kotlinx.serialization, they should wrap their converter factory like this when they add it to Retrofit:

```
Retrofit.Builder()
    .baseUrl(CAT_API_BASE_URL)
    .addConverterFactory(
        EmbraceTracedConverterFactory(
            Json { ignoreUnknownKeys = true }.asConverterFactory("application/json".toMediaType()) //kotlinx.serialization converter factory
        )
    )
    .client(okHttpClient)
    .build()
```

This PR goes along with a PR in swazzler, that will inject the embrace-android-retrofit module: https://github.com/embrace-io/embrace-swazzler3/pull/584

## Testing

Tested manually with a test app that uses retrofit (https://github.com/priettt/CatJokes)