### PR TITLE
Initialize network connectivity listeners async

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -225,9 +225,11 @@ internal class ModuleInitBootstrapper(
                                     registerFactory(networkBehavior.isRequestContentLengthCaptureEnabled())
                                 }
                             }
-                            Systrace.traceSynchronous("network-connectivity-registration") {
-                                networkConnectivityService.addNetworkConnectivityListener(pendingApiCallsSender)
-                                apiService?.let(networkConnectivityService::addNetworkConnectivityListener)
+                            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit {
+                                Systrace.traceSynchronous("network-connectivity-registration") {
+                                    networkConnectivityService.addNetworkConnectivityListener(pendingApiCallsSender)
+                                    apiService?.let(networkConnectivityService::addNetworkConnectivityListener)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Goal

Offloads network connectivity listeners so that they are registered async. These are not essential so can afford to wait a few milliseconds until startup is done.

## Profiling
<img width="789" alt="Screenshot 2024-09-02 at 16 24 29" src="https://github.com/user-attachments/assets/43d17b49-f0e7-4822-915d-3cb15382b637">
<img width="705" alt="Screenshot 2024-09-02 at 16 24 23" src="https://github.com/user-attachments/assets/2ed49f97-6bce-49ce-a7ce-8d233b94d9f2">


