### PR TITLE
fix small typo in README setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ internal class MyApplication : Application() {
 
         // Do your exporter setup before starting the SDK
 
-        Embrace.getInstance().start()
+        Embrace.getInstance().start(this)
     }
 }
 ```


### PR DESCRIPTION
Small typo in the README file that tripped me up when I was setting this up, brings it inline with the code snippet from https://embrace.io/docs/android/integration/session-reporting/#add-the-start-call