### PR TITLE
Migrate to OTel semconv keys

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/SpanAssertions.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 /**
  * Finds the first Span Event matching the given [TelemetryType]
@@ -55,7 +55,7 @@ internal fun Envelope<SessionPayload>.getSessionId(): String {
     val sessionSpan = checkNotNull(getSessionSpan()) {
         "No session span found in session message"
     }
-    return checkNotNull(sessionSpan.attributes?.findAttributeValue(embSessionId.name)) {
+    return checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key)) {
         "No session id found in session message"
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.assertions
 import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.fail
 
 /**
@@ -27,8 +27,8 @@ internal fun assertInternalErrorLogged(
     }
 
     val matchingLogs = logs.filter { log ->
-        log.attributes?.findAttributeValue(ExceptionIncubatingAttributes.EXCEPTION_TYPE.key) == exceptionClassName &&
-            log.attributes.findAttributeValue(ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key) == errorMessage
+        log.attributes?.findAttributeValue(ExceptionAttributes.EXCEPTION_TYPE.key) == exceptionClassName &&
+            log.attributes.findAttributeValue(ExceptionAttributes.EXCEPTION_MESSAGE.key) == errorMessage
     }
     if (matchingLogs.isEmpty()) {
         fail("No internal errors found matching the expected exception")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/OTelLogAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/OTelLogAssertions.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 
@@ -31,14 +31,14 @@ internal fun assertOtelLogReceived(
         assertEquals(expectedTimeMs * 1000000, log.timeUnixNano)
         expectedType?.let { assertAttribute(log, embExceptionHandling.name, it) }
         expectedExceptionName?.let {
-            assertAttribute(log, ExceptionIncubatingAttributes.EXCEPTION_TYPE.key, expectedExceptionName)
+            assertAttribute(log, ExceptionAttributes.EXCEPTION_TYPE.key, expectedExceptionName)
         }
         expectedExceptionMessage?.let {
-            assertAttribute(log, ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key, expectedExceptionMessage)
+            assertAttribute(log, ExceptionAttributes.EXCEPTION_MESSAGE.key, expectedExceptionMessage)
         }
         expectedStacktrace?.let {
             val serializedStack = EmbraceSerializer().truncatedStacktrace(it.toTypedArray())
-            assertAttribute(log, ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key, serializedStack)
+            assertAttribute(log, ExceptionAttributes.EXCEPTION_STACKTRACE.key, serializedStack)
         }
         expectedProperties?.forEach { (key, value) ->
             assertAttribute(log, key, value.toString())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/WebviewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/WebviewFeatureTest.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.payload.WebVital
 import io.embrace.android.embracesdk.payload.WebVitalType
 import io.embrace.android.embracesdk.recordSession
+import io.opentelemetry.semconv.UrlAttributes.URL_FULL
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -54,7 +55,7 @@ internal class WebviewFeatureTest {
             val attrs = checkNotNull(event.attributes)
             assertEquals("emb-webview-info", event.name)
             assertEquals("myWebView", attrs.findAttributeValue("emb.webview_info.tag"))
-            assertEquals("https://embrace.io/", attrs.findAttributeValue("emb.webview_info.url"))
+            assertEquals("https://embrace.io/", attrs.findAttributeValue(URL_FULL.key))
 
             val webVitalsAttr = checkNotNull(attrs.findAttributeValue("emb.webview_info.web_vitals"))
             val type = Types.newParameterizedType(List::class.java, WebVital::class.java)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.opentelemetry.EmbSpan
 import io.embrace.android.embracesdk.opentelemetry.EmbSpanBuilder
 import io.embrace.android.embracesdk.opentelemetry.EmbTracer
 import io.embrace.android.embracesdk.recordSession
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
@@ -26,7 +25,7 @@ import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -149,9 +148,9 @@ internal class ExternalTracerTest {
                         timestampNanos = checkNotNull(startTimeMs?.millisToNanos()),
                         attributes = listOf(
                             Attribute("bad", "yes"),
-                            Attribute(ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key, "bah"),
-                            Attribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key, stacktrace),
-                            Attribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE.key, checkNotNull(RuntimeException::class.java.canonicalName))
+                            Attribute(ExceptionAttributes.EXCEPTION_MESSAGE.key, "bah"),
+                            Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, stacktrace),
+                            Attribute(ExceptionAttributes.EXCEPTION_TYPE.key, checkNotNull(RuntimeException::class.java.canonicalName))
                         )
                     )
                 ),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -16,7 +16,7 @@ import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.worker.WorkerName
 import io.opentelemetry.api.logs.Severity
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -170,7 +170,7 @@ internal class FlutterInternalInterfaceTest {
                 expectedEmbType = "sys.flutter_exception",
             )
             val attrs = checkNotNull(log.attributes)
-            assertEquals(expectedStacktrace, attrs.findAttributeValue(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key))
+            assertEquals(expectedStacktrace, attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_STACKTRACE.key))
             assertEquals(expectedContext, attrs.findAttributeValue("emb.exception.context"))
             assertEquals(expectedLibrary, attrs.findAttributeValue("emb.exception.library"))
         }
@@ -207,7 +207,7 @@ internal class FlutterInternalInterfaceTest {
                 expectedEmbType = "sys.flutter_exception",
             )
             val attrs = checkNotNull(log.attributes)
-            assertEquals(expectedStacktrace, attrs.findAttributeValue(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key))
+            assertEquals(expectedStacktrace, attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_STACKTRACE.key))
             assertEquals(expectedContext, attrs.findAttributeValue("emb.exception.context"))
             assertEquals(expectedLibrary, attrs.findAttributeValue("emb.exception.library"))
         }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -11,8 +11,8 @@ import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.recordSession
+import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
 import io.opentelemetry.semconv.HttpAttributes
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes.EXCEPTION_MESSAGE
 import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Rule

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/V2SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/V2SessionApiTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.toMap
 import io.embrace.android.embracesdk.validatePayloadAgainstGoldenFile
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -53,8 +54,8 @@ internal class V2SessionApiTest {
             // validate session span
             val sessionSpan = snapshots.single { it.name == "emb-session" }
             assertEquals(startTime, sessionSpan.startTimeNanos?.nanosToMillis())
-            assertNotNull(sessionSpan.attributes?.findAttributeValue("emb.session_id"))
-            val attrs = checkNotNull(sessionSpan.attributes?.filter { it.key != "emb.session_id" }?.toMap())
+            assertNotNull(sessionSpan.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+            val attrs = checkNotNull(sessionSpan.attributes?.filter { it.key != SessionIncubatingAttributes.SESSION_ID.key }?.toMap())
 
             val expected = mapOf(
                 "emb.cold_start" to "true",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
@@ -10,6 +10,8 @@ import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.sdk.trace.IdGenerator
+import io.opentelemetry.semconv.JvmAttributes
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 
 /**
  * Maps captured ANRs to OTel constructs.
@@ -67,12 +69,12 @@ internal class AnrOtelMapper(
             attrs.add(Attribute("sample_code", it.toString()))
         }
         sample.threads?.singleOrNull()?.let { thread ->
-            attrs.add(Attribute("thread_state", thread.state.toString()))
+            attrs.add(Attribute(JvmAttributes.JVM_THREAD_STATE.key, thread.state.toString()))
             attrs.add(Attribute("thread_priority", thread.priority.toString()))
 
             thread.lines?.let { lines ->
                 attrs.add(Attribute("frame_count", lines.size.toString()))
-                attrs.add(Attribute("stacktrace", lines.joinToString("\n")))
+                attrs.add(Attribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key, lines.joinToString("\n")))
             }
         }
         return SpanEvent(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/AnrOtelMapper.kt
@@ -10,8 +10,8 @@ import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.payload.AnrSample
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.sdk.trace.IdGenerator
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.JvmAttributes
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 
 /**
  * Maps captured ANRs to OTel constructs.
@@ -74,7 +74,7 @@ internal class AnrOtelMapper(
 
             thread.lines?.let { lines ->
                 attrs.add(Attribute("frame_count", lines.size.toString()))
-                attrs.add(Attribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key, lines.joinToString("\n")))
+                attrs.add(Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, lines.joinToString("\n")))
             }
         }
         return SpanEvent(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
@@ -14,6 +14,8 @@ import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.sdk.trace.IdGenerator
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes
 
 internal class NativeAnrOtelMapper(
     private val nativeThreadSamplerService: NativeThreadSamplerService?,
@@ -50,10 +52,10 @@ internal class NativeAnrOtelMapper(
         attrs.add(Attribute("emb.type", "perf.native_thread_blockage"))
 
         interval.id?.let {
-            attrs.add(Attribute("thread_id", it.toString()))
+            attrs.add(Attribute(ThreadIncubatingAttributes.THREAD_ID.key, it.toString()))
         }
         interval.name?.let {
-            attrs.add(Attribute("thread_name", it))
+            attrs.add(Attribute(ThreadIncubatingAttributes.THREAD_NAME.key, it))
         }
         interval.priority?.let {
             attrs.add(Attribute("thread_priority", it.toString()))
@@ -94,7 +96,7 @@ internal class NativeAnrOtelMapper(
         }
         frames?.let { stacktrace ->
             val json = serializer.toJson(stacktrace, Types.newParameterizedType(List::class.java, NativeAnrSampleFrame::class.java))
-            attrs.add(Attribute("stacktrace", json))
+            attrs.add(Attribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key, json))
         }
         return SpanEvent(
             name = "emb_native_thread_blockage_sample",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapper.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.sdk.trace.IdGenerator
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes
 
 internal class NativeAnrOtelMapper(
@@ -96,7 +96,7 @@ internal class NativeAnrOtelMapper(
         }
         frames?.let { stacktrace ->
             val json = serializer.toJson(stacktrace, Types.newParameterizedType(List::class.java, NativeAnrSampleFrame::class.java))
-            attrs.add(Attribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key, json))
+            attrs.add(Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, json))
         }
         return SpanEvent(
             name = "emb_native_thread_blockage_sample",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriterImpl.kt
@@ -7,12 +7,12 @@ import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.spans.setFixedAttribute
 import io.embrace.android.embracesdk.internal.spans.toOtelSeverity
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.opentelemetry.embState
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 internal class LogWriterImpl(
     private val logger: Logger,
@@ -34,7 +34,7 @@ internal class LogWriterImpl(
         builder.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID, Uuid.getEmbUuid())
 
         sessionIdTracker.getActiveSessionId()?.let { sessionId ->
-            builder.setAttribute(embSessionId.attributeKey, sessionId)
+            builder.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
         }
 
         metadataService.getAppState()?.let { appState ->

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -7,9 +7,9 @@ import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.utils.NetworkUtils.getValidTraceId
 import io.opentelemetry.semconv.ErrorAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.UrlAttributes
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
@@ -139,7 +139,7 @@ internal sealed class SchemaType(
             HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key to networkRequest.bytesSent,
             HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key to networkRequest.bytesReceived,
             ErrorAttributes.ERROR_TYPE.key to networkRequest.errorType,
-            ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key to networkRequest.errorMessage,
+            ExceptionAttributes.EXCEPTION_MESSAGE.key to networkRequest.errorMessage,
             "emb.w3c_traceparent" to networkRequest.w3cTraceparent,
             "emb.trace_id" to getValidTraceId(networkRequest.traceId),
         ).toNonNullMap().mapValues { it.value.toString() }
@@ -207,7 +207,7 @@ internal sealed class SchemaType(
             SessionIncubatingAttributes.SESSION_ID.key to networkCapturedCall.sessionId,
             "start-time" to networkCapturedCall.startTime.toString(),
             "url" to networkCapturedCall.url,
-            ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key to networkCapturedCall.errorMessage,
+            ExceptionAttributes.EXCEPTION_MESSAGE.key to networkCapturedCall.errorMessage,
             "encrypted-payload" to networkCapturedCall.encryptedPayload
         ).toNonNullMap()
     }
@@ -276,12 +276,12 @@ internal sealed class SchemaType(
         fixedObjectName = "internal-error"
     ) {
         override val schemaAttributes = mapOf(
-            ExceptionIncubatingAttributes.EXCEPTION_TYPE.key to throwable.javaClass.name,
-            ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key to throwable.stackTrace.joinToString(
+            ExceptionAttributes.EXCEPTION_TYPE.key to throwable.javaClass.name,
+            ExceptionAttributes.EXCEPTION_STACKTRACE.key to throwable.stackTrace.joinToString(
                 "\n",
                 transform = StackTraceElement::toString
             ),
-            ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key to (throwable.message ?: "")
+            ExceptionAttributes.EXCEPTION_MESSAGE.key to (throwable.message ?: "")
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
@@ -26,7 +26,7 @@ import io.embrace.android.embracesdk.payload.ThreadInfo
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 
 /**
@@ -87,14 +87,14 @@ internal class CrashDataSourceImpl(
             )
 
             val crashException = LegacyExceptionInfo.ofThrowable(exception)
-            crashAttributes.setAttribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE, crashException.name)
+            crashAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, crashException.name)
             crashAttributes.setAttribute(
-                ExceptionIncubatingAttributes.EXCEPTION_MESSAGE,
+                ExceptionAttributes.EXCEPTION_MESSAGE,
                 crashException.message
                     ?: ""
             )
             crashAttributes.setAttribute(
-                ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE,
+                ExceptionAttributes.EXCEPTION_STACKTRACE,
                 encodeToUTF8String(
                     serializer.toJson(crashException.lines, List::class.java),
                 ),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -23,7 +23,7 @@ import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.BackgroundWorker
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 import java.util.NavigableMap
 import java.util.concurrent.ConcurrentSkipListMap
@@ -238,9 +238,9 @@ internal class EmbraceLogService(
         message: String?,
     ) {
         attributes.setAttribute(embExceptionHandling, logExceptionType.value)
-        type?.let { attributes.setAttribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE, it) }
-        message?.let { attributes.setAttribute(ExceptionIncubatingAttributes.EXCEPTION_MESSAGE, it) }
-        stackTrace?.let { attributes.setAttribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE, it) }
+        type?.let { attributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, it) }
+        message?.let { attributes.setAttribute(ExceptionAttributes.EXCEPTION_MESSAGE, it) }
+        stackTrace?.let { attributes.setAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE, it) }
     }
 
     private fun addLogEventData(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Envelope.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Envelope.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.Types
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 /**
  * Envelope used for Embrace API requests for different types of data:
@@ -45,5 +45,5 @@ internal fun Envelope<SessionPayload>.getSessionSpan(): Span? {
 }
 
 internal fun Envelope<SessionPayload>.getSessionId(): String? {
-    return getSessionSpan()?.attributes?.findAttributeValue(embSessionId.name)
+    return getSessionSpan()?.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -18,7 +18,7 @@ import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import java.util.concurrent.TimeUnit
 
 /**
@@ -191,7 +191,7 @@ internal fun io.embrace.android.embracesdk.Severity.toOtelSeverity(): Severity =
 
 internal fun String.isValidLongValueAttribute() = longValueAttributes.contains(this)
 
-internal val longValueAttributes = setOf(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key)
+internal val longValueAttributes = setOf(ExceptionAttributes.EXCEPTION_STACKTRACE.key)
 
 internal fun StatusCode.toStatus(): io.embrace.android.embracesdk.internal.payload.Span.Status {
     return when (this) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -22,7 +22,7 @@ import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.common.Clock
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
@@ -164,14 +164,14 @@ internal class EmbraceSpanImpl(
             }
 
             exception.javaClass.canonicalName?.let { type ->
-                eventAttributes[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key] = type
+                eventAttributes[ExceptionAttributes.EXCEPTION_TYPE.key] = type
             }
 
             exception.message?.let { message ->
-                eventAttributes[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key] = message
+                eventAttributes[ExceptionAttributes.EXCEPTION_MESSAGE.key] = message
             }
 
-            eventAttributes[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key] = exception.truncatedStacktraceText()
+            eventAttributes[ExceptionAttributes.EXCEPTION_STACKTRACE.key] = exception.truncatedStacktraceText()
 
             EmbraceSpanEvent.create(
                 name = EXCEPTION_EVENT_NAME,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSource.kt
@@ -17,11 +17,11 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.opentelemetry.embCrashNumber
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.payload.NativeCrashData
 import io.embrace.android.embracesdk.payload.NativeCrashDataError
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 internal interface NativeCrashDataSource : LogDataSource, NativeCrashService
 
@@ -43,13 +43,14 @@ internal class NativeCrashDataSourceImpl(
             sendNativeCrash(this)
         }
     }
+
     private fun sendNativeCrash(nativeCrash: NativeCrashData) {
         val nativeCrashNumber = preferencesService.incrementAndGetNativeCrashNumber()
         val crashAttributes = TelemetryAttributes(
             configService = configService,
             sessionProperties = sessionProperties
         )
-        crashAttributes.setAttribute(embSessionId, nativeCrash.sessionId)
+        crashAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, nativeCrash.sessionId)
         crashAttributes.setAttribute(embCrashNumber, nativeCrashNumber.toString())
         nativeCrash.crash?.let { crashAttributes.setAttribute(embNativeCrashException, it) }
         val nativeErrorsJson = serializer.toJson(nativeCrash.errors, errorSerializerType)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/EmbraceAttributeKeys.kt
@@ -29,11 +29,6 @@ internal val embProcessIdentifier: EmbraceAttributeKey = EmbraceAttributeKey("pr
 internal val embSequenceId: EmbraceAttributeKey = EmbraceAttributeKey(id = "sequence_id", isPrivate = true)
 
 /**
- * Attribute name for the Embrace Sesssion
- */
-internal val embSessionId: EmbraceAttributeKey = EmbraceAttributeKey("session_id")
-
-/**
  * Attribute name for the application state (foreground/background) at the time the log was recorded
  */
 internal val embState = EmbraceAttributeKey("state")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfiguration.kt
