### PR TITLE
Alter network code to avoid direct embrace reference

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlStreamHandler.java
@@ -7,8 +7,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
-import io.embrace.android.embracesdk.Embrace;
-
 /**
  * HTTP-specific implementation of EmbraceURLStreamHandler.
  */
@@ -22,8 +20,8 @@ final class EmbraceHttpUrlStreamHandler extends EmbraceUrlStreamHandler {
         super(handler);
     }
 
-    EmbraceHttpUrlStreamHandler(URLStreamHandler handler, Embrace embrace) {
-        super(handler, embrace);
+    EmbraceHttpUrlStreamHandler(URLStreamHandler handler, InternalNetworkApi internalNetworkApi) {
+        super(handler, internalNetworkApi);
     }
 
     @Override

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpsUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpsUrlStreamHandler.java
@@ -8,8 +8,6 @@ import java.net.URLStreamHandler;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import io.embrace.android.embracesdk.Embrace;
-
 /**
  * HTTPS-specific implementation of EmbraceUrlStreamHandler.
  */
@@ -23,8 +21,8 @@ final class EmbraceHttpsUrlStreamHandler extends EmbraceUrlStreamHandler {
         super(handler);
     }
 
-    EmbraceHttpsUrlStreamHandler(URLStreamHandler handler, Embrace embrace) {
-        super(handler, embrace);
+    EmbraceHttpsUrlStreamHandler(URLStreamHandler handler, InternalNetworkApi internalNetworkApi) {
+        super(handler, internalNetworkApi);
     }
 
     @Override

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandler.java
@@ -11,8 +11,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
-import io.embrace.android.embracesdk.Embrace;
-
 /**
  * Custom implementation of URLStreamHandler that wraps a base URLStreamHandler and provides a context for executing
  * Embrace-specific logic.
@@ -23,7 +21,7 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
     protected static final String MSG_ERROR_OPEN_CONNECTION =
         "An exception was thrown while attempting to open a connection";
 
-    protected final Embrace embrace;
+    protected final InternalNetworkApi internalNetworkApi;
 
     protected final URLStreamHandler handler;
 
@@ -46,12 +44,12 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
      * Given the base URLStreamHandler that will be wrapped, constructs the instance.
      */
     public EmbraceUrlStreamHandler(@NonNull URLStreamHandler handler) {
-        this(handler, Embrace.getInstance());
+        this(handler, InternalNetworkApiImplKt.getInstance());
     }
 
-    EmbraceUrlStreamHandler(@NonNull URLStreamHandler handler, @NonNull Embrace embrace) {
+    EmbraceUrlStreamHandler(@NonNull URLStreamHandler handler, @NonNull InternalNetworkApi internalNetworkApi) {
         this.handler = handler;
-        this.embrace = embrace;
+        this.internalNetworkApi = internalNetworkApi;
         try {
             this.methodOpenConnection1 = getMethodOpenConnection(URL.class);
             this.methodOpenConnection2 = getMethodOpenConnection(URL.class, Proxy.class);
@@ -113,9 +111,9 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
     }
 
     protected void injectTraceparent(@NonNull URLConnection connection) {
-        boolean networkSpanForwardingEnabled = embrace.getInternalInterface().isNetworkSpanForwardingEnabled();
+        boolean networkSpanForwardingEnabled = internalNetworkApi.isNetworkSpanForwardingEnabled();
         if (networkSpanForwardingEnabled && !connection.getRequestProperties().containsKey(TRACEPARENT_HEADER_NAME)) {
-            connection.addRequestProperty(TRACEPARENT_HEADER_NAME, embrace.generateW3cTraceparent());
+            connection.addRequestProperty(TRACEPARENT_HEADER_NAME, internalNetworkApi.generateW3cTraceparent());
         }
     }
 
@@ -125,7 +123,7 @@ abstract class EmbraceUrlStreamHandler extends URLStreamHandler {
      * @return
      */
     private URLConnection newUrlConnection(URLConnection connection) {
-        if (embrace.isStarted()) {
+        if (internalNetworkApi.isStarted()) {
             return wrapUrlConnection(connection);
         } else {
             return connection;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerFactory.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerFactory.java
@@ -7,8 +7,6 @@ import java.net.URLStreamHandlerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.embrace.android.embracesdk.Embrace;
-
 /**
  * Custom implementation of URLStreamHandlerFactory that is able to return URLStreamHandlers that log network data to
  * Embrace.
@@ -42,8 +40,10 @@ final class EmbraceUrlStreamHandlerFactory implements URLStreamHandlerFactory {
         }
     }
 
+    private static final InternalNetworkApi internalNetworkApi = InternalNetworkApiImplKt.getInstance();
+
     private static void logError(@NonNull Throwable throwable) {
-        Embrace.getInstance().getInternalInterface().logInternalError(throwable);
+        internalNetworkApi.logInternalError(throwable);
     }
 
     @Override

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApi.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.internal.network.http
+
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+
+internal interface InternalNetworkApi {
+    fun isNetworkSpanForwardingEnabled(): Boolean
+    fun recordNetworkRequest(embraceNetworkRequest: EmbraceNetworkRequest)
+    fun shouldCaptureNetworkBody(url: String, method: String): Boolean
+    fun logInternalError(error: Throwable)
+    fun getSdkCurrentTime(): Long
+    fun isStarted(): Boolean
+    fun getTraceIdHeader(): String
+    fun generateW3cTraceparent(): String?
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApiImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApiImpl.kt
@@ -1,0 +1,36 @@
+package io.embrace.android.embracesdk.internal.network.http
+
+import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+
+internal class InternalNetworkApiImpl : InternalNetworkApi {
+
+    private val embrace: Embrace
+        get() = Embrace.getInstance()
+
+    private fun getInternalInterface(): EmbraceInternalInterface = embrace.internalInterface
+
+    override fun getSdkCurrentTime(): Long = embrace.internalInterface.getSdkCurrentTime()
+
+    override fun isStarted(): Boolean = embrace.isStarted
+
+    override fun getTraceIdHeader(): String = embrace.traceIdHeader
+
+    override fun generateW3cTraceparent(): String? = embrace.generateW3cTraceparent()
+
+    override fun isNetworkSpanForwardingEnabled(): Boolean = getInternalInterface().isNetworkSpanForwardingEnabled()
+
+    override fun recordNetworkRequest(embraceNetworkRequest: EmbraceNetworkRequest) = getInternalInterface().recordNetworkRequest(
+        embraceNetworkRequest
+    )
+
+    override fun shouldCaptureNetworkBody(url: String, method: String): Boolean = getInternalInterface().shouldCaptureNetworkBody(
+        url,
+        method
+    )
+
+    override fun logInternalError(error: Throwable) = getInternalInterface().logInternalError(error)
+}
+
+internal var instance: InternalNetworkApi = InternalNetworkApiImpl()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalNetworkApi.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalNetworkApi.kt
@@ -1,0 +1,29 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehaviorImpl.Companion.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
+import io.embrace.android.embracesdk.internal.network.http.InternalNetworkApi
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+
+internal class FakeInternalNetworkApi(
+    var internalInterface: FakeEmbraceInternalInterface = FakeEmbraceInternalInterface(),
+    var time: Long = 0,
+    var started: Boolean = true,
+    var traceHeader: String = CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE,
+    var w3cTraceparent: String? = "00-3c72a77a7b51af6fb3778c06d4c165ce-4c1d710fffc88e35-01"
+) : InternalNetworkApi {
+    override fun getSdkCurrentTime(): Long = time
+    override fun isStarted(): Boolean = started
+    override fun getTraceIdHeader(): String = traceHeader
+    override fun generateW3cTraceparent(): String? = w3cTraceparent
+    override fun isNetworkSpanForwardingEnabled(): Boolean = internalInterface.isNetworkSpanForwardingEnabled()
+    override fun recordNetworkRequest(
+        embraceNetworkRequest: EmbraceNetworkRequest
+    ) = internalInterface.recordNetworkRequest(
+        embraceNetworkRequest
+    )
+    override fun shouldCaptureNetworkBody(
+        url: String,
+        method: String
+    ): Boolean = internalInterface.shouldCaptureNetworkBody(url, method)
+    override fun logInternalError(error: Throwable) = internalInterface.logInternalError(error)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
@@ -1,22 +1,19 @@
 package io.embrace.android.embracesdk.internal.network.http
 
-import io.embrace.android.embracesdk.Embrace
-import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+import io.embrace.android.embracesdk.fakes.FakeInternalNetworkApi
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehaviorImpl.Companion.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl.Companion.TRACEPARENT_HEADER_NAME
 import io.embrace.android.embracesdk.internal.network.http.EmbraceHttpPathOverride.PATH_OVERRIDE
 import io.embrace.android.embracesdk.internal.network.http.EmbraceUrlConnectionDelegate.CONTENT_ENCODING
 import io.embrace.android.embracesdk.internal.network.http.EmbraceUrlConnectionDelegate.CONTENT_LENGTH
-import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
-import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -30,34 +27,15 @@ import javax.net.ssl.HttpsURLConnection
 
 internal class EmbraceUrlConnectionDelegateTest {
 
-    private lateinit var mockEmbrace: Embrace
-    private lateinit var mockInternalInterface: EmbraceInternalInterface
-    private lateinit var capturedEmbraceNetworkRequest: CapturingSlot<EmbraceNetworkRequest>
-    private var fakeTimeMs = REQUEST_TIME
-    private var isSDKStarted = false
-    private var shouldCaptureNetworkBody = true
-    private var isNetworkSpanForwardingEnabled = false
     private var traceIdHeaderName = CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
+
+    private lateinit var internalApi: FakeInternalNetworkApi
 
     @Before
     fun setup() {
-        mockEmbrace = mockk(relaxed = true)
-        every { mockEmbrace.internalInterface } answers { mockInternalInterface }
-        every { mockEmbrace.isStarted } answers { isSDKStarted }
-        every { mockEmbrace.traceIdHeader } answers { traceIdHeaderName }
-        fakeTimeMs = REQUEST_TIME
-        isSDKStarted = true
-        shouldCaptureNetworkBody = true
-        isNetworkSpanForwardingEnabled = false
-        traceIdHeaderName = CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
-        capturedEmbraceNetworkRequest = slot()
-        mockInternalInterface = mockk(relaxed = true)
-        every { mockInternalInterface.shouldCaptureNetworkBody(any(), any()) } answers { shouldCaptureNetworkBody }
-        every {
-            mockInternalInterface.recordNetworkRequest(capture(capturedEmbraceNetworkRequest))
-        } answers { }
-        every { mockInternalInterface.isNetworkSpanForwardingEnabled() } answers { isNetworkSpanForwardingEnabled }
-        every { mockInternalInterface.getSdkCurrentTime() } answers { fakeTimeMs }
+        internalApi = FakeInternalNetworkApi()
+        instance = internalApi
+        internalApi.internalInterface.captureNetworkBody = true
     }
 
     @Test
@@ -272,23 +250,23 @@ internal class EmbraceUrlConnectionDelegateTest {
 
     @Test
     fun `completed requests are not recorded if the SDK has not started`() {
-        isSDKStarted = false
+        internalApi.started = false
         executeRequest(
             connection = createMockGzipConnection(),
             wrappedIoStream = true
         )
-        verify(exactly = 0) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertTrue(internalApi.internalInterface.networkRequests.isEmpty())
     }
 
     @Test
     fun `incomplete requests are not recorded if the SDK has not started`() {
-        isSDKStarted = false
+        internalApi.started = false
         executeRequest(
             connection = createMockGzipConnection(),
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        verify(exactly = 0) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertTrue(internalApi.internalInterface.networkRequests.isEmpty())
     }
 
     @Test
@@ -297,7 +275,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             connection = createMockUncompressedConnection(),
             wrappedIoStream = true
         )
-        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertEquals(1, internalApi.internalInterface.networkRequests.size)
     }
 
     @Test
@@ -306,7 +284,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             connection = createMockUncompressedConnection(),
             wrappedIoStream = false
         )
-        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertEquals(1, internalApi.internalInterface.networkRequests.size)
     }
 
     @Test
@@ -316,15 +294,15 @@ internal class EmbraceUrlConnectionDelegateTest {
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertEquals(1, internalApi.internalInterface.networkRequests.size)
     }
 
     @Test
     fun `disconnect called with previously not connected connection results in error request capture and no response access`() {
         val mockConnection = createMockUncompressedConnection()
-        EmbraceUrlConnectionDelegate(mockConnection, true, mockEmbrace).disconnect()
+        EmbraceUrlConnectionDelegate(mockConnection, true).disconnect()
         verifyIncompleteRequestLogged(mockConnection)
-        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertEquals(1, internalApi.internalInterface.networkRequests.size)
     }
 
     @Test
@@ -334,7 +312,7 @@ internal class EmbraceUrlConnectionDelegateTest {
 
         executeRequest(connection = mockConnection, wrappedIoStream = true)
         verifyIncompleteRequestLogged(mockConnection = mockConnection, errorType = TIMEOUT_ERROR, noResponseAccess = false)
-        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertEquals(1, internalApi.internalInterface.networkRequests.size)
     }
 
     @Test
@@ -344,7 +322,7 @@ internal class EmbraceUrlConnectionDelegateTest {
 
         executeRequest(connection = mockConnection, wrappedIoStream = true)
         verifyIncompleteRequestLogged(mockConnection = mockConnection, errorType = TIMEOUT_ERROR, noResponseAccess = false)
-        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertEquals(1, internalApi.internalInterface.networkRequests.size)
     }
 
     @Test
@@ -354,7 +332,7 @@ internal class EmbraceUrlConnectionDelegateTest {
 
         executeRequest(connection = mockConnection, wrappedIoStream = true)
         verifyIncompleteRequestLogged(mockConnection = mockConnection, errorType = TIMEOUT_ERROR, noResponseAccess = false)
-        verify(exactly = 1) { mockInternalInterface.recordNetworkRequest(any()) }
+        assertEquals(1, internalApi.internalInterface.networkRequests.size)
     }
 
     @Test
@@ -363,7 +341,8 @@ internal class EmbraceUrlConnectionDelegateTest {
         every { (mockConnection.outputStream as CountingOutputStream).requestBody } answers { throw NullPointerException() }
 
         executeRequest(connection = mockConnection, wrappedIoStream = true)
-        with(capturedEmbraceNetworkRequest.captured) {
+        val request = retrieveNetworkRequest()
+        with(request) {
             assertEquals(HTTP_OK, responseCode)
             assertNull(errorType)
         }
@@ -375,8 +354,9 @@ internal class EmbraceUrlConnectionDelegateTest {
             connection = createMockConnectionWithTraceparent(),
             wrappedIoStream = true
         )
-        assertNull(capturedEmbraceNetworkRequest.captured.w3cTraceparent)
-        assertEquals(HTTP_OK, capturedEmbraceNetworkRequest.captured.responseCode)
+        val request = retrieveNetworkRequest()
+        assertNull(request.w3cTraceparent)
+        assertEquals(HTTP_OK, request.responseCode)
     }
 
     @Test
@@ -386,46 +366,51 @@ internal class EmbraceUrlConnectionDelegateTest {
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        assertNull(capturedEmbraceNetworkRequest.captured.responseCode)
-        assertEquals(IO_ERROR, capturedEmbraceNetworkRequest.captured.errorType)
-        assertNull(capturedEmbraceNetworkRequest.captured.w3cTraceparent)
+        val request = retrieveNetworkRequest()
+        assertNull(request.responseCode)
+        assertEquals(IO_ERROR, request.errorType)
+        assertNull(request.w3cTraceparent)
     }
 
     @Test
     fun `check traceparents are forwarded if feature flag is on`() {
-        isNetworkSpanForwardingEnabled = true
+        internalApi.internalInterface.networkSpanForwardingEnabled = true
         executeRequest(
             connection = createMockConnectionWithTraceparent(),
             wrappedIoStream = true
         )
-        assertEquals(HTTP_OK, capturedEmbraceNetworkRequest.captured.responseCode)
-        assertEquals(TRACEPARENT, capturedEmbraceNetworkRequest.captured.w3cTraceparent)
+        val request = retrieveNetworkRequest()
+        assertEquals(HTTP_OK, request.responseCode)
+        assertEquals(TRACEPARENT, request.w3cTraceparent)
     }
 
     @Test
     fun `check traceparents are forwarded on errors if feature flag is on`() {
-        isNetworkSpanForwardingEnabled = true
+        internalApi.internalInterface.networkSpanForwardingEnabled = true
         executeRequest(
             connection = createMockConnectionWithTraceparent(),
             wrappedIoStream = true,
             exceptionOnInputStream = true
         )
-        assertNull(capturedEmbraceNetworkRequest.captured.responseCode)
-        assertEquals(TRACEPARENT, capturedEmbraceNetworkRequest.captured.w3cTraceparent)
-        assertEquals(IO_ERROR, capturedEmbraceNetworkRequest.captured.errorType)
+        val request = retrieveNetworkRequest()
+        assertNull(request.responseCode)
+        assertEquals(TRACEPARENT, request.w3cTraceparent)
+        assertEquals(IO_ERROR, request.errorType)
     }
 
     @Test
     fun `check traceIds are logged if a custom header name is specified`() {
         traceIdHeaderName = "my-trace-id-header"
+        internalApi.traceHeader = traceIdHeaderName
         executeRequest(
             connection = createMockGzipConnection(
-                extraRequestHeaders = mapOf(Pair("my-trace-id-header", listOf(customTraceId)))
+                extraRequestHeaders = mapOf(Pair(traceIdHeaderName, listOf(customTraceId)))
             ),
             wrappedIoStream = true
         )
-        assertEquals(HTTP_OK, capturedEmbraceNetworkRequest.captured.responseCode)
-        assertEquals(customTraceId, capturedEmbraceNetworkRequest.captured.traceId)
+        val request = retrieveNetworkRequest()
+        assertEquals(HTTP_OK, request.responseCode)
+        assertEquals(customTraceId, request.traceId)
     }
 
     private fun createMockConnectionWithPathOverride() = createMockGzipConnection(
@@ -519,7 +504,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         wrappedIoStream: Boolean = false,
         exceptionOnInputStream: Boolean = false
     ) {
-        val delegate = EmbraceUrlConnectionDelegate<HttpsURLConnection>(connection, wrappedIoStream, mockEmbrace)
+        val delegate = EmbraceUrlConnectionDelegate<HttpsURLConnection>(connection, wrappedIoStream, internalApi)
         with(delegate) {
             connect()
             setRequestProperty(requestHeaderName, requestHeaderValue)
@@ -555,28 +540,30 @@ internal class EmbraceUrlConnectionDelegateTest {
         networkDataCaptured: Boolean = false,
         responseBody: String? = null
     ) {
-        with(capturedEmbraceNetworkRequest) {
-            assertEquals(url, captured.url)
-            assertEquals(httpMethod, captured.httpMethod)
-            assertEquals(startTime, captured.startTime)
-            assertEquals(endTime, captured.endTime)
-            assertEquals(httpStatus, captured.responseCode)
-            assertEquals(requestSize?.toLong(), captured.bytesOut)
-            assertEquals(responseBodySize?.toLong(), captured.bytesIn)
-            assertEquals(errorType, captured.errorType)
-            assertEquals(errorMessage, captured.errorMessage)
-            assertEquals(traceId, captured.traceId)
-            assertEquals(w3cTraceparent, captured.w3cTraceparent)
+        val request = retrieveNetworkRequest()
+        with(request) {
+            assertEquals(url, url)
+            assertEquals(httpMethod, httpMethod)
+            assertEquals(startTime, startTime)
+            assertEquals(endTime, endTime)
+            assertEquals(httpStatus, responseCode)
+            assertEquals(requestSize?.toLong(), bytesOut)
+            assertEquals(responseBodySize?.toLong(), bytesIn)
+            assertEquals(errorType, errorType)
+            assertEquals(errorMessage, errorMessage)
+            assertEquals(traceId, traceId)
+            assertEquals(w3cTraceparent, w3cTraceparent)
             if (networkDataCaptured) {
                 validateNetworkCaptureData(responseBody)
             } else {
-                assertNull(captured.networkCaptureData)
+                assertNull(networkCaptureData)
             }
         }
     }
 
     private fun validateNetworkCaptureData(responseBody: String?) {
-        with(checkNotNull(capturedEmbraceNetworkRequest.captured.networkCaptureData)) {
+        val request = retrieveNetworkRequest()
+        with(checkNotNull(request.networkCaptureData)) {
             assertEquals(requestHeaderValue, checkNotNull(requestHeaders)[requestHeaderName])
             assertEquals(responseHeaderValue, checkNotNull(responseHeaders)[responseHeaderName])
             assertEquals(defaultQueryString, requestQueryParams)
@@ -601,9 +588,12 @@ internal class EmbraceUrlConnectionDelegateTest {
             verify(exactly = 0) { mockConnection.contentLength }
             verify(exactly = 0) { mockConnection.headerFields }
         }
-        assertNull(capturedEmbraceNetworkRequest.captured.responseCode)
-        assertEquals(errorType, capturedEmbraceNetworkRequest.captured.errorType)
+        val request = retrieveNetworkRequest()
+        assertNull(request.responseCode)
+        assertEquals(errorType, request.errorType)
     }
+
+    private fun retrieveNetworkRequest() = internalApi.internalInterface.networkRequests.single()
 
     companion object {
         private fun String.toGzipByteArray(): ByteArray {

--- a/embrace-test-fakes/lint-baseline.xml
+++ b/embrace-test-fakes/lint-baseline.xml
@@ -96,7 +96,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeApiService.kt"
-            line="36"
+            line="33"
             column="9"/>
     </issue>
 
@@ -107,7 +107,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeApiService.kt"
-            line="40"
+            line="37"
             column="9"/>
     </issue>
 
@@ -350,6 +350,237 @@
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
             line="81"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="17"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="21"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="25"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="34"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="43"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="57"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="69"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="82"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="90"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="96"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="102"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="106"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="110"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="114"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="118"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="122"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="129"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="138"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="142"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="152"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt"
+            line="164"
             column="9"/>
     </issue>
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
@@ -1,0 +1,155 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.LogType
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.spans.ErrorCode
+
+public class FakeEmbraceInternalInterface(
+    public var networkSpanForwardingEnabled: Boolean = false,
+    public var captureNetworkBody: Boolean = false
+) : EmbraceInternalInterface {
+
+    public var networkRequests: MutableList<EmbraceNetworkRequest> = mutableListOf()
+
+    override fun startSpan(name: String, parentSpanId: String?, startTimeMs: Long?): String? {
+        return null
+    }
+
+    override fun logInfo(message: String, properties: Map<String, Any>?) {
+    }
+
+    override fun logWarning(message: String, properties: Map<String, Any>?, stacktrace: String?) {
+    }
+
+    override fun logError(
+        message: String,
+        properties: Map<String, Any>?,
+        stacktrace: String?,
+        isException: Boolean
+    ) {
+    }
+
+    override fun logHandledException(
+        throwable: Throwable,
+        type: LogType,
+        properties: Map<String, Any>?,
+        customStackTrace: Array<StackTraceElement>?
+    ) {
+    }
+
+    override fun recordCompletedNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        bytesSent: Long,
+        bytesReceived: Long,
+        statusCode: Int,
+        traceId: String?,
+        networkCaptureData: NetworkCaptureData?
+    ) {
+    }
+
+    override fun recordIncompleteNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        error: Throwable?,
+        traceId: String?,
+        networkCaptureData: NetworkCaptureData?
+    ) {
+    }
+
+    override fun recordIncompleteNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        errorType: String?,
+        errorMessage: String?,
+        traceId: String?,
+        networkCaptureData: NetworkCaptureData?
+    ) {
+    }
+
+    override fun recordNetworkRequest(embraceNetworkRequest: EmbraceNetworkRequest) {
+        networkRequests.add(embraceNetworkRequest)
+    }
+
+    override fun logComposeTap(point: Pair<Float, Float>, elementName: String) {
+    }
+
+    override fun shouldCaptureNetworkBody(url: String, method: String): Boolean = captureNetworkBody
+
+    override fun setProcessStartedByNotification() {
+    }
+
+    override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwardingEnabled
+
+    override fun getSdkCurrentTime(): Long {
+        return 0
+    }
+
+    override fun isInternalNetworkCaptureDisabled(): Boolean {
+        return false
+    }
+
+    override fun isAnrCaptureEnabled(): Boolean {
+        return true
+    }
+
+    override fun isNdkEnabled(): Boolean {
+        return true
+    }
+
+    override fun logInternalError(message: String?, details: String?) {
+    }
+
+    override fun logInternalError(error: Throwable) {
+    }
+
+    override fun stopSdk() {
+    }
+
+    override fun stopSpan(spanId: String, errorCode: ErrorCode?, endTimeMs: Long?): Boolean {
+        return true
+    }
+
+    override fun addSpanEvent(
+        spanId: String,
+        name: String,
+        timestampMs: Long?,
+        attributes: Map<String, String>?
+    ): Boolean {
+        return true
+    }
+
+    override fun addSpanAttribute(spanId: String, key: String, value: String): Boolean {
+        return true
+    }
+
+    override fun <T> recordSpan(
+        name: String,
+        parentSpanId: String?,
+        attributes: Map<String, String>?,
+        events: List<Map<String, Any>>?,
+        code: () -> T
+    ): T {
+        return code()
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeMs: Long,
+        endTimeMs: Long,
+        errorCode: ErrorCode?,
+        parentSpanId: String?,
+        attributes: Map<String, String>?,
+        events: List<Map<String, Any>>?
+    ): Boolean {
+        return true
+    }
+}


### PR DESCRIPTION
## Goal

Alters our networking code to avoid direct references to the `Embrace` singleton facade.

## Testing

Updated existing test coverage.
