### PR TITLE
Span snapshots are now sent with a null end time

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -249,7 +249,7 @@ public class EmbraceSpanImpl(
                 parentSpanId = parent?.spanId ?: SpanId.getInvalid(),
                 name = getSpanName(),
                 startTimeNanos = spanStartTimeMs?.millisToNanos(),
-                endTimeNanos = spanEndTimeMs?.millisToNanos() ?: openTelemetryClock.now(),
+                endTimeNanos = spanEndTimeMs?.millisToNanos(),
                 status = status,
                 events = systemEvents.map(EmbraceSpanEvent::toNewPayload) + customEvents.map(EmbraceSpanEvent::toNewPayload),
                 attributes = getAttributesPayload()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -21,7 +21,7 @@ import org.junit.Assert.assertNull
 internal fun assertEmbraceSpanData(
     span: Span?,
     expectedStartTimeMs: Long,
-    expectedEndTimeMs: Long,
+    expectedEndTimeMs: Long?,
     expectedParentId: String,
     expectedTraceId: String? = null,
     expectedStatus: Span.Status = Span.Status.UNSET,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -247,7 +247,7 @@ internal class TracingApiTest {
             assertEmbraceSpanData(
                 span = unendingSpanSnapshot,
                 expectedStartTimeMs = testStartTimeMs + 700,
-                expectedEndTimeMs = testRule.harness.overriddenClock.now(),
+                expectedEndTimeMs = null,
                 expectedParentId = SpanId.getInvalid(),
                 expectedStatus = Span.Status.UNSET,
                 expectedCustomAttributes = mapOf(Pair("unending-key", "unending-value")),
@@ -266,7 +266,7 @@ internal class TracingApiTest {
             assertEmbraceSpanData(
                 span = sessionSpanSnapshot,
                 expectedStartTimeMs = 169220160100,
-                expectedEndTimeMs = testRule.harness.overriddenClock.now(),
+                expectedEndTimeMs = null,
                 expectedParentId = SpanId.getInvalid(),
                 expectedStatus = Span.Status.UNSET,
                 private = false

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -88,12 +88,12 @@ internal class EmbraceSpanImplTest {
             assertNotNull(traceId)
             assertNotNull(spanId)
             assertTrue(isRecording)
-            assertSnapshot(expectedStartTimeMs = expectedStartTimeMs, expectedEndTimeMs = expectedStartTimeMs)
+            assertSnapshot(expectedStartTimeMs = expectedStartTimeMs, expectedEndTimeMs = null)
             assertTrue(addEvent("eventName"))
             assertTrue(addAttribute("first", "value"))
             assertSnapshot(
                 expectedStartTimeMs = expectedStartTimeMs,
-                expectedEndTimeMs = expectedStartTimeMs,
+                expectedEndTimeMs = null,
                 eventCount = 1,
                 expectedCustomAttributeCount = 1
             )


### PR DESCRIPTION
Span snapshots denote a span that was in process when the session was sent. It makes more sense for the end time to be null, so we don't cause any issues in the backend