### PR TITLE
Rename workflows so they are more readible on the GitHub Actions page

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -1,4 +1,4 @@
-name: Pre-Release - Create New Release Candidate
+name: Build Release Candidates
 
 env:
   SONATYPE_USERNAME: ${{ secrets.SONATYPE_TOKEN_USER }}

--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -1,4 +1,4 @@
-name: Pre-Release - Cut Release Branch and Publish Release Candidate
+name: Prepare New Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/rc-release-branch.yml
+++ b/.github/workflows/rc-release-branch.yml
@@ -1,4 +1,4 @@
-name: Pre-Release - Create Release Branches
+name: Create Release Branches
 
 on:
   workflow_call:

--- a/.github/workflows/update-main-versions.yml
+++ b/.github/workflows/update-main-versions.yml
@@ -1,4 +1,4 @@
-name: Pre-Release - Update Main Versions
+name: Update Trunk Versions
 
 on:
   workflow_call:
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   update-main-versions:
-    name: Update Main Versions
+    name: Update Trunk Versions
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Goal
The names of release sub-workflows are too long and it's hard to see what they are in the UI. Give them shorter names.