### PR TITLE
Extract interface for SessionSpanAttrPopulator

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionModule.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCac
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollatorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
 
 internal interface SessionModule {
     val payloadFactory: PayloadFactory
@@ -14,4 +15,5 @@ internal interface SessionModule {
     val sessionOrchestrator: SessionOrchestrator
     val periodicSessionCacher: PeriodicSessionCacher
     val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher
+    val sessionSpanAttrPopulator: SessionSpanAttrPopulator
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionModuleImpl.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.OrchestratorB
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulatorImpl
 import io.embrace.android.embracesdk.internal.worker.WorkerName
 
 internal class SessionModuleImpl(
@@ -77,8 +78,8 @@ internal class SessionModuleImpl(
         )
     }
 
-    private val sessionSpanAttrPopulator by singleton {
-        SessionSpanAttrPopulator(
+    override val sessionSpanAttrPopulator: SessionSpanAttrPopulator by singleton {
+        SessionSpanAttrPopulatorImpl(
             openTelemetryModule.currentSessionSpan,
             dataContainerModule.eventService,
             dataCaptureServiceModule.startupService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulator.kt
@@ -1,82 +1,20 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
-import io.embrace.android.embracesdk.internal.arch.destination.SessionSpanWriter
-import io.embrace.android.embracesdk.internal.arch.destination.SpanAttributeData
-import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
-import io.embrace.android.embracesdk.internal.capture.startup.StartupService
-import io.embrace.android.embracesdk.internal.event.EventService
-import io.embrace.android.embracesdk.internal.logs.LogService
-import io.embrace.android.embracesdk.internal.opentelemetry.embCleanExit
-import io.embrace.android.embracesdk.internal.opentelemetry.embColdStart
-import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
-import io.embrace.android.embracesdk.internal.opentelemetry.embErrorLogCount
-import io.embrace.android.embracesdk.internal.opentelemetry.embFreeDiskBytes
-import io.embrace.android.embracesdk.internal.opentelemetry.embSdkStartupDuration
-import io.embrace.android.embracesdk.internal.opentelemetry.embSessionEndType
-import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
-import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartType
-import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartupDuration
-import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartupThreshold
-import io.embrace.android.embracesdk.internal.opentelemetry.embState
-import io.embrace.android.embracesdk.internal.opentelemetry.embTerminated
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.payload.SessionZygote
-import java.util.Locale
 
-internal class SessionSpanAttrPopulator(
-    private val sessionSpanWriter: SessionSpanWriter,
-    private val eventService: EventService,
-    private val startupService: StartupService,
-    private val logService: LogService,
-    private val metadataService: MetadataService
-) {
+/**
+ * Populates the attributes of a session span.
+ */
+internal interface SessionSpanAttrPopulator {
 
-    fun populateSessionSpanStartAttrs(session: SessionZygote) {
-        with(sessionSpanWriter) {
-            addCustomAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
-            addCustomAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
-            addCustomAttribute(SpanAttributeData(embState.name, session.appState.name.toLowerCase(Locale.US)))
-            addCustomAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
-            addCustomAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+    /**
+     * Populates session span attributes at the start of the session.
+     */
+    fun populateSessionSpanStartAttrs(session: SessionZygote)
 
-            session.startType.toString().toLowerCase(Locale.US).let {
-                addCustomAttribute(SpanAttributeData(embSessionStartType.name, it))
-            }
-        }
-    }
-
-    fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean) {
-        with(sessionSpanWriter) {
-            addCustomAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
-            addCustomAttribute(SpanAttributeData(embTerminated.name, false.toString()))
-            crashId?.let {
-                addCustomAttribute(SpanAttributeData(embCrashId.name, crashId))
-            }
-            endType?.toString()?.toLowerCase(Locale.US)?.let {
-                addCustomAttribute(SpanAttributeData(embSessionEndType.name, it))
-            }
-
-            val startupInfo = when {
-                coldStart -> eventService.getStartupMomentInfo()
-                else -> null
-            }
-            startupInfo?.let { info ->
-                addCustomAttribute(
-                    SpanAttributeData(
-                        embSdkStartupDuration.name,
-                        startupService.getSdkStartupDuration(coldStart).toString()
-                    )
-                )
-                addCustomAttribute(SpanAttributeData(embSessionStartupDuration.name, info.duration.toString()))
-                addCustomAttribute(SpanAttributeData(embSessionStartupThreshold.name, info.threshold.toString()))
-            }
-
-            val logCount = logService.findErrorLogIds().size
-            addCustomAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
-
-            metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
-                addCustomAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
-            }
-        }
-    }
+    /**
+     * Populates session span attributes at the end of the session.
+     */
+    fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean)
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
@@ -1,0 +1,82 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.internal.arch.destination.SessionSpanWriter
+import io.embrace.android.embracesdk.internal.arch.destination.SpanAttributeData
+import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.internal.capture.startup.StartupService
+import io.embrace.android.embracesdk.internal.event.EventService
+import io.embrace.android.embracesdk.internal.logs.LogService
+import io.embrace.android.embracesdk.internal.opentelemetry.embCleanExit
+import io.embrace.android.embracesdk.internal.opentelemetry.embColdStart
+import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
+import io.embrace.android.embracesdk.internal.opentelemetry.embErrorLogCount
+import io.embrace.android.embracesdk.internal.opentelemetry.embFreeDiskBytes
+import io.embrace.android.embracesdk.internal.opentelemetry.embSdkStartupDuration
+import io.embrace.android.embracesdk.internal.opentelemetry.embSessionEndType
+import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
+import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartType
+import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartupDuration
+import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartupThreshold
+import io.embrace.android.embracesdk.internal.opentelemetry.embState
+import io.embrace.android.embracesdk.internal.opentelemetry.embTerminated
+import io.embrace.android.embracesdk.internal.payload.LifeEventType
+import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import java.util.Locale
+
+internal class SessionSpanAttrPopulatorImpl(
+    private val sessionSpanWriter: SessionSpanWriter,
+    private val eventService: EventService,
+    private val startupService: StartupService,
+    private val logService: LogService,
+    private val metadataService: MetadataService
+) : SessionSpanAttrPopulator {
+
+    override fun populateSessionSpanStartAttrs(session: SessionZygote) {
+        with(sessionSpanWriter) {
+            addCustomAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
+            addCustomAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
+            addCustomAttribute(SpanAttributeData(embState.name, session.appState.name.toLowerCase(Locale.US)))
+            addCustomAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
+            addCustomAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+
+            session.startType.toString().toLowerCase(Locale.US).let {
+                addCustomAttribute(SpanAttributeData(embSessionStartType.name, it))
+            }
+        }
+    }
+
+    override fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean) {
+        with(sessionSpanWriter) {
+            addCustomAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
+            addCustomAttribute(SpanAttributeData(embTerminated.name, false.toString()))
+            crashId?.let {
+                addCustomAttribute(SpanAttributeData(embCrashId.name, crashId))
+            }
+            endType?.toString()?.toLowerCase(Locale.US)?.let {
+                addCustomAttribute(SpanAttributeData(embSessionEndType.name, it))
+            }
+
+            val startupInfo = when {
+                coldStart -> eventService.getStartupMomentInfo()
+                else -> null
+            }
+            startupInfo?.let { info ->
+                addCustomAttribute(
+                    SpanAttributeData(
+                        embSdkStartupDuration.name,
+                        startupService.getSdkStartupDuration(coldStart).toString()
+                    )
+                )
+                addCustomAttribute(SpanAttributeData(embSessionStartupDuration.name, info.duration.toString()))
+                addCustomAttribute(SpanAttributeData(embSessionStartupThreshold.name, info.threshold.toString()))
+            }
+
+            val logCount = logService.findErrorLogIds().size
+            addCustomAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
+
+            metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
+                addCustomAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeSessionSpanAttrPopulator.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.payload.LifeEventType
+import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
+
+internal class FakeSessionSpanAttrPopulator : SessionSpanAttrPopulator {
+
+    override fun populateSessionSpanStartAttrs(session: SessionZygote) {
+    }
+
+    override fun populateSessionSpanEndAttrs(
+        endType: LifeEventType?,
+        crashId: String?,
+        coldStart: Boolean
+    ) {
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeSessionModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes.injection
 import io.embrace.android.embracesdk.fakes.FakePayloadFactory
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.fakes.FakeSessionSpanAttrPopulator
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.injection.SessionModule
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicBackgroundActivityCacher
@@ -10,11 +11,13 @@ import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCac
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollatorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
 
 internal class FakeSessionModule(
     override val payloadFactory: PayloadFactory = FakePayloadFactory(),
     override val sessionPropertiesService: SessionPropertiesService = FakeSessionPropertiesService(),
-    override val sessionOrchestrator: SessionOrchestrator = FakeSessionOrchestrator()
+    override val sessionOrchestrator: SessionOrchestrator = FakeSessionOrchestrator(),
+    override val sessionSpanAttrPopulator: SessionSpanAttrPopulator = FakeSessionSpanAttrPopulator()
 ) : SessionModule {
 
     override val payloadMessageCollatorImpl: PayloadMessageCollatorImpl

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -36,7 +36,7 @@ import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.OrchestratorBoundaryDelegate
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
-import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulatorImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
@@ -408,7 +408,7 @@ internal class SessionOrchestratorTest {
             periodicBackgroundActivityCacher,
             dataCaptureOrchestrator,
             currentSessionSpan,
-            SessionSpanAttrPopulator(
+            SessionSpanAttrPopulatorImpl(
                 currentSessionSpan,
                 FakeEventService(),
                 FakeStartupService(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
@@ -8,21 +8,21 @@ import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.payload.SessionZygote
-import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulatorImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-internal class SessionSpanAttrPopulatorTest {
+internal class SessionSpanAttrPopulatorImplTest {
 
     private val zygote = SessionZygote("id", 1, 5, ApplicationState.FOREGROUND, false, LifeEventType.STATE)
-    private lateinit var populator: SessionSpanAttrPopulator
+    private lateinit var populator: SessionSpanAttrPopulatorImpl
     private lateinit var writer: FakeCurrentSessionSpan
 
     @Before
     fun setUp() {
         writer = FakeCurrentSessionSpan()
-        populator = SessionSpanAttrPopulator(
+        populator = SessionSpanAttrPopulatorImpl(
             writer,
             FakeEventService(),
             FakeStartupService(),


### PR DESCRIPTION
## Goal

Extracts an interface for the `SessionSpanAttrPopulator` class. This is an initial refactor that lays the groundwork for simplifying our session property implementation.

