### PR TITLE
Create interface for internal apis

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -7,7 +7,7 @@ public final class io/embrace/android/embracesdk/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi, io/embrace/android/embracesdk/internal/api/EmbraceApi, io/embrace/android/embracesdk/internal/api/LogsApi, io/embrace/android/embracesdk/internal/api/MomentsApi, io/embrace/android/embracesdk/internal/api/NetworkRequestApi, io/embrace/android/embracesdk/internal/api/OTelApi, io/embrace/android/embracesdk/internal/api/SdkStateApi, io/embrace/android/embracesdk/internal/api/SessionApi, io/embrace/android/embracesdk/internal/api/UserApi, io/embrace/android/embracesdk/spans/TracingApi {
+public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi, io/embrace/android/embracesdk/internal/api/EmbraceApi, io/embrace/android/embracesdk/internal/api/InternalInterfaceApi, io/embrace/android/embracesdk/internal/api/LogsApi, io/embrace/android/embracesdk/internal/api/MomentsApi, io/embrace/android/embracesdk/internal/api/NetworkRequestApi, io/embrace/android/embracesdk/internal/api/OTelApi, io/embrace/android/embracesdk/internal/api/SdkStateApi, io/embrace/android/embracesdk/internal/api/SessionApi, io/embrace/android/embracesdk/internal/api/UserApi, io/embrace/android/embracesdk/spans/TracingApi {
 	public fun addBreadcrumb (Ljava/lang/String;)V
 	public fun addLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
 	public fun addSessionProperty (Ljava/lang/String;Ljava/lang/String;Z)Z
@@ -236,6 +236,13 @@ public final class io/embrace/android/embracesdk/internal/InternalTracingApi$Def
 	public static synthetic fun recordSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun startSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Ljava/lang/String;
 	public static synthetic fun stopSpan$default (Lio/embrace/android/embracesdk/internal/InternalTracingApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/ErrorCode;Ljava/lang/Long;ILjava/lang/Object;)Z
+}
+
+public abstract interface class io/embrace/android/embracesdk/internal/api/InternalInterfaceApi {
+	public abstract fun getFlutterInternalInterface ()Lio/embrace/android/embracesdk/FlutterInternalInterface;
+	public abstract fun getInternalInterface ()Lio/embrace/android/embracesdk/internal/EmbraceInternalInterface;
+	public abstract fun getReactNativeInternalInterface ()Lio/embrace/android/embracesdk/ReactNativeInternalInterface;
+	public abstract fun getUnityInternalInterface ()Lio/embrace/android/embracesdk/UnityInternalInterface;
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/clock/Clock {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface;
 import io.embrace.android.embracesdk.internal.Systrace;
 import io.embrace.android.embracesdk.internal.api.EmbraceAndroidApi;
 import io.embrace.android.embracesdk.internal.api.EmbraceApi;
+import io.embrace.android.embracesdk.internal.api.InternalInterfaceApi;
 import io.embrace.android.embracesdk.internal.api.LogsApi;
 import io.embrace.android.embracesdk.internal.api.MomentsApi;
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi;
@@ -49,7 +50,8 @@ public final class Embrace implements
     EmbraceApi,
     EmbraceAndroidApi,
     SdkStateApi,
-    OTelApi {
+    OTelApi,
+    InternalInterfaceApi {
 
     /**
      * Singleton instance of the Embrace SDK.
@@ -659,7 +661,7 @@ public final class Embrace implements
     @NonNull
     @InternalApi
     public EmbraceInternalInterface getInternalInterface() {
-        return impl.getEmbraceInternalInterface();
+        return impl.getInternalInterface();
     }
 
     /**
@@ -702,7 +704,7 @@ public final class Embrace implements
             if (param == null) {
                 final String errorMessage = functionName + NULL_PARAMETER_ERROR_MESSAGE_TEMPLATE;
                 if (isStarted()) {
-                    impl.getEmbraceInternalInterface().logInternalError(new IllegalArgumentException(errorMessage));
+                    impl.getInternalInterface().logInternalError(new IllegalArgumentException(errorMessage));
                 }
                 return false;
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.Systrace.endSynchronous
 import io.embrace.android.embracesdk.internal.Systrace.startSynchronous
 import io.embrace.android.embracesdk.internal.api.BreadcrumbApi
+import io.embrace.android.embracesdk.internal.api.InternalInterfaceApi
 import io.embrace.android.embracesdk.internal.api.LogsApi
 import io.embrace.android.embracesdk.internal.api.MomentsApi
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi
@@ -72,7 +73,8 @@ internal class EmbraceImpl @JvmOverloads constructor(
     SdkStateApi by sdkStateApiDelegate,
     OTelApi by otelApiDelegate,
     BreadcrumbApi by breadcrumbApiDelegate,
-    WebViewApi by webviewApiDelegate {
+    WebViewApi by webviewApiDelegate,
+    InternalInterfaceApi {
 
     private val uninitializedSdkInternalInterface by lazy<EmbraceInternalInterface> {
         UninitializedSdkInternalInterfaceImpl(bootstrapper.openTelemetryModule.internalTracer)
@@ -276,7 +278,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
      * Gets the [EmbraceInternalInterface] that should be used as the sole source of
      * communication with other Android SDK modules.
      */
-    fun getEmbraceInternalInterface(): EmbraceInternalInterface {
+    override val internalInterface get(): EmbraceInternalInterface {
         val internalInterface = embraceInternalInterface
         return if (isStarted() && internalInterface != null) {
             internalInterface
@@ -285,17 +287,15 @@ internal class EmbraceImpl @JvmOverloads constructor(
         }
     }
 
-    fun getReactNativeInternalInterface(): ReactNativeInternalInterface? = internalInterfaceModule?.reactNativeInternalInterface
-
-    fun getUnityInternalInterface(): UnityInternalInterface? = internalInterfaceModule?.unityInternalInterface
+    override val reactNativeInternalInterface get(): ReactNativeInternalInterface? = internalInterfaceModule?.reactNativeInternalInterface
+    override val unityInternalInterface get(): UnityInternalInterface? = internalInterfaceModule?.unityInternalInterface
+    override val flutterInternalInterface get(): FlutterInternalInterface? = internalInterfaceModule?.flutterInternalInterface
 
     fun installUnityThreadSampler() {
         if (sdkCallChecker.check("install_unity_thread_sampler")) {
             sampleCurrentThreadDuringAnrs()
         }
     }
-
-    fun getFlutterInternalInterface(): FlutterInternalInterface? = internalInterfaceModule?.flutterInternalInterface
 
     private fun sampleCurrentThreadDuringAnrs() {
         try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/InternalInterfaceApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/InternalInterfaceApi.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.embracesdk.internal.api
+
+import io.embrace.android.embracesdk.FlutterInternalInterface
+import io.embrace.android.embracesdk.ReactNativeInternalInterface
+import io.embrace.android.embracesdk.UnityInternalInterface
+import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+
+public interface InternalInterfaceApi {
+
+    /**
+     * Get internal interface for the intra-Embrace, not-publicly-supported API
+     */
+    @InternalApi
+    public val internalInterface: EmbraceInternalInterface
+
+    /**
+     * Gets the [ReactNativeInternalInterface] that should be used as the sole source of
+     * communication with the Android SDK for React Native. Not part of the supported public API.
+     */
+    @InternalApi
+    public val reactNativeInternalInterface: ReactNativeInternalInterface?
+
+    /**
+     * @hide Gets the [UnityInternalInterface] that should be used as the sole source of
+     * communication with the Android SDK for Unity. Not part of the supported public API.
+     * @hide
+     */
+    @InternalApi
+    public val unityInternalInterface: UnityInternalInterface?
+
+    /**
+     * Gets the [FlutterInternalInterface] that should be used as the sole source of
+     * communication with the Android SDK for Flutter. Not part of the supported public API.
+     *
+     * @hide
+     */
+    @InternalApi
+    public val flutterInternalInterface: FlutterInternalInterface?
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/EmbraceConfigServiceTest.kt
@@ -255,7 +255,7 @@ internal class EmbraceConfigServiceTest {
         val mockInternalInterface: EmbraceInternalInterface = mockk(relaxed = true)
         mockkObject(Embrace.getImpl())
         every { Embrace.getImpl().isStarted() } returns true
-        every { Embrace.getImpl().getEmbraceInternalInterface() } returns mockInternalInterface
+        every { Embrace.getImpl().internalInterface } returns mockInternalInterface
         fakePreferenceService.sdkDisabled = true
 
         service.onForeground(true, 1100L)


### PR DESCRIPTION
## Goal

Creates an interface that is used for accessing the unity/flutter/react native internal interfaces. This change will ultimately make it easier to create a shim interface around `Embrace/EmbraceImpl`

