### PR TITLE
Prevent eager initialization of data sources

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
@@ -39,7 +39,7 @@ internal class DataSourceState<T : DataSource<*>>(
             onSessionTypeChange()
         }
 
-    private val enabledDataSource by lazy(factory)
+    private val factoryRef = lazy(factory)
 
     var dataSource: T? = null
         private set
@@ -53,7 +53,9 @@ internal class DataSourceState<T : DataSource<*>>(
      */
     private fun onSessionTypeChange() {
         updateDataSource()
-        enabledDataSource?.resetDataCaptureLimits()
+        if (factoryRef.isInitialized()) {
+            factoryRef.value?.resetDataCaptureLimits()
+        }
     }
 
     /**
@@ -68,7 +70,7 @@ internal class DataSourceState<T : DataSource<*>>(
             currentSessionType != null && currentSessionType != disabledSessionType && configGate()
 
         if (enabled && dataSource == null) {
-            dataSource = enabledDataSource?.apply {
+            dataSource = factoryRef.value?.apply {
                 enableDataCapture()
             }
         } else if (!enabled && dataSource != null) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataSourceStateTest.kt
@@ -135,27 +135,27 @@ internal class DataSourceStateTest {
         // data capture is always disabled by default.
         assertEquals(0, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
-        assertEquals(1, source.resetCount)
+        assertEquals(0, source.resetCount)
 
         // new session should enable data capture
         state.currentSessionType = SessionType.FOREGROUND
         state.currentSessionType = SessionType.FOREGROUND
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
-        assertEquals(3, source.resetCount)
+        assertEquals(2, source.resetCount)
 
         // extra payload types should not re-register listeners
         state.currentSessionType = SessionType.BACKGROUND
         state.currentSessionType = SessionType.BACKGROUND
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(1, source.disableDataCaptureCount)
-        assertEquals(5, source.resetCount)
+        assertEquals(4, source.resetCount)
 
         // functions can be called multiple times without issue
         state.currentSessionType = SessionType.FOREGROUND
         state.currentSessionType = SessionType.BACKGROUND
         assertEquals(2, source.enableDataCaptureCount)
         assertEquals(2, source.disableDataCaptureCount)
-        assertEquals(7, source.resetCount)
+        assertEquals(6, source.resetCount)
     }
 }


### PR DESCRIPTION
## Goal

Prevents the eager initialization of data sources until the `configGate` is `true` and a session is under way.
