### PR TITLE
Add integration tests to check JNI interface - CPU Info

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/cpu/EmbraceCpuInfoDelegate.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/cpu/EmbraceCpuInfoDelegate.kt
@@ -9,13 +9,14 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
  */
 public class EmbraceCpuInfoDelegate(
     private val sharedObjectLoader: SharedObjectLoader,
-    private val logger: EmbLogger
+    private val logger: EmbLogger,
+    private val cpuInfoNdkDelegate: CpuInfoNdkDelegate = EmbraceCpuInfoNdkDelegate()
 ) : CpuInfoDelegate {
 
     override fun getCpuName(): String? {
         return if (sharedObjectLoader.loadEmbraceNative()) {
             try {
-                getNativeCpuName()
+                cpuInfoNdkDelegate.getNativeCpuName()
             } catch (exception: LinkageError) {
                 logger.logWarning("Could not get the CPU name.", exception)
                 null
@@ -28,7 +29,7 @@ public class EmbraceCpuInfoDelegate(
     override fun getEgl(): String? {
         return if (sharedObjectLoader.loadEmbraceNative()) {
             try {
-                getNativeEgl()
+                cpuInfoNdkDelegate.getNativeEgl()
             } catch (exception: LinkageError) {
                 logger.logWarning("Could not get the EGL name.", exception)
                 null
@@ -37,8 +38,4 @@ public class EmbraceCpuInfoDelegate(
             null
         }
     }
-
-    private external fun getNativeCpuName(): String
-
-    private external fun getNativeEgl(): String
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/cpu/EmbraceCpuInfoNdkDelegate.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/cpu/EmbraceCpuInfoNdkDelegate.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.embracesdk.internal.capture.cpu
+
+public class EmbraceCpuInfoNdkDelegate : CpuInfoNdkDelegate {
+    external override fun getNativeCpuName(): String
+    external override fun getNativeEgl(): String
+}
+
+public interface CpuInfoNdkDelegate {
+    public fun getNativeCpuName(): String
+    public fun getNativeEgl(): String
+}

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/CpuInfoJniInterfaceTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/CpuInfoJniInterfaceTest.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.ndk.jni
+
+import io.embrace.android.embracesdk.internal.capture.cpu.EmbraceCpuInfoNdkDelegate
+import io.embrace.android.embracesdk.ndk.NativeTestSuite
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class CpuInfoJniInterfaceTest : NativeTestSuite() {
+
+    private val cpuInfoDelegate = EmbraceCpuInfoNdkDelegate()
+
+    @Test
+    fun getNativeCpuNameTest() {
+        val cpuName = cpuInfoDelegate.getNativeCpuName()
+        assertEquals("", cpuName)
+    }
+
+    @Test
+    fun getNativeEglTest() {
+        val nativeEglName = cpuInfoDelegate.getNativeEgl()
+        assertEquals("emulation", nativeEglName)
+    }
+}

--- a/embrace-android-sdk/src/main/cpp/utils/cpuinfo.c
+++ b/embrace-android-sdk/src/main/cpp/utils/cpuinfo.c
@@ -26,11 +26,11 @@ jstring emb_get_property(JNIEnv *env, const char* key) {
 }
 
 JNIEXPORT jstring JNICALL
-Java_io_embrace_android_embracesdk_internal_capture_cpu_EmbraceCpuInfoDelegate_getNativeCpuName(JNIEnv* env, jobject thiz) {
+Java_io_embrace_android_embracesdk_internal_capture_cpu_EmbraceCpuInfoNdkDelegate_getNativeCpuName(JNIEnv* env, jobject thiz) {
     return emb_get_property(env, CPUINFO_CPU_NAME_KEY);
 }
 
 JNIEXPORT jstring JNICALL
-Java_io_embrace_android_embracesdk_internal_capture_cpu_EmbraceCpuInfoDelegate_getNativeEgl(JNIEnv* env, jobject thiz) {
+Java_io_embrace_android_embracesdk_internal_capture_cpu_EmbraceCpuInfoNdkDelegate_getNativeEgl(JNIEnv* env, jobject thiz) {
     return emb_get_property(env, CPUINFO_EGL_KEY);
 }


### PR DESCRIPTION
The JNI interface relies on signatures that might break if a class is moved to another package or renamed. This is only detected in runtime, as compilation goes fine and our tests don't verify this behavior. 

The goal of this PR is to create tests that, at the very least, break when a class targeted by a JNI signature is moved or renamed. If the class is not too complex, the tests will also verify additional functionality.

Classes to test:

- [x] EmbraceCpuInfoNdkDelegate
- [ ] SigquitDataSource
- [ ] NdkDelegateImpl
- [x] NativeThreadSamplerNdkDelegate