### PR TITLE
Add limit for internal span capture

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -140,6 +140,7 @@ internal class SpanServiceImpl(
     }
 
     companion object {
+        const val MAX_INTERNAL_SPANS_PER_SESSION = 5000
         const val MAX_NON_INTERNAL_SPANS_PER_SESSION = 500
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -59,6 +59,19 @@ internal class CurrentSessionSpanImplTests {
     }
 
     @Test
+    fun `check trace limits with maximum internal not started traces`() {
+        repeat(SpanServiceImpl.MAX_NON_INTERNAL_SPANS_PER_SESSION) {
+            assertNotNull(spanService.createSpan(name = "spanzzz$it", internal = false))
+        }
+        assertNull(spanService.createSpan(name = "failed-span", internal = false))
+
+        repeat(SpanServiceImpl.MAX_INTERNAL_SPANS_PER_SESSION) {
+            assertNotNull(spanService.createSpan(name = "internal$it"))
+        }
+        assertNull(spanService.createSpan(name = "failed-span"))
+    }
+
+    @Test
     fun `check trace limited applied to spans created with span builder`() {
         repeat(SpanServiceImpl.MAX_NON_INTERNAL_SPANS_PER_SESSION) {
             assertNotNull(


### PR DESCRIPTION
## Goal

Adds a limit of 1000 for the number of internal spans that we capture. I'm open to discussion on the exact limit we enforce, but noticed during my validation of this migration that the number of internal spans was unbounded.

Technically we should always bound the number of spans in the `DataSource` implementation, but in practice I'd like to add this as a backstop to prevent the payload from getting overloaded.

## Testing

Added unit tests.
