### PR TITLE
Rename function on data source

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/sigquit/SigquitDataSource.kt
@@ -34,7 +34,7 @@ internal class SigquitDataSource(
 
     fun saveSigquit(timestamp: Long) {
         if (anrBehavior.isGoogleAnrCaptureEnabled()) {
-            alterSessionSpan(NoInputValidation) {
+            captureData(NoInputValidation) {
                 addEvent(SchemaType.Sigquit, timestamp)
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSource.kt
@@ -15,9 +15,7 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 internal interface DataSource<T> {
 
     /**
-     * The DataSource should call this function when it wants to capture a [EmbraceSpanEvent] or
-     * [EmbraceSpanAttribute] and send it to the destination. This function is only intended
-     * for one-time use - if you want to record a span, please use [startSpan] and [stopSpan].
+     * The DataSource should call this function when it wants to capture some form of data.
      *
      * The [inputValidation] parameter should return true if the user inputs are valid.
      * (e.g. an empty string is not valid for a breadcrumb message).
@@ -29,7 +27,7 @@ internal interface DataSource<T> {
      * This function returns true if data was successfully captured & false if not.
      * This is assumed to be the case if [captureAction] completed without throwing.
      */
-    fun alterSessionSpan(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean
+    fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean
 
     /**
      * Enables data capture. This should include registering any listeners, and resetting

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
@@ -25,10 +25,10 @@ internal abstract class DataSourceImpl<T>(
         limitStrategy.resetDataCaptureLimits()
     }
 
-    override fun alterSessionSpan(
+    override fun captureData(
         inputValidation: () -> Boolean,
         captureAction: T.() -> Unit
-    ): Boolean = captureDataImpl(inputValidation, captureAction, true)
+    ): Boolean = captureDataImpl(inputValidation, captureAction)
 
     protected fun captureDataImpl(
         inputValidation: () -> Boolean,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/EventDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/EventDataSource.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.arch.datasource
 import io.embrace.android.embracesdk.arch.destination.SessionSpanWriter
 
 /**
- * A [DataSource] that adds either a [EmbraceSpanEvent] or [EmbraceSpanAttribute]
+ * A [DataSource] that adds either an event or attribute
  * to the current session span.
  */
 internal typealias EventDataSource = DataSource<SessionSpanWriter>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/SpanDataSource.kt
@@ -6,13 +6,13 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.PersistableEmbraceSpan
 
 /**
- * A [DataSource] that adds or alters a new span on the [SpansService]
+ * A [DataSource] that adds or alters a span.
  */
 internal interface SpanDataSource : DataSource<SpanService> {
 
     /**
      * The DataSource should call this function when it wants to start, stop, or mutate
-     * an [EmbraceSpan]. [alterSessionSpan] should only be used for adding to the session span.
+     * an [EmbraceSpan]. [captureData] should only be used for adding to the session span.
      *
      * The [countsTowardsLimits] parameter should be true if the [captureAction] will add data
      * that should count towards the limits.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -182,7 +182,7 @@ internal class AeiDataSourceImpl(
 
     private fun sendApplicationExitInfoWithTraces(appExitInfoWithTraces: List<AppExitInfoData>) {
         appExitInfoWithTraces.forEach { data ->
-            alterSessionSpan(
+            captureData(
                 inputValidation = NoInputValidation,
                 captureAction = {
                     val schemaType = SchemaType.AeiLog(data)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSource.kt
@@ -21,7 +21,7 @@ internal class BreadcrumbDataSource(
 ) {
 
     fun logCustom(message: String, timestamp: Long) {
-        alterSessionSpan(
+        captureData(
             inputValidation = {
                 message.isNotEmpty()
             },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/PushNotificationDataSource.kt
@@ -32,7 +32,7 @@ internal class PushNotificationDataSource(
         notificationPriority: Int?,
         type: PushNotificationBreadcrumb.NotificationType
     ) {
-        alterSessionSpan(
+        captureData(
             inputValidation = NoInputValidation,
             captureAction = {
                 val captureFcmPiiData = breadcrumbBehavior.isCaptureFcmPiiDataEnabled()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/TapDataSource.kt
@@ -28,7 +28,7 @@ internal class TapDataSource(
         timestamp: Long,
         type: TapBreadcrumb.TapBreadcrumbType
     ) {
-        alterSessionSpan(
+        captureData(
             inputValidation = NoInputValidation,
             captureAction = {
                 val finalPoint = when {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crumbs/WebViewUrlDataSource.kt
@@ -26,7 +26,7 @@ internal class WebViewUrlDataSource(
 
     fun logWebView(url: String?, startTime: Long) {
         try {
-            alterSessionSpan(
+            captureData(
                 inputValidation = {
                     url != null
                 },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorDataSourceImpl.kt
@@ -22,7 +22,7 @@ internal class InternalErrorDataSourceImpl(
     ) {
 
     override fun handleInternalError(throwable: Throwable) {
-        alterSessionSpan(NoInputValidation) {
+        captureData(NoInputValidation) {
             val schemaType = SchemaType.InternalError(throwable)
             addLog(schemaType, Severity.ERROR, "", true)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/MemoryWarningDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/memory/MemoryWarningDataSource.kt
@@ -20,7 +20,7 @@ internal class MemoryWarningDataSource(
 ) {
 
     fun onMemoryWarning(timestamp: Long) {
-        alterSessionSpan(
+        captureData(
             inputValidation = NoInputValidation,
             captureAction = {
                 addEvent(SchemaType.MemoryWarning(), timestamp)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/powersave/LowPowerDataSource.kt
@@ -41,7 +41,7 @@ internal class LowPowerDataSource(
         val activeSpan = span
 
         if (powerSaveMode && activeSpan == null) {
-            alterSessionSpan(NoInputValidation) {
+            captureData(NoInputValidation) {
                 startSpanCapture(SchemaType.LowPower, clock.now())?.apply {
                     span = this
                 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/session/SessionPropertiesDataSource.kt
@@ -22,7 +22,7 @@ internal class SessionPropertiesDataSource(
      * Assume input has already been sanitized
      */
     fun addProperty(key: String, value: String): Boolean =
-        alterSessionSpan(
+        captureData(
             inputValidation = NoInputValidation,
             captureAction = {
                 addAttribute(key, value)
@@ -30,7 +30,7 @@ internal class SessionPropertiesDataSource(
         )
 
     fun addProperties(properties: Map<String, String>): Boolean =
-        alterSessionSpan(
+        captureData(
             inputValidation = NoInputValidation,
             captureAction = {
                 properties.forEach { property ->
@@ -41,7 +41,7 @@ internal class SessionPropertiesDataSource(
 
     fun removeProperty(key: String): Boolean {
         var success = false
-        alterSessionSpan(
+        captureData(
             inputValidation = NoInputValidation,
             captureAction = {
                 success = removeCustomAttribute(key.toSessionPropertyAttributeName())

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/WebViewDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/WebViewDataSource.kt
@@ -30,7 +30,7 @@ internal class WebViewDataSource(
         try {
             writer.removeEvents(EmbType.System.WebViewInfo)
             webViewInfoList.forEach { webViewInfo ->
-                alterSessionSpan(
+                captureData(
                     inputValidation = NoInputValidation,
                     captureAction = {
                         val webVitalsString = serializer

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceImplTest.kt
@@ -17,7 +17,7 @@ internal class DataSourceImplTest {
     fun `capture data successfully`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        val success = source.alterSessionSpan(inputValidation = { true }) {
+        val success = source.captureData(inputValidation = { true }) {
             initialized()
         }
         assertTrue(success)
@@ -28,7 +28,7 @@ internal class DataSourceImplTest {
     fun `capture data threw exception`() {
         val dst = FakeCurrentSessionSpan()
         val source = FakeDataSourceImpl(dst)
-        val success = source.alterSessionSpan(inputValidation = { true }) {
+        val success = source.captureData(inputValidation = { true }) {
             error("Whoops!")
         }
         assertFalse(success)
@@ -42,7 +42,7 @@ internal class DataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.alterSessionSpan(inputValidation = { true }) {
+            source.captureData(inputValidation = { true }) {
                 count++
             }
         }
@@ -56,7 +56,7 @@ internal class DataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.alterSessionSpan(inputValidation = { false }) {
+            source.captureData(inputValidation = { false }) {
                 count++
             }
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/SpanDataSourceImplTest.kt
@@ -17,7 +17,7 @@ internal class SpanDataSourceImplTest {
     fun `capture data successfully`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.alterSessionSpan(inputValidation = { true }) {
+        val success = source.captureData(inputValidation = { true }) {
             createSpan("test")
         }
         assertTrue(success)
@@ -28,7 +28,7 @@ internal class SpanDataSourceImplTest {
     fun `capture data threw exception`() {
         val dst = FakeSpanService()
         val source = FakeDataSourceImpl(dst)
-        val success = source.alterSessionSpan(inputValidation = { true }) {
+        val success = source.captureData(inputValidation = { true }) {
             error("Whoops!")
         }
         assertFalse(success)
@@ -42,7 +42,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.alterSessionSpan(inputValidation = { true }) {
+            source.captureData(inputValidation = { true }) {
                 count++
             }
         }
@@ -56,7 +56,7 @@ internal class SpanDataSourceImplTest {
 
         var count = 0
         repeat(4) {
-            source.alterSessionSpan(inputValidation = { false }) {
+            source.captureData(inputValidation = { false }) {
                 count++
             }
         }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAeiDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeAeiDataSource.kt
@@ -9,7 +9,7 @@ internal class FakeAeiDataSource : AeiDataSource {
     var data: List<AppExitInfoData> =
         listOf(AppExitInfoData(null, null, null, null, null, null, null, null, null, null, null))
 
-    override fun alterSessionSpan(
+    override fun captureData(
         inputValidation: () -> Boolean,
         captureAction: LogWriter.() -> Unit
     ): Boolean {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt
@@ -8,7 +8,7 @@ internal class FakeCrashDataSource : CrashDataSource {
     internal var exception: Throwable? = null
     internal var jsException: JsException? = null
 
-    override fun alterSessionSpan(
+    override fun captureData(
         inputValidation: () -> Boolean,
         captureAction: LogWriter.() -> Unit,
     ): Boolean {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -15,7 +15,7 @@ internal class FakeDataSource(
     var disableDataCaptureCount = 0
     var resetCount = 0
 
-    override fun alterSessionSpan(
+    override fun captureData(
         inputValidation: () -> Boolean,
         captureAction: SessionSpanWriter.() -> Unit
     ): Boolean = true
@@ -35,7 +35,7 @@ internal class FakeDataSource(
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
-        alterSessionSpan(inputValidation = { true }) {
+        captureData(inputValidation = { true }) {
             addCustomAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureDataSource.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureDataSource.kt
@@ -12,7 +12,7 @@ internal class FakeNetworkCaptureDataSource : NetworkCaptureDataSource {
         loggedCalls.add(networkCapturedCall)
     }
 
-    override fun alterSessionSpan(
+    override fun captureData(
         inputValidation: () -> Boolean,
         captureAction: LogWriter.() -> Unit
     ): Boolean {


### PR DESCRIPTION
## Goal

Renames `alterSessionSpan` to `captureData` as IMO this better reflects what the function is doing.

