### PR TITLE
Remove unused startup status

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
@@ -4,7 +4,6 @@ import android.content.SharedPreferences
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.Callable
@@ -16,7 +15,7 @@ internal class EmbracePreferencesService(
     private val lazyPrefs: Lazy<SharedPreferences>,
     private val clock: Clock,
     private val serializer: PlatformSerializer
-) : PreferencesService, StartupListener {
+) : PreferencesService {
 
     // We get SharedPreferences on a background thread because it loads data from disk
     // and can block. When client code needs to set/get a preference, getSharedPrefs() will
@@ -31,20 +30,6 @@ internal class EmbracePreferencesService(
                 }
             }
         )
-    }
-
-    init {
-        alterStartupStatus(SDK_STARTUP_IN_PROGRESS)
-    }
-
-    override fun applicationStartupComplete(): Unit = alterStartupStatus(SDK_STARTUP_COMPLETED)
-
-    private fun alterStartupStatus(status: String) {
-        backgroundWorker.submit {
-            Systrace.traceSynchronous("set-startup-status") {
-                prefs.setStringPreference(SDK_STARTUP_STATUS_KEY, status)
-            }
-        }
     }
 
     // fallback from this very unlikely case by just loading on the main thread
@@ -173,9 +158,6 @@ internal class EmbracePreferencesService(
             return newId
         }
         set(value) = prefs.setStringPreference(DEVICE_IDENTIFIER_KEY, value)
-
-    override val sdkStartupStatus: String?
-        get() = prefs.getStringPreference(SDK_STARTUP_STATUS_KEY)
 
     override var sdkDisabled: Boolean
         get() = prefs.getBooleanPreference(SDK_DISABLED_KEY, false)
@@ -341,7 +323,6 @@ internal class EmbracePreferencesService(
     public companion object {
         internal const val SDK_STARTUP_IN_PROGRESS = "startup_entered"
         internal const val SDK_STARTUP_COMPLETED = "startup_completed"
-        private const val SDK_STARTUP_STATUS_KEY = "io.embrace.sdkstartup"
         private const val DEVICE_IDENTIFIER_KEY = "io.embrace.deviceid"
         private const val PREVIOUS_APP_VERSION_KEY = "io.embrace.lastappversion"
         private const val PREVIOUS_OS_VERSION_KEY = "io.embrace.lastosversion"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/PreferencesService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/PreferencesService.kt
@@ -23,11 +23,6 @@ public interface PreferencesService {
     public var deviceIdentifier: String
 
     /**
-     * The last SDK startup status registered.
-     */
-    public val sdkStartupStatus: String?
-
-    /**
      * If the sdk is disabled
      */
     public var sdkDisabled: Boolean

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
@@ -43,27 +43,6 @@ internal class EmbracePreferencesServiceTest {
         )
     }
 
-    /**
-     * Asserts that the startup state preference is updated when creating a PreferenceService.
-     */
-    @Test
-    @Throws(InterruptedException::class)
-    fun testStartupStatePersistence() {
-        // move through two states: startup in progress + startup complete.
-        assertEquals(
-            "startup_entered",
-            service.sdkStartupStatus
-        )
-
-        service.applicationStartupComplete()
-
-        // assert the entered startup and completed startup preferences were set
-        assertEquals(
-            "startup_completed",
-            service.sdkStartupStatus
-        )
-    }
-
     @Test
     fun `test app version is saved`() {
         assertNull(service.appVersion)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -8,7 +8,6 @@ public class FakePreferenceService(
     override var osVersion: String? = null,
     override var installDate: Long? = 0,
     override var deviceIdentifier: String = "",
-    override val sdkStartupStatus: String? = null,
     override var sdkDisabled: Boolean = false,
     override var userPayer: Boolean = false,
     override var userIdentifier: String? = null,


### PR DESCRIPTION
## Goal

The SDK startup status is not used so can be removed. This is read on a background thread so won't have a major impact on startup time.
