### PR TITLE
Support async init of features

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
@@ -27,7 +27,16 @@ internal class DataSourceState<T : DataSource<*>>(
      * A session type where data capture should be disabled. For example,
      * background activities capture a subset of sessions.
      */
-    private val disabledSessionType: SessionType? = null
+    private val disabledSessionType: SessionType? = null,
+
+    /**
+     * Whether this feature supports being initialized asynchronously. Defaults to false. If
+     * the feature is set to true the feature will be initialized on a background thread.
+     *
+     * If you enable this behavior please ensure your implementation is thread safe (e.g.
+     * it can handle unbalanced calls to [enableDataCapture] and others).
+     */
+    val asyncInit: Boolean = false
 ) {
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/DataSourceModule.kt
@@ -72,7 +72,11 @@ internal class DataSourceModuleImpl(
     private val configService = essentialServiceModule.configService
 
     override val dataCaptureOrchestrator: DataCaptureOrchestrator by singleton {
-        DataCaptureOrchestrator(configService, initModule.logger)
+        DataCaptureOrchestrator(
+            configService,
+            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+            initModule.logger
+        )
     }
 
     override val embraceFeatureRegistry: EmbraceFeatureRegistry = dataCaptureOrchestrator

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/DataCaptureOrchestratorTest.kt
@@ -1,10 +1,12 @@
 package io.embrace.android.embracesdk.arch
 
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.system.mockContext
 import io.embrace.android.embracesdk.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -14,27 +16,35 @@ internal class DataCaptureOrchestratorTest {
     private lateinit var orchestrator: DataCaptureOrchestrator
     private lateinit var dataSource: FakeDataSource
     private lateinit var configService: FakeConfigService
+    private lateinit var executorService: BlockableExecutorService
     private var enabled: Boolean = true
+
+    private val syncDataSource = DataSourceState(
+        factory = { dataSource },
+        configGate = { enabled }
+    )
+
+    private val asyncDataSource = DataSourceState(
+        factory = { dataSource },
+        configGate = { enabled },
+        asyncInit = true
+    )
 
     @Before
     fun setUp() {
         dataSource = FakeDataSource(mockContext())
         configService = FakeConfigService()
+        executorService = BlockableExecutorService()
         orchestrator = DataCaptureOrchestrator(
             configService,
+            BackgroundWorker(executorService),
             EmbLoggerImpl(),
-        ).apply {
-            add(
-                DataSourceState(
-                    factory = { dataSource },
-                    configGate = { enabled }
-                )
-            )
-        }
+        )
     }
 
     @Test
     fun `config changes are propagated`() {
+        orchestrator.add(syncDataSource)
         assertEquals(0, dataSource.enableDataCaptureCount)
         orchestrator.currentSessionType = SessionType.FOREGROUND
         assertEquals(1, dataSource.enableDataCaptureCount)
@@ -46,8 +56,38 @@ internal class DataCaptureOrchestratorTest {
 
     @Test
     fun `session type change is propagated`() {
+        orchestrator.add(syncDataSource)
         assertEquals(0, dataSource.enableDataCaptureCount)
         orchestrator.currentSessionType = SessionType.FOREGROUND
+        assertEquals(1, dataSource.enableDataCaptureCount)
+    }
+
+    @Test
+    fun `async config change`() {
+        orchestrator.add(asyncDataSource)
+        executorService.blockingMode = true
+
+        orchestrator.currentSessionType = SessionType.FOREGROUND
+        assertEquals(0, dataSource.enableDataCaptureCount)
+        executorService.runNext()
+        assertEquals(1, dataSource.enableDataCaptureCount)
+
+        enabled = false
+        configService.updateListeners()
+        assertEquals(0, dataSource.disableDataCaptureCount)
+        executorService.runNext()
+        assertEquals(1, dataSource.disableDataCaptureCount)
+    }
+
+    @Test
+    fun `async session change`() {
+        orchestrator.add(asyncDataSource)
+        executorService.blockingMode = true
+
+        assertEquals(0, dataSource.enableDataCaptureCount)
+        orchestrator.currentSessionType = SessionType.FOREGROUND
+        assertEquals(0, dataSource.enableDataCaptureCount)
+        executorService.runNext()
         assertEquals(1, dataSource.enableDataCaptureCount)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
@@ -18,11 +18,17 @@ import io.embrace.android.embracesdk.capture.powersave.LowPowerDataSource
 import io.embrace.android.embracesdk.capture.session.SessionPropertiesDataSource
 import io.embrace.android.embracesdk.capture.thermalstate.ThermalStateDataSource
 import io.embrace.android.embracesdk.capture.webview.WebViewDataSource
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.injection.DataSourceModule
+import io.embrace.android.embracesdk.worker.BackgroundWorker
 
 internal class FakeDataSourceModule : DataSourceModule {
     override val dataCaptureOrchestrator: DataCaptureOrchestrator =
-        DataCaptureOrchestrator(FakeConfigService(), FakeEmbLogger())
+        DataCaptureOrchestrator(
+            FakeConfigService(),
+            BackgroundWorker(BlockableExecutorService()),
+            FakeEmbLogger()
+        )
     override val embraceFeatureRegistry: EmbraceFeatureRegistry = dataCaptureOrchestrator
     override val breadcrumbDataSource: DataSourceState<BreadcrumbDataSource> = DataSourceState({ null })
     override val viewDataSource: DataSourceState<ViewDataSource> = DataSourceState({ null })

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.worker.BackgroundWorker
+import io.embrace.android.embracesdk.worker.ScheduledWorker
+
+internal fun fakeBackgroundWorker() = BackgroundWorker(BlockableExecutorService())
+internal fun fakeScheduledWorker() = ScheduledWorker(BlockingScheduledExecutorService(blockingMode = false))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.FakeDeliveryService
 import io.embrace.android.embracesdk.FakeNdkService
 import io.embrace.android.embracesdk.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.config.remote.SessionRemoteConfig
@@ -33,6 +34,7 @@ import io.embrace.android.embracesdk.session.caching.PeriodicBackgroundActivityC
 import io.embrace.android.embracesdk.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
+import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -378,6 +380,7 @@ internal class SessionOrchestratorTest {
         fakeDataSource = FakeDataSource(mockContext())
         dataCaptureOrchestrator = DataCaptureOrchestrator(
             configService,
+            BackgroundWorker(BlockableExecutorService()),
             logger
         ).apply {
             add(


### PR DESCRIPTION
## Goal

Supports the async initialization of features in Embrace. While this changeset does not alter any feature to be initialized async it creates the infrastructure to do so.

## Testing

Added unit test coverage.
