### PR TITLE
Don't use gradle caches in release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -49,10 +49,10 @@ jobs:
 
       - name: Gradlew Release SDK to Maven Central
         run: |
-          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository -Dorg.gradle.parallel=false --stacktrace
+          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
 
       - name: Generate Documentation
-        run: ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew dokkaHtmlMultiModule --no-build-cache --no-configuration-cache
 
       - name: Configure git
         run: |
@@ -90,7 +90,7 @@ jobs:
 
       - name: Gradlew Release Swazzler to Maven Central
         run: |
-          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository -Dorg.gradle.parallel=false --stacktrace
+          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
 
       - name: Cleanup Gradle Cache
         # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies


### PR DESCRIPTION
## Goal
Don't use Gradle caches for anything in the release workflow, just in case.