### PR TITLE
Allow null for traceparent generator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -273,7 +273,7 @@ public final class Embrace implements SdkApi {
         return impl.getTraceIdHeader();
     }
 
-    @NonNull
+    @Nullable
     @Override
     public String generateW3cTraceparent() {
         return impl.generateW3cTraceparent();

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
@@ -19,5 +19,5 @@ public interface NetworkRequestApi {
 
     public val traceIdHeader: String
 
-    public fun generateW3cTraceparent(): String
+    public fun generateW3cTraceparent(): String?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
@@ -33,7 +33,12 @@ internal class NetworkRequestApiDelegate(
             return NetworkBehaviorImpl.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
         }
 
-    override fun generateW3cTraceparent(): String = IdGenerator.generateW3CTraceparent()
+    override fun generateW3cTraceparent(): String? =
+        if (configService?.networkSpanForwardingBehavior?.isNetworkSpanForwardingEnabled() == true) {
+            IdGenerator.generateW3CTraceparent()
+        } else {
+            null
+        }
 
     private fun logNetworkRequest(request: EmbraceNetworkRequest) {
         if (configService?.networkBehavior?.isUrlEnabled(request.url) == true) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
@@ -8,11 +8,14 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
+import io.embrace.android.embracesdk.fakes.fakeNetworkSpanForwardingBehavior
+import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -60,7 +63,15 @@ internal class NetworkRequestApiDelegateTest {
     }
 
     @Test
-    fun testGenerateW3cTraceparent() {
+    fun testGenerateW3cTraceparentEnabled() {
+        configService.networkSpanForwardingBehavior = fakeNetworkSpanForwardingBehavior {
+            NetworkSpanForwardingRemoteConfig(100f)
+        }
         assertNotNull(delegate.generateW3cTraceparent())
+    }
+
+    @Test
+    fun testGenerateW3cTraceparent() {
+        assertNull(delegate.generateW3cTraceparent())
     }
 }


### PR DESCRIPTION
## Goal

Allows `null` as a valid value when generating a traceparent. This is because the feature may not be enabled in which case we want to avoid generating a traceparent.

## Testing

Updated unit test coverage.

