### PR TITLE
Create registry that tracks what data source states are used in the SDK

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestrator.kt
@@ -4,16 +4,16 @@ import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.logging.EmbLogger
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Orchestrates all data sources that could potentially be used in the SDK. This is a convenient
  * place to coordinate everything in one place.
  */
 internal class DataCaptureOrchestrator(
-    private val dataSourceState: List<DataSourceState<*>>,
-    private val logger: EmbLogger,
-    configService: ConfigService
-) {
+    configService: ConfigService,
+    private val logger: EmbLogger
+) : EmbraceFeatureRegistry {
 
     init {
         configService.addListener {
@@ -21,8 +21,21 @@ internal class DataCaptureOrchestrator(
         }
     }
 
+    private val dataSourceStates = CopyOnWriteArrayList<DataSourceState<*>>()
+
+    var currentSessionType: SessionType? = null
+        set(value) {
+            field = value
+            onSessionTypeChange()
+        }
+
+    override fun add(state: DataSourceState<*>) {
+        dataSourceStates.add(state)
+        state.currentSessionType = currentSessionType
+    }
+
     private fun onConfigChange() {
-        dataSourceState.forEach { state ->
+        dataSourceStates.forEach { state ->
             try {
                 state.onConfigChange()
             } catch (exc: Throwable) {
@@ -35,11 +48,11 @@ internal class DataCaptureOrchestrator(
     /**
      * Callback that is invoked when the session type changes.
      */
-    fun onSessionTypeChange(sessionType: SessionType) {
-        dataSourceState.forEach { state ->
+    private fun onSessionTypeChange() {
+        dataSourceStates.forEach { state ->
             try {
                 // alter the session type - some data sources don't capture for background activities.
-                state.onSessionTypeChange(sessionType)
+                state.currentSessionType = currentSessionType
             } catch (exc: Throwable) {
                 logger.logError("Exception thrown starting data capture", exc)
                 logger.trackInternalError(InternalErrorType.SESSION_CHANGE_DATA_CAPTURE_FAIL, exc)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/EmbraceFeatureRegistry.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/EmbraceFeatureRegistry.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.arch
+
+import io.embrace.android.embracesdk.arch.datasource.DataSourceState
+
+/**
+ * Registry for all features whose instrumentation should be orchestrated by the Embrace SDK.
+ */
+internal interface EmbraceFeatureRegistry {
+
+    /**
+     * Adds a feature to the registry. The SDK will control when a feature is enabled/disabled
+     * based on the declared values in the [state] parameter.
+     */
+    fun add(state: DataSourceState<*>)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
@@ -24,16 +24,20 @@ internal class DataSourceState<T : DataSource<*>>(
     private val configGate: Provider<Boolean> = { true },
 
     /**
-     * The type of session that contains the data.
-     */
-    private var currentSessionType: SessionType? = null,
-
-    /**
      * A session type where data capture should be disabled. For example,
      * background activities capture a subset of sessions.
      */
     private val disabledSessionType: SessionType? = null
 ) {
+
+    /**
+     * The type of session that contains the data.
+     */
+    var currentSessionType: SessionType? = null
+        set(value) {
+            field = value
+            onSessionTypeChange()
+        }
 
     private val enabledDataSource by lazy(factory)
 
@@ -47,8 +51,7 @@ internal class DataSourceState<T : DataSource<*>>(
     /**
      * Callback that is invoked when the session type changes.
      */
-    fun onSessionTypeChange(sessionType: SessionType?) {
-        this.currentSessionType = sessionType
+    private fun onSessionTypeChange() {
         updateDataSource()
         enabledDataSource?.resetDataCaptureLimits()
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/SessionModule.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.injection
 
-import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.ndk.NativeModule
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
@@ -23,7 +22,6 @@ internal interface SessionModule {
     val sessionOrchestrator: SessionOrchestrator
     val periodicSessionCacher: PeriodicSessionCacher
     val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher
-    val dataCaptureOrchestrator: DataCaptureOrchestrator
 }
 
 internal class SessionModuleImpl(
@@ -94,11 +92,6 @@ internal class SessionModuleImpl(
         )
     }
 
-    override val dataCaptureOrchestrator: DataCaptureOrchestrator by singleton {
-        val dataSources = dataSourceModule.getDataSources()
-        DataCaptureOrchestrator(dataSources, initModule.logger, essentialServiceModule.configService)
-    }
-
     private val sessionSpanAttrPopulator by singleton {
         SessionSpanAttrPopulator(
             openTelemetryModule.currentSessionSpan,
@@ -120,7 +113,7 @@ internal class SessionModuleImpl(
             deliveryModule.deliveryService,
             periodicSessionCacher,
             periodicBackgroundActivityCacher,
-            dataCaptureOrchestrator,
+            dataSourceModule.dataCaptureOrchestrator,
             openTelemetryModule.currentSessionSpan,
             sessionSpanAttrPopulator,
             initModule.logger

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorImpl.kt
@@ -215,7 +215,7 @@ internal class SessionOrchestratorImpl(
                 ProcessState.FOREGROUND -> SessionType.FOREGROUND
                 ProcessState.BACKGROUND -> SessionType.BACKGROUND
             }
-            dataCaptureOrchestrator.onSessionTypeChange(sessionType)
+            dataCaptureOrchestrator.currentSessionType = sessionType
 
             // log the state change
             logSessionStateChange(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceMemoryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceMemoryServiceTest.kt
@@ -40,7 +40,7 @@ internal class EmbraceMemoryServiceTest {
             workerThreadModule = FakeWorkerThreadModule(),
             anrModule = FakeAnrModule()
         )
-        dataSourceModule.getDataSources().forEach { it.onSessionTypeChange(SessionType.FOREGROUND) }
+        dataSourceModule.dataCaptureOrchestrator.currentSessionType = SessionType.FOREGROUND
         embraceMemoryService = EmbraceMemoryService(fakeClock) { dataSourceModule }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceWebViewServiceTest.kt
@@ -52,9 +52,7 @@ internal class EmbraceWebViewServiceTest {
         dataSourceModule = fakeDataSourceModule(
             oTelModule = openTelemetryModule,
         ).apply {
-            getDataSources().forEach {
-                it.onSessionTypeChange(SessionType.FOREGROUND)
-            }
+            dataCaptureOrchestrator.currentSessionType = SessionType.FOREGROUND
         }
         cfg = RemoteConfig(webViewVitals = WebViewVitals(100f, 50))
         configService = FakeConfigService(webViewVitalsBehavior = fakeWebViewVitalsBehavior { cfg })

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
@@ -21,22 +21,22 @@ internal class DataCaptureOrchestratorTest {
         dataSource = FakeDataSource(mockContext())
         configService = FakeConfigService()
         orchestrator = DataCaptureOrchestrator(
-            listOf(
+            configService,
+            EmbLoggerImpl(),
+        ).apply {
+            add(
                 DataSourceState(
                     factory = { dataSource },
-                    configGate = { enabled },
-                    currentSessionType = null
+                    configGate = { enabled }
                 )
-            ),
-            EmbLoggerImpl(),
-            configService
-        )
+            )
+        }
     }
 
     @Test
     fun `config changes are propagated`() {
         assertEquals(0, dataSource.enableDataCaptureCount)
-        orchestrator.onSessionTypeChange(SessionType.FOREGROUND)
+        orchestrator.currentSessionType = SessionType.FOREGROUND
         assertEquals(1, dataSource.enableDataCaptureCount)
 
         enabled = false
@@ -47,7 +47,7 @@ internal class DataCaptureOrchestratorTest {
     @Test
     fun `session type change is propagated`() {
         assertEquals(0, dataSource.enableDataCaptureCount)
-        orchestrator.onSessionTypeChange(SessionType.FOREGROUND)
+        orchestrator.currentSessionType = SessionType.FOREGROUND
         assertEquals(1, dataSource.enableDataCaptureCount)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -17,8 +17,7 @@ internal class DataSourceStateTest {
         val source = FakeDataSource(ctx)
         val state = DataSourceState(
             factory = { source },
-            configGate = { true },
-            currentSessionType = null
+            configGate = { true }
         )
 
         // data source not retrievable if not session type is null
@@ -26,24 +25,24 @@ internal class DataSourceStateTest {
 
         // data capture is enabled by default.
         state.onConfigChange()
-        state.onSessionTypeChange(null)
+        state.currentSessionType = null
         assertEquals(0, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
 
         // data capture enabled for a session
-        state.onSessionTypeChange(SessionType.FOREGROUND)
+        state.currentSessionType = SessionType.FOREGROUND
         assertSame(source, state.dataSource)
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
 
         // data capture disabled for no session
-        state.onSessionTypeChange(null)
+        state.currentSessionType = null
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(1, source.disableDataCaptureCount)
 
         // functions can be called multiple times without issue
-        state.onSessionTypeChange(SessionType.FOREGROUND)
-        state.onSessionTypeChange(null)
+        state.currentSessionType = SessionType.FOREGROUND
+        state.currentSessionType = null
         assertEquals(2, source.enableDataCaptureCount)
         assertEquals(2, source.disableDataCaptureCount)
     }
@@ -53,13 +52,14 @@ internal class DataSourceStateTest {
         val source = FakeDataSource(ctx)
         DataSourceState(
             factory = { source },
+        ).apply {
             currentSessionType = SessionType.FOREGROUND
-        )
+        }
 
         // data capture is enabled by default.
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
-        assertEquals(0, source.resetCount)
+        assertEquals(1, source.resetCount)
     }
 
     @Test
@@ -68,8 +68,9 @@ internal class DataSourceStateTest {
         DataSourceState(
             factory = { source },
             configGate = { true },
+        ).apply {
             currentSessionType = SessionType.FOREGROUND
-        )
+        }
 
         // data capture is enabled by default.
         assertEquals(1, source.enableDataCaptureCount)
@@ -83,8 +84,9 @@ internal class DataSourceStateTest {
         val state = DataSourceState(
             factory = { source },
             configGate = { enabled },
+        ).apply {
             currentSessionType = SessionType.FOREGROUND
-        )
+        }
 
         // data source not retrievable if disabled
         assertNull(state.dataSource)
@@ -125,34 +127,35 @@ internal class DataSourceStateTest {
         val state = DataSourceState(
             factory = { source },
             configGate = { true },
-            SessionType.BACKGROUND,
             disabledSessionType = SessionType.BACKGROUND
-        )
+        ).apply {
+            currentSessionType = SessionType.BACKGROUND
+        }
 
         // data capture is always disabled by default.
         assertEquals(0, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
-        assertEquals(0, source.resetCount)
+        assertEquals(1, source.resetCount)
 
         // new session should enable data capture
-        state.onSessionTypeChange(SessionType.FOREGROUND)
-        state.onSessionTypeChange(SessionType.FOREGROUND)
+        state.currentSessionType = SessionType.FOREGROUND
+        state.currentSessionType = SessionType.FOREGROUND
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
-        assertEquals(2, source.resetCount)
+        assertEquals(3, source.resetCount)
 
         // extra payload types should not re-register listeners
-        state.onSessionTypeChange(SessionType.BACKGROUND)
-        state.onSessionTypeChange(SessionType.BACKGROUND)
+        state.currentSessionType = SessionType.BACKGROUND
+        state.currentSessionType = SessionType.BACKGROUND
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(1, source.disableDataCaptureCount)
-        assertEquals(4, source.resetCount)
+        assertEquals(5, source.resetCount)
 
         // functions can be called multiple times without issue
-        state.onSessionTypeChange(SessionType.FOREGROUND)
-        state.onSessionTypeChange(SessionType.BACKGROUND)
+        state.currentSessionType = SessionType.FOREGROUND
+        state.currentSessionType = SessionType.BACKGROUND
         assertEquals(2, source.enableDataCaptureCount)
         assertEquals(2, source.disableDataCaptureCount)
-        assertEquals(6, source.resetCount)
+        assertEquals(7, source.resetCount)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.anr.sigquit.SigquitDataSource
+import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
+import io.embrace.android.embracesdk.arch.EmbraceFeatureRegistry
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.capture.aei.AeiDataSource
 import io.embrace.android.embracesdk.capture.connectivity.NetworkStatusDataSource
@@ -19,9 +21,9 @@ import io.embrace.android.embracesdk.capture.webview.WebViewDataSource
 import io.embrace.android.embracesdk.injection.DataSourceModule
 
 internal class FakeDataSourceModule : DataSourceModule {
-
-    override fun getDataSources(): List<DataSourceState<*>> = emptyList()
-
+    override val dataCaptureOrchestrator: DataCaptureOrchestrator =
+        DataCaptureOrchestrator(FakeConfigService(), FakeEmbLogger())
+    override val embraceFeatureRegistry: EmbraceFeatureRegistry = dataCaptureOrchestrator
     override val breadcrumbDataSource: DataSourceState<BreadcrumbDataSource> = DataSourceState({ null })
     override val viewDataSource: DataSourceState<ViewDataSource> = DataSourceState({ null })
     override val tapDataSource: DataSourceState<TapDataSource> = DataSourceState({ null })

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -2,11 +2,8 @@ package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.FakePayloadFactory
 import io.embrace.android.embracesdk.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.injection.SessionModule
-import io.embrace.android.embracesdk.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.message.PayloadFactory
@@ -28,7 +25,4 @@ internal class FakeSessionModule(
 
     override val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher
         get() = TODO("Not yet implemented")
-
-    override val dataCaptureOrchestrator: DataCaptureOrchestrator =
-        DataCaptureOrchestrator(emptyList(), EmbLoggerImpl(), FakeConfigService())
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/DataSourceModuleImplTest.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.worker.WorkerName
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 internal class DataSourceModuleImplTest {
@@ -28,7 +28,8 @@ internal class DataSourceModuleImplTest {
             FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = WorkerName.BACKGROUND_REGISTRATION),
             FakeAnrModule()
         )
-        assertNotNull(module.getDataSources())
+        assertSame(module.dataCaptureOrchestrator, module.embraceFeatureRegistry)
+        assertNotNull(module.dataCaptureOrchestrator)
         assertNotNull(module.breadcrumbDataSource)
         assertNotNull(module.tapDataSource)
         assertNotNull(module.viewDataSource)
@@ -44,6 +45,5 @@ internal class DataSourceModuleImplTest {
         assertNotNull(module.thermalStateDataSource)
         assertNotNull(module.webViewDataSource)
         assertNotNull(module.internalErrorDataSource)
-        assertEquals(15, module.getDataSources().size)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionModuleImplTest.kt
@@ -103,7 +103,6 @@ internal class SessionModuleImplTest {
         assertNotNull(module.sessionPropertiesService)
         assertNotNull(module.payloadFactory)
         assertNotNull(module.sessionOrchestrator)
-        assertNotNull(module.dataCaptureOrchestrator)
     }
 
     private fun createEnabledBehavior(): FakeEssentialServiceModule {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -377,16 +377,16 @@ internal class SessionOrchestratorTest {
             PeriodicBackgroundActivityCacher(clock, ScheduledWorker(baCacheExecutor), logger)
         fakeDataSource = FakeDataSource(mockContext())
         dataCaptureOrchestrator = DataCaptureOrchestrator(
-            listOf(
+            configService,
+            logger
+        ).apply {
+            add(
                 DataSourceState(
                     factory = { fakeDataSource },
-                    configGate = { true },
-                    currentSessionType = null,
+                    configGate = { true }
                 )
-            ),
-            logger,
-            configService
-        )
+            )
+        }
 
         orchestrator = SessionOrchestratorImpl(
             processStateService,


### PR DESCRIPTION
## Goal

Currently most features in the SDK are built using a `DataSourceState`. These were passed into the `DataCaptureOrchestrator` as a list which then informs them when new data needs capturing in response to changes in the session boundary/config.

This PR alters this so a `DataSourceState` is added directly to the `DataCaptureOrchestrator`. I've also tweaked `DataSource` so that consumers of the internal API don't have the ability to set the `currentSessionType` state. Finally, this also adds support for adding `DataSourceState` values _after_ the session orchestration has started by populating the initial session state. Currently this doesn't happen but is likely to do in future.

In a future changeset I'll investigate adding a way to initialize data sources on a background thread as that should help reduce startup impact substantially.

## Testing

Updated unit test coverage.
