### PR TITLE
Update OTel Java SDK to 1.38

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -39,7 +39,7 @@ object Versions {
     val ndk = "21.4.7075529"
 
     @JvmField
-    val openTelemetryCore = "1.35.0"
+    val openTelemetryCore = "1.38.0"
 
     @JvmField
     val moshi = "1.12.0"


### PR DESCRIPTION
## Goal

Update OTel SDK to the latest version

