### PR TITLE
Track session state along with ID in SessionIdTracker

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionData.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionData.kt
@@ -1,0 +1,6 @@
+package io.embrace.android.embracesdk.internal.session.id
+
+public data class SessionData(
+    val id: String,
+    val isForeground: Boolean,
+)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTracker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTracker.kt
@@ -3,19 +3,22 @@ package io.embrace.android.embracesdk.internal.session.id
 public interface SessionIdTracker {
 
     /**
-     * Gets the currently active session ID, if present.
-     *
-     * @return an optional containing the currently active session ID
+     * Gets the currently active session, if present.
      */
-    public fun getActiveSessionId(): String?
+    public fun getActiveSession(): SessionData?
 
     /**
-     * Sets the currently active session ID.
+     * Gets the currently active session ID, if present.
+     */
+    public fun getActiveSessionId(): String? = getActiveSession()?.id
+
+    /**
+     * Sets the currently active session.
      *
      * @param sessionId the session ID that is currently active
      * @param isSession true if it's a session, false if it's a background activity
      */
-    public fun setActiveSessionId(sessionId: String?, isSession: Boolean)
+    public fun setActiveSession(sessionId: String?, isSession: Boolean)
 
     /**
      * Adds a listener that will be called when the session ID changes, and with the initial session

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImpl.kt
@@ -14,24 +14,24 @@ public class SessionIdTrackerImpl(
     private val listeners = CopyOnWriteArraySet<(String?) -> Unit>()
 
     @Volatile
-    private var sessionId: String? = null
+    private var activeSession: SessionData? = null
         set(value) {
             field = value
-            listeners.forEach { it(value) }
+            listeners.forEach { it(value?.id) }
         }
 
     override fun addListener(listener: (String?) -> Unit) {
         listeners.add(listener)
-        listener(sessionId)
+        listener(activeSession?.id)
     }
 
-    override fun getActiveSessionId(): String? = sessionId
+    override fun getActiveSession(): SessionData? = activeSession
 
-    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
-        this.sessionId = sessionId
+    override fun setActiveSession(sessionId: String?, isSession: Boolean) {
+        activeSession = sessionId?.run { SessionData(sessionId, isSession) }
 
         if (isSession) {
-            setSessionIdToProcessStateSummary(this.sessionId)
+            setSessionIdToProcessStateSummary(sessionId)
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
@@ -126,11 +126,13 @@ public class EmbraceProcessStateService(
     }
 
     override fun getAppState(): String = when {
-        isInBackground -> "background"
-        else -> "foreground"
+        isInBackground -> BACKGROUND_STATE
+        else -> FOREGROUND_STATE
     }
 
-    private companion object {
+    public companion object {
+        public const val FOREGROUND_STATE: String = "foreground"
+        public const val BACKGROUND_STATE: String = "background"
         private const val ERROR_FAILED_TO_NOTIFY =
             "Failed to notify EmbraceProcessStateService listener"
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
@@ -4,11 +4,11 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.opentelemetry.embState
-import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.spans.getAttribute
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.opentelemetry.api.logs.Severity
@@ -17,13 +17,14 @@ import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 internal class LogWriterImplTest {
     private lateinit var logger: FakeOpenTelemetryLogger
-    private lateinit var sessionIdTracker: SessionIdTracker
+    private lateinit var sessionIdTracker: FakeSessionIdTracker
     private lateinit var logWriterImpl: LogWriterImpl
     private lateinit var processStateService: FakeProcessStateService
 
@@ -41,7 +42,7 @@ internal class LogWriterImplTest {
 
     @Test
     fun `check expected values added to every OTel log`() {
-        sessionIdTracker.setActiveSessionId("session-id", true)
+        sessionIdTracker.setActiveSession("fake-session-id", true)
         logWriterImpl.addLog(
             schemaType = SchemaType.Log(
                 TelemetryAttributes(
@@ -56,7 +57,7 @@ internal class LogWriterImplTest {
             assertEquals("test", body)
             assertEquals(Severity.ERROR, severity)
             assertEquals(Severity.ERROR.name, severity.name)
-            assertEquals("session-id", attributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
+            assertEquals("fake-session-id", attributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
             assertNotNull(attributes.getAttribute(embState))
             assertNotNull(attributes.getAttribute(LogIncubatingAttributes.LOG_RECORD_UID))
             assertTrue(attributes.hasFixedAttribute(PrivateSpan))
@@ -90,6 +91,46 @@ internal class LogWriterImplTest {
         )
         with(logger.builders.last()) {
             assertFalse(attributes.hasFixedAttribute(PrivateSpan))
+        }
+    }
+
+    @Test
+    fun `foreground state matches the session a log is associated with`() {
+        sessionIdTracker.setActiveSession("foreground-session", true)
+        processStateService.isInBackground = true
+        logWriterImpl.addLog(
+            schemaType = SchemaType.Log(
+                TelemetryAttributes(
+                    configService = FakeConfigService()
+                )
+            ),
+            severity = Severity.ERROR,
+            message = "test"
+        )
+
+        with(logger.builders.last()) {
+            assertEquals("foreground-session", attributes.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+            assertEquals("foreground", attributes.findAttributeValue(embState.attributeKey.key))
+        }
+    }
+
+    @Test
+    fun `use app state for background or foreground if no session exists`() {
+        sessionIdTracker.sessionData = null
+        processStateService.isInBackground = true
+        logWriterImpl.addLog(
+            schemaType = SchemaType.Log(
+                TelemetryAttributes(
+                    configService = FakeConfigService()
+                )
+            ),
+            severity = Severity.ERROR,
+            message = "test"
+        )
+
+        with(logger.builders.last()) {
+            assertNull(attributes.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+            assertEquals("background", attributes.findAttributeValue(embState.attributeKey.key))
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImplTest.kt
@@ -21,17 +21,19 @@ internal class SessionIdTrackerImplTest {
         tracker.addListener {
             id = it
         }
+        assertNull(tracker.getActiveSession())
         assertNull(tracker.getActiveSessionId())
         assertNull(id)
 
-        tracker.setActiveSessionId("123", true)
+        tracker.setActiveSession("123", true)
+        assertEquals(SessionData("123", true), tracker.getActiveSession())
         assertEquals("123", tracker.getActiveSessionId())
         assertEquals("123", id)
 
-        tracker.setActiveSessionId("456", true)
+        tracker.setActiveSession("456", true)
         assertEquals("456", id)
 
-        tracker.setActiveSessionId(null, false)
+        tracker.setActiveSession(null, false)
         assertEquals(null, id)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -200,7 +200,7 @@ internal class SessionOrchestratorImpl(
             val newState = newSessionAction?.invoke()
             activeSession = newState
             val sessionId = newState?.sessionId
-            sessionIdTracker.setActiveSessionId(sessionId, inForeground)
+            sessionIdTracker.setActiveSession(sessionId, inForeground)
             newState?.let(sessionSpanAttrPopulator::populateSessionSpanStartAttrs)
 
             // initiate periodic caching of the payload if required

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -37,6 +37,7 @@ import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.session.id.SessionData
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.NORMAL_END
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
@@ -263,7 +264,7 @@ internal class EmbraceDeliveryServiceTest {
     fun `ignore current session when sending previously cached sessions`() {
         assertNotNull(cacheService.writeSession(sessionFileName, envelope))
         assertNotNull(cacheService.writeSession(anotherMessageFileName, anotherMessage))
-        sessionIdTracker.sessionId = anotherMessage.getSessionId()
+        sessionIdTracker.sessionData = SessionData(anotherMessage.getSessionId(), true)
         deliveryService.sendCachedSessions({ fakeNativeCrashService }, sessionIdTracker)
         assertEquals(1, apiService.sessionRequests.size)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/event/EventHandlerTest.kt
@@ -92,7 +92,7 @@ internal class EventHandlerTest {
         clock = FakeClock()
         blockingScheduledExecutorService = BlockingScheduledExecutorService()
         scheduledExecutorService = blockingScheduledExecutorService
-        fakeMetadataService = FakeMetadataService(sessionId = "session-id")
+        fakeMetadataService = FakeMetadataService(sessionId = "fake-session-id")
         processStateService = FakeProcessStateService()
         sessionIdTracker = FakeSessionIdTracker()
         eventHandler = EventHandler(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
 import io.embrace.android.embracesdk.fakes.injection.FakeCustomerLogModule
 import io.embrace.android.embracesdk.internal.payload.AppFramework
+import io.embrace.android.embracesdk.internal.session.id.SessionData
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -63,7 +64,7 @@ internal class SdkStateApiDelegateTest {
 
     @Test
     fun getCurrentSessionId() {
-        sessionIdTracker.sessionId = "test"
+        sessionIdTracker.sessionData = SessionData("test", true)
         assertEquals("test", delegate.currentSessionId)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeCrashDataSourceImplTest.kt
@@ -57,7 +57,7 @@ internal class NativeCrashDataSourceImplTest {
         fakeNdkService = FakeNdkService()
         preferencesService = FakePreferenceService()
         logger = EmbLoggerImpl()
-        sessionIdTracker = FakeSessionIdTracker().apply { setActiveSessionId("currentSessionId", true) }
+        sessionIdTracker = FakeSessionIdTracker().apply { setActiveSession("currentSessionId", true) }
         metadataService = FakeMetadataService()
         processStateService = FakeProcessStateService()
         otelLogger = FakeOpenTelemetryLogger()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -84,7 +84,7 @@ internal class EmbraceNetworkCaptureServiceTest {
         clearAllMocks()
         preferenceService = FakePreferenceService()
         networkCaptureDataSource = FakeNetworkCaptureDataSource()
-        sessionIdTracker.setActiveSessionId("session-123", true)
+        sessionIdTracker.setActiveSession("session-123", true)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureDataSourceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/network/logging/NetworkCaptureDataSourceTest.kt
@@ -38,7 +38,7 @@ internal class NetworkCaptureDataSourceTest {
         assertEquals(mapOf("response-header" to "value"), capturedCall.responseHeaders)
         assertEquals(300, capturedCall.responseSize)
         assertEquals(200, capturedCall.responseStatus)
-        assertEquals("session-id", capturedCall.sessionId)
+        assertEquals("fake-session-id", capturedCall.sessionId)
         assertEquals(1713452000L, capturedCall.startTime)
         assertEquals("https://httpbin.org/get", capturedCall.url)
         assertEquals("", capturedCall.errorMessage)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -84,7 +84,7 @@ internal class SessionOrchestratorTest {
         assertEquals(orchestrator, processStateService.listeners.single())
         assertEquals(0, payloadCollator.sessionCount.get())
         assertEquals(1, payloadCollator.baCount.get())
-        assertEquals(sessionIdTracker.sessionId, currentSessionSpan.getSessionId())
+        assertEquals(sessionIdTracker.sessionData?.id, currentSessionSpan.getSessionId())
         assertEquals(0, deliveryService.sentSessionEnvelopes.size)
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
     }
@@ -96,7 +96,7 @@ internal class SessionOrchestratorTest {
         assertEquals(orchestrator, processStateService.listeners.single())
         assertEquals(1, payloadCollator.sessionCount.get())
         assertEquals(0, payloadCollator.baCount.get())
-        assertEquals(sessionIdTracker.sessionId, currentSessionSpan.getSessionId())
+        assertEquals(sessionIdTracker.sessionData?.id, currentSessionSpan.getSessionId())
         assertEquals(0, deliveryService.sentSessionEnvelopes.size)
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCapturedCall.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCapturedCall.kt
@@ -19,7 +19,7 @@ public fun fakeNetworkCapturedCall(): NetworkCapturedCall {
         responseHeaders = mapOf("response-header" to "value"),
         responseSize = 300,
         responseStatus = 200,
-        sessionId = "session-id",
+        sessionId = "fake-session-id",
         startTime = 1713452000,
         url = "https://httpbin.org/get",
         errorMessage = "",

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
@@ -1,18 +1,17 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.session.id.SessionData
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 
 public class FakeSessionIdTracker : SessionIdTracker {
 
-    public var sessionId: String? = null
+    public var sessionData: SessionData? = null
 
     override fun addListener(listener: (String?) -> Unit) {}
 
-    override fun getActiveSessionId(): String? {
-        return sessionId
-    }
+    override fun getActiveSession(): SessionData? = sessionData
 
-    override fun setActiveSessionId(sessionId: String?, isSession: Boolean) {
-        this.sessionId = sessionId
+    override fun setActiveSession(sessionId: String?, isSession: Boolean) {
+        sessionData = sessionId?.run { SessionData(sessionId, isSession) }
     }
 }


### PR DESCRIPTION
## Goal

The way we track the current session ID leaves a gap where the current session ID may not match the current state of the app in terms of foreground and background. We address this by tracking the state associated with the session, and use that whenever we need to attach the state of the app for a log, instead of using whatever state the app is in, which may not match with the session

## Testing
Add unit test to verify this race condition

