### PR TITLE
Explicitly set the default for span creation to non-private

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/startup/AppStartupTraceEmitter.kt
@@ -236,7 +236,6 @@ internal class AppStartupTraceEmitter(
                     parent = startupTrace,
                     startTimeMs = trackedInterval.startTimeMs,
                     endTimeMs = trackedInterval.endTimeMs,
-                    private = false
                 )
             }
         } while (additionalTrackedIntervals.isNotEmpty())
@@ -257,7 +256,6 @@ internal class AppStartupTraceEmitter(
             spanService.startSpan(
                 name = "cold-time-to-initial-display",
                 startTimeMs = traceStartTimeMs,
-                private = false
             )?.apply {
                 addTraceMetadata()
 
@@ -271,7 +269,6 @@ internal class AppStartupTraceEmitter(
                         parent = this,
                         startTimeMs = traceStartTimeMs,
                         endTimeMs = applicationInitEndMs,
-                        private = false,
                     )
                 }
                 if (sdkInitStartMs != null && sdkInitEndMs != null) {
@@ -280,7 +277,6 @@ internal class AppStartupTraceEmitter(
                         parent = this,
                         startTimeMs = sdkInitStartMs,
                         endTimeMs = sdkInitEndMs,
-                        private = false,
                     )
                 }
                 val lastEventBeforeActivityInit = applicationInitEndMs ?: sdkInitEndMs
@@ -291,7 +287,6 @@ internal class AppStartupTraceEmitter(
                         parent = this,
                         startTimeMs = lastEventBeforeActivityInit,
                         endTimeMs = firstActivityInit,
-                        private = false,
                     )
                 }
                 if (activityInitStartMs != null && activityInitEndMs != null) {
@@ -300,7 +295,6 @@ internal class AppStartupTraceEmitter(
                         parent = this,
                         startTimeMs = activityInitStartMs,
                         endTimeMs = activityInitEndMs,
-                        private = false,
                     )
                 }
                 if (activityInitEndMs != null) {
@@ -314,7 +308,6 @@ internal class AppStartupTraceEmitter(
                         parent = this,
                         startTimeMs = activityInitEndMs,
                         endTimeMs = traceEndTimeMs,
-                        private = false,
                     )
                 }
             }
@@ -335,7 +328,6 @@ internal class AppStartupTraceEmitter(
             spanService.startSpan(
                 name = "warm-time-to-initial-display",
                 startTimeMs = traceStartTimeMs,
-                private = false,
             )?.apply {
                 processToActivityCreateGap?.let { gap ->
                     addAttribute("activity-init-gap-ms", gap.toString())
@@ -355,7 +347,6 @@ internal class AppStartupTraceEmitter(
                         parent = this,
                         startTimeMs = activityInitStartMs,
                         endTimeMs = activityInitEndMs,
-                        private = false,
                     )
                     val uiLoadSpanName = if (endWithFrameDraw) {
                         "first-frame-render"
@@ -367,7 +358,6 @@ internal class AppStartupTraceEmitter(
                         parent = this,
                         startTimeMs = activityInitEndMs,
                         endTimeMs = traceEndTimeMs,
-                        private = false,
                     )
                 }
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
@@ -15,7 +15,7 @@ internal interface EmbraceSpanFactory {
         name: String,
         type: TelemetryType,
         internal: Boolean,
-        private: Boolean = internal,
+        private: Boolean,
         parent: EmbraceSpan? = null
     ): PersistableEmbraceSpan
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -15,7 +15,8 @@ internal class EmbraceTracer(
         spanService.createSpan(
             name = name,
             parent = parent,
-            internal = false
+            internal = false,
+            private = false,
         )
 
     override fun startSpan(name: String, parent: EmbraceSpan?, startTimeMs: Long?): EmbraceSpan? =
@@ -23,7 +24,8 @@ internal class EmbraceTracer(
             name = name,
             parent = parent,
             startTimeMs = startTimeMs?.normalizeTimestampAsMillis(),
-            internal = false
+            internal = false,
+            private = false,
         )
 
     override fun <T> recordSpan(
@@ -36,6 +38,7 @@ internal class EmbraceTracer(
         name = name,
         parent = parent,
         internal = false,
+        private = false,
         attributes = attributes ?: emptyMap(),
         events = events ?: emptyList(),
         code = code
@@ -55,6 +58,7 @@ internal class EmbraceTracer(
         endTimeMs = endTimeMs.normalizeTimestampAsMillis(),
         parent = parent,
         internal = false,
+        private = false,
         attributes = attributes ?: emptyMap(),
         events = events ?: emptyList(),
         errorCode = errorCode

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -65,7 +65,7 @@ internal interface SpanService : Initializable {
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
-        private: Boolean = internal,
+        private: Boolean = false,
         attributes: Map<String, String> = emptyMap(),
         events: List<EmbraceSpanEvent> = emptyList(),
         code: () -> T
@@ -82,7 +82,7 @@ internal interface SpanService : Initializable {
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
-        private: Boolean = internal,
+        private: Boolean = false,
         attributes: Map<String, String> = emptyMap(),
         events: List<EmbraceSpanEvent> = emptyList(),
         errorCode: ErrorCode? = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
@@ -109,6 +109,7 @@ internal class UninitializedSdkSpanService : SpanService {
                         parent = it.parent,
                         type = it.type,
                         internal = it.internal,
+                        private = it.private,
                         attributes = it.attributes,
                         events = it.events,
                         errorCode = it.errorCode

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingService.kt
@@ -72,7 +72,6 @@ internal class EmbraceNetworkLoggingService(
                 startTimeMs = networkRequest.startTime,
                 endTimeMs = networkRequest.endTime,
                 errorCode = errorCode,
-                parent = null,
                 attributes = networkRequestSchemaType.attributes(),
                 type = EmbType.Performance.Network,
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -34,7 +34,7 @@ internal class EmbraceSpanFactoryImplTest {
 
     @Test
     fun `check public span creation`() {
-        val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = false)
+        val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = false, private = false)
         assertTrue(span.start(clock.now()))
         with(span) {
             assertTrue(hasFixedAttribute(EmbType.Performance.Default))
@@ -47,7 +47,7 @@ internal class EmbraceSpanFactoryImplTest {
 
     @Test
     fun `check internal span creation`() {
-        val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = true)
+        val span = embraceSpanFactory.create(name = "test", type = EmbType.Performance.Default, internal = true, private = true)
         assertTrue(span.start(clock.now()))
         with(span) {
             assertTrue(hasFixedAttribute(EmbType.Performance.Default))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -283,7 +283,7 @@ internal class SpanServiceImplTest {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
             assertNotKeySpan()
-            assertIsPrivateSpan()
+            assertNotPrivateSpan()
         }
         assertTrue(parentSpan.stop())
 
@@ -403,7 +403,7 @@ internal class SpanServiceImplTest {
         with(currentSpans[0]) {
             assertEquals("emb-child-span", name)
             assertNotKeySpan()
-            assertIsPrivateSpan()
+            assertNotPrivateSpan()
         }
     }
 


### PR DESCRIPTION
## Goal

Make interfaces default to creating spans that are non-private. This is already the case for the create and start span APIs, but the other methods still defaulted to pairing private with internal, which can be confusing.

In practice, the only change is that network request spans are now non-private, which they should've been anyway. All other changes are removing explicit parameters that match the default, which doesn't change existing behaviour

## Testing
Modified existing tests to verify the default. Did not add additional tests for network spans because that's just using the default now.


