### PR TITLE
Move payload generation out of essential service module

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -100,7 +100,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
     private var embraceInternalInterface: EmbraceInternalInterface? = null
     private var internalInterfaceModule: InternalInterfaceModule? = null
 
-    val metadataService by embraceImplInject { bootstrapper.essentialServiceModule.metadataService }
+    val metadataService by embraceImplInject { bootstrapper.payloadSourceModule.metadataService }
     val activityService by embraceImplInject { bootstrapper.essentialServiceModule.processStateService }
     val activityLifecycleTracker by embraceImplInject { bootstrapper.essentialServiceModule.activityLifecycleTracker }
     val internalErrorService by embraceImplInject { bootstrapper.initModule.internalErrorService }
@@ -213,6 +213,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
                 bootstrapper.initModule,
                 bootstrapper.openTelemetryModule,
                 essentialServiceModule,
+                bootstrapper.payloadSourceModule,
                 bootstrapper.logModule,
                 bootstrapper.momentsModule,
                 this,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
@@ -4,17 +4,19 @@ import io.embrace.android.embracesdk.internal.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Handles logic for features that are not fully integrated into the OTel pipeline.
  */
 internal class OtelPayloadMapperImpl(
     private val anrOtelMapper: AnrOtelMapper,
-    private val nativeAnrOtelMapper: NativeAnrOtelMapper,
+    private val nativeAnrOtelMapperProvider: Provider<NativeAnrOtelMapper?>,
 ) : OtelPayloadMapper {
 
     override fun getSessionPayload(endType: SessionSnapshotType, crashId: String?): List<Span> {
         val cacheAttempt = endType == SessionSnapshotType.PERIODIC_CACHE
-        return anrOtelMapper.snapshot(!cacheAttempt).plus(nativeAnrOtelMapper.snapshot(!cacheAttempt))
+        return anrOtelMapper.snapshot(!cacheAttempt)
+            .plus(nativeAnrOtelMapperProvider()?.snapshot(!cacheAttempt) ?: emptyList())
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
@@ -1,11 +1,9 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.cpu.CpuInfoDelegate
-import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTracker
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
@@ -14,9 +12,6 @@ import io.embrace.android.embracesdk.internal.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.comms.api.ApiUrlBuilder
 import io.embrace.android.embracesdk.internal.comms.delivery.PendingApiCallsSender
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
-import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
-import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.gating.GatingService
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
@@ -31,8 +26,6 @@ internal interface EssentialServiceModule {
     val memoryCleanerService: MemoryCleanerService
     val processStateService: ProcessStateService
     val activityLifecycleTracker: ActivityTracker
-    val metadataService: MetadataService
-    val hostedSdkVersionInfo: HostedSdkVersionInfo
     val configService: ConfigService
     val gatingService: GatingService
     val userService: UserService
@@ -41,13 +34,10 @@ internal interface EssentialServiceModule {
     val apiService: ApiService?
     val sharedObjectLoader: SharedObjectLoader
     val cpuInfoDelegate: CpuInfoDelegate
-    val deviceArchitecture: DeviceArchitecture
     val networkConnectivityService: NetworkConnectivityService
     val pendingApiCallsSender: PendingApiCallsSender
     val sessionIdTracker: SessionIdTracker
     val sessionPropertiesService: SessionPropertiesService
     val logWriter: LogWriter
-    val resourceSource: EnvelopeResourceSource
-    val metadataSource: EnvelopeMetadataSource
     val rnBundleIdTracker: RnBundleIdTracker
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.Embrace
-import io.embrace.android.embracesdk.internal.DeviceArchitecture
-import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
@@ -11,10 +9,6 @@ import io.embrace.android.embracesdk.internal.capture.connectivity.EmbraceNetwor
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.cpu.CpuInfoDelegate
 import io.embrace.android.embracesdk.internal.capture.cpu.EmbraceCpuInfoDelegate
-import io.embrace.android.embracesdk.internal.capture.envelope.resource.DeviceImpl
-import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
-import io.embrace.android.embracesdk.internal.capture.metadata.EmbraceMetadataService
-import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTracker
 import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTrackerImpl
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
@@ -34,9 +28,6 @@ import io.embrace.android.embracesdk.internal.config.EmbraceConfigService
 import io.embrace.android.embracesdk.internal.config.LocalConfigParser
 import io.embrace.android.embracesdk.internal.config.behavior.BehaviorThresholdCheck
 import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehaviorImpl
-import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSourceImpl
-import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
-import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSourceImpl
 import io.embrace.android.embracesdk.internal.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.internal.gating.GatingService
 import io.embrace.android.embracesdk.internal.payload.AppFramework
@@ -141,41 +132,6 @@ internal class EssentialServiceModuleImpl(
         EmbraceCpuInfoDelegate(sharedObjectLoader, initModule.logger)
     }
 
-    override val deviceArchitecture: DeviceArchitecture by singleton {
-        DeviceArchitectureImpl()
-    }
-
-    override val hostedSdkVersionInfo: HostedSdkVersionInfo by singleton {
-        HostedSdkVersionInfo(
-            androidServicesModule.preferencesService,
-            configService.appFramework
-        )
-    }
-
-    override val resourceSource by singleton {
-        EnvelopeResourceSourceImpl(
-            hostedSdkVersionInfo,
-            AppEnvironment(coreModule.context.applicationInfo).environment,
-            coreModule.buildInfo,
-            coreModule.packageVersionInfo,
-            configService.appFramework,
-            deviceArchitecture,
-            DeviceImpl(
-                systemServiceModule.windowManager,
-                androidServicesModule.preferencesService,
-                backgroundWorker,
-                initModule.systemInfo,
-                cpuInfoDelegate,
-                initModule.logger
-            ),
-            rnBundleIdTracker
-        )
-    }
-
-    override val metadataSource by singleton {
-        EnvelopeMetadataSourceImpl(userService::getUserInfo)
-    }
-
     override val rnBundleIdTracker: RnBundleIdTracker by singleton {
         RnBundleIdTrackerImpl(
             coreModule.buildInfo,
@@ -185,22 +141,6 @@ internal class EssentialServiceModuleImpl(
             backgroundWorker,
             initModule.logger
         )
-    }
-
-    override val metadataService: MetadataService by singleton {
-        Systrace.traceSynchronous("metadata-service-init") {
-            EmbraceMetadataService(
-                resourceSource,
-                metadataSource,
-                coreModule.context,
-                systemServiceModule.storageManager,
-                configService,
-                androidServicesModule.preferencesService,
-                backgroundWorker,
-                initModule.clock,
-                initModule.logger
-            )
-        }
     }
 
     override val urlBuilder by singleton {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
@@ -14,6 +14,7 @@ internal class InternalInterfaceModuleImpl(
     initModule: InitModule,
     openTelemetryModule: OpenTelemetryModule,
     essentialServiceModule: EssentialServiceModule,
+    payloadSourceModule: PayloadSourceModule,
     logModule: LogModule,
     momentsModule: MomentsModule,
     embrace: EmbraceImpl,
@@ -38,7 +39,7 @@ internal class InternalInterfaceModuleImpl(
             embraceInternalInterface,
             crashModule.crashDataSource,
             essentialServiceModule.rnBundleIdTracker,
-            essentialServiceModule.hostedSdkVersionInfo,
+            payloadSourceModule.hostedSdkVersionInfo,
             initModule.logger
         )
     }
@@ -47,7 +48,7 @@ internal class InternalInterfaceModuleImpl(
         UnityInternalInterfaceImpl(
             embrace,
             embraceInternalInterface,
-            essentialServiceModule.hostedSdkVersionInfo,
+            payloadSourceModule.hostedSdkVersionInfo,
             initModule.logger
         )
     }
@@ -56,7 +57,7 @@ internal class InternalInterfaceModuleImpl(
         FlutterInternalInterfaceImpl(
             embrace,
             embraceInternalInterface,
-            essentialServiceModule.hostedSdkVersionInfo,
+            payloadSourceModule.hostedSdkVersionInfo,
             initModule.logger
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/MomentsModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/MomentsModuleImpl.kt
@@ -7,6 +7,7 @@ internal class MomentsModuleImpl(
     initModule: InitModule,
     workerThreadModule: WorkerThreadModule,
     essentialServiceModule: EssentialServiceModule,
+    payloadSourceModule: PayloadSourceModule,
     deliveryModule: DeliveryModule,
     sdkStartTimeMs: Long
 ) : MomentsModule {
@@ -16,7 +17,7 @@ internal class MomentsModuleImpl(
             sdkStartTimeMs,
             deliveryModule.deliveryService,
             essentialServiceModule.configService,
-            essentialServiceModule.metadataService,
+            payloadSourceModule.metadataService,
             essentialServiceModule.processStateService,
             essentialServiceModule.sessionIdTracker,
             essentialServiceModule.userService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/MomentsModuleSupplier.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/MomentsModuleSupplier.kt
@@ -7,6 +7,7 @@ internal typealias MomentsModuleSupplier = (
     initModule: InitModule,
     workerThreadModule: WorkerThreadModule,
     essentialServiceModule: EssentialServiceModule,
+    payloadSourceModule: PayloadSourceModule,
     deliveryModule: DeliveryModule,
     startTime: Long
 ) -> MomentsModule
@@ -15,12 +16,14 @@ internal fun createMomentsModule(
     initModule: InitModule,
     workerThreadModule: WorkerThreadModule,
     essentialServiceModule: EssentialServiceModule,
+    payloadSourceModule: PayloadSourceModule,
     deliveryModule: DeliveryModule,
     startTime: Long
 ): MomentsModule = MomentsModuleImpl(
     initModule,
     workerThreadModule,
     essentialServiceModule,
+    payloadSourceModule,
     deliveryModule,
     startTime
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/NativeModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/NativeModuleImpl.kt
@@ -20,6 +20,7 @@ internal class NativeModuleImpl(
     coreModule: CoreModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    payloadSourceModule: PayloadSourceModule,
     deliveryModule: DeliveryModule,
     androidServicesModule: AndroidServicesModule,
     workerThreadModule: WorkerThreadModule
@@ -30,7 +31,7 @@ internal class NativeModuleImpl(
             EmbraceNdkService(
                 coreModule.context,
                 storageModule.storageService,
-                essentialServiceModule.metadataService,
+                payloadSourceModule.metadataService,
                 essentialServiceModule.processStateService,
                 essentialServiceModule.configService,
                 deliveryModule.deliveryService,
@@ -43,7 +44,7 @@ internal class NativeModuleImpl(
                 NdkDelegateImpl(),
                 workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
                 workerThreadModule.backgroundWorker(WorkerName.SERVICE_INIT),
-                essentialServiceModule.deviceArchitecture,
+                payloadSourceModule.deviceArchitecture,
                 initModule.jsonSerializer
             )
         }
@@ -57,7 +58,7 @@ internal class NativeModuleImpl(
                     symbols = lazy { ndkService.getSymbolsForCurrentArch() },
                     logger = initModule.logger,
                     scheduledWorker = workerThreadModule.scheduledWorker(WorkerName.BACKGROUND_REGISTRATION),
-                    deviceArchitecture = essentialServiceModule.deviceArchitecture,
+                    deviceArchitecture = payloadSourceModule.deviceArchitecture,
                     sharedObjectLoader = essentialServiceModule.sharedObjectLoader,
                 )
             } else {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/NativeModuleSupplier.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/NativeModuleSupplier.kt
@@ -8,6 +8,7 @@ internal typealias NativeModuleSupplier = (
     coreModule: CoreModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    payloadSourceModule: PayloadSourceModule,
     deliveryModule: DeliveryModule,
     androidServicesModule: AndroidServicesModule,
     workerThreadModule: WorkerThreadModule
@@ -18,6 +19,7 @@ internal fun createNativeModule(
     coreModule: CoreModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    payloadSourceModule: PayloadSourceModule,
     deliveryModule: DeliveryModule,
     androidServicesModule: AndroidServicesModule,
     workerThreadModule: WorkerThreadModule
@@ -26,6 +28,7 @@ internal fun createNativeModule(
     coreModule,
     storageModule,
     essentialServiceModule,
+    payloadSourceModule,
     deliveryModule,
     androidServicesModule,
     workerThreadModule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadModuleSupplier.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadModuleSupplier.kt
@@ -1,26 +1,40 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import io.embrace.android.embracesdk.internal.utils.Provider
+
 /**
  * Function that returns an instance of [PayloadSourceModule]. Matches the signature of the constructor for [PayloadSourceModuleImpl]
  */
 internal typealias PayloadSourceModuleSupplier = (
     initModule: InitModule,
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+    systemServiceModule: SystemServiceModule,
+    androidServicesModule: AndroidServicesModule,
     essentialServiceModule: EssentialServiceModule,
-    nativeModule: NativeModule,
+    nativeModuleProvider: Provider<NativeModule?>,
     otelModule: OpenTelemetryModule,
     anrModule: AnrModule,
 ) -> PayloadSourceModule
 
 internal fun createPayloadSourceModule(
     initModule: InitModule,
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+    systemServiceModule: SystemServiceModule,
+    androidServicesModule: AndroidServicesModule,
     essentialServiceModule: EssentialServiceModule,
-    nativeModule: NativeModule,
+    nativeModuleProvider: Provider<NativeModule?>,
     otelModule: OpenTelemetryModule,
     anrModule: AnrModule,
 ): PayloadSourceModule = PayloadSourceModuleImpl(
     initModule,
+    coreModule,
+    workerThreadModule,
+    systemServiceModule,
+    androidServicesModule,
     essentialServiceModule,
-    nativeModule,
+    nativeModuleProvider,
     otelModule,
     anrModule,
 )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
@@ -1,6 +1,11 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import io.embrace.android.embracesdk.internal.DeviceArchitecture
+import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
+import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
+import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSource
 
 /**
@@ -9,4 +14,9 @@ import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSo
 internal interface PayloadSourceModule {
     val sessionEnvelopeSource: SessionEnvelopeSource
     val logEnvelopeSource: LogEnvelopeSource
+    val metadataSource: EnvelopeMetadataSource
+    val deviceArchitecture: DeviceArchitecture
+    val resourceSource: EnvelopeResourceSource
+    val metadataService: MetadataService
+    val hostedSdkVersionInfo: HostedSdkVersionInfo
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -1,54 +1,108 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import io.embrace.android.embracesdk.internal.DeviceArchitecture
+import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
+import io.embrace.android.embracesdk.internal.Systrace
+import io.embrace.android.embracesdk.internal.capture.envelope.resource.DeviceImpl
 import io.embrace.android.embracesdk.internal.capture.envelope.session.OtelPayloadMapperImpl
 import io.embrace.android.embracesdk.internal.capture.envelope.session.SessionPayloadSourceImpl
+import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
+import io.embrace.android.embracesdk.internal.capture.metadata.EmbraceMetadataService
+import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSourceImpl
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSourceImpl
+import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
+import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSourceImpl
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.internal.worker.WorkerName
 
 internal class PayloadSourceModuleImpl(
     initModule: InitModule,
+    coreModule: CoreModule,
+    workerThreadModule: WorkerThreadModule,
+    systemServiceModule: SystemServiceModule,
+    androidServicesModule: AndroidServicesModule,
     essentialServiceModule: EssentialServiceModule,
-    nativeModule: NativeModule,
+    nativeModuleProvider: Provider<NativeModule?>,
     otelModule: OpenTelemetryModule,
     anrModule: AnrModule,
 ) : PayloadSourceModule {
 
     private val sessionPayloadSource by singleton {
         SessionPayloadSourceImpl(
-            { nativeModule.nativeThreadSamplerService?.getNativeSymbols() },
+            { nativeModuleProvider()?.nativeThreadSamplerService?.getNativeSymbols() },
             otelModule.spanSink,
             otelModule.currentSessionSpan,
             otelModule.spanRepository,
-            OtelPayloadMapperImpl(
-                anrModule.anrOtelMapper,
-                nativeModule.nativeAnrOtelMapper,
-            ),
+            OtelPayloadMapperImpl(anrModule.anrOtelMapper) { nativeModuleProvider()?.nativeAnrOtelMapper },
             initModule.logger
         )
     }
 
     private val logPayloadSource by singleton {
-        LogPayloadSourceImpl(
-            otelModule.logSink
-        )
+        LogPayloadSourceImpl(otelModule.logSink)
     }
 
     override val sessionEnvelopeSource: SessionEnvelopeSource by singleton {
-        SessionEnvelopeSourceImpl(
-            essentialServiceModule.metadataSource,
-            essentialServiceModule.resourceSource,
-            sessionPayloadSource
-        )
+        SessionEnvelopeSourceImpl(metadataSource, resourceSource, sessionPayloadSource)
     }
 
     override val logEnvelopeSource: LogEnvelopeSource by singleton {
-        LogEnvelopeSourceImpl(
-            essentialServiceModule.metadataSource,
-            essentialServiceModule.resourceSource,
-            logPayloadSource
+        LogEnvelopeSourceImpl(metadataSource, resourceSource, logPayloadSource)
+    }
+
+    override val deviceArchitecture: DeviceArchitecture by singleton {
+        DeviceArchitectureImpl()
+    }
+
+    override val hostedSdkVersionInfo: HostedSdkVersionInfo by singleton {
+        HostedSdkVersionInfo(
+            androidServicesModule.preferencesService,
+            essentialServiceModule.configService.appFramework
         )
+    }
+
+    override val resourceSource by singleton {
+        EnvelopeResourceSourceImpl(
+            hostedSdkVersionInfo,
+            AppEnvironment(coreModule.context.applicationInfo).environment,
+            coreModule.buildInfo,
+            coreModule.packageVersionInfo,
+            essentialServiceModule.configService.appFramework,
+            deviceArchitecture,
+            DeviceImpl(
+                systemServiceModule.windowManager,
+                androidServicesModule.preferencesService,
+                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                initModule.systemInfo,
+                essentialServiceModule.cpuInfoDelegate,
+                initModule.logger
+            ),
+            essentialServiceModule.rnBundleIdTracker
+        )
+    }
+
+    override val metadataSource by singleton {
+        EnvelopeMetadataSourceImpl(essentialServiceModule.userService::getUserInfo)
+    }
+
+    override val metadataService: MetadataService by singleton {
+        Systrace.traceSynchronous("metadata-service-init") {
+            EmbraceMetadataService(
+                resourceSource,
+                metadataSource,
+                coreModule.context,
+                systemServiceModule.storageManager,
+                essentialServiceModule.configService,
+                androidServicesModule.preferencesService,
+                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                initModule.clock,
+                initModule.logger
+            )
+        }
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
@@ -73,7 +73,7 @@ internal class SessionOrchestrationModuleImpl(
             momentsModule.eventService,
             dataCaptureServiceModule.startupService,
             logModule.logService,
-            essentialServiceModule.metadataService,
+            payloadSourceModule.metadataService,
             essentialServiceModule.sessionPropertiesService
         )
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -49,11 +49,11 @@ internal fun fakeModuleInitBootstrapper(
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _ -> FakeLogModule() },
-    nativeModuleSupplier: NativeModuleSupplier = { _, _, _, _, _, _, _ -> FakeNativeModule() },
-    momentsModuleSupplier: MomentsModuleSupplier = { _, _, _, _, _ -> FakeMomentsModule() },
+    nativeModuleSupplier: NativeModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeNativeModule() },
+    momentsModuleSupplier: MomentsModuleSupplier = { _, _, _, _, _, _ -> FakeMomentsModule() },
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
     crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _ -> FakeCrashModule() },
-    payloadSourceModuleSupplier: PayloadSourceModuleSupplier = { _, _, _, _, _ -> FakePayloadSourceModule() }
+    payloadSourceModuleSupplier: PayloadSourceModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() }
 ) = ModuleInitBootstrapper(
     logger = fakeEmbLogger,
     initModule = fakeInitModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadSourceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadSourceModule.kt
@@ -1,14 +1,22 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.DeviceArchitecture
+import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSource
+import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPayloadSource
 import io.embrace.android.embracesdk.internal.injection.PayloadSourceModule
 
 internal class FakePayloadSourceModule(
+    override val metadataService: MetadataService = FakeMetadataService(),
+    override val deviceArchitecture: DeviceArchitecture = FakeDeviceArchitecture(),
+    override val hostedSdkVersionInfo: HostedSdkVersionInfo = HostedSdkVersionInfo(FakePreferenceService()),
+    override val resourceSource: FakeEnvelopeResourceSource = FakeEnvelopeResourceSource(),
+    override val metadataSource: FakeEnvelopeMetadataSource = FakeEnvelopeMetadataSource(),
     sessionPayloadSource: SessionPayloadSource = FakeSessionPayloadSource(),
     logPayloadSource: LogPayloadSource = FakeLogPayloadSource()
 ) : PayloadSourceModule {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -6,34 +6,26 @@ import io.embrace.android.embracesdk.fakes.FakeApiService
 import io.embrace.android.embracesdk.fakes.FakeApiUrlBuilder
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
-import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
-import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
-import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeGatingService
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
-import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePendingApiCallsSender
-import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeRnBundleIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.NoOpNetworkConnectivityService
-import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.cpu.CpuInfoDelegate
-import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.comms.api.ApiClient
 import io.embrace.android.embracesdk.internal.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.comms.api.ApiUrlBuilder
 import io.embrace.android.embracesdk.internal.comms.delivery.PendingApiCallsSender
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.gating.GatingService
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
@@ -45,7 +37,6 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateServ
 internal class FakeEssentialServiceModule(
     override val processStateService: ProcessStateService = FakeProcessStateService(),
     override val activityLifecycleTracker: ActivityTracker = FakeActivityTracker(),
-    override val metadataService: MetadataService = FakeMetadataService(),
     override val sessionIdTracker: SessionIdTracker = FakeSessionIdTracker(),
     override val configService: ConfigService = FakeConfigService(),
     override val memoryCleanerService: MemoryCleanerService = FakeMemoryCleanerService(),
@@ -53,16 +44,12 @@ internal class FakeEssentialServiceModule(
     override val apiClient: ApiClient = FakeApiClient(),
     override val userService: UserService = FakeUserService(),
     override val sharedObjectLoader: SharedObjectLoader = SharedObjectLoader(EmbLoggerImpl()),
-    override val deviceArchitecture: DeviceArchitecture = FakeDeviceArchitecture(),
     override val apiService: ApiService = FakeApiService(),
     override val networkConnectivityService: NetworkConnectivityService = NoOpNetworkConnectivityService(),
     override val pendingApiCallsSender: PendingApiCallsSender = FakePendingApiCallsSender(),
     override val urlBuilder: ApiUrlBuilder = FakeApiUrlBuilder(),
-    override val hostedSdkVersionInfo: HostedSdkVersionInfo = HostedSdkVersionInfo(FakePreferenceService()),
     override val logWriter: LogWriter = FakeLogWriter(),
     override val cpuInfoDelegate: CpuInfoDelegate = FakeCpuInfoDelegate(),
     override val sessionPropertiesService: FakeSessionPropertiesService = FakeSessionPropertiesService(),
-    override val resourceSource: FakeEnvelopeResourceSource = FakeEnvelopeResourceSource(),
-    override val metadataSource: FakeEnvelopeMetadataSource = FakeEnvelopeMetadataSource(),
     override val rnBundleIdTracker: FakeRnBundleIdTracker = FakeRnBundleIdTracker()
 ) : EssentialServiceModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
@@ -11,11 +11,9 @@ import io.embrace.android.embracesdk.fakes.injection.FakeLogModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
-import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriterImpl
 import io.embrace.android.embracesdk.internal.capture.connectivity.EmbraceNetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.cpu.EmbraceCpuInfoDelegate
-import io.embrace.android.embracesdk.internal.capture.metadata.EmbraceMetadataService
 import io.embrace.android.embracesdk.internal.capture.user.EmbraceUserService
 import io.embrace.android.embracesdk.internal.comms.delivery.EmbracePendingApiCallsSender
 import io.embrace.android.embracesdk.internal.config.EmbraceConfigService
@@ -57,7 +55,6 @@ internal class EssentialServiceModuleImplTest {
 
         assertTrue(module.memoryCleanerService is EmbraceMemoryCleanerService)
         assertTrue(module.processStateService is EmbraceProcessStateService)
-        assertTrue(module.metadataService is EmbraceMetadataService)
         assertNotNull(module.urlBuilder)
         assertNotNull(module.apiClient)
         assertNotNull(module.apiService)
@@ -70,7 +67,6 @@ internal class EssentialServiceModuleImplTest {
         assertTrue(module.gatingService is EmbraceGatingService)
         assertTrue(module.cpuInfoDelegate is EmbraceCpuInfoDelegate)
         assertTrue(module.networkConnectivityService is EmbraceNetworkConnectivityService)
-        assertTrue(module.deviceArchitecture is DeviceArchitectureImpl)
         assertTrue(module.pendingApiCallsSender is EmbracePendingApiCallsSender)
         assertTrue(module.logWriter is LogWriterImpl)
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/MomentsModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/MomentsModuleImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
+import io.embrace.android.embracesdk.fakes.FakePayloadSourceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -16,6 +17,7 @@ internal class MomentsModuleImplTest {
             FakeInitModule(),
             FakeWorkerThreadModule(),
             FakeEssentialServiceModule(),
+            FakePayloadSourceModule(),
             FakeDeliveryModule(),
             0
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadSourceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/PayloadSourceModuleImplTest.kt
@@ -1,12 +1,19 @@
 package io.embrace.android.embracesdk.injection
 
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
+import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
+import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeModule
+import io.embrace.android.embracesdk.fakes.injection.FakeSystemServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
+import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
+import io.embrace.android.embracesdk.internal.capture.metadata.EmbraceMetadataService
 import io.embrace.android.embracesdk.internal.injection.PayloadSourceModuleImpl
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class PayloadSourceModuleImplTest {
@@ -16,12 +23,18 @@ internal class PayloadSourceModuleImplTest {
         val initModule = FakeInitModule()
         val module = PayloadSourceModuleImpl(
             initModule,
+            FakeCoreModule(),
+            FakeWorkerThreadModule(),
+            FakeSystemServiceModule(),
+            FakeAndroidServicesModule(),
             FakeEssentialServiceModule(),
-            FakeNativeModule(),
+            ::FakeNativeModule,
             FakeOpenTelemetryModule(),
             FakeAnrModule(),
         )
+        assertTrue(module.metadataService is EmbraceMetadataService)
         assertNotNull(module.sessionEnvelopeSource)
         assertNotNull(module.logEnvelopeSource)
+        assertTrue(module.deviceArchitecture is DeviceArchitectureImpl)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/InternalInterfaceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/InternalInterfaceModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.EmbraceImpl
+import io.embrace.android.embracesdk.fakes.FakePayloadSourceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCrashModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -20,6 +21,7 @@ internal class InternalInterfaceModuleImplTest {
             initModule,
             initModule.openTelemetryModule,
             FakeEssentialServiceModule(),
+            FakePayloadSourceModule(),
             FakeLogModule(),
             FakeMomentsModule(),
             EmbraceImpl(),

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/ndk/NativeModuleImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.ndk
 
+import io.embrace.android.embracesdk.fakes.FakePayloadSourceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
@@ -24,6 +25,7 @@ internal class NativeModuleImplTest {
             coreModule,
             FakeStorageModule(),
             FakeEssentialServiceModule(),
+            FakePayloadSourceModule(),
             FakeDeliveryModule(),
             FakeAndroidServicesModule(),
             FakeWorkerThreadModule()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/PayloadFactoryBaTest.kt
@@ -159,7 +159,7 @@ internal class PayloadFactoryBaTest {
                 spanRepository,
                 OtelPayloadMapperImpl(
                     fakeAnrOtelMapper(),
-                    fakeNativeAnrOtelMapper(),
+                    ::fakeNativeAnrOtelMapper,
                 ),
                 logger
             )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/session/SessionHandlerTest.kt
@@ -134,7 +134,7 @@ internal class SessionHandlerTest {
                     spanRepository,
                     OtelPayloadMapperImpl(
                         fakeAnrOtelMapper(),
-                        fakeNativeAnrOtelMapper(),
+                        ::fakeNativeAnrOtelMapper,
                     ),
                     logger
                 )


### PR DESCRIPTION
## Goal

Moves payload generation out of `EssentialServiceModule` into the `PayloadSourceModule`.

## Testing

Relied on existing test coverage.

