### PR TITLE
Store and use EmbraceSpan in an OTel Context object 

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -65,7 +65,7 @@ internal fun Tracer.embraceSpanBuilder(
     telemetryType = type,
     internal = internal,
     private = private,
-    parent = parent,
+    parentSpan = parent,
 )
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -51,7 +51,7 @@ internal class EmbraceSpanImpl(
     // do the bookkeeping separately so we don't have to worry about this
     private val eventCount = AtomicInteger(0)
 
-    override val parent: EmbraceSpan? = spanBuilder.parent
+    override val parent: EmbraceSpan? = spanBuilder.getParentSpan()
 
     override val spanContext: SpanContext?
         get() = startedSpan.get()?.spanContext

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -51,7 +51,7 @@ internal class SpanServiceImpl(
     override fun createSpan(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan? {
         return if (
             inputsValid(embraceSpanBuilder.spanName) &&
-            currentSessionSpan.canStartNewSpan(embraceSpanBuilder.parent, embraceSpanBuilder.internal)
+            currentSessionSpan.canStartNewSpan(embraceSpanBuilder.getParentSpan(), embraceSpanBuilder.internal)
         ) {
             embraceSpanFactory.create(embraceSpanBuilder)
         } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -5,11 +5,13 @@ import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import io.opentelemetry.context.ImplicitContextKeyed
 
 /**
  * An [EmbraceSpan] that has can generate a snapshot of its current state for persistence
  */
-internal interface PersistableEmbraceSpan : EmbraceSpan {
+internal interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
 
     /**
      * Create a new [Context] object based in this span and its parent's context. This can be used for the parent [Context] for a new span
@@ -46,4 +48,10 @@ internal interface PersistableEmbraceSpan : EmbraceSpan {
      * Removes all events with the given [EmbType]
      */
     fun removeEvents(type: EmbType): Boolean
+
+    override fun storeInContext(context: Context): Context = context.with(embraceSpanContextKey, this)
 }
+
+internal fun Context.getParentSpan(): PersistableEmbraceSpan? = get(embraceSpanContextKey)
+
+private val embraceSpanContextKey = ContextKey.named<PersistableEmbraceSpan>("embrace-span-key")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -40,7 +40,7 @@ internal class FakePersistableEmbraceSpan(
     var spanStartTimeMs: Long? = null
     var spanEndTimeMs: Long? = null
     var status = Span.Status.UNSET
-    var sdkSpan: io.opentelemetry.api.trace.Span? = null
+    private var sdkSpan: io.opentelemetry.api.trace.Span? = null
 
     override var spanContext: SpanContext? = null
 
@@ -124,7 +124,7 @@ internal class FakePersistableEmbraceSpan(
         return true
     }
 
-    override fun asNewContext(): Context? = sdkSpan?.run { parentContext.with(this) }
+    override fun asNewContext(): Context? = sdkSpan?.let { parentContext.with(this).with(it) }
 
     override fun snapshot(): Span? {
         return if (spanId == null) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSpan.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.spans.getParentSpan
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -7,7 +8,6 @@ import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.TraceFlags
 import io.opentelemetry.api.trace.TraceState
-import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.trace.IdGenerator
 import java.util.concurrent.TimeUnit
 
@@ -17,11 +17,7 @@ internal class FakeSpan(
 
     private val spanContext: SpanContext =
         SpanContext.create(
-            if (fakeSpanBuilder.parentContext == Context.root()) {
-                IdGenerator.random().generateTraceId()
-            } else {
-                Span.fromContext(fakeSpanBuilder.parentContext).spanContext.traceId
-            },
+            fakeSpanBuilder.parentContext.getParentSpan()?.traceId ?: IdGenerator.random().generateTraceId(),
             IdGenerator.random().generateSpanId(),
             TraceFlags.getDefault(),
             TraceState.getDefault()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -396,7 +396,7 @@ internal class EmbraceSpanImplTest {
             private = true
         )
         val newParentContext = spanBuilder.parentContext.with(fakeContextKey, "fake-value")
-        spanBuilder.setParent(newParentContext)
+        spanBuilder.setParentContext(newParentContext)
 
         embraceSpan = EmbraceSpanImpl(
             spanBuilder = spanBuilder,


### PR DESCRIPTION
## Goal

OTel's span parents are set by passing in a Context object with the appropriate parent span stashed inside it. Because our wrapper relies an instance of `EmbraceSpan` to do this within our API, it has to be compatible with the way OTel does it when we do an OTel SpanBuilder API implementation (next PR).

Therefore, we will add support now, so we look in the context for the parent `EmbraceSpan` behind the scenes in `EmbraceSpanBuilder`, and make sure it is stashed there so when a `Context` that is populated with an OTel span, as long as it's done via the Embrace distribution, it will also contain an `EmbraceSpan`, so the APIs can inter-op.

## Testing

Most of this is covered by existing test cases, but we also make sure to test that context objects in general are propagated

In the next PR, when we can start using an Embrace version of the SpanBuilder OTel API to set a context to set a parent span, then we can test the inter-op working properly.
