### PR TITLE
Allow getLastRunEndState() to be accessed via a synthetic property in Kotlin

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -5,6 +5,7 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace.AppFramework
+import io.embrace.android.embracesdk.Embrace.LastRunEndState
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.fakes.fakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
@@ -123,6 +124,15 @@ internal class PublicApiTest {
             val backgroundSessionId = embrace.currentSessionId
             assertNotNull(backgroundSessionId)
             assertNotEquals(foregroundSessionId, backgroundSessionId)
+        }
+    }
+
+    @Test
+    fun `getLastRunEndState() behave as expected`() {
+        with(testRule) {
+            assertEquals(LastRunEndState.INVALID, embrace.lastRunEndState)
+            startSdk()
+            assertEquals(LastRunEndState.CLEAN_EXIT, embrace.lastRunEndState)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
@@ -26,5 +26,5 @@ public interface SdkStateApi {
 
     public val currentSessionId: String?
 
-    public fun getLastRunEndState(): Embrace.LastRunEndState
+    public val lastRunEndState: Embrace.LastRunEndState
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
@@ -85,15 +85,18 @@ internal class SdkStateApiDelegate(
             return null
         }
 
-    override fun getLastRunEndState(): Embrace.LastRunEndState = if (isStarted && crashVerifier != null) {
-        if (crashVerifier?.didLastRunCrash() == true) {
-            Embrace.LastRunEndState.CRASH
-        } else {
-            Embrace.LastRunEndState.CLEAN_EXIT
+    override val lastRunEndState: Embrace.LastRunEndState
+        get() {
+            return if (isStarted && crashVerifier != null) {
+                if (crashVerifier?.didLastRunCrash() == true) {
+                    Embrace.LastRunEndState.CRASH
+                } else {
+                    Embrace.LastRunEndState.CLEAN_EXIT
+                }
+            } else {
+                Embrace.LastRunEndState.INVALID
+            }
         }
-    } else {
-        Embrace.LastRunEndState.INVALID
-    }
 
     companion object {
         private val appIdPattern: Pattern = Pattern.compile("^[A-Za-z0-9]{5}$")

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.Embrace.LastRunEndState
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeLogService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
@@ -73,5 +74,11 @@ internal class SdkStateApiDelegateTest {
     fun getCurrentSessionId() {
         sessionIdTracker.sessionData = SessionData("test", true)
         assertEquals("test", delegate.currentSessionId)
+    }
+
+    @Test
+    fun `last end state is invalid if SDK not enabled`() {
+        sdkCallChecker.started.set(false)
+        assertEquals(LastRunEndState.INVALID, delegate.lastRunEndState)
     }
 }


### PR DESCRIPTION
## Goal

Store the ability to access `getLastRunEndState()` via a synthetic read-only property in Kotlin as it was that way in previous versions thanks to the old Kotlin version that was used. 

We will revisit this in the next major version.

## Testing
Add integration tests that access the getter in the Java Embrace object via this

