### PR TITLE
Enable build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ android.experimental.enableArtProfiles=true
 
 # Disable buildconfig generation by default. This can be overridden on a per-module basis
 android.defaults.buildfeatures.buildconfig = false
+
+org.gradle.caching=true


### PR DESCRIPTION
## Goal

Enables the [gradle build cache](https://docs.gradle.org/current/userguide/build_cache.html), which promises faster builds. We can see what effect this has on performance when developing locally.

Right now enabling configuration cache won't do anything for us because we use kapt, but once we migrate Kotlin there should be some local perf benefits from enabling that.

## Testing

Relying on CI.

