### PR TITLE
Update cached payload when session props are updated in the background

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -115,6 +115,13 @@ internal fun IntegrationTestRule.Harness.getLastSavedSession(): Envelope<Session
 }
 
 /**
+ * Returns the last background activity that was saved by the SDK.
+ */
+internal fun IntegrationTestRule.Harness.getLastSavedBackgroundActivity(): Envelope<SessionPayload>? {
+    return overriddenDeliveryModule.deliveryService.getLastSavedBackgroundActivity()
+}
+
+/**
  * Returns the last session that was sent by the SDK.
  */
 internal fun IntegrationTestRule.Harness.getLastSentSession(): Envelope<SessionPayload>? {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SessionPropertiesTest.kt
@@ -3,9 +3,11 @@ package io.embrace.android.embracesdk.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.findSessionSpan
+import io.embrace.android.embracesdk.getLastSavedBackgroundActivity
 import io.embrace.android.embracesdk.getLastSentBackgroundActivity
 import io.embrace.android.embracesdk.getSentBackgroundActivities
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
@@ -117,6 +119,23 @@ internal class SessionPropertiesTest {
             assertEquals(TEMP_VAL, firstSession.findSessionSpan().getSessionProperty(TEMP_KEY))
             assertNull(secondBg.findSessionSpan().getSessionProperty(TEMP_KEY))
             assertNull(secondSession.findSessionSpan().getSessionProperty(TEMP_KEY))
+        }
+    }
+
+    @Test
+    fun `adding properties in bg activity modifications change the cached payload`() {
+        with(testRule) {
+            startSdk()
+            harness.recordSession()
+            embrace.addSessionProperty("temp", "value", false)
+            val bgSnapshot = checkNotNull(harness.getLastSavedBackgroundActivity())
+            checkNotNull(bgSnapshot.getSessionSpan()).assertPropertyExistence(exist = listOf("temp"))
+
+            val session = checkNotNull(harness.recordSession())
+            checkNotNull(session.getSessionSpan()).assertPropertyExistence(missing = listOf("temp"))
+
+            val bg = checkNotNull(harness.getLastSentBackgroundActivity())
+            checkNotNull(bg.getSessionSpan()).assertPropertyExistence(exist = listOf("temp"))
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
@@ -4,10 +4,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getSentBackgroundActivities
-import io.embrace.android.embracesdk.internal.spans.findAttributeValue
-import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
-import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.getSessionId
+import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Rule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegate.kt
@@ -21,7 +21,10 @@ internal class SessionApiDelegate(
      */
     override fun addSessionProperty(key: String, value: String, permanent: Boolean): Boolean {
         if (sdkCallChecker.check("add_session_property")) {
-            return sessionPropertiesService?.addProperty(key, value, permanent) ?: false
+            return sessionPropertiesService?.addProperty(key, value, permanent)
+                .apply {
+                    sessionOrchestrator?.reportBackgroundActivityStateChange()
+                } ?: false
         }
         return false
     }
@@ -31,7 +34,9 @@ internal class SessionApiDelegate(
      */
     override fun removeSessionProperty(key: String): Boolean {
         if (sdkCallChecker.check("remove_session_property")) {
-            return sessionPropertiesService?.removeProperty(key) ?: false
+            return sessionPropertiesService?.removeProperty(key).apply {
+                sessionOrchestrator?.reportBackgroundActivityStateChange()
+            } ?: false
         }
         return false
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegateTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -19,6 +20,7 @@ internal class SessionApiDelegateTest {
 
     private lateinit var delegate: SessionApiDelegate
     private lateinit var orchestrator: FakeSessionOrchestrator
+    private lateinit var sdkCallChecker: SdkCallChecker
     private lateinit var sessionPropertiesService: FakeSessionPropertiesService
 
     @Before
@@ -27,16 +29,26 @@ internal class SessionApiDelegateTest {
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext(), AppFramework.NATIVE, 0)
         orchestrator = moduleInitBootstrapper.sessionOrchestrationModule.sessionOrchestrator as FakeSessionOrchestrator
         sessionPropertiesService = moduleInitBootstrapper.essentialServiceModule.sessionPropertiesService as FakeSessionPropertiesService
-
-        val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
+        sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = SessionApiDelegate(moduleInitBootstrapper, sdkCallChecker)
+    }
+
+    @Test
+    fun `cannot modify session properties when SDK is not enabled`() {
+        sdkCallChecker.started.set(false)
+        assertFalse(delegate.addSessionProperty("test", "value", false))
+        assertFalse(delegate.removeSessionProperty("test"))
+        assertEquals(0, orchestrator.stateChangeCount)
+        delegate.endSession()
+        assertEquals(0, orchestrator.manualEndCount)
     }
 
     @Test
     fun `add session property`() {
         delegate.addSessionProperty("test", "value", false)
         assertEquals("value", sessionPropertiesService.props["test"])
+        assertEquals(1, orchestrator.stateChangeCount)
     }
 
     @Test
@@ -44,12 +56,15 @@ internal class SessionApiDelegateTest {
         delegate.addSessionProperty("test", "value", false)
         delegate.removeSessionProperty("test")
         assertNull(sessionPropertiesService.props["test"])
+        assertEquals(2, orchestrator.stateChangeCount)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `get session properties`() {
         sessionPropertiesService.props["key"] = "value"
         assertEquals(mapOf("key" to "value"), delegate.getSessionProperties())
+        assertEquals(0, orchestrator.stateChangeCount)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Update cached background session explicitly when session properties are updated using the current explicit call.

This is a temporary solution until we can refactor this to more generically trigger a cache update any time new telemetry is captured.

## Testing
Added unit and integration tests for this scenario.


