### PR TITLE
Add JNI interface tests for NativeThreadSampler

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/NativeThreadSamplerJniInterfaceTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/NativeThreadSamplerJniInterfaceTest.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.ndk.jni
+
+import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerNdkDelegate
+import io.embrace.android.embracesdk.internal.payload.NativeThreadAnrSample
+import io.embrace.android.embracesdk.ndk.NativeTestSuite
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+
+internal class NativeThreadSamplerJniInterfaceTest : NativeTestSuite() {
+
+    private val nativeThreadSamplerNdkDelegate = NativeThreadSamplerNdkDelegate()
+
+    @Test
+    fun setupNativeThreadSamplerTest() {
+        val result = nativeThreadSamplerNdkDelegate.setupNativeThreadSampler(false)
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun monitorCurrentThreadTest() {
+        val result = nativeThreadSamplerNdkDelegate.monitorCurrentThread()
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun startSamplingTest() {
+        val result = nativeThreadSamplerNdkDelegate.startSampling(1, 500)
+        // we can't really check the result because it's a void function, but if the class is moved or renamed this will fail
+        assertEquals(Unit.javaClass, result.javaClass)
+    }
+
+    @Test
+    fun finishSamplingTest() {
+        val result = nativeThreadSamplerNdkDelegate.finishSampling()
+        assertEquals(emptyList<NativeThreadAnrSample>(), result)
+    }
+}


### PR DESCRIPTION
The JNI interface relies on signatures that might break if a class is moved to another package or renamed. This is only detected in runtime, as compilation goes fine and our tests don't verify this behavior.

The goal of this PR is to create tests that, at the very least, break when a class targeted by a JNI signature is moved or renamed. If the class is not too complex, the tests will also verify additional functionality.

Classes to test:

- [x]  EmbraceCpuInfoNdkDelegate
- [x]  SigquitDataSource
- [x]  NdkDelegateImpl
- [x]  NativeThreadSamplerNdkDelegate