### PR TITLE
Start modularising into core module

### DIFF
--- a/embrace-android-core/api/embrace-android-core.api
+++ b/embrace-android-core/api/embrace-android-core.api
@@ -1,0 +1,97 @@
+public final class io/embrace/android/embracesdk/internal/arch/SessionType : java/lang/Enum {
+	public static final field BACKGROUND Lio/embrace/android/embracesdk/internal/arch/SessionType;
+	public static final field FOREGROUND Lio/embrace/android/embracesdk/internal/arch/SessionType;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/arch/SessionType;
+	public static fun values ()[Lio/embrace/android/embracesdk/internal/arch/SessionType;
+}
+
+public final class io/embrace/android/embracesdk/internal/arch/datasource/NoInputValidationKt {
+	public static final fun getNoInputValidation ()Lkotlin/jvm/functions/Function0;
+}
+
+public abstract interface class io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy {
+	public abstract fun resetDataCaptureLimits ()V
+	public abstract fun shouldCapture ()Z
+}
+
+public final class io/embrace/android/embracesdk/internal/arch/limits/NoopLimitStrategy : io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/internal/arch/limits/NoopLimitStrategy;
+	public fun resetDataCaptureLimits ()V
+	public fun shouldCapture ()Z
+}
+
+public final class io/embrace/android/embracesdk/internal/arch/limits/UpToLimitStrategy : io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun resetDataCaptureLimits ()V
+	public fun shouldCapture ()Z
+}
+
+public abstract interface class io/embrace/android/embracesdk/internal/logging/EmbLogger {
+	public abstract fun getInternalErrorService ()Lio/embrace/android/embracesdk/internal/logging/InternalErrorHandler;
+	public abstract fun logDebug (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun logError (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun logInfo (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun logSdkNotInitialized (Ljava/lang/String;)V
+	public abstract fun logWarning (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun setInternalErrorService (Lio/embrace/android/embracesdk/internal/logging/InternalErrorHandler;)V
+	public abstract fun trackInternalError (Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;Ljava/lang/Throwable;)V
+}
+
+public final class io/embrace/android/embracesdk/internal/logging/EmbLogger$DefaultImpls {
+	public static synthetic fun logDebug$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun logError$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun logInfo$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun logWarning$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+}
+
+public final class io/embrace/android/embracesdk/internal/logging/EmbLogger$Severity : java/lang/Enum {
+	public static final field DEBUG Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
+	public static final field ERROR Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
+	public static final field INFO Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
+	public static final field WARNING Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
+	public static fun values ()[Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
+}
+
+public abstract interface class io/embrace/android/embracesdk/internal/logging/InternalErrorHandler {
+	public abstract fun handleInternalError (Ljava/lang/Throwable;)V
+}
+
+public final class io/embrace/android/embracesdk/internal/logging/InternalErrorType : java/lang/Enum {
+	public static final field ACTIVITY_LISTENER_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field ANR_DATA_FETCH Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field ANR_HEARTBEAT_CHECK_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field ANR_HEARTBEAT_STOP_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field BG_SESSION_CACHE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field CFG_CHANGE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field CONFIG_LISTENER_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field DATA_SOURCE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field DISABLE_DATA_CAPTURE Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field DISK_STAT_CAPTURE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field ENABLE_DATA_CAPTURE Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field END_EVENT_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field FG_SESSION_CACHE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field INVALID_JS_EXCEPTION Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field INVALID_NATIVE_SYMBOLS Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field MEMORY_CLEAN_LISTENER_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field NATIVE_CRASH_LOAD_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field NATIVE_HANDLER_INSTALL_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field NATIVE_THREAD_SAMPLE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field NETWORK_STATUS_CAPTURE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field PROCESS_STATE_CALLBACK_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field PROCESS_STATE_SUMMARY_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field SAFE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field SCREEN_RES_CAPTURE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field SESSION_CHANGE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field START_EVENT_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field TIME_TRAVEL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field UNBALANCED_BG_CALL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field UNBALANCED_CALL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field UNBALANCED_FG_CALL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field UNCAUGHT_EXC_HANDLER Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field USER_LOAD_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static final field WEB_VITAL_PARSE_FAIL Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+	public static fun values ()[Lio/embrace/android/embracesdk/internal/logging/InternalErrorType;
+}
+

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/SessionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/SessionType.kt
@@ -1,12 +1,9 @@
 package io.embrace.android.embracesdk.internal.arch
 
-import io.embrace.android.embracesdk.annotation.InternalApi
-
 /**
  * The type of session that contains the data. Currently this is either a session (foreground)
  * or a background activity (background).
  */
-@InternalApi
 public enum class SessionType {
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/NoInputValidation.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/NoInputValidation.kt
@@ -1,10 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
-import io.embrace.android.embracesdk.annotation.InternalApi
-
 /**
  * Syntactic sugar for when no input validation is required. Developers must explicitly state
  * this is the case.
  */
-@InternalApi
 public val NoInputValidation: () -> Boolean = { true }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy.kt
@@ -1,11 +1,8 @@
 package io.embrace.android.embracesdk.internal.arch.limits
 
-import io.embrace.android.embracesdk.annotation.InternalApi
-
 /**
  * Defines a strategy for limiting the capture of data in a [DataSource].
  */
-@InternalApi
 public interface LimitStrategy {
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/limits/NoopLimitStrategy.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/limits/NoopLimitStrategy.kt
@@ -1,11 +1,8 @@
 package io.embrace.android.embracesdk.internal.arch.limits
 
-import io.embrace.android.embracesdk.annotation.InternalApi
-
 /**
  * This class captures whatever the hell it wants, whenever it wants
  */
-@InternalApi
 public object NoopLimitStrategy : LimitStrategy {
 
     override fun shouldCapture(): Boolean = true

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/limits/UpToLimitStrategy.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/limits/UpToLimitStrategy.kt
@@ -1,12 +1,10 @@
 package io.embrace.android.embracesdk.internal.arch.limits
 
-import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Allows capturing data up until a limit, then stops capturing.
  */
-@InternalApi
 public class UpToLimitStrategy(
     private val limitProvider: Provider<Int>,
 ) : LimitStrategy {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLogger.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLogger.kt
@@ -1,16 +1,10 @@
 package io.embrace.android.embracesdk.internal.logging
 
-import io.embrace.android.embracesdk.annotation.InternalApi
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorHandler
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
-
 /**
  * A simple interface that is used within the Embrace SDK for logging.
  */
-@InternalApi
 public interface EmbLogger {
 
-    @InternalApi
     public enum class Severity {
         DEBUG, INFO, WARNING, ERROR
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorHandler.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorHandler.kt
@@ -1,0 +1,5 @@
+package io.embrace.android.embracesdk.internal.logging
+
+public interface InternalErrorHandler {
+    public fun handleInternalError(throwable: Throwable)
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -1,11 +1,8 @@
-package io.embrace.android.embracesdk.capture.internal.errors
-
-import io.embrace.android.embracesdk.annotation.InternalApi
+package io.embrace.android.embracesdk.internal.logging
 
 /**
  * Represents a type of internal error that can be recorded for the Embrace SDK's telemetry.
  */
-@InternalApi
 public enum class InternalErrorType {
     UNCAUGHT_EXC_HANDLER,
     ANR_DATA_FETCH,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/Provider.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/Provider.kt
@@ -1,0 +1,6 @@
+package io.embrace.android.embracesdk.internal.utils
+
+/**
+ * Function that returns an instance of T meant to represent a provider/supplier that does not require any input parameters
+ */
+public typealias Provider<T> = () -> T

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -200,48 +200,6 @@ public abstract interface annotation class io/embrace/android/embracesdk/annotat
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/StartupActivity : java/lang/annotation/Annotation {
 }
 
-public abstract interface class io/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler {
-	public abstract fun handleInternalError (Ljava/lang/Throwable;)V
-}
-
-public final class io/embrace/android/embracesdk/capture/internal/errors/InternalErrorType : java/lang/Enum {
-	public static final field ACTIVITY_LISTENER_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field ANR_DATA_FETCH Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field ANR_HEARTBEAT_CHECK_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field ANR_HEARTBEAT_STOP_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field BG_SESSION_CACHE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field CFG_CHANGE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field CONFIG_LISTENER_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field DATA_SOURCE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field DISABLE_DATA_CAPTURE Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field DISK_STAT_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field ENABLE_DATA_CAPTURE Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field END_EVENT_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field FG_SESSION_CACHE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field INVALID_JS_EXCEPTION Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field INVALID_NATIVE_SYMBOLS Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field MEMORY_CLEAN_LISTENER_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field NATIVE_CRASH_LOAD_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field NATIVE_HANDLER_INSTALL_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field NATIVE_THREAD_SAMPLE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field NETWORK_STATUS_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field PROCESS_STATE_CALLBACK_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field PROCESS_STATE_SUMMARY_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field SAFE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field SCREEN_RES_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field SESSION_CHANGE_DATA_CAPTURE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field START_EVENT_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field TIME_TRAVEL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field UNBALANCED_BG_CALL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field UNBALANCED_CALL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field UNBALANCED_FG_CALL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field UNCAUGHT_EXC_HANDLER Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field USER_LOAD_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static final field WEB_VITAL_PARSE_FAIL Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-	public static fun values ()[Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;
-}
-
 public abstract interface class io/embrace/android/embracesdk/internal/EmbraceInternalInterface : io/embrace/android/embracesdk/internal/InternalTracingApi {
 	public abstract fun getSdkCurrentTime ()J
 	public abstract fun isAnrCaptureEnabled ()Z
@@ -399,13 +357,6 @@ public abstract interface class io/embrace/android/embracesdk/internal/arch/Embr
 	public abstract fun add (Lio/embrace/android/embracesdk/internal/arch/datasource/DataSourceState;)V
 }
 
-public final class io/embrace/android/embracesdk/internal/arch/SessionType : java/lang/Enum {
-	public static final field BACKGROUND Lio/embrace/android/embracesdk/internal/arch/SessionType;
-	public static final field FOREGROUND Lio/embrace/android/embracesdk/internal/arch/SessionType;
-	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/arch/SessionType;
-	public static fun values ()[Lio/embrace/android/embracesdk/internal/arch/SessionType;
-}
-
 public abstract interface class io/embrace/android/embracesdk/internal/arch/datasource/DataSource {
 	public abstract fun captureData (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Z
 	public abstract fun disableDataCapture ()V
@@ -430,10 +381,6 @@ public final class io/embrace/android/embracesdk/internal/arch/datasource/DataSo
 	public final fun getDataSource ()Lio/embrace/android/embracesdk/internal/arch/datasource/DataSource;
 	public final fun onConfigChange ()V
 	public final fun setCurrentSessionType (Lio/embrace/android/embracesdk/internal/arch/SessionType;)V
-}
-
-public final class io/embrace/android/embracesdk/internal/arch/datasource/NoInputValidationKt {
-	public static final fun getNoInputValidation ()Lkotlin/jvm/functions/Function0;
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/arch/destination/LogWriter {
@@ -462,23 +409,6 @@ public final class io/embrace/android/embracesdk/internal/arch/destination/SpanA
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy {
-	public abstract fun resetDataCaptureLimits ()V
-	public abstract fun shouldCapture ()Z
-}
-
-public final class io/embrace/android/embracesdk/internal/arch/limits/NoopLimitStrategy : io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy {
-	public static final field INSTANCE Lio/embrace/android/embracesdk/internal/arch/limits/NoopLimitStrategy;
-	public fun resetDataCaptureLimits ()V
-	public fun shouldCapture ()Z
-}
-
-public final class io/embrace/android/embracesdk/internal/arch/limits/UpToLimitStrategy : io/embrace/android/embracesdk/internal/arch/limits/LimitStrategy {
-	public fun <init> (Lkotlin/jvm/functions/Function0;)V
-	public fun resetDataCaptureLimits ()V
-	public fun shouldCapture ()Z
 }
 
 public abstract class io/embrace/android/embracesdk/internal/arch/schema/EmbType : io/embrace/android/embracesdk/internal/arch/schema/TelemetryType {
@@ -1014,33 +944,6 @@ public final class io/embrace/android/embracesdk/internal/config/remote/Unwinder
 	public static final field LIBUNWINDSTACK Lio/embrace/android/embracesdk/internal/config/remote/Unwinder;
 	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/config/remote/Unwinder;
 	public static fun values ()[Lio/embrace/android/embracesdk/internal/config/remote/Unwinder;
-}
-
-public abstract interface class io/embrace/android/embracesdk/internal/logging/EmbLogger {
-	public abstract fun getInternalErrorService ()Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler;
-	public abstract fun logDebug (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public abstract fun logError (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public abstract fun logInfo (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public abstract fun logSdkNotInitialized (Ljava/lang/String;)V
-	public abstract fun logWarning (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public abstract fun setInternalErrorService (Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler;)V
-	public abstract fun trackInternalError (Lio/embrace/android/embracesdk/capture/internal/errors/InternalErrorType;Ljava/lang/Throwable;)V
-}
-
-public final class io/embrace/android/embracesdk/internal/logging/EmbLogger$DefaultImpls {
-	public static synthetic fun logDebug$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
-	public static synthetic fun logError$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
-	public static synthetic fun logInfo$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
-	public static synthetic fun logWarning$default (Lio/embrace/android/embracesdk/internal/logging/EmbLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
-}
-
-public final class io/embrace/android/embracesdk/internal/logging/EmbLogger$Severity : java/lang/Enum {
-	public static final field DEBUG Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
-	public static final field ERROR Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
-	public static final field INFO Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
-	public static final field WARNING Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
-	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
-	public static fun values ()[Lio/embrace/android/embracesdk/internal/logging/EmbLogger$Severity;
 }
 
 public class io/embrace/android/embracesdk/internal/network/http/EmbraceHttpPathOverride {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.opentelemetry.EmbSpan
 import io.embrace.android.embracesdk.opentelemetry.EmbSpanBuilder
 import io.embrace.android.embracesdk.opentelemetry.EmbTracer
 import io.embrace.android.embracesdk.recordSession
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
 import io.embrace.android.embracesdk.payload.TapBreadcrumb.TapBreadcrumbType;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/EmbraceAnrService.kt
@@ -5,11 +5,11 @@ import androidx.annotation.VisibleForTesting
 import io.embrace.android.embracesdk.anr.detection.LivenessCheckScheduler
 import io.embrace.android.embracesdk.anr.detection.ThreadMonitoringState
 import io.embrace.android.embracesdk.anr.detection.UnbalancedCallDetector
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.enforceThread
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.payload.AnrInterval
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.lifecycle.ProcessStateListener

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/LivenessCheckScheduler.kt
@@ -2,11 +2,11 @@ package io.embrace.android.embracesdk.anr.detection
 
 import android.os.Message
 import io.embrace.android.embracesdk.anr.detection.TargetThreadHandler.Companion.HEARTBEAT_REQUEST
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.enforceThread
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/anr/detection/UnbalancedCallDetector.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.anr.detection
 
 import io.embrace.android.embracesdk.anr.BlockedThreadListener
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 
 internal class UnbalancedCallDetector(
     private val logger: EmbLogger

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/aei/AeiDataSourceImpl.kt
@@ -5,7 +5,6 @@ import android.app.ApplicationExitInfo
 import android.os.Build.VERSION_CODES
 import androidx.annotation.RequiresApi
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.arch.datasource.LogDataSourceImpl
 import io.embrace.android.embracesdk.internal.arch.datasource.NoInputValidation
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
@@ -13,6 +12,7 @@ import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.config.behavior.AppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.utils.toUTF8String

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -5,11 +5,11 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.injection.DataSourceModule
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.net.Inet4Address

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/crash/EmbraceUncaughtExceptionHandler.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.capture.crash
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 
 /**
  * Intercepts uncaught exceptions from the JVM and forwards them to the Embrace API. Once handled,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/envelope/resource/Device.kt
@@ -6,9 +6,9 @@ import android.os.StatFs
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import io.embrace.android.embracesdk.capture.cpu.CpuInfoDelegate
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.prefs.PreferencesService
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import java.io.File

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorDataSource.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorDataSource.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.capture.internal.errors
 
 import io.embrace.android.embracesdk.internal.arch.datasource.LogDataSource
+import io.embrace.android.embracesdk.internal.logging.InternalErrorHandler
 
 internal interface InternalErrorDataSource : LogDataSource, InternalErrorHandler

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorHandler.kt
@@ -1,8 +1,0 @@
-package io.embrace.android.embracesdk.capture.internal.errors
-
-import io.embrace.android.embracesdk.annotation.InternalApi
-
-@InternalApi
-public interface InternalErrorHandler {
-    public fun handleInternalError(throwable: Throwable)
-}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/internal/errors/InternalErrorService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.capture.internal.errors
 
+import io.embrace.android.embracesdk.internal.logging.InternalErrorHandler
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/metadata/EmbraceMetadataService.kt
@@ -13,13 +13,13 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import io.embrace.android.embracesdk.BuildConfig
 import io.embrace.android.embracesdk.capture.cpu.CpuInfoDelegate
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.payload.AppInfo
 import io.embrace.android.embracesdk.payload.DeviceInfo

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/user/EmbraceUserService.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.capture.user
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.payload.UserInfo
 import io.embrace.android.embracesdk.payload.UserInfo.Companion.ofStored

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/EmbraceWebViewService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/capture/webview/EmbraceWebViewService.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.capture.webview
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.injection.DataSourceModule
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.payload.WebViewInfo

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/event/EmbraceEventService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.event
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.delivery.DeliveryService
@@ -9,6 +8,7 @@ import io.embrace.android.embracesdk.internal.StartupEventInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.session.id.SessionIdTracker

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapper.kt
@@ -2,11 +2,11 @@ package io.embrace.android.embracesdk.injection
 
 import android.content.Context
 import io.embrace.android.embracesdk.anr.ndk.isUnityMainThread
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.network.http.HttpUrlConnectionTracker.registerFactory
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.utils.AndroidServicesModuleSupplier

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestrator.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.internal.arch
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.worker.BackgroundWorker
 import io.embrace.android.embracesdk.worker.TaskPriority
 import java.util.concurrent.CopyOnWriteArrayList

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 
 /**
  * Base class for data sources.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.config
 
 import io.embrace.android.embracesdk.Embrace
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.behavior.AnrBehavior
@@ -36,6 +35,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehav
 import io.embrace.android.embracesdk.internal.config.local.LocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.prefs.PreferencesService

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logging/EmbLoggerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/logging/EmbLoggerImpl.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.logging
 
 import android.util.Log
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorHandler
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.ApkToolsConfig
 
 internal const val EMBRACE_TAG = "[Embrace]"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/utils/Types.kt
@@ -233,8 +233,3 @@ internal typealias PayloadModuleSupplier = (
     sessionPropertiesServiceProvider: Provider<SessionPropertiesService>,
     webViewServiceProvider: Provider<WebViewService>,
 ) -> PayloadModule
-
-/**
- * Function that returns an instance of T meant to represent a provider/supplier that does not require any input parameters
- */
-internal typealias Provider<T> = () -> T

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ndk/EmbraceNdkService.kt
@@ -7,7 +7,6 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Base64
 import io.embrace.android.embracesdk.EventType
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.capture.user.UserService
 import io.embrace.android.embracesdk.comms.api.ApiClient
@@ -19,6 +18,7 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/EmbraceMemoryCleanerService.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.utils.stream
 import java.util.concurrent.CopyOnWriteArrayList
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/SafeCaptureExtension.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.session
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicBackgroundActivityCacher.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.session.caching
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.utils.Provider

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/caching/PeriodicSessionCacher.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.session.caching
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.utils.Provider

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/id/SessionIdTrackerImpl.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.session.id
 
 import android.app.ActivityManager
 import android.os.Build
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.ndk.NdkService
 
 internal class SessionIdTrackerImpl(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/ActivityLifecycleTracker.kt
@@ -4,8 +4,8 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import io.embrace.android.embracesdk.annotation.StartupActivity
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.utils.stream
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/session/lifecycle/EmbraceProcessStateService.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.utils.ThreadUtils
 import io.embrace.android.embracesdk.utils.stream

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorHandler
-import io.embrace.android.embracesdk.capture.internal.errors.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorHandler
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 
 internal class FakeEmbLogger : EmbLogger {
 


### PR DESCRIPTION
## Goal

Starts the modularisation effort by moving several architecture related classes into the `embrace-android-core` module.

## Testing

Relied on existing test coverage.
