### PR TITLE
Add telemetry.distro.* resource attributes to OTel SDK instance

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanTest.kt
@@ -54,8 +54,8 @@ internal class SpanTest {
                 testSpan.assertHasEmbraceAttribute(embSequenceId, "6")
                 testSpan.assertHasEmbraceAttribute(embProcessIdentifier, harness.overriddenInitModule.processIdentifier)
                 testSpan.resource.assertExpectedAttributes(
-                    expectedServiceName = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceServiceName,
-                    expectedServiceVersion = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceVersionName,
+                    expectedServiceName = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceSdkName,
+                    expectedServiceVersion = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceSdkVersion,
                     systemInfo = harness.overriddenInitModule.systemInfo
                 )
                 val sessionSpan = checkNotNull(exportedSpans["emb-session"])

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryAttributeKeys.kt
@@ -10,11 +10,14 @@ import io.opentelemetry.api.common.AttributeKey
  */
 
 internal val androidApiLevel: AttributeKey<String> = AttributeKey.stringKey("android.os.api_level")
-internal val androidState: AttributeKey<String> = AttributeKey.stringKey("android.state")
 
 internal val deviceManufacturer: AttributeKey<String> = AttributeKey.stringKey("device.manufacturer")
 internal val deviceModelIdentifier: AttributeKey<String> = AttributeKey.stringKey("os.model.identifier")
 internal val deviceModelName: AttributeKey<String> = AttributeKey.stringKey("os.model.name")
+
+internal val exceptionMessage: AttributeKey<String> = AttributeKey.stringKey("exception.message")
+internal val exceptionStacktrace: AttributeKey<String> = AttributeKey.stringKey("exception.stacktrace")
+internal val exceptionType: AttributeKey<String> = AttributeKey.stringKey("exception.type")
 
 internal val logRecordUid: AttributeKey<String> = AttributeKey.stringKey("log.record.uid")
 
@@ -26,6 +29,5 @@ internal val osBuildId: AttributeKey<String> = AttributeKey.stringKey("os.build_
 internal val serviceName: AttributeKey<String> = AttributeKey.stringKey("service.name")
 internal val serviceVersion: AttributeKey<String> = AttributeKey.stringKey("service.version")
 
-internal val exceptionMessage: AttributeKey<String> = AttributeKey.stringKey("exception.message")
-internal val exceptionStacktrace: AttributeKey<String> = AttributeKey.stringKey("exception.stacktrace")
-internal val exceptionType: AttributeKey<String> = AttributeKey.stringKey("exception.type")
+internal val telemetryDistroName: AttributeKey<String> = AttributeKey.stringKey("telemetry.distro.name")
+internal val telemetryDistroVersion: AttributeKey<String> = AttributeKey.stringKey("telemetry.distro.version")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
@@ -20,11 +20,11 @@ internal class OpenTelemetryConfiguration(
     systemInfo: SystemInfo,
     processIdentifier: String
 ) {
-    val embraceServiceName = BuildConfig.LIBRARY_PACKAGE_NAME
-    val embraceVersionName = BuildConfig.VERSION_NAME
+    val embraceSdkName = BuildConfig.LIBRARY_PACKAGE_NAME
+    val embraceSdkVersion = BuildConfig.VERSION_NAME
     val resource: Resource = Resource.getDefault().toBuilder()
-        .put(serviceName, embraceServiceName)
-        .put(serviceVersion, embraceVersionName)
+        .put(serviceName, embraceSdkName)
+        .put(serviceVersion, embraceSdkVersion)
         .put(osName, systemInfo.osName)
         .put(osVersion, systemInfo.osVersion)
         .put(osType, systemInfo.osType)
@@ -33,6 +33,8 @@ internal class OpenTelemetryConfiguration(
         .put(deviceManufacturer, systemInfo.deviceManufacturer)
         .put(deviceModelIdentifier, systemInfo.deviceModel)
         .put(deviceModelName, systemInfo.deviceModel)
+        .put(telemetryDistroName, embraceSdkName)
+        .put(telemetryDistroVersion, embraceSdkVersion)
         .build()
 
     private val externalSpanExporters = mutableListOf<SpanExporter>()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdk.kt
@@ -30,7 +30,7 @@ internal class OpenTelemetrySdk(
 
     val sdkTracer: Tracer by lazy {
         Systrace.traceSynchronous("otel-tracer-init") {
-            sdk.getTracer(configuration.embraceServiceName, configuration.embraceVersionName)
+            sdk.getTracer(configuration.embraceSdkName, configuration.embraceSdkVersion)
         }
     }
 
@@ -55,7 +55,7 @@ internal class OpenTelemetrySdk(
 
     private val logger: Logger by lazy {
         Systrace.traceSynchronous("otel-logger-init") {
-            sdk.logsBridge.loggerBuilder(configuration.embraceServiceName).build()
+            sdk.logsBridge.loggerBuilder(configuration.embraceSdkName).build()
         }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OTelAssertions.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OTelAssertions.kt
@@ -14,6 +14,8 @@ internal fun Resource.assertExpectedAttributes(
 ) {
     assertEquals(expectedServiceName, getAttribute(serviceName))
     assertEquals(expectedServiceVersion, getAttribute(serviceVersion))
+    assertEquals(expectedServiceName, getAttribute(telemetryDistroName))
+    assertEquals(expectedServiceVersion, getAttribute(telemetryDistroVersion))
     assertEquals(systemInfo.osName, getAttribute(osName))
     assertEquals(systemInfo.osVersion, getAttribute(osVersion))
     assertEquals(systemInfo.osType, getAttribute(osType))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfigurationTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfigurationTest.kt
@@ -27,8 +27,10 @@ internal class OpenTelemetryConfigurationTest {
             processIdentifier = "fakeProcessIdentifier"
         )
 
-        assertEquals(configuration.embraceServiceName, configuration.resource.getAttribute(serviceName))
-        assertEquals(configuration.embraceVersionName, configuration.resource.getAttribute(serviceVersion))
+        assertEquals(configuration.embraceSdkName, configuration.resource.getAttribute(serviceName))
+        assertEquals(configuration.embraceSdkVersion, configuration.resource.getAttribute(serviceVersion))
+        assertEquals(configuration.embraceSdkName, configuration.resource.getAttribute(telemetryDistroName))
+        assertEquals(configuration.embraceSdkVersion, configuration.resource.getAttribute(telemetryDistroVersion))
         assertEquals(systemInfo.osName, configuration.resource.getAttribute(osName))
         assertEquals(systemInfo.osVersion, configuration.resource.getAttribute(osVersion))
         assertEquals(systemInfo.osType, configuration.resource.getAttribute(osType))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdkTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetrySdkTest.kt
@@ -50,8 +50,8 @@ internal class OpenTelemetrySdkTest {
     fun `check resource added by sdk tracer`() {
         sdk.sdkTracer.spanBuilder("test").startSpan().end()
         spanExporter.exportedSpans.single().resource.assertExpectedAttributes(
-            expectedServiceName = configuration.embraceServiceName,
-            expectedServiceVersion = configuration.embraceVersionName,
+            expectedServiceName = configuration.embraceSdkName,
+            expectedServiceVersion = configuration.embraceSdkVersion,
             systemInfo = systemInfo
         )
     }
@@ -60,8 +60,8 @@ internal class OpenTelemetrySdkTest {
     fun `check resource added by default logger`() {
         sdk.getOpenTelemetryLogger().logRecordBuilder().emit()
         checkNotNull(logExporter.exportedLogs).single().resource.assertExpectedAttributes(
-            expectedServiceName = configuration.embraceServiceName,
-            expectedServiceVersion = configuration.embraceVersionName,
+            expectedServiceName = configuration.embraceSdkName,
+            expectedServiceVersion = configuration.embraceSdkVersion,
             systemInfo = systemInfo
         )
     }
@@ -73,8 +73,8 @@ internal class OpenTelemetrySdkTest {
             .startSpan()
             .end()
         with(spanExporter.exportedSpans.single().instrumentationScopeInfo) {
-            assertEquals(configuration.embraceServiceName, name)
-            assertEquals(configuration.embraceVersionName, version)
+            assertEquals(configuration.embraceSdkName, name)
+            assertEquals(configuration.embraceSdkVersion, version)
             assertNull(schemaUrl)
         }
     }


### PR DESCRIPTION
## Goal

Add two attributes associated with the distribution providing the OTel recording capabilities (i.e. us) to resources.

Note: We are still using the SDK name and version for the `service.*` attributes, which is wrong - but we need to find a way to be able to retrieve that fast and not block SDK startup

## Testing
Added to tests that verify resource attributes on signals

