### PR TITLE
Change storage and application of start time on wrappers

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
@@ -29,6 +29,7 @@ internal class EmbraceSpanBuilder(
         name
     }
 
+    var startTimeMs: Long? = null
     private val otelSpanBuilder = tracer.spanBuilder(spanName)
     private val fixedAttributes = mutableListOf<FixedAttribute>(telemetryType)
     private val customAttributes = mutableMapOf<String, String>()
@@ -51,10 +52,9 @@ internal class EmbraceSpanBuilder(
         }
     }
 
-    fun startSpan(startTimeMs: Long? = null): Span {
-        startTimeMs?.apply { otelSpanBuilder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS) }
-        val startedSpan = otelSpanBuilder.startSpan()
-        return startedSpan
+    fun startSpan(startTimeMs: Long): Span {
+        otelSpanBuilder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
+        return otelSpanBuilder.startSpan()
     }
 
     fun getFixedAttributes(): List<FixedAttribute> = fixedAttributes

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -69,7 +69,10 @@ internal class EmbraceSpanImpl(
             false
         } else {
             var successful: Boolean
-            val attemptedStartTimeMs = startTimeMs?.normalizeTimestampAsMillis() ?: openTelemetryClock.now().nanosToMillis()
+            val attemptedStartTimeMs = startTimeMs?.normalizeTimestampAsMillis()
+                ?: spanBuilder.startTimeMs
+                ?: openTelemetryClock.now().nanosToMillis()
+
             synchronized(startedSpan) {
                 startedSpan.set(spanBuilder.startSpan(attemptedStartTimeMs))
                 successful = spanStarted()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
@@ -36,7 +36,7 @@ internal class EmbraceSpanBuilderTest {
             assertTrue(contains(EmbType.Performance.Default))
             assertTrue(contains(KeySpan))
         }
-        val span = spanBuilder.startSpan()
+        val span = spanBuilder.startSpan(clock.now())
         assertTrue(span.isRecording)
         span.end()
         assertFalse(span.isRecording)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -344,6 +344,48 @@ internal class EmbraceSpanImplTest {
         }
     }
 
+    @Test
+    fun `start time from span start method overrides all`() {
+        val spanBuilder = tracer.embraceSpanBuilder(
+            name = EXPECTED_SPAN_NAME,
+            type = EmbType.System.LowPower,
+            internal = true,
+            private = true
+        )
+        spanBuilder.startTimeMs = fakeClock.tick()
+        embraceSpan = EmbraceSpanImpl(
+            spanBuilder = spanBuilder,
+            openTelemetryClock = openTelemetryClock,
+            spanRepository = spanRepository,
+        )
+
+        val timePassedIn = fakeClock.tick()
+        fakeClock.tick()
+        assertTrue(embraceSpan.start(startTimeMs = timePassedIn))
+        assertEquals(timePassedIn, embraceSpan.snapshot()?.startTimeUnixNano?.nanosToMillis())
+    }
+
+    @Test
+    fun `start time from span builder used if no start time passed into start method`() {
+        val spanBuilder = tracer.embraceSpanBuilder(
+            name = EXPECTED_SPAN_NAME,
+            type = EmbType.System.LowPower,
+            internal = true,
+            private = true
+        )
+
+        val timeOnSpanBuilder = fakeClock.tick()
+        spanBuilder.startTimeMs = timeOnSpanBuilder
+        embraceSpan = EmbraceSpanImpl(
+            spanBuilder = spanBuilder,
+            openTelemetryClock = openTelemetryClock,
+            spanRepository = spanRepository,
+        )
+        fakeClock.tick()
+        assertTrue(embraceSpan.start())
+        assertEquals(timeOnSpanBuilder, embraceSpan.snapshot()?.startTimeUnixNano?.nanosToMillis())
+    }
+
     private fun EmbraceSpanImpl.assertSnapshot(
         expectedStartTimeMs: Long,
         expectedEndTimeMs: Long? = null,


### PR DESCRIPTION
## Goal

Require span start time to be passed in when `EmbraceSpanBuilder.startSpan()` is called. This puts a burden on `EmbraceSpan` to find the current time if one isn't passed into it - or use the one set on EmbraceSpanBuilder if one was provided already, though still leaving the start time explicitly set on the EmbraceSpanImpl to override that.

## Testing
Covered mostly by existing tests. New one added to test to overridding.
