### PR TITLE
Cut branches for both sdk and swazzler before updating master

### DIFF
--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -17,10 +17,16 @@ jobs:
     secrets: inherit
     with:
       version_to_release: ${{ github.event.inputs.version_to_release }}
+
+  update-main-versions:
+    name: Update Main Versions
+    uses: ./.github/workflows/update-main-versions.yml
+    secrets: inherit
+    with:
       next_version: ${{ github.event.inputs.next_version }}
 
   release-candidate:
-    name: Create Release Candidate
+    name: Build Release Candidates
     needs: release-branch
     uses: ./.github/workflows/build-rc-workflow.yml
     secrets: inherit

--- a/.github/workflows/rc-release-branch.yml
+++ b/.github/workflows/rc-release-branch.yml
@@ -6,16 +6,10 @@ on:
       version_to_release:
         required: true
         type: string
-      next_version:
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       version_to_release:
         description: 'Version to release. Specify <major.minor> only, without the patch number, e.g. 6.3. A new branch called "release/<version>" will be created where the release-specific changes will be committed.'
-        required: true
-      next_version:
-        description: 'Next version. Specify <major.minor>, e.g. 6.4 (Do NOT include -SNAPSHOT, will be added automatically)'
         required: true
 
 permissions:
@@ -65,31 +59,3 @@ jobs:
           git add gradle.properties
           git commit -m "CI/CD: change version to be released: ${{ github.event.inputs.version_to_release }}.0"
           git push --set-upstream origin release/${{ github.event.inputs.version_to_release }}
-
-      - name: Checkout SDK
-        uses: actions/checkout@v4
-        with:
-          ref: master
-
-      - name: Set next SDK version
-        run: |
-          git checkout master
-          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
-          git add gradle.properties
-          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"
-          git push
-
-      - name: Checkout Swazzler
-        uses: actions/checkout@v4
-        with:
-          repository: embrace-io/embrace-swazzler3
-          ref: master
-          token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
-
-      - name: Set Next Swazzler Version
-        run: |
-          git checkout master
-          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
-          git add gradle.properties
-          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"
-          git push

--- a/.github/workflows/rc-release-branch.yml
+++ b/.github/workflows/rc-release-branch.yml
@@ -48,14 +48,6 @@ jobs:
           git commit -m "CI/CD: change version to be released: ${{ github.event.inputs.version_to_release }}.0"
           git push --set-upstream origin release/${{ github.event.inputs.version_to_release }}
 
-      - name: Set next SDK version
-        run: |
-          git checkout master
-          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
-          git add gradle.properties
-          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"
-          git push
-
       - name: Checkout Swazzler
         uses: actions/checkout@v4
         with:
@@ -73,6 +65,26 @@ jobs:
           git add gradle.properties
           git commit -m "CI/CD: change version to be released: ${{ github.event.inputs.version_to_release }}.0"
           git push --set-upstream origin release/${{ github.event.inputs.version_to_release }}
+
+      - name: Checkout SDK
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set next SDK version
+        run: |
+          git checkout master
+          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
+          git add gradle.properties
+          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"
+          git push
+
+      - name: Checkout Swazzler
+        uses: actions/checkout@v4
+        with:
+          repository: embrace-io/embrace-swazzler3
+          ref: master
+          token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
       - name: Set Next Swazzler Version
         run: |

--- a/.github/workflows/update-main-versions.yml
+++ b/.github/workflows/update-main-versions.yml
@@ -1,0 +1,55 @@
+name: Pre-Release - Update Main Versions
+
+on:
+  workflow_call:
+    inputs:
+      next_version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: 'Next version. Specify <major.minor>, e.g. 6.4 (Do NOT include -SNAPSHOT, will be added automatically)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  update-main-versions:
+    name: Update Main Versions
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git
+        run: |
+          git config --global user.name 'embrace-ci[bot]'
+          git config --global user.email 'embrace-ci@users.noreply.github.com'
+
+      - name: Checkout SDK
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set next SDK version
+        run: |
+          git checkout master
+          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
+          git add gradle.properties
+          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"
+          git push
+
+      - name: Checkout Swazzler
+        uses: actions/checkout@v4
+        with:
+          repository: embrace-io/embrace-swazzler3
+          ref: master
+          token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
+
+      - name: Set Next Swazzler Version
+        run: |
+          git checkout master
+          sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
+          git add gradle.properties
+          git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"
+          git push


### PR DESCRIPTION
## Goal

Changing the order so the master properties file updates don't make the swazzler branch cutting fail

