### PR TITLE
Add extension function to turn OTel Attributes into a map of strings

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -119,6 +119,13 @@ internal fun Span.endSpan(errorCode: ErrorCode? = null, endTimeMs: Long? = null)
 }
 
 /**
+ * Returns the attributes as a new Map<String, String>
+ */
+internal fun Attributes.toStringMap(): Map<String, String> = asMap().entries.associate {
+    it.key.key.toString() to it.value.toString()
+}
+
+/**
  * Populate an [AttributesBuilder] with String key-value pairs from a [Map]
  */
 internal fun AttributesBuilder.fromMap(attributes: Map<String, String>): AttributesBuilder {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
@@ -49,7 +49,7 @@ internal data class EmbraceSpanData(
         endTimeNanos = spanData.endEpochNanos,
         status = spanData.status.statusCode,
         events = fromEventData(eventDataList = spanData.events),
-        attributes = spanData.attributes.asMap().entries.associate { it.key.key to it.value.toString() }
+        attributes = spanData.attributes.toStringMap(),
     )
 
     companion object {
@@ -59,7 +59,7 @@ internal data class EmbraceSpanData(
                 val event = EmbraceSpanEvent.create(
                     name = eventData.name,
                     timestampMs = eventData.epochNanos.nanosToMillis(),
-                    attributes = eventData.attributes.asMap().entries.associate { it.key.key to it.value.toString() }
+                    attributes = eventData.attributes.toStringMap(),
                 )
                 if (event != null) {
                     events.add(event)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/payload/LogMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/payload/LogMapperTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.payload
 
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
+import io.embrace.android.embracesdk.internal.spans.toStringMap
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -17,7 +18,7 @@ internal class LogMapperTest {
         assertEquals(input.spanContext.traceId, output.traceId)
         assertEquals(input.spanContext.spanId, output.spanId)
 
-        val inputMap = input.attributes.asMap().entries.associate { it.key.key to it.value }
+        val inputMap = input.attributes.toStringMap()
         val outputMap = checkNotNull(output.attributes).associateBy { it.key }.mapValues { it.value.data }
         assertEquals(inputMap, outputMap)
     }


### PR DESCRIPTION
## Goal

Add extension function to consolidate logic to convert an OTel Attributes object into a map of strings, which we rely on as the data structure to pass attributes around

