### PR TITLE
Preparatory refactor for initializing NDK error handling on background thread

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehavior.kt
@@ -10,11 +10,6 @@ public interface SdkModeBehavior {
     public fun isBetaFeaturesEnabled(): Boolean
 
     /**
-     * Checks if an expanded list of services' initialization during startup will be done on a background thread
-     */
-    public fun isServiceInitDeferred(): Boolean
-
-    /**
      * Given a Config instance, computes if the SDK is enabled based on the threshold and the offset.
      *
      * @return true if the sdk is enabled, false otherwise

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
@@ -30,12 +30,6 @@ public class SdkModeBehaviorImpl(
         private const val DEFAULT_BETA_FEATURES_PCT = 1.0f
 
         /**
-         * The percentage of devices that defer some expensive service initialization to a background
-         * thread to improve startup performance in exchange for delayed enablement of some features of the SDK
-         */
-        private const val DEFAULT_DEFER_SERVICE_INIT_PCT = 0.0f
-
-        /**
          * The default percentage of devices for which the SDK is enabled.
          */
         private const val DEFAULT_THRESHOLD = 100
@@ -56,11 +50,6 @@ public class SdkModeBehaviorImpl(
         }
 
         val pct = remote?.pctBetaFeaturesEnabled ?: DEFAULT_BETA_FEATURES_PCT
-        return thresholdCheck.isBehaviorEnabled(pct)
-    }
-
-    override fun isServiceInitDeferred(): Boolean {
-        val pct = remote?.pctDeferServiceInitEnabled ?: DEFAULT_DEFER_SERVICE_INIT_PCT
         return thresholdCheck.isBehaviorEnabled(pct)
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
@@ -36,7 +36,6 @@ internal class SdkModeBehaviorImplTest {
         ) {
             assertFalse(isBetaFeaturesEnabled())
             assertFalse(isSdkDisabled())
-            assertFalse(isServiceInitDeferred())
         }
     }
 
@@ -85,28 +84,6 @@ internal class SdkModeBehaviorImplTest {
                 remoteCfg = { RemoteConfig(pctBetaFeaturesEnabled = 0f) }
             )
         assertFalse(behavior.isBetaFeaturesEnabled())
-    }
-
-    @Test
-    fun `verify defer service init checks`() {
-        // Default is disabled regardless of the deviceId
-        assertFalse(fakeSdkModeBehavior(thresholdCheck = enabled).isServiceInitDeferred())
-
-        // Enabled if remote flag set to 100%
-        assertTrue(
-            fakeSdkModeBehavior(
-                thresholdCheck = enabled,
-                remoteCfg = { RemoteConfig(pctDeferServiceInitEnabled = 100f) }
-            ).isServiceInitDeferred()
-        )
-
-        // Disabled if remote flag set to 0% regardless of deviceId
-        assertFalse(
-            fakeSdkModeBehavior(
-                thresholdCheck = enabled,
-                remoteCfg = { RemoteConfig(pctDeferServiceInitEnabled = 0f) }
-            ).isServiceInitDeferred()
-        )
     }
 
     @Test

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
@@ -108,12 +108,5 @@ public data class RemoteConfig(
      * Web view vitals settings
      */
     @Json(name = "webview_vitals_beta")
-    val webViewVitals: WebViewVitals? = null,
-
-    /**
-     * Enable deferral of initialization of some services to a background thread during startup.
-     * Currently, the only feature that uses this is native crash capture
-     */
-    @Json(name = "pct_defer_service_init")
-    val pctDeferServiceInitEnabled: Float? = null,
+    val webViewVitals: WebViewVitals? = null
 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.IntegrationTestRule.Harness
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
+import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.fakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeNetworkBehavior
 import io.embrace.android.embracesdk.fakes.fakeNetworkSpanForwardingBehavior
@@ -108,7 +109,8 @@ internal class IntegrationTestRule(
                 workerThreadModuleSupplier = { _ -> overriddenWorkerThreadModule },
                 androidServicesModuleSupplier = { _, _, _ -> overriddenAndroidServicesModule },
                 deliveryModuleSupplier = { _, _, _, _ -> overriddenDeliveryModule },
-                anrModuleSupplier = { _, _, _, _ -> fakeAnrModule }
+                anrModuleSupplier = { _, _, _, _ -> fakeAnrModule },
+                nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> fakeNativeFeatureModule }
             )
             val embraceImpl = EmbraceImpl(bootstrapper)
             Embrace.setImpl(embraceImpl)
