### PR TITLE
Remove end type from session object

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
@@ -6,6 +6,8 @@ import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getSentSessions
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
+import io.embrace.android.embracesdk.opentelemetry.embSessionEndType
+import io.embrace.android.embracesdk.opentelemetry.embSessionStartType
 import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifySessionHappened
@@ -47,8 +49,8 @@ internal class StatefulSessionTest {
             val first = messages[0]
             verifySessionHappened(first)
             val attrs = checkNotNull(first.findSessionSpan().attributes)
-            assertEquals(LifeEventType.STATE.name.toLowerCase(), attrs.findAttributeValue("emb.session_start_type"))
-            assertEquals(LifeEventType.STATE, first.session.endType)
+            assertEquals(LifeEventType.STATE.name.toLowerCase(), attrs.findAttributeValue(embSessionStartType.name))
+            assertEquals(LifeEventType.STATE.name.toLowerCase(), attrs.findAttributeValue(embSessionEndType.name))
 
             // verify second session
             val second = messages[1]

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/Session.kt
@@ -49,10 +49,7 @@ internal data class Session @JvmOverloads internal constructor(
     val networkLogIds: List<String>? = null,
 
     @Json(name = "ri")
-    val crashReportId: String? = null,
-
-    @Json(name = "em")
-    val endType: LifeEventType? = null
+    val crashReportId: String? = null
 ) {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
@@ -109,7 +109,6 @@ internal class PayloadMessageCollatorImpl(
                 eventService.findEventIdsForSession()
             },
             lastHeartbeatTime = endTime,
-            endType = lifeEventType,
             crashReportId = crashId
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/SessionTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk
 
 import com.squareup.moshi.JsonDataException
 import io.embrace.android.embracesdk.payload.Session
-import io.embrace.android.embracesdk.payload.Session.LifeEventType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -20,8 +19,7 @@ internal class SessionTest {
         warningLogIds = listOf("fake-warn-id"),
         errorLogIds = listOf("fake-err-id"),
         networkLogIds = listOf("fake-network-id"),
-        crashReportId = "fake-crash-id",
-        endType = LifeEventType.STATE
+        crashReportId = "fake-crash-id"
     )
 
     @Test
@@ -46,7 +44,6 @@ internal class SessionTest {
             assertEquals(listOf("fake-err-id"), errorLogIds)
             assertEquals(listOf("fake-network-id"), networkLogIds)
             assertEquals("fake-crash-id", crashReportId)
-            assertEquals(LifeEventType.STATE, endType)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
@@ -65,7 +65,6 @@ internal class FakeV2PayloadCollator(
         return initial.toSession().copy(
             endTime = endTime,
             lastHeartbeatTime = endTime,
-            endType = lifeEventType,
             crashReportId = crashId
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityTest.kt
@@ -19,8 +19,7 @@ internal class BackgroundActivityTest {
         infoLogIds = listOf("fake-info-id"),
         warningLogIds = listOf("fake-warn-id"),
         errorLogIds = listOf("fake-err-id"),
-        crashReportId = "fake-crash-id",
-        endType = Session.LifeEventType.BKGND_STATE
+        crashReportId = "fake-crash-id"
     )
 
     @Test
@@ -43,7 +42,6 @@ internal class BackgroundActivityTest {
             assertEquals(listOf("fake-warn-id"), warningLogIds)
             assertEquals(listOf("fake-err-id"), errorLogIds)
             assertEquals("fake-crash-id", crashReportId)
-            assertEquals(Session.LifeEventType.BKGND_STATE, endType)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -212,7 +212,6 @@ internal class SessionHandlerTest {
         with(session) {
             assertEquals(emptyList<String>(), eventIds)
             assertEquals(NOW, lastHeartbeatTime)
-            assertEquals(Session.LifeEventType.STATE, endType)
             assertEquals(crashId, crashReportId)
             assertEquals(NOW, endTime)
             assertEquals(sdkStartupDuration, sdkStartupDuration)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
@@ -26,11 +26,6 @@ internal class PayloadMessageCollatorImplTest {
     private lateinit var collator: PayloadMessageCollatorImpl
     private lateinit var gatingService: FakeGatingService
 
-    private enum class PayloadType {
-        BACKGROUND_ACTIVITY,
-        SESSION
-    }
-
     @Before
     fun setUp() {
         initModule = FakeInitModule()
@@ -100,7 +95,7 @@ internal class PayloadMessageCollatorImplTest {
                 "crashId"
             )
         )
-        payload.verifyFinalFieldsPopulated(PayloadType.BACKGROUND_ACTIVITY)
+        payload.verifyFinalFieldsPopulated()
         assertEquals(1, gatingService.envelopesFiltered.size)
     }
 
@@ -128,20 +123,18 @@ internal class PayloadMessageCollatorImplTest {
                 "crashId",
             )
         )
-        payload.verifyFinalFieldsPopulated(PayloadType.SESSION)
+        payload.verifyFinalFieldsPopulated()
         assertEquals(1, gatingService.envelopesFiltered.size)
     }
 
-    private fun SessionMessage.verifyFinalFieldsPopulated(
-        payloadType: PayloadType
-    ) {
+    private fun SessionMessage.verifyFinalFieldsPopulated() {
         assertNotNull(resource)
         assertNotNull(metadata)
         assertNotNull(data)
         assertNotNull(newVersion)
         assertNotNull(type)
         session.verifyInitialFieldsPopulated()
-        session.verifyFinalFieldsPopulated(payloadType)
+        session.verifyFinalFieldsPopulated()
     }
 
     private fun Session.verifyInitialFieldsPopulated() {
@@ -149,13 +142,8 @@ internal class PayloadMessageCollatorImplTest {
         assertEquals(5L, startTime)
     }
 
-    private fun Session.verifyFinalFieldsPopulated(payloadType: PayloadType) {
-        val expectedEndType = when (payloadType) {
-            PayloadType.BACKGROUND_ACTIVITY -> Session.LifeEventType.BKGND_STATE
-            PayloadType.SESSION -> Session.LifeEventType.STATE
-        }
+    private fun Session.verifyFinalFieldsPopulated() {
         assertEquals(15000000000L, endTime)
-        assertEquals(expectedEndType, endType)
         assertEquals(15000000000L, lastHeartbeatTime)
         assertEquals("crashId", crashReportId)
         assertNotNull(eventIds)

--- a/embrace-android-sdk/src/test/resources/bg_activity_expected.json
+++ b/embrace-android-sdk/src/test/resources/bg_activity_expected.json
@@ -15,6 +15,5 @@
   "el": [
     "fake-err-id"
   ],
-  "ri": "fake-crash-id",
-  "em": "bs"
+  "ri": "fake-crash-id"
 }

--- a/embrace-android-sdk/src/test/resources/session_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_expected.json
@@ -19,6 +19,5 @@
   "nc": [
     "fake-network-id"
   ],
-  "ri": "fake-crash-id",
-  "em": "s"
+  "ri": "fake-crash-id"
 }


### PR DESCRIPTION
## Goal

`endType` is no longer required on the session object as it is set as an attribute on the session span.

