### PR TITLE
Add ability to rename spans that have not ended

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -342,6 +342,7 @@ public abstract interface class io/embrace/android/embracesdk/spans/EmbraceSpan 
 	public abstract fun stop (Lio/embrace/android/embracesdk/spans/ErrorCode;)Z
 	public abstract fun stop (Lio/embrace/android/embracesdk/spans/ErrorCode;Ljava/lang/Long;)Z
 	public abstract fun stop (Ljava/lang/Long;)Z
+	public abstract fun updateName (Ljava/lang/String;)Z
 }
 
 public final class io/embrace/android/embracesdk/spans/EmbraceSpan$DefaultImpls {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.isValidName
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -121,10 +122,11 @@ internal class SpanServiceImpl(
         name: String,
         events: List<EmbraceSpanEvent>? = null,
         attributes: Map<String, String>? = null
-    ) = name.isNotBlank() &&
-        name.length <= EmbraceSpanImpl.MAX_NAME_LENGTH &&
-        (events == null || events.size <= EmbraceSpanImpl.MAX_EVENT_COUNT) &&
-        (attributes == null || attributes.size <= EmbraceSpanImpl.MAX_ATTRIBUTE_COUNT)
+    ): Boolean {
+        return name.isValidName() &&
+            ((events == null) || (events.size <= EmbraceSpanImpl.MAX_EVENT_COUNT)) &&
+            ((attributes == null) || (attributes.size <= EmbraceSpanImpl.MAX_ATTRIBUTE_COUNT))
+    }
 
     companion object {
         const val MAX_NON_INTERNAL_SPANS_PER_SESSION = 500

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -116,4 +116,9 @@ public interface EmbraceSpan {
      * if the validation at the Embrace Level has passed and the call to add the Attribute at the OpenTelemetry level was successful.
      */
     public fun addAttribute(key: String, value: String): Boolean
+
+    /**
+     * Update the name of the span. Returns false if the update was not successful, like when it has already been stopped
+     */
+    public fun updateName(newName: String): Boolean
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -98,6 +98,10 @@ internal class FakePersistableEmbraceSpan(
         return true
     }
 
+    override fun updateName(newName: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
     override fun snapshot(): Span? {
         return if (spanId == null) {
             null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_EVENT_NAME
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_EVENT_NAME
+import io.embrace.android.embracesdk.fixtures.TOO_LONG_SPAN_NAME
 import io.embrace.android.embracesdk.fixtures.maxSizeEventAttributes
 import io.embrace.android.embracesdk.fixtures.tooBigEventAttributes
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
@@ -159,6 +160,23 @@ internal class EmbraceSpanImplTest {
             assertTrue(
                 addEvent(name = "future event", timestampMs = fakeClock.now() + 2L, mapOf(Pair("key", "value"), Pair("key2", "value1")))
             )
+        }
+    }
+
+    @Test
+    fun `span name update`() {
+        with(embraceSpan) {
+            assertTrue(embraceSpan.updateName("new-name"))
+            assertFalse(embraceSpan.updateName(TOO_LONG_SPAN_NAME))
+            assertFalse(embraceSpan.updateName(""))
+            assertFalse(embraceSpan.updateName(" "))
+            assertTrue(start())
+            assertEquals("new-name", embraceSpan.snapshot()?.name)
+            assertTrue(embraceSpan.updateName("new-new-name"))
+            assertEquals("new-new-name", embraceSpan.snapshot()?.name)
+            assertTrue(stop())
+            assertFalse(embraceSpan.updateName("failed-to-update"))
+            assertEquals("new-new-name", embraceSpan.snapshot()?.name)
         }
     }
 


### PR DESCRIPTION
## Goal

Add the ability to rename a span that hasn't been stopped. This is so we can expose this functionality in our OTel Span API wrapper.

## Testing
Added unit tests
