### PR TITLE
Add ability to reset parent and add SpanKind to EmbraceSpanBuilder

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpan.kt
@@ -1,0 +1,67 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.IdGenerator
+import java.util.concurrent.TimeUnit
+
+internal class FakeSpan(
+    val fakeSpanBuilder: FakeSpanBuilder
+) : Span {
+
+    private val spanContext: SpanContext =
+        SpanContext.create(
+            if (fakeSpanBuilder.parentContext == Context.root()) {
+                IdGenerator.random().generateTraceId()
+            } else {
+                Span.fromContext(fakeSpanBuilder.parentContext).spanContext.traceId
+            },
+            IdGenerator.random().generateSpanId(),
+            TraceFlags.getDefault(),
+            TraceState.getDefault()
+        )
+
+    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T): Span {
+        TODO("Not yet implemented")
+    }
+
+    override fun addEvent(name: String, attributes: Attributes): Span {
+        TODO("Not yet implemented")
+    }
+
+    override fun addEvent(name: String, attributes: Attributes, timestamp: Long, unit: TimeUnit): Span {
+        TODO("Not yet implemented")
+    }
+
+    override fun setStatus(statusCode: StatusCode, description: String): Span {
+        TODO("Not yet implemented")
+    }
+
+    override fun recordException(exception: Throwable, additionalAttributes: Attributes): Span {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateName(name: String): Span {
+        TODO("Not yet implemented")
+    }
+
+    override fun end() {
+        TODO("Not yet implemented")
+    }
+
+    override fun end(timestamp: Long, unit: TimeUnit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSpanContext(): SpanContext = spanContext
+
+    override fun isRecording(): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
@@ -1,0 +1,68 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.context.Context
+import java.util.concurrent.TimeUnit
+
+internal class FakeSpanBuilder(
+    val spanName: String
+) : SpanBuilder {
+
+    var spanKind: SpanKind? = null
+    var parentContext: Context = Context.root()
+    var startTimestampMs: Long? = null
+
+    override fun setParent(context: Context): SpanBuilder {
+        this.parentContext = context
+        return this
+    }
+
+    override fun setNoParent(): SpanBuilder {
+        this.parentContext = Context.root()
+        return this
+    }
+
+    override fun addLink(spanContext: SpanContext): SpanBuilder {
+        TODO("Not yet implemented")
+    }
+
+    override fun addLink(spanContext: SpanContext, attributes: Attributes): SpanBuilder {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAttribute(key: String, value: String): SpanBuilder {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAttribute(key: String, value: Long): SpanBuilder {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAttribute(key: String, value: Double): SpanBuilder {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAttribute(key: String, value: Boolean): SpanBuilder {
+        TODO("Not yet implemented")
+    }
+
+    override fun setSpanKind(spanKind: SpanKind): SpanBuilder {
+        this.spanKind = spanKind
+        return this
+    }
+
+    override fun setStartTimestamp(startTimestamp: Long, unit: TimeUnit): SpanBuilder {
+        startTimestampMs = unit.toMillis(startTimestamp)
+        return this
+    }
+
+    override fun startSpan(): FakeSpan = FakeSpan(this)
+
+    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T): SpanBuilder {
+        TODO("Not yet implemented")
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracer.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeTracer.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.opentelemetry.api.trace.Tracer
+
+internal class FakeTracer : Tracer {
+    override fun spanBuilder(spanName: String): FakeSpanBuilder = FakeSpanBuilder(spanName)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilderTest.kt
@@ -4,41 +4,158 @@ import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.KeySpan
 import io.embrace.android.embracesdk.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.opentelemetry.api.trace.Tracer
+import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeSpan
+import io.embrace.android.embracesdk.fakes.FakeTracer
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.context.Context
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 internal class EmbraceSpanBuilderTest {
     private val clock = FakeClock()
-    private lateinit var tracer: Tracer
+    private lateinit var tracer: FakeTracer
 
     @Before
     fun setup() {
-        val initModule = FakeInitModule(clock)
-        tracer = initModule.openTelemetryModule.tracer
+        tracer = FakeTracer()
     }
 
     @Test
-    fun `check public span creation`() {
+    fun `check private and internal span creation`() {
         val spanBuilder = EmbraceSpanBuilder(
             tracer = tracer,
             name = "test",
             telemetryType = EmbType.Performance.Default,
-            internal = false,
+            internal = true,
             private = true,
             parent = null,
         )
+        val originalStartTime = clock.now()
+        spanBuilder.startTimeMs = originalStartTime
+        val startTime = clock.tick()
         with(spanBuilder.getFixedAttributes().toSet()) {
             assertTrue(contains(PrivateSpan))
             assertTrue(contains(EmbType.Performance.Default))
             assertTrue(contains(KeySpan))
         }
-        val span = spanBuilder.startSpan(clock.now())
-        assertTrue(span.isRecording)
-        span.end()
-        assertFalse(span.isRecording)
+        assertEquals("emb-test", spanBuilder.spanName)
+        spanBuilder.startSpan(startTime).assertFakeSpanBuilder(
+            expectedName = "emb-test",
+            expectedStartTimeMs = startTime
+        )
+        assertEquals(originalStartTime, spanBuilder.startTimeMs)
+    }
+
+    @Test
+    fun `add parent after initial creation`() {
+        val spanBuilder = EmbraceSpanBuilder(
+            tracer = tracer,
+            name = "test",
+            telemetryType = EmbType.Performance.Default,
+            internal = false,
+            private = false,
+            parent = null,
+        )
+        val parent = tracer.spanBuilder("parent-span").startSpan()
+        val parentContext = Context.current().with(parent)
+        spanBuilder.setParent(parentContext)
+        with(spanBuilder.getFixedAttributes().toSet()) {
+            assertFalse(contains(KeySpan))
+        }
+        val startTime = clock.now()
+        spanBuilder.startSpan(startTime).assertFakeSpanBuilder(
+            expectedName = "test",
+            expectedParentContext = parentContext,
+            expectedStartTimeMs = startTime,
+            expectedTraceId = parent.spanContext.traceId
+        )
+    }
+
+    @Test
+    fun `remove parent after initial creation`() {
+        val parent = FakePersistableEmbraceSpan.started()
+        val startTime = clock.now()
+        val spanBuilder = EmbraceSpanBuilder(
+            tracer = tracer,
+            name = "test",
+            telemetryType = EmbType.Performance.Default,
+            internal = false,
+            private = false,
+            parent = parent,
+        )
+
+        assertNull(spanBuilder.getFixedAttributes().find { it == KeySpan })
+        spanBuilder.setNoParent()
+        assertNotNull(spanBuilder.getFixedAttributes().find { it == KeySpan })
+        with(spanBuilder.startSpan(startTime)) {
+            assertFakeSpanBuilder(
+                expectedName = "test",
+                expectedStartTimeMs = startTime
+            )
+        }
+
+        val uxSpanBuilder = EmbraceSpanBuilder(
+            tracer = tracer,
+            name = "ux-test",
+            telemetryType = EmbType.Ux.View,
+            internal = false,
+            private = false,
+            parent = parent,
+        )
+
+        assertNull(uxSpanBuilder.getFixedAttributes().find { it == KeySpan })
+        uxSpanBuilder.setNoParent()
+        assertNull(uxSpanBuilder.getFixedAttributes().find { it == KeySpan })
+        with(uxSpanBuilder.startSpan(startTime)) {
+            assertFakeSpanBuilder(
+                expectedName = "ux-test",
+                expectedStartTimeMs = startTime
+            )
+        }
+    }
+
+    @Test
+    fun `add span kind`() {
+        val spanBuilder = EmbraceSpanBuilder(
+            tracer = tracer,
+            name = "test",
+            telemetryType = EmbType.Performance.Default,
+            internal = false,
+            private = false,
+            parent = null,
+        )
+        val startTime = clock.now()
+        spanBuilder.setSpanKind(SpanKind.CLIENT)
+        spanBuilder.startSpan(startTime).assertFakeSpanBuilder(
+            expectedName = "test",
+            expectedStartTimeMs = startTime,
+            expectedSpanKind = SpanKind.CLIENT
+        )
+    }
+
+    private fun Span.assertFakeSpanBuilder(
+        expectedName: String,
+        expectedParentContext: Context = Context.root(),
+        expectedSpanKind: SpanKind? = null,
+        expectedStartTimeMs: Long,
+        expectedTraceId: String? = null
+    ) {
+        val fakeSpan = this as FakeSpan
+        with(fakeSpan.fakeSpanBuilder) {
+            assertEquals(expectedName, spanName)
+            assertEquals(expectedParentContext, parentContext)
+            assertEquals(expectedSpanKind, spanKind)
+            assertEquals(expectedStartTimeMs, startTimestampMs)
+            if (expectedTraceId != null) {
+                assertEquals(expectedTraceId, spanContext.traceId)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Goal

Let the parent be changed on an `EmbraceSpanBuilder` so that the eventual OTel SpanBuilder wrapper can propagate the change down here.

As well, we will allow `spanKind` to be set in the underlying SDK implementation through `EmbraceSpanBuilder`. While it won't be shown in Embrace and we won't use it, the exported span will have this set properly.

## Testing
Added unit tests to verify the calls into the wrapped implementation of SpanBuilder. To facilitate this, a bunch of fakes were added.

