### PR TITLE
Set device free disk bytes to null when not available

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulator.kt
@@ -74,8 +74,9 @@ internal class SessionSpanAttrPopulator(
             val logCount = logService.findErrorLogIds().size
             addCustomAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
 
-            val free = metadataService.getDiskUsage()?.deviceDiskFree
-            addCustomAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
+            metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
+                addCustomAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
+            }
         }
     }
 }


### PR DESCRIPTION
## Goal

Avoid serializing `"null"` when `deviceDiskFree` is not available.

