### PR TITLE
Fix missing sdk_version

### DIFF
--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -11,6 +11,9 @@ plugins {
 
 description = "Embrace Android SDK: Core"
 
+val version: String by project
+
+
 android {
     ndkVersion = Versions.NDK
 
@@ -21,7 +24,7 @@ android {
         // For library projects only, the BuildConfig.VERSION_NAME and BuildConfig.VERSION_CODE properties have been removed from the generated BuildConfig class
         //
         // https://developer.android.com/studio/releases/gradle-plugin#version_properties_removed_from_buildconfig_class_in_library_projects
-        buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
+        buildConfigField("String", "VERSION_NAME", "\"${version}\"")
         buildConfigField("String", "VERSION_CODE", "\"${53}\"")
     }
 


### PR DESCRIPTION
## Goal

`sdk_version` is null in latest version.

## Testing

Manual testing.

## Release Notes

Fix null sdk_version

**WHAT**:SDK Version was reported as null
**WHY**:It's affecting the dashboard filtering behavior

