### PR TITLE
suppress unwanted docs

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/FlutterInternalInterface.kt
@@ -6,22 +6,26 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 /**
  * Provides an internal interface to Embrace that is intended for use by Flutter as its
  * sole source of communication with the Android SDK.
+ * @suppress
  */
 @InternalApi
 public interface FlutterInternalInterface : EmbraceInternalInterface {
 
     /**
      * Sets the Embrace Flutter SDK version - this is not intended for public use.
+     * @suppress
      */
     public fun setEmbraceFlutterSdkVersion(version: String?)
 
     /**
      * Sets the Dart version - this is not intended for public use.
+     * @suppress
      */
     public fun setDartVersion(version: String?)
 
     /**
      * Logs a handled Dart error to the Embrace SDK - this is not intended for public use.
+     * @suppress
      */
     public fun logHandledDartException(
         stack: String?,
@@ -33,6 +37,7 @@ public interface FlutterInternalInterface : EmbraceInternalInterface {
 
     /**
      * Logs an unhandled Dart error to the Embrace SDK - this is not intended for public use.
+     * @suppress
      */
     public fun logUnhandledDartException(
         stack: String?,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ReactNativeInternalInterface.kt
@@ -7,10 +7,14 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 /**
  * Provides an internal interface to Embrace that is intended for use by the React Native SDK as its
  * sole source of communication with the Android SDK.
+ * @suppress
  */
 @InternalApi
 public interface ReactNativeInternalInterface : EmbraceInternalInterface {
 
+    /**
+     * @suppress
+     */
     public fun logUnhandledJsException(
         name: String,
         message: String,
@@ -18,6 +22,9 @@ public interface ReactNativeInternalInterface : EmbraceInternalInterface {
         stacktrace: String?
     )
 
+    /**
+     * @suppress
+     */
     public fun logHandledJsException(
         name: String,
         message: String,
@@ -25,16 +32,26 @@ public interface ReactNativeInternalInterface : EmbraceInternalInterface {
         stacktrace: String?
     )
 
+    /**
+     * @suppress
+     */
     public fun setJavaScriptPatchNumber(number: String?)
 
+    /**
+     * @suppress
+     */
     public fun setReactNativeSdkVersion(version: String?)
 
+    /**
+     * @suppress
+     */
     public fun setReactNativeVersionNumber(version: String?)
 
     /**
      * Sets the React Native Bundle URL.
      * @param context the context
      * @param url the JavaScript bundle URL
+     * @suppress
      */
     public fun setJavaScriptBundleUrl(context: Context, url: String)
 
@@ -45,11 +62,13 @@ public interface ReactNativeInternalInterface : EmbraceInternalInterface {
      * @param context the context
      * @param url the JavaScript bundle URL
      * @param didUpdate if the bundle was updated
+     * @suppress
      */
     public fun setCacheableJavaScriptBundleUrl(context: Context, url: String, didUpdate: Boolean)
 
     /**
      * Logs a React Native Redux Action - this is not intended for public use.
+     * @suppress
      */
     public fun logRnAction(
         name: String,
@@ -67,6 +86,7 @@ public interface ReactNativeInternalInterface : EmbraceInternalInterface {
      * logged.
      *
      * @param screen the name of the view to log
+     * @suppress
      */
     public fun logRnView(screen: String)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/UnityInternalInterface.kt
@@ -6,24 +6,37 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 /**
  * Provides an internal interface to Embrace that is intended for use by the Embrace Unity SDK as its
  * sole source of communication with the Android SDK.
+ * @suppress
  */
 @InternalApi
 public interface UnityInternalInterface : EmbraceInternalInterface {
 
+    /**
+     * @suppress
+     */
     public fun setUnityMetaData(unityVersion: String?, buildGuid: String?, unitySdkVersion: String?)
 
+    /**
+     * @suppress
+     */
     public fun logUnhandledUnityException(
         name: String,
         message: String,
         stacktrace: String?
     )
 
+    /**
+     * @suppress
+     */
     public fun logHandledUnityException(
         name: String,
         message: String,
         stacktrace: String?
     )
 
+    /**
+     * @suppress
+     */
     public fun recordIncompleteNetworkRequest(
         url: String,
         httpMethod: String,
@@ -34,6 +47,9 @@ public interface UnityInternalInterface : EmbraceInternalInterface {
         traceId: String?
     )
 
+    /**
+     * @suppress
+     */
     public fun recordCompletedNetworkRequest(
         url: String,
         httpMethod: String,
@@ -45,5 +61,8 @@ public interface UnityInternalInterface : EmbraceInternalInterface {
         traceId: String?
     )
 
+    /**
+     * @suppress
+     */
     public fun installUnityThreadSampler()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/InternalInterfaceApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/InternalInterfaceApi.kt
@@ -6,11 +6,15 @@ import io.embrace.android.embracesdk.UnityInternalInterface
 import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 
+/**
+ * @suppress
+ */
 @InternalApi
 public interface InternalInterfaceApi {
 
     /**
      * Get internal interface for the intra-Embrace, not-publicly-supported API
+     * @suppress
      */
     @InternalApi
     public val internalInterface: EmbraceInternalInterface
@@ -18,14 +22,15 @@ public interface InternalInterfaceApi {
     /**
      * Gets the [ReactNativeInternalInterface] that should be used as the sole source of
      * communication with the Android SDK for React Native. Not part of the supported public API.
+     * @suppress
      */
     @InternalApi
     public val reactNativeInternalInterface: ReactNativeInternalInterface?
 
     /**
-     * @hide Gets the [UnityInternalInterface] that should be used as the sole source of
+     * Gets the [UnityInternalInterface] that should be used as the sole source of
      * communication with the Android SDK for Unity. Not part of the supported public API.
-     * @hide
+     * @suppress
      */
     @InternalApi
     public val unityInternalInterface: UnityInternalInterface?
@@ -33,8 +38,7 @@ public interface InternalInterfaceApi {
     /**
      * Gets the [FlutterInternalInterface] that should be used as the sole source of
      * communication with the Android SDK for Flutter. Not part of the supported public API.
-     *
-     * @hide
+     * @suppress
      */
     @InternalApi
     public val flutterInternalInterface: FlutterInternalInterface?

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/InternalWebViewApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/InternalWebViewApi.kt
@@ -3,9 +3,24 @@ package io.embrace.android.embracesdk.internal.api
 import android.webkit.ConsoleMessage
 import io.embrace.android.embracesdk.annotation.InternalApi
 
+/**
+ * @suppress
+ */
 @InternalApi
 public interface InternalWebViewApi {
+
+    /**
+     * @suppress
+     */
     public fun logWebView(url: String?)
+
+    /**
+     * @suppress
+     */
     public fun trackWebViewPerformance(tag: String, consoleMessage: ConsoleMessage)
+
+    /**
+     * @suppress
+     */
     public fun trackWebViewPerformance(tag: String, message: String)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/LogsApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/LogsApi.kt
@@ -177,6 +177,7 @@ public interface LogsApi {
      * @param messageDeliveredPriority the priority of the message (as resolved on the server)
      * @param isNotification           if it is a notification message.
      * @param hasData                  if the message contains payload data.
+     * @suppress
      */
     public fun logPushNotification(
         title: String?,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkApi.kt
@@ -3,6 +3,9 @@ package io.embrace.android.embracesdk.internal.api
 import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.spans.TracingApi
 
+/**
+ * @suppress
+ */
 @InternalApi
 public interface SdkApi :
     LogsApi,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
@@ -29,10 +29,17 @@ public data class EmbraceSpanEvent internal constructor(
     @Json(name = "attributes")
     val attributes: Map<String, String>
 ) {
+
+    /**
+     * @suppress
+     */
     public companion object {
         internal const val MAX_EVENT_NAME_LENGTH = 100
         internal const val MAX_EVENT_ATTRIBUTE_COUNT = 10
 
+        /**
+         * @suppress
+         */
         public fun create(name: String, timestampMs: Long, attributes: Map<String, String>?): EmbraceSpanEvent? {
             if (inputsValid(name, attributes)) {
                 return EmbraceSpanEvent(name = name, timestampNanos = timestampMs.millisToNanos(), attributes = attributes ?: emptyMap())


### PR DESCRIPTION
## Goal

Suppresses unwanted symbols that are internal-only from our KDoc. `@hide` should not be used - [`@supress` should be used instead](https://kotlinlang.org/docs/kotlin-doc.html#suppress). Anything inside an `internal.**` package is automatically hidden by our Dokka setup.

This hides the vast majority of unwanted symbols. We may want to convert some Java classes as part of the major bump to have a mechanism for hiding them (and also get rid of Java code).

