### PR TITLE
Proguard rules improvements

### DIFF
--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -1,8 +1,13 @@
 -keepattributes LineNumberTable, SourceFile
 
-## Proguard configuration for Embrace
--keep class io.embrace.android.embracesdk.** { *; }
--dontwarn io.embrace.android.embracesdk.**
+## Keep classes used by hosted SDKs
+-keep class io.embrace.android.embracesdk.Embrace { *; }
+-keep class io.embrace.android.embracesdk.Embrace$AppFramework { *; }
+-keep class io.embrace.android.embracesdk.Embrace$LastRunEndState { *; }
+-keep class io.embrace.android.embracesdk.Severity { *; }
+-keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface {
+    *;
+}
 
 ## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -5,9 +5,12 @@
 -keep class io.embrace.android.embracesdk.Embrace$AppFramework { *; }
 -keep class io.embrace.android.embracesdk.Embrace$LastRunEndState { *; }
 -keep class io.embrace.android.embracesdk.Severity { *; }
--keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface {
-    *;
-}
+-keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface { *; }
+
+## Keep classes used from native code
+-keep class io.embrace.android.embracesdk.payload.NativeThreadAnrSample { *; }
+-keep class io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe { *; }
+-keep class io.embrace.android.embracesdk.anr.sigquit.SigquitDataSource { *; }
 
 ## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -1,4 +1,4 @@
--keepattributes Exceptions, InnerClasses, Signature, LineNumberTable, SourceFile
+-keepattributes LineNumberTable, SourceFile
 
 ## Proguard configuration for Embrace
 -keep class io.embrace.android.embracesdk.** { *; }

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -4,10 +4,6 @@
 -keep class io.embrace.android.embracesdk.** { *; }
 -dontwarn io.embrace.android.embracesdk.**
 
-## Proguard configuration for OkHTTP3 / Okio
--dontwarn okhttp3.**
--dontwarn okio.**
-
 ## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }
 -dontwarn com.google.auto.value.extension.memoized.Memoized

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -12,6 +12,11 @@
 -keep class io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe { *; }
 -keep class io.embrace.android.embracesdk.anr.sigquit.SigquitDataSource { *; }
 
+## Keep classes with JNI calls to native code
+-keep class io.embrace.android.embracesdk.capture.cpu.EmbraceCpuInfoDelegate { *; }
+-keep class io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerNdkDelegate { *; }
+-keep class io.embrace.android.embracesdk.ndk.NdkDelegateImpl { *; }
+
 ## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }
 -dontwarn com.google.auto.value.extension.memoized.Memoized

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -8,6 +8,10 @@
 -keep class io.opentelemetry.api.trace.StatusCode { *; }
 -dontwarn com.google.auto.value.extension.memoized.Memoized
 
+## Keep OkHttp class so we can fetch the version correctly via reflection.
+-keep class okhttp3.OkHttp { *; }
+-keep class okhttp3.OkHttpClient { *; }
+
 ## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) at compile time. No need to keep them for runtime.
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -24,3 +24,10 @@
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.errorprone.annotations.MustBeClosed
+
+## Keep swazzler hooks
+-keep class io.embrace.android.embracesdk.okhttp3.** { *; }
+-keep class io.embrace.android.embracesdk.ViewSwazzledHooks { *; }
+-keep class io.embrace.android.embracesdk.WebViewClientSwazzledHooks { *; }
+-keep class io.embrace.android.embracesdk.WebViewChromeClientSwazzledHooks { *; }
+-keep class io.embrace.android.embracesdk.fcm.swazzle.callback.com.android.fcm.FirebaseSwazzledHooks { *; }

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -8,13 +8,11 @@
 -dontwarn okhttp3.**
 -dontwarn okio.**
 
-## Proguard configuration for Arrow
--keep class java9.** { *; }
--dontwarn java9.**
-
 ## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }
--dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.auto.value.extension.memoized.Memoized
+
+## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) at compile time. No need to keep them for runtime.
 -dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.errorprone.annotations.MustBeClosed

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EventType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EventType.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk
 
 import android.annotation.SuppressLint
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.embrace.android.embracesdk.annotation.InternalApi
 
 /**
@@ -9,6 +10,7 @@ import io.embrace.android.embracesdk.annotation.InternalApi
  */
 @InternalApi
 @SuppressLint("EmbracePublicApiPackageRule")
+@JsonClass(generateAdapter = false)
 internal enum class EventType(
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/AppEnvironment.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/AppEnvironment.kt
@@ -2,12 +2,14 @@ package io.embrace.android.embracesdk.capture.metadata
 
 import android.content.pm.ApplicationInfo
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
 internal class AppEnvironment(appInfo: ApplicationInfo) {
     val isDebug: Boolean = with(appInfo) { flags and ApplicationInfo.FLAG_DEBUGGABLE != 0 }
 
     val environment: Environment = if (isDebug) Environment.DEV else Environment.PROD
 
+    @JsonClass(generateAdapter = false)
     internal enum class Environment(val value: String) {
         @Json(name = "dev")
         DEV("dev"),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -198,6 +198,7 @@ internal data class EnvelopeResource(
      *
      * Values: NATIVE,REACT_NATIVE,UNITY,FLUTTER
      */
+    @JsonClass(generateAdapter = false)
     internal enum class AppFramework(val value: Int) {
         @Json(name = "1")
         NATIVE(1),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Span.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Span.kt
@@ -61,6 +61,7 @@ internal data class Span(
      *
      * Values: UNSET,ERROR,OK
      */
+    @JsonClass(generateAdapter = false)
     internal enum class Status(val value: String) {
         @Json(name = "Unset")
         UNSET("Unset"),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/LifeEventType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/LifeEventType.kt
@@ -1,10 +1,12 @@
 package io.embrace.android.embracesdk.payload
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
 /**
  * Enum to discriminate the different ways a session can start / end
  */
+@JsonClass(generateAdapter = false)
 internal enum class LifeEventType {
 
     /* Session values */

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/TapBreadcrumb.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload/TapBreadcrumb.kt
@@ -50,6 +50,7 @@ internal class TapBreadcrumb(
 
     override fun getStartTime(): Long = timestamp
 
+    @JsonClass(generateAdapter = false)
     internal enum class TapBreadcrumbType(val value: String) {
         @Json(name = "s")
         TAP("tap"),


### PR DESCRIPTION
## Goal

Customers using R8 to obfuscate and shrink their app weren't able to shrink Embrace, because we had proguard rules instructing to keep all classes. This PR changes that. 

In `android-test-app`, turning this on reduced Embrace size by 70%, comparing against master (from 800kb to 250kb, it's not like we were too heavy in the first place 😅)

- Remove unnecessary rules:
    - java9.**
    - okhttp3.** and okio.**
    - Attributes: Exceptions, InnerClasses, Signature.  

- Removed keep rule for the whole embrace package
    - Anyone using r8 to either obfuscate or shrink their apk can now remove unused Embrace code.
 
- Added rules to keep classes used by hosted SDKs, native code, okhttp, swazzled and serialized classes.

## Testing

- Tested in these apps: 
    - https://github.com/embrace-io/small-android-test-app
    - https://github.com/embrace-io/android-test-suite
    - https://github.com/embrace-io/embrace-react-native-sdk/tree/master/examples/react-native-test-suite
    - https://github.com/embrace-io/embrace-unity-sdk-internal/tree/main/UnityProjects/2023 (created a project from the Unity editor and tested in Android Studio with that project)

- Ran swazzler tests