### PR TITLE
Use further semantic convention constants

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.assertions
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.findLogAttribute
 import io.embrace.android.embracesdk.injection.ModuleInitBootstrapper
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 import org.junit.Assert.fail
 
 /**
@@ -26,8 +27,8 @@ internal fun assertInternalErrorLogged(
     }
 
     val matchingLogs = logs.filter { log ->
-        log.findLogAttribute("exception.type") == exceptionClassName &&
-            log.findLogAttribute("exception.message") == errorMessage
+        log.findLogAttribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE.key) == exceptionClassName &&
+            log.findLogAttribute(ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key) == errorMessage
     }
     if (matchingLogs.isEmpty()) {
         fail("No internal errors found matching the expected exception")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/CrashTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/CrashTest.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.payload.LegacyExceptionInfo
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.verifySessionHappened
 import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -71,7 +72,7 @@ internal class CrashTest {
         val message = checkNotNull(testRule.harness.getLastSentSession())
         verifySessionHappened(message)
         assertNotNull(message.session.crashReportId)
-        assertEquals(message.session.crashReportId, log?.findLogAttribute("log.record.uid"))
+        assertEquals(message.session.crashReportId, log?.findLogAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key))
     }
 
     @Test
@@ -114,6 +115,6 @@ internal class CrashTest {
         val message = checkNotNull(testRule.harness.getLastSentSession())
         verifySessionHappened(message)
         assertNotNull(message.session.crashReportId)
-        assertEquals(message.session.crashReportId, log?.findLogAttribute("log.record.uid"))
+        assertEquals(message.session.crashReportId, log?.findLogAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key))
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -21,6 +21,7 @@ import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.semconv.HttpAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -212,7 +213,7 @@ internal class EmbraceInternalInterfaceTest {
                 )
             }
 
-            val requests = checkNotNull(session?.spans?.filter { it.attributes.containsKey("http.request.method") })
+            val requests = checkNotNull(session?.spans?.filter { it.attributes.containsKey(HttpAttributes.HTTP_REQUEST_METHOD.key) })
             assertEquals(
                 "Unexpected number of requests in sent session: ${requests.size}",
                 4,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -160,7 +161,7 @@ internal class FlutterInternalInterfaceTest {
                 expectedExceptionMessage = expectedMessage,
                 expectedEmbType = "sys.flutter_exception",
             )
-            assertEquals(expectedStacktrace, log?.findLogAttribute("exception.stacktrace"))
+            assertEquals(expectedStacktrace, log?.findLogAttribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key))
             assertEquals(expectedContext, log?.findLogAttribute("emb.exception.context"))
             assertEquals(expectedLibrary, log?.findLogAttribute("emb.exception.library"))
         }
@@ -196,7 +197,7 @@ internal class FlutterInternalInterfaceTest {
                 expectedExceptionMessage = expectedMessage,
                 expectedEmbType = "sys.flutter_exception",
             )
-            assertEquals(expectedStacktrace, log?.findLogAttribute("exception.stacktrace"))
+            assertEquals(expectedStacktrace, log?.findLogAttribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key))
             assertEquals(expectedContext, log?.findLogAttribute("emb.exception.context"))
             assertEquals(expectedLibrary, log?.findLogAttribute("emb.exception.library"))
         }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -10,6 +10,8 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.recordSession
+import io.opentelemetry.semconv.HttpAttributes
+import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -228,7 +230,7 @@ internal class NetworkRequestApiTest {
 
             val session = checkNotNull(testRule.harness.getLastSentSession())
 
-            val spans = checkNotNull(session.spans?.filter { it.attributes.containsKey("http.request.method") })
+            val spans = checkNotNull(session.spans?.filter { it.attributes.containsKey(HttpAttributes.HTTP_REQUEST_METHOD.key) })
             assertEquals(
                 "Unexpected number of requests in sent session: ${spans.size}",
                 2,
@@ -252,21 +254,21 @@ internal class NetworkRequestApiTest {
             val networkSpan = validateAndReturnExpectedNetworkSpan()
             with(networkSpan) {
                 assertEquals(expectedRequest.url, this.attributes["url.full"])
-                assertEquals(expectedRequest.httpMethod, this.attributes["http.request.method"])
+                assertEquals(expectedRequest.httpMethod, this.attributes[HttpAttributes.HTTP_REQUEST_METHOD.key])
                 assertEquals(expectedRequest.startTime.millisToNanos(), this.startTimeNanos)
                 assertEquals(expectedRequest.endTime.millisToNanos(), this.endTimeNanos)
                 assertEquals(expectedRequest.traceId, this.attributes["emb.trace_id"])
                 assertEquals(expectedRequest.w3cTraceparent, this.attributes["emb.w3c_traceparent"])
                 if (completed) {
-                    assertEquals(expectedRequest.responseCode.toString(), this.attributes["http.response.status_code"])
-                    assertEquals(expectedRequest.bytesSent.toString(), this.attributes["http.request.body.size"])
-                    assertEquals(expectedRequest.bytesReceived.toString(), this.attributes["http.response.body.size"])
+                    assertEquals(expectedRequest.responseCode.toString(), this.attributes[HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key])
+                    assertEquals(expectedRequest.bytesSent.toString(), this.attributes[HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key])
+                    assertEquals(expectedRequest.bytesReceived.toString(), this.attributes[HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key])
                     assertEquals(null, this.attributes["error.type"])
                     assertEquals(null, this.attributes["error.message"])
                 } else {
-                    assertEquals(null, this.attributes["http.response.status_code"])
-                    assertEquals(null, this.attributes["http.request.body.size"])
-                    assertEquals(null, this.attributes["http.response.body.size"])
+                    assertEquals(null, this.attributes[HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key])
+                    assertEquals(null, this.attributes[HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key])
+                    assertEquals(null, this.attributes[HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key])
                     assertEquals(expectedRequest.errorType, this.attributes["error.type"])
                     assertEquals(expectedRequest.errorMessage, this.attributes["error.message"])
                 }
@@ -277,7 +279,7 @@ internal class NetworkRequestApiTest {
     private fun validateAndReturnExpectedNetworkSpan(): EmbraceSpanData {
         val session = checkNotNull(testRule.harness.getLastSentSession())
 
-        val spans = checkNotNull(session.spans?.filter { it.attributes.containsKey("http.request.method") })
+        val spans = checkNotNull(session.spans?.filter { it.attributes.containsKey(HttpAttributes.HTTP_REQUEST_METHOD.key) })
         assertEquals(
             "Unexpected number of requests in sent session: ${spans.size}",
             1,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -7,6 +7,10 @@ import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.utils.NetworkUtils.getValidTraceId
+import io.opentelemetry.semconv.ErrorAttributes
+import io.opentelemetry.semconv.HttpAttributes
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
 
 /**
  * The collections of attribute schemas used by the associated telemetry types.
@@ -211,11 +215,11 @@ internal sealed class SchemaType(
     internal class NetworkRequest(networkRequest: EmbraceNetworkRequest) : SchemaType(EmbType.Performance.Network) {
         override val schemaAttributes = mapOf(
             "url.full" to networkRequest.url,
-            "http.request.method" to networkRequest.httpMethod,
-            "http.response.status_code" to networkRequest.responseCode,
-            "http.request.body.size" to networkRequest.bytesSent,
-            "http.response.body.size" to networkRequest.bytesReceived,
-            "error.type" to networkRequest.errorType,
+            HttpAttributes.HTTP_REQUEST_METHOD.key to networkRequest.httpMethod,
+            HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key to networkRequest.responseCode,
+            HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key to networkRequest.bytesSent,
+            HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key to networkRequest.bytesReceived,
+            ErrorAttributes.ERROR_TYPE.key to networkRequest.errorType,
             "error.message" to networkRequest.errorMessage,
             "emb.w3c_traceparent" to networkRequest.w3cTraceparent,
             "emb.trace_id" to getValidTraceId(networkRequest.traceId),
@@ -353,9 +357,12 @@ internal sealed class SchemaType(
         fixedObjectName = "internal-error"
     ) {
         override val schemaAttributes = mapOf(
-            "exception.type" to throwable.javaClass.name,
-            "exception.stacktrace" to throwable.stackTrace.joinToString("\n", transform = StackTraceElement::toString),
-            "exception.message" to (throwable.message ?: "")
+            ExceptionIncubatingAttributes.EXCEPTION_TYPE.key to throwable.javaClass.name,
+            ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key to throwable.stackTrace.joinToString(
+                "\n",
+                transform = StackTraceElement::toString
+            ),
+            ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key to (throwable.message ?: "")
         )
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImplTest.kt
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.JsException
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
+import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
@@ -98,7 +99,10 @@ internal class CrashDataSourceImplTest {
         assertEquals(1, anrService.forceAnrTrackingStopOnCrashCount)
         assertEquals(1, logWriter.logEvents.size)
         val lastSentCrash = logWriter.logEvents.single()
-        assertEquals(logWriter.logEvents.single().schemaType.attributes()["log.record.uid"], sessionOrchestrator.crashId)
+        assertEquals(
+            logWriter.logEvents.single().schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key],
+            sessionOrchestrator.crashId
+        )
 
         /*
          * Verify mainCrashHandled is true after the first execution
@@ -119,7 +123,10 @@ internal class CrashDataSourceImplTest {
 
         assertEquals(1, anrService.forceAnrTrackingStopOnCrashCount)
         assertEquals(1, logWriter.logEvents.size)
-        assertEquals(logWriter.logEvents.single().schemaType.attributes()["log.record.uid"], sessionOrchestrator.crashId)
+        assertEquals(
+            logWriter.logEvents.single().schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key],
+            sessionOrchestrator.crashId
+        )
         assertEquals(ndkService.lastUnityCrashId, sessionOrchestrator.crashId)
     }
 
@@ -143,7 +150,7 @@ internal class CrashDataSourceImplTest {
         val lastSentCrashAttributes = logEvent.schemaType.attributes()
         assertEquals(1, anrService.forceAnrTrackingStopOnCrashCount)
         assertEquals(1, logWriter.logEvents.size)
-        assertEquals(lastSentCrashAttributes["log.record.uid"], sessionOrchestrator.crashId)
+        assertEquals(lastSentCrashAttributes[LogIncubatingAttributes.LOG_RECORD_UID.key], sessionOrchestrator.crashId)
         assertEquals(
             "{\"n\":\"NullPointerException\",\"" +
                 "m\":\"Null pointer exception occurred\",\"" +

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/InternalErrorDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/InternalErrorDataSourceImplTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorDataSo
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -33,9 +34,9 @@ internal class InternalErrorDataSourceImplTest {
         dataSource.handleInternalError(IllegalStateException())
         val data = logWriter.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
-        assertEquals("java.lang.IllegalStateException", attrs["exception.type"])
-        assertEquals("", attrs["exception.message"])
-        assertNotNull(attrs["exception.stacktrace"])
+        assertEquals("java.lang.IllegalStateException", attrs[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
+        assertEquals("", attrs[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
+        assertNotNull(attrs[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key])
     }
 
     @Test
@@ -43,9 +44,9 @@ internal class InternalErrorDataSourceImplTest {
         dataSource.handleInternalError(IllegalArgumentException("Whoops!"))
         val data = logWriter.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
-        assertEquals("java.lang.IllegalArgumentException", attrs["exception.type"])
-        assertEquals("Whoops!", attrs["exception.message"])
-        assertNotNull(attrs["exception.stacktrace"])
+        assertEquals("java.lang.IllegalArgumentException", attrs[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
+        assertEquals("Whoops!", attrs[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
+        assertNotNull(attrs[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key])
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.utils.at
+import io.opentelemetry.semconv.HttpAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -40,7 +41,7 @@ internal class EmbraceNetworkLoggingServiceTest {
 
         val spans = spanService
             .createdSpans
-            .filter { it.attributes.containsKey("http.request.method") }
+            .filter { it.attributes.containsKey(HttpAttributes.HTTP_REQUEST_METHOD.key) }
             .mapNotNull { it.snapshot() }
 
         assertEquals(4, spans.size)
@@ -68,7 +69,7 @@ internal class EmbraceNetworkLoggingServiceTest {
         // Network request is recorded correctly
         val spans = spanService
             .createdSpans
-            .filter { it.attributes.containsKey("http.request.method") }
+            .filter { it.attributes.containsKey(HttpAttributes.HTTP_REQUEST_METHOD.key) }
             .mapNotNull { it.snapshot() }
         assertEquals(1, spans.size)
 
@@ -82,7 +83,7 @@ internal class EmbraceNetworkLoggingServiceTest {
 
         val spans = spanService
             .createdSpans
-            .filter { it.attributes.containsKey("http.request.method") }
+            .filter { it.attributes.containsKey(HttpAttributes.HTTP_REQUEST_METHOD.key) }
             .mapNotNull { it.snapshot() }
 
         assertTrue(spans.isEmpty())
@@ -95,7 +96,7 @@ internal class EmbraceNetworkLoggingServiceTest {
 
         val spans = spanService
             .createdSpans
-            .filter { it.attributes.containsKey("http.request.method") }
+            .filter { it.attributes.containsKey(HttpAttributes.HTTP_REQUEST_METHOD.key) }
             .mapNotNull { it.snapshot() }
 
         assertTrue(spans.isEmpty())


### PR DESCRIPTION
## Goal

I searched through the [semantic convention attribute registry](https://opentelemetry.io/docs/specs/semconv/attributes-registry/) and replaced string literals with constants where there was a direct match.

## Testing

Relied on existing test coverage.
