### PR TITLE
Release 6.8.2

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -30,7 +30,7 @@ internal class EmbraceBreadcrumbService(
 ) : BreadcrumbService, ActivityLifecycleListener, MemoryCleanerListener {
 
     override fun logView(screen: String?, timestamp: Long) {
-        dataSourceModuleProvider()?.viewDataSource?.dataSource?.changeView(screen, false)
+        dataSourceModuleProvider()?.viewDataSource?.dataSource?.changeView(screen)
     }
 
     override fun startView(name: String?): Boolean {
@@ -107,7 +107,7 @@ internal class EmbraceBreadcrumbService(
     }
 
     override fun onView(activity: Activity) {
-        if (configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled()) {
+        if (configService.breadcrumbBehavior.isAutomaticActivityCaptureEnabled()) {
             logView(activity.javaClass.name, clock.now())
         }
     }
@@ -116,10 +116,9 @@ internal class EmbraceBreadcrumbService(
      * Close all open fragments when the activity closes
      */
     override fun onViewClose(activity: Activity) {
-        if (!configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled()) {
-            return
+        if (configService.breadcrumbBehavior.isAutomaticActivityCaptureEnabled()) {
+            dataSourceModuleProvider()?.viewDataSource?.dataSource?.onViewClose()
         }
-        dataSourceModuleProvider()?.viewDataSource?.dataSource?.onViewClose()
     }
 
     override fun cleanCollections() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
@@ -48,11 +48,9 @@ internal class ViewDataSource(
     /**
      * Called when a view is started, ending the last view.
      */
-    fun changeView(name: String?, force: Boolean) {
+    fun changeView(name: String?) {
         val lastView = viewSpans.keys.lastOrNull()
-        if (force || name.equals(lastView, ignoreCase = true)) {
-            endView(lastView)
-        }
+        endView(lastView)
         startView(name)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BreadcrumbBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/BreadcrumbBehavior.kt
@@ -45,7 +45,7 @@ internal class BreadcrumbBehavior(
     /**
      * Controls whether activity lifecycle changes are captured in breadcrumbs
      */
-    fun isActivityBreadcrumbCaptureEnabled() =
+    fun isAutomaticActivityCaptureEnabled() =
         local?.viewConfig?.enableAutomaticActivityCapture
             ?: ENABLE_AUTOMATIC_ACTIVITY_CAPTURE_DEFAULT
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -116,8 +116,7 @@ internal class DataSourceModuleImpl(
                     otelModule.spanService,
                     initModule.logger
                 )
-            },
-            configGate = { configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled() }
+            }
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/BreadcrumbBehaviorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/config/behavior/BreadcrumbBehaviorTest.kt
@@ -40,7 +40,7 @@ internal class BreadcrumbBehaviorTest {
             assertEquals(100, getWebViewBreadcrumbLimit())
             assertEquals(100, getFragmentBreadcrumbLimit())
             assertTrue(isTapCoordinateCaptureEnabled())
-            assertTrue(isActivityBreadcrumbCaptureEnabled())
+            assertTrue(isAutomaticActivityCaptureEnabled())
             assertTrue(isWebViewBreadcrumbCaptureEnabled())
             assertTrue(isQueryParamCaptureEnabled())
             assertFalse(isCaptureFcmPiiDataEnabled())
@@ -51,7 +51,7 @@ internal class BreadcrumbBehaviorTest {
     fun testLocalOnly() {
         with(fakeBreadcrumbBehavior(localCfg = { local })) {
             assertFalse(isTapCoordinateCaptureEnabled())
-            assertFalse(isActivityBreadcrumbCaptureEnabled())
+            assertFalse(isAutomaticActivityCaptureEnabled())
             assertFalse(isWebViewBreadcrumbCaptureEnabled())
             assertFalse(isQueryParamCaptureEnabled())
             assertTrue(isCaptureFcmPiiDataEnabled())


### PR DESCRIPTION
**WHAT**: the enable_automatic_activity_capture flag now doesn't affect logRnView nor startView/endView.
**WHY**: when that flag was enabled, logRnView and startView/endView didn't work.
**WHO**: customers using logRnView and startView/endView.

