### PR TITLE
Don't use build and config gradle caches in RC building workflows

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate SDK RC - Publish and close Sonatype repository
         run: |
-          ./gradlew clean publishReleasePublicationToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --stacktrace
+          ./gradlew clean publishReleasePublicationToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
 
       - name: Archive Test Results
         if: ${{ always() }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Generate Swazzler RC - Publish and Close repository
         run: |
-          ./gradlew clean check publishToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --stacktrace
+          ./gradlew clean check publishToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
 
       - name: Set version tag in Swazzler
         run: |


### PR DESCRIPTION
## Goal

The nexus plugin doesn't like config cache, so disabling both that and the build cache.