### PR TITLE
Add JNI interface tests for NdkDelegate

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/NdkJniInterfaceTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/NdkJniInterfaceTest.kt
@@ -1,0 +1,78 @@
+package io.embrace.android.embracesdk.ndk.jni
+
+import io.embrace.android.embracesdk.internal.ndk.NdkDelegateImpl
+import io.embrace.android.embracesdk.ndk.NativeTestSuite
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class NdkJniInterfaceTest : NativeTestSuite() {
+
+    private val ndkDelegate = NdkDelegateImpl()
+
+    @Before
+    fun setUp() {
+        // install signal handlers first so we can test the other methods without race conditions
+        val result = ndkDelegate._installSignalHandlers(
+            "report_path",
+            "markerFilePath",
+            "device_meta_data",
+            "null",
+            "app_state",
+            "report_id",
+            29,
+            false,
+            true
+        )
+        // we can't really check the result because it's a void function, but if the class is moved or renamed this will fail
+        assertEquals(Unit.javaClass, result.javaClass)
+    }
+
+    @Test
+    fun updateMetaDataTest() {
+        val result = ndkDelegate._updateMetaData("new_device_meta_data")
+        assertEquals(Unit.javaClass, result.javaClass)
+    }
+
+    @Test
+    fun updateSessionIdTest() {
+        val result = ndkDelegate._updateSessionId("new_session_id")
+        assertEquals(Unit.javaClass, result.javaClass)
+    }
+
+    @Test
+    fun updateAppStateTest() {
+        val result = ndkDelegate._updateAppState("new_app_state")
+        assertEquals(Unit.javaClass, result.javaClass)
+    }
+
+    @Test
+    fun getCrashReportTest() {
+        val result = ndkDelegate._getCrashReport("path")
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun getErrorsTest() {
+        val result = ndkDelegate._getErrors("path")
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun checkForOverwrittenHandlersTest() {
+        val result = ndkDelegate._checkForOverwrittenHandlers()
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun uninstallSignalsTest() {
+        val result = ndkDelegate._uninstallSignals()
+        assertEquals(Unit.javaClass, result.javaClass)
+    }
+
+    @Test
+    fun reinstallSignalHandlersTest() {
+        val result = ndkDelegate._reinstallSignalHandlers()
+        assertEquals(false, result)
+    }
+}


### PR DESCRIPTION
The JNI interface relies on signatures that might break if a class is moved to another package or renamed. This is only detected in runtime, as compilation goes fine and our tests don't verify this behavior.

The goal of this PR is to create tests that, at the very least, break when a class targeted by a JNI signature is moved or renamed. If the class is not too complex, the tests will also verify additional functionality.

Classes to test:

- [x]  EmbraceCpuInfoNdkDelegate
- [x]  SigquitDataSource
- [x]  NdkDelegateImpl
- [x]  NativeThreadSamplerNdkDelegate