### PR TITLE
Set signing credentials

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,10 @@ nexusPublishing {
 }
 
 allprojects {
+    ext.properties["signing.keyId"] = System.getenv("mavenSigningKeyId") ?: localProperties.getProperty("signing.keyId")
+    ext.properties["signing.secretKeyRingFile"] = System.getenv("mavenSigningKeyRingFile") ?: localProperties.getProperty("signing.secretKeyRingFile")
+    ext.properties["signing.password"] = System.getenv("mavenSigningKeyPassword") ?: localProperties.getProperty("signing.password")
+
     repositories {
         google()
         maven(url = "https://plugins.gradle.org/m2/")


### PR DESCRIPTION
## Goal

Set the environment variables required for the signing task. This was set in `release.gradle` previously but was not ported over as far as I can see when we changed the build files.
