### PR TITLE
Fix flaky test

### DIFF
--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/TestPlatformSerializer.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/TestPlatformSerializer.kt
@@ -5,11 +5,12 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import java.io.InputStream
 import java.io.OutputStream
+import java.lang.reflect.Type
 
 internal class TestPlatformSerializer(
     private val realSerializer: PlatformSerializer = EmbraceSerializer(),
     private val operationWrapper: ExecutionCoordinator.OperationWrapper = ExecutionCoordinator.OperationWrapper()
-) : PlatformSerializer by realSerializer, ExecutionCoordinator.ExecutionModifiers by operationWrapper {
+) : PlatformSerializer, ExecutionCoordinator.ExecutionModifiers by operationWrapper {
 
     override fun <T> toJson(any: T, clazz: Class<T>, outputStream: OutputStream) {
         operationWrapper.wrapOperation { realSerializer.toJson(any, clazz, outputStream) }
@@ -17,5 +18,33 @@ internal class TestPlatformSerializer(
 
     override fun <T> fromJson(inputStream: InputStream, clz: Class<T>): T {
         return operationWrapper.wrapOperation { realSerializer.fromJson(inputStream, clz) }
+    }
+
+    override fun <T> toJson(src: T): String {
+        return operationWrapper.wrapOperation { realSerializer.toJson(src) }
+    }
+
+    override fun <T> toJson(src: T, clz: Class<T>): String {
+        return operationWrapper.wrapOperation { realSerializer.toJson(src, clz) }
+    }
+
+    override fun <T> toJson(src: T, type: Type): String {
+        return operationWrapper.wrapOperation { realSerializer.toJson(src, type) }
+    }
+
+    override fun <T> toJson(any: T, type: Type, outputStream: OutputStream) {
+        return operationWrapper.wrapOperation { realSerializer.toJson(any, type, outputStream) }
+    }
+
+    override fun <T> fromJson(json: String, clz: Class<T>): T {
+        return operationWrapper.wrapOperation { realSerializer.fromJson(json, clz) }
+    }
+
+    override fun <T> fromJson(json: String, type: Type): T {
+        return operationWrapper.wrapOperation { realSerializer.fromJson(json, type) }
+    }
+
+    override fun <T> fromJson(inputStream: InputStream, type: Type): T {
+        return operationWrapper.wrapOperation { realSerializer.fromJson(inputStream, type) }
     }
 }


### PR DESCRIPTION
## Goal

`EmbraceCacheServiceConcurrentAccessTest` started failing sporadically because the `TestPlatformSerializer` did not override all serializer functions. The serialization code was recently changed to use a different function signature & therefore execution wasn't paused, resulting in a race condition that failed some assertions.

I ran this test case ~10 times locally to verify it now passes & also avoided inheritance by delegation to ensure this problem is more obvious if it ever happens in future.
