### PR TITLE
Only start a new session span if it's appropriate

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSource.kt
@@ -5,5 +5,5 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 
 internal interface SessionEnvelopeSource {
-    fun getEnvelope(endType: SessionSnapshotType, crashId: String? = null): Envelope<SessionPayload>
+    fun getEnvelope(endType: SessionSnapshotType, startNewSession: Boolean, crashId: String? = null): Envelope<SessionPayload>
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImpl.kt
@@ -12,13 +12,13 @@ internal class SessionEnvelopeSourceImpl(
     private val sessionPayloadSource: SessionPayloadSource,
 ) : SessionEnvelopeSource {
 
-    override fun getEnvelope(endType: SessionSnapshotType, crashId: String?): Envelope<SessionPayload> {
+    override fun getEnvelope(endType: SessionSnapshotType, startNewSession: Boolean, crashId: String?): Envelope<SessionPayload> {
         return Envelope(
             resourceSource.getEnvelopeResource(),
             metadataSource.getEnvelopeMetadata(),
             "0.1.0",
             "spans",
-            sessionPayloadSource.getSessionPayload(endType, crashId)
+            sessionPayloadSource.getSessionPayload(endType, startNewSession, crashId)
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSource.kt
@@ -7,5 +7,5 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
  * Creates a [SessionPayload] object.
  */
 internal interface SessionPayloadSource {
-    fun getSessionPayload(endType: SessionSnapshotType, crashId: String? = null): SessionPayload
+    fun getSessionPayload(endType: SessionSnapshotType, startNewSession: Boolean, crashId: String? = null): SessionPayload
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImpl.kt
@@ -58,8 +58,8 @@ internal class SessionPayloadSourceImpl(
                         else -> null
                     }
                     val spans = currentSessionSpan.endSession(
-                        appTerminationCause = appTerminationCause,
-                        startNewSession = startNewSession
+                        startNewSession = startNewSession,
+                        appTerminationCause = appTerminationCause
                     )
                     if (appTerminationCause == null) {
                         sessionPropertiesServiceProvider().populateCurrentSession()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -12,7 +12,7 @@ internal interface CurrentSessionSpan : Initializable, SessionSpanWriter {
     /**
      * End the current session span and start a new one if the app is not terminating
      */
-    fun endSession(appTerminationCause: AppTerminationCause? = null): List<EmbraceSpanData>
+    fun endSession(appTerminationCause: AppTerminationCause? = null, startNewSession: Boolean): List<EmbraceSpanData>
 
     /**
      * Returns true if a span with the given parameters can be started in the current session

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -12,7 +12,7 @@ internal interface CurrentSessionSpan : Initializable, SessionSpanWriter {
     /**
      * End the current session span and start a new one if the app is not terminating
      */
-    fun endSession(appTerminationCause: AppTerminationCause? = null, startNewSession: Boolean): List<EmbraceSpanData>
+    fun endSession(startNewSession: Boolean, appTerminationCause: AppTerminationCause? = null): List<EmbraceSpanData>
 
     /**
      * Returns true if a span with the given parameters can be started in the current session

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -83,7 +83,7 @@ internal class CurrentSessionSpanImpl(
         return sessionSpan.get()?.getSystemAttribute(embSessionId) ?: ""
     }
 
-    override fun endSession(appTerminationCause: AppTerminationCause?): List<EmbraceSpanData> {
+    override fun endSession(appTerminationCause: AppTerminationCause?, startNewSession: Boolean): List<EmbraceSpanData> {
         synchronized(sessionSpan) {
             val endingSessionSpan = sessionSpan.get()
             return if (endingSessionSpan != null && endingSessionSpan.isRecording) {
@@ -98,7 +98,9 @@ internal class CurrentSessionSpanImpl(
                 if (appTerminationCause == null) {
                     endingSessionSpan.stop()
                     spanRepository.clearCompletedSpans()
-                    sessionSpan.set(startSessionSpan(openTelemetryClock.now().nanosToMillis()))
+                    if (startNewSession) {
+                        sessionSpan.set(startSessionSpan(openTelemetryClock.now().nanosToMillis()))
+                    }
                 } else {
                     val crashTime = openTelemetryClock.now().nanosToMillis()
                     spanRepository.failActiveSpans(crashTime)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.telemetry.TelemetryService
 import io.opentelemetry.sdk.common.Clock
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
@@ -30,6 +31,7 @@ internal class CurrentSessionSpanImpl(
      */
     private val traceCount = AtomicInteger(0)
     private val internalTraceCount = AtomicInteger(0)
+    private val initialized = AtomicBoolean(false)
 
     /**
      * The span that models the lifetime of the current session or background activity
@@ -37,16 +39,17 @@ internal class CurrentSessionSpanImpl(
     private val sessionSpan: AtomicReference<PersistableEmbraceSpan?> = AtomicReference(null)
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
-        if (sessionSpan.get() == null) {
+        if (!initialized.get()) {
             synchronized(sessionSpan) {
-                if (sessionSpan.get() == null) {
+                if (!initialized.get()) {
                     sessionSpan.set(startSessionSpan(sdkInitStartTimeMs))
+                    initialized.set(sessionSpan.get() != null)
                 }
             }
         }
     }
 
-    override fun initialized(): Boolean = sessionSpan.get() != null
+    override fun initialized(): Boolean = initialized.get()
 
     /**
      * Creating a new Span is only possible if the current session span is active, the parent has already been started, and the total
@@ -83,7 +86,7 @@ internal class CurrentSessionSpanImpl(
         return sessionSpan.get()?.getSystemAttribute(embSessionId) ?: ""
     }
 
-    override fun endSession(appTerminationCause: AppTerminationCause?, startNewSession: Boolean): List<EmbraceSpanData> {
+    override fun endSession(startNewSession: Boolean, appTerminationCause: AppTerminationCause?): List<EmbraceSpanData> {
         synchronized(sessionSpan) {
             val endingSessionSpan = sessionSpan.get()
             return if (endingSessionSpan != null && endingSessionSpan.isRecording) {
@@ -98,9 +101,12 @@ internal class CurrentSessionSpanImpl(
                 if (appTerminationCause == null) {
                     endingSessionSpan.stop()
                     spanRepository.clearCompletedSpans()
-                    if (startNewSession) {
-                        sessionSpan.set(startSessionSpan(openTelemetryClock.now().nanosToMillis()))
+                    val newSession = if (startNewSession) {
+                        startSessionSpan(openTelemetryClock.now().nanosToMillis())
+                    } else {
+                        null
                     }
+                    sessionSpan.set(newSession)
                 } else {
                     val crashTime = openTelemetryClock.now().nanosToMillis()
                     spanRepository.failActiveSpans(crashTime)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParams.kt
@@ -12,6 +12,7 @@ internal class FinalEnvelopeParams(
     val initial: SessionZygote,
     val endType: SessionSnapshotType,
     val logger: EmbLogger,
+    backgroundActivityEnabled: Boolean,
     crashId: String? = null,
 ) {
 
@@ -19,4 +20,6 @@ internal class FinalEnvelopeParams(
         crashId.isNullOrEmpty() -> null
         else -> crashId
     }
+
+    val startNewSession: Boolean = endType.shouldStartNewSession && backgroundActivityEnabled
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadFactoryImpl.kt
@@ -60,7 +60,8 @@ internal class PayloadFactoryImpl(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionSnapshotType.NORMAL_END,
-                logger = logger
+                logger = logger,
+                backgroundActivityEnabled = isBackgroundActivityEnabled(),
             )
         )
     }
@@ -77,7 +78,7 @@ internal class PayloadFactoryImpl(
     }
 
     private fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): SessionZygote? {
-        if (!configService.isBackgroundActivityCaptureEnabled()) {
+        if (!isBackgroundActivityEnabled()) {
             return null
         }
 
@@ -102,13 +103,14 @@ internal class PayloadFactoryImpl(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionSnapshotType.NORMAL_END,
-                logger = logger
+                logger = logger,
+                backgroundActivityEnabled = isBackgroundActivityEnabled(),
             )
         )
     }
 
     private fun endBackgroundActivityWithState(initial: SessionZygote): Envelope<SessionPayload>? {
-        if (!configService.isBackgroundActivityCaptureEnabled()) {
+        if (!isBackgroundActivityEnabled()) {
             return null
         }
 
@@ -118,7 +120,8 @@ internal class PayloadFactoryImpl(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionSnapshotType.NORMAL_END,
-                logger = logger
+                logger = logger,
+                backgroundActivityEnabled = true,
             )
         )
     }
@@ -132,6 +135,7 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endType = SessionSnapshotType.JVM_CRASH,
                 logger = logger,
+                backgroundActivityEnabled = isBackgroundActivityEnabled(),
                 crashId = crashId
             )
         )
@@ -141,7 +145,7 @@ internal class PayloadFactoryImpl(
         initial: SessionZygote,
         crashId: String
     ): Envelope<SessionPayload>? {
-        if (!configService.isBackgroundActivityCaptureEnabled()) {
+        if (!isBackgroundActivityEnabled()) {
             return null
         }
         return payloadMessageCollator.buildFinalEnvelope(
@@ -149,6 +153,7 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endType = SessionSnapshotType.JVM_CRASH,
                 logger = logger,
+                backgroundActivityEnabled = true,
                 crashId = crashId
             )
         )
@@ -162,21 +167,25 @@ internal class PayloadFactoryImpl(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionSnapshotType.PERIODIC_CACHE,
-                logger = logger
+                logger = logger,
+                backgroundActivityEnabled = isBackgroundActivityEnabled()
             )
         )
     }
 
     private fun snapshotBackgroundActivity(initial: SessionZygote): Envelope<SessionPayload>? {
-        if (!configService.isBackgroundActivityCaptureEnabled()) {
+        if (!isBackgroundActivityEnabled()) {
             return null
         }
         return payloadMessageCollator.buildFinalEnvelope(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionSnapshotType.PERIODIC_CACHE,
-                logger = logger
+                logger = logger,
+                backgroundActivityEnabled = true
             )
         )
     }
+
+    private fun isBackgroundActivityEnabled(): Boolean = configService.isBackgroundActivityCaptureEnabled()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImpl.kt
@@ -31,8 +31,12 @@ internal class PayloadMessageCollatorImpl(
 
     override fun buildFinalEnvelope(params: FinalEnvelopeParams): Envelope<SessionPayload> {
         val envelope = gatingService.gateSessionEnvelope(
-            params.crashId != null,
-            sessionEnvelopeSource.getEnvelope(params.endType, params.crashId)
+            hasCrash = params.crashId != null,
+            envelope = sessionEnvelopeSource.getEnvelope(
+                endType = params.endType,
+                startNewSession = params.startNewSession,
+                crashId = params.crashId
+            )
         )
         return Envelope<SessionPayload>(
             // future work: make legacy fields null here.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionSnapshotType.kt
@@ -13,22 +13,27 @@ internal enum class SessionSnapshotType(
     /**
      * Whether the session process experienced a force quit/unexpected termination.
      */
-    val forceQuit: Boolean
+    val forceQuit: Boolean,
+
+    /**
+     * Whether this type of end should lead to the start of a new session
+     */
+    val shouldStartNewSession: Boolean
 ) {
 
     /**
      * The end session happened in the normal way (i.e. process state changes or manual/timed end).
      */
-    NORMAL_END(true, false),
+    NORMAL_END(endedCleanly = true, forceQuit = false, shouldStartNewSession = true),
 
     /**
      * The end session is being constructed so that it can be periodically cached. This avoids
      * the scenario of data loss in the event of NDK crashes.
      */
-    PERIODIC_CACHE(false, true),
+    PERIODIC_CACHE(endedCleanly = false, forceQuit = true, shouldStartNewSession = false),
 
     /**
      * The end session is being constructed because of a JVM crash.
      */
-    JVM_CRASH(false, false)
+    JVM_CRASH(endedCleanly = false, forceQuit = false, shouldStartNewSession = false)
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionEnvelopeSourceImplTest.kt
@@ -19,7 +19,7 @@ internal class SessionEnvelopeSourceImplTest {
             resourceSource,
             sessionPayloadSource,
         )
-        val payload = source.getEnvelope(SessionSnapshotType.NORMAL_END)
+        val payload = source.getEnvelope(SessionSnapshotType.NORMAL_END, true)
         assertEquals(metadataSource.metadata, payload.metadata)
         assertEquals(resourceSource.resource, payload.resource)
         assertEquals(sessionPayloadSource.sessionPayload, payload.data)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/envelope/session/SessionPayloadSourceImplTest.kt
@@ -47,20 +47,20 @@ internal class SessionPayloadSourceImplTest {
             fakeNativeAnrOtelMapper(),
             EmbLoggerImpl(),
             ::FakeWebViewService,
-            ::FakeSessionPropertiesService
+            ::FakeSessionPropertiesService,
         )
     }
 
     @Test
     fun `session crash`() {
-        val payload = impl.getSessionPayload(SessionSnapshotType.JVM_CRASH)
+        val payload = impl.getSessionPayload(SessionSnapshotType.JVM_CRASH, false)
         assertPayloadPopulated(payload)
         assertNotNull(payload.spans?.single())
     }
 
     @Test
     fun `session cache`() {
-        val payload = impl.getSessionPayload(SessionSnapshotType.PERIODIC_CACHE)
+        val payload = impl.getSessionPayload(SessionSnapshotType.PERIODIC_CACHE, false)
         assertPayloadPopulated(payload)
         val span = checkNotNull(payload.spans?.single())
         assertEquals("cache-span", span.name)
@@ -68,7 +68,7 @@ internal class SessionPayloadSourceImplTest {
 
     @Test
     fun `session lifecycle change`() {
-        val payload = impl.getSessionPayload(SessionSnapshotType.NORMAL_END)
+        val payload = impl.getSessionPayload(SessionSnapshotType.NORMAL_END, true)
         assertPayloadPopulated(payload)
         assertNotNull(payload.spans?.single())
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -46,7 +46,7 @@ internal class FakeCurrentSessionSpan(
         return true
     }
 
-    override fun endSession(appTerminationCause: AppTerminationCause?, startNewSession: Boolean): List<EmbraceSpanData> {
+    override fun endSession(startNewSession: Boolean, appTerminationCause: AppTerminationCause?): List<EmbraceSpanData> {
         val endingSessionSpan = checkNotNull(sessionSpan)
         endingSessionSpan.endTimeNanos = clock.nowInNanos()
         endingSessionSpan.spanStatus = if (appTerminationCause == null) StatusData.ok() else StatusData.error()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -46,7 +46,7 @@ internal class FakeCurrentSessionSpan(
         return true
     }
 
-    override fun endSession(appTerminationCause: AppTerminationCause?): List<EmbraceSpanData> {
+    override fun endSession(appTerminationCause: AppTerminationCause?, startNewSession: Boolean): List<EmbraceSpanData> {
         val endingSessionSpan = checkNotNull(sessionSpan)
         endingSessionSpan.endTimeNanos = clock.nowInNanos()
         endingSessionSpan.spanStatus = if (appTerminationCause == null) StatusData.ok() else StatusData.error()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionPayloadSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionPayloadSource.kt
@@ -7,5 +7,5 @@ import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
 internal class FakeSessionPayloadSource : SessionPayloadSource {
 
     var sessionPayload: SessionPayload = SessionPayload()
-    override fun getSessionPayload(endType: SessionSnapshotType, crashId: String?) = sessionPayload
+    override fun getSessionPayload(endType: SessionSnapshotType, startNewSession: Boolean, crashId: String?) = sessionPayload
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
@@ -28,7 +28,7 @@ internal class CurrentSessionSpanAttributeTests {
 
     @Test
     fun `attributes added to cold start session span`() {
-        val span = currentSessionSpan.endSession(null).single()
+        val span = currentSessionSpan.endSession(null, true).single()
         assertEquals("emb-session", span.name)
 
         // assert attributes added by default
@@ -38,8 +38,8 @@ internal class CurrentSessionSpanAttributeTests {
     @Test
     fun `attributes added to hot session span`() {
         // end the first session span then create another one
-        currentSessionSpan.endSession(null)
-        val span = currentSessionSpan.endSession(null).single()
+        currentSessionSpan.endSession(null, true)
+        val span = currentSessionSpan.endSession(null, true).single()
         assertEquals("emb-session", span.name)
 
         // assert attributes added by default

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
@@ -28,7 +28,7 @@ internal class CurrentSessionSpanAttributeTests {
 
     @Test
     fun `attributes added to cold start session span`() {
-        val span = currentSessionSpan.endSession(null, true).single()
+        val span = currentSessionSpan.endSession(true).single()
         assertEquals("emb-session", span.name)
 
         // assert attributes added by default
@@ -38,8 +38,8 @@ internal class CurrentSessionSpanAttributeTests {
     @Test
     fun `attributes added to hot session span`() {
         // end the first session span then create another one
-        currentSessionSpan.endSession(null, true)
-        val span = currentSessionSpan.endSession(null, true).single()
+        currentSessionSpan.endSession(true)
+        val span = currentSessionSpan.endSession(true).single()
         assertEquals("emb-session", span.name)
 
         // assert attributes added by default

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanServiceTest.kt
@@ -51,7 +51,7 @@ internal class EmbraceSpanServiceTest {
         spanService.recordSpan("test-span") { lambdaRan = true }
         assertTrue(lambdaRan)
         assertEquals(2, spanSink.completedSpans().size)
-        assertEquals(3, currentSessionSpan.endSession().size)
+        assertEquals(3, currentSessionSpan.endSession(startNewSession = true).size)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -156,7 +156,7 @@ internal class SpanServiceImplTest {
     @Test
     fun `start span created from previous session`() {
         val embraceSpan = checkNotNull(spansService.createSpan(name = "test-span"))
-        currentSessionSpan.endSession()
+        currentSessionSpan.endSession(startNewSession = true)
         assertTrue(embraceSpan.start())
     }
 
@@ -301,7 +301,7 @@ internal class SpanServiceImplTest {
         val parentSpan = checkNotNull(spansService.createSpan(name = "test-span"))
         assertTrue(parentSpan.start())
         assertTrue(parentSpan.stop())
-        currentSessionSpan.endSession()
+        currentSessionSpan.endSession(startNewSession = true)
         assertTrue(
             spansService.recordCompletedSpan(
                 name = expectedName,
@@ -358,7 +358,8 @@ internal class SpanServiceImplTest {
     @Test
     fun `cannot record completed span if there is not current session span`() {
         currentSessionSpan.endSession(
-            appTerminationCause = AppTerminationCause.UserTermination
+            appTerminationCause = AppTerminationCause.UserTermination,
+            startNewSession = true
         )
         assertFalse(
             spansService.recordCompletedSpan(
@@ -449,7 +450,8 @@ internal class SpanServiceImplTest {
     @Test
     fun `recording span as lambda with no current active session will run code but not log span`() {
         currentSessionSpan.endSession(
-            appTerminationCause = AppTerminationCause.UserTermination
+            appTerminationCause = AppTerminationCause.UserTermination,
+            startNewSession = true
         )
         var executed = false
         spansService.recordSpan(name = "test-span") {
@@ -462,7 +464,7 @@ internal class SpanServiceImplTest {
 
     @Test
     fun `after ending session with app termination, spans cannot be recorded`() {
-        currentSessionSpan.endSession(AppTerminationCause.UserTermination)
+        currentSessionSpan.endSession(AppTerminationCause.UserTermination, true)
         spansService.recordSpan("test-span") {
             // do thing
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -358,8 +358,8 @@ internal class SpanServiceImplTest {
     @Test
     fun `cannot record completed span if there is not current session span`() {
         currentSessionSpan.endSession(
-            appTerminationCause = AppTerminationCause.UserTermination,
-            startNewSession = true
+            startNewSession = true,
+            appTerminationCause = AppTerminationCause.UserTermination
         )
         assertFalse(
             spansService.recordCompletedSpan(
@@ -450,8 +450,8 @@ internal class SpanServiceImplTest {
     @Test
     fun `recording span as lambda with no current active session will run code but not log span`() {
         currentSessionSpan.endSession(
-            appTerminationCause = AppTerminationCause.UserTermination,
-            startNewSession = true
+            startNewSession = true,
+            appTerminationCause = AppTerminationCause.UserTermination
         )
         var executed = false
         spansService.recordSpan(name = "test-span") {
@@ -464,7 +464,7 @@ internal class SpanServiceImplTest {
 
     @Test
     fun `after ending session with app termination, spans cannot be recorded`() {
-        currentSessionSpan.endSession(AppTerminationCause.UserTermination, true)
+        currentSessionSpan.endSession(true, AppTerminationCause.UserTermination)
         spansService.recordSpan("test-span") {
             // do thing
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParamsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/FinalEnvelopeParamsTest.kt
@@ -1,0 +1,74 @@
+package io.embrace.android.embracesdk.session.message
+
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.fakeSessionZygote
+import io.embrace.android.embracesdk.session.orchestrator.SessionSnapshotType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class FinalEnvelopeParamsTest {
+    private val logger = FakeEmbLogger()
+
+    @Test
+    fun `verify new session creation of different end types when background activity is enabled`() {
+        assertTrue(
+            FinalEnvelopeParams(
+                initial = fakeSessionZygote(),
+                endType = SessionSnapshotType.NORMAL_END,
+                logger = logger,
+                backgroundActivityEnabled = true,
+            ).startNewSession
+        )
+
+        assertFalse(
+            FinalEnvelopeParams(
+                initial = fakeSessionZygote(),
+                endType = SessionSnapshotType.PERIODIC_CACHE,
+                logger = logger,
+                backgroundActivityEnabled = true,
+            ).startNewSession
+        )
+
+        assertFalse(
+            FinalEnvelopeParams(
+                initial = fakeSessionZygote(),
+                endType = SessionSnapshotType.JVM_CRASH,
+                logger = logger,
+                backgroundActivityEnabled = true,
+                crashId = "crashId"
+            ).startNewSession
+        )
+    }
+
+    @Test
+    fun `verify new session creation of different end types when background activity is disabled`() {
+        assertFalse(
+            FinalEnvelopeParams(
+                initial = fakeSessionZygote(),
+                endType = SessionSnapshotType.NORMAL_END,
+                logger = logger,
+                backgroundActivityEnabled = false,
+            ).startNewSession
+        )
+
+        assertFalse(
+            FinalEnvelopeParams(
+                initial = fakeSessionZygote(),
+                endType = SessionSnapshotType.PERIODIC_CACHE,
+                logger = logger,
+                backgroundActivityEnabled = false,
+            ).startNewSession
+        )
+
+        assertFalse(
+            FinalEnvelopeParams(
+                initial = fakeSessionZygote(),
+                endType = SessionSnapshotType.JVM_CRASH,
+                logger = logger,
+                backgroundActivityEnabled = false,
+                crashId = "crashId"
+            ).startNewSession
+        )
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/message/PayloadMessageCollatorImplTest.kt
@@ -86,10 +86,11 @@ internal class PayloadMessageCollatorImplTest {
         // create session
         val payload = collator.buildFinalEnvelope(
             FinalEnvelopeParams(
-                startMsg,
-                SessionSnapshotType.NORMAL_END,
-                initModule.logger,
-                "crashId"
+                initial = startMsg,
+                endType = SessionSnapshotType.NORMAL_END,
+                logger = initModule.logger,
+                backgroundActivityEnabled = true,
+                crashId = "crashId"
             )
         )
         payload.verifyFinalFieldsPopulated()
@@ -112,10 +113,11 @@ internal class PayloadMessageCollatorImplTest {
         // create session
         val payload = collator.buildFinalEnvelope(
             FinalEnvelopeParams(
-                startMsg,
-                SessionSnapshotType.NORMAL_END,
-                initModule.logger,
-                "crashId",
+                initial = startMsg,
+                endType = SessionSnapshotType.NORMAL_END,
+                logger = initModule.logger,
+                backgroundActivityEnabled = true,
+                crashId = "crashId",
             )
         )
         payload.verifyFinalFieldsPopulated()


### PR DESCRIPTION
## Goal

Pass down whether or not ending a session in the CurrentSessionSpan should start a new session, and make the check appropriately based on end type as well as whether background sessions are enabled.

## Testing
Added new tests for the condition

