### PR TITLE
Use token user and password for Sonatype publishing

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -1,8 +1,8 @@
 name: Pre-Release - Create New Release Candidates
 
 env:
-  SONATYPE_USERNAME: embrace-io
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USER }}
+  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_USER_PASSWORD }}
   MAVEN_QA_USER: github
   MAVEN_QA_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
   mavenSigningKeyId: ${{ secrets.MAVEN_ANDROID_SIGNING_KEY }}

--- a/.github/workflows/pre-patch-workflow.yml
+++ b/.github/workflows/pre-patch-workflow.yml
@@ -1,8 +1,8 @@
 name: Patch - Create Release Candidate
 
 env:
-  SONATYPE_USERNAME: embrace-io
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USER }}
+  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_USER_PASSWORD }}
   MAVEN_QA_USER: github
   MAVEN_QA_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
   mavenSigningKeyId: ${{ secrets.MAVEN_ANDROID_SIGNING_KEY }}

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -1,8 +1,8 @@
 name: Pre-Release - Cut Release Branch and Publish Release Candidate
 
 env:
-  SONATYPE_USERNAME: embrace-io
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USER }}
+  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_USER_PASSWORD }}
   MAVEN_QA_USER: github
   MAVEN_QA_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
   mavenSigningKeyId: ${{ secrets.MAVEN_ANDROID_SIGNING_KEY }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,8 +1,8 @@
 name: Release - Release RC and Update Documentation
 
 env:
-  SONATYPE_USERNAME: embrace-io
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+  SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USER }}
+  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN_USER_PASSWORD }}
   MAVEN_QA_USER: github
   MAVEN_QA_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
   mavenSigningKeyId: ${{ secrets.MAVEN_ANDROID_SIGNING_KEY }}


### PR DESCRIPTION
## Goal
Use token user and password for publishing per [new Maven Central requirements](https://central.sonatype.org/news/20240617_migration_of_accounts/#the-impact-on-ossrh-and-the-central-publisher-portal)

I generated the token user and password per instructions [here](https://central.sonatype.org/publish/generate-token/) and added them to the repo as a secret that I now reference in the workflows, which is this change.