### PR TITLE
GH-7786 - Cleanup of CD_GITHUB_TOKEN in all workflows.

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -25,6 +25,9 @@ on:
         default: '0'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   release:
     timeout-minutes: 60
@@ -49,7 +52,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: release/${{ github.event.inputs.version_of_rc }}
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
 
       - uses: actions/cache@v4
         with:
@@ -100,7 +102,7 @@ jobs:
         with:
           repository: embrace-io/embrace-swazzler3
           ref: release/${{ github.event.inputs.version_of_rc }}
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
       - name: Generate Swazzler RC - Publish and Close repository
         run: |

--- a/.github/workflows/generate_baseline_profile.yml
+++ b/.github/workflows/generate_baseline_profile.yml
@@ -7,6 +7,9 @@ on:
       token:
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: macos-latest
@@ -23,7 +26,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.CD_GITHUB_TOKEN || secrets.token }}
 
       - name: Checkout Android SDK Benchmark
         uses: actions/checkout@v4
@@ -31,7 +33,7 @@ jobs:
           repository: embrace-io/android-sdk-benchmark
           ref: main
           path: ./android-sdk-benchmark
-          token: ${{ secrets.CD_GITHUB_TOKEN || secrets.token }}
+          token: ${{ secrets.GH_ANDROID_SDK_TOKEN || secrets.token }} # NOTE: read android-sdk-benchmark
 
       - uses: actions/cache@v4
         with:
@@ -62,7 +64,7 @@ jobs:
       - name: Clean Managed Devices
         run: |
           cd android-sdk-benchmark
-          ./gradlew cleanManagedDevices --unused-only  
+          ./gradlew cleanManagedDevices --unused-only
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -17,7 +17,7 @@ jobs:
     name: Update Baseline Profile
     uses: ./.github/workflows/generate_baseline_profile.yml
     secrets:
-      token: ${{ secrets.CD_GITHUB_TOKEN }}
+      token: ${{ secrets.GH_ANDROID_SDK_TOKEN }} # NOTE: read android-sdk-benchmark
   sdk:
     name: Publish SDK to Maven Internal
     needs: [functional, baseline-profile]
@@ -81,12 +81,12 @@ jobs:
           repository: embrace-io/embrace-swazzler3
           ref: master
           path: ./embrace-swazzler3
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
       - name: Swazzler Release
         run: |
           cd ./embrace-swazzler3
-          ./gradlew clean publishPluginMavenPublicationToSnapshotRepository --stacktrace          
+          ./gradlew clean publishPluginMavenPublicationToSnapshotRepository --stacktrace
 
       - name: Cleanup Gradle Cache
         # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies

--- a/.github/workflows/rc-release-branch.yml
+++ b/.github/workflows/rc-release-branch.yml
@@ -18,6 +18,9 @@ on:
         description: 'Next version. Specify <major.minor>, e.g. 6.4 (Do NOT include -SNAPSHOT, will be added automatically)'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   release-branch:
     name: Create Release Branches
@@ -33,7 +36,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: master
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
 
       - name: Create SDK Release Branch "release/${{ github.event.inputs.version_to_release }}"
         run: |
@@ -59,7 +61,7 @@ jobs:
         with:
           repository: embrace-io/embrace-swazzler3
           ref: master
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
       - name: Create Swazzler Release Branch "release/${{ github.event.inputs.version_to_release }}"
         run: |

--- a/.github/workflows/rc-update-test-apps.yml
+++ b/.github/workflows/rc-update-test-apps.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: ${{ matrix.repo }}
           ref: master
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_ANDROID_SDK_TOKEN }} # NOTE: write embrace-io/android-sdk-benchmark, embrace-io/android-test-suite, embrace-io/ndk-test-app-ndkbuild, embrace-io/ndk-test-app-custombuild, embrace-io/ndk-test-app, embrace-io/android-size-measure
 
       - name: Set next SDK version
         run: |

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -20,6 +20,9 @@ on:
         required: true
         default: '0'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -34,8 +37,7 @@ jobs:
         with:
           ref: release/${{ github.event.inputs.version_to_release }}
           fetch-depth: 0
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
-      
+
       - name: Set up JDK ${{ matrix.jdk-version }}
         uses: actions/setup-java@v4
         with:
@@ -81,7 +83,7 @@ jobs:
         with:
           repository: embrace-io/embrace-swazzler3
           ref: release/${{ github.event.inputs.version_to_release }}
-          token: ${{ secrets.CD_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/swazzler-tests-subset.yml
+++ b/.github/workflows/swazzler-tests-subset.yml
@@ -1,5 +1,0 @@
-name: "Run subset of swazzler-tests"
-
-on:
-  push:
-  workflow_dispatch:


### PR DESCRIPTION
I'm going through all repos that use CD_GITHUB_TOKEN and replacing it with a more granular one. You probably should view this PR with 'ignore whitespace changes' :)

