### PR TITLE
Remove unnecessary parameters from log counter

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/gating/EmbraceGatingService.kt
@@ -43,7 +43,7 @@ internal class EmbraceGatingService(
     }
 
     private fun hasErrorLogs(): Boolean {
-        return logService.findErrorLogIds(0, Long.MAX_VALUE).isNotEmpty() &&
+        return logService.findErrorLogIds().isNotEmpty() &&
             configService.sessionBehavior.shouldSendFullForErrorLog()
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/BaseLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/BaseLogService.kt
@@ -6,9 +6,7 @@ internal interface BaseLogService : MemoryCleanerListener {
     /**
      * Finds all IDs of log events at error level within the given time window.
      *
-     * @param startTime the beginning of the time window
-     * @param endTime   the end of the time window
      * @return the list of log IDs within the specified range
      */
-    fun findErrorLogIds(startTime: Long, endTime: Long): List<String>
+    fun findErrorLogIds(): List<String>
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -210,8 +210,8 @@ internal class EmbraceLogService(
         }
     }
 
-    override fun findErrorLogIds(startTime: Long, endTime: Long): List<String> {
-        return logCounters.getValue(Severity.ERROR).findLogIds(startTime, endTime)
+    override fun findErrorLogIds(): List<String> {
+        return logCounters.getValue(Severity.ERROR).findLogIds()
     }
 
     override fun cleanCollections() {
@@ -334,11 +334,8 @@ internal class LogCounter(
         return true
     }
 
-    fun findLogIds(
-        startTime: Long,
-        endTime: Long,
-    ): List<String> {
-        return cache.value { ArrayList(logIds.subMap(startTime, endTime).values) }
+    fun findLogIds(): List<String> {
+        return cache.value { ArrayList(logIds.values) }
     }
 
     fun getCount(): Int = count.get()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
@@ -71,7 +71,7 @@ internal class SessionSpanAttrPopulator(
                 addCustomAttribute(SpanAttributeData(embSessionStartupThreshold.name, info.threshold.toString()))
             }
 
-            val logCount = logService.findErrorLogIds(0, Long.MAX_VALUE).size
+            val logCount = logService.findErrorLogIds().size
             addCustomAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
 
             val free = metadataService.getDiskUsage()?.deviceDiskFree

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -50,7 +50,7 @@ internal class FakeLogService : LogService {
         )
     }
 
-    override fun findErrorLogIds(startTime: Long, endTime: Long): List<String> {
+    override fun findErrorLogIds(): List<String> {
         return errorLogIds
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -232,7 +232,7 @@ internal class EmbraceLogServiceTest {
             logWithoutException("Test error $k", EventType.ERROR_LOG)
         }
 
-        assertEquals(250, logService.findErrorLogIds(0L, Long.MAX_VALUE).size)
+        assertEquals(250, logService.findErrorLogIds().size)
     }
 
     @Test
@@ -253,7 +253,7 @@ internal class EmbraceLogServiceTest {
             logWithoutException("Test error $k", EventType.ERROR_LOG)
         }
 
-        assertEquals(150, logService.findErrorLogIds(0L, Long.MAX_VALUE).size)
+        assertEquals(150, logService.findErrorLogIds().size)
     }
 
     @Test
@@ -318,11 +318,11 @@ internal class EmbraceLogServiceTest {
             logWithoutException("Test warning $k", EventType.WARNING_LOG)
             logWithoutException("Test error $k", EventType.ERROR_LOG)
         }
-        assertEquals(10, logService.findErrorLogIds(0L, Long.MAX_VALUE).size)
+        assertEquals(10, logService.findErrorLogIds().size)
 
         logService.cleanCollections()
 
-        assertEquals(0, logService.findErrorLogIds(0L, Long.MAX_VALUE).size)
+        assertEquals(0, logService.findErrorLogIds().size)
     }
 
     // If the session components are null, no gating should be applied


### PR DESCRIPTION
## Goal

The `LogCounter` class will on rare ocassions throw an exception complaining about an inconsistent range from the when finding a submap of log IDs. This is reported as an internal error. It's unclear under what circumstances this happens but we don't need to supply those parameters any more in the v2 payload so we may as well just get rid of them.

