### PR TITLE
Remove unnecessary warning

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -69,11 +69,6 @@ internal class EmbraceProcessStateService(
      */
     override fun onForeground() {
         logger.logDebug("AppState: App entered foreground.")
-
-        if (!isInBackground) {
-            val msg = "Unbalanced call to onForeground(). This will contribute to session loss."
-            logger.logError(msg, InternalError(msg))
-        }
         isInBackground = false
         val timestamp = clock.now()
 


### PR DESCRIPTION
## Goal

Removes a misleading error message. `isInBackground` relies on the current state of the `LifecycleOwner`. The internal implementation of this sets the new state & then invokes the callback, meaning it's possible for an 'unbalanced' call to happen on the first launch, although practically speaking this makes no difference.

