### PR TITLE
Add JNI interface tests for Sigquit

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/EmbraceSigquitNdkDelegate.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/EmbraceSigquitNdkDelegate.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.anr.sigquit
+
+// IMPORTANT: This class is referenced by emb_anr_manager.c. Move or rename both at the same time, or it will break.
+public class EmbraceSigquitNdkDelegate : SigquitNdkDelegate {
+    external override fun installGoogleAnrHandler(googleThreadId: Int): Int
+}
+
+public interface SigquitNdkDelegate {
+    public fun installGoogleAnrHandler(googleThreadId: Int): Int
+}

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSource.kt
@@ -11,13 +11,13 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.utils.ThreadUtils
 import java.util.concurrent.atomic.AtomicBoolean
 
-// IMPORTANT: This class is referenced by anr.c. Move or rename both at the same time, or it will break.
 public class SigquitDataSource(
     private val sharedObjectLoader: SharedObjectLoader,
     private val anrThreadIdDelegate: AnrThreadIdDelegate,
     private val anrBehavior: AnrBehavior,
     private val logger: EmbLogger,
-    writer: SessionSpanWriter
+    writer: SessionSpanWriter,
+    private val sigquitNdkDelegate: SigquitNdkDelegate = EmbraceSigquitNdkDelegate()
 ) : DataSourceImpl<SessionSpanWriter>(
     writer,
     logger,
@@ -42,7 +42,7 @@ public class SigquitDataSource(
 
     private fun install(googleThreadId: Int): Int {
         return try {
-            val res = installGoogleAnrHandler(googleThreadId)
+            val res = sigquitNdkDelegate.installGoogleAnrHandler(googleThreadId)
             if (res > 0) {
                 googleAnrTrackerInstalled.set(false)
                 logger.logError("Could not initialize Google ANR tracking {code=$res}")
@@ -73,6 +73,4 @@ public class SigquitDataSource(
         // they were called.
         install(googleThreadId)
     }
-
-    private external fun installGoogleAnrHandler(googleThreadId: Int): Int
 }

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/SigquitJniInterfaceTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/SigquitJniInterfaceTest.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.ndk.jni
+
+import io.embrace.android.embracesdk.internal.anr.sigquit.EmbraceSigquitNdkDelegate
+import io.embrace.android.embracesdk.ndk.NativeTestSuite
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class SigquitJniInterfaceTest : NativeTestSuite() {
+
+    private val sigquitNdkDelegate = EmbraceSigquitNdkDelegate()
+
+    @Test
+    fun installGoogleAnrHandlerTest() {
+        val result = sigquitNdkDelegate.installGoogleAnrHandler(1)
+        assertEquals(0, result)
+    }
+}

--- a/embrace-android-sdk/src/main/cpp/anr/emb_anr_manager.c
+++ b/embrace-android-sdk/src/main/cpp/anr/emb_anr_manager.c
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 JNIEXPORT jint JNICALL
-Java_io_embrace_android_embracesdk_internal_anr_sigquit_SigquitDataSource_installGoogleAnrHandler(
+Java_io_embrace_android_embracesdk_internal_anr_sigquit_EmbraceSigquitNdkDelegate_installGoogleAnrHandler(
         JNIEnv *env, jobject thiz,
         jint google_thread_id) {
     return emb_install_google_anr_handler(env, thiz, google_thread_id);


### PR DESCRIPTION
The JNI interface relies on signatures that might break if a class is moved to another package or renamed. This is only detected in runtime, as compilation goes fine and our tests don't verify this behavior.

The goal of this PR is to create tests that, at the very least, break when a class targeted by a JNI signature is moved or renamed. If the class is not too complex, the tests will also verify additional functionality.

Classes to test:

- [x]  EmbraceCpuInfoNdkDelegate
- [x]  SigquitDataSource
- [x]  NdkDelegateImpl
- [x]  NativeThreadSamplerNdkDelegate