### PR TITLE
Stop testing deprecated start methods

### DIFF
--- a/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/PreSdkStartTest.java
+++ b/embrace-android-sdk/src/integrationTest/java/io/embrace/android/embracesdk/PreSdkStartTest.java
@@ -26,15 +26,12 @@ public class PreSdkStartTest {
     public void testStartWithNullContext() {
         embrace.start(null);
         embrace.start(null, Embrace.AppFramework.NATIVE);
-        embrace.start(null, true);
-        embrace.start(null, false, Embrace.AppFramework.NATIVE);
         assertFalse(embrace.isStarted());
     }
 
     @Test
     public void testStartWithNullAppFramework() {
         Context context = testRule.harness.getOverriddenCoreModule().getContext();
-        embrace.start(context, false, null);
         embrace.start(context, null);
         assertFalse(embrace.isStarted());
     }


### PR DESCRIPTION
## Goal

Remove tests for deprecated start method so the compiler doesn't yell at me.

