### PR TITLE
Make ActivityLifecycleListener extend ActivityLifecycleCallacks with no-op defaults

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleListener.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleListener.kt
@@ -1,32 +1,25 @@
 package io.embrace.android.embracesdk.internal.session.lifecycle
 
 import android.app.Activity
+import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 
 /**
- * Listener implemented by observers of the [ActivityLifecycleTracker].
+ * Implementation of [ActivityLifecycleCallbacks] with no-op defaults
  */
-public interface ActivityLifecycleListener {
+public interface ActivityLifecycleListener : ActivityLifecycleCallbacks {
 
-    /**
-     * Triggered when an activity is opened.
-     *
-     * @param activity details of the activity
-     */
-    public fun onActivityStarted(activity: Activity) {}
+    override public fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
 
-    /**
-     * Triggered when an activity is closed.
-     *
-     * @param activity details of the activity
-     */
-    public fun onActivityStopped(activity: Activity) {}
+    override public fun onActivityStarted(activity: Activity) {}
 
-    /**
-     * Triggered when an activity is created.
-     *
-     * @param activity the activity
-     * @param bundle   the bundle
-     */
-    public fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
+    override public fun onActivityResumed(activity: Activity) {}
+
+    override public fun onActivityPaused(activity: Activity) {}
+
+    override public fun onActivityStopped(activity: Activity) {}
+
+    override public fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+    override public fun onActivityDestroyed(activity: Activity) {}
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleListener.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleListener.kt
@@ -9,17 +9,17 @@ import android.os.Bundle
  */
 public interface ActivityLifecycleListener : ActivityLifecycleCallbacks {
 
-    override public fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
+    public override fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
 
-    override public fun onActivityStarted(activity: Activity) {}
+    public override fun onActivityStarted(activity: Activity) {}
 
-    override public fun onActivityResumed(activity: Activity) {}
+    public override fun onActivityResumed(activity: Activity) {}
 
-    override public fun onActivityPaused(activity: Activity) {}
+    public override fun onActivityPaused(activity: Activity) {}
 
-    override public fun onActivityStopped(activity: Activity) {}
+    public override fun onActivityStopped(activity: Activity) {}
 
-    override public fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+    public override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
 
-    override public fun onActivityDestroyed(activity: Activity) {}
+    public override fun onActivityDestroyed(activity: Activity) {}
 }


### PR DESCRIPTION
## Goal

Make the listener implement `ActivityLifecycleCallbacks` with default no-op implementations so we can observe more lifecycle events.
