### PR TITLE
Make internal api symbols visible

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -200,6 +200,416 @@ public abstract interface annotation class io/embrace/android/embracesdk/annotat
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/StartupActivity : java/lang/annotation/Annotation {
 }
 
+public abstract interface class io/embrace/android/embracesdk/arch/EmbraceFeatureRegistry {
+	public abstract fun add (Lio/embrace/android/embracesdk/arch/datasource/DataSourceState;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/SessionType : java/lang/Enum {
+	public static final field BACKGROUND Lio/embrace/android/embracesdk/arch/SessionType;
+	public static final field FOREGROUND Lio/embrace/android/embracesdk/arch/SessionType;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/arch/SessionType;
+	public static fun values ()[Lio/embrace/android/embracesdk/arch/SessionType;
+}
+
+public abstract interface class io/embrace/android/embracesdk/arch/datasource/DataSource {
+	public abstract fun captureData (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Z
+	public abstract fun disableDataCapture ()V
+	public abstract fun enableDataCapture ()V
+	public abstract fun resetDataCaptureLimits ()V
+}
+
+public abstract class io/embrace/android/embracesdk/arch/datasource/DataSourceImpl : io/embrace/android/embracesdk/arch/datasource/DataSource {
+	public fun <init> (Ljava/lang/Object;Lio/embrace/android/embracesdk/logging/EmbLogger;Lio/embrace/android/embracesdk/arch/limits/LimitStrategy;)V
+	public fun captureData (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Z
+	protected final fun captureDataImpl (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Z)Z
+	public static synthetic fun captureDataImpl$default (Lio/embrace/android/embracesdk/arch/datasource/DataSourceImpl;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Z
+	public fun disableDataCapture ()V
+	public fun enableDataCapture ()V
+	public fun resetDataCaptureLimits ()V
+}
+
+public final class io/embrace/android/embracesdk/arch/datasource/DataSourceState {
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/embrace/android/embracesdk/arch/SessionType;Z)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lio/embrace/android/embracesdk/arch/SessionType;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCurrentSessionType ()Lio/embrace/android/embracesdk/arch/SessionType;
+	public final fun getDataSource ()Lio/embrace/android/embracesdk/arch/datasource/DataSource;
+	public final fun onConfigChange ()V
+	public final fun setCurrentSessionType (Lio/embrace/android/embracesdk/arch/SessionType;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/datasource/NoInputValidationKt {
+	public static final fun getNoInputValidation ()Lkotlin/jvm/functions/Function0;
+}
+
+public abstract interface class io/embrace/android/embracesdk/arch/destination/LogWriter {
+	public abstract fun addLog (Lio/embrace/android/embracesdk/arch/schema/SchemaType;Lio/embrace/android/embracesdk/Severity;Ljava/lang/String;Z)V
+}
+
+public final class io/embrace/android/embracesdk/arch/destination/LogWriter$DefaultImpls {
+	public static synthetic fun addLog$default (Lio/embrace/android/embracesdk/arch/destination/LogWriter;Lio/embrace/android/embracesdk/arch/schema/SchemaType;Lio/embrace/android/embracesdk/Severity;Ljava/lang/String;ZILjava/lang/Object;)V
+}
+
+public abstract interface class io/embrace/android/embracesdk/arch/destination/SessionSpanWriter {
+	public abstract fun addCustomAttribute (Lio/embrace/android/embracesdk/arch/destination/SpanAttributeData;)Z
+	public abstract fun addEvent (Lio/embrace/android/embracesdk/arch/schema/SchemaType;J)Z
+	public abstract fun removeCustomAttribute (Ljava/lang/String;)Z
+	public abstract fun removeEvents (Lio/embrace/android/embracesdk/arch/schema/EmbType;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/destination/SpanAttributeData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/embrace/android/embracesdk/arch/destination/SpanAttributeData;
+	public static synthetic fun copy$default (Lio/embrace/android/embracesdk/arch/destination/SpanAttributeData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/embrace/android/embracesdk/arch/destination/SpanAttributeData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/embrace/android/embracesdk/arch/limits/LimitStrategy {
+	public abstract fun resetDataCaptureLimits ()V
+	public abstract fun shouldCapture ()Z
+}
+
+public final class io/embrace/android/embracesdk/arch/limits/NoopLimitStrategy : io/embrace/android/embracesdk/arch/limits/LimitStrategy {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/limits/NoopLimitStrategy;
+	public fun resetDataCaptureLimits ()V
+	public fun shouldCapture ()Z
+}
+
+public final class io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy : io/embrace/android/embracesdk/arch/limits/LimitStrategy {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun resetDataCaptureLimits ()V
+	public fun shouldCapture ()Z
+}
+
+public abstract class io/embrace/android/embracesdk/arch/schema/EmbType : io/embrace/android/embracesdk/arch/schema/TelemetryType {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getKey ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+	public fun getSendImmediately ()Z
+	public fun getValue ()Ljava/lang/String;
+	public fun toEmbraceKeyValuePair ()Lkotlin/Pair;
+	public fun toPayload ()Lio/embrace/android/embracesdk/internal/payload/Attribute;
+}
+
+public abstract class io/embrace/android/embracesdk/arch/schema/EmbType$Performance : io/embrace/android/embracesdk/arch/schema/EmbType {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$Default : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$Default;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$MemoryWarning : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$MemoryWarning;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$NativeThreadBlockage : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$NativeThreadBlockage;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$NativeThreadBlockageSample : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$NativeThreadBlockageSample;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$Network : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$Network;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$ThermalState : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$ThermalState;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$ThreadBlockage : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$ThreadBlockage;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Performance$ThreadBlockageSample : io/embrace/android/embracesdk/arch/schema/EmbType$Performance {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Performance$ThreadBlockageSample;
+}
+
+public abstract class io/embrace/android/embracesdk/arch/schema/EmbType$System : io/embrace/android/embracesdk/arch/schema/EmbType {
+	public synthetic fun <init> (Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getSendImmediately ()Z
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$Breadcrumb : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$Breadcrumb;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$Crash : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$Crash;
+	public final fun getEmbAndroidCrashExceptionCause ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$Exception : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$Exception;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$Exit : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$Exit;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$FlutterException : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$FlutterException;
+	public final fun getEmbFlutterExceptionContext ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+	public final fun getEmbFlutterExceptionLibrary ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$InternalError : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$InternalError;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$Log : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$Log;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$LowPower : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$LowPower;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$NativeCrash : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$NativeCrash;
+	public final fun getEmbNativeCrashErrors ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+	public final fun getEmbNativeCrashException ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+	public final fun getEmbNativeCrashSymbols ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+	public final fun getEmbNativeCrashUnwindError ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$NetworkCapturedRequest : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$NetworkCapturedRequest;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$NetworkStatus : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$NetworkStatus;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$PushNotification : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$PushNotification;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$ReactNativeAction : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$ReactNativeAction;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$ReactNativeCrash : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$ReactNativeCrash;
+	public final fun getEmbAndroidReactNativeCrashJsException ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$Sigquit : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$Sigquit;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$System$WebViewInfo : io/embrace/android/embracesdk/arch/schema/EmbType$System {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$System$WebViewInfo;
+}
+
+public abstract class io/embrace/android/embracesdk/arch/schema/EmbType$Ux : io/embrace/android/embracesdk/arch/schema/EmbType {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Ux$Session : io/embrace/android/embracesdk/arch/schema/EmbType$Ux {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Ux$Session;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Ux$Tap : io/embrace/android/embracesdk/arch/schema/EmbType$Ux {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Ux$Tap;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Ux$View : io/embrace/android/embracesdk/arch/schema/EmbType$Ux {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Ux$View;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbType$Ux$WebView : io/embrace/android/embracesdk/arch/schema/EmbType$Ux {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/EmbType$Ux$WebView;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey : io/embrace/android/embracesdk/arch/schema/EmbraceAttribute {
+	public fun <init> (Ljava/lang/String;Lio/opentelemetry/api/common/AttributeKey;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/opentelemetry/api/common/AttributeKey;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAttributeKey ()Lio/opentelemetry/api/common/AttributeKey;
+	public fun getId ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class io/embrace/android/embracesdk/arch/schema/FixedAttribute {
+	public abstract fun getKey ()Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;
+	public abstract fun getValue ()Ljava/lang/String;
+	public abstract fun toEmbraceKeyValuePair ()Lkotlin/Pair;
+	public abstract fun toPayload ()Lio/embrace/android/embracesdk/internal/payload/Attribute;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/FixedAttribute$DefaultImpls {
+	public static fun toEmbraceKeyValuePair (Lio/embrace/android/embracesdk/arch/schema/FixedAttribute;)Lkotlin/Pair;
+	public static fun toPayload (Lio/embrace/android/embracesdk/arch/schema/FixedAttribute;)Lio/embrace/android/embracesdk/internal/payload/Attribute;
+}
+
+public abstract class io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public synthetic fun <init> (Lio/embrace/android/embracesdk/arch/schema/TelemetryType;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun attributes ()Ljava/util/Map;
+	public final fun getFixedObjectName ()Ljava/lang/String;
+	protected abstract fun getSchemaAttributes ()Ljava/util/Map;
+	public final fun getTelemetryType ()Lio/embrace/android/embracesdk/arch/schema/TelemetryType;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$Breadcrumb : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$Crash : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Lio/embrace/android/embracesdk/arch/schema/TelemetryAttributes;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$Exception : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Lio/embrace/android/embracesdk/arch/schema/TelemetryAttributes;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$FlutterException : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Lio/embrace/android/embracesdk/arch/schema/TelemetryAttributes;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$InternalError : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$Log : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Lio/embrace/android/embracesdk/arch/schema/TelemetryAttributes;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$LowPower : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/SchemaType$LowPower;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$MemoryWarning : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> ()V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$NativeCrash : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Lio/embrace/android/embracesdk/arch/schema/TelemetryAttributes;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$NativeThreadBlockage : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (ILjava/lang/String;ILjava/lang/String;JLjava/lang/String;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$NativeThreadBlockageSample : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (IJLjava/lang/String;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$NetworkRequest : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$PushNotification : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$ReactNativeAction : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$ReactNativeCrash : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Lio/embrace/android/embracesdk/arch/schema/TelemetryAttributes;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$Sigquit : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/arch/schema/SchemaType$Sigquit;
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$Tap : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$ThermalState : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (I)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$ThreadBlockage : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (IJI)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$ThreadBlockageSample : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (JILjava/lang/String;ILjava/lang/Thread$State;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$View : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$WebViewInfo : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/SchemaType$WebViewUrl : io/embrace/android/embracesdk/arch/schema/SchemaType {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/TelemetryAttributes {
+	public fun <init> (Lio/embrace/android/embracesdk/config/ConfigService;Lkotlin/jvm/functions/Function0;Ljava/util/Map;)V
+	public synthetic fun <init> (Lio/embrace/android/embracesdk/config/ConfigService;Lkotlin/jvm/functions/Function0;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAttribute (Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;)Ljava/lang/String;
+	public final fun getAttribute (Lio/opentelemetry/api/common/AttributeKey;)Ljava/lang/String;
+	public final fun setAttribute (Lio/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey;Ljava/lang/String;)V
+	public final fun setAttribute (Lio/opentelemetry/api/common/AttributeKey;Ljava/lang/String;)V
+	public final fun snapshot ()Ljava/util/Map;
+}
+
+public abstract interface class io/embrace/android/embracesdk/arch/schema/TelemetryType : io/embrace/android/embracesdk/arch/schema/FixedAttribute {
+	public abstract fun getSendImmediately ()Z
+}
+
+public final class io/embrace/android/embracesdk/arch/schema/TelemetryType$DefaultImpls {
+	public static fun toEmbraceKeyValuePair (Lio/embrace/android/embracesdk/arch/schema/TelemetryType;)Lkotlin/Pair;
+	public static fun toPayload (Lio/embrace/android/embracesdk/arch/schema/TelemetryType;)Lio/embrace/android/embracesdk/internal/payload/Attribute;
+}
+
+public abstract interface class io/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler {
+	public abstract fun handleInternalError (Ljava/lang/Throwable;)V
+}
+
+public final class io/embrace/android/embracesdk/capture/internal/errors/InternalErrorType : java/lang/Enum {
+	public static final field ACTIVITY_LISTENER_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field ANR_DATA_FETCH Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field ANR_HEARTBEAT_CHECK_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field ANR_HEARTBEAT_STOP_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field BG_SESSION_CACHE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field CFG_CHANGE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field CONFIG_LISTENER_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field DATA_SOURCE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field DISABLE_DATA_CAPTURE Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field DISK_STAT_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field ENABLE_DATA_CAPTURE Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field END_EVENT_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field FG_SESSION_CACHE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field INVALID_JS_EXCEPTION Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field INVALID_NATIVE_SYMBOLS Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field MEMORY_CLEAN_LISTENER_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field NATIVE_CRASH_LOAD_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field NATIVE_HANDLER_INSTALL_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field NATIVE_THREAD_SAMPLE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field NETWORK_STATUS_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field PROCESS_STATE_CALLBACK_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field PROCESS_STATE_SUMMARY_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field SAFE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field SCREEN_RES_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field SESSION_CHANGE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field START_EVENT_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field TIME_TRAVEL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field UNBALANCED_BG_CALL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field UNBALANCED_CALL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field UNBALANCED_FG_CALL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field UNCAUGHT_EXC_HANDLER Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field USER_LOAD_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static final field WEB_VITAL_PARSE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+	public static fun values ()[Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
+}
+
 public abstract interface class io/embrace/android/embracesdk/config/ConfigService : java/io/Closeable {
 	public abstract fun addListener (Lkotlin/jvm/functions/Function0;)V
 	public abstract fun getAnrBehavior ()Lio/embrace/android/embracesdk/config/behavior/AnrBehavior;
@@ -650,6 +1060,57 @@ public final class io/embrace/android/embracesdk/internal/payload/AppFramework :
 	public static final field UNITY Lio/embrace/android/embracesdk/internal/payload/AppFramework;
 	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/payload/AppFramework;
 	public static fun values ()[Lio/embrace/android/embracesdk/internal/payload/AppFramework;
+}
+
+public final class io/embrace/android/embracesdk/internal/payload/Attribute {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/payload/Attribute;
+	public static synthetic fun copy$default (Lio/embrace/android/embracesdk/internal/payload/Attribute;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/embrace/android/embracesdk/internal/payload/Attribute;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/embrace/android/embracesdk/internal/payload/AttributeJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/embrace/android/embracesdk/internal/payload/Attribute;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/embrace/android/embracesdk/internal/payload/Attribute;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/embrace/android/embracesdk/logging/EmbLogger {
+	public abstract fun getInternalErrorService ()Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler;
+	public abstract fun logDebug (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun logError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun logInfo (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun logSdkNotInitialized (Ljava/lang/String;)V
+	public abstract fun logWarning (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun setInternalErrorService (Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler;)V
+	public abstract fun trackInternalError (Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;Ljava/lang/Throwable;)V
+}
+
+public final class io/embrace/android/embracesdk/logging/EmbLogger$DefaultImpls {
+	public static synthetic fun logDebug$default (Lio/embrace/android/embracesdk/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun logError$default (Lio/embrace/android/embracesdk/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun logInfo$default (Lio/embrace/android/embracesdk/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun logWarning$default (Lio/embrace/android/embracesdk/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+}
+
+public final class io/embrace/android/embracesdk/logging/EmbLogger$Severity : java/lang/Enum {
+	public static final field DEBUG Lio/embrace/android/embracesdk/logging/EmbLogger$Severity;
+	public static final field ERROR Lio/embrace/android/embracesdk/logging/EmbLogger$Severity;
+	public static final field INFO Lio/embrace/android/embracesdk/logging/EmbLogger$Severity;
+	public static final field WARNING Lio/embrace/android/embracesdk/logging/EmbLogger$Severity;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/logging/EmbLogger$Severity;
+	public static fun values ()[Lio/embrace/android/embracesdk/logging/EmbLogger$Severity;
 }
 
 public final class io/embrace/android/embracesdk/network/EmbraceNetworkRequest {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/EmbraceFeatureRegistry.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/EmbraceFeatureRegistry.kt
@@ -1,15 +1,17 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.arch.datasource.DataSourceState
 
 /**
  * Registry for all features whose instrumentation should be orchestrated by the Embrace SDK.
  */
-internal interface EmbraceFeatureRegistry {
+@InternalApi
+public interface EmbraceFeatureRegistry {
 
     /**
      * Adds a feature to the registry. The SDK will control when a feature is enabled/disabled
      * based on the declared values in the [state] parameter.
      */
-    fun add(state: DataSourceState<*>)
+    public fun add(state: DataSourceState<*>)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/SessionType.kt
@@ -1,10 +1,13 @@
 package io.embrace.android.embracesdk.arch
 
+import io.embrace.android.embracesdk.annotation.InternalApi
+
 /**
  * The type of session that contains the data. Currently this is either a session (foreground)
  * or a background activity (background).
  */
-internal enum class SessionType {
+@InternalApi
+public enum class SessionType {
 
     /**
      * A period of time where the app was in the foreground.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSource.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch.datasource
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 
@@ -12,7 +13,8 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
  *
  * See [EventDataSource], [SpanDataSource], and [LogDataSource] for more information.
  */
-internal interface DataSource<T> {
+@InternalApi
+public interface DataSource<T> {
 
     /**
      * The DataSource should call this function when it wants to capture some form of data.
@@ -27,7 +29,7 @@ internal interface DataSource<T> {
      * This function returns true if data was successfully captured & false if not.
      * This is assumed to be the case if [captureAction] completed without throwing.
      */
-    fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean
+    public fun captureData(inputValidation: () -> Boolean, captureAction: T.() -> Unit): Boolean
 
     /**
      * Enables data capture. This should include registering any listeners, and resetting
@@ -35,7 +37,7 @@ internal interface DataSource<T> {
      *
      * You should NOT attempt to track state within the [DataSource] with a boolean flag.
      */
-    fun enableDataCapture()
+    public fun enableDataCapture()
 
     /**
      * Disables data capture. This should include unregistering any listeners, and resetting
@@ -43,10 +45,10 @@ internal interface DataSource<T> {
      *
      * You should NOT attempt to track state within the [DataSource] with a boolean flag.
      */
-    fun disableDataCapture()
+    public fun disableDataCapture()
 
     /**
      * Resets any data capture limits since the last time [enableDataCapture] was called.
      */
-    fun resetDataCaptureLimits()
+    public fun resetDataCaptureLimits()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.logging.EmbLogger
 /**
  * Base class for data sources.
  */
-internal abstract class DataSourceImpl<T>(
+public abstract class DataSourceImpl<T>(
     private val destination: T,
     private val logger: EmbLogger,
     private val limitStrategy: LimitStrategy,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/DataSourceState.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch.datasource
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.arch.SessionType
 import io.embrace.android.embracesdk.internal.utils.Provider
 
@@ -8,7 +9,8 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  * that enable/disable the service, and creates new instances of the service as required.
  * It also is capable of disabling the service if the [SessionType] is not supported.
  */
-internal class DataSourceState<T : DataSource<*>>(
+@InternalApi
+public class DataSourceState<T : DataSource<*>>(
 
     /**
      * Provides instances of services. A service must define an interface
@@ -36,13 +38,13 @@ internal class DataSourceState<T : DataSource<*>>(
      * If you enable this behavior please ensure your implementation is thread safe (e.g.
      * it can handle unbalanced calls to [enableDataCapture] and others).
      */
-    val asyncInit: Boolean = false
+    internal val asyncInit: Boolean = false
 ) {
 
     /**
      * The type of session that contains the data.
      */
-    var currentSessionType: SessionType? = null
+    public var currentSessionType: SessionType? = null
         set(value) {
             field = value
             onSessionTypeChange()
@@ -50,7 +52,7 @@ internal class DataSourceState<T : DataSource<*>>(
 
     private val factoryRef = lazy(factory)
 
-    var dataSource: T? = null
+    public var dataSource: T? = null
         private set
 
     init {
@@ -70,7 +72,7 @@ internal class DataSourceState<T : DataSource<*>>(
     /**
      * Callback that is invoked when the config layer experiences a change.
      */
-    fun onConfigChange() {
+    public fun onConfigChange() {
         updateDataSource()
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/NoInputValidation.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/datasource/NoInputValidation.kt
@@ -1,7 +1,10 @@
 package io.embrace.android.embracesdk.arch.datasource
 
+import io.embrace.android.embracesdk.annotation.InternalApi
+
 /**
  * Syntactic sugar for when no input validation is required. Developers must explicitly state
  * this is the case.
  */
-internal val NoInputValidation = { true }
+@InternalApi
+public val NoInputValidation: () -> Boolean = { true }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/LogWriter.kt
@@ -1,13 +1,15 @@
 package io.embrace.android.embracesdk.arch.destination
 
 import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 
 /**
  * Declares functions for writing a log to the current session span.
  */
-internal interface LogWriter {
-    fun addLog(
+@InternalApi
+public interface LogWriter {
+    public fun addLog(
         schemaType: SchemaType,
         severity: Severity,
         message: String,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SessionSpanWriter.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch.destination
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.arch.schema.EmbType
 import io.embrace.android.embracesdk.arch.schema.SchemaType
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -7,7 +8,8 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 /**
  * Declares functions for writing an [EmbraceSpanEvent] or attributes to the current session span.
  */
-internal interface SessionSpanWriter {
+@InternalApi
+public interface SessionSpanWriter {
 
     /**
      * Add an [EmbraceSpanEvent] with the given [name]. If [spanStartTimeMs] is null, the
@@ -16,24 +18,24 @@ internal interface SessionSpanWriter {
      *
      * Returns true if the event was added, otherwise false.
      */
-    fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean
+    public fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean
 
     /**
      * Remove all events with the given [EmbType].
      */
-    fun removeEvents(type: EmbType)
+    public fun removeEvents(type: EmbType)
 
     /**
      * Add the given key-value pair as an Attribute to the Event.
      *
      * Returns true if the attribute was added, otherwise false.
      */
-    fun addCustomAttribute(attribute: SpanAttributeData): Boolean
+    public fun addCustomAttribute(attribute: SpanAttributeData): Boolean
 
     /**
      * Remove the attribute with the given key
      *
      * Returns true if attribute was removed, otherwise false.
      */
-    fun removeCustomAttribute(key: String): Boolean
+    public fun removeCustomAttribute(key: String): Boolean
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanAttributeData.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/destination/SpanAttributeData.kt
@@ -1,9 +1,12 @@
 package io.embrace.android.embracesdk.arch.destination
 
+import io.embrace.android.embracesdk.annotation.InternalApi
+
 /**
  * Represents a span attribute that can be added to the current session span.
  */
-internal data class SpanAttributeData(
+@InternalApi
+public data class SpanAttributeData(
     val key: String,
     val value: String
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/LimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/LimitStrategy.kt
@@ -1,18 +1,21 @@
 package io.embrace.android.embracesdk.arch.limits
 
+import io.embrace.android.embracesdk.annotation.InternalApi
+
 /**
  * Defines a strategy for limiting the capture of data in a [DataSource].
  */
-internal interface LimitStrategy {
+@InternalApi
+public interface LimitStrategy {
 
     /**
      * Whether data should be captured or not. Each invocation of this increments an internal
      * counter by one, as it assumes that data has been captured.
      */
-    fun shouldCapture(): Boolean
+    public fun shouldCapture(): Boolean
 
     /**
      * Resets the internal count of data that has been captured.
      */
-    fun resetDataCaptureLimits()
+    public fun resetDataCaptureLimits()
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/NoopLimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/NoopLimitStrategy.kt
@@ -1,9 +1,12 @@
 package io.embrace.android.embracesdk.arch.limits
 
+import io.embrace.android.embracesdk.annotation.InternalApi
+
 /**
  * This class captures whatever the hell it wants, whenever it wants
  */
-internal object NoopLimitStrategy : LimitStrategy {
+@InternalApi
+public object NoopLimitStrategy : LimitStrategy {
 
     override fun shouldCapture(): Boolean = true
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/limits/UpToLimitStrategy.kt
@@ -1,11 +1,13 @@
 package io.embrace.android.embracesdk.arch.limits
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Allows capturing data up until a limit, then stops capturing.
  */
-internal class UpToLimitStrategy(
+@InternalApi
+public class UpToLimitStrategy(
     private val limitProvider: Provider<Int>,
 ) : LimitStrategy {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbType.kt
@@ -1,126 +1,134 @@
 package io.embrace.android.embracesdk.arch.schema
 
-internal sealed class EmbType(type: String, subtype: String?) : TelemetryType {
-    override val key = EmbraceAttributeKey(id = "type")
-    override val value = type + (subtype?.run { ".$this" } ?: "")
+import io.embrace.android.embracesdk.annotation.InternalApi
+
+@InternalApi
+public sealed class EmbType(type: String, subtype: String?) : TelemetryType {
+    override val key: EmbraceAttributeKey = EmbraceAttributeKey(id = "type")
+    override val value: String = type + (subtype?.run { ".$this" } ?: "")
     override val sendImmediately: Boolean = false
 
     /**
      * Keys that track how fast a time interval is. Only applies to spans.
      */
-    internal sealed class Performance(subtype: String?) : EmbType("perf", subtype) {
+    public sealed class Performance(subtype: String?) : EmbType("perf", subtype) {
 
-        internal object Default : Performance(null)
+        public object Default : Performance(null)
 
-        internal object Network : Performance("network_request")
+        public object Network : Performance("network_request")
 
-        internal object ThreadBlockage : Performance("thread_blockage")
+        public object ThreadBlockage : Performance("thread_blockage")
 
-        internal object ThreadBlockageSample : Performance("thread_blockage_sample")
+        public object ThreadBlockageSample : Performance("thread_blockage_sample")
 
-        internal object MemoryWarning : Performance("memory_warning")
+        public object MemoryWarning : Performance("memory_warning")
 
-        internal object NativeThreadBlockage : Performance("native_thread_blockage")
+        public object NativeThreadBlockage : Performance("native_thread_blockage")
 
-        internal object NativeThreadBlockageSample : Performance("native_thread_blockage_sample")
+        public object NativeThreadBlockageSample : Performance("native_thread_blockage_sample")
 
-        internal object ThermalState : Performance("thermal_state")
+        public object ThermalState : Performance("thermal_state")
     }
 
     /**
      * Keys that track telemetry that is explicitly tied to user behaviour or visual in nature.
      * Applies to spans, logs, and span events.
      */
-    internal sealed class Ux(subtype: String) : EmbType("ux", subtype) {
+    public sealed class Ux(subtype: String) : EmbType("ux", subtype) {
 
-        internal object Session : Ux("session")
+        public object Session : Ux("session")
 
-        internal object View : Ux("view")
+        public object View : Ux("view")
 
-        internal object Tap : Ux("tap")
+        public object Tap : Ux("tap")
 
-        internal object WebView : Ux("webview")
+        public object WebView : Ux("webview")
     }
 
     /**
      * Keys that track telemetry that is not explicitly tied to user behaviour and is not visual in nature.
      * Applies to spans, logs, and span events.
      */
-    internal sealed class System(
+    public sealed class System(
         subtype: String,
         override val sendImmediately: Boolean = false
     ) : EmbType("sys", subtype) {
 
-        internal object Breadcrumb : System("breadcrumb")
+        public object Breadcrumb : System("breadcrumb")
 
-        internal object Log : System("log")
+        public object Log : System("log")
 
-        internal object Exception : System("exception")
+        public object Exception : System("exception")
 
-        internal object InternalError : System("internal")
+        public object InternalError : System("internal")
 
-        internal object FlutterException : System("flutter_exception") {
+        public object FlutterException : System("flutter_exception") {
             /**
              * Attribute name for the exception context in a log representing an exception
              */
-            val embFlutterExceptionContext = EmbraceAttributeKey("exception.context")
+            public val embFlutterExceptionContext: EmbraceAttributeKey = EmbraceAttributeKey("exception.context")
 
             /**
              * Attribute name for the exception library in a log representing an exception
              */
-            val embFlutterExceptionLibrary = EmbraceAttributeKey("exception.library")
+            public val embFlutterExceptionLibrary: EmbraceAttributeKey = EmbraceAttributeKey("exception.library")
         }
 
-        internal object Exit : System("exit", true)
+        public object Exit : System("exit", true)
 
-        internal object PushNotification : System("push_notification")
+        public object PushNotification : System("push_notification")
 
-        internal object Crash : System("android.crash", true) {
+        public object Crash : System("android.crash", true) {
             /**
              * The list of [Throwable] that caused the exception responsible for a crash
              */
-            val embAndroidCrashExceptionCause = EmbraceAttributeKey("android.crash.exception_cause")
+            public val embAndroidCrashExceptionCause: EmbraceAttributeKey =
+                EmbraceAttributeKey("android.crash.exception_cause")
         }
 
-        internal object ReactNativeCrash : System("android.react_native_crash", true) {
+        public object ReactNativeCrash : System("android.react_native_crash", true) {
             /**
              * The JavaScript unhandled exception from the ReactNative layer
              */
-            val embAndroidReactNativeCrashJsException = EmbraceAttributeKey("android.react_native_crash.js_exception")
+            public val embAndroidReactNativeCrashJsException: EmbraceAttributeKey = EmbraceAttributeKey(
+                "android.react_native_crash.js_exception"
+            )
         }
 
-        internal object ReactNativeAction : System("rn_action", true)
+        public object ReactNativeAction : System("rn_action", true)
 
-        internal object NativeCrash : System("android.native_crash", true) {
+        public object NativeCrash : System("android.native_crash", true) {
             /**
              * Exception coming from the native layer
              */
-            val embNativeCrashException = EmbraceAttributeKey("android.native_crash.exception")
+            public val embNativeCrashException: EmbraceAttributeKey =
+                EmbraceAttributeKey("android.native_crash.exception")
 
             /**
              * Native symbols used to symbolicate a native crash
              */
-            val embNativeCrashSymbols = EmbraceAttributeKey("android.native_crash.symbols")
+            public val embNativeCrashSymbols: EmbraceAttributeKey = EmbraceAttributeKey("android.native_crash.symbols")
 
             /**
              * Errors associated with the native crash
              */
-            val embNativeCrashErrors = EmbraceAttributeKey("android.native_crash.errors")
+            public val embNativeCrashErrors: EmbraceAttributeKey = EmbraceAttributeKey("android.native_crash.errors")
 
             /**
              * Error encountered during stack unwinding
              */
-            val embNativeCrashUnwindError = EmbraceAttributeKey("android.native_crash.unwind_error")
+            public val embNativeCrashUnwindError: EmbraceAttributeKey =
+                EmbraceAttributeKey("android.native_crash.unwind_error")
         }
 
-        internal object LowPower : System("low_power")
+        public object LowPower : System("low_power")
 
-        internal object Sigquit : System("sigquit")
+        public object Sigquit : System("sigquit")
 
-        internal object NetworkCapturedRequest : System("network_capture", true)
+        public object NetworkCapturedRequest : System("network_capture", true)
 
-        internal object NetworkStatus : System("network_status")
+        public object NetworkStatus : System("network_status")
 
-        internal object WebViewInfo : System("webview_info")
+        public object WebViewInfo : System("webview_info")
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/EmbraceAttributeKey.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.arch.schema
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.spans.toEmbraceAttributeName
 import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Defines a unique object to represent a [EmbraceAttribute]
  */
-internal class EmbraceAttributeKey(
+@InternalApi
+public class EmbraceAttributeKey(
     override val id: String,
     otelAttributeKey: AttributeKey<String>? = null,
     useIdAsAttributeName: Boolean = false,
@@ -21,5 +23,5 @@ internal class EmbraceAttributeKey(
     /**
      * The [AttributeKey] equivalent for this object to be used in conjunction with OTel objects
      */
-    val attributeKey: AttributeKey<String> = otelAttributeKey ?: AttributeKey.stringKey(name)
+    public val attributeKey: AttributeKey<String> = otelAttributeKey ?: AttributeKey.stringKey(name)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/FixedAttribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/FixedAttribute.kt
@@ -1,26 +1,28 @@
 package io.embrace.android.embracesdk.arch.schema
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.payload.Attribute
 
 /**
  * Instance of a fixed key-value pair for a attribute, used for low cardinality dimensions with a known, fixed set of valid values.
  */
-internal interface FixedAttribute {
+@InternalApi
+public interface FixedAttribute {
 
-    val key: EmbraceAttributeKey
+    public val key: EmbraceAttributeKey
 
     /**
      * The value of the particular instance of the attribute
      */
-    val value: String
+    public val value: String
 
     /**
      * Return as a key-value pair appropriate to use as an OpenTelemetry attribute
      */
-    fun toEmbraceKeyValuePair() = Pair(key.name, value)
+    public fun toEmbraceKeyValuePair(): Pair<String, String> = Pair(key.name, value)
 
     /**
      * Return as a [Attribute] representation, to be used used for Embrace payloads
      */
-    fun toPayload() = Attribute(key.name, value)
+    public fun toPayload(): Attribute = Attribute(key.name, value)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/SchemaType.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.arch.schema
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
@@ -18,9 +19,11 @@ import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
  * Each schema contains a [TelemetryType] that it is being applied to, as well as an optional [fixedObjectName] used for the recorded
  * telemetry data object if the same, fixed name is used for every instance.
  */
-internal sealed class SchemaType(
-    val telemetryType: TelemetryType,
-    val fixedObjectName: String = "",
+
+@InternalApi
+public sealed class SchemaType(
+    public val telemetryType: TelemetryType,
+    public val fixedObjectName: String = "",
 ) {
     protected abstract val schemaAttributes: Map<String, String>
 
@@ -33,26 +36,26 @@ internal sealed class SchemaType(
     /**
      * The attributes defined for this schema that should be used to populate telemetry objects
      */
-    fun attributes(): Map<String, String> = schemaAttributes.plus(commonAttributes)
+    public fun attributes(): Map<String, String> = schemaAttributes.plus(commonAttributes)
 
-    internal class Breadcrumb(message: String) : SchemaType(
+    public class Breadcrumb(message: String) : SchemaType(
         telemetryType = EmbType.System.Breadcrumb,
         fixedObjectName = "breadcrumb"
     ) {
-        override val schemaAttributes = mapOf("message" to message)
+        override val schemaAttributes: Map<String, String> = mapOf("message" to message)
     }
 
-    internal class View(viewName: String) : SchemaType(
+    public class View(viewName: String) : SchemaType(
         telemetryType = EmbType.Ux.View,
         fixedObjectName = "screen-view"
     ) {
-        override val schemaAttributes = mapOf("view.name" to viewName)
+        override val schemaAttributes: Map<String, String> = mapOf("view.name" to viewName)
     }
 
     /**
      * Represents a span in which a thread was blocked.
      */
-    internal class ThreadBlockage(
+    public class ThreadBlockage(
         threadPriority: Int,
         lastKnownTimeMs: Long,
         intervalCode: Int
@@ -60,7 +63,7 @@ internal sealed class SchemaType(
         telemetryType = EmbType.Performance.ThreadBlockage,
         fixedObjectName = "thread_blockage"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "thread_priority" to threadPriority.toString(),
             "last_known_time_unix_nano" to lastKnownTimeMs.millisToNanos().toString(),
             "interval_code" to intervalCode.toString()
@@ -70,7 +73,7 @@ internal sealed class SchemaType(
     /**
      * Represents a point in time when a thread was blocked.
      */
-    internal class ThreadBlockageSample(
+    public class ThreadBlockageSample(
         sampleOverheadMs: Long,
         frameCount: Int,
         stacktrace: String,
@@ -80,7 +83,7 @@ internal sealed class SchemaType(
         telemetryType = EmbType.Performance.ThreadBlockageSample,
         fixedObjectName = "thread_blockage_sample"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "sample_overhead" to sampleOverheadMs.millisToNanos().toString(),
             "frame_count" to frameCount.toString(),
             "stacktrace" to stacktrace,
@@ -95,7 +98,7 @@ internal sealed class SchemaType(
      * @param type The type of tap event. "tap"/"long_press". "tap" is the default.
      * @param coords The coordinates of the tap event.
      */
-    internal class PushNotification(
+    public class PushNotification(
         title: String?,
         type: String?,
         body: String?,
@@ -106,7 +109,7 @@ internal sealed class SchemaType(
         telemetryType = EmbType.System.PushNotification,
         fixedObjectName = "push-notification"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "notification.title" to title,
             "notification.type" to type,
             "notification.body" to body,
@@ -119,7 +122,7 @@ internal sealed class SchemaType(
     /**
      * Represents a span in which a native thread was blocked.
      */
-    internal class NativeThreadBlockage(
+    public class NativeThreadBlockage(
         threadId: Int,
         threadName: String,
         threadPriority: Int,
@@ -130,7 +133,7 @@ internal sealed class SchemaType(
         telemetryType = EmbType.Performance.NativeThreadBlockage,
         fixedObjectName = "native_thread_blockage"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "thread_id" to threadId.toString(),
             "thread_name" to threadName,
             "thread_priority" to threadPriority.toString(),
@@ -143,7 +146,7 @@ internal sealed class SchemaType(
     /**
      * Represents a point in time when a native thread was blocked.
      */
-    internal class NativeThreadBlockageSample(
+    public class NativeThreadBlockageSample(
         result: Int,
         sampleOverheadMs: Long,
         stacktrace: String,
@@ -151,7 +154,7 @@ internal sealed class SchemaType(
         telemetryType = EmbType.Performance.NativeThreadBlockageSample,
         fixedObjectName = "native_thread_blockage_sample"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "result" to result.toString(),
             "sample_overhead_ms" to sampleOverheadMs.toString(),
             "stacktrace" to stacktrace
@@ -164,7 +167,7 @@ internal sealed class SchemaType(
      * @param type The type of tap event. "tap"/"long_press". "tap" is the default.
      * @param coords The coordinates of the tap event.
      */
-    internal class Tap(
+    public class Tap(
         viewName: String?,
         type: String = "tap",
         coords: String
@@ -172,33 +175,33 @@ internal sealed class SchemaType(
         telemetryType = EmbType.Ux.Tap,
         fixedObjectName = "ui-tap"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "view.name" to viewName,
             "tap.type" to type,
             "tap.coords" to coords
         ).toNonNullMap()
     }
 
-    internal class WebViewUrl(
+    public class WebViewUrl(
         url: String
     ) : SchemaType(
         telemetryType = EmbType.Ux.WebView,
         fixedObjectName = "web-view"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "webview.url" to url
         ).toNonNullMap()
     }
 
-    internal class MemoryWarning : SchemaType(
+    public class MemoryWarning : SchemaType(
         telemetryType = EmbType.Performance.MemoryWarning,
         fixedObjectName = "memory-warning"
     ) {
-        override val schemaAttributes = emptyMap<String, String>()
+        override val schemaAttributes: Map<String, String> = emptyMap<String, String>()
     }
 
     internal class AeiLog(message: AppExitInfoData) : SchemaType(EmbType.System.Exit) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "aei_session_id" to message.sessionId,
             "session_id_error" to message.sessionIdError,
             "process_importance" to message.importance.toString(),
@@ -212,8 +215,8 @@ internal sealed class SchemaType(
         ).toNonNullMap()
     }
 
-    internal class NetworkRequest(networkRequest: EmbraceNetworkRequest) : SchemaType(EmbType.Performance.Network) {
-        override val schemaAttributes = mapOf(
+    public class NetworkRequest(networkRequest: EmbraceNetworkRequest) : SchemaType(EmbType.Performance.Network) {
+        override val schemaAttributes: Map<String, String> = mapOf(
             "url.full" to networkRequest.url,
             HttpAttributes.HTTP_REQUEST_METHOD.key to networkRequest.httpMethod,
             HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key to networkRequest.responseCode,
@@ -226,50 +229,50 @@ internal sealed class SchemaType(
         ).toNonNullMap().mapValues { it.value.toString() }
     }
 
-    internal class Log(attributes: TelemetryAttributes) : SchemaType(EmbType.System.Log) {
-        override val schemaAttributes = attributes.snapshot()
+    public class Log(attributes: TelemetryAttributes) : SchemaType(EmbType.System.Log) {
+        override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 
-    internal class Exception(attributes: TelemetryAttributes) :
+    public class Exception(attributes: TelemetryAttributes) :
         SchemaType(EmbType.System.Exception) {
-        override val schemaAttributes = attributes.snapshot()
+        override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 
-    internal class FlutterException(attributes: TelemetryAttributes) :
+    public class FlutterException(attributes: TelemetryAttributes) :
         SchemaType(EmbType.System.FlutterException) {
-        override val schemaAttributes = attributes.snapshot()
+        override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 
-    internal class Crash(attributes: TelemetryAttributes) : SchemaType(EmbType.System.Crash) {
-        override val schemaAttributes = attributes.snapshot()
+    public class Crash(attributes: TelemetryAttributes) : SchemaType(EmbType.System.Crash) {
+        override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 
-    internal class ReactNativeCrash(attributes: TelemetryAttributes) : SchemaType(EmbType.System.ReactNativeCrash) {
-        override val schemaAttributes = attributes.snapshot()
+    public class ReactNativeCrash(attributes: TelemetryAttributes) : SchemaType(EmbType.System.ReactNativeCrash) {
+        override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 
-    internal class NativeCrash(attributes: TelemetryAttributes) : SchemaType(EmbType.System.NativeCrash) {
-        override val schemaAttributes = attributes.snapshot()
+    public class NativeCrash(attributes: TelemetryAttributes) : SchemaType(EmbType.System.NativeCrash) {
+        override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 
-    internal object LowPower : SchemaType(
+    public object LowPower : SchemaType(
         telemetryType = EmbType.System.LowPower,
         fixedObjectName = "device-low-power"
     ) {
-        override val schemaAttributes = emptyMap<String, String>()
+        override val schemaAttributes: Map<String, String> = emptyMap<String, String>()
     }
 
-    internal object Sigquit : SchemaType(
+    public object Sigquit : SchemaType(
         telemetryType = EmbType.System.Sigquit,
         fixedObjectName = "sigquit"
     ) {
-        override val schemaAttributes = emptyMap<String, String>()
+        override val schemaAttributes: Map<String, String> = emptyMap<String, String>()
     }
 
     internal class NetworkCapturedRequest(networkCapturedCall: NetworkCapturedCall) : SchemaType(
         telemetryType = EmbType.System.NetworkCapturedRequest
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "duration" to networkCapturedCall.duration.toString(),
             "end-time" to networkCapturedCall.endTime.toString(),
             "http-method" to networkCapturedCall.httpMethod,
@@ -299,12 +302,12 @@ internal sealed class SchemaType(
         telemetryType = EmbType.System.NetworkStatus,
         fixedObjectName = "network-status"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "network" to networkStatus.value
         ).toNonNullMap()
     }
 
-    internal class WebViewInfo(
+    public class WebViewInfo(
         url: String,
         webVitals: String,
         tag: String?
@@ -312,14 +315,14 @@ internal sealed class SchemaType(
         telemetryType = EmbType.System.WebViewInfo,
         fixedObjectName = "webview-info"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "emb.webview_info.url" to url,
             "emb.webview_info.web_vitals" to webVitals,
             "emb.webview_info.tag" to tag
         ).toNonNullMap()
     }
 
-    internal class ReactNativeAction(
+    public class ReactNativeAction(
         name: String,
         outcome: String,
         payloadSize: Int,
@@ -328,7 +331,7 @@ internal sealed class SchemaType(
         telemetryType = EmbType.System.ReactNativeAction,
         fixedObjectName = "rn-action"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "name" to name,
             "outcome" to outcome,
             "payload_size" to payloadSize.toString(),
@@ -341,22 +344,22 @@ internal sealed class SchemaType(
             .toNonNullMap()
     }
 
-    internal class ThermalState(
+    public class ThermalState(
         status: Int
     ) : SchemaType(
         telemetryType = EmbType.Performance.ThermalState,
         fixedObjectName = "thermal-state"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             "status" to status.toString()
         )
     }
 
-    internal class InternalError(throwable: Throwable) : SchemaType(
+    public class InternalError(throwable: Throwable) : SchemaType(
         telemetryType = EmbType.System.InternalError,
         fixedObjectName = "internal-error"
     ) {
-        override val schemaAttributes = mapOf(
+        override val schemaAttributes: Map<String, String> = mapOf(
             ExceptionIncubatingAttributes.EXCEPTION_TYPE.key to throwable.javaClass.name,
             ExceptionIncubatingAttributes.EXCEPTION_STACKTRACE.key to throwable.stackTrace.joinToString(
                 "\n",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributes.kt
@@ -1,16 +1,17 @@
 package io.embrace.android.embracesdk.arch.schema
 
+import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.config.ConfigService
 import io.embrace.android.embracesdk.internal.spans.toSessionPropertyAttributeName
-import io.embrace.android.embracesdk.session.properties.EmbraceSessionProperties
 import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Object that aggregates various attributes and returns a [Map] that represents the values at the current state
  */
-internal class TelemetryAttributes(
+@InternalApi
+public class TelemetryAttributes(
     private val configService: ConfigService,
-    private val sessionProperties: EmbraceSessionProperties? = null,
+    private val sessionPropertiesProvider: () -> Map<String, String>? = { null },
     private val customAttributes: Map<String, String>? = null
 ) {
     private val map: MutableMap<AttributeKey<String>, String> = mutableMapOf()
@@ -19,7 +20,7 @@ internal class TelemetryAttributes(
      * Return a snapshot of the current values of the attributes set on this as a [Map]. Schema keys will always overwrite any previous
      * entries set on the object.
      */
-    fun snapshot(): Map<String, String> {
+    public fun snapshot(): Map<String, String> {
         val shouldGateLogProperties = configService.sessionBehavior.shouldGateLogProperties()
         val shouldGateSessionProperties = configService.sessionBehavior.shouldGateSessionProperties()
         val result = mutableMapOf<String, String>()
@@ -29,7 +30,7 @@ internal class TelemetryAttributes(
         }
 
         if (!shouldGateSessionProperties) {
-            sessionProperties?.get()?.let { properties ->
+            sessionPropertiesProvider()?.let { properties ->
                 result.putAll(properties.mapKeys { property -> property.key.toSessionPropertyAttributeName() })
             }
         }
@@ -39,15 +40,15 @@ internal class TelemetryAttributes(
         return result
     }
 
-    fun setAttribute(key: EmbraceAttributeKey, value: String) {
+    public fun setAttribute(key: EmbraceAttributeKey, value: String) {
         setAttribute(key.attributeKey, value)
     }
 
-    fun setAttribute(key: AttributeKey<String>, value: String) {
+    public fun setAttribute(key: AttributeKey<String>, value: String) {
         map[key] = value
     }
 
-    fun getAttribute(key: EmbraceAttributeKey): String? = map[key.attributeKey]
+    public fun getAttribute(key: EmbraceAttributeKey): String? = map[key.attributeKey]
 
-    fun getAttribute(key: AttributeKey<String>): String? = map[key]
+    public fun getAttribute(key: AttributeKey<String>): String? = map[key]
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/arch/schema/TelemetryType.kt
@@ -1,10 +1,13 @@
 package io.embrace.android.embracesdk.arch.schema
 
+import io.embrace.android.embracesdk.annotation.InternalApi
+
 /**
  * Represents a telemetry type (emb.type). For example, "ux.view" is a type that represents
  * a visual event around a UI element. ux is the type, and view is the subtype. This tells the
  * backend that it can assume the data in the event follows a particular schema.
  */
-internal interface TelemetryType : FixedAttribute {
-    val sendImmediately: Boolean
+@InternalApi
+public interface TelemetryType : FixedAttribute {
+    public val sendImmediately: Boolean
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/CrashDataSourceImpl.kt
@@ -83,7 +83,7 @@ internal class CrashDataSourceImpl(
             val crashNumber = preferencesService.incrementAndGetCrashNumber()
             val crashAttributes = TelemetryAttributes(
                 configService = configService,
-                sessionProperties = sessionProperties,
+                sessionPropertiesProvider = sessionProperties::get,
             )
 
             val crashException = LegacyExceptionInfo.ofThrowable(exception)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.capture.internal.errors
 
-internal interface InternalErrorHandler {
-    fun handleInternalError(throwable: Throwable)
+import io.embrace.android.embracesdk.annotation.InternalApi
+
+@InternalApi
+public interface InternalErrorHandler {
+    public fun handleInternalError(throwable: Throwable)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorType.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorType.kt
@@ -1,9 +1,12 @@
 package io.embrace.android.embracesdk.capture.internal.errors
 
+import io.embrace.android.embracesdk.annotation.InternalApi
+
 /**
  * Represents a type of internal error that can be recorded for the Embrace SDK's telemetry.
  */
-internal enum class InternalErrorType {
+@InternalApi
+public enum class InternalErrorType {
     UNCAUGHT_EXC_HANDLER,
     ANR_DATA_FETCH,
     UNBALANCED_CALL,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -221,7 +221,7 @@ internal class EmbraceLogService(
     private fun createTelemetryAttributes(customProperties: Map<String, Any>?): TelemetryAttributes {
         val attributes = TelemetryAttributes(
             configService = configService,
-            sessionProperties = sessionProperties,
+            sessionPropertiesProvider = sessionProperties::get,
             customAttributes = customProperties?.mapValues { it.value.toString() } ?: emptyMap()
         )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Attribute.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Attribute.kt
@@ -10,7 +10,7 @@ import com.squareup.moshi.JsonClass
  * @param data The value of the attribute
  */
 @JsonClass(generateAdapter = true)
-internal data class Attribute(
+public data class Attribute(
 
     /* The name of the attribute */
     @Json(name = "key")

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLogger.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLogger.kt
@@ -1,47 +1,50 @@
 package io.embrace.android.embracesdk.logging
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorService
+import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorHandler
 import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 
 /**
  * A simple interface that is used within the Embrace SDK for logging.
  */
-internal interface EmbLogger {
+@InternalApi
+public interface EmbLogger {
 
-    enum class Severity {
+    @InternalApi
+    public enum class Severity {
         DEBUG, INFO, WARNING, ERROR
     }
 
-    var internalErrorService: InternalErrorService?
+    public var internalErrorService: InternalErrorHandler?
 
     /**
      * Logs a debug message with an optional throwable.
      */
-    fun logDebug(msg: String, throwable: Throwable? = null)
+    public fun logDebug(msg: String, throwable: Throwable? = null)
 
     /**
      * Logs an informational message.
      */
-    fun logInfo(msg: String, throwable: Throwable? = null)
+    public fun logInfo(msg: String, throwable: Throwable? = null)
 
     /**
      * Logs a warning message with an optional throwable.
      */
-    fun logWarning(msg: String, throwable: Throwable? = null)
+    public fun logWarning(msg: String, throwable: Throwable? = null)
 
     /**
      * Logs a warning message with an optional error.
      */
-    fun logError(msg: String, throwable: Throwable? = null)
+    public fun logError(msg: String, throwable: Throwable? = null)
 
     /**
      * Logs a warning message that the SDK is not yet initialized for the given action.
      */
-    fun logSdkNotInitialized(action: String)
+    public fun logSdkNotInitialized(action: String)
 
     /**
      * Tracks an internal error. This is sent to our own telemetry so should be used sparingly
      * & only for states that we can take actions to improve.
      */
-    fun trackInternalError(type: InternalErrorType, throwable: Throwable)
+    public fun trackInternalError(type: InternalErrorType, throwable: Throwable)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLoggerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/logging/EmbLoggerImpl.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.logging
 
 import android.util.Log
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorService
+import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorHandler
 import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 import io.embrace.android.embracesdk.logging.EmbLogger.Severity
@@ -14,7 +14,7 @@ internal const val EMBRACE_TAG = "[Embrace]"
  */
 internal class EmbLoggerImpl : EmbLogger {
 
-    override var internalErrorService: InternalErrorService? = null
+    override var internalErrorService: InternalErrorHandler? = null
 
     override fun logDebug(msg: String, throwable: Throwable?) {
         log(msg, Severity.DEBUG, throwable)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSource.kt
@@ -47,7 +47,7 @@ internal class NativeCrashDataSourceImpl(
         val nativeCrashNumber = preferencesService.incrementAndGetNativeCrashNumber()
         val crashAttributes = TelemetryAttributes(
             configService = configService,
-            sessionProperties = sessionProperties
+            sessionPropertiesProvider = sessionProperties::get
         )
         crashAttributes.setAttribute(embSessionId, nativeCrash.sessionId)
         crashAttributes.setAttribute(embCrashNumber, nativeCrashNumber.toString())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/arch/schema/TelemetryAttributesTest.kt
@@ -55,7 +55,7 @@ internal class TelemetryAttributesTest {
     fun `all attributes types`() {
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
-            sessionProperties = sessionProperties,
+            sessionPropertiesProvider = sessionProperties::get,
             customAttributes = customAttributes
         )
         telemetryAttributes.setAttribute(embSessionId, sessionId)
@@ -76,7 +76,7 @@ internal class TelemetryAttributesTest {
         val newSessionId = Uuid.getEmbUuid()
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
-            sessionProperties = sessionProperties
+            sessionPropertiesProvider = sessionProperties::get,
         )
         telemetryAttributes.setAttribute(embSessionId, sessionId)
         telemetryAttributes.setAttribute(embSessionId, newSessionId)
@@ -124,7 +124,7 @@ internal class TelemetryAttributesTest {
 
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
-            sessionProperties = sessionProperties,
+            sessionPropertiesProvider = sessionProperties::get,
             customAttributes = customAttributes
         )
         telemetryAttributes.setAttribute(embSessionId, sessionId)
@@ -152,7 +152,7 @@ internal class TelemetryAttributesTest {
 
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
-            sessionProperties = sessionProperties,
+            sessionPropertiesProvider = sessionProperties::get,
             customAttributes = customAttributes
         )
         telemetryAttributes.setAttribute(embSessionId, sessionId)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorService
+import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorHandler
 import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.logging.EmbLogger
 
@@ -18,7 +18,7 @@ internal class FakeEmbLogger : EmbLogger {
     var sdkNotInitializedMessages: MutableList<LogMessage> = mutableListOf()
     var internalErrorMessages: MutableList<LogMessage> = mutableListOf()
 
-    override var internalErrorService: InternalErrorService? = null
+    override var internalErrorService: InternalErrorHandler? = null
 
     override fun logDebug(msg: String, throwable: Throwable?) {
         debugMessages.add(LogMessage(msg, throwable))


### PR DESCRIPTION
## Goal

Makes classes public & marks them as an `@InternalApi` where the feature module needs to access them. In a future changeset I'll also move these to a package under the `internal` namespace.

