### PR TITLE
Fix cpuinfo.c JNI call to address the correct package

### DIFF
--- a/embrace-android-sdk/src/main/cpp/utils/cpuinfo.c
+++ b/embrace-android-sdk/src/main/cpp/utils/cpuinfo.c
@@ -26,11 +26,11 @@ jstring emb_get_property(JNIEnv *env, const char* key) {
 }
 
 JNIEXPORT jstring JNICALL
-Java_io_embrace_android_embracesdk_capture_cpu_EmbraceCpuInfoDelegate_getNativeCpuName(JNIEnv* env, jobject thiz) {
+Java_io_embrace_android_embracesdk_internal_capture_cpu_EmbraceCpuInfoDelegate_getNativeCpuName(JNIEnv* env, jobject thiz) {
     return emb_get_property(env, CPUINFO_CPU_NAME_KEY);
 }
 
 JNIEXPORT jstring JNICALL
-Java_io_embrace_android_embracesdk_capture_cpu_EmbraceCpuInfoDelegate_getNativeEgl(JNIEnv* env, jobject thiz) {
+Java_io_embrace_android_embracesdk_internal_capture_cpu_EmbraceCpuInfoDelegate_getNativeEgl(JNIEnv* env, jobject thiz) {
     return emb_get_property(env, CPUINFO_EGL_KEY);
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/cpu/EmbraceCpuInfoDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/cpu/EmbraceCpuInfoDelegate.kt
@@ -3,6 +3,10 @@ package io.embrace.android.embracesdk.internal.capture.cpu
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 
+/**
+ * This class is responsible for getting the CPU name and EGL name from the native library.
+ * Make sure to update the JNI call in cpuinfo.c with any method or package name changes.
+ */
 internal class EmbraceCpuInfoDelegate(
     private val sharedObjectLoader: SharedObjectLoader,
     private val logger: EmbLogger


### PR DESCRIPTION
## Goal

EmbraceCpuInfoDelegate is in a new package now, so I updated the JNI method to address it correctly.

