### PR TITLE
Populate session properties in session span during transition

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
@@ -60,8 +60,9 @@ internal class SessionPropertiesServiceImplTest {
             ::dataSource
         )
         assertEquals(0, fakeCurrentSessionSpan.attributeCount())
+        service.addProperty("temp", "value", false)
         assertTrue(service.populateCurrentSession())
-        assertEquals(1, fakeCurrentSessionSpan.attributeCount())
+        assertEquals(2, fakeCurrentSessionSpan.attributeCount())
     }
 
     @Test

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.internal.capture.envelope.session
 
 import io.embrace.android.embracesdk.internal.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeAnrOtelMapper
-import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
-import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
@@ -13,21 +11,10 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapsh
 internal class OtelPayloadMapperImpl(
     private val anrOtelMapper: AnrOtelMapper,
     private val nativeAnrOtelMapper: NativeAnrOtelMapper,
-    private val sessionPropertiesService: SessionPropertiesService
 ) : OtelPayloadMapper {
 
     override fun getSessionPayload(endType: SessionSnapshotType, crashId: String?): List<Span> {
         val cacheAttempt = endType == SessionSnapshotType.PERIODIC_CACHE
-        val appTerminationCause = when {
-            crashId != null -> AppTerminationCause.Crash
-            else -> null
-        }
-        if (!cacheAttempt) {
-            if (appTerminationCause == null) {
-                sessionPropertiesService.populateCurrentSession()
-            }
-        }
-        return anrOtelMapper.snapshot(!cacheAttempt)
-            .plus(nativeAnrOtelMapper.snapshot(!cacheAttempt))
+        return anrOtelMapper.snapshot(!cacheAttempt).plus(nativeAnrOtelMapper.snapshot(!cacheAttempt))
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -354,7 +354,6 @@ internal class ModuleInitBootstrapper(
                             nativeModule,
                             openTelemetryModule,
                             anrModule,
-                            essentialServiceModule.sessionPropertiesService
                         )
                     }
 
@@ -410,10 +409,6 @@ internal class ModuleInitBootstrapper(
                             dataContainerModule,
                             logModule
                         )
-                    }
-
-                    workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit {
-                        essentialServiceModule.sessionPropertiesService.populateCurrentSession()
                     }
 
                     crashModule = init(CrashModule::class) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadModuleImpl.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.internal.capture.envelope.resource.DeviceIm
 import io.embrace.android.embracesdk.internal.capture.envelope.session.OtelPayloadMapperImpl
 import io.embrace.android.embracesdk.internal.capture.envelope.session.SessionPayloadSourceImpl
 import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
