### PR TITLE
Clean up version definition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-import io.embrace.gradle.Versions
-import java.util.Properties
 import java.io.FileInputStream
+import java.util.Properties
 
 buildscript {
     repositories {
@@ -10,9 +9,9 @@ buildscript {
     }
 
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
-        classpath("org.jetbrains.dokka:android-documentation-plugin:1.9.10")
+        classpath(libs.detekt.gradle.plugin)
+        classpath(libs.dokka.gradle.plugin)
+        classpath(libs.dokka.docs)
     }
 }
 

--- a/buildSrc/src/main/kotlin/embrace-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-defaults.gradle.kts
@@ -1,9 +1,9 @@
 import io.embrace.gradle.Versions
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import java.net.URI
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.net.URI
 
 plugins {
     id("com.android.library") apply false
@@ -17,14 +17,14 @@ plugins {
 }
 
 android {
-    compileSdk = Versions.compileSdk
+    compileSdk = Versions.COMPILE_SDK
 
     defaultConfig {
-        minSdk = Versions.minSdk
+        minSdk = Versions.MIN_SDK
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         aarMetadata {
-            minCompileSdk = Versions.minSdk
+            minCompileSdk = Versions.MIN_SDK
         }
     }
 
@@ -74,9 +74,9 @@ android {
 }
 
 dependencies {
-    testImplementation("junit:junit:${Versions.junit}")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlinExposed}")
-    add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.detekt}")
+    testImplementation("junit:junit:${Versions.JUNIT}")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_EXPOSED}")
+    add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.DETEKT}")
     add("lintChecks", project.project(":embrace-lint"))
 }
 

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -1,52 +1,21 @@
 package io.embrace.gradle
 
 /**
- * Defines dependency versions that are used in the project.
+ * Defines dependency versions that are used in the project that cannot be defined in libs.versions.toml
  */
 object Versions {
-    @JvmField
-    val compileSdk = 34
+    const val COMPILE_SDK = 34
 
-    @JvmField
-    val minSdk = 21
+    const val MIN_SDK = 21
 
-    @JvmField
-    val junit = "4.13.2"
-
-    // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
-    @JvmField
-    val kotlin = "1.7.21"
+    const val JUNIT = "4.13.2"
 
     // kotin library exposed to the customer
-    @JvmField
-    val kotlinExposed = "1.4.32"
-
-    @JvmField
-    val dokka = "1.9.10"
+    const val KOTLIN_EXPOSED = "1.4.32"
 
     // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
-    @JvmField
-    val detekt = "1.23.0" // kotlin 1.9 required before any further upgrades
+    // kotlin 1.9 required before any further upgrades
+    const val DETEKT = "1.23.0"
 
-    // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
-    @JvmField
-    val agp = "8.3.2"
-
-    @JvmField
-    val lint = "30.1.0"
-
-    @JvmField
-    val ndk = "21.4.7075529"
-
-    @JvmField
-    val openTelemetryCore = "1.38.0"
-
-    @JvmField
-    val openTelementrySemConv = "1.24.0-alpha"
-
-    @JvmField
-    val moshi = "1.12.0"
-
-    @JvmField
-    val lifecycle = "2.5.0"
+    const val NDK = "21.4.7075529"
 }

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -15,7 +15,7 @@ android {
     useLibrary("android.test.runner")
     useLibrary("android.test.base")
     useLibrary("android.test.mock")
-    ndkVersion = Versions.ndk
+    ndkVersion = Versions.NDK
 
     defaultConfig {
         namespace = "io.embrace.android.embracesdk"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 
+detektGradlePlugin = "1.23.0"
 junit = "4.13.2"
 kotlinExposed = "1.4.32"
 dokka = "1.9.10"
@@ -21,6 +22,8 @@ firebase = "23.1.0"
 compose = "1.0.5"
 
 [libraries]
+detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektGradlePlugin" }
+dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "lifecycle" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-extensions = { group = "androidx.lifecycle", name = "lifecycle-extensions", version.ref = "lifecycle-extensions" }


### PR DESCRIPTION
## Goal

Adding a couple more versions to the library catalogue to reduce the number of duplicate definitions. This was motivated by the need to do some clean up before adding the OTel BOM.

It be nice to get rid of all of them but that doesn't seem possible, at least in some of the places we are using them? I don't know enough about this feature to address this.
