### PR TITLE
Create test module that holds fake implementations

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
@@ -1,0 +1,72 @@
+import io.embrace.gradle.Versions
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("com.android.library") apply false
+    id("kotlin-android") apply false
+    id("io.gitlab.arturbosch.detekt") apply false
+}
+
+android {
+    compileSdk = Versions.COMPILE_SDK
+
+    defaultConfig {
+        minSdk = Versions.MIN_SDK
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    lint {
+        abortOnError = true
+        warningsAsErrors = true
+        checkAllWarnings = true
+        checkReleaseBuilds = false // run on CI instead, speeds up release builds
+        baseline = project.file("lint-baseline.xml")
+        disable.addAll(mutableSetOf("GradleDependency", "NewerVersionAvailable"))
+    }
+}
+
+dependencies {
+    add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.DETEKT}")
+}
+
+detekt {
+    buildUponDefaultConfig = true
+    autoCorrect = true
+    config.from(project.files("${project.rootDir}/config/detekt/detekt.yml")) // overwrite default behaviour here
+    baseline =
+        project.file("${project.projectDir}/config/detekt/baseline.xml") // suppress pre-existing issues
+}
+
+project.tasks.withType(Detekt::class.java).configureEach {
+    jvmTarget = "1.8"
+    reports {
+        html.required.set(true)
+        xml.required.set(false)
+        txt.required.set(true)
+        sarif.required.set(false)
+        md.required.set(false)
+    }
+}
+
+project.tasks.withType(DetektCreateBaselineTask::class.java).configureEach {
+    jvmTarget = "1.8"
+}
+
+project.tasks.withType(JavaCompile::class.java).configureEach {
+    options.compilerArgs.addAll(listOf("-Xlint:unchecked", "-Xlint:deprecation"))
+}
+
+project.tasks.withType(KotlinCompile::class.java).configureEach {
+    kotlinOptions {
+        apiVersion = "1.8"
+        languageVersion = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
+    }
+}

--- a/embrace-android-api/build.gradle.kts
+++ b/embrace-android-api/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
 }
 
 description = "Embrace Android SDK: API"

--- a/embrace-android-compose/build.gradle.kts
+++ b/embrace-android-compose/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
 }
 
 description = "Embrace Android SDK: Jetpack Compose"

--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
 }
 
 description = "Embrace Android SDK: Core"

--- a/embrace-android-fcm/build.gradle.kts
+++ b/embrace-android-fcm/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
 }
 
 description = "Embrace Android SDK: Firebase Cloud Messaging"

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
 }
 
 description = "Embrace Android SDK: Features"

--- a/embrace-android-okhttp3/build.gradle.kts
+++ b/embrace-android-okhttp3/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
 }
 
 description = "Embrace Android SDK: OkHttp3"

--- a/embrace-android-payload/build.gradle.kts
+++ b/embrace-android-payload/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
     id("com.google.devtools.ksp")
 }
 

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -1,7 +1,7 @@
 import io.embrace.gradle.Versions
 
 plugins {
-    id("embrace-defaults")
+    id("embrace-prod-defaults")
     id("com.google.devtools.ksp")
 }
 
@@ -86,6 +86,7 @@ dependencies {
     // Please, don"t update it until we update compileSdk.
     implementation(libs.profileinstaller)
 
+    testImplementation(project(":embrace-test-fakes"))
     testImplementation(libs.protobuf.java)
     testImplementation(libs.protobuf.java.util)
     testImplementation(libs.kotlin.reflect)

--- a/embrace-test-common/build.gradle.kts
+++ b/embrace-test-common/build.gradle.kts
@@ -1,17 +1,7 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    id("java-library")
-    id("kotlin")
+    id("embrace-test-defaults")
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-project.tasks.withType(KotlinCompile::class.java).configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
+android {
+    namespace = "io.embrace.android.embracesdk.test.common"
 }

--- a/embrace-test-common/lint-baseline.xml
+++ b/embrace-test-common/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.5.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.1)" variant="all" version="8.5.1">
+
+</issues>

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/ResourceReader.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/ResourceReader.kt
@@ -2,14 +2,14 @@ package io.embrace.android.embracesdk
 
 import java.io.InputStream
 
-object ResourceReader {
-    fun readResource(name: String): InputStream {
+public object ResourceReader {
+    public fun readResource(name: String): InputStream {
         val classLoader = checkNotNull(javaClass.classLoader)
         return classLoader.getResourceAsStream(name)
             ?: error("Could not find resource '$name'")
     }
 
-    fun readResourceAsText(name: String): String {
+    public fun readResourceAsText(name: String): String {
         return readResource(name).bufferedReader().readText()
     }
 }

--- a/embrace-test-fakes/README.md
+++ b/embrace-test-fakes/README.md
@@ -1,0 +1,3 @@
+# embrace-test-fakes
+
+Fake implementations that are used for writing unit/integration tests.

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("embrace-test-defaults")
+}
+
+android {
+    namespace = "io.embrace.android.embracesdk.test.fakes"
+}
+
+dependencies {
+    compileOnly(project(":embrace-android-core"))
+}

--- a/embrace-test-fakes/lint-baseline.xml
+++ b/embrace-test-fakes/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.5.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.1)" variant="all" version="8.5.1">
+
+</issues>

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeClock.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeClock.kt
@@ -2,25 +2,25 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.clock.Clock
 
-internal class FakeClock(
+public class FakeClock(
     @Volatile
     private var currentTime: Long = DEFAULT_FAKE_CURRENT_TIME
 ) : Clock {
 
-    fun setCurrentTime(currentTime: Long) {
+    public fun setCurrentTime(currentTime: Long) {
         this.currentTime = currentTime
     }
 
-    fun tick(millis: Long = 1): Long {
+    public fun tick(millis: Long = 1): Long {
         currentTime += millis
         return currentTime
     }
 
-    fun tickSecond() = tick(1000)
+    public fun tickSecond(): Long = tick(1000)
 
     override fun now(): Long = currentTime
 
-    companion object {
-        const val DEFAULT_FAKE_CURRENT_TIME = 1692201601000L
+    public companion object {
+        public const val DEFAULT_FAKE_CURRENT_TIME: Long = 1692201601000L
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,5 +8,6 @@ include(
     ":embrace-android-fcm",
     ":embrace-android-compose",
     ":embrace-lint",
-    ":embrace-test-common"
+    ":embrace-test-common",
+    ":embrace-test-fakes"
 )


### PR DESCRIPTION
## Goal

Creates a new module that contains fake implementations used in our test code. Access to fakes is becoming a bit of an obstacle in migrating code over as unit/integration tests typically use fake implementations of a real interface. Currently these are all in `embrace-android-sdk` under the `unitTest` sourceSet, so they become inaccessible if we wish to move unit tests anywhere else.

The solution I've chosen is to create a new module that implements the fakes & added it as a test dependency. I've also taken the opportunity to standardise the quality checks for test modules, as we also have `embrace-test-common` which holds _no_ references to other embrace code & is intended for pure util code.

