### PR TITLE
Remove otel dep in core module

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -7,12 +7,3 @@ description = "Embrace Android SDK: Core"
 android {
     namespace = "io.embrace.android.embracesdk.core"
 }
-
-dependencies {
-    compileOnly(platform(libs.opentelemetry.bom))
-    compileOnly(libs.opentelemetry.api)
-    compileOnly(libs.opentelemetry.sdk)
-    compileOnly(libs.opentelemetry.context)
-    compileOnly(libs.opentelemetry.semconv)
-    compileOnly(libs.opentelemetry.semconv.incubating)
-}


### PR DESCRIPTION
## Goal

Removes the OTel dependency in the core module. After discussion our aim is to keep this module free of dependencies such as OTel/Moshi & confine these to other modules.

