### PR TITLE
Return an error when configure_reporting fails for Sigquit capture

### DIFF
--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/NativeThreadSamplerJniInterfaceTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/NativeThreadSamplerJniInterfaceTest.kt
@@ -30,6 +30,11 @@ internal class NativeThreadSamplerJniInterfaceTest : NativeTestSuite() {
         assertEquals(Unit.javaClass, result.javaClass)
     }
 
+    /**
+     * Besides testing finishSampling(), this is also verifying that the JNI FindClass method called in populate_jni_cache works.
+     * We are currently looking for NativeThreadAnrSample and NativeThreadAnrStackframe, so if any of those classes are moved or renamed,
+     * this test will fail.
+     */
     @Test
     fun finishSamplingTest() {
         val result = nativeThreadSamplerNdkDelegate.finishSampling()

--- a/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/SigquitJniInterfaceTest.kt
+++ b/embrace-android-sdk/src/androidTest/java/io/embrace/android/embracesdk/ndk/jni/SigquitJniInterfaceTest.kt
@@ -9,6 +9,11 @@ internal class SigquitJniInterfaceTest : NativeTestSuite() {
 
     private val sigquitNdkDelegate = EmbraceSigquitNdkDelegate()
 
+    /**
+     * Besides testing installGoogleAnrHandler(), this is also verifying that the JNI FindClass method called
+     * in anr.c -> configure_reporting works.
+     * We are currently looking for SigquitDataSource, so if any of it's moved or renamed, this test will fail.
+     */
     @Test
     fun installGoogleAnrHandlerTest() {
         val result = sigquitNdkDelegate.installGoogleAnrHandler(1)

--- a/embrace-android-sdk/src/main/cpp/anr/anr.c
+++ b/embrace-android-sdk/src/main/cpp/anr/anr.c
@@ -245,6 +245,8 @@ int emb_install_google_anr_handler(JNIEnv *env, jobject anr_service, jint _googl
             anr_service_obj = (*env)->NewGlobalRef(env, anr_service);
             res = install_signal_handler();
             installed = true;
+        } else {
+            res = EMB_ANR_INSTALL_REPORTING_CONFIGURATION_FAIL;
         }
     }
     pthread_mutex_unlock(&emb_anr_install_lock);

--- a/embrace-android-sdk/src/main/cpp/anr/anr.h
+++ b/embrace-android-sdk/src/main/cpp/anr/anr.h
@@ -13,6 +13,7 @@
 #define EMB_ANR_INSTALL_NO_SEMAPHORE 1 << 0
 #define EMB_ANR_INSTALL_WATCHDOG_THREAD_CREATE_FAIL 1 << 1
 #define EMB_ANR_INSTALL_HANDLER_FAIL 1 << 2
+#define EMB_ANR_INSTALL_REPORTING_CONFIGURATION_FAIL 1 << 3
 
 int emb_install_google_anr_handler(JNIEnv *env, jobject anr_service, jint _google_thread_id);
 


### PR DESCRIPTION
When we called FindClass on SigquitDataSource and it was not found, we were returning 0 as the result of installGoogleAnrHandler. This means we would've logged that Google ANR was correctly installed, but it wouldn't have worked.

This PR fixes that, and also adds a comment in some interface tests that are also testing classes targeted by JNI FindClass