### PR TITLE
Remove dead code used for constructing session payloads

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -46,8 +46,7 @@ internal class SessionModuleImpl(
             essentialServiceModule.gatingService,
             payloadModule.sessionEnvelopeSource,
             androidServicesModule.preferencesService,
-            openTelemetryModule.currentSessionSpan,
-            initModule.logger
+            openTelemetryModule.currentSessionSpan
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -1,106 +1,22 @@
 package io.embrace.android.embracesdk.session.message
 
-import io.embrace.android.embracesdk.event.EventService
-import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.logging.EmbLogger
-import io.embrace.android.embracesdk.payload.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionZygote
-import io.embrace.android.embracesdk.session.captureDataSafely
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 /**
  * Holds the parameters & logic needed to create a final session object that can be
  * sent to the backend.
  */
-internal sealed class FinalEnvelopeParams(
+internal class FinalEnvelopeParams(
     val initial: SessionZygote,
-    val endTime: Long,
-    val lifeEventType: LifeEventType?,
-    crashId: String?,
     val endType: SessionSnapshotType,
-    val isCacheAttempt: Boolean,
-    val captureSpans: Boolean,
-    val logger: EmbLogger
+    val logger: EmbLogger,
+    crashId: String? = null,
 ) {
 
     val crashId: String? = when {
         crashId.isNullOrEmpty() -> null
         else -> crashId
-    }
-
-    abstract val terminationTime: Long?
-    abstract val receivedTermination: Boolean?
-    abstract val endTimeVal: Long?
-    abstract fun getStartupEventInfo(eventService: EventService): StartupEventInfo?
-
-    /**
-     * Initial parameters required to create a background activity object.
-     */
-    internal class BackgroundActivityParams(
-        initial: SessionZygote,
-        endTime: Long,
-        lifeEventType: LifeEventType?,
-        endType: SessionSnapshotType,
-        logger: EmbLogger,
-        captureSpans: Boolean = true,
-        crashId: String? = null,
-    ) : FinalEnvelopeParams(
-        initial,
-        endTime,
-        lifeEventType,
-        crashId,
-        endType,
-        lifeEventType == null,
-        captureSpans,
-        logger
-    ) {
-        override val terminationTime: Long? = null
-        override val receivedTermination: Boolean? = null
-        override val endTimeVal: Long? = null
-        override fun getStartupEventInfo(eventService: EventService): StartupEventInfo? = null
-    }
-
-    /**
-     * Initial parameters required to create a session object.
-     */
-    internal class SessionParams(
-        initial: SessionZygote,
-        endTime: Long,
-        lifeEventType: LifeEventType?,
-        endType: SessionSnapshotType,
-        logger: EmbLogger,
-        captureSpans: Boolean = true,
-        crashId: String? = null,
-    ) : FinalEnvelopeParams(
-        initial,
-        endTime,
-        lifeEventType,
-        crashId,
-        endType,
-        endType == SessionSnapshotType.PERIODIC_CACHE,
-        captureSpans,
-        logger
-    ) {
-
-        override val terminationTime: Long? = when {
-            endType.forceQuit -> endTime
-            else -> null
-        }
-        override val receivedTermination: Boolean? = when {
-            endType.forceQuit -> true
-            else -> null
-        }
-
-        // We don't set end time for force-quit, as the API interprets this to be a clean
-        // termination
-        override val endTimeVal: Long? = when {
-            endType.forceQuit -> null
-            else -> endTime
-        }
-
-        override fun getStartupEventInfo(eventService: EventService) = when {
-            initial.isColdStart -> captureDataSafely(logger, eventService::getStartupMomentInfo)
-            else -> null
-        }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/InitialEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/InitialEnvelopeParams.kt
@@ -3,50 +3,19 @@ package io.embrace.android.embracesdk.session.message
 import io.embrace.android.embracesdk.payload.ApplicationState
 import io.embrace.android.embracesdk.payload.LifeEventType
 import io.embrace.android.embracesdk.prefs.PreferencesService
-import io.embrace.android.embracesdk.session.properties.SessionPropertiesService
 
 /**
  * Holds the parameters & logic needed to create an initial session object.
  */
-internal sealed class InitialEnvelopeParams(
+internal class InitialEnvelopeParams(
     val coldStart: Boolean,
     val startType: LifeEventType,
-    val startTime: Long
+    val startTime: Long,
+    val appState: ApplicationState
 ) {
-    abstract val appState: ApplicationState
-    abstract fun getSessionNumber(service: PreferencesService): Int
-    abstract fun getProperties(service: SessionPropertiesService): Map<String, String>?
 
-    /**
-     * Initial parameters required to create a session object.
-     */
-    internal class SessionParams(
-        coldStart: Boolean,
-        startType: LifeEventType,
-        startTime: Long
-    ) : InitialEnvelopeParams(coldStart, startType, startTime) {
-
-        override val appState = ApplicationState.FOREGROUND
-        override fun getSessionNumber(service: PreferencesService): Int =
-            service.incrementAndGetSessionNumber()
-
-        override fun getProperties(service: SessionPropertiesService): Map<String, String> =
-            service.getProperties()
-    }
-
-    /**
-     * Initial parameters required to create a background activity object.
-     */
-    internal class BackgroundActivityParams(
-        coldStart: Boolean,
-        startType: LifeEventType,
-        startTime: Long
-    ) : InitialEnvelopeParams(coldStart, startType, startTime) {
-
-        override val appState = ApplicationState.BACKGROUND
-        override fun getSessionNumber(service: PreferencesService): Int =
-            service.incrementAndGetBackgroundActivityNumber()
-
-        override fun getProperties(service: SessionPropertiesService): Map<String, String>? = null
+    fun getSessionNumber(service: PreferencesService): Int = when (appState) {
+        ApplicationState.FOREGROUND -> service.incrementAndGetSessionNumber()
+        ApplicationState.BACKGROUND -> service.incrementAndGetBackgroundActivityNumber()
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.EmbLogger
+import io.embrace.android.embracesdk.payload.ApplicationState
 import io.embrace.android.embracesdk.payload.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.SessionZygote
@@ -22,8 +23,8 @@ internal class PayloadFactoryImpl(
 
     override fun endPayloadWithState(state: ProcessState, timestamp: Long, initial: SessionZygote) =
         when (state) {
-            ProcessState.FOREGROUND -> endSessionWithState(initial, timestamp)
-            ProcessState.BACKGROUND -> endBackgroundActivityWithState(initial, timestamp)
+            ProcessState.FOREGROUND -> endSessionWithState(initial)
+            ProcessState.BACKGROUND -> endBackgroundActivityWithState(initial)
         }
 
     override fun endPayloadWithCrash(
@@ -32,32 +33,31 @@ internal class PayloadFactoryImpl(
         initial: SessionZygote,
         crashId: String
     ) = when (state) {
-        ProcessState.FOREGROUND -> endSessionWithCrash(initial, timestamp, crashId)
-        ProcessState.BACKGROUND -> endBackgroundActivityWithCrash(initial, timestamp, crashId)
+        ProcessState.FOREGROUND -> endSessionWithCrash(initial, crashId)
+        ProcessState.BACKGROUND -> endBackgroundActivityWithCrash(initial, crashId)
     }
 
     override fun snapshotPayload(state: ProcessState, timestamp: Long, initial: SessionZygote) =
         when (state) {
-            ProcessState.FOREGROUND -> snapshotSession(initial, timestamp)
-            ProcessState.BACKGROUND -> snapshotBackgroundActivity(initial, timestamp)
+            ProcessState.FOREGROUND -> snapshotSession(initial)
+            ProcessState.BACKGROUND -> snapshotBackgroundActivity(initial)
         }
 
     override fun startSessionWithManual(timestamp: Long): SessionZygote {
         return payloadMessageCollator.buildInitialSession(
-            InitialEnvelopeParams.SessionParams(
+            InitialEnvelopeParams(
                 false,
                 LifeEventType.MANUAL,
-                timestamp
+                timestamp,
+                ApplicationState.FOREGROUND
             )
         )
     }
 
     override fun endSessionWithManual(timestamp: Long, initial: SessionZygote): SessionMessage {
         return payloadMessageCollator.buildFinalSessionMessage(
-            FinalEnvelopeParams.SessionParams(
+            FinalEnvelopeParams(
                 initial = initial,
-                endTime = timestamp,
-                lifeEventType = LifeEventType.MANUAL,
                 endType = SessionSnapshotType.NORMAL_END,
                 logger = logger
             )
@@ -66,10 +66,11 @@ internal class PayloadFactoryImpl(
 
     private fun startSessionWithState(timestamp: Long, coldStart: Boolean): SessionZygote {
         return payloadMessageCollator.buildInitialSession(
-            InitialEnvelopeParams.SessionParams(
+            InitialEnvelopeParams(
                 coldStart,
                 LifeEventType.STATE,
-                timestamp
+                timestamp,
+                ApplicationState.FOREGROUND
             )
         )
     }
@@ -86,38 +87,35 @@ internal class PayloadFactoryImpl(
             else -> timestamp + 1
         }
         return payloadMessageCollator.buildInitialSession(
-            InitialEnvelopeParams.BackgroundActivityParams(
+            InitialEnvelopeParams(
                 coldStart = coldStart,
                 startType = LifeEventType.BKGND_STATE,
-                startTime = time
+                startTime = time,
+                ApplicationState.BACKGROUND
             )
         )
     }
 
-    private fun endSessionWithState(initial: SessionZygote, timestamp: Long): SessionMessage {
+    private fun endSessionWithState(initial: SessionZygote): SessionMessage {
         return payloadMessageCollator.buildFinalSessionMessage(
-            FinalEnvelopeParams.SessionParams(
+            FinalEnvelopeParams(
                 initial = initial,
-                endTime = timestamp,
-                lifeEventType = LifeEventType.STATE,
                 endType = SessionSnapshotType.NORMAL_END,
                 logger = logger
             )
         )
     }
 
-    private fun endBackgroundActivityWithState(initial: SessionZygote, timestamp: Long): SessionMessage? {
+    private fun endBackgroundActivityWithState(initial: SessionZygote): SessionMessage? {
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }
 
         // kept for backwards compat. the backend expects the start time to be 1 ms greater
         // than the adjacent session, and manually adjusts.
-        return payloadMessageCollator.buildFinalBackgroundActivityMessage(
-            FinalEnvelopeParams.BackgroundActivityParams(
+        return payloadMessageCollator.buildFinalSessionMessage(
+            FinalEnvelopeParams(
                 initial = initial,
-                endTime = timestamp - 1,
-                lifeEventType = LifeEventType.BKGND_STATE,
                 endType = SessionSnapshotType.NORMAL_END,
                 logger = logger
             )
@@ -126,37 +124,31 @@ internal class PayloadFactoryImpl(
 
     private fun endSessionWithCrash(
         initial: SessionZygote,
-        timestamp: Long,
         crashId: String
     ): SessionMessage {
         return payloadMessageCollator.buildFinalSessionMessage(
-            FinalEnvelopeParams.SessionParams(
+            FinalEnvelopeParams(
                 initial = initial,
-                endTime = timestamp,
-                lifeEventType = LifeEventType.STATE,
-                crashId = crashId,
                 endType = SessionSnapshotType.JVM_CRASH,
-                logger = logger
+                logger = logger,
+                crashId = crashId
             )
         )
     }
 
     private fun endBackgroundActivityWithCrash(
         initial: SessionZygote,
-        timestamp: Long,
         crashId: String
     ): SessionMessage? {
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }
-        return payloadMessageCollator.buildFinalBackgroundActivityMessage(
-            FinalEnvelopeParams.BackgroundActivityParams(
+        return payloadMessageCollator.buildFinalSessionMessage(
+            FinalEnvelopeParams(
                 initial = initial,
-                endTime = timestamp,
-                lifeEventType = LifeEventType.BKGND_STATE,
-                crashId = crashId,
                 endType = SessionSnapshotType.JVM_CRASH,
-                logger = logger
+                logger = logger,
+                crashId = crashId
             )
         )
     }
@@ -164,27 +156,23 @@ internal class PayloadFactoryImpl(
     /**
      * Called when the session is persisted every 2s to cache its state.
      */
-    private fun snapshotSession(initial: SessionZygote, timestamp: Long): SessionMessage {
+    private fun snapshotSession(initial: SessionZygote): SessionMessage {
         return payloadMessageCollator.buildFinalSessionMessage(
-            FinalEnvelopeParams.SessionParams(
+            FinalEnvelopeParams(
                 initial = initial,
-                endTime = timestamp,
-                lifeEventType = LifeEventType.STATE,
                 endType = SessionSnapshotType.PERIODIC_CACHE,
                 logger = logger
             )
         )
     }
 
-    private fun snapshotBackgroundActivity(initial: SessionZygote, timestamp: Long): SessionMessage? {
+    private fun snapshotBackgroundActivity(initial: SessionZygote): SessionMessage? {
         if (!configService.isBackgroundActivityCaptureEnabled()) {
             return null
         }
-        return payloadMessageCollator.buildFinalBackgroundActivityMessage(
-            FinalEnvelopeParams.BackgroundActivityParams(
+        return payloadMessageCollator.buildFinalSessionMessage(
+            FinalEnvelopeParams(
                 initial = initial,
-                endTime = timestamp,
-                lifeEventType = null,
                 endType = SessionSnapshotType.PERIODIC_CACHE,
                 logger = logger
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollator.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.session.message
 
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.SessionZygote
-import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams.BackgroundActivityParams
-import io.embrace.android.embracesdk.session.message.FinalEnvelopeParams.SessionParams
 
 internal interface PayloadMessageCollator {
 
@@ -14,13 +12,7 @@ internal interface PayloadMessageCollator {
     fun buildInitialSession(params: InitialEnvelopeParams): SessionZygote
 
     /**
-     * Builds a fully populated session message. This can be sent to the backend (or stored
-     * on disk).
+     * Builds a fully populated payload.
      */
-    fun buildFinalSessionMessage(params: SessionParams): SessionMessage
-
-    /**
-     * Create the background session message with the current state of the background activity.
-     */
-    fun buildFinalBackgroundActivityMessage(params: BackgroundActivityParams): SessionMessage
+    fun buildFinalSessionMessage(params: FinalEnvelopeParams): SessionMessage
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
@@ -3,11 +3,9 @@ package io.embrace.android.embracesdk.session.message
 import io.embrace.android.embracesdk.capture.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.gating.GatingService
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
-import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.SessionZygote
 import io.embrace.android.embracesdk.prefs.PreferencesService
-import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 /**
  * Generates a V2 payload
@@ -16,54 +14,24 @@ internal class PayloadMessageCollatorImpl(
     private val gatingService: GatingService,
     private val sessionEnvelopeSource: SessionEnvelopeSource,
     private val preferencesService: PreferencesService,
-    private val currentSessionSpan: CurrentSessionSpan,
-    private val logger: EmbLogger,
+    private val currentSessionSpan: CurrentSessionSpan
 ) : PayloadMessageCollator {
 
-    override fun buildInitialSession(params: InitialEnvelopeParams): SessionZygote {
-        return with(params) {
-            SessionZygote(
-                sessionId = currentSessionSpan.getSessionId(),
-                startTime = startTime,
-                isColdStart = coldStart,
-                appState = appState,
-                startType = startType,
-                number = getSessionNumber(preferencesService)
-            )
-        }
-    }
-
-    override fun buildFinalSessionMessage(params: FinalEnvelopeParams.SessionParams): SessionMessage {
-        val newParams = FinalEnvelopeParams.SessionParams(
-            initial = params.initial,
-            endTime = params.endTime,
-            lifeEventType = params.lifeEventType,
-            crashId = params.crashId,
-            endType = params.endType,
-            captureSpans = false,
-            logger = logger
+    override fun buildInitialSession(params: InitialEnvelopeParams) = with(params) {
+        SessionZygote(
+            sessionId = currentSessionSpan.getSessionId(),
+            startTime = startTime,
+            isColdStart = coldStart,
+            appState = appState,
+            startType = startType,
+            number = getSessionNumber(preferencesService)
         )
-        val obj = gatingService.gateSessionMessage(SessionMessage())
-        return obj.convertToV2Payload(newParams.endType, newParams.crashId)
     }
 
-    override fun buildFinalBackgroundActivityMessage(params: FinalEnvelopeParams.BackgroundActivityParams): SessionMessage {
-        val newParams = FinalEnvelopeParams.BackgroundActivityParams(
-            initial = params.initial,
-            endTime = params.endTime,
-            lifeEventType = params.lifeEventType,
-            crashId = params.crashId,
-            endType = params.endType,
-            captureSpans = false,
-            logger = logger
-        )
+    override fun buildFinalSessionMessage(params: FinalEnvelopeParams): SessionMessage {
         val obj = gatingService.gateSessionMessage(SessionMessage())
-        return obj.convertToV2Payload(newParams.endType, newParams.crashId)
-    }
-
-    private fun SessionMessage.convertToV2Payload(endType: SessionSnapshotType, crashId: String?): SessionMessage {
-        val envelope = gatingService.gateSessionEnvelope(this, sessionEnvelopeSource.getEnvelope(endType, crashId))
-        return copy(
+        val envelope = gatingService.gateSessionEnvelope(obj, sessionEnvelopeSource.getEnvelope(params.endType, params.crashId))
+        return obj.copy(
             // future work: make legacy fields null here.
             resource = envelope.resource,
             metadata = envelope.metadata,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
@@ -11,11 +11,7 @@ internal class FakePayloadCollator : PayloadMessageCollator {
         TODO("Not yet implemented")
     }
 
-    override fun buildFinalSessionMessage(params: FinalEnvelopeParams.SessionParams): SessionMessage {
-        TODO("Not yet implemented")
-    }
-
-    override fun buildFinalBackgroundActivityMessage(params: FinalEnvelopeParams.BackgroundActivityParams): SessionMessage {
+    override fun buildFinalSessionMessage(params: FinalEnvelopeParams): SessionMessage {
         TODO("Not yet implemented")
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
@@ -41,11 +41,5 @@ internal class FakeV2PayloadCollator(
      * Builds a fully populated session message. This can be sent to the backend (or stored
      * on disk).
      */
-    override fun buildFinalSessionMessage(
-        params: FinalEnvelopeParams.SessionParams
-    ): SessionMessage = SessionMessage()
-
-    override fun buildFinalBackgroundActivityMessage(
-        params: FinalEnvelopeParams.BackgroundActivityParams
-    ): SessionMessage = SessionMessage()
+    override fun buildFinalSessionMessage(params: FinalEnvelopeParams) = SessionMessage()
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -171,8 +171,7 @@ internal class PayloadFactoryBaTest {
             gatingService,
             sessionEnvelopeSource,
             preferencesService,
-            currentSessionSpan,
-            logger
+            currentSessionSpan
         )
         return PayloadFactoryImpl(collator, configService, logger).apply {
             if (createInitialSession) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactorySessionTest.kt
@@ -165,8 +165,7 @@ internal class PayloadFactorySessionTest {
             gatingService,
             sessionEnvelopeSource,
             preferencesService,
-            currentSessionSpan,
-            logger
+            currentSessionSpan
         )
         service = PayloadFactoryImpl(collator, FakeConfigService(), logger)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -146,8 +146,7 @@ internal class SessionHandlerTest {
                 )
             ),
             preferencesService,
-            currentSessionSpan,
-            logger,
+            currentSessionSpan
         )
         payloadFactory = PayloadFactoryImpl(collator, configService, logger)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImplTest.kt
@@ -34,7 +34,6 @@ internal class PayloadFactoryImplTest {
             gatingService = FakeGatingService(),
             preferencesService = FakePreferenceService(),
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
-            logger = initModule.logger,
             sessionEnvelopeSource = SessionEnvelopeSourceImpl(
                 FakeEnvelopeMetadataSource(),
                 FakeEnvelopeResourceSource(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.payload.ApplicationState
 import io.embrace.android.embracesdk.payload.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionMessage
 import io.embrace.android.embracesdk.payload.SessionZygote
@@ -38,7 +39,6 @@ internal class PayloadMessageCollatorImplTest {
             gatingService = gatingService,
             preferencesService = FakePreferenceService(),
             currentSessionSpan = initModule.openTelemetryModule.currentSessionSpan,
-            logger = initModule.logger,
             sessionEnvelopeSource = sessionEnvelopeSource
         )
     }
@@ -46,10 +46,11 @@ internal class PayloadMessageCollatorImplTest {
     @Test
     fun `create background activity initial message`() {
         val msg = collator.buildInitialSession(
-            InitialEnvelopeParams.BackgroundActivityParams(
+            InitialEnvelopeParams(
                 false,
                 LifeEventType.BKGND_STATE,
-                5
+                5,
+                ApplicationState.BACKGROUND
             )
         )
         msg.verifyInitialFieldsPopulated()
@@ -58,10 +59,11 @@ internal class PayloadMessageCollatorImplTest {
     @Test
     fun `create session initial message`() {
         val msg = collator.buildInitialSession(
-            InitialEnvelopeParams.SessionParams(
+            InitialEnvelopeParams(
                 false,
                 LifeEventType.STATE,
-                5
+                5,
+                ApplicationState.FOREGROUND
             )
         )
         msg.verifyInitialFieldsPopulated()
@@ -71,23 +73,21 @@ internal class PayloadMessageCollatorImplTest {
     fun `create background activity end message`() {
         // create start message
         val startMsg = collator.buildInitialSession(
-            InitialEnvelopeParams.BackgroundActivityParams(
+            InitialEnvelopeParams(
                 false,
                 LifeEventType.BKGND_STATE,
-                5
+                5,
+                ApplicationState.BACKGROUND
             )
         )
         startMsg.verifyInitialFieldsPopulated()
 
         // create session
-        val payload = collator.buildFinalBackgroundActivityMessage(
-            FinalEnvelopeParams.BackgroundActivityParams(
+        val payload = collator.buildFinalSessionMessage(
+            FinalEnvelopeParams(
                 startMsg,
-                15000000000,
-                LifeEventType.BKGND_STATE,
                 SessionSnapshotType.NORMAL_END,
                 initModule.logger,
-                true,
                 "crashId"
             )
         )
@@ -99,23 +99,21 @@ internal class PayloadMessageCollatorImplTest {
     fun `create session end message`() {
         // create start message
         val startMsg = collator.buildInitialSession(
-            InitialEnvelopeParams.SessionParams(
+            InitialEnvelopeParams(
                 false,
                 LifeEventType.STATE,
-                5
+                5,
+                ApplicationState.FOREGROUND
             )
         )
         startMsg.verifyInitialFieldsPopulated()
 
         // create session
         val payload = collator.buildFinalSessionMessage(
-            FinalEnvelopeParams.SessionParams(
+            FinalEnvelopeParams(
                 startMsg,
-                15000000000,
-                LifeEventType.STATE,
                 SessionSnapshotType.NORMAL_END,
                 initModule.logger,
-                true,
                 "crashId",
             )
         )


### PR DESCRIPTION
## Goal

Removes dead code used for constructing session payloads. These conditions are no longer required after the migration to OTel so the code can be simplified.

## Testing

Relied on existing test coverage.

