### PR TITLE
Implementation for Tracer, TracerBuilder, and TracerProvider OTel APIs

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbTracer.kt
@@ -1,0 +1,27 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.embrace.android.embracesdk.internal.spans.embraceSpanBuilder
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.common.Clock
+
+internal class EmbTracer(
+    private val sdkTracer: Tracer,
+    private val spanService: SpanService,
+    private val clock: Clock
+) : Tracer {
+
+    override fun spanBuilder(spanName: String): SpanBuilder =
+        EmbSpanBuilder(
+            embraceSpanBuilder = sdkTracer.embraceSpanBuilder(
+                name = spanName,
+                type = EmbType.Performance.Default,
+                private = false,
+                internal = false,
+            ),
+            spanService = spanService,
+            clock = clock,
+        )
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerBuilder.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.trace.TracerBuilder
+
+internal class EmbTracerBuilder(
+    instrumentationScopeName: String,
+    private val tracerSupplier: (tracerKey: TracerKey) -> Tracer
+) : TracerBuilder {
+
+    private val tracerKey: TracerKey = TracerKey(instrumentationScopeName = instrumentationScopeName)
+
+    override fun setSchemaUrl(schemaUrl: String): TracerBuilder {
+        tracerKey.schemaUrl = schemaUrl
+        return this
+    }
+
+    override fun setInstrumentationVersion(instrumentationScopeVersion: String): TracerBuilder {
+        tracerKey.instrumentationScopeVersion = instrumentationScopeVersion
+        return this
+    }
+
+    override fun build(): Tracer = tracerSupplier(tracerKey)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerProvider.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerProvider.kt
@@ -1,0 +1,63 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.embrace.android.embracesdk.internal.spans.SpanService
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.trace.TracerBuilder
+import io.opentelemetry.api.trace.TracerProvider
+import io.opentelemetry.sdk.common.Clock
+import java.util.concurrent.ConcurrentHashMap
+
+internal class EmbTracerProvider(
+    private val sdkTracerProvider: TracerProvider,
+    private val spanService: SpanService,
+    private val clock: Clock,
+) : TracerProvider {
+
+    private val tracers = ConcurrentHashMap<TracerKey, Tracer>()
+
+    override fun get(instrumentationScopeName: String): Tracer = tracerBuilder(instrumentationScopeName).build()
+
+    override fun get(instrumentationScopeName: String, instrumentationScopeVersion: String): Tracer =
+        tracerBuilder(instrumentationScopeName).setInstrumentationVersion(instrumentationScopeVersion).build()
+
+    override fun tracerBuilder(instrumentationScopeName: String): TracerBuilder {
+        return EmbTracerBuilder(
+            instrumentationScopeName = instrumentationScopeName,
+            tracerSupplier = ::getTracer
+        )
+    }
+
+    private fun getTracer(key: TracerKey): Tracer {
+        return tracers[key]
+            ?: synchronized(tracers) {
+                return tracers[key] ?: createTracer(key)
+            }
+    }
+
+    private fun createTracer(key: TracerKey): Tracer {
+        val tracer = EmbTracer(
+            sdkTracer = buildSdkTracer(key),
+            spanService = spanService,
+            clock = clock
+        )
+        tracers[key] = tracer
+        return tracer
+    }
+
+    private fun buildSdkTracer(key: TracerKey): Tracer {
+        val builder = sdkTracerProvider.tracerBuilder(key.instrumentationScopeName)
+        key.instrumentationScopeVersion?.apply {
+            builder.setInstrumentationVersion(this)
+        }
+        key.schemaUrl?.apply {
+            builder.setSchemaUrl(this)
+        }
+        return builder.build()
+    }
+}
+
+internal data class TracerKey(
+    val instrumentationScopeName: String,
+    var instrumentationScopeVersion: String? = null,
+    var schemaUrl: String? = null
+)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.opentelemetry.TracerKey
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanBuilder
@@ -9,7 +10,8 @@ import io.opentelemetry.context.Context
 import java.util.concurrent.TimeUnit
 
 internal class FakeSpanBuilder(
-    val spanName: String
+    val spanName: String,
+    val tracerKey: TracerKey = TracerKey("fake-scope")
 ) : SpanBuilder {
 
     var spanKind: SpanKind? = null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracer.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracer.kt
@@ -1,7 +1,10 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.opentelemetry.TracerKey
 import io.opentelemetry.api.trace.Tracer
 
-internal class FakeTracer : Tracer {
-    override fun spanBuilder(spanName: String): FakeSpanBuilder = FakeSpanBuilder(spanName)
+internal class FakeTracer(
+    val tracerKey: TracerKey = TracerKey(instrumentationScopeName = "fake-scope")
+) : Tracer {
+    override fun spanBuilder(spanName: String): FakeSpanBuilder = FakeSpanBuilder(spanName, tracerKey)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracerBuilder.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracerBuilder.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.opentelemetry.TracerKey
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.trace.TracerBuilder
+
+internal class FakeTracerBuilder(
+    val instrumentationScopeName: String
+) : TracerBuilder {
+
+    var scopeVersion: String? = null
+    var schema: String? = null
+
+    override fun setInstrumentationVersion(instrumentationScopeVersion: String): TracerBuilder {
+        scopeVersion = instrumentationScopeVersion
+        return this
+    }
+
+    override fun setSchemaUrl(schemaUrl: String): TracerBuilder {
+        schema = schemaUrl
+        return this
+    }
+
+    override fun build(): Tracer =
+        FakeTracer(
+            TracerKey(
+                instrumentationScopeName = instrumentationScopeName,
+                instrumentationScopeVersion = scopeVersion,
+                schemaUrl = schema
+            )
+        )
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracerProvider.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracerProvider.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.trace.TracerProvider
+
+internal class FakeTracerProvider : TracerProvider {
+    override fun get(instrumentationScopeName: String): Tracer = tracerBuilder(instrumentationScopeName).build()
+
+    override fun get(instrumentationScopeName: String, instrumentationScopeVersion: String): Tracer =
+        tracerBuilder(instrumentationScopeName).setInstrumentationVersion(instrumentationScopeVersion).build()
+
+    override fun tracerBuilder(instrumentationScopeName: String): FakeTracerBuilder = FakeTracerBuilder(instrumentationScopeName)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerBuilderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerBuilderTest.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.embrace.android.embracesdk.fakes.FakeTracer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class EmbTracerBuilderTest {
+
+    @Test
+    fun `check tracer attributes from builder`() {
+        val expectedKey = TracerKey("foo", "v1", "url")
+        val embTracerBuilder = EmbTracerBuilder(
+            instrumentationScopeName = "foo",
+            tracerSupplier = ::createTracer
+        )
+
+        val tracer = embTracerBuilder.setSchemaUrl("url").setInstrumentationVersion("v1").build() as FakeTracer
+        assertEquals(expectedKey, tracer.tracerKey)
+    }
+
+    private fun createTracer(key: TracerKey): FakeTracer = FakeTracer(tracerKey = key)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerProviderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerProviderTest.kt
@@ -1,0 +1,59 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
+import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.FakeTracerProvider
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class EmbTracerProviderTest {
+    private val clock = FakeClock()
+    private val openTelemetryClock = FakeOpenTelemetryClock(clock)
+
+    private lateinit var spanService: FakeSpanService
+    private lateinit var sdkTracerProvider: FakeTracerProvider
+    private lateinit var embTracerProvider: EmbTracerProvider
+
+    @Before
+    fun setup() {
+        spanService = FakeSpanService()
+        sdkTracerProvider = FakeTracerProvider()
+        embTracerProvider = EmbTracerProvider(
+            sdkTracerProvider = sdkTracerProvider,
+            spanService = spanService,
+            clock = openTelemetryClock
+        )
+    }
+
+    @Test
+    fun `same instrumentation scope names return the same tracer instance`() {
+        val tracer = embTracerProvider.get("foo")
+        assertTrue(tracer is EmbTracer)
+        val dupeTracer = embTracerProvider.get("foo")
+        val differentTracer = embTracerProvider.get("food")
+        assertSame(tracer, dupeTracer)
+        assertNotSame(tracer, differentTracer)
+    }
+
+    @Test
+    fun `same instrumentation scope version return the same tracer instance`() {
+        val tracer = embTracerProvider.get("foo", "v1")
+        val dupeTracer = embTracerProvider.get("foo", "v1")
+        val differentTracer = embTracerProvider.get("foo", "v2")
+        assertSame(tracer, dupeTracer)
+        assertNotSame(tracer, differentTracer)
+    }
+
+    @Test
+    fun `same instrumentation schema url returns the same tracer instance`() {
+        val tracer = embTracerProvider.tracerBuilder("foo").setSchemaUrl("url1").build()
+        val dupeTracer = embTracerProvider.tracerBuilder("foo").setSchemaUrl("url1").build()
+        val differentTracer = embTracerProvider.tracerBuilder("foo").setSchemaUrl("url2").build()
+        assertSame(tracer, dupeTracer)
+        assertNotSame(tracer, differentTracer)
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbTracerTest.kt
@@ -1,0 +1,42 @@
+package io.embrace.android.embracesdk.opentelemetry
+
+import io.embrace.android.embracesdk.arch.schema.EmbType
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
+import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.FakeTracer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+internal class EmbTracerTest {
+    private val clock = FakeClock()
+    private val openTelemetryClock = FakeOpenTelemetryClock(clock)
+
+    private lateinit var spanService: FakeSpanService
+    private lateinit var sdkTracer: FakeTracer
+    private lateinit var tracer: EmbTracer
+
+    @Before
+    fun setup() {
+        spanService = FakeSpanService()
+        sdkTracer = FakeTracer()
+        tracer = EmbTracer(
+            sdkTracer = sdkTracer,
+            spanService = spanService,
+            clock = openTelemetryClock,
+        )
+    }
+
+    @Test
+    fun `check span generated with default parameters`() {
+        tracer.spanBuilder("foo").startSpan().end()
+        val fakeCreatedSpan = spanService.createdSpans.single()
+        with(fakeCreatedSpan) {
+            assertNull(parent)
+            assertEquals("foo", name)
+            assertEquals(EmbType.Performance.Default, type)
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Create implementations for the OTel Span APIs that allow the creation of unique `Tracer` instances that are tied to a specific instrumentation source. This way, the Embrace SDK can create `Tracer` instances on behalf of third party instrumentations so that it can identify itself as the instrumentation scope for the telemetry recorded by it.

## Testing
Unit tests at every layer

