### PR TITLE
Support app startup initialization

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-defaults.gradle.kts
@@ -85,6 +85,7 @@ android {
 }
 
 dependencies {
+    implementation("androidx.startup:startup-runtime:1.1.1")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_EXPOSED}")
     add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.DETEKT}")
     add("lintChecks", project.project(":embrace-lint"))

--- a/embrace-android-sdk/src/main/AndroidManifest.xml
+++ b/embrace-android-sdk/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -8,5 +9,14 @@
         <meta-data
             android:name="hostAppId"
             android:value="${applicationId}" />
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="io.embrace.android.embracesdk.internal.EmbraceCoreInitializer"
+                android:value="androidx.startup" />
+        </provider>
     </application>
 </manifest>

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceCoreInitializer.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/EmbraceCoreInitializer.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.internal
+
+import android.content.Context
+import androidx.startup.Initializer
+import io.embrace.android.embracesdk.Embrace
+
+internal class EmbraceCoreInitializer : Initializer<Embrace> {
+
+    override fun create(context: Context): Embrace {
+        val embrace = Embrace.getInstance()
+        embrace.start(context)
+        return embrace
+    }
+
+    override fun dependencies() = emptyList<Class<out Initializer<*>>>()
+}


### PR DESCRIPTION
## Goal

Initializes the SDK using the [App Startup library](https://developer.android.com/topic/libraries/app-startup) rather than manual invocation. This happens earlier in the process lifecycle & requires less manual intervention from a user during the integration process.

## Testing

Manually tested via our test app.

