### PR TITLE
Propagate full parent context in EmbraceSpanBuilder

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
@@ -69,21 +69,26 @@ internal class EmbraceSpanBuilder(
     fun setParent(context: Context) {
         parentContext = context
         sdkSpanBuilder.setParent(context)
-        val parentSpanContext = Span.fromContext(context).spanContext
-        if (fixedAttributes.contains(EmbType.Performance.Default) && parentSpanContext != Context.root()) {
-            fixedAttributes.remove(KeySpan)
-        }
+        updateKeySpan()
     }
 
     fun setNoParent() {
         parentContext = Context.root()
         sdkSpanBuilder.setNoParent()
-        if (fixedAttributes.contains(EmbType.Performance.Default)) {
-            fixedAttributes.add(KeySpan)
-        }
+        updateKeySpan()
     }
 
     fun setSpanKind(spanKind: SpanKind) {
         sdkSpanBuilder.setSpanKind(spanKind)
+    }
+
+    private fun updateKeySpan() {
+        if (fixedAttributes.contains(EmbType.Performance.Default)) {
+            if (Span.fromContext(parentContext) == Span.getInvalid()) {
+                fixedAttributes.add(KeySpan)
+            } else {
+                fixedAttributes.remove(KeySpan)
+            }
+        }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -20,6 +20,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -209,6 +210,8 @@ internal class EmbraceSpanImpl(
         return false
     }
 
+    override fun asNewContext(): Context? = startedSpan.get()?.run { spanBuilder.parentContext.with(this) }
+
     override fun snapshot(): Span? {
         return if (canSnapshot()) {
             Span(
@@ -261,8 +264,6 @@ internal class EmbraceSpanImpl(
     private fun spanStarted() = startedSpan.get() != null
 
     private fun getSpanName() = synchronized(startedSpan) { updatedName ?: spanBuilder.spanName }
-
-    internal fun wrappedSpan(): io.opentelemetry.api.trace.Span? = startedSpan.get()
 
     companion object {
         internal const val MAX_NAME_LENGTH = 50

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -4,11 +4,18 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.opentelemetry.context.Context
 
 /**
  * An [EmbraceSpan] that has can generate a snapshot of its current state for persistence
  */
 internal interface PersistableEmbraceSpan : EmbraceSpan {
+
+    /**
+     * Create a new [Context] object based in this span and its parent's context. This can be used for the parent [Context] for a new span
+     * with this span as its parent.
+     */
+    fun asNewContext(): Context?
 
     /**
      * Create a snapshot of the current state of the object

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.opentelemetry.embSequenceId
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.context.ContextKey
 
 internal val testSpan = EmbraceSpanData(
     traceId = "19bb482ec1c7e6b2f10fb89e0ccc85fa",
@@ -51,6 +52,8 @@ internal val testSpanSnapshot = Span(
     events = emptyList(),
     attributes = emptyList()
 )
+
+internal val fakeContextKey = ContextKey.named<String>("fake-context-key")
 
 private fun createMapOfSize(size: Int): Map<String, String> {
     val mutableMap = mutableMapOf<String, String>()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
@@ -157,9 +157,9 @@ internal class EmbraceSpanBuilderTest {
     }
 
     @Test
-    fun `context propagated even if it does not context a span`() {
-        val fakeContext = Context.root().with(fakeContextKey, "fake-value")
-        val parent = FakePersistableEmbraceSpan.started(parentContext = fakeContext)
+    fun `context value propagated even if it does not context a span`() {
+        val fakeRootContext = Context.root().with(fakeContextKey, "fake-value")
+        val parent = FakePersistableEmbraceSpan.started(parentContext = fakeRootContext)
         val spanBuilder = EmbraceSpanBuilder(
             tracer = tracer,
             name = "parent",
@@ -169,11 +169,11 @@ internal class EmbraceSpanBuilderTest {
             parent = parent,
         )
 
-        assertEquals(fakeContext, spanBuilder.parentContext)
+        assertEquals("fake-value", spanBuilder.parentContext.get(fakeContextKey))
 
         val span = spanBuilder.startSpan(clock.now()) as FakeSpan
         assertNotEquals(parent.spanContext?.traceId, span.spanContext.traceId)
-        assertEquals(fakeContext, span.fakeSpanBuilder.parentContext)
+        assertEquals("fake-value", span.fakeSpanBuilder.parentContext.get(fakeContextKey))
     }
 
     private fun Span.assertFakeSpanBuilder(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
@@ -7,11 +7,13 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
 import io.embrace.android.embracesdk.fakes.FakeSpan
 import io.embrace.android.embracesdk.fakes.FakeTracer
+import io.embrace.android.embracesdk.fixtures.fakeContextKey
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -64,7 +66,7 @@ internal class EmbraceSpanBuilderTest {
             parent = null,
         )
         val parent = tracer.spanBuilder("parent-span").startSpan()
-        val parentContext = Context.current().with(parent)
+        val parentContext = Context.root().with(parent).with(fakeContextKey, "value")
         spanBuilder.setParent(parentContext)
         with(spanBuilder.getFixedAttributes().toSet()) {
             assertFalse(contains(KeySpan))
@@ -138,6 +140,40 @@ internal class EmbraceSpanBuilderTest {
             expectedStartTimeMs = startTime,
             expectedSpanKind = SpanKind.CLIENT
         )
+    }
+
+    @Test
+    fun `custom attribute setting`() {
+        val spanBuilder = EmbraceSpanBuilder(
+            tracer = tracer,
+            name = "test",
+            telemetryType = EmbType.Performance.Default,
+            internal = false,
+            private = false,
+            parent = null,
+        )
+        spanBuilder.setCustomAttribute("test-key", "test-value")
+        assertEquals("test-value", spanBuilder.getCustomAttributes()["test-key"])
+    }
+
+    @Test
+    fun `context propagated even if it does not context a span`() {
+        val fakeContext = Context.root().with(fakeContextKey, "fake-value")
+        val parent = FakePersistableEmbraceSpan.started(parentContext = fakeContext)
+        val spanBuilder = EmbraceSpanBuilder(
+            tracer = tracer,
+            name = "parent",
+            telemetryType = EmbType.Performance.Default,
+            internal = false,
+            private = false,
+            parent = parent,
+        )
+
+        assertEquals(fakeContext, spanBuilder.parentContext)
+
+        val span = spanBuilder.startSpan(clock.now()) as FakeSpan
+        assertNotEquals(parent.spanContext?.traceId, span.spanContext.traceId)
+        assertEquals(fakeContext, span.fakeSpanBuilder.parentContext)
     }
 
     private fun Span.assertFakeSpanBuilder(


### PR DESCRIPTION
## Goal

Alter the wrapper to store and propagate the entire OTel Context - not just the SpanContext - when setting parents. This allows us to not only pass down the entire Context object to the `SpanProcessor` to more fully implement the API, but will also support us stashing our wrapper span in the Context as well, which will be added later.

## Testing

Added appropriate unit tests

