### PR TITLE
Fix lint warning in agp 8.5

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehavior.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/config/behavior/DataCaptureEventBehavior.kt
@@ -9,9 +9,8 @@ internal class DataCaptureEventBehavior(
     thresholdCheck: BehaviorThresholdCheck,
     remoteSupplier: Provider<RemoteConfig?> = { null }
 ) : MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
-    thresholdCheck,
-    { null },
-    remoteSupplier
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
 
     companion object {


### PR DESCRIPTION
## Goal

Fixes a lint warning in AGP 8.5 that showed up in #1032. Basically the supplied parameter value is not used & we can use the default value instead.