-import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSourceImpl
@@ -24,7 +23,6 @@ internal class PayloadModuleImpl(
     nativeModule: NativeModule,
     otelModule: OpenTelemetryModule,
     anrModule: AnrModule,
-    sessionPropertiesService: SessionPropertiesService
 ) : PayloadModule {
 
     private val backgroundWorker =
@@ -63,7 +61,6 @@ internal class PayloadModuleImpl(
             OtelPayloadMapperImpl(
                 anrModule.anrOtelMapper,
                 nativeModule.nativeAnrOtelMapper,
-                sessionPropertiesService
             ),
             initModule.logger,
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadModuleSupplier.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadModuleSupplier.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
-
 /**
  * Function that returns an instance of [PayloadModule]. Matches the signature of the constructor for [PayloadModuleImpl]
  */
@@ -15,7 +13,6 @@ internal typealias PayloadModuleSupplier = (
     nativeModule: NativeModule,
     otelModule: OpenTelemetryModule,
     anrModule: AnrModule,
-    sessionPropertiesService: SessionPropertiesService
 ) -> PayloadModule
 
 internal fun createPayloadModule(
@@ -28,7 +25,6 @@ internal fun createPayloadModule(
     nativeModule: NativeModule,
     otelModule: OpenTelemetryModule,
     anrModule: AnrModule,
-    sessionPropertiesService: SessionPropertiesService
 ): PayloadModule = PayloadModuleImpl(
     initModule,
     coreModule,
@@ -39,5 +35,4 @@ internal fun createPayloadModule(
     nativeModule,
     otelModule,
     anrModule,
-    sessionPropertiesService
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionModuleImpl.kt
@@ -73,7 +73,8 @@ internal class SessionModuleImpl(
             dataContainerModule.eventService,
             dataCaptureServiceModule.startupService,
             logModule.logService,
-            essentialServiceModule.metadataService
+            essentialServiceModule.metadataService,
+            essentialServiceModule.sessionPropertiesService
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.internal.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.startup.StartupService
 import io.embrace.android.embracesdk.internal.event.EventService
 import io.embrace.android.embracesdk.internal.logs.LogService
@@ -28,10 +29,12 @@ internal class SessionSpanAttrPopulatorImpl(
     private val eventService: EventService,
     private val startupService: StartupService,
     private val logService: LogService,
-    private val metadataService: MetadataService
+    private val metadataService: MetadataService,
+    private val sessionPropertiesService: SessionPropertiesService
 ) : SessionSpanAttrPopulator {
 
     override fun populateSessionSpanStartAttrs(session: SessionZygote) {
+        sessionPropertiesService.populateCurrentSession()
         with(sessionSpanWriter) {
             addSystemAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
             addSystemAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -53,7 +53,7 @@ internal fun fakeModuleInitBootstrapper(
     dataContainerModuleSupplier: DataContainerModuleSupplier = { _, _, _, _, _ -> FakeDataContainerModule() },
     sessionModuleSupplier: SessionModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeSessionModule() },
     crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _ -> FakeCrashModule() },
-    payloadModuleSupplier: PayloadModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakePayloadModule() }
+    payloadModuleSupplier: PayloadModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakePayloadModule() }
 ) = ModuleInitBootstrapper(
     logger = fakeEmbLogger,
     initModule = fakeInitModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadModuleImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
-import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
@@ -30,7 +29,6 @@ internal class PayloadModuleImplTest {
             FakeNativeModule(),
             FakeOpenTelemetryModule(),
             FakeAnrModule(),
-            FakeSessionPropertiesService()
         )
         assertNotNull(module.sessionEnvelopeSource)
         assertNotNull(module.logEnvelopeSource)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.fakes.FakeNdkService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
-import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
 import io.embrace.android.embracesdk.fakes.fakeNativeAnrOtelMapper
@@ -161,7 +160,6 @@ internal class PayloadFactoryBaTest {
                 OtelPayloadMapperImpl(
                     fakeAnrOtelMapper(),
                     fakeNativeAnrOtelMapper(),
-                    FakeSessionPropertiesService(),
                 ),
                 logger
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -135,7 +135,6 @@ internal class SessionHandlerTest {
                     OtelPayloadMapperImpl(
                         fakeAnrOtelMapper(),
                         fakeNativeAnrOtelMapper(),
-                        FakeSessionPropertiesService(),
                     ),
                     logger
                 )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/orchestrator/SessionOrchestratorTest.kt
@@ -413,7 +413,8 @@ internal class SessionOrchestratorTest {
                 FakeEventService(),
                 FakeStartupService(),
                 FakeLogService(),
-                FakeMetadataService()
+                FakeMetadataService(),
+                FakeSessionPropertiesService()
             ),
             logger
         )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -17,7 +17,7 @@ public class FakeCurrentSessionSpan(
 ) : CurrentSessionSpan {
     public var initializedCallCount: Int = 0
     public var addedEvents: MutableList<SpanEventData> = mutableListOf()
-    public var addedAttributes: MutableList<SpanAttributeData> = mutableListOf()
+    public var attributes: MutableMap<String, String> = mutableMapOf()
     public var sessionSpan: FakeSpanData? = null
 
     private val sessionIteration = AtomicInteger(1)
@@ -36,12 +36,11 @@ public class FakeCurrentSessionSpan(
     }
 
     override fun addSystemAttribute(attribute: SpanAttributeData) {
-        addedAttributes.add(attribute)
+        attributes[attribute.key] = attribute.value
     }
 
     override fun removeSystemAttribute(key: String) {
-        val attributeToRemove = addedAttributes.find { it.key == key } ?: return
-        addedAttributes.remove(attributeToRemove)
+        attributes.remove(key)
     }
 
     override fun initialized(): Boolean {
@@ -71,9 +70,9 @@ public class FakeCurrentSessionSpan(
         return "testSessionId$sessionIteration"
     }
 
-    public fun getAttribute(key: String): String? = addedAttributes.lastOrNull { it.key == key }?.value
+    public fun getAttribute(key: String): String? = attributes[key]
 
-    public fun attributeCount(): Int = addedAttributes.size
+    public fun attributeCount(): Int = attributes.size
 
     private fun newSessionSpan(startTimeMs: Long) =
         FakeSpanData(


### PR DESCRIPTION
## Goal

We were populating session properties in a session span as a side effect of constructing the end payload of the previous session. This caused a couple of problems: session-only properties not being cleared before the population, and if background activity is disabled, session properties population fails.

Changing where we do the population fixes both of these, as well as allow us to remove the extra population call during SDK startup. 

This change also supersedes #1206 as literal removal is no longer necessary - session only properties will be added or removed from the current session's session span by the `SessionPropertiesService` 

## Testing

Add integration tests for all cases, as well as the one added in #1206 to verify that session-only props don't bleed into the next session. Unit tests were also modified accordingly.