### PR TITLE
Remove token requirement for running function test workflow

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,11 +1,6 @@
 name: Run Functional Tests
 
 on:
-  workflow_dispatch:
-  workflow_call:
-    secrets:
-      token:
-        required: true
   schedule:
     - cron: '0 3 * * *'
   pull_request:
@@ -29,7 +24,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CD_GITHUB_TOKEN || secrets.token }}
           fetch-depth: 0
 
       - uses: actions/cache@v4


### PR DESCRIPTION
## Goal

Remove setting and requiring of a Github token for Function Test runs. We don't need it since we aren't checkout out files from another repo, and requiring it makes the dependabot PRs fail as secrets are managed differently

## Testing
This is a test