### PR TITLE
Remove startup fields from session object

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/SessionSanitizer.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.gating.SessionGatingKeys.LOGS_INFO
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.LOGS_WARN
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_MOMENTS
 import io.embrace.android.embracesdk.gating.SessionGatingKeys.SESSION_USER_TERMINATION
-import io.embrace.android.embracesdk.gating.SessionGatingKeys.STARTUP_MOMENT
 import io.embrace.android.embracesdk.payload.Session
 
 internal class SessionSanitizer(
@@ -30,21 +29,11 @@ internal class SessionSanitizer(
             !shouldSendMoment() -> null
             else -> session.eventIds
         }
-        val startupDuration = when {
-            !shouldSendStartupMoment() -> null
-            else -> session.startupDuration
-        }
-        val startupThreshold = when {
-            !shouldSendStartupMoment() -> null
-            else -> session.startupThreshold
-        }
         return session.copy(
             terminationTime = terminationTime,
             infoLogIds = infoLogIds,
             warningLogIds = warnLogIds,
-            eventIds = eventIds,
-            startupDuration = startupDuration,
-            startupThreshold = startupThreshold
+            eventIds = eventIds
         )
     }
 
@@ -59,7 +48,4 @@ internal class SessionSanitizer(
 
     private fun shouldSendWarnLog() =
         enabledComponents.contains(LOGS_WARN)
-
-    private fun shouldSendStartupMoment() =
-        enabledComponents.contains(STARTUP_MOMENT)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -401,11 +401,11 @@ internal class ModuleInitBootstrapper(
                             nativeModule,
                             dataContainerModule,
                             deliveryModule,
-                            dataCaptureServiceModule,
                             customerLogModule,
                             workerThreadModule,
                             dataSourceModule,
-                            payloadModule
+                            payloadModule,
+                            dataCaptureServiceModule
                         )
                     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -195,11 +195,11 @@ internal typealias SessionModuleSupplier = (
     nativeModule: NativeModule,
     dataContainerModule: DataContainerModule,
     deliveryModule: DeliveryModule,
-    dataCaptureServiceModule: DataCaptureServiceModule,
     customerLogModule: CustomerLogModule,
     workerThreadModule: WorkerThreadModule,
     dataSourceModule: DataSourceModule,
-    payloadModule: PayloadModule
+    payloadModule: PayloadModule,
+    dataCaptureServiceModule: DataCaptureServiceModule
 ) -> SessionModule
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -77,3 +77,18 @@ internal val embSessionStartType = EmbraceAttributeKey("session_start_type")
  * Attribute name that identifies the session end type
  */
 internal val embSessionEndType = EmbraceAttributeKey("session_end_type")
+
+/**
+ * Attribute name that identifies the startup duration
+ */
+internal val embSessionStartupDuration = EmbraceAttributeKey("startup_duration")
+
+/**
+ * Attribute name that identifies the startup threshold
+ */
+internal val embSessionStartupThreshold = EmbraceAttributeKey("threshold")
+
+/**
+ * Attribute name that identifies the SDK duration
+ */
+internal val embSdkStartupDuration = EmbraceAttributeKey("sdk_startup_duration")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
@@ -52,16 +52,7 @@ internal data class Session @JvmOverloads internal constructor(
     val crashReportId: String? = null,
 
     @Json(name = "em")
-    val endType: LifeEventType? = null,
-
-    @Json(name = "sd")
-    val startupDuration: Long? = null,
-
-    @Json(name = "sdt")
-    val startupThreshold: Long? = null,
-
-    @Json(name = "si")
-    val sdkStartupDuration: Long? = null
+    val endType: LifeEventType? = null
 ) {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
-import io.embrace.android.embracesdk.capture.startup.StartupService
 import io.embrace.android.embracesdk.event.EventService
 import io.embrace.android.embracesdk.event.LogMessageService
 import io.embrace.android.embracesdk.gating.GatingService
@@ -25,7 +24,6 @@ internal class PayloadMessageCollatorImpl(
     private val logMessageService: LogMessageService,
     private val preferencesService: PreferencesService,
     private val currentSessionSpan: CurrentSessionSpan,
-    private val startupService: StartupService,
     private val logger: EmbLogger,
 ) : PayloadMessageCollator {
 
@@ -54,7 +52,6 @@ internal class PayloadMessageCollatorImpl(
         )
         val obj = with(newParams) {
             val base = buildFinalBackgroundActivity(newParams)
-            val startupInfo = getStartupEventInfo(eventService)
 
             val endSession = base.copy(
                 networkLogIds = captureDataSafely(logger) {
@@ -64,10 +61,7 @@ internal class PayloadMessageCollatorImpl(
                     )
                 },
                 terminationTime = terminationTime,
-                endTime = endTimeVal,
-                sdkStartupDuration = startupService.getSdkStartupDuration(initial.isColdStart),
-                startupDuration = startupInfo?.duration,
-                startupThreshold = startupInfo?.threshold
+                endTime = endTimeVal
             )
             val envelope = buildWrapperEnvelope(endSession)
             gatingService.gateSessionMessage(envelope)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
@@ -1,0 +1,64 @@
+package io.embrace.android.embracesdk.session.orchestrator
+
+import io.embrace.android.embracesdk.arch.destination.SessionSpanWriter
+import io.embrace.android.embracesdk.arch.destination.SpanAttributeData
+import io.embrace.android.embracesdk.capture.startup.StartupService
+import io.embrace.android.embracesdk.event.EventService
+import io.embrace.android.embracesdk.opentelemetry.embCleanExit
+import io.embrace.android.embracesdk.opentelemetry.embColdStart
+import io.embrace.android.embracesdk.opentelemetry.embCrashId
+import io.embrace.android.embracesdk.opentelemetry.embSdkStartupDuration
+import io.embrace.android.embracesdk.opentelemetry.embSessionEndType
+import io.embrace.android.embracesdk.opentelemetry.embSessionNumber
+import io.embrace.android.embracesdk.opentelemetry.embSessionStartType
+import io.embrace.android.embracesdk.opentelemetry.embSessionStartupDuration
+import io.embrace.android.embracesdk.opentelemetry.embSessionStartupThreshold
+import io.embrace.android.embracesdk.opentelemetry.embState
+import io.embrace.android.embracesdk.opentelemetry.embTerminated
+import io.embrace.android.embracesdk.payload.Session
+import io.embrace.android.embracesdk.payload.SessionZygote
+import java.util.Locale
+
+internal class SessionSpanAttrPopulator(
+    private val sessionSpanWriter: SessionSpanWriter,
+    private val eventService: EventService,
+    private val startupService: StartupService,
+) {
+
+    fun populateSessionSpanStartAttrs(session: SessionZygote) {
+        with(sessionSpanWriter) {
+            addCustomAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
+            addCustomAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
+            addCustomAttribute(SpanAttributeData(embState.name, session.appState))
+            addCustomAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
+            session.startType.toString().toLowerCase(Locale.US).let {
+                addCustomAttribute(SpanAttributeData(embSessionStartType.name, it))
+            }
+        }
+    }
+
+    fun populateSessionSpanEndAttrs(endType: Session.LifeEventType?, crashId: String?, coldStart: Boolean) {
+        with(sessionSpanWriter) {
+            addCustomAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
+            addCustomAttribute(SpanAttributeData(embTerminated.name, false.toString()))
+            crashId?.let {
+                addCustomAttribute(SpanAttributeData(embCrashId.name, crashId))
+            }
+            endType?.toString()?.toLowerCase(Locale.US)?.let {
+                addCustomAttribute(SpanAttributeData(embSessionEndType.name, it))
+            }
+
+            val startupInfo = when {
+                coldStart -> eventService.getStartupMomentInfo()
+                else -> null
+            }
+            startupInfo?.let { info ->
+                addCustomAttribute(
+                    SpanAttributeData(embSdkStartupDuration.name, startupService.getSdkStartupDuration(coldStart).toString())
+                )
+                addCustomAttribute(SpanAttributeData(embSessionStartupDuration.name, info.duration.toString()))
+                addCustomAttribute(SpanAttributeData(embSessionStartupThreshold.name, info.threshold.toString()))
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionSanitizerFacadeTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionSanitizerFacadeTest.kt
@@ -16,9 +16,7 @@ internal class SessionSanitizerFacadeTest {
         terminationTime = 100L,
         infoLogIds = listOf("infoLog"),
         warningLogIds = listOf("warningLog"),
-        eventIds = listOf("eventId"),
-        startupDuration = 100L,
-        startupThreshold = 500L
+        eventIds = listOf("eventId")
     )
 
     private val sessionMessage = SessionMessage(
@@ -64,8 +62,6 @@ internal class SessionSanitizerFacadeTest {
         assertNotNull(sanitizedMessage.session.infoLogIds)
         assertNotNull(sanitizedMessage.session.warningLogIds)
         assertNotNull(sanitizedMessage.session.eventIds)
-        assertNotNull(sanitizedMessage.session.startupDuration)
-        assertNotNull(sanitizedMessage.session.startupThreshold)
         assertNotNull(sanitizedMessage.resource?.diskTotalCapacity)
     }
 
@@ -81,8 +77,6 @@ internal class SessionSanitizerFacadeTest {
         assertNull(sanitizedMessage.session.infoLogIds)
         assertNull(sanitizedMessage.session.warningLogIds)
         assertNull(sanitizedMessage.session.eventIds)
-        assertNull(sanitizedMessage.session.startupDuration)
-        assertNull(sanitizedMessage.session.startupThreshold)
         assertNull(sanitizedMessage.resource?.diskTotalCapacity)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionSanitizerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionSanitizerTest.kt
@@ -13,9 +13,7 @@ internal class SessionSanitizerTest {
         terminationTime = 100L,
         infoLogIds = listOf("infoLog"),
         warningLogIds = listOf("warningLog"),
-        eventIds = listOf("eventId"),
-        startupDuration = 100L,
-        startupThreshold = 500L
+        eventIds = listOf("eventId")
     )
 
     @Test
@@ -37,8 +35,6 @@ internal class SessionSanitizerTest {
         assertNotNull(result.infoLogIds)
         assertNotNull(result.warningLogIds)
         assertNotNull(result.eventIds)
-        assertNotNull(result.startupDuration)
-        assertNotNull(result.startupThreshold)
     }
 
     @Test
@@ -51,7 +47,5 @@ internal class SessionSanitizerTest {
         assertNull(result.infoLogIds)
         assertNull(result.warningLogIds)
         assertNull(result.eventIds)
-        assertNull(result.startupDuration)
-        assertNull(result.startupThreshold)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
@@ -21,10 +21,7 @@ internal class SessionTest {
         errorLogIds = listOf("fake-err-id"),
         networkLogIds = listOf("fake-network-id"),
         crashReportId = "fake-crash-id",
-        endType = LifeEventType.STATE,
-        startupDuration = 1223,
-        startupThreshold = 5000,
-        sdkStartupDuration = 109
+        endType = LifeEventType.STATE
     )
 
     @Test
@@ -50,9 +47,6 @@ internal class SessionTest {
             assertEquals(listOf("fake-network-id"), networkLogIds)
             assertEquals("fake-crash-id", crashReportId)
             assertEquals(LifeEventType.STATE, endType)
-            assertEquals(1223L, startupDuration)
-            assertEquals(5000L, startupThreshold)
-            assertEquals(109L, sdkStartupDuration)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
@@ -47,10 +47,7 @@ internal class FakeV2PayloadCollator(
     ): SessionMessage = with(params) {
         val endSession = buildFinalBackgroundActivity(params).copy(
             terminationTime = terminationTime,
-            endTime = endTimeVal,
-            sdkStartupDuration = if (initial.isColdStart) 100L else null,
-            startupDuration = if (initial.isColdStart) 1000L else null,
-            startupThreshold = if (initial.isColdStart) 5000L else null,
+            endTime = endTimeVal
         )
         return buildWrapperEnvelope(endSession)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -25,7 +25,6 @@ import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
-import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
@@ -188,7 +187,6 @@ internal class PayloadFactoryBaTest {
             logMessageService,
             preferencesService,
             currentSessionSpan,
-            FakeStartupService(),
             logger
         )
         return PayloadFactoryImpl(collator, configService, logger).apply {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -24,7 +24,6 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
-import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.SystemInfo
@@ -177,7 +176,6 @@ internal class PayloadFactorySessionTest {
             logMessageService,
             preferencesService,
             currentSessionSpan,
-            FakeStartupService(),
             logger
         )
         service = PayloadFactoryImpl(collator, FakeConfigService(), logger)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -24,7 +24,6 @@ import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
-import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeWebViewService
 import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
@@ -164,7 +163,6 @@ internal class SessionHandlerTest {
             logMessageService,
             preferencesService,
             currentSessionSpan,
-            FakeStartupService(),
             logger,
         )
         payloadFactory = PayloadFactoryImpl(collator, configService, logger)
@@ -218,8 +216,6 @@ internal class SessionHandlerTest {
             assertEquals(crashId, crashReportId)
             assertEquals(NOW, endTime)
             assertEquals(sdkStartupDuration, sdkStartupDuration)
-            assertEquals(0L, startupDuration)
-            assertEquals(0L, startupThreshold)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -56,11 +56,11 @@ internal class SessionModuleImplTest {
             FakeNativeModule(),
             FakeDataContainerModule(),
             FakeDeliveryModule(),
-            FakeDataCaptureServiceModule(),
             FakeCustomerLogModule(),
             workerThreadModule,
             dataSourceModule,
-            FakePayloadModule()
+            FakePayloadModule(),
+            FakeDataCaptureServiceModule()
         )
         assertNotNull(module.payloadMessageCollatorImpl)
         assertNotNull(module.sessionPropertiesService)
@@ -93,11 +93,11 @@ internal class SessionModuleImplTest {
             FakeNativeModule(),
             FakeDataContainerModule(),
             FakeDeliveryModule(),
-            FakeDataCaptureServiceModule(),
             FakeCustomerLogModule(),
             workerThreadModule,
             dataSourceModule,
-            FakePayloadModule()
+            FakePayloadModule(),
+            FakeDataCaptureServiceModule()
         )
         assertNotNull(module.payloadMessageCollatorImpl)
         assertNotNull(module.sessionPropertiesService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
-import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.fakeOTelBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.session.lifecycle.ProcessState.FOREGROUND
@@ -39,7 +38,6 @@ internal class PayloadFactoryImplTest {
             eventService = FakeEventService(),
             logMessageService = FakeLogMessageService(),
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
-            startupService = FakeStartupService(),
             logger = initModule.logger,
             sessionEnvelopeSource = SessionEnvelopeSourceImpl(
                 FakeEnvelopeMetadataSource(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeLogMessageService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
-import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.payload.Session
@@ -48,7 +47,6 @@ internal class PayloadMessageCollatorImplTest {
             eventService = FakeEventService(),
             logMessageService = FakeLogMessageService(),
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
-            startupService = FakeStartupService(),
             logger = initModule.logger,
             sessionEnvelopeSource = sessionEnvelopeSource
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -11,10 +11,12 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeDataSource
+import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeV2PayloadCollator
 import io.embrace.android.embracesdk.fakes.fakeEmbraceSessionProperties
@@ -417,6 +419,7 @@ internal class SessionOrchestratorTest {
             periodicBackgroundActivityCacher,
             dataCaptureOrchestrator,
             currentSessionSpan,
+            SessionSpanAttrPopulator(currentSessionSpan, FakeEventService(), FakeStartupService()),
             logger
         )
         orchestratorStartTimeMs = clock.now()

--- a/embrace-android-sdk/src/test/resources/session_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_expected.json
@@ -20,8 +20,5 @@
     "fake-network-id"
   ],
   "ri": "fake-crash-id",
-  "em": "s",
-  "sd": 1223,
-  "sdt": 5000,
-  "si": 109
+  "em": "s"
 }


### PR DESCRIPTION
## Goal

Removes the startup fields from the session object as these should be calculated from spans instead.

