### PR TITLE
Move classes into separate source files

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
@@ -57,9 +57,3 @@ internal abstract class DataSourceImpl<T>(
         }
     }
 }
-
-/**
- * Syntactic sugar for when no input validation is required. Developers must explicitly state
- * this is the case.
- */
-internal val NoInputValidation = { true }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/NoInputValidation.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/NoInputValidation.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.arch.datasource
+
+/**
+ * Syntactic sugar for when no input validation is required. Developers must explicitly state
+ * this is the case.
+ */
+internal val NoInputValidation = { true }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -124,12 +124,3 @@ internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
         internal object WebViewInfo : System("webview_info")
     }
 }
-
-/**
- * Represents a telemetry type (emb.type). For example, "ux.view" is a type that represents
- * a visual event around a UI element. ux is the type, and view is the subtype. This tells the
- * backend that it can assume the data in the event follows a particular schema.
- */
-internal interface TelemetryType : FixedAttribute {
-    val sendImmediately: Boolean
-}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttribute.kt
@@ -1,9 +1,5 @@
 package io.embrace.android.embracesdk.arch.schema
 
-import io.embrace.android.embracesdk.internal.payload.Attribute
-import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
-import io.opentelemetry.api.common.AttributeKey
-
 /**
  * An attribute to be used in telemetry objects and payload envelopes
  */
@@ -18,48 +14,4 @@ internal interface EmbraceAttribute {
      * Return the appropriate name for this attribute to be use in the representation of a telemetry object
      */
     val name: String
-}
-
-/**
- * Defines a unique object to represent a [EmbraceAttribute]
- */
-internal class EmbraceAttributeKey(
-    override val id: String,
-    otelAttributeKey: AttributeKey<String>? = null,
-    useIdAsAttributeName: Boolean = false,
-    isPrivate: Boolean = false
-) : EmbraceAttribute {
-    override val name: String = if (!useIdAsAttributeName && otelAttributeKey?.key != null) {
-        otelAttributeKey.key
-    } else {
-        id.toEmbraceAttributeName(isPrivate)
-    }
-
-    /**
-     * The [AttributeKey] equivalent for this object to be used in conjunction with OTel objects
-     */
-    val attributeKey: AttributeKey<String> = otelAttributeKey ?: AttributeKey.stringKey(name)
-}
-
-/**
- * Instance of a fixed key-value pair for a attribute, used for low cardinality dimensions with a known, fixed set of valid values.
- */
-internal interface FixedAttribute {
-
-    val key: EmbraceAttributeKey
-
-    /**
-     * The value of the particular instance of the attribute
-     */
-    val value: String
-
-    /**
-     * Return as a key-value pair appropriate to use as an OpenTelemetry attribute
-     */
-    fun toEmbraceKeyValuePair() = Pair(key.name, value)
-
-    /**
-     * Return as a [Attribute] representation, to be used used for Embrace payloads
-     */
-    fun toPayload() = Attribute(key.name, value)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.arch.schema
+
+import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
+import io.opentelemetry.api.common.AttributeKey
+
+/**
+ * Defines a unique object to represent a [EmbraceAttribute]
+ */
+internal class EmbraceAttributeKey(
+    override val id: String,
+    otelAttributeKey: AttributeKey<String>? = null,
+    useIdAsAttributeName: Boolean = false,
+    isPrivate: Boolean = false
+) : EmbraceAttribute {
+    override val name: String = if (!useIdAsAttributeName && otelAttributeKey?.key != null) {
+        otelAttributeKey.key
+    } else {
+        id.toEmbraceAttributeName(isPrivate)
+    }
+
+    /**
+     * The [AttributeKey] equivalent for this object to be used in conjunction with OTel objects
+     */
+    val attributeKey: AttributeKey<String> = otelAttributeKey ?: AttributeKey.stringKey(name)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/FixedAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/FixedAttribute.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.arch.schema
+
+import io.embrace.android.embracesdk.internal.payload.Attribute
+
+/**
+ * Instance of a fixed key-value pair for a attribute, used for low cardinality dimensions with a known, fixed set of valid values.
+ */
+internal interface FixedAttribute {
+
+    val key: EmbraceAttributeKey
+
+    /**
+     * The value of the particular instance of the attribute
+     */
+    val value: String
+
+    /**
+     * Return as a key-value pair appropriate to use as an OpenTelemetry attribute
+     */
+    fun toEmbraceKeyValuePair() = Pair(key.name, value)
+
+    /**
+     * Return as a [Attribute] representation, to be used used for Embrace payloads
+     */
+    fun toPayload() = Attribute(key.name, value)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryType.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.arch.schema
+
+/**
+ * Represents a telemetry type (emb.type). For example, "ux.view" is a type that represents
+ * a visual event around a UI element. ux is the type, and view is the subtype. This tells the
+ * backend that it can assume the data in the event follows a particular schema.
+ */
+internal interface TelemetryType : FixedAttribute {
+    val sendImmediately: Boolean
+}


### PR DESCRIPTION
## Goal

Moves some internal arch classes into separate source files so there's only one class per file. This should make subsequent refactoring easier to follow.
