### PR TITLE
Move declaration of data sources to feature module

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/FeatureModule.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/FeatureModule.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.embracesdk.internal.capture
+
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.internal.capture.crumbs.BreadcrumbDataSource
+import io.embrace.android.embracesdk.internal.capture.memory.MemoryWarningDataSource
+import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.injection.CoreModule
+import io.embrace.android.embracesdk.internal.injection.InitModule
+import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
+import io.embrace.android.embracesdk.internal.injection.singleton
+
+public class FeatureModule(
+    coreModule: CoreModule,
+    initModule: InitModule,
+    otelModule: OpenTelemetryModule,
+    configService: ConfigService
+) {
+    public val memoryWarningDataSource: DataSourceState<MemoryWarningDataSource> by singleton {
+        DataSourceState(
+            factory = {
+                MemoryWarningDataSource(
+                    application = coreModule.application,
+                    clock = initModule.clock,
+                    sessionSpanWriter = otelModule.currentSessionSpan,
+                    logger = initModule.logger,
+                )
+            },
+            configGate = { configService.autoDataCaptureBehavior.isMemoryServiceEnabled() },
+        )
+    }
+
+    public val breadcrumbDataSource: DataSourceState<BreadcrumbDataSource> by singleton {
+        DataSourceState(
+            factory = {
+                BreadcrumbDataSource(
+                    breadcrumbBehavior = configService.breadcrumbBehavior,
+                    writer = otelModule.currentSessionSpan,
+                    logger = initModule.logger
+                )
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Goal

Moves the declaration of 2 data sources so that their instantiation is dealt with in the feature module.

In future changesets we'll leverage the app startup library to automatically add these `DataSourceState` references when initializing the SDK, so that the main SDK module/core module don't need to know anything about the features.

## Testing

Relied on existing test coverage.
