### PR TITLE
Specify end time for in progress anrs

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AnrFeatureTest.kt
@@ -148,7 +148,7 @@ internal class AnrFeatureTest {
             // assert ANRs received
             val spans = message.findAnrSpans()
             val span = spans.single()
-            assertAnrReceived(span, START_TIME_MS, sampleCount, endTime = 0)
+            assertAnrReceived(span, START_TIME_MS, sampleCount, endTime = 10000032000)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.anr
 
 import io.embrace.android.embracesdk.arch.DataCaptureServiceOtelConverter
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -14,7 +15,8 @@ import io.opentelemetry.sdk.trace.IdGenerator
  * Maps captured ANRs to OTel constructs.
  */
 internal class AnrOtelMapper(
-    private val anrService: AnrService
+    private val anrService: AnrService,
+    private val clock: Clock
 ) : DataCaptureServiceOtelConverter {
 
     override fun snapshot(isFinalPayload: Boolean): List<Span> {
@@ -29,7 +31,7 @@ internal class AnrOtelMapper(
                 parentSpanId = SpanId.getInvalid(),
                 name = "emb-thread-blockage",
                 startTimeNanos = interval.startTime.millisToNanos(),
-                endTimeNanos = interval.endTime?.millisToNanos(),
+                endTimeNanos = (interval.endTime ?: clock.now()).millisToNanos(),
                 status = Span.Status.OK,
                 attributes = attrs,
                 events = events

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Types
 import io.embrace.android.embracesdk.arch.DataCaptureServiceOtelConverter
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -16,7 +17,8 @@ import io.opentelemetry.sdk.trace.IdGenerator
 
 internal class NativeAnrOtelMapper(
     private val nativeThreadSamplerService: NativeThreadSamplerService?,
-    private val serializer: EmbraceSerializer
+    private val serializer: EmbraceSerializer,
+    private val clock: Clock
 ) : DataCaptureServiceOtelConverter {
 
     override fun snapshot(isFinalPayload: Boolean): List<Span> {
@@ -35,6 +37,7 @@ internal class NativeAnrOtelMapper(
                 parentSpanId = SpanId.getInvalid(),
                 name = "emb_native_thread_blockage",
                 startTimeNanos = interval.threadBlockedTimestamp?.millisToNanos(),
+                endTimeNanos = clock.now().millisToNanos(),
                 status = Span.Status.OK,
                 attributes = attrs,
                 events = events

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/AnrModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/AnrModule.kt
@@ -56,7 +56,7 @@ internal class AnrModuleImpl(
     }
 
     override val anrOtelMapper: AnrOtelMapper by singleton {
-        AnrOtelMapper(anrService)
+        AnrOtelMapper(anrService, initModule.clock)
     }
 
     override val responsivenessMonitorService: ResponsivenessMonitorService by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeModule.kt
@@ -76,7 +76,7 @@ internal class NativeModuleImpl(
     }
 
     override val nativeAnrOtelMapper: NativeAnrOtelMapper by singleton {
-        NativeAnrOtelMapper(nativeThreadSamplerService, initModule.jsonSerializer)
+        NativeAnrOtelMapper(nativeThreadSamplerService, initModule.jsonSerializer, initModule.clock)
     }
 
     override val nativeThreadSamplerInstaller: NativeThreadSamplerInstaller? by singleton {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.anr.ndk
 
 import io.embrace.android.embracesdk.config.remote.AnrRemoteConfig
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeNativeThreadSamplerService
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.payload.Attribute
@@ -22,12 +23,12 @@ internal class NativeAnrOtelMapperTest {
     @Before
     fun setUp() {
         service = FakeNativeThreadSamplerService()
-        mapper = NativeAnrOtelMapper(service, EmbraceSerializer())
+        mapper = NativeAnrOtelMapper(service, EmbraceSerializer(), FakeClock())
     }
 
     @Test
     fun `disabled service`() {
-        val disabledMapper = NativeAnrOtelMapper(null, EmbraceSerializer())
+        val disabledMapper = NativeAnrOtelMapper(null, EmbraceSerializer(), FakeClock())
         assertEquals(emptyList<Span>(), disabledMapper.snapshot(false))
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAnrOtelMapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAnrOtelMapper.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.anr.AnrOtelMapper
+import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
+import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+
+internal fun fakeAnrOtelMapper() = AnrOtelMapper(FakeAnrService(), FakeClock())
+internal fun fakeNativeAnrOtelMapper() = NativeAnrOtelMapper(null, EmbraceSerializer(), FakeClock())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.anr.sigquit.SigquitDataSource
 import io.embrace.android.embracesdk.capture.monitor.NoOpResponsivenessMonitorService
 import io.embrace.android.embracesdk.capture.monitor.ResponsivenessMonitorService
 import io.embrace.android.embracesdk.fakes.FakeAnrService
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.fakeAnrBehavior
 import io.embrace.android.embracesdk.injection.AnrModule
@@ -15,7 +16,7 @@ import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 
 internal class FakeAnrModule(
     override val anrService: AnrService = FakeAnrService(),
-    override val anrOtelMapper: AnrOtelMapper = AnrOtelMapper(anrService),
+    override val anrOtelMapper: AnrOtelMapper = AnrOtelMapper(anrService, FakeClock()),
     override val responsivenessMonitorService: ResponsivenessMonitorService = NoOpResponsivenessMonitorService(),
     override val sigquitDataSource: SigquitDataSource = SigquitDataSource(
         SharedObjectLoader(EmbLoggerImpl()),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeNativeModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeNativeModule.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerInstaller
 import io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerService
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.ndk.NativeModule
 import io.embrace.android.embracesdk.ndk.NdkService
@@ -12,5 +13,5 @@ internal class FakeNativeModule(
     override val nativeThreadSamplerService: NativeThreadSamplerService? = null,
     override val nativeThreadSamplerInstaller: NativeThreadSamplerInstaller? = null,
     override val ndkService: NdkService = FakeNdkService(),
-    override val nativeAnrOtelMapper: NativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer())
+    override val nativeAnrOtelMapper: NativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer(), FakeClock())
 ) : NativeModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -3,8 +3,6 @@ package io.embrace.android.embracesdk.session
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.anr.AnrOtelMapper
-import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
@@ -15,7 +13,6 @@ import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.fakeBackgroundActivity
-import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -32,6 +29,8 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
+import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
+import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
@@ -178,8 +177,8 @@ internal class PayloadFactoryBaTest {
             currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService(),
-            AnrOtelMapper(FakeAnrService()),
-            NativeAnrOtelMapper(null, EmbraceSerializer()),
+            fakeAnrOtelMapper(),
+            fakeNativeAnrOtelMapper(),
             logger
         )
         val sessionEnvelopeSource = SessionEnvelopeSourceImpl(
@@ -198,8 +197,8 @@ internal class PayloadFactoryBaTest {
             currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService(),
-            AnrOtelMapper(FakeAnrService()),
-            NativeAnrOtelMapper(null, EmbraceSerializer()),
+            fakeAnrOtelMapper(),
+            fakeNativeAnrOtelMapper(),
             logger
         )
         return PayloadFactoryImpl(collator, v2Collator, configService, logger).apply {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -3,8 +3,6 @@ package io.embrace.android.embracesdk.session
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.anr.AnrOtelMapper
-import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorService
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
@@ -14,7 +12,6 @@ import io.embrace.android.embracesdk.config.LocalConfigParser
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -30,6 +27,8 @@ import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
+import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
@@ -188,8 +187,8 @@ internal class PayloadFactorySessionTest {
             currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService(),
-            AnrOtelMapper(FakeAnrService()),
-            NativeAnrOtelMapper(null, EmbraceSerializer()),
+            fakeAnrOtelMapper(),
+            fakeNativeAnrOtelMapper(),
             logger
         )
         service = PayloadFactoryImpl(v1Collator, v2Collator, FakeConfigService(), logger)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -3,8 +3,6 @@ package io.embrace.android.embracesdk.session
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.anr.AnrOtelMapper
-import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.capture.internal.errors.EmbraceInternalErrorService
 import io.embrace.android.embracesdk.capture.webview.WebViewService
@@ -15,7 +13,6 @@ import io.embrace.android.embracesdk.config.local.SessionLocalConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -31,12 +28,13 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
+import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
+import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
@@ -158,8 +156,8 @@ internal class SessionHandlerTest {
             initModule.openTelemetryModule.currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService(),
-            AnrOtelMapper(FakeAnrService()),
-            NativeAnrOtelMapper(null, EmbraceSerializer()),
+            fakeAnrOtelMapper(),
+            fakeNativeAnrOtelMapper(),
             logger
         )
         val v2Collator = V2PayloadMessageCollator(
@@ -177,8 +175,8 @@ internal class SessionHandlerTest {
             currentSessionSpan,
             FakeSessionPropertiesService(),
             FakeStartupService(),
-            AnrOtelMapper(FakeAnrService()),
-            NativeAnrOtelMapper(null, EmbraceSerializer()),
+            fakeAnrOtelMapper(),
+            fakeNativeAnrOtelMapper(),
             logger,
         )
         payloadFactory = PayloadFactoryImpl(payloadMessageCollator, v2Collator, configService, logger)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/V1PayloadMessageCollatorTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.FakeAnrService
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
@@ -54,6 +55,7 @@ internal class V1PayloadMessageCollatorTest {
             data = listOf(fakeCompletedAnrInterval, fakeInProgressAnrInterval)
         }
 
+        val clock = FakeClock()
         collator = V1PayloadMessageCollator(
             gatingService = gatingService,
             nativeThreadSamplerService = null,
@@ -69,8 +71,8 @@ internal class V1PayloadMessageCollatorTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
-            anrOtelMapper = AnrOtelMapper(anrService),
-            nativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer()),
+            anrOtelMapper = AnrOtelMapper(anrService, clock),
+            nativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer(), clock),
             logger = initModule.logger
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -1,12 +1,9 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.anr.AnrOtelMapper
-import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.config.remote.OTelRemoteConfig
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
@@ -18,9 +15,10 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
+import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
+import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.fakeOTelBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState.FOREGROUND
 import org.junit.Before
@@ -56,8 +54,8 @@ internal class PayloadFactoryImplTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
-            anrOtelMapper = AnrOtelMapper(FakeAnrService()),
-            nativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer()),
+            anrOtelMapper = fakeAnrOtelMapper(),
+            nativeAnrOtelMapper = fakeNativeAnrOtelMapper(),
             logger = initModule.logger
         )
         val v2Collator = V2PayloadMessageCollator(
@@ -70,8 +68,8 @@ internal class PayloadFactoryImplTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
-            anrOtelMapper = AnrOtelMapper(FakeAnrService()),
-            nativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer()),
+            anrOtelMapper = fakeAnrOtelMapper(),
+            nativeAnrOtelMapper = fakeNativeAnrOtelMapper(),
             logger = initModule.logger,
             sessionEnvelopeSource = SessionEnvelopeSourceImpl(
                 FakeEnvelopeMetadataSource(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/V2PayloadMessageCollatorTest.kt
@@ -1,10 +1,7 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.anr.AnrOtelMapper
-import io.embrace.android.embracesdk.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSourceImpl
-import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeEventService
@@ -15,9 +12,10 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
+import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
+import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.payload.LegacyExceptionError
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
@@ -60,8 +58,8 @@ internal class V2PayloadMessageCollatorTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
-            anrOtelMapper = AnrOtelMapper(FakeAnrService()),
-            nativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer()),
+            anrOtelMapper = fakeAnrOtelMapper(),
+            nativeAnrOtelMapper = fakeNativeAnrOtelMapper(),
             logger = initModule.logger
         )
         val sessionEnvelopeSource = SessionEnvelopeSourceImpl(
@@ -79,8 +77,8 @@ internal class V2PayloadMessageCollatorTest {
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
             sessionPropertiesService = FakeSessionPropertiesService(),
             startupService = FakeStartupService(),
-            anrOtelMapper = AnrOtelMapper(FakeAnrService()),
-            nativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer()),
+            anrOtelMapper = fakeAnrOtelMapper(),
+            nativeAnrOtelMapper = fakeNativeAnrOtelMapper(),
             logger = initModule.logger,
             sessionEnvelopeSource = sessionEnvelopeSource
         )


### PR DESCRIPTION
## Goal

Specifies an end time for ANRs that are in-progress if one does not already exist. Ordinarily the OTel infrastructure would take care of this, but we've chosen to go outside of that for ANRs.

## Testing

Updated unit test coverage.

