### PR TITLE
Enable configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,6 @@ android.experimental.enableArtProfiles=true
 android.defaults.buildfeatures.buildconfig = false
 
 org.gradle.caching=true
+
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=fail


### PR DESCRIPTION
## Goal

Enables Gradle's [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache) now that #1118 addresses the last remaining problems. This should allow substantial speed improvements when developing locally.

