### PR TITLE
Stop auto closing the last spans for automatic activity capture

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/ActivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/ActivityFeatureTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.config.local.ViewLocalConfig
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.findSpanAttribute
-import io.embrace.android.embracesdk.findSpansOfType
+import io.embrace.android.embracesdk.findSpanSnapshotsOfType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert
@@ -45,7 +45,7 @@ internal class ActivityFeatureTest {
                 startTimeMs = harness.overriddenClock.now()
             })
 
-            val viewSpans = message.findSpansOfType(EmbType.Ux.View)
+            val viewSpans = message.findSpanSnapshotsOfType(EmbType.Ux.View)
             Assert.assertEquals(1, viewSpans.size)
 
             val span1 = viewSpans[0]
@@ -53,7 +53,6 @@ internal class ActivityFeatureTest {
             with(span1) {
                 Assert.assertEquals("android.app.Activity", findSpanAttribute("view.name"))
                 Assert.assertEquals(startTimeMs, startTimeNanos.nanosToMillis())
-                Assert.assertEquals(startTimeMs + 30000L, endTimeNanos.nanosToMillis())
             }
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -112,15 +112,6 @@ internal class EmbraceBreadcrumbService(
         }
     }
 
-    /**
-     * Close all open fragments when the activity closes
-     */
-    override fun onViewClose(activity: Activity) {
-        if (configService.breadcrumbBehavior.isAutomaticActivityCaptureEnabled()) {
-            dataSourceModuleProvider()?.viewDataSource?.dataSource?.onViewClose()
-        }
-    }
-
     override fun cleanCollections() {
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/ViewDataSource.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.capture.crumbs
 
-import io.embrace.android.embracesdk.arch.datasource.NoInputValidation
 import io.embrace.android.embracesdk.arch.datasource.SpanDataSourceImpl
 import io.embrace.android.embracesdk.arch.datasource.startSpanCapture
 import io.embrace.android.embracesdk.arch.destination.StartSpanData
@@ -66,21 +65,6 @@ internal class ViewDataSource(
             viewSpans.remove(name)?.stop()
         }
     )
-
-    /**
-     * Called when the activity is closed (and therefore all views are assumed to close).
-     */
-    fun onViewClose() {
-        viewSpans.forEach { (_, span) ->
-            captureSpanData(
-                countsTowardsLimits = false,
-                inputValidation = NoInputValidation,
-                captureAction = {
-                    span.stop()
-                }
-            )
-        }
-    }
 
     override fun toStartSpanData(obj: FragmentBreadcrumb): StartSpanData = with(obj) {
         StartSpanData(


### PR DESCRIPTION
I want to make this change for consistency. When the session ends:
- If we start a view and don't end it, it is sent as a span snapshot.
- If we used the changeView API, the last span, the one from the view that hasn't changed yet, is sent as a span snapshot.
- **Why should we send a closed span for the last activity tracked if we could also send it as a span snapshot?**

Any span that hasn't ended is sent as a span snapshot and is shown correctly in our session timeline in the dashboard. I think we should make the different APIs in the BreadcrumbService behave in the same way.