### PR TITLE
Don't set span status to OK on every successful trace stopping

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -5,20 +5,14 @@ import io.embrace.android.embracesdk.arch.assertIsKeySpan
 import io.embrace.android.embracesdk.arch.assertIsPrivateSpan
 import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
-import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.payload.SpanEvent
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
-import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 
 /**
  * Assert the [EmbraceSpanData] is as expected
@@ -29,7 +23,7 @@ internal fun assertEmbraceSpanData(
     expectedEndTimeMs: Long,
     expectedParentId: String,
     expectedTraceId: String? = null,
-    expectedStatus: StatusCode = StatusCode.OK,
+    expectedStatus: StatusCode = StatusCode.UNSET,
     expectedErrorCode: ErrorCode? = null,
     expectedCustomAttributes: Map<String, String> = emptyMap(),
     expectedEvents: List<EmbraceSpanEvent> = emptyList(),
@@ -68,53 +62,5 @@ internal fun assertEmbraceSpanData(
         } else {
             assertNotKeySpan()
         }
-    }
-}
-
-internal fun Span.assertSpanPayload(
-    expectedStartTimeMs: Long,
-    expectedEndTimeMs: Long?,
-    expectedParentId: String?,
-    expectedTraceId: String? = null,
-    errorCode: ErrorCode? = null,
-    expectedCustomAttributes: Map<String, String> = emptyMap(),
-    expectedEvents: List<SpanEvent> = emptyList(),
-    private: Boolean = false,
-    key: Boolean = false,
-) {
-    assertEquals(expectedStartTimeMs, startTimeUnixNano?.nanosToMillis())
-    assertEquals(expectedEndTimeMs, endTimeUnixNano?.nanosToMillis())
-    assertEquals(expectedParentId, parentSpanId)
-    if (expectedTraceId != null) {
-        assertEquals(expectedTraceId, traceId)
-    } else {
-        assertEquals(32, traceId?.length)
-    }
-
-    if (endTimeUnixNano == null) {
-        assertEquals(Span.Status.UNSET, status)
-    } else if (errorCode == null) {
-        assertSuccessful()
-    } else {
-        assertError(errorCode)
-    }
-
-    val attributeSet = attributes?.toHashSet() ?: emptySet()
-    expectedCustomAttributes.toNewPayload().forEach {
-        assertTrue("$it is missing", attributeSet.contains(it))
-    }
-
-    assertArrayEquals(expectedEvents.toList().toTypedArray(), checkNotNull(events).toTypedArray())
-
-    if (private) {
-        assertIsPrivateSpan()
-    } else {
-        assertNotPrivateSpan()
-    }
-
-    if (key) {
-        assertIsKeySpan()
-    } else {
-        assertNotKeySpan()
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -268,7 +268,7 @@ internal class NetworkRequestApiTest {
                     assertEquals(null, this.attributes["error.message"])
                     val statusCode = expectedRequest.responseCode
                     val expectedStatus = if (statusCode != null && statusCode >= 200 && statusCode < 400) {
-                        StatusCode.OK
+                        StatusCode.UNSET
                     } else {
                         StatusCode.ERROR
                     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
@@ -30,7 +30,7 @@ internal class AnrOtelMapper(
                 name = "emb-thread-blockage",
                 startTimeUnixNano = interval.startTime.millisToNanos(),
                 endTimeUnixNano = interval.endTime?.millisToNanos(),
-                status = Span.Status.OK,
+                status = Span.Status.UNSET,
                 attributes = attrs,
                 events = events
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
@@ -35,7 +35,7 @@ internal class NativeAnrOtelMapper(
                 parentSpanId = SpanId.getInvalid(),
                 name = "emb_native_thread_blockage",
                 startTimeUnixNano = interval.threadBlockedTimestamp?.millisToNanos(),
-                status = Span.Status.OK,
+                status = Span.Status.UNSET,
                 attributes = attrs,
                 events = events
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -103,9 +103,7 @@ internal fun LogRecordBuilder.setFixedAttribute(fixedAttribute: FixedAttribute):
  * is not specified, it means the [Span] completed successfully, and no [ErrorCode] will be set.
  */
 internal fun Span.endSpan(errorCode: ErrorCode? = null, endTimeMs: Long? = null): Span {
-    if (errorCode == null) {
-        setStatus(StatusCode.OK)
-    } else {
+    if (errorCode != null) {
         setStatus(StatusCode.ERROR)
         setFixedAttribute(errorCode.fromErrorCode())
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -128,10 +128,8 @@ internal class EmbraceSpanImpl(
                 successful = !isRecording
                 if (successful) {
                     spanId?.let { spanRepository.trackedSpanStopped(it) }
-                    status = if (errorCode != null) {
-                        Span.Status.ERROR
-                    } else {
-                        Span.Status.OK
+                    if (errorCode != null) {
+                        status = Span.Status.ERROR
                     }
                     spanEndTimeMs = attemptedEndTimeMs
                 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbSpan.kt
@@ -67,19 +67,16 @@ internal class EmbSpan(
 
     override fun end() = end(timestamp = clock.now(), unit = TimeUnit.NANOSECONDS)
 
-    /**
-     * One difference between the implementation of this method and the equivalent implementation in the Java SDK is that [StatusCode] for
-     * the underlying span is set to [StatusCode.OK] automatically if this is called before [setStatus] is called.
-     */
     override fun end(timestamp: Long, unit: TimeUnit) {
         if (isRecording) {
             val endTimeMs = unit.toMillis(timestamp)
             synchronized(pendingStatus) {
-                when (pendingStatus.get()) {
+                val finalStatus = pendingStatus.get()
+                setStatus(finalStatus)
+                when (finalStatus) {
                     StatusCode.ERROR -> {
                         embraceSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = endTimeMs)
                     }
-
                     else -> {
                         embraceSpan.stop(endTimeMs = endTimeMs)
                     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/FakeBackgroundActivity.kt
@@ -15,7 +15,7 @@ internal fun fakeBackgroundActivityMessage(): SessionMessage {
     val userInfo = UserInfo("fake-user-id")
     val appInfo = AppInfo("fake-app-id")
     val deviceInfo = DeviceInfo("fake-manufacturer")
-    val spans = listOf(EmbraceSpanData("fake-span-id", "", "", "", 0, 0, StatusCode.OK))
+    val spans = listOf(EmbraceSpanData("fake-span-id", "", "", "", 0, 0, StatusCode.UNSET))
     val perfInfo = PerformanceInfo(DiskUsage(1, 2))
 
     return SessionMessage(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.anr
 
+import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.Attribute
@@ -176,7 +177,7 @@ internal class AnrOtelMapperTest {
         assertEquals(SpanId.getInvalid(), parentSpanId)
         assertEquals("emb-thread-blockage", name)
         assertEquals(START_TIME_MS, startTimeUnixNano?.nanosToMillis())
-        assertEquals(Span.Status.OK, status)
+        assertSuccessful()
         assertEquals("perf.thread_blockage", attributes?.findAttribute("emb.type")?.data)
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 
@@ -60,7 +61,7 @@ internal fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
  * Assert [EmbraceSpanData] has ended successfully
  */
 internal fun EmbraceSpanData.assertSuccessful() {
-    assertEquals(StatusCode.OK, status)
+    assertNotEquals(StatusCode.ERROR, status)
     assertNull(attributes[ErrorCodeAttribute.Failure.key.name])
 }
 
@@ -90,7 +91,7 @@ internal fun Span.assertError(errorCode: ErrorCode) {
 }
 
 internal fun Span.assertSuccessful() {
-    assertEquals(Span.Status.OK, status)
+    assertNotEquals(Span.Status.ERROR, status)
     assertEquals(0, checkNotNull(attributes).filter { it.key == ErrorCodeAttribute.Failure.key.name }.size)
 }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.capture.startup
 
 import io.embrace.android.embracesdk.arch.assertIsPrivateSpan
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
+import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -11,7 +12,6 @@ import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -57,7 +57,7 @@ internal class StartupServiceImplTest {
             assertEquals(endTimeMillis, endTimeNanos.nanosToMillis())
             assertIsTypePerformance()
             assertIsPrivateSpan()
-            assertEquals(StatusCode.OK, status)
+            assertSuccessful()
             assertEquals("false", findSpanAttribute("ended-in-foreground"))
             assertEquals("main", findSpanAttribute("thread-name"))
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -34,7 +34,6 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType.NO
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -188,7 +187,7 @@ internal class EmbraceDeliveryServiceTest {
     @Test
     fun `do not add failed span from a snapshot if a span with the same id is already in the payload`() {
         val startedSnapshot = EmbraceSpanData(perfSpanSnapshot)
-        val completedSpan = startedSnapshot.copy(status = StatusCode.OK, endTimeNanos = startedSnapshot.startTimeNanos + 10000000L)
+        val completedSpan = startedSnapshot.copy(endTimeNanos = startedSnapshot.startTimeNanos + 10000000L)
         val snapshots = listOfNotNull(startedSnapshot)
         val spans = listOf(completedSpan)
         val messedUpSession = fakeV1EndedSessionMessage().copy(spans = spans, spanSnapshots = snapshots)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -71,12 +71,10 @@ internal class FakePersistableEmbraceSpan(
         if (isRecording) {
             checkNotNull(sdkSpan).endSpan(errorCode, endTimeMs)
             errorCode = code
-            status = if (code == null) {
-                Span.Status.OK
-            } else {
+            if (code != null) {
                 val error = code.fromErrorCode()
                 setSystemAttribute(error.key, error.value)
-                Span.Status.ERROR
+                status = Span.Status.ERROR
             }
             spanEndTimeMs = endTimeMs ?: fakeClock.now()
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -18,7 +18,7 @@ internal val testSpan = EmbraceSpanData(
     name = "emb-sdk-init",
     startTimeNanos = 1681972471806000000L,
     endTimeNanos = 1681972471871000000L,
-    status = StatusCode.OK,
+    status = StatusCode.UNSET,
     events = listOf(
         checkNotNull(
             EmbraceSpanEvent.create(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -106,7 +106,6 @@ internal class EmbraceSpanImplTest {
             assertSnapshot(
                 expectedStartTimeMs = expectedStartTimeMs,
                 expectedEndTimeMs = expectedEndTimeMs,
-                expectedStatus = Span.Status.OK
             )
             validateStoppedSpan()
         }
@@ -339,7 +338,7 @@ internal class EmbraceSpanImplTest {
             assertTrue(hasFixedAttribute(EmbType.System.LowPower))
             assertTrue(hasFixedAttribute(PrivateSpan))
             assertEquals(expectedStartTimeMs.millisToNanos(), snapshot.startTimeUnixNano)
-            assertEquals(Span.Status.UNSET, snapshot.status)
+            assertNull(snapshot.endTimeUnixNano)
 
             val snapshotEvent = checkNotNull(snapshot.events).single()
             assertEquals(EXPECTED_EVENT_NAME, snapshotEvent.name)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
@@ -75,7 +75,6 @@ internal class EmbraceNetworkLoggingServiceTest {
         checkNotNull(requestSpans["www.example1.com"]).assertNetworkRequest(
             expectedStartTimeMs = 100L,
             expectedEndTimeMs = 200L,
-            expectedStatus = Span.Status.OK
         )
         checkNotNull(requestSpans["www.example2.com"]).assertNetworkRequest(
             expectedStartTimeMs = 200L,
@@ -178,7 +177,7 @@ internal class EmbraceNetworkLoggingServiceTest {
     private fun Span.assertNetworkRequest(
         expectedStartTimeMs: Long,
         expectedEndTimeMs: Long,
-        expectedStatus: Span.Status = Span.Status.OK
+        expectedStatus: Span.Status = Span.Status.UNSET
     ) {
         assertEquals(expectedStartTimeMs, startTimeUnixNano?.nanosToMillis())
         assertEquals(expectedEndTimeMs, endTimeUnixNano?.nanosToMillis())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbSpanTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/EmbSpanTest.kt
@@ -44,14 +44,12 @@ internal class EmbSpanTest {
         with(fakeEmbraceSpan) {
             assertEquals(fakeClock.now(), spanStartTimeMs)
             assertNull(spanEndTimeMs)
-            assertEquals(status, Span.Status.UNSET)
         }
         val stopTime = fakeClock.tick()
         embSpan.end()
         assertFalse(embSpan.isRecording)
         with(fakeEmbraceSpan) {
             assertEquals(stopTime, spanEndTimeMs)
-            assertEquals(status, Span.Status.OK)
         }
     }
 
@@ -86,7 +84,7 @@ internal class EmbSpanTest {
         }
 
         with(fakeEmbraceSpan) {
-            assertEquals(status, Span.Status.OK)
+            assertEquals(status, Span.Status.UNSET)
             assertFalse(attributes.hasFixedAttribute(ErrorCodeAttribute.Failure))
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/BackgroundActivityMessageTest.kt
@@ -17,7 +17,7 @@ internal class BackgroundActivityMessageTest {
     private val userInfo = UserInfo("fake-user-id")
     private val appInfo = AppInfo("fake-app-id")
     private val deviceInfo = DeviceInfo("fake-manufacturer")
-    private val spans = listOf(EmbraceSpanData("fake-span-id", "", "", "", 0, 0, StatusCode.OK))
+    private val spans = listOf(EmbraceSpanData("fake-span-id", "", "", "", 0, 0, StatusCode.UNSET))
     private val perfInfo = PerformanceInfo(DiskUsage(1, 2))
 
     private val info = SessionMessage(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/payload/SessionMessageTest.kt
@@ -31,7 +31,7 @@ internal class SessionMessageTest {
             "",
             0,
             0,
-            StatusCode.OK,
+            StatusCode.UNSET,
             emptyList()
         )
     )

--- a/embrace-android-sdk/src/test/resources/bg_activity_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/bg_activity_message_expected.json
@@ -31,7 +31,7 @@
       "name": "",
       "start_time_unix_nano": 0,
       "end_time_unix_nano": 0,
-      "status": "OK",
+      "status": "UNSET",
       "events": [],
       "attributes": {}
     }

--- a/embrace-android-sdk/src/test/resources/session_message_expected.json
+++ b/embrace-android-sdk/src/test/resources/session_message_expected.json
@@ -32,7 +32,7 @@
       "name": "",
       "start_time_unix_nano": 0,
       "end_time_unix_nano": 0,
-      "status": "OK",
+      "status": "UNSET",
       "events": [],
       "attributes": {}
     }

--- a/embrace-android-sdk/src/test/resources/span_expected.json
+++ b/embrace-android-sdk/src/test/resources/span_expected.json
@@ -23,6 +23,6 @@
   "parent_span_id": "0000000000000000",
   "span_id": "342eb9c7f8cb54ff",
   "start_time_unix_nano": 1681972471806000000,
-  "status": "OK",
+  "status": "UNSET",
   "trace_id": "19bb482ec1c7e6b2f10fb89e0ccc85fa"
 }


### PR DESCRIPTION
## Goal

Don't explicit set the status of a span when we call `end()` in `EmbraceSpan`. This means that UNSET will be a valid status value for a completed span, per OTLP.

## Testing
Fixed up tests to not look for OK status to denote a completed span, but rather that an end time has been set.
