### PR TITLE
Fall back to heartbeat time when converted span snapshots

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryService.kt
@@ -201,10 +201,11 @@ internal class EmbraceDeliveryService(
      * time, so we just leave it at 0.
      */
     private fun getFailedSpanEndTimeMs(envelope: Envelope<SessionPayload>): Long {
-        return envelope.getSessionSpan()?.run {
-            max(endTimeNanos ?: 0L, attributes?.findAttributeValue(embHeartbeatTimeUnixNano.attributeKey.key)?.toLongOrNull() ?: 0L)
-                .nanosToMillis()
-        } ?: 0L
+        val sessionSpan = envelope.getSessionSpan() ?: return 0L
+        val endTimeMs = sessionSpan.endTimeNanos ?: 0L
+        val lastHeartbeatTimeMs =
+            sessionSpan.attributes?.findAttributeValue(embHeartbeatTimeUnixNano.attributeKey.key)?.toLongOrNull() ?: 0L
+        return max(endTimeMs, lastHeartbeatTimeMs).nanosToMillis()
     }
 
     override fun sendMoment(eventMessage: EventMessage) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -47,6 +47,27 @@ public fun fakeSessionEnvelope(
     )
 }
 
+public fun fakeIncompleteSessionEnvelope(
+    sessionId: String = "fakeIncompleteSessionId",
+    startMs: Long = 1691000000000L,
+    lastHeartbeatTimeMs: Long = 1691000300000L,
+): Envelope<SessionPayload> {
+    val fakeClock = FakeClock(currentTime = startMs)
+    val incompleteSessionSpan = FakePersistableEmbraceSpan.sessionSpan(
+        sessionId = sessionId,
+        startTimeMs = startMs,
+        lastHeartbeatTimeMs = lastHeartbeatTimeMs
+    )
+    return Envelope(
+        data = SessionPayload(
+            spanSnapshots = listOfNotNull(
+                incompleteSessionSpan.snapshot(),
+                FakePersistableEmbraceSpan.started(clock = fakeClock).snapshot()
+            )
+        )
+    )
+}
+
 public fun Envelope<SessionPayload>.mutateSessionSpan(action: (original: Span) -> Span): Envelope<SessionPayload> {
     val spans = data.spans
     val sessionSpan = checkNotNull(getSessionSpan())
@@ -55,12 +76,4 @@ public fun Envelope<SessionPayload>.mutateSessionSpan(action: (original: Span) -
             spans?.minus(sessionSpan)?.plus(action(sessionSpan))
         )
     )
-}
-
-public fun fakeCachedSessionEnvelopeWithTerminationTime(): Envelope<SessionPayload> {
-    return fakeSessionEnvelope(sessionId = "fakeSessionWithTerminationTime")
-}
-
-public fun fakeCachedSessionEnvelopeWithHeartbeatTime(): Envelope<SessionPayload> {
-    return fakeSessionEnvelope(sessionId = "fakeSessionWithHeartbeat")
 }


### PR DESCRIPTION
## Goal

Use the last heartbeat time of the session span if the end time was missing, like if the session itself wasn't terminated properly, like during a native crash or a user kill while the app is in background.

Previously we were assuming that there's always an end time, and we even tested for that case too, which yield and end of 0 in those cases. The backend is able to work with that in most case, as it just figures it out by looking at other timestamps. So while customers don't see this problem for the most part, like for sessions associated with native crashes, the session span is wrong. I was also seeing some 0-length sessions for background kills where the session span contains a heartbeat time, so it's better than we do this population properly, and test it properly as well.

## Testing
Modify and extend unit test on the `EmbraceDeliveryService`. Tweaking some testing infra to make this easier too.