### PR TITLE
Prevent lateinit property exception

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -30,10 +30,6 @@ internal class EmbraceNetworkConnectivityService(
     private val networkConnectivityListeners = mutableListOf<NetworkConnectivityListener>()
     override val ipAddress by lazy { calculateIpAddress() }
 
-    init {
-        registerConnectivityActionReceiver()
-    }
-
     override fun onReceive(context: Context, intent: Intent) = handleNetworkStatus(true)
 
     override fun networkStatusOnSessionStarted(startTime: Long) = handleNetworkStatus(false, startTime)
@@ -94,7 +90,7 @@ internal class EmbraceNetworkConnectivityService(
     private fun didNetworkStatusChange(newNetworkStatus: NetworkStatus) =
         lastNetworkStatus == null || lastNetworkStatus != newNetworkStatus
 
-    private fun registerConnectivityActionReceiver() {
+    override fun register() {
         backgroundWorker.submit {
             try {
                 context.registerReceiver(this, intentFilter)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NetworkConnectivityService.kt
@@ -35,4 +35,9 @@ internal interface NetworkConnectivityService : Closeable {
      * Calculate the device's IP address
      */
     val ipAddress: String?
+
+    /**
+     * Start listening for network connectivity changes
+     */
+    fun register()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NoOpNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/NoOpNetworkConnectivityService.kt
@@ -15,5 +15,7 @@ internal class NoOpNetworkConnectivityService : NetworkConnectivityService {
         return NetworkStatus.UNKNOWN
     }
 
+    override fun register() {}
+
     override val ipAddress: String? = null
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -226,6 +226,9 @@ internal class ModuleInitBootstrapper(
                             anrModule
                         )
                     }
+                    Systrace.traceSynchronous("network-connectivity-registration") {
+                        essentialServiceModule.networkConnectivityService.register()
+                    }
                     initModule.internalErrorService.internalErrorDataSource = { dataSourceModule.internalErrorDataSource.dataSource }
 
                     dataCaptureServiceModule = init(DataCaptureServiceModule::class) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNetworkConnectivityServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceNetworkConnectivityServiceTest.kt
@@ -91,6 +91,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
     @Test
     @Throws(InterruptedException::class)
     fun `test connectivity broadcast receiver can register and unregister`() {
+        service.register()
         verify { context.registerReceiver(service, any()) }
         service.close()
         verify { context.unregisterReceiver(service) }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
@@ -17,7 +17,7 @@ internal class FakeNetworkConnectivityService(
             notifyListeners()
         }
 
-    public var networkStatusOnSessionStartedCount = 0
+    var networkStatusOnSessionStartedCount = 0
 
     override fun networkStatusOnSessionStarted(startTime: Long) {
         notifyListeners()
@@ -35,6 +35,9 @@ internal class FakeNetworkConnectivityService(
     override fun getCurrentNetworkStatus(): NetworkStatus = networkStatus
 
     override fun close() {
+    }
+
+    override fun register() {
     }
 
     private fun notifyListeners() {


### PR DESCRIPTION
## Goal

The `NetworkConnectivityService` registers for network changes during its initialization. As this service has a bootstrapped reference to the `DataSourceModule` which is initialized after it, in rare circumstances where startup is slow + a network connectivity change happens this could result in access to a lateinit var that isn't initialized, which was captured as an internal error.

I've fixed this by ensuring that connectivity change registration only happens after the `DataSourceModule` is initialized.