@@ -13,10 +13,10 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SpanProcessor
 import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
 
 internal class OpenTelemetryConfiguration(
@@ -28,8 +28,8 @@ internal class OpenTelemetryConfiguration(
     val embraceSdkName = BuildConfig.LIBRARY_PACKAGE_NAME
     val embraceSdkVersion = BuildConfig.VERSION_NAME
     val resource: Resource = Resource.getDefault().toBuilder()
-        .put(ServiceIncubatingAttributes.SERVICE_NAME, embraceSdkName)
-        .put(ServiceIncubatingAttributes.SERVICE_VERSION, embraceSdkVersion)
+        .put(ServiceAttributes.SERVICE_NAME, embraceSdkName)
+        .put(ServiceAttributes.SERVICE_VERSION, embraceSdkVersion)
         .put(OsIncubatingAttributes.OS_NAME, systemInfo.osName)
         .put(OsIncubatingAttributes.OS_VERSION, systemInfo.osVersion)
         .put(OsIncubatingAttributes.OS_TYPE, systemInfo.osType)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/PersistableEmbraceSpan.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.spans
 
 import io.embrace.android.embracesdk.arch.schema.EmbType
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
@@ -33,12 +33,12 @@ internal interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
     /**
      * Get the value of the attribute with the given key. Returns null if the attribute does not exist.
      */
-    fun getSystemAttribute(key: EmbraceAttributeKey): String?
+    fun getSystemAttribute(key: AttributeKey<String>): String?
 
     /**
      * Set the value of the attribute with the given key, overwriting the original value if it's already set
      */
-    fun setSystemAttribute(key: EmbraceAttributeKey, value: String)
+    fun setSystemAttribute(key: AttributeKey<String>, value: String)
 
     /**
      * Remove the custom attribute with the given key name

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.WebVital
 import io.embrace.android.embracesdk.payload.WebVitalType
+import io.opentelemetry.semconv.UrlAttributes.URL_FULL
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -72,7 +73,7 @@ internal class EmbraceWebViewServiceTest {
         writer.addedEvents.first().let {
             assert(it.schemaType is SchemaType.WebViewInfo)
             val webViewInfo = it.schemaType as SchemaType.WebViewInfo
-            assertEquals("https://embrace.io/", webViewInfo.attributes()["emb.webview_info.url"])
+            assertEquals("https://embrace.io/", webViewInfo.attributes()[URL_FULL.key])
             val webVitals = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { it1 ->
                 serializer.fromJson(it1, List::class.java)
             }
@@ -90,7 +91,7 @@ internal class EmbraceWebViewServiceTest {
         writer.addedEvents.forEach {
             assert(it.schemaType is SchemaType.WebViewInfo)
             val webViewInfo = it.schemaType as SchemaType.WebViewInfo
-            assertEquals("https://embrace.io/", webViewInfo.attributes()["emb.webview_info.url"])
+            assertEquals("https://embrace.io/", webViewInfo.attributes()[URL_FULL.key])
             val webVitals = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { it1 ->
                 serializer.fromJson(it1, List::class.java)
             }
@@ -108,7 +109,7 @@ internal class EmbraceWebViewServiceTest {
         val event = writer.addedEvents.first()
         assert(event.schemaType is SchemaType.WebViewInfo)
         val webViewInfo = event.schemaType as SchemaType.WebViewInfo
-        assertEquals("https://embrace.io/", webViewInfo.attributes()["emb.webview_info.url"])
+        assertEquals("https://embrace.io/", webViewInfo.attributes()[URL_FULL.key])
         val webVitals: List<WebVital>? = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { wv ->
             val type = Types.newParameterizedType(List::class.java, WebVital::class.java)
             serializer.fromJson(wv, type)
@@ -134,7 +135,7 @@ internal class EmbraceWebViewServiceTest {
         writer.addedEvents.forEach {
             assert(it.schemaType is SchemaType.WebViewInfo)
             val webViewInfo = it.schemaType as SchemaType.WebViewInfo
-            assertEquals("https://embrace.io/", webViewInfo.attributes()["emb.webview_info.url"])
+            assertEquals("https://embrace.io/", webViewInfo.attributes()[URL_FULL.key])
             val webVitals = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { it1 ->
                 serializer.fromJson(it1, List::class.java)
             }
@@ -151,7 +152,7 @@ internal class EmbraceWebViewServiceTest {
         val event = writer.addedEvents.first()
         assert(event.schemaType is SchemaType.WebViewInfo)
         val webViewInfo = event.schemaType as SchemaType.WebViewInfo
-        assertEquals("https://embrace.io/", webViewInfo.attributes()["emb.webview_info.url"])
+        assertEquals("https://embrace.io/", webViewInfo.attributes()[URL_FULL.key])
         val webVitals: List<WebVital>? = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { wv ->
             val type = Types.newParameterizedType(List::class.java, WebVital::class.java)
             serializer.fromJson(wv, type)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
@@ -14,8 +14,8 @@ import io.embrace.android.embracesdk.payload.AnrSampleList
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import io.embrace.android.embracesdk.payload.extensions.clearSamples
 import io.opentelemetry.api.trace.SpanId
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.JvmAttributes
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -203,7 +203,7 @@ internal class AnrOtelMapperTest {
         assertEquals(thread.state.toString(), attrs.findAttribute(JvmAttributes.JVM_THREAD_STATE.key).data)
         assertEquals(thread.priority, attrs.findAttribute("thread_priority").data?.toInt())
         assertEquals(thread.lines?.size, attrs.findAttribute("frame_count").data?.toInt())
-        assertEquals(thread.lines?.joinToString("\n"), attrs.findAttribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key).data)
+        assertEquals(thread.lines?.joinToString("\n"), attrs.findAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key).data)
     }
 
     private fun List<Attribute>.findAttribute(key: String): Attribute {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/AnrOtelMapperTest.kt
@@ -14,6 +14,8 @@ import io.embrace.android.embracesdk.payload.AnrSampleList
 import io.embrace.android.embracesdk.payload.ThreadInfo
 import io.embrace.android.embracesdk.payload.extensions.clearSamples
 import io.opentelemetry.api.trace.SpanId
+import io.opentelemetry.semconv.JvmAttributes
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -198,10 +200,10 @@ internal class AnrOtelMapperTest {
 
         // validate threads
         val thread = checkNotNull(sample.threads?.single())
-        assertEquals(thread.state.toString(), attrs.findAttribute("thread_state").data)
+        assertEquals(thread.state.toString(), attrs.findAttribute(JvmAttributes.JVM_THREAD_STATE.key).data)
         assertEquals(thread.priority, attrs.findAttribute("thread_priority").data?.toInt())
         assertEquals(thread.lines?.size, attrs.findAttribute("frame_count").data?.toInt())
-        assertEquals(thread.lines?.joinToString("\n"), attrs.findAttribute("stacktrace").data)
+        assertEquals(thread.lines?.joinToString("\n"), attrs.findAttribute(ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key).data)
     }
 
     private fun List<Attribute>.findAttribute(key: String): Attribute {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe
 import io.embrace.android.embracesdk.payload.ThreadState
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE
+import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
 import org.junit.Assert.assertEquals

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/anr/ndk/NativeAnrOtelMapperTest.kt
@@ -11,6 +11,9 @@ import io.embrace.android.embracesdk.payload.NativeThreadAnrInterval
 import io.embrace.android.embracesdk.payload.NativeThreadAnrSample
 import io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe
 import io.embrace.android.embracesdk.payload.ThreadState
+import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE
+import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
+import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -81,8 +84,8 @@ internal class NativeAnrOtelMapperTest {
         // assert span attrs
         val attrs = checkNotNull(span.attributes)
         assertEquals("perf.native_thread_blockage", attrs.findAttribute("emb.type").data)
-        assertEquals("1", attrs.findAttribute("thread_id").data)
-        assertEquals("main", attrs.findAttribute("thread_name").data)
+        assertEquals("1", attrs.findAttribute(THREAD_ID.key).data)
+        assertEquals("main", attrs.findAttribute(THREAD_NAME.key).data)
         assertEquals("2", attrs.findAttribute("thread_state").data)
         assertEquals("100", attrs.findAttribute("sampling_offset_ms").data)
         assertEquals("1", attrs.findAttribute("stack_unwinder").data)
@@ -102,7 +105,7 @@ internal class NativeAnrOtelMapperTest {
         val expectedStacktrace =
             "[{\"program_counter\":\"0x8000050209\",\"so_load_addr\":\"0x500234500\"," +
                 "\"so_name\":\"/data/app/lib.so\",\"result\":0}]"
-        assertEquals(expectedStacktrace, eventAttrs.findAttribute("stacktrace").data)
+        assertEquals(expectedStacktrace, eventAttrs.findAttribute(EXCEPTION_STACKTRACE.key).data)
     }
 
     private fun List<Attribute>.findAttribute(key: String): Attribute {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/destination/LogWriterImplTest.kt
@@ -9,11 +9,11 @@ import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.internal.spans.getAttribute
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.opentelemetry.embState
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -56,7 +56,7 @@ internal class LogWriterImplTest {
             assertEquals("test", body)
             assertEquals(Severity.ERROR, severity)
             assertEquals(Severity.ERROR.name, severity.name)
-            assertEquals("session-id", attributes.getAttribute(embSessionId))
+            assertEquals("session-id", attributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
             assertNotNull(attributes.getAttribute(embState))
             assertNotNull(attributes.getAttribute(LogIncubatingAttributes.LOG_RECORD_UID))
             assertTrue(attributes.hasFixedAttribute(PrivateSpan))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
@@ -9,9 +9,9 @@ import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -41,13 +41,13 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
         )
-        telemetryAttributes.setAttribute(embSessionId, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
         telemetryAttributes.setAttribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE, "exceptionValue")
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
-        assertEquals(sessionId, attributes[embSessionId.name])
+        assertEquals(sessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
         assertEquals("exceptionValue", attributes[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
-        assertEquals(sessionId, telemetryAttributes.getAttribute(embSessionId))
+        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
         assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE))
     }
 
@@ -58,7 +58,7 @@ internal class TelemetryAttributesTest {
             sessionProperties = sessionProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(embSessionId, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
         sessionProperties.add("perm", "permVal", true)
         sessionProperties.add("temp", "tempVal", false)
 
@@ -66,7 +66,7 @@ internal class TelemetryAttributesTest {
         assertEquals("attributeValue", attributes["custom"])
         assertEquals("permVal", attributes.getSessionProperty("perm"))
         assertEquals("tempVal", attributes.getSessionProperty("temp"))
-        assertEquals(sessionId, attributes[embSessionId.name])
+        assertEquals(sessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
         sessionProperties.add("temp", "newVal", false)
         assertEquals("newVal", telemetryAttributes.snapshot().getSessionProperty("temp"))
     }
@@ -78,8 +78,8 @@ internal class TelemetryAttributesTest {
             configService = configService,
             sessionProperties = sessionProperties
         )
-        telemetryAttributes.setAttribute(embSessionId, sessionId)
-        telemetryAttributes.setAttribute(embSessionId, newSessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, newSessionId)
         sessionProperties.add("perm", "permVal", true)
         sessionProperties.add("temp", "tempVal", false)
         sessionProperties.add("perm", "newPermVal", true)
@@ -89,7 +89,7 @@ internal class TelemetryAttributesTest {
         assertEquals(3, attributes.size)
         assertEquals("newPermVal", attributes.getSessionProperty("perm"))
         assertEquals("newTempVal", attributes.getSessionProperty("temp"))
-        assertEquals(newSessionId, attributes[embSessionId.name])
+        assertEquals(newSessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
     }
 
     @Test
@@ -97,12 +97,12 @@ internal class TelemetryAttributesTest {
         val newSessionId = Uuid.getEmbUuid()
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
-            customAttributes = mapOf(embSessionId.name to sessionId)
+            customAttributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to sessionId)
         )
-        telemetryAttributes.setAttribute(embSessionId, newSessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, newSessionId)
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
-        assertEquals(newSessionId, attributes[embSessionId.name])
+        assertEquals(newSessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
     }
 
     @Test
@@ -127,7 +127,7 @@ internal class TelemetryAttributesTest {
             sessionProperties = sessionProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(embSessionId, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
@@ -155,7 +155,7 @@ internal class TelemetryAttributesTest {
             sessionProperties = sessionProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(embSessionId, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(4, attributes.size)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -42,13 +42,13 @@ internal class TelemetryAttributesTest {
             configService = configService,
         )
         telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
-        telemetryAttributes.setAttribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE, "exceptionValue")
+        telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, "exceptionValue")
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
         assertEquals(sessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
-        assertEquals("exceptionValue", attributes[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
+        assertEquals("exceptionValue", attributes[ExceptionAttributes.EXCEPTION_TYPE.key])
         assertEquals(sessionId, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
-        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionIncubatingAttributes.EXCEPTION_TYPE))
+        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE))
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/InternalErrorDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crash/InternalErrorDataSourceImplTest.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.LogEventData
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -34,9 +34,9 @@ internal class InternalErrorDataSourceImplTest {
         dataSource.handleInternalError(IllegalStateException())
         val data = logWriter.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
-        assertEquals("java.lang.IllegalStateException", attrs[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
-        assertEquals("", attrs[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
-        assertNotNull(attrs[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key])
+        assertEquals("java.lang.IllegalStateException", attrs[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals("", attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key])
+        assertNotNull(attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key])
     }
 
     @Test
@@ -44,9 +44,9 @@ internal class InternalErrorDataSourceImplTest {
         dataSource.handleInternalError(IllegalArgumentException("Whoops!"))
         val data = logWriter.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
-        assertEquals("java.lang.IllegalArgumentException", attrs[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
-        assertEquals("Whoops!", attrs[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
-        assertNotNull(attrs[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key])
+        assertEquals("java.lang.IllegalArgumentException", attrs[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals("Whoops!", attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key])
+        assertNotNull(attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key])
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSourceTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.fakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.opentelemetry.semconv.UrlAttributes.URL_FULL
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -51,7 +52,7 @@ internal class WebViewUrlDataSourceTest {
             assertEquals(15000000000, spanStartTimeMs)
             assertEquals(
                 mapOf(
-                    "webview.url" to "http://www.google.com?query=123"
+                    URL_FULL.key to "http://www.google.com?query=123"
                 ),
                 schemaType.attributes()
             )
@@ -86,7 +87,7 @@ internal class WebViewUrlDataSourceTest {
             assertEquals(15000000000, spanStartTimeMs)
             assertEquals(
                 mapOf(
-                    "webview.url" to "http://www.google.com"
+                    URL_FULL.key to "http://www.google.com"
                 ),
                 schemaType.attributes()
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/webview/WebViewDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/capture/webview/WebViewDataSourceTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.payload.WebViewInfo
 import io.embrace.android.embracesdk.payload.WebVital
 import io.embrace.android.embracesdk.payload.WebVitalType
+import io.opentelemetry.semconv.UrlAttributes.URL_FULL
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -43,8 +44,8 @@ internal class WebViewDataSourceTest {
         dataSource.loadDataIntoSession(listOf(webViewInfo1, webViewInfo2))
         assertEquals(2, writer.addedEvents.size)
         assertEquals(2, writer.addedEvents.count { it.schemaType.fixedObjectName == "webview-info" })
-        assertEquals("https://example1.com", writer.addedEvents[0].schemaType.attributes()["emb.webview_info.url"])
-        assertEquals("https://example2.com", writer.addedEvents[1].schemaType.attributes()["emb.webview_info.url"])
+        assertEquals("https://example1.com", writer.addedEvents[0].schemaType.attributes()[URL_FULL.key])
+        assertEquals("https://example2.com", writer.addedEvents[1].schemaType.attributes()[URL_FULL.key])
     }
 
     private fun getWebViewInfo(url: String): WebViewInfo {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.arch.schema.EmbType
-import io.embrace.android.embracesdk.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.arch.schema.TelemetryType
@@ -17,6 +16,7 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.spans.getEmbraceSpan
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
@@ -79,7 +79,7 @@ internal class FakePersistableEmbraceSpan(
 
             if (status == Span.Status.ERROR) {
                 val error = errorCode?.fromErrorCode() ?: ErrorCodeAttribute.Failure
-                setSystemAttribute(error.key, error.value)
+                setSystemAttribute(error.key.attributeKey, error.value)
             }
 
             val timestamp = endTimeMs ?: fakeClock.now()
@@ -148,10 +148,10 @@ internal class FakePersistableEmbraceSpan(
     override fun hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
         attributes.hasFixedAttribute(fixedAttribute)
 
-    override fun getSystemAttribute(key: EmbraceAttributeKey): String? = attributes[key.name]
+    override fun getSystemAttribute(key: AttributeKey<String>): String? = attributes[key.key]
 
-    override fun setSystemAttribute(key: EmbraceAttributeKey, value: String) {
-        attributes[key.name] = value
+    override fun setSystemAttribute(key: AttributeKey<String>, value: String) {
+        attributes[key.key] = value
     }
 
     override fun removeCustomAttribute(key: String): Boolean = attributes.remove(key) != null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -8,10 +8,10 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.payload.ApplicationState
 import io.embrace.android.embracesdk.payload.LifeEventType
 import io.embrace.android.embracesdk.payload.SessionZygote
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 internal fun fakeSessionZygote() = SessionZygote(
     sessionId = "fakeSessionId",
@@ -32,7 +32,7 @@ internal fun fakeSessionEnvelope(
         endTimeNanos = endMs.millisToNanos(),
         attributes = listOf(
             Attribute("emb.type", EmbType.Ux.Session.value),
-            Attribute(embSessionId.name, sessionId)
+            Attribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
         )
     )
     val spans = listOf(testSpan, sessionSpan)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -28,7 +28,7 @@ import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.embrace.android.embracesdk.worker.BackgroundWorker
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -90,19 +90,19 @@ internal class EmbraceLogServiceTest {
         assertEquals(Severity.INFO, first.severity)
         assertEquals("bar", first.schemaType.attributes()["foo"])
         assertNotNull(first.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
-        assertNull(first.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
+        assertNull(first.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key])
 
         val second = logs[1]
         assertEquals("Warning world", second.message)
         assertEquals(Severity.WARNING, second.severity)
         assertNotNull(second.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
-        assertNull(second.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
+        assertNull(second.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key])
 
         val third = logs[2]
         assertEquals("Hello errors", third.message)
         assertEquals(Severity.ERROR, third.severity)
         assertNotNull(third.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
-        assertNull(third.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
+        assertNull(third.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key])
         third.assertIsType(EmbType.System.Log)
     }
 
@@ -125,11 +125,11 @@ internal class EmbraceLogServiceTest {
         assertEquals(Severity.WARNING, log.severity)
         assertNotNull(log.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
         assertEquals(LogExceptionType.HANDLED.value, log.schemaType.attributes()[embExceptionHandling.name])
-        assertEquals("NullPointerException", log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
-        assertEquals("exception message", log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
+        assertEquals("NullPointerException", log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals("exception message", log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_MESSAGE.key])
         assertEquals(
             exception.stackTrace.toExceptionSchema(),
-            log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key]
+            log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_STACKTRACE.key]
         )
         log.assertIsType(EmbType.System.Exception)
     }
@@ -157,11 +157,11 @@ internal class EmbraceLogServiceTest {
         assertEquals(Severity.ERROR, log.severity)
         assertNotNull(log.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
         assertEquals(LogExceptionType.HANDLED.value, log.schemaType.attributes()[embExceptionHandling.name])
-        assertEquals("NullPointerException", log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
-        assertEquals("exception message", log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
+        assertEquals("NullPointerException", log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals("exception message", log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_MESSAGE.key])
         assertEquals(
             exception.stackTrace.toExceptionSchema(),
-            log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key]
+            log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_STACKTRACE.key]
         )
         assertEquals("context", log.schemaType.attributes()[embFlutterExceptionContext.name])
         assertEquals("library", log.schemaType.attributes()[embFlutterExceptionLibrary.name])
@@ -186,11 +186,11 @@ internal class EmbraceLogServiceTest {
         val log = logWriter.logEvents.single()
         assertEquals("Hello world", log.message)
         assertEquals(Severity.WARNING, log.severity)
-        assertEquals("NullPointerException", log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
-        assertEquals("exception message", log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
+        assertEquals("NullPointerException", log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals("exception message", log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_MESSAGE.key])
         assertEquals(
             exception.stackTrace.toExceptionSchema(),
-            log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key]
+            log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_STACKTRACE.key]
         )
         assertNotNull(log.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
         assertEquals(LogExceptionType.UNHANDLED.value, log.schemaType.attributes()[embExceptionHandling.name])
@@ -311,9 +311,9 @@ internal class EmbraceLogServiceTest {
         assertEquals(Severity.INFO, log.severity)
         assertNotNull(log.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
 
-        assertEquals("my stacktrace", log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key])
-        assertEquals(null, log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_TYPE.key])
-        assertEquals(null, log.schemaType.attributes()[ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key])
+        assertEquals("my stacktrace", log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_STACKTRACE.key])
+        assertEquals(null, log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals(null, log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_MESSAGE.key])
         assertEquals(LogExceptionType.HANDLED.value, log.schemaType.attributes()[embExceptionHandling.name])
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.spans
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.findAttributeValue
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -47,7 +48,7 @@ internal class CurrentSessionSpanAttributeTests {
     }
 
     private fun EmbraceSpanData.assertCommonSessionSpanAttrs() {
-        assertNotNull(attributes.findAttributeValue("emb.session_id"))
+        assertNotNull(attributes.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
         assertEquals("ux.session", attributes.findAttributeValue("emb.type"))
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -25,7 +25,7 @@ import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.trace.SdkTracerProvider
-import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
+import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -211,12 +211,12 @@ internal class EmbraceSpanImplTest {
                 assertEquals(timestampNanos, timestampNanos)
                 assertEquals(
                     IllegalStateException::class.java.canonicalName,
-                    attributes.single { it.key == ExceptionIncubatingAttributes.EXCEPTION_TYPE.key }.data
+                    attributes.single { it.key == ExceptionAttributes.EXCEPTION_TYPE.key }.data
                 )
-                assertEquals("oops", attributes.single { it.key == ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key }.data)
+                assertEquals("oops", attributes.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE.key }.data)
                 assertEquals(
                     firstExceptionStackTrace,
-                    attributes.single { it.key == ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key }.data
+                    attributes.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE.key }.data
                 )
             }
             with(events.last()) {
@@ -225,13 +225,13 @@ internal class EmbraceSpanImplTest {
                 assertEquals(timestampNanos, timestampNanos)
                 assertEquals(
                     RuntimeException::class.java.canonicalName,
-                    attributes.single { it.key == ExceptionIncubatingAttributes.EXCEPTION_TYPE.key }.data
+                    attributes.single { it.key == ExceptionAttributes.EXCEPTION_TYPE.key }.data
                 )
-                assertEquals("haha", attributes.single { it.key == ExceptionIncubatingAttributes.EXCEPTION_MESSAGE.key }.data)
+                assertEquals("haha", attributes.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE.key }.data)
                 assertEquals("myValue", attributes.single { it.key == "myKey" }.data)
                 assertEquals(
                     secondExceptionStackTrace,
-                    attributes.single { it.key == ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key }.data
+                    attributes.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE.key }.data
                 )
             }
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
@@ -23,11 +23,11 @@ import io.embrace.android.embracesdk.internal.utils.toUTF8String
 import io.embrace.android.embracesdk.logging.EmbLogger
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.opentelemetry.embCrashNumber
-import io.embrace.android.embracesdk.opentelemetry.embSessionId
 import io.embrace.android.embracesdk.payload.NativeCrashDataError
 import io.embrace.android.embracesdk.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -84,7 +84,7 @@ internal class NativeCrashDataSourceImplTest {
             assertEquals(1, emitCalled)
             assertTrue(attributes.hasFixedAttribute(EmbType.System.NativeCrash))
             assertNotNull(attributes.getAttribute(LogIncubatingAttributes.LOG_RECORD_UID))
-            assertEquals(testNativeCrashData.sessionId, attributes.getAttribute(embSessionId))
+            assertEquals(testNativeCrashData.sessionId, attributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
             assertEquals("1", attributes.getAttribute(embCrashNumber))
             assertEquals(testNativeCrashData.crash, attributes.getAttribute(embNativeCrashException))
             assertEquals(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OTelAssertions.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OTelAssertions.kt
@@ -5,10 +5,10 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
 import org.junit.Assert.assertEquals
 
@@ -17,8 +17,8 @@ internal fun Resource.assertExpectedAttributes(
     expectedServiceVersion: String,
     systemInfo: SystemInfo
 ) {
-    assertEquals(expectedServiceName, getAttribute(ServiceIncubatingAttributes.SERVICE_NAME))
-    assertEquals(expectedServiceVersion, getAttribute(ServiceIncubatingAttributes.SERVICE_VERSION))
+    assertEquals(expectedServiceName, getAttribute(ServiceAttributes.SERVICE_NAME))
+    assertEquals(expectedServiceVersion, getAttribute(ServiceAttributes.SERVICE_VERSION))
     assertEquals(expectedServiceName, getAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME))
     assertEquals(expectedServiceVersion, getAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION))
     assertEquals(systemInfo.osName, getAttribute(OsIncubatingAttributes.OS_NAME))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfigurationTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/opentelemetry/OpenTelemetryConfigurationTest.kt
@@ -3,10 +3,10 @@ package io.embrace.android.embracesdk.opentelemetry
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
+import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
-import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -32,8 +32,8 @@ internal class OpenTelemetryConfigurationTest {
             processIdentifier = "fakeProcessIdentifier"
         )
 
-        assertEquals(configuration.embraceSdkName, configuration.resource.getAttribute(ServiceIncubatingAttributes.SERVICE_NAME))
-        assertEquals(configuration.embraceSdkVersion, configuration.resource.getAttribute(ServiceIncubatingAttributes.SERVICE_VERSION))
+        assertEquals(configuration.embraceSdkName, configuration.resource.getAttribute(ServiceAttributes.SERVICE_NAME))
+        assertEquals(configuration.embraceSdkVersion, configuration.resource.getAttribute(ServiceAttributes.SERVICE_VERSION))
         assertEquals(configuration.embraceSdkName, configuration.resource.getAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME))
         assertEquals(
             configuration.embraceSdkVersion,


### PR DESCRIPTION
- Alter the keys used in the payload to match OTel’s semantic conventions.
- Deleted unused SchemaType objects.

Backend ready! Tested and ready to merge :)