### PR TITLE
Separate startup listener from ActivityLifecycleListener interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAutomaticVerification.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceAutomaticVerification.kt
@@ -11,7 +11,6 @@ import android.widget.Toast
 import io.embrace.android.embracesdk.samples.AutomaticVerificationChecker
 import io.embrace.android.embracesdk.samples.VerificationActions
 import io.embrace.android.embracesdk.samples.VerifyIntegrationException
-import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
@@ -33,7 +32,7 @@ import kotlin.system.exitProcess
  */
 internal class EmbraceAutomaticVerification(
     private val scheduledExecutorService: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
-) : ActivityLifecycleListener, ProcessStateListener {
+) : ProcessStateListener {
     private val handler = Handler(Looper.getMainLooper())
 
     private var foregroundEventTriggered = false
@@ -73,7 +72,6 @@ internal class EmbraceAutomaticVerification(
         if (!::processStateService.isInitialized) {
             processStateService = checkNotNull(Embrace.getImpl().activityService)
         }
-        activityLifecycleTracker.addListener(this)
         processStateService.addListener(this)
     }
 
@@ -336,6 +334,7 @@ internal class EmbraceAutomaticVerification(
     private fun logWarning(message: String) {
         Embrace.getInstance().internalInterface.logWarning("$TAG $message", null, null)
     }
+
     private fun logError(message: String) {
         Embrace.getInstance().internalInterface.logError("$TAG $message", null, null, false)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -25,8 +25,8 @@ import io.embrace.android.embracesdk.payload.AppInfo
 import io.embrace.android.embracesdk.payload.DeviceInfo
 import io.embrace.android.embracesdk.payload.DiskUsage
 import io.embrace.android.embracesdk.prefs.PreferencesService
-import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
+import io.embrace.android.embracesdk.session.lifecycle.StartupListener
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
@@ -67,7 +67,7 @@ internal class EmbraceMetadataService private constructor(
     private val embraceCpuInfoDelegate: CpuInfoDelegate,
     private val deviceArchitecture: DeviceArchitecture,
     private val logger: EmbLogger
-) : MetadataService, ActivityLifecycleListener {
+) : MetadataService, StartupListener {
 
     private val statFs = lazy { StatFs(Environment.getDataDirectory().path) }
     private var reactNativeBundleId: Future<String?>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -13,8 +13,8 @@ import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
-import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
+import io.embrace.android.embracesdk.session.lifecycle.StartupListener
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.utils.stream
 import io.embrace.android.embracesdk.worker.BackgroundWorker
@@ -43,7 +43,7 @@ internal class EmbraceEventService(
     private val logger: EmbLogger,
     workerThreadModule: WorkerThreadModule,
     private val clock: Clock
-) : EventService, ActivityLifecycleListener, ProcessStateListener, MemoryCleanerListener {
+) : EventService, ProcessStateListener, MemoryCleanerListener, StartupListener {
     private val backgroundWorker: BackgroundWorker
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -440,6 +440,7 @@ internal class ModuleInitBootstrapper(
                     serviceRegistry.registerActivityListeners(essentialServiceModule.processStateService)
                     serviceRegistry.registerMemoryCleanerListeners(essentialServiceModule.memoryCleanerService)
                     serviceRegistry.registerActivityLifecycleListeners(essentialServiceModule.activityLifecycleTracker)
+                    serviceRegistry.registerStartupListener(essentialServiceModule.activityLifecycleTracker)
 
                     asyncInitTask.set(initTask)
                     synchronousInitCompletionMs = initModule.clock.now()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/prefs/EmbracePreferencesService.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
-import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
+import io.embrace.android.embracesdk.session.lifecycle.StartupListener
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
@@ -16,7 +16,7 @@ internal class EmbracePreferencesService(
     lazyPrefs: Lazy<SharedPreferences>,
     private val clock: Clock,
     private val serializer: EmbraceSerializer
-) : PreferencesService, ActivityLifecycleListener {
+) : PreferencesService, StartupListener {
 
     private val preferences: Future<SharedPreferences>
     private val lazyPrefs: Lazy<SharedPreferences>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/registry/ServiceRegistry.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateService
+import io.embrace.android.embracesdk.session.lifecycle.StartupListener
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -27,6 +28,7 @@ internal class ServiceRegistry(
     val memoryCleanerListeners by lazy { registry.filterIsInstance<MemoryCleanerListener>() }
     val processStateListeners by lazy { registry.filterIsInstance<ProcessStateListener>() }
     val activityLifecycleListeners by lazy { registry.filterIsInstance<ActivityLifecycleListener>() }
+    val startupListener by lazy { registry.filterIsInstance<StartupListener>() }
 
     fun registerServices(vararg services: Any?) {
         services.forEach(::registerService)
@@ -60,6 +62,12 @@ internal class ServiceRegistry(
         memoryCleanerListeners.forEachSafe(
             "Failed to register memory cleaner listener",
             memoryCleanerService::addListener
+        )
+
+    fun registerStartupListener(activityLifecycleTracker: ActivityTracker) =
+        startupListener.forEachSafe(
+            "Failed to register application lifecycle listener",
+            activityLifecycleTracker::addStartupListener
         )
 
     // close all of the services in one go. this prevents someone creating a Closeable service

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleListener.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleListener.kt
@@ -29,9 +29,4 @@ internal interface ActivityLifecycleListener {
      * @param bundle   the bundle
      */
     fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
-
-    /**
-     * Triggered when the application has completed startup;
-     */
-    fun applicationStartupComplete() {}
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
@@ -27,8 +27,12 @@ internal class ActivityLifecycleTracker(
     /**
      * List of listeners that subscribe to activity events.
      */
-
     val listeners = CopyOnWriteArrayList<ActivityLifecycleListener>()
+
+    /**
+     * List of listeners notified when application startup is complete
+     */
+    val startupListeners = CopyOnWriteArrayList<StartupListener>()
 
     /**
      * The currently active activity.
@@ -102,7 +106,7 @@ internal class ActivityLifecycleTracker(
         if (!activity.javaClass.isAnnotationPresent(StartupActivity::class.java)) {
             // If the activity coming to foreground doesn't have the StartupActivity annotation
             // the the SDK will finalize any pending startup moment.
-            stream(listeners) { listener: ActivityLifecycleListener ->
+            stream(startupListeners) { listener: StartupListener ->
                 try {
                     listener.applicationStartupComplete()
                 } catch (ex: Exception) {
@@ -135,18 +139,24 @@ internal class ActivityLifecycleTracker(
         }
     }
 
+    override fun addStartupListener(listener: StartupListener) {
+        if (!startupListeners.contains(listener)) {
+            startupListeners.addIfAbsent(listener)
+        }
+    }
+
     override fun close() {
         try {
-            logger.logDebug("Shutting down EmbraceActivityService")
+            logger.logDebug("Shutting down ActivityLifecycleTracker")
             application.unregisterActivityLifecycleCallbacks(this)
             listeners.clear()
+            startupListeners.clear()
         } catch (ex: Exception) {
-            logger.logWarning("Error when closing EmbraceActivityService", ex)
+            logger.logWarning("Error when closing ActivityLifecycleTracker", ex)
         }
     }
 
     companion object {
-        private const val ERROR_FAILED_TO_NOTIFY =
-            "Failed to notify ActivityLifecycleTracker listener"
+        private const val ERROR_FAILED_TO_NOTIFY = "Failed to notify ActivityLifecycleTracker listener"
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityTracker.kt
@@ -17,4 +17,6 @@ internal interface ActivityTracker : Application.ActivityLifecycleCallbacks, Clo
     val foregroundActivity: Activity?
 
     fun addListener(listener: ActivityLifecycleListener)
+
+    fun addStartupListener(listener: StartupListener)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/StartupListener.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/StartupListener.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.session.lifecycle
+
+internal interface StartupListener {
+    /**
+     * Triggered when the application has completed startup;
+     */
+    fun applicationStartupComplete() {}
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt
@@ -4,14 +4,21 @@ import android.app.Activity
 import android.os.Bundle
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityTracker
+import io.embrace.android.embracesdk.session.lifecycle.StartupListener
 
 internal class FakeActivityTracker(
     override var foregroundActivity: Activity? = null
 ) : ActivityTracker {
 
     val listeners = mutableListOf<ActivityLifecycleListener>()
+    val startupListeners = mutableListOf<StartupListener>()
+
     override fun addListener(listener: ActivityLifecycleListener) {
         listeners.add(listener)
+    }
+
+    override fun addStartupListener(listener: StartupListener) {
+        startupListeners.add(listener)
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/registry/ServiceRegistryTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/registry/ServiceRegistryTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener
+import io.embrace.android.embracesdk.session.lifecycle.StartupListener
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -27,6 +28,7 @@ internal class ServiceRegistryTest {
         assertEquals(expected, registry.processStateListeners)
         assertEquals(expected, registry.activityLifecycleListeners)
         assertEquals(expected, registry.memoryCleanerListeners)
+        assertEquals(expected, registry.startupListener)
     }
 
     @Test
@@ -42,7 +44,9 @@ internal class ServiceRegistryTest {
 
         val activityLifecycleTracker = FakeActivityTracker()
         registry.registerActivityLifecycleListeners(activityLifecycleTracker)
+        registry.registerStartupListener(activityLifecycleTracker)
         assertEquals(expected, activityLifecycleTracker.listeners)
+        assertEquals(expected, activityLifecycleTracker.startupListeners)
 
         val memoryCleanerService = FakeMemoryCleanerService()
         registry.registerMemoryCleanerListeners(memoryCleanerService)
@@ -64,7 +68,8 @@ internal class ServiceRegistryTest {
         Closeable,
         MemoryCleanerListener,
         ProcessStateListener,
-        ActivityLifecycleListener {
+        ActivityLifecycleListener,
+        StartupListener {
 
         var closed = false
 


### PR DESCRIPTION
## Goal

ActivityLifecycleListener serves two purposes: to provide a hook to for callback invocations when Activities are opened and closed, along with a callback to invoke when app startup is complete. This PR separates the two so that the activity lifecycle one can be added to without indirectly modifying services that really only care about app startup, which is all but two of the services that implement this interface.

For now, we will keep the object that holds all the listeners the same, but eventually, this could be merged with the `StartupTracker` which provides a super set of functionality.

## Testing
Use existing tests to verify functionality, add unit tests to verify this second set of callbacks can be registered properlyl.