### PR TITLE
Avoid dropping sessions

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImpl.kt
@@ -17,7 +17,7 @@ internal class SessionEnvelopeSourceImpl(
             resourceSource.getEnvelopeResource(),
             metadataSource.getEnvelopeMetadata(),
             "0.1.0",
-            "session",
+            "spans",
             sessionPayloadSource.getSessionPayload(endType, crashId)
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/comms/api/EmbraceApiService.kt
@@ -192,6 +192,8 @@ internal class EmbraceApiService(
             var successfullySent = false
             try {
                 successfullySent = handleApiRequest(request, action)
+            } catch (e: Exception) {
+                logger.logWarning("API call failed.", e)
             } finally {
                 onComplete?.invoke(successfullySent)
             }
@@ -216,7 +218,7 @@ internal class EmbraceApiService(
 
             if (response !is ApiResponse.Success) {
                 // If the API call failed, propagate the error to the caller.
-                error("Failed to post Embrace API call. ")
+                error("Failed to post Embrace API call. $response")
             } else {
                 return true
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Envelope.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Envelope.kt
@@ -41,6 +41,7 @@ internal data class Envelope<T>(
 
 internal fun Envelope<SessionPayload>.getSessionSpan(): Span? {
     return data.spans?.singleOrNull { it.hasFixedAttribute(EmbType.Ux.Session) }
+        ?: data.spanSnapshots?.singleOrNull { it.hasFixedAttribute(EmbType.Ux.Session) }
 }
 
 internal fun Envelope<SessionPayload>.getSessionId(): String? {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImplTest.kt
@@ -23,7 +23,7 @@ internal class SessionEnvelopeSourceImplTest {
         assertEquals(metadataSource.metadata, payload.metadata)
         assertEquals(resourceSource.resource, payload.resource)
         assertEquals(sessionPayloadSource.sessionPayload, payload.data)
-        assertEquals("session", payload.type)
+        assertEquals("spans", payload.type)
         assertEquals("0.1.0", payload.version)
     }
 }

--- a/embrace-android-sdk/src/test/resources/v2_session_expected.json
+++ b/embrace-android-sdk/src/test/resources/v2_session_expected.json
@@ -36,6 +36,6 @@
     "disk_space": "__EMBRACE_TEST_IGNORE__"
   },
   "s": "__EMBRACE_TEST_IGNORE__",
-  "type": "session",
+  "type": "spans",
   "version": "0.1.0"
 }


### PR DESCRIPTION
## Goal

Resolves an issue with the integration branch where sessions weren't persisted to disk as the session ID couldn't be found in the payload. The fix is to look first in the `spans` field, and then in the `span_snapshots` field for the session span.

I've also improved the error messaging around failed HTTP requests as it was initially very hard to tell that a 400 status code was received by the server. Finally, I've tweaked the `type` value to `spans` as this seems to be what the mock api expects, although the field is unused by the actual implementation at this time.

