### PR TITLE
Remove getTracer methods from the API

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -42,9 +42,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun getSessionProperties ()Ljava/util/Map;
 	public fun getSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public fun getTraceIdHeader ()Ljava/lang/String;
-	public fun getTracer ()Lio/opentelemetry/api/trace/Tracer;
-	public fun getTracer (Ljava/lang/String;)Lio/opentelemetry/api/trace/Tracer;
-	public fun getTracer (Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/api/trace/Tracer;
 	public fun getUnityInternalInterface ()Lio/embrace/android/embracesdk/UnityInternalInterface;
 	public fun isStarted ()Z
 	public fun isTracingAvailable ()Z

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -64,7 +64,7 @@ internal class ExternalTracerTest {
     @Test
     fun `check correctness of implementations used by Tracer`() {
         assertSame(
-            testRule.embrace.getTracer("foo"),
+            testRule.embrace.getOpenTelemetry().getTracer("foo"),
             embOpenTelemetry.getTracer("foo")
         )
         assertTrue(embTracer is EmbTracer)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -28,7 +28,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent;
 import io.embrace.android.embracesdk.spans.ErrorCode;
 import io.embrace.android.embracesdk.spans.TracingApi;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import kotlin.jvm.functions.Function0;
@@ -583,24 +582,6 @@ public final class Embrace implements
     @Override
     public OpenTelemetry getOpenTelemetry() {
         return impl.getOpenTelemetry();
-    }
-
-    @NonNull
-    @Override
-    public Tracer getTracer() {
-        return impl.getTracer(null, null);
-    }
-
-    @NonNull
-    @Override
-    public Tracer getTracer(@Nullable String instrumentationModuleName) {
-        return impl.getTracer(instrumentationModuleName, null);
-    }
-
-    @NonNull
-    @Override
-    public Tracer getTracer(@Nullable String instrumentationModuleName, @Nullable String instrumentationModuleVersion) {
-        return impl.getTracer(instrumentationModuleName, instrumentationModuleVersion);
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/OTelApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/OTelApi.kt
@@ -21,24 +21,8 @@ internal interface OTelApi {
     fun addSpanExporter(spanExporter: SpanExporter)
 
     /**
-     * Returns an [OpenTelemetry] that provides working [Tracer] implementations.
+     * Returns an [OpenTelemetry] that provides working [Tracer] implementations that will record spans that fit into the Embrace data
+     * model.
      */
     fun getOpenTelemetry(): OpenTelemetry
-
-    /**
-     * Returns a [Tracer] that can be used to log spans. This instance will identify itself as the Embrace SDK.
-     */
-    fun getTracer(): Tracer = getTracer(null, null)
-
-    /**
-     * Returns a [Tracer] that can be used to log spans. This instance will identify itself with the given [instrumentationModuleName] if
-     * it's non-null.
-     */
-    fun getTracer(instrumentationModuleName: String?): Tracer = getTracer(instrumentationModuleName, null)
-
-    /**
-     * Returns a [Tracer] that can be used to log spans. This instance will identify itself with the given [instrumentationModuleName]
-     * and [instrumentationModuleVersion] if the former is non-null.
-     */
-    fun getTracer(instrumentationModuleName: String?, instrumentationModuleVersion: String?): Tracer
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
@@ -3,8 +3,6 @@ package io.embrace.android.embracesdk.internal.api.delegate
 import io.embrace.android.embracesdk.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.api.OTelApi
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerProvider
 import io.opentelemetry.sdk.logs.export.LogRecordExporter
 import io.opentelemetry.sdk.trace.export.SpanExporter
 
@@ -37,19 +35,5 @@ internal class OTelApiDelegate(
             return
         }
         bootstrapper.openTelemetryModule.openTelemetryConfiguration.addLogExporter(logRecordExporter)
-    }
-
-    override fun getTracer(instrumentationModuleName: String?, instrumentationModuleVersion: String?): Tracer {
-        return if (sdkCallChecker.started.get()) {
-            if (instrumentationModuleName == null) {
-                bootstrapper.openTelemetryModule.sdkTracer
-            } else if (instrumentationModuleVersion == null) {
-                bootstrapper.openTelemetryModule.externalTracerProvider.get(instrumentationModuleName)
-            } else {
-                bootstrapper.openTelemetryModule.externalTracerProvider.get(instrumentationModuleName, instrumentationModuleVersion)
-            }
-        } else {
-            TracerProvider.noop().get("")
-        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -67,11 +67,11 @@ internal class OTelApiDelegateTest {
     @Test
     fun `get tracer before start`() {
         sdkCallChecker.started.set(false)
-        assertFalse(delegate.getTracer().spanBuilder("test").startSpan().spanContext.isValid)
+        assertFalse(delegate.getOpenTelemetry().getTracer("foo").spanBuilder("test").startSpan().spanContext.isValid)
     }
 
     @Test
     fun `get tracer after start`() {
-        assertTrue(delegate.getTracer().spanBuilder("test").startSpan().spanContext.isValid)
+        assertTrue(delegate.getOpenTelemetry().getTracer("foo").spanBuilder("test").startSpan().spanContext.isValid)
     }
 }


### PR DESCRIPTION
## Goal

Remove `getTracer()` methods from the API and instead serve up an `OpenTelemetry` implementation from which Tracers can be obtained. This reduces the number of methods in the API but also allow for 3rd party instrumentation libraries to consume our OTel API implementations in the way they want.

## Testing
Existing tests cover this