### PR TITLE
Initialize ndk on background thread

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
@@ -45,7 +45,6 @@ internal class NativeFeatureModuleImpl(
                 embraceNdkServiceRepository,
                 NdkDelegateImpl(),
                 workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
-                workerThreadModule.backgroundWorker(WorkerName.SERVICE_INIT),
                 payloadSourceModule.deviceArchitecture,
                 initModule.jsonSerializer
             )

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
@@ -20,4 +20,6 @@ public interface NdkService : NativeCrashService {
      * Retrieves symbol information for the current architecture.
      */
     public val symbolsForCurrentArch: Map<String, String>?
+
+    public fun initializeService()
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
@@ -12,6 +12,9 @@ public class FakeNdkService : NdkService {
     public var lastUnityCrashId: String? = null
     private var nativeCrashData: NativeCrashData? = null
 
+    override fun initializeService() {
+    }
+
     override fun updateSessionId(newSessionId: String) {
         sessionId = newSessionId
     }


### PR DESCRIPTION
## Goal

Alters the SDK so that NDK error detection is initialized on a background thread, which offloads the loading of a SO file (and other I/O) away from the main thread.

This involved two parts: firstly the NDK service is initialized async from `ModuleInitBootstrapper`, and posts the signal handler installation to the front of the message queue so that it is installed on the main thread asap. Secondly, the Unity ANR thread sampling is called directly from the Unity interface. It appears the Unity SDK already [appears to be doing this](https://github.com/embrace-io/embrace-unity-sdk/blob/2eb7231547bb7a63c69eb1f4f52bef6fa4f4b3e8/io.embrace.sdk/Scripts/Native/Embrace_Android.cs#L511) so it shouldn't affect functionality.

## Profiling

This change reduces startup time from ~16ms to ~14ms on a OnePlus 7 running Android 10. Additionally it removes all but one direct call to I/O on the main thread as part of our initialization sequence.

<img width="988" alt="Screenshot 2024-09-02 at 11 29 01" src="https://github.com/user-attachments/assets/5929723c-0867-48f4-8e38-5d249bdc7d50">
<img width="938" alt="Screenshot 2024-09-02 at 11 29 09" src="https://github.com/user-attachments/assets/9a9d25d0-b50e-4ffc-a8ad-62d1cb842ace">


## Testing

Updated test coverage & manually verified that NDK crashes are still reported to the dashboard.

