### PR TITLE
Create session zygote class

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
@@ -2,7 +2,10 @@ package io.embrace.android.embracesdk.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getSentBackgroundActivities
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.opentelemetry.embSessionNumber
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifyBgActivityMessage
 import org.junit.Assert.assertEquals
@@ -35,12 +38,14 @@ internal class BackgroundActivityTest {
             // verify first bg activity
             val first = bgActivities[0]
             verifyBgActivityMessage(first)
-            assertEquals(1, first.session.number)
+            val firstAttrs = checkNotNull(first.findSessionSpan().attributes)
+            assertEquals("1", firstAttrs.findAttributeValue(embSessionNumber.name))
 
             // verify second bg activity
             val second = bgActivities[1]
             verifyBgActivityMessage(second)
-            assertEquals(2, second.session.number)
+            val secondAttrs = checkNotNull(second.findSessionSpan().attributes)
+            assertEquals("2", secondAttrs.findAttributeValue(embSessionNumber.name))
 
             // ID should be different for each
             assertNotEquals(first.session.sessionId, second.session.sessionId)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -5,7 +5,10 @@ import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getSentSessions
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.opentelemetry.embSessionNumber
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifySessionHappened
 import org.junit.Assert.assertEquals
@@ -43,8 +46,12 @@ internal class ManualSessionTest {
             val manualSession = messages[1] // started manually, ended via state
             verifySessionHappened(stateSession)
             verifySessionHappened(manualSession)
-            assertEquals(1, stateSession.session.number)
-            assertEquals(2, manualSession.session.number)
+
+            val stateAttrs = checkNotNull(stateSession.findSessionSpan().attributes)
+            assertEquals("1", stateAttrs.findAttributeValue(embSessionNumber.name))
+
+            val manualAttrs = checkNotNull(manualSession.findSessionSpan().attributes)
+            assertEquals("2", manualAttrs.findAttributeValue(embSessionNumber.name))
         }
     }
 
@@ -76,7 +83,8 @@ internal class ManualSessionTest {
             }
             val message = harness.getSentSessions().single()
             verifySessionHappened(message)
