### PR TITLE
Refactor attribute storage in EmbraceSpan and EmbraceSpanBuilder

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.arch.destination.SpanEventData
 import io.embrace.android.embracesdk.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setFixedAttribute
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.opentelemetry.embSessionId
@@ -70,7 +69,7 @@ internal class CurrentSessionSpanImpl(
     }
 
     override fun getSessionId(): String {
-        return sessionSpan.get()?.getAttribute(embSessionId) ?: ""
+        return sessionSpan.get()?.getSystemAttribute(embSessionId) ?: ""
     }
 
     override fun endSession(appTerminationCause: AppTerminationCause?): List<EmbraceSpanData> {
@@ -91,7 +90,7 @@ internal class CurrentSessionSpanImpl(
             } else {
                 val crashTime = openTelemetryClock.now().nanosToMillis()
                 spanRepository.failActiveSpans(crashTime)
-                endingSessionSpan.setFixedAttribute(appTerminationCause)
+                endingSessionSpan.setSystemAttribute(appTerminationCause.key, appTerminationCause.value)
                 endingSessionSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
             }
             return spanSink.flushSpans()
@@ -136,7 +135,7 @@ internal class CurrentSessionSpanImpl(
             private = false
         ).apply {
             start(startTimeMs = startTimeMs)
-            addAttribute(embSessionId.name, Uuid.getEmbUuid())
+            setSystemAttribute(embSessionId, Uuid.getEmbUuid())
         }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
@@ -29,8 +29,9 @@ internal class EmbraceSpanBuilder(
         name
     }
 
-    private val fixedAttributes = mutableListOf<FixedAttribute>(telemetryType)
     private val otelSpanBuilder = tracer.spanBuilder(spanName)
+    private val fixedAttributes = mutableListOf<FixedAttribute>(telemetryType)
+    private val customAttributes = mutableMapOf<String, String>()
 
     init {
         // If there is a parent, extract the wrapped OTel span and set it as the parent in the wrapped OTel SpanBuilder
@@ -53,11 +54,10 @@ internal class EmbraceSpanBuilder(
     fun startSpan(startTimeMs: Long? = null): Span {
         startTimeMs?.apply { otelSpanBuilder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS) }
         val startedSpan = otelSpanBuilder.startSpan()
-        fixedAttributes.forEach { attribute ->
-            startedSpan.setFixedAttribute(attribute)
-        }
         return startedSpan
     }
 
     fun getFixedAttributes(): List<FixedAttribute> = fixedAttributes
+
+    fun getCustomAttributes(): Map<String, String> = customAttributes
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
@@ -70,7 +70,7 @@ internal class SpanRepository {
      * Stop the existing active spans and mark them as failed
      */
     fun failActiveSpans(failureTimeMs: Long) {
-        getActiveSpans().filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) }.forEach { span ->
+        getActiveSpans().filterNot { it.hasFixedAttribute(EmbType.Ux.Session) }.forEach { span ->
             span.stop(ErrorCode.FAILURE, failureTimeMs)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -18,12 +18,17 @@ internal interface PersistableEmbraceSpan : EmbraceSpan {
     /**
      * Checks to see if the given span has a particular [FixedAttribute]
      */
-    fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean
+    fun hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean
 
     /**
      * Get the value of the attribute with the given key. Returns null if the attribute does not exist.
      */
-    fun getAttribute(key: EmbraceAttributeKey): String?
+    fun getSystemAttribute(key: EmbraceAttributeKey): String?
+
+    /**
+     * Set the value of the attribute with the given key, overwriting the original value if it's already set
+     */
+    fun setSystemAttribute(key: EmbraceAttributeKey, value: String)
 
     /**
      * Remove the custom attribute with the given key name

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.EXCEPTION_EVENT_NAME
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.setFixedAttribute
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -66,7 +65,8 @@ internal class FakePersistableEmbraceSpan(
             status = if (errorCode == null) {
                 Span.Status.OK
             } else {
-                setFixedAttribute(errorCode.fromErrorCode())
+                val code = errorCode.fromErrorCode()
+                setSystemAttribute(code.key, code.value)
                 Span.Status.ERROR
             }
             spanEndTimeMs = endTimeMs ?: fakeClock.now()
@@ -124,10 +124,14 @@ internal class FakePersistableEmbraceSpan(
         }
     }
 
-    override fun hasEmbraceAttribute(fixedAttribute: FixedAttribute): Boolean =
+    override fun hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
         attributes.hasFixedAttribute(fixedAttribute)
 
-    override fun getAttribute(key: EmbraceAttributeKey): String? = attributes[key.name]
+    override fun getSystemAttribute(key: EmbraceAttributeKey): String? = attributes[key.name]
+
+    override fun setSystemAttribute(key: EmbraceAttributeKey, value: String) {
+        attributes[key.name] = value
+    }
 
     override fun removeCustomAttribute(key: String): Boolean = attributes.remove(key) != null
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -37,9 +37,9 @@ internal class EmbraceSpanFactoryImplTest {
         val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = false)
         assertTrue(span.start(clock.now()))
         with(span) {
-            assertTrue(hasEmbraceAttribute(EmbType.Performance.Default))
+            assertTrue(hasFixedAttribute(EmbType.Performance.Default))
             assertNull(parent)
-            assertFalse(hasEmbraceAttribute(PrivateSpan))
+            assertFalse(hasFixedAttribute(PrivateSpan))
             assertEquals("test", snapshot()?.name)
         }
         assertNotNull(spanRepository.getSpan(spanId = checkNotNull(span.spanId)))
@@ -50,9 +50,9 @@ internal class EmbraceSpanFactoryImplTest {
         val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = true)
         assertTrue(span.start(clock.now()))
         with(span) {
-            assertTrue(hasEmbraceAttribute(EmbType.Performance.Default))
+            assertTrue(hasFixedAttribute(EmbType.Performance.Default))
             assertNull(parent)
-            assertTrue(hasEmbraceAttribute(PrivateSpan))
+            assertTrue(hasFixedAttribute(PrivateSpan))
             assertEquals("emb-test", snapshot()?.name)
         }
     }
@@ -62,9 +62,9 @@ internal class EmbraceSpanFactoryImplTest {
         val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = true, private = false)
         assertTrue(span.start(clock.now()))
         with(span) {
-            assertTrue(hasEmbraceAttribute(EmbType.Performance.Default))
+            assertTrue(hasFixedAttribute(EmbType.Performance.Default))
             assertNull(parent)
-            assertFalse(hasEmbraceAttribute(PrivateSpan))
+            assertFalse(hasFixedAttribute(PrivateSpan))
             assertEquals("emb-test", snapshot()?.name)
         }
     }
@@ -82,9 +82,9 @@ internal class EmbraceSpanFactoryImplTest {
 
         with(embraceSpanFactory.create(embraceSpanBuilder = spanBuilder)) {
             assertTrue(start(clock.now()))
-            assertTrue(hasEmbraceAttribute(EmbType.System.LowPower))
+            assertTrue(hasFixedAttribute(EmbType.System.LowPower))
             assertEquals(spanParent, parent)
-            assertFalse(hasEmbraceAttribute(PrivateSpan))
+            assertFalse(hasFixedAttribute(PrivateSpan))
             assertEquals("from-span-builder", snapshot()?.name)
         }
     }


### PR DESCRIPTION
## Goal

Split storage of attributes in EmbraceSpan/EmbraceSpanBuilder into attributes that can only be modified by the SDK, and others that can be added and removed by SDK users ("system" vs "custom"). 

The PR splits the concepts at the level of the object, but some attributes are set on the "custom" map right now that will need to be refactored into storing it in the "system" map. That will come in a different PR

## Testing
Added more tests to verify new scenarios