### PR TITLE
Migrate tests

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-prod-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-prod-defaults.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     testImplementation("org.robolectric:robolectric:${Versions.ROBOLECTRIC}")
     testImplementation("com.squareup.okhttp3:mockwebserver:${Versions.MOCKWEBSERVER}")
     testImplementation(project(":embrace-test-common"))
+    testImplementation(project(":embrace-test-fakes"))
 
     androidTestImplementation("androidx.test:core:${Versions.ANDROIDX_TEST}")
     androidTestImplementation("androidx.test:runner:${Versions.ANDROIDX_TEST}")

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -18,6 +18,16 @@ dependencies {
     compileOnly(libs.opentelemetry.semconv)
     compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.lifecycle.process)
+
+    testImplementation(project(":embrace-android-api"))
+    testImplementation(project(":embrace-android-core"))
+    testImplementation(project(":embrace-android-payload"))
+    testImplementation(platform(libs.opentelemetry.bom))
+    testImplementation(libs.opentelemetry.api)
+    testImplementation(libs.opentelemetry.sdk)
+    testImplementation(libs.opentelemetry.semconv)
+    testImplementation(libs.opentelemetry.semconv.incubating)
+    testImplementation(libs.lifecycle.process)
 }
 
 apiValidation.validationDisabled = true

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/capture/crumbs/BreadcrumbDataSourceTest.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.capture.crumbs
 
 import io.embrace.android.embracesdk.arch.assertIsType
