### PR TITLE
Only try to send failed API requests if the ApiClient is initialized

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSender.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSender.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.max
 
 private const val RETRY_PERIOD = 120L // In seconds
@@ -28,14 +29,14 @@ internal class EmbracePendingApiCallsSender(
     }
     private var lastDeliveryTask: ScheduledFuture<*>? = null
     private var lastNetworkStatus: NetworkStatus = NetworkStatus.UNKNOWN
-    private lateinit var sendMethod: (request: ApiRequest, action: SerializationAction) -> ApiResponse
+    private val sendMethodRef: AtomicReference<SendMethod?> = AtomicReference(null)
 
     init {
         scheduledWorker.submit(this::scheduleApiCallsDelivery)
     }
 
-    override fun setSendMethod(sendMethod: (request: ApiRequest, action: SerializationAction) -> ApiResponse) {
-        this.sendMethod = sendMethod
+    override fun setSendMethod(sendMethod: SendMethod) {
+        sendMethodRef.set(sendMethod)
     }
 
     override fun savePendingApiCall(request: ApiRequest, action: SerializationAction, sync: Boolean) {
@@ -93,7 +94,7 @@ internal class EmbracePendingApiCallsSender(
     /**
      * Returns true if there is an active pending retry task
      */
-    public fun isDeliveryTaskActive(): Boolean =
+    fun isDeliveryTaskActive(): Boolean =
         lastDeliveryTask?.let { task ->
             !task.isCancelled && !task.isDone
         } ?: false
@@ -128,73 +129,79 @@ internal class EmbracePendingApiCallsSender(
     /**
      * Sends all pending API calls.
      */
+    @Suppress("CyclomaticComplexMethod", "ComplexMethod")
     private fun executeDelivery(delayInSeconds: Long) {
         if (!lastNetworkStatus.isReachable) {
             logger.logInfo("Did not retry api calls as scheduled because network is not reachable")
             return
         }
-        try {
-            val failedApiCallsToRetry = mutableListOf<PendingApiCall>()
-            var applyExponentialBackoff = false
 
-            while (true) {
-                val pendingApiCall = pendingApiCallQueue.pollNextPendingApiCall() ?: break
-                val response = sendPendingApiCall(pendingApiCall)
-                response?.let {
-                    val url = EmbraceUrl.create(pendingApiCall.apiRequest.url.url)
-                    clearRateLimitIfApplies(url.endpoint(), response)
+        sendMethodRef.get()?.let { sendMethod ->
+            try {
+                val failedApiCallsToRetry = mutableListOf<PendingApiCall>()
+                var applyExponentialBackoff = false
 
-                    if (response.shouldRetry) {
-                        when (response) {
-                            is ApiResponse.TooManyRequests -> {
-                                with(response.endpoint.limiter) {
-                                    updateRateLimitStatus()
-                                    scheduleRetry(
-                                        scheduledWorker,
-                                        response.retryAfter,
-                                        this@EmbracePendingApiCallsSender::scheduleApiCallsDelivery
-                                    )
+                while (true) {
+                    val pendingApiCall = pendingApiCallQueue.pollNextPendingApiCall() ?: break
+                    val response = sendPendingApiCall(sendMethod, pendingApiCall)
+                    response.let {
+                        val url = EmbraceUrl.create(pendingApiCall.apiRequest.url.url)
+                        clearRateLimitIfApplies(url.endpoint(), response)
+
+                        if (response.shouldRetry) {
+                            when (response) {
+                                is ApiResponse.TooManyRequests -> {
+                                    with(response.endpoint.limiter) {
+                                        updateRateLimitStatus()
+                                        scheduleRetry(
+                                            scheduledWorker,
+                                            response.retryAfter,
+                                            this@EmbracePendingApiCallsSender::scheduleApiCallsDelivery
+                                        )
+                                    }
+                                }
+
+                                is ApiResponse.Incomplete -> {
+                                    applyExponentialBackoff = true
+                                }
+
+                                else -> {
+                                    // Not expected
                                 }
                             }
-                            is ApiResponse.Incomplete -> {
-                                applyExponentialBackoff = true
-                            }
-                            else -> {
-                                // Not expected
-                            }
+                            // Should retry, so we add it back to the queue.
+                            failedApiCallsToRetry.add(pendingApiCall)
+                        } else {
+                            // Shouldn't retry, so delete the payload and save the pending api calls.
+                            cacheManager.deletePayload(pendingApiCall.cachedPayloadFilename)
+                            cacheManager.savePendingApiCallQueue(pendingApiCallQueue)
                         }
-                        // Should retry, so we add it back to the queue.
-                        failedApiCallsToRetry.add(pendingApiCall)
-                    } else {
-                        // Shouldn't retry, so delete the payload and save the pending api calls.
-                        cacheManager.deletePayload(pendingApiCall.cachedPayloadFilename)
-                        cacheManager.savePendingApiCallQueue(pendingApiCallQueue)
                     }
                 }
-            }
 
-            // Add back to the queue all retries that failed.
-            failedApiCallsToRetry.forEach {
-                pendingApiCallQueue.add(it)
-            }
-
-            if (pendingApiCallQueue.hasPendingApiCallsToSend()) {
-                scheduledWorker.submit {
-                    scheduleNextApiCallsDelivery(
-                        applyExponentialBackoff,
-                        delayInSeconds
-                    )
+                // Add back to the queue all retries that failed.
+                failedApiCallsToRetry.forEach {
+                    pendingApiCallQueue.add(it)
                 }
+
+                if (pendingApiCallQueue.hasPendingApiCallsToSend()) {
+                    scheduledWorker.submit {
+                        scheduleNextApiCallsDelivery(
+                            applyExponentialBackoff,
+                            delayInSeconds
+                        )
+                    }
+                }
+            } catch (ex: Exception) {
+                logger.logDebug("Error when sending API call", ex)
             }
-        } catch (ex: Exception) {
-            logger.logDebug("Error when sending API call", ex)
         }
     }
 
     /**
      * Send the request for a PendingApiCall.
      */
-    private fun sendPendingApiCall(call: PendingApiCall): ApiResponse? {
+    private fun sendPendingApiCall(sendMethod: SendMethod, call: PendingApiCall): ApiResponse {
         // If payload is null, the file could have been removed. We don't have to retry this call.
         val payload: SerializationAction = cacheManager.loadPayloadAsAction(call.cachedPayloadFilename)
         return sendMethod(call.apiRequest, payload)
@@ -225,3 +232,5 @@ internal class EmbracePendingApiCallsSender(
         }
     }
 }
+
+public typealias SendMethod = (request: ApiRequest, action: SerializationAction) -> ApiResponse

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -287,6 +287,30 @@ internal class EmbracePendingApiCallsSenderTest {
         assertEquals(sessionRequest, queue.pollNextPendingApiCall()?.apiRequest)
     }
 
+    @Test
+    fun `no pending api calls remains if SendMethod is set`() {
+        initPendingApiCallsSender(runRetryJobAfterScheduling = false)
+        pendingApiCallsSender.onNetworkConnectivityStatusChanged(NetworkStatus.WIFI)
+        retryTaskActive(NetworkStatus.WIFI)
+        assertTrue(queue.hasPendingApiCallsToSend())
+        blockingScheduledExecutorService.runCurrentlyBlocked()
+        checkRequestSendAttempt()
+        assertFalse(queue.hasPendingApiCallsToSend())
+    }
+
+    @Test
+    fun `pending api calls remains if SendMethod is not set`() {
+        initPendingApiCallsSender(
+            runRetryJobAfterScheduling = false,
+            sendMethod = null
+        )
+        pendingApiCallsSender.onNetworkConnectivityStatusChanged(NetworkStatus.WIFI)
+        retryTaskActive(NetworkStatus.WIFI)
+        assertTrue(queue.hasPendingApiCallsToSend())
+        blockingScheduledExecutorService.runCurrentlyBlocked()
+        assertTrue(queue.hasPendingApiCallsToSend())
+    }
+
     private fun clearApiPipeline() {
         clearMocks(mockRetryMethod, answers = false)
         pendingApiCalls = PendingApiCalls()
@@ -297,6 +321,7 @@ internal class EmbracePendingApiCallsSenderTest {
     private fun initPendingApiCallsSender(
         loadFailedRequest: Boolean = true,
         runRetryJobAfterScheduling: Boolean = false,
+        sendMethod: SendMethod? = mockRetryMethod
     ) {
         pendingApiCalls = PendingApiCalls()
         every { mockCacheManager.loadPendingApiCallQueue() } returns queue
@@ -308,7 +333,9 @@ internal class EmbracePendingApiCallsSenderTest {
             logger = EmbLoggerImpl()
         )
 
-        pendingApiCallsSender.setSendMethod(mockRetryMethod)
+        if (sendMethod != null) {
+            pendingApiCallsSender.setSendMethod(mockRetryMethod)
+        }
 
         if (loadFailedRequest) {
             val request = ApiRequest(


### PR DESCRIPTION
## Goal

The method used to send failed requests is being invoked before the ApiService is initialized, before `setSendMethod()` is ever called. This leads to a crash in a background thread because a `lateinit var` was being accessed before it was initialized. This leads to `failed_api_calls..json` to re overridden, which leads to lost data.

To fix this, ditch the lateinit var and use an atomic reference to hold the queue. Before trying to access it, check its nullness, and skip if it's null. This will force the api request to retry at the next interval.

A better fix for this will be to delay the retry attempt until after ApiClient is done, but this change is a more appropriate, surgical fix, so we can use this until we make the bigger fix later.

## Testing

Added unit test to verify the state of the pending API calls queue depending on whether the SendMethod is set.