### PR TITLE
Strip URL of network request of parameters

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.payload.AppExitInfoData
 import io.embrace.android.embracesdk.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.utils.NetworkUtils.getValidTraceId
+import io.embrace.android.embracesdk.utils.NetworkUtils.stripUrl
 import io.opentelemetry.semconv.ErrorAttributes
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.incubating.ExceptionIncubatingAttributes
@@ -214,7 +215,7 @@ internal sealed class SchemaType(
 
     internal class NetworkRequest(networkRequest: EmbraceNetworkRequest) : SchemaType(EmbType.Performance.Network) {
         override val schemaAttributes = mapOf(
-            "url.full" to networkRequest.url,
+            "url.full" to stripUrl(networkRequest.url),
             HttpAttributes.HTTP_REQUEST_METHOD.key to networkRequest.httpMethod,
             HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key to networkRequest.responseCode,
             HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key to networkRequest.bytesSent,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkLoggingServiceTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.utils.NetworkUtils.stripUrl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -144,6 +145,20 @@ internal class EmbraceNetworkLoggingServiceTest {
         }
 
         assertEquals(2, getNetworkSpans().size)
+    }
+
+    @Test
+    fun `URL parameters will be truncated`() {
+        val url = "https://www.example1.com/a?b=c"
+        logNetworkRequest(
+            url = url,
+            startTime = 100,
+            endTime = 200,
+        )
+
+        with(checkNotNull(getNetworkSpans().single())) {
+            assertEquals(stripUrl(url), attributes?.single { it.key == "url.full" }?.data)
+        }
     }
 
     private fun logNetworkRequest(


### PR DESCRIPTION
## Goal

Strip the URL for logged network requests so it doesn't contain URL parameters that take up space and may trigger the attribute to be dropped

