### PR TITLE
Hook up session gating

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/GatingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/GatingService.kt
@@ -3,29 +3,19 @@ package io.embrace.android.embracesdk.gating
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.payload.EventMessage
-import io.embrace.android.embracesdk.payload.SessionMessage
 
 internal interface GatingService {
-
-    /**
-     * Sanitizes a session message before send it to backend based on the Gating configuration.
-     * Breadcrumbs, session properties, ANRs, logs, etc can be removed from the session payload.
-     * This method should be called before send the session message to the ApiClient class.
-     *
-     * @param sessionMessage to be sanitized
-     */
-    fun gateSessionMessage(sessionMessage: SessionMessage): SessionMessage
 
     /**
      * Sanitizes a v2 session message before sending it to the backend based on the Gating configuration.
      * Breadcrumbs, session properties, ANRs, logs, etc can be removed from the session payload.
      * This method should be called before send the session message to the ApiClient class.
      *
-     * @param sessionMessage to be sanitized
+     * @param hasCrash if any crash occurred
      * @param envelope to be sanitized
      */
     fun gateSessionEnvelope(
-        sessionMessage: SessionMessage,
+        hasCrash: Boolean,
         envelope: Envelope<SessionPayload>
     ): Envelope<SessionPayload>
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeSanitizerFacade.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/v2/EnvelopeSanitizerFacade.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.gating.v2
 
+import io.embrace.android.embracesdk.gating.SpanSanitizer
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -14,7 +15,10 @@ internal class EnvelopeSanitizerFacade(
             metadata = EnvelopeMetadataSanitizer(
                 envelope.metadata ?: EnvelopeMetadata(),
                 components
-            ).sanitize()
+            ).sanitize(),
+            data = envelope.data.copy(
+                spans = SpanSanitizer(envelope.data.spans, components).sanitize()
+            )
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
@@ -29,9 +29,11 @@ internal class PayloadMessageCollatorImpl(
     }
 
     override fun buildFinalSessionMessage(params: FinalEnvelopeParams): SessionMessage {
-        val obj = gatingService.gateSessionMessage(SessionMessage())
-        val envelope = gatingService.gateSessionEnvelope(obj, sessionEnvelopeSource.getEnvelope(params.endType, params.crashId))
-        return obj.copy(
+        val envelope = gatingService.gateSessionEnvelope(
+            params.crashId != null,
+            sessionEnvelopeSource.getEnvelope(params.endType, params.crashId)
+        )
+        return SessionMessage(
             // future work: make legacy fields null here.
             resource = envelope.resource,
             metadata = envelope.metadata,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeGatingService.kt
@@ -7,30 +7,22 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.EventMessage
-import io.embrace.android.embracesdk.payload.SessionMessage
 
 /**
  * An implementation of [GatingService] that does a pass-through to [EmbraceGatingService] but tracks the message that go through it
  */
 internal class FakeGatingService(configService: ConfigService = FakeConfigService()) :
     GatingService {
-    val sessionMessagesFiltered = mutableListOf<SessionMessage>()
     val envelopesFiltered = mutableListOf<Envelope<SessionPayload>>()
     val eventMessagesFiltered = mutableListOf<EventMessage>()
 
     private val realGatingService = EmbraceGatingService(configService, FakeLogMessageService(), EmbLoggerImpl())
 
-    override fun gateSessionMessage(sessionMessage: SessionMessage): SessionMessage {
-        val filteredMessage = realGatingService.gateSessionMessage(sessionMessage)
-        sessionMessagesFiltered.add(sessionMessage)
-        return filteredMessage
-    }
-
     override fun gateSessionEnvelope(
-        sessionMessage: SessionMessage,
+        hasCrash: Boolean,
         envelope: Envelope<SessionPayload>
     ): Envelope<SessionPayload> {
-        val filteredMessage = realGatingService.gateSessionEnvelope(sessionMessage, envelope)
+        val filteredMessage = realGatingService.gateSessionEnvelope(hasCrash, envelope)
         envelopesFiltered.add(filteredMessage)
         return envelope
     }


### PR DESCRIPTION
## Goal

Session gating was previously relying on the v1 implementation. This hooks up the gating service so that spans in the v2 payload are sanitized.

## Testing

Updated existing test coverage.
