### PR TITLE
Rename methods in ActivityLifecycleListenerInterface to match lifecycle methods

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleListener.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleListener.kt
@@ -13,14 +13,14 @@ public interface ActivityLifecycleListener {
      *
      * @param activity details of the activity
      */
-    public fun onView(activity: Activity) {}
+    public fun onActivityStarted(activity: Activity) {}
 
     /**
      * Triggered when an activity is closed.
      *
      * @param activity details of the activity
      */
-    public fun onViewClose(activity: Activity) {}
+    public fun onActivityStopped(activity: Activity) {}
 
     /**
      * Triggered when an activity is created.

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/crumbs/EmbraceBreadcrumbService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/crumbs/EmbraceBreadcrumbService.kt
@@ -96,7 +96,7 @@ internal class EmbraceBreadcrumbService(
         }
     }
 
-    override fun onView(activity: Activity) {
+    override fun onActivityStarted(activity: Activity) {
         if (configService.breadcrumbBehavior.isAutomaticActivityCaptureEnabled()) {
             logView(activity.javaClass.name, clock.now())
         }
@@ -105,7 +105,7 @@ internal class EmbraceBreadcrumbService(
     /**
      * Close all open fragments when the activity closes
      */
-    override fun onViewClose(activity: Activity) {
+    override fun onActivityStopped(activity: Activity) {
         if (configService.breadcrumbBehavior.isAutomaticActivityCaptureEnabled()) {
             dataSourceModuleProvider()?.viewDataSource?.dataSource?.onViewClose()
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleTracker.kt
@@ -77,7 +77,7 @@ internal class ActivityLifecycleTracker(
         updateStateWithActivity(activity)
         stream(listeners) { listener: ActivityLifecycleListener ->
             try {
-                listener.onView(activity)
+                listener.onActivityStarted(activity)
             } catch (ex: Exception) {
                 logger.logWarning(ERROR_FAILED_TO_NOTIFY)
                 logger.trackInternalError(InternalErrorType.ACTIVITY_LISTENER_FAIL, ex)
@@ -104,7 +104,7 @@ internal class ActivityLifecycleTracker(
     override fun onActivityStopped(activity: Activity) {
         stream(listeners) { listener: ActivityLifecycleListener ->
             try {
-                listener.onViewClose(activity)
+                listener.onActivityStopped(activity)
             } catch (ex: Exception) {
                 logger.logWarning(ERROR_FAILED_TO_NOTIFY)
                 logger.trackInternalError(InternalErrorType.ACTIVITY_LISTENER_FAIL, ex)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ActivityLifecycleTrackerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/ActivityLifecycleTrackerTest.kt
@@ -121,7 +121,7 @@ internal class ActivityLifecycleTrackerTest {
 
         activityLifecycleTracker.onActivityStarted(mockActivity)
 
-        verify { mockActivityLifecycleListener.onView(mockActivity) }
+        verify { mockActivityLifecycleListener.onActivityStarted(mockActivity) }
         assertEquals(mockActivity, activityLifecycleTracker.foregroundActivity)
     }
 
@@ -153,7 +153,7 @@ internal class ActivityLifecycleTrackerTest {
 
         activityLifecycleTracker.onActivityStopped(mockActivity)
 
-        verify { mockActivityLifecycleListener.onViewClose(mockActivity) }
+        verify { mockActivityLifecycleListener.onActivityStopped(mockActivity) }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Remove the bespoke names and use names that match the lifecycle method that the methods actually map to. This will enable  future changes to be more understandable.