### PR TITLE
Allow system events to exceed custom event limit

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
@@ -9,21 +9,18 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 public interface SessionSpanWriter {
 
     /**
-     * Add an [EmbraceSpanEvent] with the given [name]. If [spanStartTimeMs] is null, the
-     * current time will be used. Optionally, the specific
-     * time of the event and a set of attributes can be passed in associated with the event.
-     *
-     * Returns true if the event was added, otherwise false.
+     * Add a span event for the given [schemaType] to the session span. If [spanStartTimeMs] is null, the
+     * current time will be used. Returns true if the event was added, otherwise false.
      */
     public fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean
 
     /**
-     * Remove all events with the given [EmbType].
+     * Remove all span events with the given [EmbType].
      */
     public fun removeEvents(type: EmbType)
 
     /**
-     * Add the given key-value pair as an Attribute to the Event.
+     * Add the given key-value pair as an Attribute to the session span
      *
      * Returns true if the attribute was added, otherwise false.
      */

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
 import io.embrace.android.embracesdk.internal.Systrace
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.MAX_SYSTEM_EVENT_COUNT
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
 import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.SpanLimits
 
 /**
  * Wrapper that instantiates a copy of the OpenTelemetry SDK configured with the appropriate settings and the given components so
@@ -23,6 +25,7 @@ public class OpenTelemetrySdk(
                 .builder()
                 .addResource(configuration.resource)
                 .addSpanProcessor(configuration.spanProcessor)
+                .setSpanLimits(SpanLimits.getDefault().toBuilder().setMaxNumberOfEvents(MAX_SYSTEM_EVENT_COUNT).build())
                 .setClock(openTelemetryClock)
                 .build()
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -133,7 +133,7 @@ public class CurrentSessionSpanImpl(
 
     override fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean {
         val currentSession = sessionSpan.get() ?: return false
-        return currentSession.addEvent(
+        return currentSession.addSystemEvent(
             schemaType.fixedObjectName.toEmbraceObjectName(),
             startTimeMs,
             schemaType.attributes() + schemaType.telemetryType.toEmbraceKeyValuePair()
@@ -142,7 +142,7 @@ public class CurrentSessionSpanImpl(
 
     override fun removeEvents(type: EmbType) {
         val currentSession = sessionSpan.get() ?: return
-        currentSession.removeEvents(type)
+        currentSession.removeSystemEvents(type)
     }
 
     override fun addCustomAttribute(attribute: SpanAttributeData): Boolean {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -22,6 +22,7 @@ import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.semconv.ExceptionAttributes
+import java.util.Queue
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
@@ -39,7 +40,8 @@ public class EmbraceSpanImpl(
     private var spanEndTimeMs: Long? = null
     private var status = Span.Status.UNSET
     private var updatedName: String? = null
-    private val events = ConcurrentLinkedQueue<EmbraceSpanEvent>()
+    private val systemEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
+    private val customEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     private val systemAttributes = ConcurrentHashMap<AttributeKey<String>, String>().apply {
         putAll(spanBuilder.getFixedAttributes().associate { it.key.attributeKey to it.value })
     }
@@ -49,7 +51,8 @@ public class EmbraceSpanImpl(
 
     // size for ConcurrentLinkedQueues is not a constant operation, so it could be subject to race conditions
     // do the bookkeeping separately so we don't have to worry about this
-    private val eventCount = AtomicInteger(0)
+    private val systemEventCount = AtomicInteger(0)
+    private val customEventCount = AtomicInteger(0)
 
     override val parent: EmbraceSpan? = spanBuilder.getParentSpan()
 
@@ -111,7 +114,7 @@ public class EmbraceSpanImpl(
                     spanToStop.setAttribute(attribute.key, attribute.value)
                 }
 
-                events.forEach { event ->
+                (systemEvents + customEvents).forEach { event ->
                     val eventAttributes = if (event.attributes.isNotEmpty()) {
                         Attributes.builder().fromMap(event.attributes).build()
                     } else {
@@ -146,7 +149,7 @@ public class EmbraceSpanImpl(
     }
 
     override fun addEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean =
-        recordEvent {
+        recordEvent(customEvents, customEventCount, MAX_EVENT_COUNT) {
             EmbraceSpanEvent.create(
                 name = name,
                 timestampMs = timestampMs?.normalizeTimestampAsMillis() ?: openTelemetryClock.now().nanosToMillis(),
@@ -155,7 +158,7 @@ public class EmbraceSpanImpl(
         }
 
     override fun recordException(exception: Throwable, attributes: Map<String, String>?): Boolean =
-        recordEvent {
+        recordEvent(customEvents, customEventCount, MAX_EVENT_COUNT) {
             val eventAttributes = mutableMapOf<String, String>()
             if (attributes != null) {
                 eventAttributes.putAll(attributes)
@@ -178,12 +181,21 @@ public class EmbraceSpanImpl(
             )
         }
 
-    override fun removeEvents(type: EmbType): Boolean {
-        synchronized(eventCount) {
-            events.forEach { event ->
+    override fun addSystemEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean =
+        recordEvent(systemEvents, systemEventCount, MAX_SYSTEM_EVENT_COUNT) {
+            EmbraceSpanEvent.create(
+                name = name,
+                timestampMs = timestampMs?.normalizeTimestampAsMillis() ?: openTelemetryClock.now().nanosToMillis(),
+                attributes = attributes
+            )
+        }
+
+    override fun removeSystemEvents(type: EmbType): Boolean {
+        synchronized(systemEventCount) {
+            systemEvents.forEach { event ->
                 if (event.hasFixedAttribute(type)) {
-                    events.remove(event)
-                    eventCount.decrementAndGet()
+                    systemEvents.remove(event)
+                    systemEventCount.decrementAndGet()
                     return true
                 }
             }
@@ -239,7 +251,7 @@ public class EmbraceSpanImpl(
                 startTimeNanos = spanStartTimeMs?.millisToNanos(),
                 endTimeNanos = spanEndTimeMs?.millisToNanos() ?: openTelemetryClock.now(),
                 status = status,
-                events = events.map(EmbraceSpanEvent::toNewPayload),
+                events = systemEvents.map(EmbraceSpanEvent::toNewPayload) + customEvents.map(EmbraceSpanEvent::toNewPayload),
                 attributes = getAttributesPayload()
             )
         } else {
@@ -263,13 +275,18 @@ public class EmbraceSpanImpl(
 
     private fun canSnapshot(): Boolean = spanId != null && spanStartTimeMs != null
 
-    private fun recordEvent(eventSupplier: () -> EmbraceSpanEvent?): Boolean {
-        if (eventCount.get() < MAX_EVENT_COUNT) {
-            synchronized(eventCount) {
-                if (eventCount.get() < MAX_EVENT_COUNT && isRecording) {
+    private fun recordEvent(
+        events: Queue<EmbraceSpanEvent>,
+        count: AtomicInteger,
+        max: Int,
+        eventSupplier: () -> EmbraceSpanEvent?
+    ): Boolean {
+        if (count.get() < max) {
+            synchronized(count) {
+                if (count.get() < max && isRecording) {
                     eventSupplier()?.apply {
                         events.add(this)
-                        eventCount.incrementAndGet()
+                        count.incrementAndGet()
                         return true
                     }
                 }
@@ -286,6 +303,7 @@ public class EmbraceSpanImpl(
     public companion object {
         public const val MAX_NAME_LENGTH: Int = 50
         public const val MAX_EVENT_COUNT: Int = 10
+        public const val MAX_SYSTEM_EVENT_COUNT: Int = 1000
         public const val MAX_ATTRIBUTE_COUNT: Int = 50
         public const val MAX_ATTRIBUTE_KEY_LENGTH: Int = 50
         public const val MAX_ATTRIBUTE_VALUE_LENGTH: Int = 500

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -303,7 +303,7 @@ public class EmbraceSpanImpl(
     public companion object {
         public const val MAX_NAME_LENGTH: Int = 50
         public const val MAX_EVENT_COUNT: Int = 10
-        public const val MAX_SYSTEM_EVENT_COUNT: Int = 1000
+        public const val MAX_SYSTEM_EVENT_COUNT: Int = 11000
         public const val MAX_ATTRIBUTE_COUNT: Int = 50
         public const val MAX_ATTRIBUTE_KEY_LENGTH: Int = 50
         public const val MAX_ATTRIBUTE_VALUE_LENGTH: Int = 500

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
@@ -47,9 +47,18 @@ public interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
     public fun removeCustomAttribute(key: String): Boolean
 
     /**
-     * Removes all events with the given [EmbType]
+     * Add a system event to the span that will subjected to a different maximum than typical span events.
      */
-    public fun removeEvents(type: EmbType): Boolean
+    public fun addSystemEvent(
+        name: String,
+        timestampMs: Long?,
+        attributes: Map<String, String>?
+    ): Boolean
+
+    /**
+     * Removes all system events with the given [EmbType]
+     */
+    public fun removeSystemEvents(type: EmbType): Boolean
 
     /**
      * Set the [StatusCode] and status description of the wrapped Span

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/BreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/BreadcrumbFeatureTest.kt
@@ -2,9 +2,9 @@ package io.embrace.android.embracesdk.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.findEventOfType
 import io.embrace.android.embracesdk.findSessionSpan
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SessionSpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SessionSpanTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.internal.payload.extensions.getSessionSpan
+import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SessionSpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SessionSpanTest.kt
@@ -2,7 +2,9 @@ package io.embrace.android.embracesdk.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.internal.payload.extensions.getSessionSpan
 import io.embrace.android.embracesdk.recordSession
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -45,6 +47,19 @@ internal class SessionSpanTest {
             checkNotNull(harness.recordSession {
                 assertFalse(embrace.currentSessionId.isNullOrBlank())
             })
+        }
+    }
+
+    @Test
+    fun `session span event do no affect logging maximum breadcrumbs`() {
+        with(testRule) {
+            startSdk()
+            val session = checkNotNull(harness.recordSession {
+                repeat(101) {
+                    embrace.addBreadcrumb("breadcrumb $it")
+                }
+            })
+            assertEquals(100, session.getSessionSpan()?.events?.size)
         }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -106,7 +106,10 @@ internal class FakePersistableEmbraceSpan(
     override fun recordException(exception: Throwable, attributes: Map<String, String>?): Boolean =
         addEvent(EXCEPTION_EVENT_NAME, null, attributes)
 
-    override fun removeEvents(type: EmbType): Boolean {
+    override fun addSystemEvent(name: String, timestampMs: Long?, attributes: Map<String, String>?): Boolean =
+        addEvent(name, timestampMs, attributes)
+
+    override fun removeSystemEvents(type: EmbType): Boolean {
         events.removeAll { it.hasFixedAttribute(type) }
         return true
     }


### PR DESCRIPTION
## Goal

Track span events added by the SDK differently so session spans don't artificially cap the amount of telemetry it can hold.

## Testing
Add unit and integration tests
