### PR TITLE
Use latest action for gradle wrapper validation

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -76,7 +76,7 @@ jobs:
           ln -sfn $ANDROID_SDK_ROOT/ndk/${{ matrix.ndk-version }} $ANDROID_NDK_ROOT
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Generate SDK RC - Publish and close Sonatype repository
         run: |

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: ${{ matrix.jdk-version }}
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       # Build the entire project, run the tests, and run all static analysis
       - name: Gradle Build

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -65,7 +65,7 @@ jobs:
           java-version: ${{ matrix.jdk-version }}
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Run Functional Tests
         uses: embrace-io/android-emulator-runner@v2

--- a/.github/workflows/generate_baseline_profile.yml
+++ b/.github/workflows/generate_baseline_profile.yml
@@ -65,7 +65,7 @@ jobs:
           ./gradlew cleanManagedDevices --unused-only  
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Generate Baseline Profile
         run: |

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -58,7 +58,7 @@ jobs:
           ln -sfn $ANDROID_SDK_ROOT/ndk/${{ matrix.ndk-version }} $ANDROID_NDK_ROOT
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       # Build the entire project, run the tests, and run all static analysis
       - name: Gradle Build

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -43,7 +43,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Gradlew Release SDK to Maven Central
         run: |
@@ -84,7 +84,7 @@ jobs:
           token: ${{ secrets.CD_GITHUB_TOKEN }}
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Gradlew Release Swazzler to Maven Central
         run: |


### PR DESCRIPTION
## Goal

Use a non-deprecated action for validating our gradle wrapper: https://github.com/gradle/wrapper-validation-action/releases

