### PR TITLE
Increase span attribute limit at the OTel layer

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
@@ -21,15 +21,11 @@ public interface SessionSpanWriter {
 
     /**
      * Add the given key-value pair as an Attribute to the session span
-     *
-     * Returns true if the attribute was added, otherwise false.
      */
-    public fun addCustomAttribute(attribute: SpanAttributeData): Boolean
+    public fun addSystemAttribute(attribute: SpanAttributeData)
 
     /**
      * Remove the attribute with the given key
-     *
-     * Returns true if attribute was removed, otherwise false.
      */
-    public fun removeCustomAttribute(key: String): Boolean
+    public fun removeSystemAttribute(key: String)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesDataSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesDataSource.kt
@@ -39,17 +39,14 @@ public class SessionPropertiesDataSource(
             }
         )
 
-    public fun removeProperty(key: String): Boolean {
-        var success = false
+    public fun removeProperty(key: String): Boolean =
         captureData(
             inputValidation = NoInputValidation,
             captureAction = {
-                success = removeCustomAttribute(key.toSessionPropertyAttributeName())
+                removeSystemAttribute(key.toSessionPropertyAttributeName())
             }
         )
-        return success
-    }
 
     private fun SessionSpanWriter.addAttribute(key: String, value: String) =
-        addCustomAttribute(SpanAttributeData(key.toSessionPropertyAttributeName(), value))
+        addSystemAttribute(SpanAttributeData(key.toSessionPropertyAttributeName(), value))
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.opentelemetry
 
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.MAX_SYSTEM_EVENT_COUNT
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.MAX_TOTAL_ATTRIBUTE_COUNT
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -25,7 +26,14 @@ public class OpenTelemetrySdk(
                 .builder()
                 .addResource(configuration.resource)
                 .addSpanProcessor(configuration.spanProcessor)
-                .setSpanLimits(SpanLimits.getDefault().toBuilder().setMaxNumberOfEvents(MAX_SYSTEM_EVENT_COUNT).build())
+                .setSpanLimits(
+                    SpanLimits
+                        .getDefault()
+                        .toBuilder()
+                        .setMaxNumberOfEvents(MAX_SYSTEM_EVENT_COUNT)
+                        .setMaxNumberOfAttributes(MAX_TOTAL_ATTRIBUTE_COUNT)
+                        .build()
+                )
                 .setClock(openTelemetryClock)
                 .build()
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -145,14 +145,14 @@ public class CurrentSessionSpanImpl(
         currentSession.removeSystemEvents(type)
     }
 
-    override fun addCustomAttribute(attribute: SpanAttributeData): Boolean {
-        val currentSession = sessionSpan.get() ?: return false
-        return currentSession.addAttribute(attribute.key, attribute.value)
+    override fun addSystemAttribute(attribute: SpanAttributeData) {
+        val currentSession = sessionSpan.get() ?: return
+        currentSession.addSystemAttribute(attribute.key, attribute.value)
     }
 
-    override fun removeCustomAttribute(key: String): Boolean {
-        val currentSession = sessionSpan.get() ?: return false
-        return currentSession.removeCustomAttribute(key)
+    override fun removeSystemAttribute(key: String) {
+        val currentSession = sessionSpan.get() ?: return
+        currentSession.removeSystemAttribute(key)
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -42,8 +42,8 @@ public class EmbraceSpanImpl(
     private var updatedName: String? = null
     private val systemEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     private val customEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
-    private val systemAttributes = ConcurrentHashMap<AttributeKey<String>, String>().apply {
-        putAll(spanBuilder.getFixedAttributes().associate { it.key.attributeKey to it.value })
+    private val systemAttributes = ConcurrentHashMap<String, String>().apply {
+        putAll(spanBuilder.getFixedAttributes().associate { it.key.attributeKey.key to it.value })
     }
     private val customAttributes = ConcurrentHashMap<String, String>().apply {
         putAll(spanBuilder.getCustomAttributes())
@@ -213,9 +213,9 @@ public class EmbraceSpanImpl(
     }
 
     override fun addAttribute(key: String, value: String): Boolean {
-        if (customAttributes.size < MAX_ATTRIBUTE_COUNT && attributeValid(key, value)) {
+        if (customAttributes.size < MAX_CUSTOM_ATTRIBUTE_COUNT && attributeValid(key, value)) {
             synchronized(customAttributes) {
-                if (customAttributes.size < MAX_ATTRIBUTE_COUNT && isRecording) {
+                if (customAttributes.size < MAX_CUSTOM_ATTRIBUTE_COUNT && isRecording) {
                     customAttributes[key] = value
                     return true
                 }
@@ -260,18 +260,24 @@ public class EmbraceSpanImpl(
     }
 
     override fun hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
-        systemAttributes[fixedAttribute.key.attributeKey] == fixedAttribute.value
+        systemAttributes[fixedAttribute.key.attributeKey.key] == fixedAttribute.value
 
-    override fun getSystemAttribute(key: AttributeKey<String>): String? = systemAttributes[key]
+    override fun getSystemAttribute(key: AttributeKey<String>): String? = systemAttributes[key.key]
 
     override fun setSystemAttribute(key: AttributeKey<String>, value: String) {
+        addSystemAttribute(key.key, value)
+    }
+
+    override fun addSystemAttribute(key: String, value: String) {
         systemAttributes[key] = value
     }
 
-    override fun removeCustomAttribute(key: String): Boolean = customAttributes.remove(key) != null
+    override fun removeSystemAttribute(key: String) {
+        systemAttributes.remove(key)
+    }
 
     private fun getAttributesPayload(): List<Attribute> =
-        systemAttributes.map { Attribute(it.key.key, it.value) } + customAttributes.toNewPayload()
+        systemAttributes.map { Attribute(it.key, it.value) } + customAttributes.toNewPayload()
 
     private fun canSnapshot(): Boolean = spanId != null && spanStartTimeMs != null
 
@@ -304,7 +310,8 @@ public class EmbraceSpanImpl(
         public const val MAX_NAME_LENGTH: Int = 50
         public const val MAX_EVENT_COUNT: Int = 10
         public const val MAX_SYSTEM_EVENT_COUNT: Int = 11000
-        public const val MAX_ATTRIBUTE_COUNT: Int = 50
+        public const val MAX_CUSTOM_ATTRIBUTE_COUNT: Int = 50
+        public const val MAX_TOTAL_ATTRIBUTE_COUNT: Int = 300
         public const val MAX_ATTRIBUTE_KEY_LENGTH: Int = 50
         public const val MAX_ATTRIBUTE_VALUE_LENGTH: Int = 500
         public const val EXCEPTION_EVENT_NAME: String = "exception"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
@@ -42,9 +42,14 @@ public interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
     public fun setSystemAttribute(key: AttributeKey<String>, value: String)
 
     /**
-     * Remove the custom attribute with the given key name
+     * Add the given key value pair as a system attribute to ths span
      */
-    public fun removeCustomAttribute(key: String): Boolean
+    public fun addSystemAttribute(key: String, value: String)
+
+    /**
+     * Remove the system attribute with the given key name
+     */
+    public fun removeSystemAttribute(key: String)
 
     /**
      * Add a system event to the span that will subjected to a different maximum than typical span events.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -135,7 +135,7 @@ public class SpanServiceImpl(
     ): Boolean {
         return name.isValidName() &&
             ((events == null) || (events.size <= EmbraceSpanImpl.MAX_EVENT_COUNT)) &&
-            ((attributes == null) || (attributes.size <= EmbraceSpanImpl.MAX_ATTRIBUTE_COUNT))
+            ((attributes == null) || (attributes.size <= EmbraceSpanImpl.MAX_CUSTOM_ATTRIBUTE_COUNT))
     }
 
     public companion object {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -18,6 +18,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.MAX_SYSTEM_EVENT_COUNT
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.MAX_TOTAL_ATTRIBUTE_COUNT
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -381,9 +382,9 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add and remove attribute forwarded to span`() {
-        currentSessionSpan.addCustomAttribute(SpanAttributeData("my_key", "my_value"))
-        currentSessionSpan.addCustomAttribute(SpanAttributeData("missing", "my_value"))
-        currentSessionSpan.removeCustomAttribute("missing")
+        currentSessionSpan.addSystemAttribute(SpanAttributeData("my_key", "my_value"))
+        currentSessionSpan.addSystemAttribute(SpanAttributeData("missing", "my_value"))
+        currentSessionSpan.removeSystemAttribute("missing")
         val span = currentSessionSpan.endSession(true).single()
         assertEquals("emb-session", span.name)
 
@@ -392,23 +393,37 @@ internal class CurrentSessionSpanImplTests {
         assertNull(span.attributes["missing"])
     }
 
+    @Test
+    fun `validate maximum attributes on session span`() {
+        repeat(MAX_TOTAL_ATTRIBUTE_COUNT + 1) {
+            currentSessionSpan.addSystemAttribute(SpanAttributeData("attribute-$it", "value"))
+        }
+
+        val span = currentSessionSpan.endSession(true).single()
+        assertEquals("emb-session", span.name)
+
+        // verify event was added to the span
+        assertEquals(MAX_TOTAL_ATTRIBUTE_COUNT, span.toNewPayload().attributes?.size)
+    }
+
     private fun CurrentSessionSpan.assertNoSessionSpan() {
         assertEquals("", getSessionId())
         assertFalse(canStartNewSpan(parent = null, internal = true))
         assertTrue(endSession(true).isEmpty())
-        assertFalse(addCustomAttribute(attribute = SpanAttributeData("test", "test")))
-        assertFalse(removeCustomAttribute("test"))
         assertFalse(addEvent(SchemaType.Breadcrumb("test"), clock.now()))
         // check doesn't throw exception
+        addSystemAttribute(attribute = SpanAttributeData("test", "test"))
+        removeSystemAttribute("test")
         removeEvents(EmbType.System.Breadcrumb)
     }
 
     private fun CurrentSessionSpan.assertSessionSpan() {
         assertTrue(getSessionId().isNotBlank())
         assertTrue(canStartNewSpan(parent = null, internal = true))
-        assertTrue(addCustomAttribute(attribute = SpanAttributeData("test", "test")))
-        assertTrue(removeCustomAttribute("test"))
         assertTrue(addEvent(SchemaType.Breadcrumb("test"), clock.now()))
+        // check doesn't throw exception
+        addSystemAttribute(attribute = SpanAttributeData("test", "test"))
+        removeSystemAttribute("test")
         removeEvents(EmbType.System.Breadcrumb)
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -20,6 +20,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.MAX_CUSTOM_ATTRIBUTE_COUNT
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
@@ -285,17 +286,22 @@ internal class EmbraceSpanImplTest {
     }
 
     @Test
-    fun `check adding and removing custom attributes`() {
+    fun `check adding and removing system attributes not affected by custom attributes`() {
         with(embraceSpan) {
             assertTrue(start())
-            assertTrue(addAttribute("test", "value"))
-            assertTrue(removeCustomAttribute("test"))
-            assertFalse(removeCustomAttribute("test"))
+            repeat(MAX_CUSTOM_ATTRIBUTE_COUNT) {
+                assertTrue(addAttribute(key = "key$it", value = "value"))
+            }
+            assertFalse(addAttribute(key = "failed", value = "value"))
+            addSystemAttribute("system-attribute", "value")
+            assertEquals("value", embraceSpan.snapshot()?.attributes?.findAttributeValue("system-attribute"))
+            removeSystemAttribute("system-attribute")
+            assertNull("value", embraceSpan.snapshot()?.attributes?.findAttributeValue("system-attribute"))
         }
     }
 
     @Test
-    fun `check attribute limits`() {
+    fun `check custom attribute limits`() {
         with(embraceSpan) {
             assertTrue(start())
             assertFalse(addAttribute(key = TOO_LONG_ATTRIBUTE_KEY, value = "value"))
@@ -303,7 +309,7 @@ internal class EmbraceSpanImplTest {
             assertTrue(addAttribute(key = MAX_LENGTH_ATTRIBUTE_KEY, value = "value"))
             assertTrue(addAttribute(key = "key", value = MAX_LENGTH_ATTRIBUTE_VALUE))
             assertTrue(addAttribute(key = "Key", value = MAX_LENGTH_ATTRIBUTE_VALUE))
-            repeat(EmbraceSpanImpl.MAX_ATTRIBUTE_COUNT - 3) {
+            repeat(MAX_CUSTOM_ATTRIBUTE_COUNT - 3) {
                 assertTrue(addAttribute(key = "key$it", value = "value"))
             }
             assertFalse(addAttribute(key = "failedKey", value = "value"))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -557,7 +557,7 @@ internal class SpanServiceImplTest {
             Pair(TOO_LONG_ATTRIBUTE_KEY, "value"),
             Pair("key", TOO_LONG_ATTRIBUTE_VALUE),
         )
-        repeat(EmbraceSpanImpl.MAX_ATTRIBUTE_COUNT - 2) {
+        repeat(EmbraceSpanImpl.MAX_CUSTOM_ATTRIBUTE_COUNT - 2) {
             attributesMap["key$it"] = "value"
         }
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesDataSourceTest.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.internal.arch.schema.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -25,11 +24,10 @@ internal class SessionPropertiesDataSourceTest {
     }
 
     @Test
-    fun `add and remove custom property`() {
+    fun `add and remove session property`() {
         assertTrue(dataSource.addProperty("blah", "value"))
         assertEquals("value", fakeCurrentSessionSpan.getAttribute("blah".toSessionPropertyAttributeName()))
         assertTrue(dataSource.removeProperty("blah"))
-        assertFalse(dataSource.removeProperty("blah"))
         assertEquals(0, fakeCurrentSessionSpan.attributeCount())
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -290,8 +290,8 @@ internal class SessionOrchestratorImpl(
     private fun updatePeriodicCacheAttrs() {
         val now = clock.now().millisToNanos()
         val attr = SpanAttributeData(embHeartbeatTimeUnixNano.name, now.toString())
-        sessionSpanWriter.addCustomAttribute(attr)
-        sessionSpanWriter.addCustomAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+        sessionSpanWriter.addSystemAttribute(attr)
+        sessionSpanWriter.addSystemAttribute(SpanAttributeData(embTerminated.name, true.toString()))
     }
 
     private fun logSessionStateChange(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulator.kt
@@ -33,27 +33,27 @@ internal class SessionSpanAttrPopulator(
 
     fun populateSessionSpanStartAttrs(session: SessionZygote) {
         with(sessionSpanWriter) {
-            addCustomAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
-            addCustomAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
-            addCustomAttribute(SpanAttributeData(embState.name, session.appState.name.toLowerCase(Locale.US)))
-            addCustomAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
-            addCustomAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+            addSystemAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
+            addSystemAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
+            addSystemAttribute(SpanAttributeData(embState.name, session.appState.name.toLowerCase(Locale.US)))
+            addSystemAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
+            addSystemAttribute(SpanAttributeData(embTerminated.name, true.toString()))
 
             session.startType.toString().toLowerCase(Locale.US).let {
-                addCustomAttribute(SpanAttributeData(embSessionStartType.name, it))
+                addSystemAttribute(SpanAttributeData(embSessionStartType.name, it))
             }
         }
     }
 
     fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean) {
         with(sessionSpanWriter) {
-            addCustomAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
-            addCustomAttribute(SpanAttributeData(embTerminated.name, false.toString()))
+            addSystemAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
+            addSystemAttribute(SpanAttributeData(embTerminated.name, false.toString()))
             crashId?.let {
-                addCustomAttribute(SpanAttributeData(embCrashId.name, crashId))
+                addSystemAttribute(SpanAttributeData(embCrashId.name, crashId))
             }
             endType?.toString()?.toLowerCase(Locale.US)?.let {
-                addCustomAttribute(SpanAttributeData(embSessionEndType.name, it))
+                addSystemAttribute(SpanAttributeData(embSessionEndType.name, it))
             }
 
             val startupInfo = when {
@@ -61,21 +61,21 @@ internal class SessionSpanAttrPopulator(
                 else -> null
             }
             startupInfo?.let { info ->
-                addCustomAttribute(
+                addSystemAttribute(
                     SpanAttributeData(
                         embSdkStartupDuration.name,
                         startupService.getSdkStartupDuration(coldStart).toString()
                     )
                 )
-                addCustomAttribute(SpanAttributeData(embSessionStartupDuration.name, info.duration.toString()))
-                addCustomAttribute(SpanAttributeData(embSessionStartupThreshold.name, info.threshold.toString()))
+                addSystemAttribute(SpanAttributeData(embSessionStartupDuration.name, info.duration.toString()))
+                addSystemAttribute(SpanAttributeData(embSessionStartupThreshold.name, info.threshold.toString()))
             }
 
             val logCount = logService.findErrorLogIds().size
-            addCustomAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
+            addSystemAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
 
             metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
-                addCustomAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
+                addSystemAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
             }
         }
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -35,11 +35,13 @@ public class FakeCurrentSessionSpan(
         addedEvents.removeAll { it.schemaType.telemetryType.key == type.key }
     }
 
-    override fun addCustomAttribute(attribute: SpanAttributeData): Boolean = addedAttributes.add(attribute)
+    override fun addSystemAttribute(attribute: SpanAttributeData) {
+        addedAttributes.add(attribute)
+    }
 
-    override fun removeCustomAttribute(key: String): Boolean {
-        val attributeToRemove = addedAttributes.find { it.key == key } ?: return false
-        return addedAttributes.remove(attributeToRemove)
+    override fun removeSystemAttribute(key: String) {
+        val attributeToRemove = addedAttributes.find { it.key == key } ?: return
+        addedAttributes.remove(attributeToRemove)
     }
 
     override fun initialized(): Boolean {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -36,7 +36,7 @@ public class FakeDataSource(
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         captureData(inputValidation = { true }) {
-            addCustomAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
+            addSystemAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -155,10 +155,16 @@ public class FakePersistableEmbraceSpan(
     override fun getSystemAttribute(key: AttributeKey<String>): String? = attributes[key.key]
 
     override fun setSystemAttribute(key: AttributeKey<String>, value: String) {
-        attributes[key.key] = value
+        addSystemAttribute(key.key, value)
     }
 
-    override fun removeCustomAttribute(key: String): Boolean = attributes.remove(key) != null
+    override fun addSystemAttribute(key: String, value: String) {
+        attributes[key] = value
+    }
+
+    override fun removeSystemAttribute(key: String) {
+        attributes.remove(key)
+    }
 
     private fun started(): Boolean = sdkSpan != null
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -84,8 +84,8 @@ public val TOO_LONG_ATTRIBUTE_KEY: String = "s".repeat(EmbraceSpanImpl.MAX_ATTRI
 public val MAX_LENGTH_ATTRIBUTE_VALUE: String = "s".repeat(EmbraceSpanImpl.MAX_ATTRIBUTE_VALUE_LENGTH)
 public val TOO_LONG_ATTRIBUTE_VALUE: String = "s".repeat(EmbraceSpanImpl.MAX_ATTRIBUTE_VALUE_LENGTH + 1)
 
-public val maxSizeAttributes: Map<String, String> = createMapOfSize(EmbraceSpanImpl.MAX_ATTRIBUTE_COUNT)
-public val tooBigAttributes: Map<String, String> = createMapOfSize(EmbraceSpanImpl.MAX_ATTRIBUTE_COUNT + 1)
+public val maxSizeAttributes: Map<String, String> = createMapOfSize(EmbraceSpanImpl.MAX_CUSTOM_ATTRIBUTE_COUNT)
+public val tooBigAttributes: Map<String, String> = createMapOfSize(EmbraceSpanImpl.MAX_CUSTOM_ATTRIBUTE_COUNT + 1)
 public val maxSizeEventAttributes: Map<String, String> = createMapOfSize(MAX_EVENT_ATTRIBUTE_COUNT)
 public val tooBigEventAttributes: Map<String, String> = createMapOfSize(MAX_EVENT_ATTRIBUTE_COUNT + 1)
 public val maxSizeEvents: List<EmbraceSpanEvent> = createEventsListOfSize(EmbraceSpanImpl.MAX_EVENT_COUNT)


### PR DESCRIPTION
## Goal

OTel imposes a limit on how many attributes are allowed on a span, which is 128 by default. For the session span, we require more than that because you can theoretically have 100 session properties.

To support this, we bump the total limit set in the OTel layer to 300, and validate that our custom limit of 50 for SDK users is not enforced when the SDK adds attributes via the internal `addSystemAttribute()` method. This will also bump the total number of other attributes the SDK can add to the session span to a safer ceiling.

## Testing

Added and modified appropriate unit tests to ensure the expected maximums can be written.
