### PR TITLE
Update proguard rules with new delegates location 

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSource.kt
@@ -32,6 +32,7 @@ public class SigquitDataSource(
         }
     }
 
+    // IMPORTANT: This class and method are referenced by anr.c. Move or rename both at the same time, or it will break.
     public fun saveSigquit(timestamp: Long) {
         if (anrBehavior.isGoogleAnrCaptureEnabled()) {
             captureData(NoInputValidation) {

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -8,14 +8,14 @@
 -keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface { *; }
 
 ## Keep classes used from native code
--keep class io.embrace.android.embracesdk.payload.NativeThreadAnrSample { *; }
--keep class io.embrace.android.embracesdk.payload.NativeThreadAnrStackframe { *; }
--keep class io.embrace.android.embracesdk.anr.sigquit.SigquitDataSource { *; }
+-keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrSample { *; }
+-keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrStackframe { *; }
+-keep class io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSource { *; }
 
 ## Keep classes with JNI calls to native code
--keep class io.embrace.android.embracesdk.capture.cpu.EmbraceCpuInfoDelegate { *; }
--keep class io.embrace.android.embracesdk.anr.ndk.NativeThreadSamplerNdkDelegate { *; }
--keep class io.embrace.android.embracesdk.ndk.NdkDelegateImpl { *; }
+-keep class io.embrace.android.embracesdk.internal.capture.cpu.EmbraceCpuInfoNdkDelegate { *; }
+-keep class io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerNdkDelegate { *; }
+-keep class io.embrace.android.embracesdk.internal.ndk.NdkDelegateImpl { *; }
 
 ## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }


### PR DESCRIPTION
Some proguard rules were pointing to a wrong location. We should also try to add some swazzler-tests or integration tests to avoid outdated proguard rules.