### PR TITLE
 Don't enforce span name length limit for spans the SDK logs

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -238,7 +238,7 @@ internal class EmbraceSpanImpl(
     }
 
     override fun updateName(newName: String): Boolean {
-        if (newName.isValidName()) {
+        if (newName.isValidName(spanBuilder.internal)) {
             synchronized(startedSpan) {
                 if (!spanStarted() || isRecording) {
                     updatedName = newName
@@ -333,6 +333,6 @@ internal class EmbraceSpanImpl(
         internal fun attributeValid(key: String, value: String) =
             key.length <= MAX_CUSTOM_ATTRIBUTE_KEY_LENGTH && value.length <= MAX_CUSTOM_ATTRIBUTE_VALUE_LENGTH
 
-        internal fun String.isValidName(): Boolean = isNotBlank() && (length <= MAX_NAME_LENGTH)
+        internal fun String.isValidName(internal: Boolean): Boolean = isNotBlank() && (internal || length <= MAX_NAME_LENGTH)
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_CUSTOM
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_KEY_LENGTH
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_VALUE_LENGTH
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_CUSTOM_EVENT_COUNT
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_INTERNAL_NAME_LENGTH
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_NAME_LENGTH
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_TOTAL_EVENT_COUNT
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
@@ -333,6 +334,7 @@ internal class EmbraceSpanImpl(
         internal fun attributeValid(key: String, value: String) =
             key.length <= MAX_CUSTOM_ATTRIBUTE_KEY_LENGTH && value.length <= MAX_CUSTOM_ATTRIBUTE_VALUE_LENGTH
 
-        internal fun String.isValidName(internal: Boolean): Boolean = isNotBlank() && (internal || length <= MAX_NAME_LENGTH)
+        internal fun String.isValidName(internal: Boolean): Boolean =
+            isNotBlank() && ((internal && length <= MAX_INTERNAL_NAME_LENGTH) || length <= MAX_NAME_LENGTH)
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanLimits.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanLimits.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 object EmbraceSpanLimits {
+    const val MAX_INTERNAL_NAME_LENGTH: Int = 2000
     const val MAX_NAME_LENGTH: Int = 50
     const val MAX_CUSTOM_EVENT_COUNT: Int = 10
     const val MAX_TOTAL_EVENT_COUNT: Int = 11000

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -34,7 +34,7 @@ internal class SpanServiceImpl(
         internal: Boolean,
         private: Boolean
     ): PersistableEmbraceSpan? {
-        return if (inputsValid(name) && currentSessionSpan.canStartNewSpan(parent, internal)) {
+        return if (inputsValid(name, internal) && currentSessionSpan.canStartNewSpan(parent, internal)) {
             embraceSpanFactory.create(
                 name = name,
                 type = type,
@@ -49,7 +49,7 @@ internal class SpanServiceImpl(
 
     override fun createSpan(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan? {
         return if (
-            inputsValid(embraceSpanBuilder.spanName) &&
+            inputsValid(embraceSpanBuilder.spanName, embraceSpanBuilder.internal) &&
             currentSessionSpan.canStartNewSpan(embraceSpanBuilder.getParentSpan(), embraceSpanBuilder.internal)
         ) {
             embraceSpanFactory.create(embraceSpanBuilder)
@@ -110,7 +110,7 @@ internal class SpanServiceImpl(
             return false
         }
 
-        if (inputsValid(name, events, attributes) && currentSessionSpan.canStartNewSpan(parent, internal)) {
+        if (inputsValid(name, internal, events, attributes) && currentSessionSpan.canStartNewSpan(parent, internal)) {
             val newSpan = embraceSpanFactory.create(name = name, type = type, internal = internal, private = private, parent = parent)
             if (newSpan.start(startTimeMs)) {
                 attributes.forEach {
@@ -130,10 +130,11 @@ internal class SpanServiceImpl(
 
     private fun inputsValid(
         name: String,
+        internal: Boolean,
         events: List<EmbraceSpanEvent>? = null,
         attributes: Map<String, String>? = null
     ): Boolean {
-        return name.isValidName() &&
+        return (name.isValidName(internal)) &&
             ((events == null) || (events.size <= EmbraceSpanLimits.MAX_CUSTOM_EVENT_COUNT)) &&
             ((attributes == null) || (attributes.size <= EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_COUNT))
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -473,14 +473,14 @@ internal class SpanServiceImplTest {
     }
 
     @Test
-    fun `check name length limit`() {
-        assertNull(spansService.createSpan(name = TOO_LONG_SPAN_NAME))
-        assertFalse(spansService.recordCompletedSpan(name = TOO_LONG_SPAN_NAME, startTimeMs = 100L, endTimeMs = 200L))
-        assertNotNull(spansService.recordSpan(name = TOO_LONG_SPAN_NAME) { 1 })
+    fun `check name length limit for non-internal spans`() {
+        assertNull(spansService.createSpan(name = TOO_LONG_SPAN_NAME, internal = false))
+        assertFalse(spansService.recordCompletedSpan(name = TOO_LONG_SPAN_NAME, startTimeMs = 100L, endTimeMs = 200L, internal = false))
+        assertNotNull(spansService.recordSpan(name = TOO_LONG_SPAN_NAME, internal = false) { 1 })
         assertEquals(0, spanSink.completedSpans().size)
-        assertNotNull(spansService.createSpan(name = MAX_LENGTH_SPAN_NAME))
-        assertNotNull(spansService.recordSpan(name = MAX_LENGTH_SPAN_NAME) { 2 })
-        assertTrue(spansService.recordCompletedSpan(name = MAX_LENGTH_SPAN_NAME, startTimeMs = 100L, endTimeMs = 200L))
+        assertNotNull(spansService.createSpan(name = MAX_LENGTH_SPAN_NAME, internal = false))
+        assertNotNull(spansService.recordSpan(name = MAX_LENGTH_SPAN_NAME, internal = false) { 2 })
+        assertTrue(spansService.recordCompletedSpan(name = MAX_LENGTH_SPAN_NAME, startTimeMs = 100L, endTimeMs = 200L, internal = false))
         assertEquals(2, spanSink.completedSpans().size)
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -10,9 +10,11 @@ import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_INTERNAL_SPAN_NAME
 import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_SPAN_NAME
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
+import io.embrace.android.embracesdk.fixtures.TOO_LONG_INTERNAL_SPAN_NAME
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_SPAN_NAME
 import io.embrace.android.embracesdk.fixtures.maxSizeAttributes
 import io.embrace.android.embracesdk.fixtures.maxSizeEvents
@@ -481,6 +483,32 @@ internal class SpanServiceImplTest {
         assertNotNull(spansService.createSpan(name = MAX_LENGTH_SPAN_NAME, internal = false))
         assertNotNull(spansService.recordSpan(name = MAX_LENGTH_SPAN_NAME, internal = false) { 2 })
         assertTrue(spansService.recordCompletedSpan(name = MAX_LENGTH_SPAN_NAME, startTimeMs = 100L, endTimeMs = 200L, internal = false))
+        assertEquals(2, spanSink.completedSpans().size)
+    }
+
+    @Test
+    fun `check name length limit for spans by internally by the SDK`() {
+        assertNull(spansService.createSpan(name = TOO_LONG_INTERNAL_SPAN_NAME, internal = true))
+        assertFalse(
+            spansService.recordCompletedSpan(
+                name = TOO_LONG_INTERNAL_SPAN_NAME,
+                startTimeMs = 100L,
+                endTimeMs = 200L,
+                internal = true
+            )
+        )
+        assertNotNull(spansService.recordSpan(name = TOO_LONG_INTERNAL_SPAN_NAME, internal = true) { 1 })
+        assertEquals(0, spanSink.completedSpans().size)
+        assertNotNull(spansService.createSpan(name = MAX_LENGTH_INTERNAL_SPAN_NAME, internal = true))
+        assertNotNull(spansService.recordSpan(name = MAX_LENGTH_INTERNAL_SPAN_NAME, internal = true) { 2 })
+        assertTrue(
+            spansService.recordCompletedSpan(
+                name = MAX_LENGTH_INTERNAL_SPAN_NAME,
+                startTimeMs = 100L,
+                endTimeMs = 200L,
+                internal = true
+            )
+        )
         assertEquals(2, spanSink.completedSpans().size)
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -77,6 +77,8 @@ private const val MAX_EVENT_ATTRIBUTE_COUNT = 10
 
 val MAX_LENGTH_SPAN_NAME: String = "s".repeat(EmbraceSpanLimits.MAX_NAME_LENGTH)
 val TOO_LONG_SPAN_NAME: String = "s".repeat(EmbraceSpanLimits.MAX_NAME_LENGTH + 1)
+val MAX_LENGTH_INTERNAL_SPAN_NAME: String = "s".repeat(EmbraceSpanLimits.MAX_INTERNAL_NAME_LENGTH)
+val TOO_LONG_INTERNAL_SPAN_NAME: String = "s".repeat(EmbraceSpanLimits.MAX_INTERNAL_NAME_LENGTH + 1)
 val MAX_LENGTH_EVENT_NAME: String = "s".repeat(MAX_EVENT_NAME_LENGTH)
 val TOO_LONG_EVENT_NAME: String = "s".repeat(MAX_EVENT_NAME_LENGTH + 1)
 val MAX_LENGTH_ATTRIBUTE_KEY: String = "s".repeat(EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_KEY_LENGTH)


### PR DESCRIPTION
## Goal

Names of spans we record internally can be longer than than the custom performance traces that we have a name length restriction for. Make the validate not apply to spans logged by the SDK, i.e. internal = true.