-            assertEquals(1, message.session.number)
+            val attrs = checkNotNull(message.findSessionSpan().attributes)
+            assertEquals("1", attrs.findAttributeValue(embSessionNumber.name))
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SequentialSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SequentialSessionTest.kt
@@ -2,6 +2,10 @@ package io.embrace.android.embracesdk.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.findSessionSpan
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.opentelemetry.embColdStart
+import io.embrace.android.embracesdk.opentelemetry.embSessionNumber
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -27,12 +31,17 @@ internal class SequentialSessionTest {
             val second = checkNotNull(harness.recordSession())
             val third = checkNotNull(harness.recordSession())
 
-            assertEquals(1, first.session.number)
-            assertEquals(2, second.session.number)
-            assertEquals(3, third.session.number)
-            assertTrue(first.session.isColdStart)
-            assertFalse(second.session.isColdStart)
-            assertFalse(third.session.isColdStart)
+            val firstAttrs = checkNotNull(first.findSessionSpan().attributes)
+            assertEquals("1", firstAttrs.findAttributeValue(embSessionNumber.name))
+            assertTrue(firstAttrs.findAttributeValue(embColdStart.name).toBoolean())
+
+            val secondAttrs = checkNotNull(second.findSessionSpan().attributes)
+            assertEquals("2", secondAttrs.findAttributeValue(embSessionNumber.name))
+            assertFalse(secondAttrs.findAttributeValue(embColdStart.name).toBoolean())
+
+            val thirdAttrs = checkNotNull(third.findSessionSpan().attributes)
+            assertEquals("3", thirdAttrs.findAttributeValue(embSessionNumber.name))
+            assertFalse(thirdAttrs.findAttributeValue(embColdStart.name).toBoolean())
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
@@ -2,7 +2,10 @@ package io.embrace.android.embracesdk.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getSentSessions
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifySessionHappened
@@ -43,7 +46,8 @@ internal class StatefulSessionTest {
             val messages = testRule.harness.getSentSessions()
             val first = messages[0]
             verifySessionHappened(first)
-            assertEquals(LifeEventType.STATE, first.session.startType)
+            val attrs = checkNotNull(first.findSessionSpan().attributes)
+            assertEquals(LifeEventType.STATE.name.toLowerCase(), attrs.findAttributeValue("emb.session_start_type"))
             assertEquals(LifeEventType.STATE, first.session.endType)
 
             // verify second session

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
@@ -22,21 +22,6 @@ internal data class Session @JvmOverloads internal constructor(
     val startTime: Long,
 
     /**
-     * The ordinal of the session, starting from 1.
-     */
-    @Json(name = "sn")
-    val number: Int,
-
-    /**
-     * Application state for this session (foreground or background)
-     */
-    @Json(name = "as")
-    val appState: String,
-
-    @Json(name = "cs")
-    val isColdStart: Boolean,
-
-    /**
      * The time that the session ended.
      */
     @Json(name = "et")
@@ -68,9 +53,6 @@ internal data class Session @JvmOverloads internal constructor(
 
     @Json(name = "em")
     val endType: LifeEventType? = null,
-
-    @Json(name = "sm")
-    val startType: LifeEventType? = null,
 
     @Json(name = "sd")
     val startupDuration: Long? = null,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionZygote.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/SessionZygote.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.embracesdk.payload
+
+/**
+ * A precursor object that holds state associated with a newly started session.
+ */
+internal data class SessionZygote(
+
+    /**
+     * A unique ID which identifies the session.
+     */
+    val sessionId: String,
+
+    /**
+     * The time that the session started.
+     */
+    val startTime: Long,
+
+    /**
+     * The ordinal of the session, starting from 1.
+     */
+    val number: Int,
+
+    /**
+     * Application state for this session (foreground or background)
+     */
+    val appState: String,
+
+    /**
+     * Whether the session is a cold start or not.
+     */
+    val isColdStart: Boolean,
+
+    /**
+     * The type of start event that triggered this session.
+     */
+    val startType: Session.LifeEventType
+) {
+
+    companion object {
+        fun SessionZygote.toSession() = Session(
+            sessionId = sessionId,
+            startTime = startTime
+        )
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
@@ -12,7 +13,7 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
  * sent to the backend.
  */
 internal sealed class FinalEnvelopeParams(
-    val initial: Session,
+    val initial: SessionZygote,
     val endTime: Long,
     val lifeEventType: Session.LifeEventType?,
     crashId: String?,
@@ -36,7 +37,7 @@ internal sealed class FinalEnvelopeParams(
      * Initial parameters required to create a background activity object.
      */
     internal class BackgroundActivityParams(
-        initial: Session,
+        initial: SessionZygote,
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,
@@ -63,7 +64,7 @@ internal sealed class FinalEnvelopeParams(
      * Initial parameters required to create a session object.
      */
     internal class SessionParams(
-        initial: Session,
+        initial: SessionZygote,
         endTime: Long,
         lifeEventType: Session.LifeEventType?,
         endType: SessionSnapshotType,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactory.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.session.message
 
-import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 
 /**
@@ -12,12 +12,12 @@ internal interface PayloadFactory {
     /**
      * Starts a session in response to a state event.
      */
-    fun startPayloadWithState(state: ProcessState, timestamp: Long, coldStart: Boolean): Session?
+    fun startPayloadWithState(state: ProcessState, timestamp: Long, coldStart: Boolean): SessionZygote?
 
     /**
      * Ends a session in response to a state event.
      */
-    fun endPayloadWithState(state: ProcessState, timestamp: Long, initial: Session): SessionMessage?
+    fun endPayloadWithState(state: ProcessState, timestamp: Long, initial: SessionZygote): SessionMessage?
 
     /**
      * Handles an uncaught exception, ending the session and saving the session to disk.
@@ -25,22 +25,22 @@ internal interface PayloadFactory {
     fun endPayloadWithCrash(
         state: ProcessState,
         timestamp: Long,
-        initial: Session,
+        initial: SessionZygote,
         crashId: String
     ): SessionMessage?
 
     /**
      * Provides a snapshot of the active session
      */
-    fun snapshotPayload(state: ProcessState, timestamp: Long, initial: Session): SessionMessage?
+    fun snapshotPayload(state: ProcessState, timestamp: Long, initial: SessionZygote): SessionMessage?
 
     /**
      * Starts a session manually.
      */
-    fun startSessionWithManual(timestamp: Long): Session
+    fun startSessionWithManual(timestamp: Long): SessionZygote
 
     /**
      * Ends a session manually.
      */
-    fun endSessionWithManual(timestamp: Long, initial: Session): SessionMessage
+    fun endSessionWithManual(timestamp: Long, initial: SessionZygote): SessionMessage
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -2,9 +2,9 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.EmbLogger
-import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
@@ -20,7 +20,7 @@ internal class PayloadFactoryImpl(
             ProcessState.BACKGROUND -> startBackgroundActivityWithState(timestamp, coldStart)
         }
 
-    override fun endPayloadWithState(state: ProcessState, timestamp: Long, initial: Session) =
+    override fun endPayloadWithState(state: ProcessState, timestamp: Long, initial: SessionZygote) =
         when (state) {
             ProcessState.FOREGROUND -> endSessionWithState(initial, timestamp)
             ProcessState.BACKGROUND -> endBackgroundActivityWithState(initial, timestamp)
@@ -29,20 +29,20 @@ internal class PayloadFactoryImpl(
     override fun endPayloadWithCrash(
         state: ProcessState,
         timestamp: Long,
-        initial: Session,
+        initial: SessionZygote,
         crashId: String
     ) = when (state) {
         ProcessState.FOREGROUND -> endSessionWithCrash(initial, timestamp, crashId)
         ProcessState.BACKGROUND -> endBackgroundActivityWithCrash(initial, timestamp, crashId)
     }
 
-    override fun snapshotPayload(state: ProcessState, timestamp: Long, initial: Session) =
+    override fun snapshotPayload(state: ProcessState, timestamp: Long, initial: SessionZygote) =
         when (state) {
             ProcessState.FOREGROUND -> snapshotSession(initial, timestamp)
             ProcessState.BACKGROUND -> snapshotBackgroundActivity(initial, timestamp)
         }
 
-    override fun startSessionWithManual(timestamp: Long): Session {
+    override fun startSessionWithManual(timestamp: Long): SessionZygote {
         return payloadMessageCollator.buildInitialSession(
             InitialEnvelopeParams.SessionParams(
                 false,
@@ -52,7 +52,7 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    override fun endSessionWithManual(timestamp: Long, initial: Session): SessionMessage {
+    override fun endSessionWithManual(timestamp: Long, initial: SessionZygote): SessionMessage {
         return payloadMessageCollator.buildFinalSessionMessage(
             FinalEnvelopeParams.SessionParams(
                 initial = initial,
@@ -64,7 +64,7 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    private fun startSessionWithState(timestamp: Long, coldStart: Boolean): Session {
+    private fun startSessionWithState(timestamp: Long, coldStart: Boolean): SessionZygote {
         return payloadMessageCollator.buildInitialSession(
             InitialEnvelopeParams.SessionParams(
                 coldStart,
@@ -74,7 +74,7 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    private fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): Session? {
+    private fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): SessionZygote? {
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }
@@ -94,7 +94,7 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    private fun endSessionWithState(initial: Session, timestamp: Long): SessionMessage {
+    private fun endSessionWithState(initial: SessionZygote, timestamp: Long): SessionMessage {
         return payloadMessageCollator.buildFinalSessionMessage(
             FinalEnvelopeParams.SessionParams(
                 initial = initial,
@@ -106,7 +106,7 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    private fun endBackgroundActivityWithState(initial: Session, timestamp: Long): SessionMessage? {
+    private fun endBackgroundActivityWithState(initial: SessionZygote, timestamp: Long): SessionMessage? {
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }
@@ -125,7 +125,7 @@ internal class PayloadFactoryImpl(
     }
 
     private fun endSessionWithCrash(
-        initial: Session,
+        initial: SessionZygote,
         timestamp: Long,
         crashId: String
     ): SessionMessage {
@@ -142,7 +142,7 @@ internal class PayloadFactoryImpl(
     }
 
     private fun endBackgroundActivityWithCrash(
-        initial: Session,
+        initial: SessionZygote,
         timestamp: Long,
         crashId: String
     ): SessionMessage? {
@@ -164,7 +164,7 @@ internal class PayloadFactoryImpl(
     /**
      * Called when the session is persisted every 2s to cache its state.
      */
-    private fun snapshotSession(initial: Session, timestamp: Long): SessionMessage {
+    private fun snapshotSession(initial: SessionZygote, timestamp: Long): SessionMessage {
         return payloadMessageCollator.buildFinalSessionMessage(
             FinalEnvelopeParams.SessionParams(
                 initial = initial,
@@ -176,7 +176,7 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    private fun snapshotBackgroundActivity(initial: Session, timestamp: Long): SessionMessage? {
+    private fun snapshotBackgroundActivity(initial: SessionZygote, timestamp: Long): SessionMessage? {
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -1,17 +1,17 @@
 package io.embrace.android.embracesdk.session.message
 
-import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams.BackgroundActivityParams
 import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams.SessionParams
 
 internal interface PayloadMessageCollator {
 
     /**
-     * Builds a new session object. This should not be sent to the backend but is used
-     * to populate essential session information (such as ID), etc
+     * Builds a new precursor session object. This is not sent to the backend but is used
+     * to hold essential session information (such as ID), etc
      */
-    fun buildInitialSession(params: InitialEnvelopeParams): Session
+    fun buildInitialSession(params: InitialEnvelopeParams): SessionZygote
 
     /**
      * Builds a fully populated session message. This can be sent to the backend (or stored

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
@@ -9,6 +9,8 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
+import io.embrace.android.embracesdk.payload.SessionZygote.Companion.toSession
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
@@ -27,9 +29,9 @@ internal class PayloadMessageCollatorImpl(
     private val logger: EmbLogger,
 ) : PayloadMessageCollator {
 
-    override fun buildInitialSession(params: InitialEnvelopeParams): Session {
+    override fun buildInitialSession(params: InitialEnvelopeParams): SessionZygote {
         return with(params) {
-            Session(
+            SessionZygote(
                 sessionId = currentSessionSpan.getSessionId(),
                 startTime = startTime,
                 isColdStart = coldStart,
@@ -107,7 +109,7 @@ internal class PayloadMessageCollatorImpl(
     private fun buildFinalBackgroundActivity(
         params: FinalEnvelopeParams
     ): Session = with(params) {
-        return initial.copy(
+        return initial.toSession().copy(
             endTime = endTime,
             eventIds = captureDataSafely(logger) {
                 eventService.findEventIdsForSession()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.session.orchestrator
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.logging.EmbLogger
-import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 
 /**
@@ -16,7 +16,7 @@ private const val MIN_SESSION_MS = 5000L
 internal fun shouldEndManualSession(
     configService: ConfigService,
     clock: Clock,
-    activeSession: Session?,
+    activeSession: SessionZygote?,
     state: ProcessState,
     logger: EmbLogger
 ): Boolean {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
@@ -22,9 +22,5 @@ internal fun fakeBackgroundActivityMessage(): SessionMessage {
 
 internal fun fakeBackgroundActivity() = Session(
     "fake-activity",
-    0,
-    appState = "background",
-    number = 1,
-    isColdStart = false,
-    startType = Session.LifeEventType.STATE
+    0
 )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeDeliveryService.kt
@@ -3,8 +3,10 @@ package io.embrace.android.embracesdk
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.ndk.NativeCrashService
+import io.embrace.android.embracesdk.opentelemetry.embState
 import io.embrace.android.embracesdk.payload.EventMessage
 import io.embrace.android.embracesdk.payload.NetworkEvent
 import io.embrace.android.embracesdk.payload.Session
@@ -72,24 +74,26 @@ internal open class FakeDeliveryService : DeliveryService {
     }
 
     fun getSentSessions(): List<SessionMessage> {
-        return sentSessionMessages.filter { it.first.session.appState == Session.APPLICATION_STATE_FOREGROUND }.map { it.first }
+        return sentSessionMessages.filter { it.first.findAppState() == Session.APPLICATION_STATE_FOREGROUND }.map { it.first }
     }
 
     fun getSentBackgroundActivities(): List<SessionMessage> {
-        return sentSessionMessages.filter { it.first.session.appState == Session.APPLICATION_STATE_BACKGROUND }.map { it.first }
+        return sentSessionMessages.filter { it.first.findAppState() == Session.APPLICATION_STATE_BACKGROUND }.map { it.first }
     }
 
     fun getSavedSessions(): List<SessionMessage> {
         return savedSessionMessages.filter {
-            it.first.session.appState == Session.APPLICATION_STATE_FOREGROUND
+            it.first.findAppState() == Session.APPLICATION_STATE_FOREGROUND
         }.map { it.first }
     }
 
     fun getSavedBackgroundActivities(): List<SessionMessage> {
         return savedSessionMessages.filter {
-            it.first.session.appState == Session.APPLICATION_STATE_BACKGROUND
+            it.first.findAppState() == Session.APPLICATION_STATE_BACKGROUND
         }.map { it.first }
     }
+
+    private fun SessionMessage.findAppState() = findSessionSpan().attributes?.findAttributeValue(embState.name)
 
     fun getLastSentSession(): SessionMessage? {
         return getSentSessions().lastOrNull()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionTest {
@@ -14,10 +13,7 @@ internal class SessionTest {
         sessionId = "fake-session-id",
         startTime = 123456789L,
         endTime = 987654321L,
-        number = 5,
-        appState = "foreground",
         lastHeartbeatTime = 123456780L,
-        isColdStart = true,
         terminationTime = 16090292309L,
         eventIds = listOf("fake-event-id"),
         infoLogIds = listOf("fake-info-id"),
@@ -26,7 +22,6 @@ internal class SessionTest {
         networkLogIds = listOf("fake-network-id"),
         crashReportId = "fake-crash-id",
         endType = LifeEventType.STATE,
-        startType = LifeEventType.STATE,
         startupDuration = 1223,
         startupThreshold = 5000,
         sdkStartupDuration = 109
@@ -46,11 +41,8 @@ internal class SessionTest {
             assertEquals("fake-session-id", sessionId)
             assertEquals(123456789L, startTime)
             assertEquals(987654321L, endTime)
-            assertEquals(5, number)
-            assertEquals("foreground", appState)
             assertEquals(16090292309L, terminationTime)
             assertEquals(123456780L, lastHeartbeatTime)
-            assertTrue(isColdStart)
             assertEquals(listOf("fake-event-id"), eventIds)
             assertEquals(listOf("fake-info-id"), infoLogIds)
             assertEquals(listOf("fake-warn-id"), warningLogIds)
@@ -58,7 +50,6 @@ internal class SessionTest {
             assertEquals(listOf("fake-network-id"), networkLogIds)
             assertEquals("fake-crash-id", crashReportId)
             assertEquals(LifeEventType.STATE, endType)
-            assertEquals(LifeEventType.STATE, startType)
             assertEquals(1223L, startupDuration)
             assertEquals(5000L, startupThreshold)
             assertEquals(109L, sdkStartupDuration)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams
 import io.embrace.android.embracesdk.session.message.InitialEnvelopeParams
 import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
 
 internal class FakePayloadCollator : PayloadMessageCollator {
-    override fun buildInitialSession(params: InitialEnvelopeParams): Session {
+    override fun buildInitialSession(params: InitialEnvelopeParams): SessionZygote {
         TODO("Not yet implemented")
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -8,15 +8,20 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.Session.Companion.APPLICATION_STATE_FOREGROUND
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
 
 internal fun fakeSession(
     sessionId: String = "fakeSessionId",
-    startMs: Long = 160000000000L,
-    number: Int = 1
+    startMs: Long = 160000000000L
 ): Session = Session(
     sessionId = sessionId,
-    startTime = startMs,
-    number = number,
+    startTime = startMs
+)
+
+internal fun fakeSessionZygote() = SessionZygote(
+    sessionId = "fakeSessionId",
+    startTime = 160000000000L,
+    number = 1,
     appState = APPLICATION_STATE_FOREGROUND,
     isColdStart = true,
     startType = Session.LifeEventType.STATE

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
+import io.embrace.android.embracesdk.payload.SessionZygote.Companion.toSession
 import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams
 import io.embrace.android.embracesdk.session.message.InitialEnvelopeParams
 import io.embrace.android.embracesdk.session.message.PayloadMessageCollator
@@ -26,7 +28,7 @@ internal class FakeV2PayloadCollator(
                 error("Unknown appState")
             }
         }
-        Session(
+        SessionZygote(
             sessionId = currentSessionSpan.getSessionId(),
             startTime = startTime,
             isColdStart = coldStart,
@@ -63,7 +65,7 @@ internal class FakeV2PayloadCollator(
     private fun buildFinalBackgroundActivity(
         params: FinalEnvelopeParams
     ): Session = with(params) {
-        return initial.copy(
+        return initial.toSession().copy(
             endTime = endTime,
             lastHeartbeatTime = endTime,
             endType = lifeEventType,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SessionTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SessionTestFixtures.kt
@@ -20,7 +20,6 @@ internal val testSessionMessageOneMinuteLater =
 internal val testSessionMessage2 = SessionMessage(
     session = fakeSession(
         sessionId = "03FC033631F346C48AF6E3D5B56F6AA3",
-        startMs = testSessionMessageOneMinuteLater.session.startTime + 300000L,
-        number = testSessionMessageOneMinuteLater.session.number + 1
+        startMs = testSessionMessageOneMinuteLater.session.startTime + 300000L
     )
 )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.deserializeEmptyJsonString
 import io.embrace.android.embracesdk.deserializeJsonFromResource
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class BackgroundActivityTest {
@@ -14,18 +13,14 @@ internal class BackgroundActivityTest {
     private val info = Session(
         sessionId = "fake-session-id",
         startTime = 123456789L,
-        appState = "foreground",
         endTime = 987654321L,
-        number = 5,
         lastHeartbeatTime = 123456780L,
-        isColdStart = true,
         eventIds = listOf("fake-event-id"),
         infoLogIds = listOf("fake-info-id"),
         warningLogIds = listOf("fake-warn-id"),
         errorLogIds = listOf("fake-err-id"),
         crashReportId = "fake-crash-id",
-        endType = Session.LifeEventType.BKGND_STATE,
-        startType = Session.LifeEventType.BKGND_STATE
+        endType = Session.LifeEventType.BKGND_STATE
     )
 
     @Test
@@ -42,17 +37,13 @@ internal class BackgroundActivityTest {
             assertEquals("fake-session-id", sessionId)
             assertEquals(123456789L, startTime)
             assertEquals(987654321L, endTime)
-            assertEquals(5, number)
-            assertEquals("foreground", appState)
             assertEquals(123456780L, lastHeartbeatTime)
-            assertTrue(checkNotNull(isColdStart))
             assertEquals(listOf("fake-event-id"), eventIds)
             assertEquals(listOf("fake-info-id"), infoLogIds)
             assertEquals(listOf("fake-warn-id"), warningLogIds)
             assertEquals(listOf("fake-err-id"), errorLogIds)
             assertEquals("fake-crash-id", crashReportId)
             assertEquals(Session.LifeEventType.BKGND_STATE, endType)
-            assertEquals(Session.LifeEventType.BKGND_STATE, startType)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.config.LocalConfigParser
 import io.embrace.android.embracesdk.config.local.LocalConfig
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
-import io.embrace.android.embracesdk.fakeBackgroundActivity
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -31,6 +30,7 @@ import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
+import io.embrace.android.embracesdk.fakes.fakeSessionZygote
 import io.embrace.android.embracesdk.fakes.fakeV2OtelBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.SystemInfo
@@ -53,7 +53,7 @@ import org.junit.Test
 
 internal class PayloadFactoryBaTest {
 
-    private val initial = fakeBackgroundActivity()
+    private val initial = fakeSessionZygote()
     private lateinit var service: PayloadFactoryImpl
     private lateinit var clock: FakeClock
     private lateinit var metadataService: MetadataService

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -33,6 +33,7 @@ import io.embrace.android.embracesdk.fakes.fakeDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.fakeSession
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.fakeSessionZygote
 import io.embrace.android.embracesdk.fakes.fakeV2OtelBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -44,6 +45,7 @@ import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.session.message.PayloadFactory
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
@@ -73,7 +75,7 @@ internal class SessionHandlerTest {
         private val emptyMapSessionProperties: Map<String, String> = emptyMap()
     }
 
-    private val initial = fakeSession(startMs = NOW)
+    private val initial = fakeSessionZygote().copy(startTime = NOW)
     private val userService: FakeUserService = FakeUserService()
     private var activeSession: Session = fakeSession()
 
@@ -193,8 +195,7 @@ internal class SessionHandlerTest {
         val startTime = 120L
         val sdkStartupDuration = 2L
         activeSession = fakeSession().copy(
-            startTime = startTime,
-            isColdStart = true
+            startTime = startTime
         )
 
         val msg = payloadFactory.endPayloadWithCrash(
@@ -211,7 +212,6 @@ internal class SessionHandlerTest {
         verify(exactly = 0) { sessionProperties.clearTemporary() }
 
         with(session) {
-            assertEquals("foreground", appState)
             assertEquals(emptyList<String>(), eventIds)
             assertEquals(NOW, lastHeartbeatTime)
             assertEquals(Session.LifeEventType.STATE, endType)
@@ -296,7 +296,7 @@ internal class SessionHandlerTest {
         assertEquals(0, spanSink.completedSpans().size)
     }
 
-    private fun startFakeSession(): Session {
+    private fun startFakeSession(): SessionZygote {
         return checkNotNull(payloadFactory.startPayloadWithState(ProcessState.FOREGROUND, NOW, true))
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
@@ -13,8 +13,8 @@ import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.payload.Session
 import io.embrace.android.embracesdk.payload.SessionMessage
+import io.embrace.android.embracesdk.payload.SessionZygote.Companion.toSession
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -63,7 +63,7 @@ internal class PayloadMessageCollatorImplTest {
                 5
             )
         )
-        msg.verifyInitialFieldsPopulated(PayloadType.BACKGROUND_ACTIVITY)
+        msg.toSession().verifyInitialFieldsPopulated()
     }
 
     @Test
@@ -75,7 +75,7 @@ internal class PayloadMessageCollatorImplTest {
                 5
             )
         )
-        msg.verifyInitialFieldsPopulated(PayloadType.SESSION)
+        msg.toSession().verifyInitialFieldsPopulated()
     }
 
     @Test
@@ -88,7 +88,7 @@ internal class PayloadMessageCollatorImplTest {
                 5
             )
         )
-        startMsg.verifyInitialFieldsPopulated(PayloadType.BACKGROUND_ACTIVITY)
+        startMsg.toSession().verifyInitialFieldsPopulated()
 
         // create session
         val payload = collator.buildFinalBackgroundActivityMessage(
@@ -116,7 +116,7 @@ internal class PayloadMessageCollatorImplTest {
                 5
             )
         )
-        startMsg.verifyInitialFieldsPopulated(PayloadType.SESSION)
+        startMsg.toSession().verifyInitialFieldsPopulated()
 
         // create session
         val payload = collator.buildFinalSessionMessage(
@@ -142,26 +142,13 @@ internal class PayloadMessageCollatorImplTest {
         assertNotNull(data)
         assertNotNull(newVersion)
         assertNotNull(type)
-        session.verifyInitialFieldsPopulated(payloadType)
+        session.verifyInitialFieldsPopulated()
         session.verifyFinalFieldsPopulated(payloadType)
     }
 
-    private fun Session.verifyInitialFieldsPopulated(payloadType: PayloadType) {
+    private fun Session.verifyInitialFieldsPopulated() {
         assertNotNull(sessionId)
         assertEquals(5L, startTime)
-        Assert.assertFalse(isColdStart)
-        assertNotNull(number)
-
-        val expectedState = when (payloadType) {
-            PayloadType.BACKGROUND_ACTIVITY -> Session.APPLICATION_STATE_BACKGROUND
-            PayloadType.SESSION -> Session.APPLICATION_STATE_FOREGROUND
-        }
-        val expectedStartType = when (payloadType) {
-            PayloadType.BACKGROUND_ACTIVITY -> Session.LifeEventType.BKGND_STATE
-            PayloadType.SESSION -> Session.LifeEventType.STATE
-        }
-        assertEquals(expectedState, appState)
-        assertEquals(expectedStartType, startType)
     }
 
     private fun Session.verifyFinalFieldsPopulated(payloadType: PayloadType) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -130,12 +130,12 @@ internal class SessionOrchestratorTest {
         clock.tick()
         baCacheExecutor.runCurrentlyBlocked()
         assertEquals(SessionSnapshotType.PERIODIC_CACHE, checkNotNull(deliveryService.savedSessionMessages.last().second))
-        assertEquals(1, deliveryService.getSavedBackgroundActivities().count())
+        assertEquals(1, deliveryService.savedSessionMessages.size)
         orchestrator.onForeground(true, clock.now())
         clock.tick()
         orchestrator.onBackground(clock.now())
         assertEquals(SessionSnapshotType.NORMAL_END, checkNotNull(deliveryService.savedSessionMessages.last().second))
-        assertEquals(2, deliveryService.getSavedBackgroundActivities().count())
+        assertEquals(3, deliveryService.savedSessionMessages.size)
     }
 
     @Test
@@ -156,11 +156,11 @@ internal class SessionOrchestratorTest {
         clock.tick()
         sessionCacheExecutor.runCurrentlyBlocked()
         assertEquals(SessionSnapshotType.PERIODIC_CACHE, checkNotNull(deliveryService.savedSessionMessages.last().second))
-        assertEquals(1, deliveryService.getSavedSessions().count())
+        assertEquals(1, deliveryService.savedSessionMessages.size)
         orchestrator.onBackground(clock.now())
         clock.tick()
         assertEquals(SessionSnapshotType.NORMAL_END, checkNotNull(deliveryService.savedSessionMessages.last().second))
-        assertEquals(2, deliveryService.getSavedSessions().count())
+        assertEquals(2, deliveryService.savedSessionMessages.size)
     }
 
     @Test
@@ -245,7 +245,7 @@ internal class SessionOrchestratorTest {
         assertEquals(1, payloadCollator.sessionCount.get())
         orchestrator.endSessionWithManual(true)
         assertEquals(2, payloadCollator.sessionCount.get())
-        assertNotNull(deliveryService.getLastSentSession())
+        assertNotNull(deliveryService.sentSessionMessages.last().first)
     }
 
     @Test
@@ -308,7 +308,7 @@ internal class SessionOrchestratorTest {
     fun `test session span cold start`() {
         createOrchestrator(true)
         orchestrator.onForeground(true, clock.now())
-        checkNotNull(deliveryService.getLastSentBackgroundActivity())
+        checkNotNull(deliveryService.sentSessionMessages.last().first)
     }
 
     @Test
@@ -316,7 +316,7 @@ internal class SessionOrchestratorTest {
         createOrchestrator(true)
         orchestrator.onForeground(true, orchestratorStartTimeMs)
         orchestrator.onBackground(orchestratorStartTimeMs)
-        checkNotNull(deliveryService.getLastSentBackgroundActivity())
+        checkNotNull(deliveryService.sentSessionMessages.last().first)
     }
 
     @Test
@@ -324,7 +324,7 @@ internal class SessionOrchestratorTest {
         createOrchestrator(true)
         orchestrator.onForeground(true, orchestratorStartTimeMs)
         orchestrator.endSessionWithCrash("my-crash-id")
-        checkNotNull(deliveryService.getLastSentSession())
+        checkNotNull(deliveryService.sentSessionMessages.last().first)
     }
 
     @Test
@@ -436,7 +436,7 @@ internal class SessionOrchestratorTest {
         assertEquals(endTimeMs, checkNotNull(currentSessionSpan.sessionSpan).startEpochNanos.nanosToMillis())
     }
 
-    private fun getOnlySentSession() = checkNotNull(deliveryService.getSentSessions().single().session)
+    private fun getOnlySentSession() = checkNotNull(deliveryService.sentSessionMessages.single().first.session)
 
-    private fun getOnlySentBackgroundActivity() = checkNotNull(deliveryService.getSentBackgroundActivities().single().session)
+    private fun getOnlySentBackgroundActivity() = checkNotNull(deliveryService.sentSessionMessages.single().first.session)
 }

--- a/embrace-android-sdk/src/test/resources/bg_activity_expected.json
+++ b/embrace-android-sdk/src/test/resources/bg_activity_expected.json
@@ -1,11 +1,8 @@
 {
   "id": "fake-session-id",
   "st": 123456789,
-  "as": "foreground",
   "et": 987654321,
-  "sn": 5,
   "ht": 123456780,
-  "cs": true,
   "ss": [
     "fake-event-id"
   ],
@@ -19,6 +16,5 @@
     "fake-err-id"
   ],
   "ri": "fake-crash-id",
-  "em": "bs",
-  "sm": "bs"
+  "em": "bs"
 }

--- a/embrace-android-sdk/src/test/resources/bg_activity_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/bg_activity_message_expected.json
@@ -1,10 +1,6 @@
 {
   "s": {
     "id": "fake-activity",
-    "st": 0,
-    "sn": 1,
-    "as": "background",
-    "cs": false,
-    "sm": "s"
+    "st": 0
   }
 }

--- a/embrace-android-sdk/src/test/resources/session_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_expected.json
@@ -1,9 +1,6 @@
 {
   "id": "fake-session-id",
   "st": 123456789,
-  "sn": 5,
-  "as": "foreground",
-  "cs": true,
   "et": 987654321,
   "ht": 123456780,
   "tt": 16090292309,
@@ -24,7 +21,6 @@
   ],
   "ri": "fake-crash-id",
   "em": "s",
-  "sm": "s",
   "sd": 1223,
   "sdt": 5000,
   "si": 109

--- a/embrace-android-sdk/src/test/resources/session_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_message_expected.json
@@ -1,10 +1,6 @@
 {
   "s": {
     "id": "fakeSessionId",
-    "st": 160000000000,
-    "sn": 1,
-    "as": "foreground",
-    "cs": true,
-    "sm": "s"
+    "st": 160000000000
   }
 }


### PR DESCRIPTION
## Goal

Creates a `SessionZygote` class. This holds the state information at the very start of a session & is used when the session ends to create a full payload. Separating the concept of state holding & serialization will make it easier to fully remove `Session` from the payload in future.

## Testing

Relied on existing test coverage.

