### PR TITLE
Fix build warnings

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/StartupServiceImpl.kt
@@ -41,7 +41,7 @@ internal class StartupServiceImpl(
                 private = true,
                 attributes = mapOf(
                     "ended-in-foreground" to endedInForeground.toString(),
-                    "thread-name" to (threadName ?: "unknown"),
+                    "thread-name" to threadName,
                 ),
             )
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.api.delegate
 
 import android.annotation.SuppressLint
@@ -52,7 +54,6 @@ internal class EmbraceInternalInterfaceImpl(
         embraceImpl.logMessage(message, Severity.ERROR, properties)
     }
 
-    @Suppress("DEPRECATION")
     override fun logHandledException(
         throwable: Throwable,
         type: LogType,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UninitializedSdkInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UninitializedSdkInternalInterfaceImpl.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.api.delegate
 
 import android.annotation.SuppressLint

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/ViewTrackingApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/ViewTrackingApiDelegate.kt
@@ -28,7 +28,7 @@ internal class ViewTrackingApiDelegate(
     override fun registerComposeActivityListener(app: Application) {
         try {
             val composeActivityListener = Class.forName("io.embrace.android.embracesdk.compose.ComposeActivityListener")
-            composeActivityListenerInstance = composeActivityListener.newInstance()
+            composeActivityListenerInstance = composeActivityListener.getDeclaredConstructor().newInstance()
             app.registerActivityLifecycleCallbacks(composeActivityListenerInstance as Application.ActivityLifecycleCallbacks?)
         } catch (e: Throwable) {
             logger.logError("registerComposeActivityListener error", e)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerFactory.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerFactory.java
@@ -33,7 +33,7 @@ final class EmbraceUrlStreamHandlerFactory implements URLStreamHandlerFactory {
 
     static URLStreamHandler newUrlStreamHandler(String className) {
         try {
-            return (URLStreamHandler) Class.forName(className).newInstance();
+            return (URLStreamHandler) Class.forName(className).getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             // We catch Exception here instead of the specific exceptions that can be thrown due to a change in the way some
             // of these exceptions are compiled on different OS versions.

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogRecordBuilder.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeLogRecordBuilder.kt
@@ -58,7 +58,7 @@ internal class FakeLogRecordBuilder : LogRecordBuilder {
         return this
     }
 
-    override fun <T : Any?> setAttribute(key: AttributeKey<T>, value: T): LogRecordBuilder {
+    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T): LogRecordBuilder {
         attributes[key.key.toString()] = value.toString()
         return this
     }


### PR DESCRIPTION
## Goal

Resolve miscellaneous compiler warnings , mostly about deprecated method usage. Made changes to proper methods, or added suppression annotation regarding the use of our own deprecated enum `LogType`. 

## Testing
Existing tests cover these changes