### PR TITLE
Remove the NDK setup step from GH actions

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -35,7 +35,6 @@ jobs:
     strategy:
       matrix:
         jdk-version: [ "17" ]
-        ndk-version: [ "21.4.7075529" ]
     steps:
       - name: Decode Keystore
         run: |
@@ -69,13 +68,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.jdk-version }}
-
-      - name: Setup NDK ${{ matrix.ndk-version }}
-        run: |
-          export ANDROID_ROOT=/usr/local/lib/android
-          export ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-          export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-          ln -sfn $ANDROID_SDK_ROOT/ndk/${{ matrix.ndk-version }} $ANDROID_NDK_ROOT
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   gradle-test:
-    runs-on: macos-14
+    runs-on: macos-latest
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         jdk-version: ["17"]
-        ndk-version: ["21.4.7075529"]
         api-level: [29]
         target: [default]
 

--- a/.github/workflows/generate_baseline_profile.yml
+++ b/.github/workflows/generate_baseline_profile.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         jdk-version: [ "17" ]
-        ndk-version: [ "21.4.7075529" ]
         api-level: [ 29 ]
         target: [ default ]
 

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -29,7 +29,6 @@ jobs:
     strategy:
       matrix:
         jdk-version: [ "17" ]
-        ndk-version: [ "21.4.7075529" ]
     steps:
       - name: Configure git
         run: |

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         jdk-version: ["17"]
-        ndk-version: ["21.4.7075529"]
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v4
@@ -49,13 +48,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.jdk-version }}
-
-      - name: Setup NDK ${{ matrix.ndk-version }}
-        run: |
-          export ANDROID_ROOT=/usr/local/lib/android
-          export ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-          export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-          ln -sfn $ANDROID_SDK_ROOT/ndk/${{ matrix.ndk-version }} $ANDROID_NDK_ROOT
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -30,7 +30,6 @@ jobs:
     strategy:
       matrix:
         jdk-version: [ "17" ]
-        ndk-version: [ "21.4.7075529" ]
     steps:
       - name: Checkout SDK
         uses: actions/checkout@v4


### PR DESCRIPTION
## Goal

It doesn't seem setting up the NDK is necessary for the various GH workflows that are doing it, so removing them to see if that's actually.

Also consolidated all the actions that run on Macs to use macos-14
