### PR TITLE
Expose deviceId as a synthetic immutible property

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
@@ -75,7 +75,7 @@ internal class BackgroundActivityDisabledTest {
             // Check what should and shouldn't be logged when there is no background activity and the app is in the background
             assertTrue(embrace.isStarted)
             assertTrue(embrace.currentSessionId.isNullOrBlank())
-            assertTrue(embrace.getDeviceId().isNotBlank())
+            assertTrue(embrace.deviceId.isNotBlank())
             assertNull(embrace.startSpan("test"))
             embrace.logError("error")
             runLoggingThread()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
@@ -22,7 +22,7 @@ public interface SdkStateApi {
      */
     public fun setAppId(appId: String): Boolean
 
-    public fun getDeviceId(): String
+    public val deviceId: String
 
     public val currentSessionId: String?
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
@@ -62,13 +62,14 @@ internal class SdkStateApiDelegate(
         return true
     }
 
-    override fun getDeviceId(): String = when {
-        sdkCallChecker.check("get_device_id") ->
-            preferencesService?.deviceIdentifier
-                ?: ""
-
-        else -> ""
-    }
+    override val deviceId: String
+        get() {
+            return if (sdkCallChecker.check("get_device_id")) {
+                preferencesService?.deviceIdentifier ?: ""
+            } else {
+                ""
+            }
+        }
 
     override val currentSessionId: String?
         get() {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -59,7 +59,14 @@ internal class SdkStateApiDelegateTest {
     @Test
     fun getDeviceId() {
         preferencesService.deviceIdentifier = "foo"
-        assertEquals("foo", delegate.getDeviceId())
+        assertEquals("foo", delegate.deviceId)
+    }
+
+    @Test
+    fun `device ID not returned SDK is not enabled`() {
+        preferencesService.deviceIdentifier = "foo"
+        sdkCallChecker.started.set(false)
+        assertEquals("", delegate.deviceId)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Previous SDK versions had getDeviceId() exposed as a synthetic property on the Java `Embrace` object in Kotlin, but it's no longer true, likely because of the Kotlin version change. Restored this ability by exposing it as an actual properly on the interface.

## Testing
Added additional testing for the case when the SDK is not started. This doesn't change how part behaved, but codecov yelled at me, so I obliged.