-import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.capture.crumbs.BreadcrumbDataSource
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -19,9 +19,9 @@ internal class BreadcrumbDataSourceTest {
     fun setUp() {
         writer = FakeCurrentSessionSpan()
         source = BreadcrumbDataSource(
-            FakeConfigService().breadcrumbBehavior,
+            FakeBreadcrumbBehavior(),
             writer,
-            EmbLoggerImpl(),
+            FakeEmbLogger()
         )
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/BehaviorFakes.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/BehaviorFakes.kt
@@ -81,6 +81,7 @@ internal fun fakeAutoDataCaptureBehavior(
 /**
  * A fake [BreadcrumbBehaviorImpl] that returns default values.
  */
+@Deprecated("Use FakeBreadcrumberBehavior class instead")
 internal fun fakeBreadcrumbBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     localCfg: Provider<SdkLocalConfig?> = { null },

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.junit)
     compileOnly(project(":embrace-android-core"))
     compileOnly(project(":embrace-android-sdk"))
     compileOnly(project(":embrace-android-payload"))

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
@@ -24,36 +24,36 @@ import org.junit.Assert.assertTrue
 /**
  * Assert [EmbraceSpanData] is of type [EmbType.Performance.Default]
  */
-internal fun EmbraceSpanData.assertIsTypePerformance() = assertIsType(EmbType.Performance.Default)
+public fun EmbraceSpanData.assertIsTypePerformance(): Unit = assertIsType(EmbType.Performance.Default)
 
 /**
  * Assert [EmbraceSpanData] is of type [telemetryType]
  */
-internal fun EmbraceSpanData.assertIsType(telemetryType: TelemetryType) = assertHasEmbraceAttribute(telemetryType)
+public fun EmbraceSpanData.assertIsType(telemetryType: TelemetryType): Unit = assertHasEmbraceAttribute(telemetryType)
 
-internal fun EmbraceSpanData.assertIsKeySpan() = assertHasEmbraceAttribute(KeySpan)
+public fun EmbraceSpanData.assertIsKeySpan(): Unit = assertHasEmbraceAttribute(KeySpan)
 
-internal fun EmbraceSpanData.assertNotKeySpan() = assertDoesNotHaveEmbraceAttribute(KeySpan)
+public fun EmbraceSpanData.assertNotKeySpan(): Unit = assertDoesNotHaveEmbraceAttribute(KeySpan)
 
-internal fun EmbraceSpanData.assertIsPrivateSpan() = assertHasEmbraceAttribute(PrivateSpan)
+public fun EmbraceSpanData.assertIsPrivateSpan(): Unit = assertHasEmbraceAttribute(PrivateSpan)
 
-internal fun EmbraceSpanData.assertNotPrivateSpan() = assertDoesNotHaveEmbraceAttribute(PrivateSpan)
+public fun EmbraceSpanData.assertNotPrivateSpan(): Unit = assertDoesNotHaveEmbraceAttribute(PrivateSpan)
 
 /**
  * Assert [EmbraceSpanData] has the [FixedAttribute] defined by [fixedAttribute]
  */
-internal fun EmbraceSpanData.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
+public fun EmbraceSpanData.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
     assertTrue(hasFixedAttribute(fixedAttribute))
 }
 
-internal fun EmbraceSpanData.assertDoesNotHaveEmbraceAttribute(fixedAttribute: FixedAttribute) {
+public fun EmbraceSpanData.assertDoesNotHaveEmbraceAttribute(fixedAttribute: FixedAttribute) {
     assertFalse(attributes[fixedAttribute.key.name]?.equals(fixedAttribute.value) ?: false)
 }
 
 /**
  * Assert [EmbraceSpanData] has ended with the error defined by [errorCode]
  */
-internal fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
+public fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
     assertEquals(StatusCode.ERROR, status)
     assertHasEmbraceAttribute(errorCode.fromErrorCode())
 }
@@ -61,37 +61,37 @@ internal fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
 /**
  * Assert [EmbraceSpanData] has ended successfully
  */
-internal fun EmbraceSpanData.assertSuccessful() {
+public fun EmbraceSpanData.assertSuccessful() {
     assertNotEquals(StatusCode.ERROR, status)
     assertNull(attributes[ErrorCodeAttribute.Failure.key.name])
 }
 
-internal fun Span.assertIsTypePerformance() = assertIsType(EmbType.Performance.Default)
+public fun Span.assertIsTypePerformance(): Unit = assertIsType(EmbType.Performance.Default)
 
-internal fun Span.assertIsType(telemetryType: TelemetryType) = assertHasEmbraceAttribute(telemetryType)
+public fun Span.assertIsType(telemetryType: TelemetryType): Unit = assertHasEmbraceAttribute(telemetryType)
 
-internal fun Span.assertIsKeySpan() = assertHasEmbraceAttribute(KeySpan)
+public fun Span.assertIsKeySpan(): Unit = assertHasEmbraceAttribute(KeySpan)
 
-internal fun Span.assertNotKeySpan() = assertDoesNotHaveEmbraceAttribute(KeySpan)
+public fun Span.assertNotKeySpan(): Unit = assertDoesNotHaveEmbraceAttribute(KeySpan)
 
-internal fun Span.assertIsPrivateSpan() = assertHasEmbraceAttribute(PrivateSpan)
+public fun Span.assertIsPrivateSpan(): Unit = assertHasEmbraceAttribute(PrivateSpan)
 
-internal fun Span.assertNotPrivateSpan() = assertDoesNotHaveEmbraceAttribute(PrivateSpan)
+public fun Span.assertNotPrivateSpan(): Unit = assertDoesNotHaveEmbraceAttribute(PrivateSpan)
 
-internal fun Span.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
+public fun Span.assertHasEmbraceAttribute(fixedAttribute: FixedAttribute) {
     assertTrue(checkNotNull(attributes).contains(fixedAttribute.toPayload()))
 }
 
-internal fun Span.assertDoesNotHaveEmbraceAttribute(fixedAttribute: FixedAttribute) {
+public fun Span.assertDoesNotHaveEmbraceAttribute(fixedAttribute: FixedAttribute) {
     assertFalse(checkNotNull(attributes).contains(fixedAttribute.toPayload()))
 }
 
-internal fun Span.assertError(errorCode: ErrorCode) {
+public fun Span.assertError(errorCode: ErrorCode) {
     assertEquals(Span.Status.ERROR, status)
     assertHasEmbraceAttribute(errorCode.fromErrorCode())
 }
 
-internal fun Span.assertSuccessful() {
+public fun Span.assertSuccessful() {
     assertNotEquals(Span.Status.ERROR, status)
     assertEquals(0, checkNotNull(attributes).filter { it.key == ErrorCodeAttribute.Failure.key.name }.size)
 }
@@ -99,13 +99,13 @@ internal fun Span.assertSuccessful() {
 /**
  * Assert [SpanEventData] is of type [telemetryType]
  */
-internal fun SpanEventData.assertIsType(
+public fun SpanEventData.assertIsType(
     telemetryType: TelemetryType
-) = assertEquals(telemetryType, schemaType.telemetryType)
+): Unit = assertEquals(telemetryType, schemaType.telemetryType)
 
 /**
  * Assert [LogEventData] is of type [telemetryType]
  */
-internal fun LogEventData.assertIsType(
+public fun LogEventData.assertIsType(
     telemetryType: TelemetryType
-) = assertEquals(telemetryType, schemaType.telemetryType)
+): Unit = assertEquals(telemetryType, schemaType.telemetryType)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeBreadcrumbBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeBreadcrumbBehavior.kt
@@ -1,0 +1,27 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
+
+public class FakeBreadcrumbBehavior(
+    public var customBreadcrumbLimitImpl: Int = 100,
+    public var fragmentBreadcrumbLimitImpl: Int = 100,
+    public var tapBreadcrumbLimitImpl: Int = 100,
+    public var viewBreadcrumbLimitImpl: Int = 100,
+    public var webviewBreadcrumbLimitImpl: Int = 100,
+    public var tapCoordinateCaptureEnabled: Boolean = true,
+    public var automaticActivityCaptureEnabled: Boolean = true,
+    public var webViewBreadcrumbCaptureEnabled: Boolean = true,
+    public var queryParamCaptureEnabled: Boolean = true,
+    public var captureFcmPiiDataEnabled: Boolean = true
+): BreadcrumbBehavior {
+    override fun getCustomBreadcrumbLimit(): Int = customBreadcrumbLimitImpl
+    override fun getFragmentBreadcrumbLimit(): Int = fragmentBreadcrumbLimitImpl
+    override fun getTapBreadcrumbLimit(): Int = tapBreadcrumbLimitImpl
+    override fun getViewBreadcrumbLimit(): Int = viewBreadcrumbLimitImpl
+    override fun getWebViewBreadcrumbLimit(): Int = webviewBreadcrumbLimitImpl
+    override fun isTapCoordinateCaptureEnabled(): Boolean  = tapCoordinateCaptureEnabled
+    override fun isAutomaticActivityCaptureEnabled(): Boolean = automaticActivityCaptureEnabled
+    override fun isWebViewBreadcrumbCaptureEnabled(): Boolean = webViewBreadcrumbCaptureEnabled
+    override fun isQueryParamCaptureEnabled(): Boolean = queryParamCaptureEnabled
+    override fun isCaptureFcmPiiDataEnabled(): Boolean = captureFcmPiiDataEnabled
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -12,13 +12,13 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.sdk.trace.data.StatusData
 import java.util.concurrent.atomic.AtomicInteger
 
-internal class FakeCurrentSessionSpan(
+public class FakeCurrentSessionSpan(
     private val clock: FakeClock = FakeClock()
 ) : CurrentSessionSpan {
-    var initializedCallCount = 0
-    var addedEvents = mutableListOf<SpanEventData>()
-    var addedAttributes = mutableListOf<SpanAttributeData>()
-    var sessionSpan: FakeSpanData? = null
+    public var initializedCallCount: Int = 0
+    public var addedEvents: MutableList<SpanEventData> = mutableListOf()
+    public var addedAttributes: MutableList<SpanAttributeData> = mutableListOf()
+    public var sessionSpan: FakeSpanData? = null
 
     private val sessionIteration = AtomicInteger(1)
 
@@ -69,9 +69,9 @@ internal class FakeCurrentSessionSpan(
         return "testSessionId$sessionIteration"
     }
 
-    fun getAttribute(key: String): String? = addedAttributes.lastOrNull { it.key == key }?.value
+    public fun getAttribute(key: String): String? = addedAttributes.lastOrNull { it.key == key }?.value
 
-    fun attributeCount(): Int = addedAttributes.size
+    public fun attributeCount(): Int = addedAttributes.size
 
     private fun newSessionSpan(startTimeMs: Long) =
         FakeSpanData(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -21,7 +21,7 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.data.StatusData
 import kotlin.random.Random
 
-internal class FakeSpanData(
+public class FakeSpanData(
     private var name: String = "fake-started-span",
     private var kind: SpanKind = SpanKind.INTERNAL,
     private var spanContext: SpanContext = newTraceRootContext(),
@@ -44,8 +44,8 @@ internal class FakeSpanData(
     ),
     private var links: MutableList<LinkData> = mutableListOf(),
     private var resource: Resource = Resource.empty(),
-    var spanStatus: StatusData = StatusData.unset(),
-    var endTimeNanos: Long = 0L
+    public var spanStatus: StatusData = StatusData.unset(),
+    public var endTimeNanos: Long = 0L
 ) : SpanData {
     override fun getName(): String = name
     override fun getKind(): SpanKind = kind
@@ -63,13 +63,13 @@ internal class FakeSpanData(
     override fun getTotalAttributeCount(): Int = attributes.size()
 
     @Deprecated("Deprecated in Java")
-    override fun getInstrumentationLibraryInfo() = InstrumentationLibraryInfo.empty()
+    override fun getInstrumentationLibraryInfo(): InstrumentationLibraryInfo = InstrumentationLibraryInfo.empty()
     override fun getResource(): Resource = resource
 
-    companion object {
+    public companion object {
         private const val DEFAULT_START_TIME_MS = FakeClock.DEFAULT_FAKE_CURRENT_TIME
-        val perfSpanSnapshot = FakeSpanData(name = "snapshot-perf-span")
-        val perfSpanCompleted =
+        public val perfSpanSnapshot: FakeSpanData = FakeSpanData(name = "snapshot-perf-span")
+        public val perfSpanCompleted: FakeSpanData =
             FakeSpanData(
                 name = "completed-perf-span",
                 spanStatus = StatusData.ok(),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/LogEventData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/LogEventData.kt
@@ -12,8 +12,8 @@ import io.opentelemetry.api.logs.Severity
  * @param severity the severity of the log
  * @param message the message of the log
  */
-internal class LogEventData(
-    val schemaType: SchemaType,
-    val severity: Severity,
-    val message: String
+public class LogEventData(
+    public val schemaType: SchemaType,
+    public val severity: Severity,
+    public val message: String
 )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/SpanEventData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/SpanEventData.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
  * by the backend.
  * @param spanStartTimeMs the start time of the span event in milliseconds.
  */
-internal class SpanEventData(
-    val schemaType: SchemaType,
-    val spanStartTimeMs: Long
+public class SpanEventData(
+    public val schemaType: SchemaType,
+    public val spanStartTimeMs: Long
 )


### PR DESCRIPTION
## Goal

Migrates the breadcrumb test to the features module. This necessitates altering some of the build dependencies & moving fakes around. This is an intermediate step to making some data sources + implementation details internally visible.

