### PR TITLE
Add linker flag to make library compatible with 16 kb page sizes.

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -17,7 +17,7 @@ object Versions {
     // kotlin 1.9 required before any further upgrades
     const val DETEKT = "1.23.6"
 
-    const val NDK = "21.4.7075529"
+    const val NDK = "22.1.7171670"
     const val MOCKK = "1.12.2"
     const val ANDROIDX_TEST = "1.4.0"
     const val ANDROIDX_JUNIT = "1.1.3"

--- a/embrace-android-sdk/src/main/cpp/CMakeLists.txt
+++ b/embrace-android-sdk/src/main/cpp/CMakeLists.txt
@@ -84,6 +84,7 @@ set_target_properties(embrace-native
 
 add_subdirectory(3rdparty/libunwindstack-ndk/cmake)
 target_link_libraries(embrace-native unwindstack)
+target_link_options(embrace-native PRIVATE "-Wl,-z,max-page-size=16384")
 if (${ANDROID_ABI} STREQUAL "armeabi" OR ${ANDROID_ABI} STREQUAL "armeabi-v7a")
     add_library(libunwind STATIC IMPORTED)
     set_target_properties(libunwind PROPERTIES IMPORTED_LOCATION


### PR DESCRIPTION
Adding this allows our library to work on devices with a 16kb memory page size. 

If we don't do this, even if the customer has ndk_enabled set to false, the app will crash with a SIGSEGV when we try to load the native library.

This was done following the steps here: https://developer.android.com/guide/practices/page-sizes

I verified the correct alignment of the test apk after the changes using the alignment script here: https://developer.android.com/guide/practices/page-sizes#test