### PR TITLE
Setup common module for test code

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-defaults.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     testImplementation("androidx.test.ext:junit:${Versions.ANDROIDX_JUNIT}")
     testImplementation("org.robolectric:robolectric:${Versions.ROBOLECTRIC}")
     testImplementation("com.squareup.okhttp3:mockwebserver:${Versions.MOCKWEBSERVER}")
+    testImplementation(project(":embrace-test-common"))
 
     androidTestImplementation("androidx.test:core:${Versions.ANDROIDX_TEST}")
     androidTestImplementation("androidx.test:runner:${Versions.ANDROIDX_TEST}")

--- a/embrace-test-common/README.md
+++ b/embrace-test-common/README.md
@@ -1,0 +1,3 @@
+# embrace-test-common
+
+Common utility code that is used for writing unit/integration tests.

--- a/embrace-test-common/build.gradle.kts
+++ b/embrace-test-common/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("java-library")
+    id("kotlin")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/ResourceReader.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/ResourceReader.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk
 
 import java.io.InputStream
 
-internal object ResourceReader {
+object ResourceReader {
     fun readResource(name: String): InputStream {
         val classLoader = checkNotNull(javaClass.classLoader)
         return classLoader.getResourceAsStream(name)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,5 +3,6 @@ include(
     ":embrace-android-okhttp3",
     ":embrace-android-fcm",
     ":embrace-android-compose",
-    ":embrace-lint"
+    ":embrace-lint",
+    ":embrace-test-common"
 )


### PR DESCRIPTION
## Goal

Creates a new common module that is added as a `testImplementation` dependency for all modules in the project. This will make it easier to share test code between modules. Initially I've just moved `ResourceReader` over but will do a pass of other classes in a separate changeset.

@bidetofevil I think there's also a bit of a ideological question here - do we want the `embrace-test-common` module to have zero dependencies on any other module? Or should it have a dependency on the `embrace-android-sdk` module so that it can host most of the fakes? Perhaps this is something that will become more apparent later on in the modularisation?
