### PR TITLE
Use Android Test Orchestrator to run tests in individual Instrumentation instances

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-prod-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-prod-defaults.gradle.kts
@@ -19,6 +19,11 @@ android {
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        // The following argument makes the Android Test Orchestrator run its
+        // "pm clear" command after each test invocation. This command ensures
+        // that the app's state is completely cleared between tests.
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+
         aarMetadata {
             minCompileSdk = Versions.MIN_COMPILE_SDK
         }
@@ -38,6 +43,7 @@ android {
                 test.maxParallelForks = (Runtime.getRuntime().availableProcessors() / 3) + 1
             }
         }
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
 
     buildTypes {
@@ -79,6 +85,7 @@ dependencies {
 
     androidTestImplementation("androidx.test:core:${Versions.ANDROIDX_TEST}")
     androidTestImplementation("androidx.test:runner:${Versions.ANDROIDX_TEST}")
+    androidTestUtil("androidx.test:orchestrator:${Versions.ANDROIDX_TEST}")
 }
 
 checkstyle {

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -19,7 +19,7 @@ object Versions {
 
     const val NDK = "22.1.7171670"
     const val MOCKK = "1.12.2"
-    const val ANDROIDX_TEST = "1.4.0"
+    const val ANDROIDX_TEST = "1.5.0"
     const val ANDROIDX_JUNIT = "1.1.3"
     const val ROBOLECTRIC = "4.12.1"
     const val MOCKWEBSERVER = "4.9.3"


### PR DESCRIPTION
## Goal

Some of the JNI interface tests were affecting other integration tests. We needed a way to run every component in isolation so it wouldn't affect the outcome of other tests. Android Test Orchestrator allows that to happen.