### PR TITLE
Don't disable SDK until the next cold start

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -278,7 +278,6 @@ internal class EmbraceConfigService(
     override fun onForeground(coldStart: Boolean, timestamp: Long) {
         // Refresh the config on resume if it has expired
         getConfig()
-        foregroundAction()
     }
 
     override val appFramework: AppFramework = localConfig.sdkConfig.appFramework?.let {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -247,17 +247,6 @@ internal class EmbraceConfigServiceTest {
     }
 
     @Test
-    fun `test onForeground() with sdk started and config sdkDisabled=true stops the SDK`() {
-        var stopped = false
-        service = createService(worker) {
-            stopped = true
-        }
-        fakePreferenceService.sdkDisabled = true
-        service.onForeground(true, 1100L)
-        assertTrue(stopped)
-    }
-
-    @Test
     fun `test isSdkDisabled returns true`() {
         fakePreferenceService.sdkDisabled = true
         assertTrue(service.isSdkDisabled())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ConfigServiceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ConfigServiceTest.kt
@@ -1,0 +1,67 @@
+@file:Suppress("DEPRECATION")
+
+package io.embrace.android.embracesdk.testcases
+
+import android.os.Build.VERSION_CODES.TIRAMISU
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.Embrace.AppFramework
+import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.recordSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Validation of the basic and miscellaneous functionality of the Android SDK
+ */
+@Config(sdk = [TIRAMISU])
+@RunWith(AndroidJUnit4::class)
+internal class ConfigServiceTest {
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule {
+        IntegrationTestRule.Harness(startImmediately = false)
+    }
+
+    @Test
+    fun `SDK can start`() {
+        with(testRule) {
+            assertFalse(embrace.isStarted)
+            startSdk()
+            assertEquals(AppFramework.NATIVE, harness.appFramework)
+            assertFalse(harness.overriddenConfigService.isSdkDisabled())
+            assertTrue(embrace.isStarted)
+        }
+    }
+
+    @Test
+    fun `SDK disabled via config cannot start`() {
+        with(testRule) {
+            harness.overriddenConfigService.sdkDisabled = true
+            startSdk()
+            assertFalse(embrace.isStarted)
+        }
+    }
+
+    @Test
+    fun `disabling SDK will not resort to a stopping after foregrounding agian`() {
+        with(testRule) {
+            startSdk()
+            assertTrue(embrace.isStarted)
+            with(harness) {
+                val session = recordSession {
+                    harness.overriddenConfigService.sdkDisabled = true
+                    harness.overriddenConfigService.updateListeners()
+                }
+                assertNotNull(session)
+                assertNotNull(recordSession())
+                assertTrue(embrace.isStarted)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Don't stop the SDK when it is fully active even if the config service says to do so. Instead, just don't start it up next time.

This is to avoid any weird race conditions that can cause unpredictable behavior like partially recorded sessions or even crashes.