@@ -186,7 +188,8 @@ internal class IntegrationTestRule(
             FakeDeliveryModule(
                 deliveryService = FakeDeliveryService(),
             ),
-        val fakeAnrModule: AnrModule = FakeAnrModule()
+        val fakeAnrModule: AnrModule = FakeAnrModule(),
+        val fakeNativeFeatureModule: FakeNativeFeatureModule = FakeNativeFeatureModule()
     ) {
         fun logWebView(url: String) {
             Embrace.getImpl().logWebView(url)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
@@ -181,7 +181,7 @@ internal class BackgroundActivityDisabledTest {
                 startMs = session2StartMs,
                 endMs = session2EndMs,
                 sessionNumber = 2,
-                sequenceId = 6,
+                sequenceId = 5,
                 coldStart = false,
             )
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
@@ -38,7 +38,7 @@ internal class SpanExporterTest {
                 fakeSpanExporter.awaitSpanExport(1)
             )
             // Verify that 4 spans have been logged - the exported ones and 3 private diagnostic traces
-            assertEquals(4, harness.overriddenOpenTelemetryModule.spanSink.completedSpans().size)
+            assertEquals(3, harness.overriddenOpenTelemetryModule.spanSink.completedSpans().size)
 
             harness.recordSession {
                 assertTrue(
@@ -49,7 +49,7 @@ internal class SpanExporterTest {
                 assertEquals(2, fakeSpanExporter.exportedSpans.size)
                 val exportedSpans = fakeSpanExporter.exportedSpans.associateBy { it.name }
                 val testSpan = checkNotNull(exportedSpans["test"])
-                testSpan.assertHasEmbraceAttribute(embSequenceId, "6")
+                testSpan.assertHasEmbraceAttribute(embSequenceId, "5")
                 testSpan.assertHasEmbraceAttribute(embProcessIdentifier, harness.overriddenInitModule.processIdentifier)
                 testSpan.resource.assertExpectedAttributes(
                     expectedServiceName = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceSdkName,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.injection
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
@@ -35,8 +36,11 @@ internal class ModuleInitBootstrapperTest {
     fun setup() {
         logger = EmbLoggerImpl()
         coreModule = FakeCoreModule(logger = logger)
-        moduleInitBootstrapper =
-            ModuleInitBootstrapper(coreModuleSupplier = { _, _ -> coreModule }, logger = logger)
+        moduleInitBootstrapper = ModuleInitBootstrapper(
+            coreModuleSupplier = { _, _ -> coreModule },
+            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
+            logger = logger
+        )
         context = RuntimeEnvironment.getApplication().applicationContext
     }
 
@@ -44,6 +48,7 @@ internal class ModuleInitBootstrapperTest {
     fun `test default implementation`() {
         val moduleInitBootstrapper = ModuleInitBootstrapper(
             coreModuleSupplier = { _, _ -> coreModule },
+            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = EmbLoggerImpl()
         )
         with(moduleInitBootstrapper) {
@@ -109,6 +114,7 @@ internal class ModuleInitBootstrapperTest {
             initModule = fakeInitModule,
             coreModuleSupplier = { _, _ -> fakeCoreModule },
             workerThreadModuleSupplier = { _ -> fakeWorkerThreadModule },
+            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = EmbLoggerImpl()
         )
         assertTrue(


### PR DESCRIPTION
## Goal

This changeset contains several preparations for initializing NDK error handling on a background thread:

- Removed `isServiceInitDeferred` config as the current implementation breaks signal handler installation, and we should also IMO just default to the correct behavior on this rather than giving a choice
- Remove redundant lock/installed checks within `EmbraceNdkService` as the JNI functions can be called as soon as the SO file is loaded
- Attempted to simplify `ModuleInitBootstrapper` section for NDK/native thread sampling installation, without making any functional changes (yet)

## Testing

Relied on existing test coverage.
