### PR TITLE
Optimize process id generation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
@@ -31,13 +31,6 @@ public interface InitModule {
     public val systemInfo: SystemInfo
 
     /**
-     * Unique ID generated for an instance of the app process and not related to the actual process ID assigned by the OS.
-     * This allows us to explicitly relate all the sessions associated with a particular app launch rather than having the backend figure
-     * this out by proximity for stitched sessions.
-     */
-    public val processIdentifier: String
-
-    /**
      * Tracks internal errors
      */
     public val internalErrorService: InternalErrorService

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.IdGenerator
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
@@ -31,8 +30,6 @@ internal class InitModuleImpl(
             systemInfo = systemInfo
         )
     }
-
-    override val processIdentifier: String = IdGenerator.generateLaunchInstanceId()
 
     override val jsonSerializer: PlatformSerializer by singleton {
         EmbraceSerializer()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -39,12 +39,7 @@ internal class OpenTelemetryModuleImpl(
     }
 
     override val openTelemetryConfiguration: OpenTelemetryConfiguration by lazy {
-        OpenTelemetryConfiguration(
-            spanSink,
-            logSink,
-            initModule.systemInfo,
-            initModule.processIdentifier,
-        )
+        OpenTelemetryConfiguration(spanSink, logSink, initModule.systemInfo)
     }
 
     private val openTelemetrySdk: OpenTelemetrySdk by lazy {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfiguration.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
 import io.embrace.android.embracesdk.core.BuildConfig
+import io.embrace.android.embracesdk.internal.IdGenerator
 import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogRecordExporter
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogRecordProcessor
 import io.embrace.android.embracesdk.internal.logs.LogSink
@@ -22,8 +24,7 @@ import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
 public class OpenTelemetryConfiguration(
     spanSink: SpanSink,
     logSink: LogSink,
-    systemInfo: SystemInfo,
-    processIdentifier: String
+    systemInfo: SystemInfo
 ) {
     public val embraceSdkName: String = BuildConfig.LIBRARY_PACKAGE_NAME
     public val embraceSdkVersion: String = BuildConfig.VERSION_NAME
@@ -41,6 +42,15 @@ public class OpenTelemetryConfiguration(
         .put(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME, embraceSdkName)
         .put(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION, embraceSdkVersion)
         .build()
+
+    /**
+     * Unique ID generated for an instance of the app process and not related to the actual process ID assigned by the OS.
+     * This allows us to explicitly relate all the sessions associated with a particular app launch rather than having the backend figure
+     * this out by proximity for stitched sessions.
+     */
+    private val processIdentifier: String by lazy {
+        Systrace.traceSynchronous("process-identifier-init", IdGenerator.Companion::generateLaunchInstanceId)
+    }
 
     private val externalSpanExporters = mutableListOf<SpanExporter>()
     private val externalLogExporters = mutableListOf<LogRecordExporter>()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/LocalConfigTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/LocalConfigTest.kt
@@ -21,8 +21,7 @@ internal class LocalConfigTest {
     private val cfg = OpenTelemetryConfiguration(
         SpanSinkImpl(),
         LogSinkImpl(),
-        SystemInfo(),
-        "my-id"
+        SystemInfo()
     )
 
     @Test(expected = IllegalArgumentException::class)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
@@ -153,8 +153,7 @@ internal class NetworkBehaviorImplTest {
         val otelCfg = OpenTelemetryConfiguration(
             SpanSinkImpl(),
             LogSinkImpl(),
-            SystemInfo(),
-            "my-id"
+            SystemInfo()
         )
         val json = ResourceReader.readResourceAsText("public_key_config.json")
         val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), otelCfg, EmbLoggerImpl())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/InitModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/InitModuleImplTest.kt
@@ -20,7 +20,6 @@ internal class InitModuleImplTest {
         assertNotNull(initModule.clock)
         assertTrue(initModule.telemetryService is EmbraceTelemetryService)
         assertEquals(initModule.systemInfo, SystemInfo())
-        assertEquals(initModule.processIdentifier.length, 16)
         assertNotNull(initModule.jsonSerializer)
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -55,8 +55,7 @@ internal class EmbraceNetworkCaptureServiceTest {
             val otelCfg = OpenTelemetryConfiguration(
                 SpanSinkImpl(),
                 LogSinkImpl(),
-                SystemInfo(),
-                "my-id"
+                SystemInfo()
             )
             mockLocalConfig =
                 LocalConfigParser.buildConfig(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfigurationTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfigurationTest.kt
@@ -28,8 +28,7 @@ internal class OpenTelemetryConfigurationTest {
         val configuration = OpenTelemetryConfiguration(
             spanSink = SpanSinkImpl(),
             logSink = LogSinkImpl(),
-            systemInfo = systemInfo,
-            processIdentifier = "fakeProcessIdentifier"
+            systemInfo = systemInfo
         )
 
         assertEquals(configuration.embraceSdkName, configuration.resource.getAttribute(ServiceAttributes.SERVICE_NAME))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdkTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdkTest.kt
@@ -33,8 +33,7 @@ internal class OpenTelemetrySdkTest {
         configuration = OpenTelemetryConfiguration(
             spanSink = spanSink,
             logSink = logSink,
-            systemInfo = systemInfo,
-            processIdentifier = "fakeProcessIdentifier"
+            systemInfo = systemInfo
         )
         spanExporter = FakeSpanExporter()
         logExporter = FakeLogRecordExporter()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -82,8 +82,7 @@ internal class PayloadFactoryBaTest {
         val otelCfg = OpenTelemetryConfiguration(
             SpanSinkImpl(),
             LogSinkImpl(),
-            SystemInfo(),
-            "my-id"
+            SystemInfo()
         )
         localConfig = LocalConfigParser.buildConfig(
             "GrCPU",

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionTest.kt
@@ -108,8 +108,7 @@ internal class PayloadFactorySessionTest {
         val otelCfg = OpenTelemetryConfiguration(
             SpanSinkImpl(),
             LogSinkImpl(),
-            SystemInfo(),
-            "my-id"
+            SystemInfo()
         )
         localConfig = LocalConfigParser.buildConfig(
             "GrCPU",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
@@ -10,7 +10,9 @@ import io.embrace.android.embracesdk.assertions.assertHasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.opentelemetry.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.opentelemetry.embSequenceId
 import io.embrace.android.embracesdk.recordSession
+import io.opentelemetry.api.common.AttributeKey
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -50,7 +52,7 @@ internal class SpanExporterTest {
                 val exportedSpans = fakeSpanExporter.exportedSpans.associateBy { it.name }
                 val testSpan = checkNotNull(exportedSpans["test"])
                 testSpan.assertHasEmbraceAttribute(embSequenceId, "5")
-                testSpan.assertHasEmbraceAttribute(embProcessIdentifier, harness.overriddenInitModule.processIdentifier)
+                assertNotNull(testSpan.attributes.get(embProcessIdentifier.attributeKey))
                 testSpan.resource.assertExpectedAttributes(
                     expectedServiceName = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceSdkName,
                     expectedServiceVersion = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceSdkVersion,
@@ -58,7 +60,7 @@ internal class SpanExporterTest {
                 )
                 val sessionSpan = checkNotNull(exportedSpans["emb-session"])
                 sessionSpan.assertHasEmbraceAttribute(embSequenceId, "1")
-                testSpan.assertHasEmbraceAttribute(embProcessIdentifier, harness.overriddenInitModule.processIdentifier)
+                assertNotNull(sessionSpan.attributes.get(embProcessIdentifier.attributeKey))
             }
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.Systrace.endSynchronous
 import io.embrace.android.embracesdk.internal.Systrace.startSynchronous
 import io.embrace.android.embracesdk.internal.anr.ndk.isUnityMainThread
@@ -52,7 +53,7 @@ import io.embrace.android.embracesdk.spans.TracingApi
  */
 @SuppressLint("EmbracePublicApiPackageRule")
 internal class EmbraceImpl @JvmOverloads constructor(
-    private val bootstrapper: ModuleInitBootstrapper = ModuleInitBootstrapper(),
+    private val bootstrapper: ModuleInitBootstrapper = Systrace.traceSynchronous("bootstrapper-init", ::ModuleInitBootstrapper),
     private val sdkCallChecker: SdkCallChecker =
         SdkCallChecker(bootstrapper.initModule.logger, bootstrapper.initModule.telemetryService),
     private val userApiDelegate: UserApiDelegate = UserApiDelegate(bootstrapper, sdkCallChecker),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -25,9 +25,11 @@ import kotlin.reflect.KClass
  * A class that wires together and initializes modules in a manner that makes them work as a cohesive whole.
  */
 internal class ModuleInitBootstrapper(
-    public val logger: EmbLogger = EmbLoggerImpl(),
-    val initModule: InitModule = createInitModule(logger = logger),
-    val openTelemetryModule: OpenTelemetryModule = createOpenTelemetryModule(initModule),
+    public val logger: EmbLogger = Systrace.traceSynchronous("logger-init", ::EmbLoggerImpl),
+    val initModule: InitModule = Systrace.traceSynchronous("init-module", { createInitModule(logger = logger) }),
+    val openTelemetryModule: OpenTelemetryModule = Systrace.traceSynchronous("otel-module", {
+        createOpenTelemetryModule(initModule)
+    }),
     private val coreModuleSupplier: CoreModuleSupplier = ::createCoreModule,
     private val configModuleSupplier: ConfigModuleSupplier = ::createConfigModule,
     private val systemServiceModuleSupplier: SystemServiceModuleSupplier = ::createSystemServiceModule,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -26,7 +26,7 @@ public class FakeOpenTelemetryModule(
     override val spanRepository: SpanRepository = SpanRepository(),
 ) : OpenTelemetryModule {
     override val openTelemetryConfiguration: OpenTelemetryConfiguration =
-        OpenTelemetryConfiguration(spanSink, logSink, SystemInfo(), "my.example")
+        OpenTelemetryConfiguration(spanSink, logSink, SystemInfo())
     override val sdkTracer: Tracer
         get() = FakeTracer()
     override val spanService: SpanService


### PR DESCRIPTION
## Goal

Generating a process ID for the OTel configuration object was taking a surprisingly long period of time (~1ms). I've offloaded this to the background thread as it didn't need to be on the main thread.

## Profiling
<img width="1027" alt="Screenshot 2024-09-02 at 14 19 49" src="https://github.com/user-attachments/assets/8fdcc1ad-5a4e-4e87-bbc3-4a574f0ce356">
<img width="1051" alt="Screenshot 2024-09-02 at 14 19 40" src="https://github.com/user-attachments/assets/7e61ba56-a0e2-42cc-9379-02ee260645e2">

