### PR TITLE
Fix miscellaneous build warnings

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
@@ -68,5 +68,6 @@ project.tasks.withType(KotlinCompile::class.java).configureEach {
         languageVersion = "1.8"
         jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
+        allWarningsAsErrors = true
     }
 }

--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -35,12 +35,11 @@ dependencies {
     compileOnly(libs.lifecycle.common.java8)
     implementation(libs.lifecycle.process)
 
-
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)
     testImplementation(libs.opentelemetry.sdk)
     testImplementation(libs.opentelemetry.semconv)
     testImplementation(libs.opentelemetry.semconv.incubating)
     testImplementation(libs.lifecycle.common.java8)
-    implementation(libs.lifecycle.process)
+    testImplementation(libs.kotlin.reflect)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImpl.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.injection
 
 import android.preference.PreferenceManager

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.capture.session
 
 import android.content.Context

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationCaptureService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationCaptureService.kt
@@ -29,7 +29,6 @@ public class PushNotificationCaptureService(
         private const val RESERVED_MESSAGE_TYPE = "message_type"
         private const val RESERVED_COLLAPSE_KEY = "collapse_key"
         private const val RESERVED_GOOGLE_MESSAGE_ID = "google.message_id"
-        private const val RESERVED_GOOGLE_DELIVERED_PRIORITY = "google.delivered_priority"
 
         /**
          * This is so to have compatibility with com.google.firebase.messaging.RemoteMessage.
@@ -67,7 +66,6 @@ public class PushNotificationCaptureService(
      * @param topic    the notification topic (if a user subscribed to one), or null
      * @param id       A unique ID identifying the message
      * @param notificationPriority the priority of the message (as resolved on the device)
-     * @param messageDeliveredPriority the priority of the message (as resolved on the server)
      * @param type the notification type
      */
     public fun logPushNotification(
@@ -76,7 +74,6 @@ public class PushNotificationCaptureService(
         topic: String?,
         id: String?,
         notificationPriority: Int?,
-        messageDeliveredPriority: Int,
         type: PushNotificationBreadcrumb.NotificationType
     ) {
         pushNotificationDataSource?.logPushNotification(title, body, topic, id, notificationPriority, type)
@@ -103,9 +100,6 @@ public class PushNotificationCaptureService(
                     // ** //
                     topic = getString(RESERVED_FROM),
                     id = getString(RESERVED_GOOGLE_MESSAGE_ID),
-                    messageDeliveredPriority = getMessagePriority(
-                        getString(RESERVED_GOOGLE_DELIVERED_PRIORITY)
-                    ),
                     type = determineNotificationType(this)
                 )
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk
 
 import android.content.Context

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -190,6 +190,7 @@ public final class Embrace implements SdkApi {
 
     @Override
     @Nullable
+    @Deprecated
     public Map<String, String> getSessionProperties() {
         return impl.getSessionProperties();
     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -35,6 +35,7 @@ public class FakeCoreModule(
 
     public companion object {
 
+        @Suppress("DEPRECATION")
         private val fakePackageInfo = PackageInfo().apply {
             packageName = "com.fake.package"
             versionName = "2.5.1"

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.api
 
 import android.net.Uri

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/UninitializedSdkInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/UninitializedSdkInternalInterfaceImplTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.LogType

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.LogType


### PR DESCRIPTION
## Goal

Fix miscellaneous build warnings. I've also enabled warnings as errors since the Kotlin version we use no longer blocks us from enabling that.

