### PR TITLE
Populate span attributes with end time as required

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
@@ -34,6 +34,8 @@ internal class SessionSpanAttrPopulator(
             addCustomAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
             addCustomAttribute(SpanAttributeData(embState.name, session.appState.name.toLowerCase(Locale.US)))
             addCustomAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
+            addCustomAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+
             session.startType.toString().toLowerCase(Locale.US).let {
                 addCustomAttribute(SpanAttributeData(embSessionStartType.name, it))
             }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulatorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulatorTest.kt
@@ -1,0 +1,63 @@
+package io.embrace.android.embracesdk.session.orchestrator
+
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import io.embrace.android.embracesdk.fakes.FakeEventService
+import io.embrace.android.embracesdk.fakes.FakeLogMessageService
+import io.embrace.android.embracesdk.fakes.FakeStartupService
+import io.embrace.android.embracesdk.payload.ApplicationState
+import io.embrace.android.embracesdk.payload.LifeEventType
+import io.embrace.android.embracesdk.payload.SessionZygote
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class SessionSpanAttrPopulatorTest {
+
+    private val zygote = SessionZygote("id", 1, 5, ApplicationState.FOREGROUND, false, LifeEventType.STATE)
+    private lateinit var populator: SessionSpanAttrPopulator
+    private lateinit var writer: FakeCurrentSessionSpan
+
+    @Before
+    fun setUp() {
+        writer = FakeCurrentSessionSpan()
+        populator = SessionSpanAttrPopulator(
+            writer,
+            FakeEventService(),
+            FakeStartupService(),
+            FakeLogMessageService()
+        )
+    }
+
+    @Test
+    fun `start attributes populated`() {
+        populator.populateSessionSpanStartAttrs(zygote)
+
+        val attrs = getSpanAttrs()
+        val expected = mapOf(
+            "emb.cold_start" to "false",
+            "emb.session_number" to "5",
+            "emb.state" to "foreground",
+            "emb.clean_exit" to "false",
+            "emb.terminated" to "true",
+            "emb.session_start_type" to "state"
+        )
+        assertEquals(expected, attrs)
+    }
+
+    @Test
+    fun `end attributes populated`() {
+        populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false)
+
+        val attrs = getSpanAttrs()
+        val expected = mapOf(
+            "emb.clean_exit" to "true",
+            "emb.terminated" to "false",
+            "emb.crash_id" to "crashId",
+            "emb.session_end_type" to "state",
+            "emb.error_log_count" to "0"
+        )
+        assertEquals(expected, attrs)
+    }
+
+    private fun getSpanAttrs() = writer.addedAttributes.associateBy { it.key }.mapValues { it.value.value }
+}


### PR DESCRIPTION
## Goal

The Android SDK now sends the following fields that are all that is necessary to calculate end time for the backend:

1. `emb.terminated` as a boolean
2. `emb.clean_exit` as a boolean
3. The session span end time

## Testing

Added unit test coverage.

