### PR TITLE
Sensitive keys denylist

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.capture.session
 
 import io.embrace.android.embracesdk.internal.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 
@@ -26,7 +27,7 @@ internal class SessionPropertiesServiceImpl(
         }
 
         val sanitizedValue = if (configService.sensitiveKeysBehavior.isSensitiveKey(sanitizedKey)) {
-            "<redacted>"
+            REDACTED_LABEL
         } else {
             enforceLength(originalValue, SESSION_PROPERTY_VALUE_LIMIT)
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 
 internal class SessionPropertiesServiceImpl(
     preferencesService: PreferencesService,
-    configService: ConfigService,
+    private val configService: ConfigService,
     logger: EmbLogger,
     writer: SessionSpanWriter
 ) : SessionPropertiesService {
@@ -24,7 +24,12 @@ internal class SessionPropertiesServiceImpl(
         if (!isValidValue(originalValue)) {
             return false
         }
-        val sanitizedValue = enforceLength(originalValue, SESSION_PROPERTY_VALUE_LIMIT)
+
+        val sanitizedValue = if (configService.sensitiveKeysBehavior.isSensitiveKey(sanitizedKey)) {
+            "<redacted>"
+        } else {
+            enforceLength(originalValue, SESSION_PROPERTY_VALUE_LIMIT)
+        }
 
         val added = props.add(sanitizedKey, sanitizedValue, permanent)
         if (added) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehavior
@@ -94,6 +95,11 @@ public interface ConfigService {
      * How the network span forwarding feature should behave
      */
     public val networkSpanForwardingBehavior: NetworkSpanForwardingBehavior
+
+    /**
+     * Provides behavior for keys that might be sensitive and should be redacted when they are sent to the server
+     */
+    public val sensitiveKeysBehavior: SensitiveKeysBehavior
 
     /**
      * The app framework that is currently in use.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -24,6 +24,8 @@ import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehavio
 import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SessionBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
@@ -105,6 +107,8 @@ internal class EmbraceConfigService(
             localSupplier = localConfig::sdkConfig,
             remoteSupplier = remoteSupplier
         )
+
+    override val sensitiveKeysBehavior: SensitiveKeysBehavior = SensitiveKeysBehaviorImpl(localConfig.sdkConfig)
 
     override val logMessageBehavior: LogMessageBehavior =
         LogMessageBehaviorImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehavior.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+public interface SensitiveKeysBehavior {
+
+    /**
+     * Checks if the given key is sensitive.
+     *
+     * @param key The key to check.
+     * @return true if the key is sensitive, otherwise false.
+     */
+    public fun isSensitiveKey(key: String): Boolean
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehavior.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-public interface SensitiveKeysBehavior {
+public fun interface SensitiveKeysBehavior {
 
     /**
      * Checks if the given key is sensitive.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
+
+private const val SENSITIVE_KEY_MAX_LENGTH = 128
+private const val SENSITIVE_KEYS_LIST_MAX_SIZE = 10000
+
+internal class SensitiveKeysBehaviorImpl(
+    localConfig: SdkLocalConfig
+) : SensitiveKeysBehavior {
+
+    private val denyList = localConfig.sensitiveKeysDenylist?.take(SENSITIVE_KEYS_LIST_MAX_SIZE)
+
+    override fun isSensitiveKey(key: String): Boolean {
+        return denyList?.any { it.take(SENSITIVE_KEY_MAX_LENGTH) == key } ?: false
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 private const val SENSITIVE_KEY_MAX_LENGTH = 128
 private const val SENSITIVE_KEYS_LIST_MAX_SIZE = 10000
 
-internal class SensitiveKeysBehaviorImpl(
+public class SensitiveKeysBehaviorImpl(
     localConfig: SdkLocalConfig
 ) : SensitiveKeysBehavior {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
@@ -5,6 +5,8 @@ import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 private const val SENSITIVE_KEY_MAX_LENGTH = 128
 private const val SENSITIVE_KEYS_LIST_MAX_SIZE = 10000
 
+public const val REDACTED_LABEL: String = "<redacted>"
+
 public class SensitiveKeysBehaviorImpl(
     localConfig: SdkLocalConfig
 ) : SensitiveKeysBehavior {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -230,7 +231,7 @@ internal class EmbraceEventService(
 
     private fun redactSensitiveProperties(properties: Map<String, Any>?): Map<String, Any>? {
         return properties?.mapValues { (key, value) ->
-            if (configService.sensitiveKeysBehavior.isSensitiveKey(key)) "<redacted>" else value
+            if (configService.sensitiveKeysBehavior.isSensitiveKey(key)) REDACTED_LABEL else value
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
@@ -154,7 +154,7 @@ internal class EmbraceEventService(
                 name,
                 sanitizedStartTime,
                 sessionPropertiesService,
-                properties,
+                redactSensitiveProperties(properties),
                 Runnable { endEvent(name, identifier, true, null) }
             )
 
@@ -210,7 +210,7 @@ internal class EmbraceEventService(
             val (event) = eventHandler.onEventEnded(
                 originEventDescription,
                 late,
-                properties,
+                redactSensitiveProperties(properties),
                 sessionPropertiesService
             )
             if (isStartupEvent(name)) {
@@ -225,6 +225,12 @@ internal class EmbraceEventService(
                 ex
             )
             logger.trackInternalError(InternalErrorType.END_EVENT_FAIL, ex)
+        }
+    }
+
+    private fun redactSensitiveProperties(properties: Map<String, Any>?): Map<String, Any>? {
+        return properties?.mapValues { (key, value) ->
+            if (configService.sensitiveKeysBehavior.isSensitiveKey(key)) "<redacted>" else value
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.logs.LogSink
 import io.embrace.android.embracesdk.internal.opentelemetry.OpenTelemetryConfiguration
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
@@ -22,6 +23,11 @@ public interface OpenTelemetryModule {
      * Configuration for the OpenTelemetry SDK
      */
     public val openTelemetryConfiguration: OpenTelemetryConfiguration
+
+    /**
+     * Setup configuration for redacting sensitive keys
+     */
+    public fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior)
 
     /**
      * Caches span instances that are in progress or completed in the current session

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -2,8 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.Systrace
-import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.logs.LogSink
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.opentelemetry.EmbOpenTelemetry
@@ -66,14 +65,19 @@ internal class OpenTelemetryModuleImpl(
         openTelemetrySdk.sdkTracer
     }
 
+    private var sensitiveKeysBehavior: SensitiveKeysBehavior? = null
+
+    override fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior) {
+        this.sensitiveKeysBehavior = sensitiveKeysBehavior
+        embraceSpanFactory.setupSensitiveKeysBehavior(sensitiveKeysBehavior)
+    }
+
     private val embraceSpanFactory: EmbraceSpanFactory by singleton {
         EmbraceSpanFactoryImpl(
             tracer = sdkTracer,
             openTelemetryClock = openTelemetryClock,
             spanRepository = spanRepository,
-            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-                SdkLocalConfig(sensitiveKeysDenylist = listOf("password"))
-            ), // todo: add dependency on config module
+            sensitiveKeysBehavior = sensitiveKeysBehavior
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.OpenTelemetryClock
 import io.embrace.android.embracesdk.internal.Systrace
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.logs.LogSink
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.opentelemetry.EmbOpenTelemetry
@@ -68,7 +70,10 @@ internal class OpenTelemetryModuleImpl(
         EmbraceSpanFactoryImpl(
             tracer = sdkTracer,
             openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository
+            spanRepository = spanRepository,
+            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
+                SdkLocalConfig(sensitiveKeysDenylist = listOf("password"))
+            ), // todo: add dependency on config module
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType.Log
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.internal.payload.AppFramework
@@ -293,7 +294,7 @@ public class EmbraceLogService(
 
     private fun redactSensitiveProperties(properties: Map<String, Any>?): Map<String, Any>? {
         return properties?.mapValues { (key, value) ->
-            if (configService.sensitiveKeysBehavior.isSensitiveKey(key)) "<redacted>" else value
+            if (configService.sensitiveKeysBehavior.isSensitiveKey(key)) REDACTED_LABEL else value
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -72,16 +72,17 @@ public class EmbraceLogService(
         // Currently, any call to this log method can only have an event type of INFO_LOG,
         // WARNING_LOG, or ERROR_LOG, since it is taken from the fromSeverity() method
         // in EventType.
-        if (type.getSeverity() == null) {
+        val severity = type.getSeverity()
+        if (severity == null) {
             logger.logError("Invalid event type for log: $type")
             return
         }
-        val severity = type.getSeverity() ?: Severity.INFO
+        val redactedProperties = redactSensitiveProperties(properties)
         if (logExceptionType == LogExceptionType.NONE) {
             log(
                 message,
                 severity,
-                properties
+                redactedProperties
             )
         } else {
             val stacktrace = if (stackTraceElements != null) {
@@ -94,7 +95,7 @@ public class EmbraceLogService(
                     message = message,
                     severity = severity,
                     logExceptionType = logExceptionType,
-                    properties = properties,
+                    properties = redactedProperties,
                     stackTrace = stacktrace,
                     exceptionName = exceptionName,
                     exceptionMessage = exceptionMessage,
@@ -106,7 +107,7 @@ public class EmbraceLogService(
                     message = message,
                     severity = severity,
                     logExceptionType = logExceptionType,
-                    properties = properties,
+                    properties = redactedProperties,
                     stackTrace = stacktrace,
                     exceptionName = exceptionName,
                     exceptionMessage = exceptionMessage
@@ -287,6 +288,12 @@ public class EmbraceLogService(
             return message.take(maxLength - endChars.length) + endChars
         } else {
             return message
+        }
+    }
+
+    private fun redactSensitiveProperties(properties: Map<String, Any>?): Map<String, Any>? {
+        return properties?.mapValues { (key, value) ->
+            if (configService.sensitiveKeysBehavior.isSensitiveKey(key)) "<redacted>" else value
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
@@ -17,4 +18,6 @@ internal interface EmbraceSpanFactory {
     ): PersistableEmbraceSpan
 
     fun create(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan
+
+    fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
@@ -11,7 +11,7 @@ internal class EmbraceSpanFactoryImpl(
     private val tracer: Tracer,
     private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
-    public var sensitiveKeysBehavior: SensitiveKeysBehavior? = null
+    private var sensitiveKeysBehavior: SensitiveKeysBehavior? = null
 ) : EmbraceSpanFactory {
 
     override fun create(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
@@ -11,7 +11,7 @@ internal class EmbraceSpanFactoryImpl(
     private val tracer: Tracer,
     private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
-    private val sensitiveKeysBehavior: SensitiveKeysBehavior
+    public var sensitiveKeysBehavior: SensitiveKeysBehavior? = null
 ) : EmbraceSpanFactory {
 
     override fun create(
@@ -37,4 +37,8 @@ internal class EmbraceSpanFactoryImpl(
             spanRepository = spanRepository,
             sensitiveKeysBehavior = sensitiveKeysBehavior
         )
+
+    override fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior) {
+        this.sensitiveKeysBehavior = sensitiveKeysBehavior
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.api.trace.Tracer
@@ -10,6 +11,7 @@ internal class EmbraceSpanFactoryImpl(
     private val tracer: Tracer,
     private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
+    private val sensitiveKeysBehavior: SensitiveKeysBehavior
 ) : EmbraceSpanFactory {
 
     override fun create(
@@ -32,6 +34,7 @@ internal class EmbraceSpanFactoryImpl(
         EmbraceSpanImpl(
             spanBuilder = embraceSpanBuilder,
             openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository
+            spanRepository = spanRepository,
+            sensitiveKeysBehavior = sensitiveKeysBehavior
         )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -321,7 +322,7 @@ internal class EmbraceSpanImpl(
     private fun Map<String, String>.redactIfSensitive(): Map<String, String> {
         return mapValues {
             if (sensitiveKeysBehavior != null && sensitiveKeysBehavior.isSensitiveKey(it.key)) {
-                "<redacted>"
+                REDACTED_LABEL
             } else {
                 it.value
             }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -41,7 +41,7 @@ internal class EmbraceSpanImpl(
     private val spanBuilder: EmbraceSpanBuilder,
     private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
-    private val sensitiveKeysBehavior: SensitiveKeysBehavior
+    private val sensitiveKeysBehavior: SensitiveKeysBehavior?
 ) : PersistableEmbraceSpan {
 
     private val startedSpan: AtomicReference<io.opentelemetry.api.trace.Span?> = AtomicReference(null)
@@ -320,7 +320,7 @@ internal class EmbraceSpanImpl(
 
     private fun Map<String, String>.redactIfSensitive(): Map<String, String> {
         return mapValues {
-            if (sensitiveKeysBehavior.isSensitiveKey(it.key)) {
+            if (sensitiveKeysBehavior != null && sensitiveKeysBehavior.isSensitiveKey(it.key)) {
                 "<redacted>"
             } else {
                 it.value

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
@@ -4,6 +4,8 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -18,10 +20,18 @@ internal class SessionPropertiesServiceImplTest {
 
     @Before
     fun setUp() {
+        val fakeConfigService =
+            FakeConfigService(
+                sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
+                    SdkLocalConfig(
+                        sensitiveKeysDenylist = listOf("password")
+                    )
+                )
+            )
         fakeCurrentSessionSpan = FakeCurrentSessionSpan()
         service = SessionPropertiesServiceImpl(
             FakePreferenceService(),
-            FakeConfigService(),
+            fakeConfigService,
             FakeEmbLogger(),
             fakeCurrentSessionSpan
         )
@@ -39,6 +49,17 @@ internal class SessionPropertiesServiceImplTest {
 
         service.removeProperty("key")
         assertEquals(emptyMap<String, String>(), propState)
+        assertEquals(0, fakeCurrentSessionSpan.attributeCount())
+    }
+
+    @Test
+    fun testAddRedactedSessionProp() {
+        service.addProperty("password", "value", false)
+        val expected = mapOf("password" to "<redacted>")
+        assertEquals(expected, service.getProperties())
+        assertEquals(1, fakeCurrentSessionSpan.attributeCount())
+
+        service.removeProperty("password")
         assertEquals(0, fakeCurrentSessionSpan.attributeCount())
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import org.junit.Assert.assertEquals
@@ -55,7 +56,7 @@ internal class SessionPropertiesServiceImplTest {
     @Test
     fun testAddRedactedSessionProp() {
         service.addProperty("password", "value", false)
-        val expected = mapOf("password" to "<redacted>")
+        val expected = mapOf("password" to REDACTED_LABEL)
         assertEquals(expected, service.getProperties())
         assertEquals(1, fakeCurrentSessionSpan.attributeCount())
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
@@ -1,6 +1,5 @@
-package io.embrace.android.embracesdk.config.behavior
+package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
@@ -1,0 +1,103 @@
+package io.embrace.android.embracesdk.config.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class SensitiveKeysBehaviorImplTest {
+
+    @Test
+    fun `keys are not sensitive if they are not in the sensitive keys list`() {
+        // given an empty sensitive list
+        val behavior = getBehaviorWithSensitiveList(emptyList())
+
+        // when checking if a key is sensitive
+        val isSensitive = behavior.isSensitiveKey("password")
+
+        // then the keys are not sensitive
+        assertFalse(isSensitive)
+    }
+
+    @Test
+    fun `keys are not sensitive with a null sensitive keys list`() {
+        // given a null sensitive list
+        val behavior = getBehaviorWithSensitiveList(null)
+
+        // when checking if a key is sensitive
+        val isSensitive = behavior.isSensitiveKey("password")
+
+        // then the keys are not sensitive
+        assertFalse(isSensitive)
+    }
+
+    @Test
+    fun `keys are sensitive when found in the sensitive keys list`() {
+        // given a sensitive list with a key
+        val behavior = getBehaviorWithSensitiveList(listOf("password"))
+
+        // when checking if a key present in the list is sensitive
+        val isSensitive = behavior.isSensitiveKey("password")
+
+        // then the key is sensitive
+        assertTrue(isSensitive)
+    }
+
+    @Test
+    fun `keys in the sensitive list are truncated to 128 characters`() {
+        // given a sensitive list with a long key
+        val behavior = getBehaviorWithSensitiveList(listOf("a".repeat(200)))
+
+        // when checking if a key present in the list is sensitive
+        val sensitiveKey = behavior.isSensitiveKey("a".repeat(128))
+        val notSensitiveKey = behavior.isSensitiveKey("a".repeat(129))
+
+        // then the key is sensitive if it has 128 characters
+        assertTrue(sensitiveKey)
+        assertFalse(notSensitiveKey)
+    }
+
+    @Test
+    fun `sensitive list is truncated to 10000 keys`() {
+        // given a sensitive list with more than 10000 keys
+        val behavior = getBehaviorWithSensitiveList(
+            List(10000) { it.toString() } + "password"
+        )
+
+        // when checking a key present in the 10001st position
+        val sensitiveKey = behavior.isSensitiveKey("password")
+
+        // then the key is not sensitive
+        assertFalse(sensitiveKey)
+    }
+
+    @Test
+    fun `sensitive list with multiple keys`() {
+        // given a sensitive list with multiple keys
+        val behavior = getBehaviorWithSensitiveList(
+            listOf(
+                "password",
+                "passkey"
+            )
+        )
+
+        // when checking if a key present in the list is sensitive
+        val sensitiveKey = behavior.isSensitiveKey("password")
+        val anotherSensitiveKey = behavior.isSensitiveKey("passkey")
+        val notSensitiveKey = behavior.isSensitiveKey("username")
+
+        // then the sensitivity is returned accordingly
+        assertTrue(sensitiveKey)
+        assertTrue(anotherSensitiveKey)
+        assertFalse(notSensitiveKey)
+    }
+
+    private fun getBehaviorWithSensitiveList(list: List<String>?): SensitiveKeysBehaviorImpl {
+        return SensitiveKeysBehaviorImpl(
+            SdkLocalConfig(
+                sensitiveKeysDenylist = list
+            )
+        )
+    }
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
@@ -19,6 +19,8 @@ import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.EmbraceUserService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.local.StartupMomentLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.gating.EmbraceGatingService
@@ -29,9 +31,6 @@ import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.internal.worker.WorkerName
-import io.mockk.clearAllMocks
-import io.mockk.unmockkAll
-import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -77,23 +76,10 @@ internal class EmbraceEventServiceTest {
                 logger = logger
             )
         }
-
-        @AfterClass
-        @JvmStatic
-        fun tearDown() {
-            unmockkAll()
-        }
     }
 
     @Before
     fun before() {
-        clearAllMocks(
-            answers = false,
-            objectMocks = false,
-            constructorMocks = false,
-            staticMocks = false
-        )
-
         fakeClock = FakeClock()
         fakeClock.setCurrentTime(10L)
         remoteConfig = RemoteConfig()
@@ -101,7 +87,12 @@ internal class EmbraceEventServiceTest {
         startupMomentLocalConfig = StartupMomentLocalConfig()
         configService = FakeConfigService(
             startupBehavior = fakeStartupBehavior { startupMomentLocalConfig },
-            dataCaptureEventBehavior = fakeDataCaptureEventBehavior { remoteConfig }
+            dataCaptureEventBehavior = fakeDataCaptureEventBehavior { remoteConfig },
+            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
+                SdkLocalConfig(
+                    sensitiveKeysDenylist = listOf("password")
+                )
+            )
         )
         sessionPropertiesService = FakeSessionPropertiesService()
         gatingService = FakeGatingService(EmbraceGatingService(configService, FakeLogService(), FakeEmbLogger()))
@@ -371,5 +362,26 @@ internal class EmbraceEventServiceTest {
         assertEquals(1, deliveryService.eventSentAsyncInvokedCount)
         assertNotEquals(EventType.END, lastEvent?.event?.type)
         assertNotEquals(STARTUP_EVENT_NAME, lastEvent?.event?.name)
+    }
+
+    @Test
+    fun `sensitive keys are redacted on event start`() {
+        val eventName = "event-to-start"
+        val customProperties = mapOf("password" to "123456", "non-sensitive-key" to "hello")
+        eventService.startEvent(eventName, null, customProperties)
+        val eventDescription = eventService.getActiveEvent(eventName, null)
+        assertEquals("<redacted>", eventDescription?.event?.customProperties?.get("password"))
+        assertEquals("hello", eventDescription?.event?.customProperties?.get("non-sensitive-key"))
+    }
+
+    @Test
+    fun `sensitive keys are redacted on event end`() {
+        val eventName = "event-to-end"
+        val customProperties = mapOf("password" to "123456", "non-sensitive-key" to "hello")
+        eventService.startEvent(eventName)
+        eventService.endEvent(eventName, customProperties)
+        val event = deliveryService.lastEventSentAsync?.event
+        assertEquals("<redacted>", event?.customProperties?.get("password"))
+        assertEquals("hello", event?.customProperties?.get("non-sensitive-key"))
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.EmbraceUserService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.local.StartupMomentLocalConfig
@@ -370,7 +371,7 @@ internal class EmbraceEventServiceTest {
         val customProperties = mapOf("password" to "123456", "non-sensitive-key" to "hello")
         eventService.startEvent(eventName, null, customProperties)
         val eventDescription = eventService.getActiveEvent(eventName, null)
-        assertEquals("<redacted>", eventDescription?.event?.customProperties?.get("password"))
+        assertEquals(REDACTED_LABEL, eventDescription?.event?.customProperties?.get("password"))
         assertEquals("hello", eventDescription?.event?.customProperties?.get("non-sensitive-key"))
     }
 
@@ -381,7 +382,7 @@ internal class EmbraceEventServiceTest {
         eventService.startEvent(eventName)
         eventService.endEvent(eventName, customProperties)
         val event = deliveryService.lastEventSentAsync?.event
-        assertEquals("<redacted>", event?.customProperties?.get("password"))
+        assertEquals(REDACTED_LABEL, event?.customProperties?.get("password"))
         assertEquals("hello", event?.customProperties?.get("non-sensitive-key"))
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.fakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.LogRemoteConfig
@@ -87,8 +88,9 @@ internal class EmbraceLogServiceTest {
 
         // then the sensitive key is redacted
         val log = fakeLogWriter.logEvents.single()
-        assertEquals("<redacted>", log.schemaType.attributes()["password"])
-        assertEquals("success", log.schemaType.attributes()["status"])
+        val attributes = log.schemaType.attributes()
+        assertEquals(REDACTED_LABEL, attributes["password"])
+        assertEquals("success", attributes["status"])
     }
 
     @Test
@@ -102,10 +104,9 @@ internal class EmbraceLogServiceTest {
 
         // then the telemetry attributes are set correctly
         val log = fakeLogWriter.logEvents.single()
-        assertEquals("someValue", log.schemaType.attributes()["emb.properties.someProperty"])
-        assertTrue(
-            log.schemaType.attributes().containsKey(LogIncubatingAttributes.LOG_RECORD_UID.key)
-        )
+        val attributes = log.schemaType.attributes()
+        assertEquals("someValue", attributes["emb.properties.someProperty"])
+        assertTrue(attributes.containsKey(LogIncubatingAttributes.LOG_RECORD_UID.key))
     }
 
     @Test
@@ -312,19 +313,11 @@ internal class EmbraceLogServiceTest {
         val log = fakeLogWriter.logEvents.single()
         assertEquals(message, log.message)
         assertEquals(Severity.WARN, log.severity)
-        Assert.assertNotNull(log.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
-        assertEquals(
-            LogExceptionType.HANDLED.value,
-            log.schemaType.attributes()[embExceptionHandling.name]
-        )
-        assertEquals(
-            exception.javaClass.simpleName,
-            log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key]
-        )
-        assertEquals(
-            exception.message,
-            log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_MESSAGE.key]
-        )
+        val attributes = log.schemaType.attributes()
+        Assert.assertNotNull(attributes[LogIncubatingAttributes.LOG_RECORD_UID.key])
+        assertEquals(LogExceptionType.HANDLED.value, attributes[embExceptionHandling.name])
+        assertEquals(exception.javaClass.simpleName, attributes[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals(exception.message, attributes[ExceptionAttributes.EXCEPTION_MESSAGE.key])
         log.assertIsType(EmbType.System.Exception)
     }
 
@@ -354,27 +347,13 @@ internal class EmbraceLogServiceTest {
         val log = fakeLogWriter.logEvents.single()
         assertEquals(flutterMessage, log.message)
         assertEquals(Severity.ERROR, log.severity)
-        Assert.assertNotNull(log.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
-        assertEquals(
-            LogExceptionType.HANDLED.value,
-            log.schemaType.attributes()[embExceptionHandling.name]
-        )
-        assertEquals(
-            flutterException.javaClass.simpleName,
-            log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_TYPE.key]
-        )
-        assertEquals(
-            flutterException.message,
-            log.schemaType.attributes()[ExceptionAttributes.EXCEPTION_MESSAGE.key]
-        )
-        assertEquals(
-            flutterContext,
-            log.schemaType.attributes()[EmbType.System.FlutterException.embFlutterExceptionContext.name]
-        )
-        assertEquals(
-            flutterLibrary,
-            log.schemaType.attributes()[EmbType.System.FlutterException.embFlutterExceptionLibrary.name]
-        )
+        val attributes = log.schemaType.attributes()
+        Assert.assertNotNull(attributes[LogIncubatingAttributes.LOG_RECORD_UID.key])
+        assertEquals(LogExceptionType.HANDLED.value, attributes[embExceptionHandling.name])
+        assertEquals(flutterException.javaClass.simpleName, attributes[ExceptionAttributes.EXCEPTION_TYPE.key])
+        assertEquals(flutterException.message, attributes[ExceptionAttributes.EXCEPTION_MESSAGE.key])
+        assertEquals(flutterContext, attributes[EmbType.System.FlutterException.embFlutterExceptionContext.name])
+        assertEquals(flutterLibrary, attributes[EmbType.System.FlutterException.embFlutterExceptionLibrary.name])
         log.assertIsType(EmbType.System.FlutterException)
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.MAX_TOTAL_ATTRIBUTE_COUNT
@@ -438,5 +439,8 @@ internal class CurrentSessionSpanImplTests {
         ): PersistableEmbraceSpan = stoppedSpan
 
         override fun create(embraceSpanBuilder: EmbraceSpanBuilder) = stoppedSpan
+        override fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior) {
+            // no-op
+        }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -6,6 +6,8 @@ import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -30,6 +32,11 @@ internal class EmbraceSpanFactoryImplTest {
             tracer = tracer,
             openTelemetryClock = initModule.openTelemetryModule.openTelemetryClock,
             spanRepository = spanRepository,
+            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
+                SdkLocalConfig(
+                    sensitiveKeysDenylist = listOf("password")
+                )
+            )
         )
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
@@ -428,7 +429,7 @@ internal class EmbraceSpanImplTest {
         val snapshot = embraceSpan.snapshot()
 
         // then the sensitive keys should be redacted
-        assertTrue(snapshot?.attributes?.any { it.key == "password" && it.data == "<redacted>" } ?: false)
+        assertTrue(snapshot?.attributes?.any { it.key == "password" && it.data == REDACTED_LABEL } ?: false)
         assertTrue(snapshot?.attributes?.any { it.key == "status" && it.data == "ok" } ?: false)
     }
 
@@ -447,9 +448,9 @@ internal class EmbraceSpanImplTest {
         // then the sensitive keys should be redacted
         val event = snapshot?.events?.first { it.name == "event" }
         val anotherEvent = snapshot?.events?.first { it.name == "anotherEvent" }
-        assertTrue(event?.attributes?.any { it.key == "password" && it.data == "<redacted>" } ?: false)
+        assertTrue(event?.attributes?.any { it.key == "password" && it.data == REDACTED_LABEL } ?: false)
         assertTrue(event?.attributes?.any { it.key == "status" && it.data == "ok" } ?: false)
-        assertTrue(anotherEvent?.attributes?.any { it.key == "password" && it.data == "<redacted>" } ?: false)
+        assertTrue(anotherEvent?.attributes?.any { it.key == "password" && it.data == REDACTED_LABEL } ?: false)
         assertTrue(anotherEvent?.attributes?.any { it.key == "someKey" && it.data == "someValue" } ?: false)
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -17,6 +17,8 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
@@ -46,6 +48,12 @@ internal class EmbraceSpanImplTest {
         .setTracerProvider(SdkTracerProvider.builder().build()).build()
         .getTracer(EmbraceSpanImplTest::class.java.name)
 
+    private val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
+        SdkLocalConfig(
+            sensitiveKeysDenylist = listOf("password")
+        )
+    )
+
     @Before
     fun setup() {
         fakeClock = FakeClock()
@@ -53,15 +61,13 @@ internal class EmbraceSpanImplTest {
         openTelemetryClock = fakeInitModule.openTelemetryModule.openTelemetryClock
         spanRepository = SpanRepository()
         serializer = fakeInitModule.jsonSerializer
-        embraceSpan = EmbraceSpanImpl(
+        embraceSpan = createEmbraceSpanImpl(
             spanBuilder = tracer.embraceSpanBuilder(
                 name = EXPECTED_SPAN_NAME,
                 type = EmbType.Performance.Default,
                 internal = false,
                 private = false
-            ),
-            openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository,
+            )
         )
         fakeClock.tick(100)
     }
@@ -318,15 +324,8 @@ internal class EmbraceSpanImplTest {
 
     @Test
     fun `validate full snapshot`() {
-        embraceSpan = EmbraceSpanImpl(
-            spanBuilder = tracer.embraceSpanBuilder(
-                name = EXPECTED_SPAN_NAME,
-                type = EmbType.System.LowPower,
-                internal = true,
-                private = true
-            ),
-            openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository,
+        embraceSpan = createEmbraceSpanImpl(
+            spanBuilder = createEmbraceSpanBuilder()
         )
         assertTrue(embraceSpan.start())
         assertNotNull(embraceSpan.snapshot())
@@ -370,18 +369,9 @@ internal class EmbraceSpanImplTest {
 
     @Test
     fun `start time from span start method overrides all`() {
-        val spanBuilder = tracer.embraceSpanBuilder(
-            name = EXPECTED_SPAN_NAME,
-            type = EmbType.System.LowPower,
-            internal = true,
-            private = true
-        )
+        val spanBuilder = createEmbraceSpanBuilder()
         spanBuilder.startTimeMs = fakeClock.tick()
-        embraceSpan = EmbraceSpanImpl(
-            spanBuilder = spanBuilder,
-            openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository,
-        )
+        embraceSpan = createEmbraceSpanImpl(spanBuilder)
 
         val timePassedIn = fakeClock.tick()
         fakeClock.tick()
@@ -392,17 +382,8 @@ internal class EmbraceSpanImplTest {
     @Test
     fun `OTel clock used if start time passed is zero`() {
         val fakeOpenTelemetryClock = FakeOpenTelemetryClock(fakeClock)
-        val spanBuilder = tracer.embraceSpanBuilder(
-            name = EXPECTED_SPAN_NAME,
-            type = EmbType.System.LowPower,
-            internal = true,
-            private = true
-        )
-        embraceSpan = EmbraceSpanImpl(
-            spanBuilder = spanBuilder,
-            openTelemetryClock = fakeOpenTelemetryClock,
-            spanRepository = spanRepository,
-        )
+        val spanBuilder = createEmbraceSpanBuilder()
+        embraceSpan = createEmbraceSpanImpl(spanBuilder, fakeOpenTelemetryClock)
 
         assertTrue(embraceSpan.start(startTimeMs = 0L))
         assertEquals(fakeOpenTelemetryClock.now(), embraceSpan.snapshot()?.startTimeNanos)
@@ -410,20 +391,11 @@ internal class EmbraceSpanImplTest {
 
     @Test
     fun `start time from span builder used if no start time passed into start method`() {
-        val spanBuilder = tracer.embraceSpanBuilder(
-            name = EXPECTED_SPAN_NAME,
-            type = EmbType.System.LowPower,
-            internal = true,
-            private = true
-        )
+        val spanBuilder = createEmbraceSpanBuilder()
 
         val timeOnSpanBuilder = fakeClock.tick()
         spanBuilder.startTimeMs = timeOnSpanBuilder
-        embraceSpan = EmbraceSpanImpl(
-            spanBuilder = spanBuilder,
-            openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository,
-        )
+        embraceSpan = createEmbraceSpanImpl(spanBuilder)
         fakeClock.tick()
         assertTrue(embraceSpan.start())
         assertEquals(timeOnSpanBuilder, embraceSpan.snapshot()?.startTimeNanos?.nanosToMillis())
@@ -431,26 +403,51 @@ internal class EmbraceSpanImplTest {
 
     @Test
     fun `validate context objects are propagated from the parent to the child span`() {
-        val spanBuilder = tracer.embraceSpanBuilder(
-            name = EXPECTED_SPAN_NAME,
-            type = EmbType.System.LowPower,
-            internal = true,
-            private = true
-        )
+        val spanBuilder = createEmbraceSpanBuilder()
         val newParentContext = spanBuilder.parentContext.with(fakeContextKey, "fake-value")
         spanBuilder.setParentContext(newParentContext)
 
-        embraceSpan = EmbraceSpanImpl(
-            spanBuilder = spanBuilder,
-            openTelemetryClock = openTelemetryClock,
-            spanRepository = spanRepository,
-        )
+        embraceSpan = createEmbraceSpanImpl(spanBuilder)
 
         assertNull(embraceSpan.asNewContext())
         assertTrue(embraceSpan.start())
         val newSpanContext = checkNotNull(embraceSpan.asNewContext())
         assertEquals("fake-value", newSpanContext.get(fakeContextKey))
     }
+
+    @Test
+    fun `custom attributes are redacted if their key is sensitive when getting a span snapshot`() {
+        // given a span with a sensitive key
+        val spanBuilder = createEmbraceSpanBuilder()
+        spanBuilder.setCustomAttribute("password", "123456")
+        spanBuilder.setCustomAttribute("status", "ok")
+        embraceSpan = createEmbraceSpanImpl(spanBuilder)
+        embraceSpan.start()
+
+        // when getting a span snapshot
+        val snapshot = embraceSpan.snapshot()
+
+        // then the sensitive keys should be redacted
+        assertTrue(snapshot?.attributes?.any { it.key == "password" && it.data == "<redacted>" } ?: false)
+        assertTrue(snapshot?.attributes?.any { it.key == "status" && it.data == "ok" } ?: false)
+    }
+
+    private fun createEmbraceSpanBuilder() = tracer.embraceSpanBuilder(
+        name = EXPECTED_SPAN_NAME,
+        type = EmbType.System.LowPower,
+        internal = true,
+        private = true
+    )
+
+    private fun createEmbraceSpanImpl(
+        spanBuilder: EmbraceSpanBuilder,
+        clock: Clock = openTelemetryClock
+    ) = EmbraceSpanImpl(
+        spanBuilder = spanBuilder,
+        openTelemetryClock = clock,
+        spanRepository = spanRepository,
+        sensitiveKeysBehavior = sensitiveKeysBehavior
+    )
 
     private fun EmbraceSpanImpl.assertSnapshot(
         expectedStartTimeMs: Long,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -21,8 +21,6 @@ import io.embrace.android.embracesdk.fixtures.tooBigEvents
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
@@ -55,11 +53,6 @@ internal class SpanServiceImplTest {
                 tracer = initModule.openTelemetryModule.sdkTracer,
                 openTelemetryClock = initModule.openTelemetryModule.openTelemetryClock,
                 spanRepository = initModule.openTelemetryModule.spanRepository,
-                sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-                    SdkLocalConfig(
-                        sensitiveKeysDenylist = listOf("password")
-                    )
-                )
             )
         )
         spansService.initializeService(initModule.clock.now())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -21,6 +21,8 @@ import io.embrace.android.embracesdk.fixtures.tooBigEvents
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
@@ -53,6 +55,11 @@ internal class SpanServiceImplTest {
                 tracer = initModule.openTelemetryModule.sdkTracer,
                 openTelemetryClock = initModule.openTelemetryModule.openTelemetryClock,
                 spanRepository = initModule.openTelemetryModule.spanRepository,
+                sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
+                    SdkLocalConfig(
+                        sensitiveKeysDenylist = listOf("password")
+                    )
+                )
             )
         )
         spansService.initializeService(initModule.clock.now())

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/local/SdkLocalConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/local/SdkLocalConfig.kt
@@ -59,6 +59,12 @@ public class SdkLocalConfig(
     @Json(name = "networking")
     public val networking: NetworkLocalConfig? = null,
 
+    /**
+     * List of string or regexes for sensitive keys that should be redacted when they are sent to the server.
+     */
+    @Json(name = "sensitive_keys_denylist")
+    public val sensitiveKeysDenylist: List<String>? = null,
+
     @Json(name = "capture_public_key")
     public val capturePublicKey: String? = null,
 

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/local/SdkLocalConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/local/SdkLocalConfig.kt
@@ -60,7 +60,7 @@ public class SdkLocalConfig(
     public val networking: NetworkLocalConfig? = null,
 
     /**
-     * List of string or regexes for sensitive keys that should be redacted when they are sent to the server.
+     * List of strings for sensitive keys that should be redacted when they are sent to the server.
      */
     @Json(name = "sensitive_keys_denylist")
     public val sensitiveKeysDenylist: List<String>? = null,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
@@ -1,0 +1,50 @@
+package io.embrace.android.embracesdk.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.recordSession
+import junit.framework.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class SensitiveKeysRedactionFeatureTest {
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule {
+        IntegrationTestRule.Harness(startImmediately = false)
+    }
+
+    @Before
+    fun setUp() {
+        testRule.harness.overriddenConfigService.sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
+            localConfig = SdkLocalConfig(
+                sensitiveKeysDenylist = listOf("password")
+            )
+        )
+    }
+
+    @Test
+    fun `custom span properties are redacted if they are sensitive`() {
+        with(testRule) {
+            startSdk()
+            val session = harness.recordSession {
+                val span = embrace.startSpan("test span")
+                span?.addAttribute("password", "1234")
+                span?.addAttribute("not a password", "1234")
+                span?.stop()
+            }
+
+            val recordedSpan = session?.data?.spans?.find { it.name == "test span" }
+            val sensitiveAttribute = recordedSpan?.attributes?.first { it.key == "password" }
+            val notSensitiveAttribute = recordedSpan?.attributes?.first { it.key == "not a password" }
+
+            assertEquals("<redacted>", sensitiveAttribute?.data)
+            assertEquals("1234", notSensitiveAttribute?.data)
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.recordSession
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.recordSession
@@ -44,7 +45,7 @@ internal class SensitiveKeysRedactionFeatureTest {
             val sensitiveAttribute = recordedSpan?.attributes?.first { it.key == "password" }
             val notSensitiveAttribute = recordedSpan?.attributes?.first { it.key == "not a password" }
 
-            assertEquals("<redacted>", sensitiveAttribute?.data)
+            assertEquals(REDACTED_LABEL, sensitiveAttribute?.data)
             assertEquals("1234", notSensitiveAttribute?.data)
         }
     }
@@ -64,9 +65,9 @@ internal class SensitiveKeysRedactionFeatureTest {
 
             val event = recordedSpan?.events?.first { it.name == "event" }
             val anotherEvent = recordedSpan?.events?.first { it.name == "anotherEvent" }
-            assertTrue(event?.attributes?.any { it.key == "password" && it.data == "<redacted>" } ?: false)
+            assertTrue(event?.attributes?.any { it.key == "password" && it.data == REDACTED_LABEL } ?: false)
             assertTrue(event?.attributes?.any { it.key == "status" && it.data == "ok" } ?: false)
-            assertTrue(anotherEvent?.attributes?.any { it.key == "password" && it.data == "<redacted>" } ?: false)
+            assertTrue(anotherEvent?.attributes?.any { it.key == "password" && it.data == REDACTED_LABEL } ?: false)
             assertTrue(anotherEvent?.attributes?.any { it.key == "someKey" && it.data == "someValue" } ?: false)
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -165,6 +165,7 @@ internal class ModuleInitBootstrapper(
                     }
                     postInit(ConfigModule::class) {
                         serviceRegistry.registerService(lazy { configModule.configService })
+                        openTelemetryModule.setupSensitiveKeysBehavior(configModule.configService.sensitiveKeysBehavior)
                     }
 
                     storageModule = init(StorageModule::class) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/BehaviorFakes.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/BehaviorFakes.kt
@@ -21,6 +21,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehavio
 import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SessionBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
@@ -156,3 +157,10 @@ public fun fakeWebViewVitalsBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     remoteCfg: Provider<RemoteConfig?> = { null },
 ): WebViewVitalsBehavior = WebViewVitalsBehaviorImpl(thresholdCheck, remoteCfg)
+
+/**
+ * A fake [SensitiveKeysBehaviorImpl] that returns default values.
+ */
+internal fun fakeSensitiveKeysBehavior() = SensitiveKeysBehaviorImpl(
+    SdkLocalConfig()
+)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehavior
@@ -42,7 +43,8 @@ public class FakeConfigService(
     override var sdkEndpointBehavior: SdkEndpointBehavior = fakeSdkEndpointBehavior(),
     override var webViewVitalsBehavior: WebViewVitalsBehavior = fakeWebViewVitalsBehavior(),
     override var appExitInfoBehavior: AppExitInfoBehavior = fakeAppExitInfoBehavior(),
-    override var networkSpanForwardingBehavior: NetworkSpanForwardingBehavior = fakeNetworkSpanForwardingBehavior()
+    override var networkSpanForwardingBehavior: NetworkSpanForwardingBehavior = fakeNetworkSpanForwardingBehavior(),
+    override val sensitiveKeysBehavior: SensitiveKeysBehavior = fakeSensitiveKeysBehavior()
 ) : ConfigService {
 
     override var remoteConfigSource: RemoteConfigSource? = null

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -44,7 +44,7 @@ public class FakeConfigService(
     override var webViewVitalsBehavior: WebViewVitalsBehavior = fakeWebViewVitalsBehavior(),
     override var appExitInfoBehavior: AppExitInfoBehavior = fakeAppExitInfoBehavior(),
     override var networkSpanForwardingBehavior: NetworkSpanForwardingBehavior = fakeNetworkSpanForwardingBehavior(),
-    override val sensitiveKeysBehavior: SensitiveKeysBehavior = fakeSensitiveKeysBehavior()
+    override var sensitiveKeysBehavior: SensitiveKeysBehavior = fakeSensitiveKeysBehavior()
 ) : ConfigService {
 
     override var remoteConfigSource: RemoteConfigSource? = null

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.logs.LogSink
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
@@ -27,6 +28,11 @@ public class FakeOpenTelemetryModule(
 ) : OpenTelemetryModule {
     override val openTelemetryConfiguration: OpenTelemetryConfiguration =
         OpenTelemetryConfiguration(spanSink, logSink, SystemInfo())
+
+    override fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior) {
+        // no-op
+    }
+
     override val sdkTracer: Tracer
         get() = FakeTracer()
     override val spanService: SpanService


### PR DESCRIPTION
## Goal

If a `sensitive_keys_denylist` is provided in `embrace-config.json`, the following components will be scanned:

- [x] Moments
- [x] Session properties
- [x] Log attrs + log event attributes
- [x] Span attrs + span event attributes
- [x] Event attributes

If the key in any of those properties is present in the denylist, the value will be changed to`<redacted>`.