### PR TITLE
Avoid unnecessary HTTP request for crashes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiService.kt
@@ -32,13 +32,6 @@ public interface ApiService : RemoteConfigSource, NetworkConnectivityListener {
     public fun sendEvent(eventMessage: EventMessage)
 
     /**
-     * Sends a crash event to the API and reschedules it if the request times out
-     *
-     * @param crash the event message containing the crash
-     */
-    public fun sendCrash(crash: EventMessage): Future<*>
-
-    /**
      * Sends a session to the API. This can be either a v1 or v2 session - the implementation
      * is responsible for routing the payload correctly.
      */

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.comms.api
 import io.embrace.android.embracesdk.core.BuildConfig
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.TypeUtils
-import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryCacheManager
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.comms.delivery.PendingApiCallsSender
 import io.embrace.android.embracesdk.internal.compression.ConditionalGzipOutputStream
@@ -26,7 +25,6 @@ internal class EmbraceApiService(
     private val cachedConfigProvider: (url: String, request: ApiRequest) -> CachedConfig,
     private val logger: EmbLogger,
     private val backgroundWorker: BackgroundWorker,
-    private val cacheManager: DeliveryCacheManager,
     private val pendingApiCallsSender: PendingApiCallsSender,
     lazyDeviceId: Lazy<String>,
     appId: String,
@@ -131,10 +129,6 @@ internal class EmbraceApiService(
 
     override fun sendEvent(eventMessage: EventMessage) {
         post(eventMessage, mapper::eventMessageRequest)
-    }
-
-    override fun sendCrash(crash: EventMessage): Future<*> {
-        return post(crash, mapper::eventMessageRequest) { cacheManager.deleteCrash() }
     }
 
     override fun sendSession(action: SerializationAction, onFinish: ((successful: Boolean) -> Unit)?): Future<*> {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/DeliveryCacheManager.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/DeliveryCacheManager.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.comms.delivery
 
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import io.embrace.android.embracesdk.internal.payload.Envelope
-import io.embrace.android.embracesdk.internal.payload.EventMessage
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
@@ -12,9 +11,6 @@ public interface DeliveryCacheManager {
     public fun loadSessionAsAction(sessionId: String): SerializationAction?
     public fun deleteSession(sessionId: String)
     public fun getAllCachedSessionIds(): List<CachedSession>
-    public fun saveCrash(crash: EventMessage)
-    public fun loadCrash(): EventMessage?
-    public fun deleteCrash()
     public fun savePayload(action: SerializationAction, sync: Boolean = false): String
     public fun loadPayloadAsAction(name: String): SerializationAction
     public fun deletePayload(name: String)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/DeliveryService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/DeliveryService.kt
@@ -17,6 +17,5 @@ public interface DeliveryService {
     )
     public fun sendLogs(logEnvelope: Envelope<LogPayload>)
     public fun saveLogs(logEnvelope: Envelope<LogPayload>)
-    public fun sendCrash(crash: EventMessage, processTerminating: Boolean)
     public fun sendMoment(eventMessage: EventMessage)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryCacheManager.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryCacheManager.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
-import io.embrace.android.embracesdk.internal.payload.EventMessage
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.getSessionId
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
@@ -22,10 +21,6 @@ internal class EmbraceDeliveryCacheManager(
 ) : Closeable, DeliveryCacheManager {
 
     companion object {
-        /**
-         * File name to cache JVM crash information
-         */
-        private const val CRASH_FILE_NAME = "crash.json"
 
         /**
          * File name for pending api calls
@@ -102,18 +97,6 @@ internal class EmbraceDeliveryCacheManager(
         }
 
         return cachedSessions.values.toList()
-    }
-
-    override fun saveCrash(crash: EventMessage) {
-        cacheService.cacheObject(CRASH_FILE_NAME, crash, EventMessage::class.java)
-    }
-
-    override fun loadCrash(): EventMessage? {
-        return cacheService.loadObject(CRASH_FILE_NAME, EventMessage::class.java)
-    }
-
-    override fun deleteCrash() {
-        cacheService.deleteFile(CRASH_FILE_NAME)
     }
 
     override fun savePayload(action: SerializationAction, sync: Boolean): String {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryService.kt
@@ -22,8 +22,6 @@ import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import java.io.OutputStream
 import java.util.concurrent.TimeUnit
 import kotlin.math.max
@@ -31,14 +29,12 @@ import kotlin.math.max
 internal class EmbraceDeliveryService(
     private val cacheManager: DeliveryCacheManager,
     private val apiService: ApiService,
-    private val backgroundWorker: BackgroundWorker,
     private val serializer: PlatformSerializer,
     private val logger: EmbLogger
 ) : DeliveryService {
 
     private companion object {
         private const val SEND_SESSION_TIMEOUT = 1L
-        private const val CRASH_TIMEOUT = 1L // Seconds to wait before timing out when sending a crash
     }
 
     /**
@@ -88,59 +84,33 @@ internal class EmbraceDeliveryService(
         apiService.saveLogEnvelope(logEnvelope)
     }
 
-    override fun sendCrash(crash: EventMessage, processTerminating: Boolean) {
-        runCatching {
-            cacheManager.saveCrash(crash)
-            val future = apiService.sendCrash(crash)
-
-            if (processTerminating) {
-                future.get(CRASH_TIMEOUT, TimeUnit.SECONDS)
-            }
-        }
-    }
-
     override fun sendCachedSessions(
         nativeCrashServiceProvider: Provider<NativeCrashService?>,
         sessionIdTracker: SessionIdTracker
     ) {
-        sendCachedCrash()
-        backgroundWorker.submit(TaskPriority.HIGH) {
-            val allSessions = cacheManager.getAllCachedSessionIds().filter {
-                it.sessionId != sessionIdTracker.getActiveSessionId()
-            }
+        val nativeCrashData = nativeCrashServiceProvider()?.getAndSendNativeCrash()
+        val allSessions = cacheManager.getAllCachedSessionIds().filter {
+            it.sessionId != sessionIdTracker.getActiveSessionId()
+        }
 
-            allSessions.map { it.sessionId }.forEach { sessionId ->
-                cacheManager.transformSession(sessionId = sessionId) {
-                    val completedSpanIds = data.spans?.map { it.spanId }?.toSet() ?: emptySet()
-                    val spansToFail = data.spanSnapshots
-                        ?.filterNot { completedSpanIds.contains(it.spanId) }
-                        ?.map { it.toFailedSpan(endTimeMs = getFailedSpanEndTimeMs(this)) }
-                        ?: emptyList()
-                    val completedSpans = (data.spans ?: emptyList()) + spansToFail
-                    copy(
-                        data = data.copy(
-                            spans = completedSpans,
-                            spanSnapshots = emptyList(),
-                        )
+        allSessions.map { it.sessionId }.forEach { sessionId ->
+            cacheManager.transformSession(sessionId = sessionId) {
+                val completedSpanIds = data.spans?.map { it.spanId }?.toSet() ?: emptySet()
+                val spansToFail = data.spanSnapshots
+                    ?.filterNot { completedSpanIds.contains(it.spanId) }
+                    ?.map { it.toFailedSpan(endTimeMs = getFailedSpanEndTimeMs(this)) }
+                    ?: emptyList()
+                val completedSpans = (data.spans ?: emptyList()) + spansToFail
+                copy(
+                    data = data.copy(
+                        spans = completedSpans,
+                        spanSnapshots = emptyList(),
                     )
-                }
+                )
             }
-
-            nativeCrashServiceProvider()?.let { service ->
-                val nativeCrashData = service.getAndSendNativeCrash()
-                if (nativeCrashData != null) {
-                    addCrashDataToCachedSession(nativeCrashData)
-                }
-            }
-            sendCachedSessions(allSessions)
         }
-    }
-
-    private fun sendCachedCrash() {
-        val crash = cacheManager.loadCrash()
-        crash?.let {
-            apiService.sendCrash(it)
-        }
+        nativeCrashData?.let(::addCrashDataToCachedSession)
+        sendCachedSessions(allSessions)
     }
 
     private fun addCrashDataToCachedSession(nativeCrashData: NativeCrashData) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/NoopDeliveryService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/NoopDeliveryService.kt
@@ -26,9 +26,6 @@ internal class NoopDeliveryService : DeliveryService {
     override fun saveLogs(logEnvelope: Envelope<LogPayload>) {
     }
 
-    override fun sendCrash(crash: EventMessage, processTerminating: Boolean) {
-    }
-
     override fun sendMoment(eventMessage: EventMessage) {
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -4,11 +4,9 @@ import io.embrace.android.embracesdk.internal.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.comms.delivery.EmbraceDeliveryService
 import io.embrace.android.embracesdk.internal.comms.delivery.NoopDeliveryService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
 
 internal class DeliveryModuleImpl(
     initModule: InitModule,
-    workerThreadModule: WorkerThreadModule,
     storageModule: StorageModule,
     apiService: ApiService?
 ) : DeliveryModule {
@@ -20,7 +18,6 @@ internal class DeliveryModuleImpl(
             EmbraceDeliveryService(
                 storageModule.deliveryCacheManager,
                 apiService,
-                workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
                 initModule.jsonSerializer,
                 initModule.logger
             )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
@@ -7,19 +7,16 @@ import io.embrace.android.embracesdk.internal.comms.api.ApiService
  */
 public typealias DeliveryModuleSupplier = (
     initModule: InitModule,
-    workerThreadModule: WorkerThreadModule,
     storageModule: StorageModule,
     apiService: ApiService?,
 ) -> DeliveryModule
 
 public fun createDeliveryModule(
     initModule: InitModule,
-    workerThreadModule: WorkerThreadModule,
     storageModule: StorageModule,
     apiService: ApiService?,
 ): DeliveryModule = DeliveryModuleImpl(
     initModule,
-    workerThreadModule,
     storageModule,
     apiService,
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -122,7 +122,6 @@ public class EssentialServiceModuleImpl(
                 },
                 logger = initModule.logger,
                 backgroundWorker = networkRequestWorker,
-                cacheManager = Systrace.traceSynchronous("cache-manager") { storageModule.deliveryCacheManager },
                 pendingApiCallsSender = pendingApiCallsSender,
                 lazyDeviceId = lazyDeviceId,
                 appId = appId,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -170,23 +170,6 @@ internal class EmbraceApiServiceTest {
     }
 
     @Test
-    fun `send crash request is as expected`() {
-        val crash = EventMessage(
-            event = Event(
-                eventId = "crash-id",
-                activeEventIds = listOf("event-1", "event-2"),
-                type = EventType.CRASH
-            )
-        )
-        apiService.sendCrash(crash)
-        verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v1/log/events",
-            expectedEventId = "c:event-1,event-2",
-            expectedPayload = getExpectedPayloadSerialized(crash, EventMessage::class.java)
-        )
-    }
-
-    @Test
     fun `send v2 session`() {
         fakeApiClient.queueResponse(successfulPostResponse)
         val payload = "".toByteArray(Charsets.UTF_8)
@@ -479,7 +462,6 @@ internal class EmbraceApiServiceTest {
             cachedConfigProvider = { _, _ -> cachedConfig },
             logger = EmbLoggerImpl(),
             backgroundWorker = BackgroundWorker(testScheduledExecutor),
-            cacheManager = fakeCacheManager,
             pendingApiCallsSender = fakePendingApiCallsSender,
             lazyDeviceId = lazy { fakeDeviceId },
             appId = fakeAppId,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -88,7 +88,6 @@ internal class EmbraceDeliveryServiceTest {
         deliveryService = EmbraceDeliveryService(
             deliveryCacheManager,
             apiService,
-            worker,
             testPlatformSerializer,
             logger
         )
@@ -315,13 +314,6 @@ internal class EmbraceDeliveryServiceTest {
         val obj = EventMessage(Event(eventId = "abc", type = EventType.END))
         deliveryService.sendMoment(obj)
         assertEquals(obj, apiService.eventRequests.single())
-    }
-
-    @Test
-    fun testSaveCrash() {
-        val obj = EventMessage(Event(eventId = "abc", type = EventType.CRASH))
-        deliveryService.sendCrash(obj, true)
-        assertEquals(obj, apiService.crashRequests.single())
     }
 
     @Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.fakes.FakeApiService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
-import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -14,7 +13,6 @@ internal class DeliveryModuleImplTest {
         val initModule = FakeInitModule()
         val module = createDeliveryModule(
             initModule,
-            FakeWorkerThreadModule(),
             FakeStorageModule(),
             FakeApiService(),
         )

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
@@ -22,7 +22,6 @@ internal class NativeFeatureModuleImpl(
     essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
     payloadSourceModule: PayloadSourceModule,
-    deliveryModule: DeliveryModule,
     androidServicesModule: AndroidServicesModule,
     workerThreadModule: WorkerThreadModule,
     nativeCoreModule: NativeCoreModule
@@ -36,9 +35,7 @@ internal class NativeFeatureModuleImpl(
                 payloadSourceModule.metadataService,
                 essentialServiceModule.processStateService,
                 configModule.configService,
-                deliveryModule.deliveryService,
                 essentialServiceModule.userService,
-                androidServicesModule.preferencesService,
                 essentialServiceModule.sessionPropertiesService,
                 nativeCoreModule.sharedObjectLoader,
                 initModule.logger,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleSupplier.kt
@@ -10,7 +10,6 @@ public typealias NativeFeatureModuleSupplier = (
     essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
     payloadSourceModule: PayloadSourceModule,
-    deliveryModule: DeliveryModule,
     androidServicesModule: AndroidServicesModule,
     workerThreadModule: WorkerThreadModule,
     nativeCoreModule: NativeCoreModule
@@ -23,7 +22,6 @@ public fun createNativeFeatureModule(
     essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
     payloadSourceModule: PayloadSourceModule,
-    deliveryModule: DeliveryModule,
     androidServicesModule: AndroidServicesModule,
     workerThreadModule: WorkerThreadModule,
     nativeCoreModule: NativeCoreModule
@@ -34,7 +32,6 @@ public fun createNativeFeatureModule(
     essentialServiceModule,
     configModule,
     payloadSourceModule,
-    deliveryModule,
     androidServicesModule,
     workerThreadModule,
     nativeCoreModule

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.ndk
 
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 
-public interface NdkService : NativeCrashService {
+public interface NdkService {
     public fun updateSessionId(newSessionId: String)
 
     public fun onSessionPropertiesUpdate(properties: Map<String, String>)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImplTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
-import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeCoreModule
@@ -31,7 +30,6 @@ internal class NativeFeatureModuleImplTest {
             FakeEssentialServiceModule(),
             FakeConfigModule(),
             FakePayloadSourceModule(),
-            FakeDeliveryModule(),
             FakeAndroidServicesModule(),
             FakeWorkerThreadModule(),
             FakeNativeCoreModule()

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
@@ -154,9 +154,7 @@ internal class EmbraceNdkServiceTest {
                 metadataService,
                 activityService,
                 configService,
-                deliveryService,
                 userService,
-                preferencesService,
                 sessionPropertiesService,
                 sharedObjectLoader,
                 logger,
@@ -316,7 +314,7 @@ internal class EmbraceNdkServiceTest {
     fun `test checkForNativeCrash does nothing if there are no matchingFiles`() {
         every { repository.sortNativeCrashes(false) } returns listOf()
         initializeService()
-        val result = embraceNdkService.getAndSendNativeCrash()
+        val result = embraceNdkService.getNativeCrash()
         assertNull(result)
         verify { repository.sortNativeCrashes(false) }
         verify(exactly = 0) { delegate._getCrashReport(any()) }
@@ -371,7 +369,7 @@ internal class EmbraceNdkServiceTest {
         every { repository.sortNativeCrashes(false) } returns listOf(crashFile)
         every { delegate._getCrashReport(any()) } returns ""
         initializeService()
-        val crashData = embraceNdkService.getAndSendNativeCrash()
+        val crashData = embraceNdkService.getNativeCrash()
         assertNull(crashData)
     }
 
@@ -391,7 +389,7 @@ internal class EmbraceNdkServiceTest {
         every { delegate._getCrashReport(any()) } returns json
 
         initializeService()
-        val crashData = embraceNdkService.getAndSendNativeCrash()
+        val crashData = embraceNdkService.getNativeCrash()
         assertNull(crashData)
     }
 
@@ -414,7 +412,7 @@ internal class EmbraceNdkServiceTest {
         initializeService()
         every { embraceNdkService.symbolsForCurrentArch } returns mockk()
 
-        val result = embraceNdkService.getAndSendNativeCrash()
+        val result = embraceNdkService.getNativeCrash()
         assertNotNull(result)
 
         verify { embraceNdkService["getNativeCrashErrors"](any() as NativeCrashData, errorFile) }
@@ -431,7 +429,7 @@ internal class EmbraceNdkServiceTest {
         configService.appFramework = AppFramework.UNITY
         initializeService()
 
-        val result = embraceNdkService.getAndSendNativeCrash()
+        val result = embraceNdkService.getNativeCrash()
         assertNull(result)
 
         verify(exactly = 1) { repository.sortNativeCrashes(false) }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -108,9 +108,9 @@ internal class IntegrationTestRule(
                 coreModuleSupplier = { _, _ -> overriddenCoreModule },
                 workerThreadModuleSupplier = { _ -> overriddenWorkerThreadModule },
                 androidServicesModuleSupplier = { _, _, _ -> overriddenAndroidServicesModule },
-                deliveryModuleSupplier = { _, _, _, _ -> overriddenDeliveryModule },
+                deliveryModuleSupplier = { _, _, _ -> overriddenDeliveryModule },
                 anrModuleSupplier = { _, _, _, _ -> fakeAnrModule },
-                nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> fakeNativeFeatureModule }
+                nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> fakeNativeFeatureModule }
             )
             val embraceImpl = EmbraceImpl(bootstrapper)
             Embrace.setImpl(embraceImpl)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -302,7 +302,6 @@ internal class ModuleInitBootstrapper(
                     deliveryModule = init(DeliveryModule::class) {
                         deliveryModuleSupplier(
                             initModule,
-                            workerThreadModule,
                             storageModule,
                             essentialServiceModule.apiService
                         )
@@ -355,7 +354,6 @@ internal class ModuleInitBootstrapper(
                             essentialServiceModule,
                             configModule,
                             payloadSourceModule,
-                            deliveryModule,
                             androidServicesModule,
                             workerThreadModule,
                             nativeCoreModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -48,7 +48,7 @@ internal fun fakeModuleInitBootstrapper(
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
-    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _ -> FakeDeliveryModule() },
+    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _ -> FakeNativeCoreModule() },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -38,7 +38,7 @@ internal class ModuleInitBootstrapperTest {
         coreModule = FakeCoreModule(logger = logger)
         moduleInitBootstrapper = ModuleInitBootstrapper(
             coreModuleSupplier = { _, _ -> coreModule },
-            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
+            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = logger
         )
         context = RuntimeEnvironment.getApplication().applicationContext
@@ -48,7 +48,7 @@ internal class ModuleInitBootstrapperTest {
     fun `test default implementation`() {
         val moduleInitBootstrapper = ModuleInitBootstrapper(
             coreModuleSupplier = { _, _ -> coreModule },
-            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
+            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = EmbLoggerImpl()
         )
         with(moduleInitBootstrapper) {
@@ -114,7 +114,7 @@ internal class ModuleInitBootstrapperTest {
             initModule = fakeInitModule,
             coreModuleSupplier = { _, _ -> fakeCoreModule },
             workerThreadModuleSupplier = { _ -> fakeWorkerThreadModule },
-            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
+            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = EmbLoggerImpl()
         )
         assertTrue(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeApiService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeApiService.kt
@@ -49,11 +49,6 @@ public class FakeApiService : ApiService {
         eventRequests.add(eventMessage)
     }
 
-    override fun sendCrash(crash: EventMessage): Future<*> {
-        crashRequests.add(crash)
-        return ObservableFutureTask { }
-    }
-
     override fun sendSession(action: SerializationAction, onFinish: ((successful: Boolean) -> Unit)?): Future<*> {
         if (throwExceptionSendSession) {
             error("FakeApiService.sendSession")

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt
@@ -42,18 +42,6 @@ public class FakeDeliveryCacheManager : DeliveryCacheManager {
         return cachedSessions.map { CachedSession.create(it.getSessionId(), 0, false) }
     }
 
-    override fun saveCrash(crash: EventMessage) {
-        saveCrashRequests.add(crash)
-    }
-
-    override fun loadCrash(): EventMessage? {
-        return null
-    }
-
-    override fun deleteCrash() {
-        TODO("Not yet implemented")
-    }
-
     override fun deletePayload(name: String) {
         TODO("Not yet implemented")
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryService.kt
@@ -22,13 +22,11 @@ import java.util.concurrent.ConcurrentLinkedQueue
  * invocations. Please add additional tracking functionality as tests require them.
  */
 public open class FakeDeliveryService : DeliveryService {
-    public var lastSentCrash: EventMessage? = null
     public val lastSentLogPayloads: MutableList<Envelope<LogPayload>> = mutableListOf()
     public val lastSavedLogPayloads: MutableList<Envelope<LogPayload>> = mutableListOf()
     public val sentMoments: MutableList<EventMessage> = mutableListOf()
     public var lastEventSentAsync: EventMessage? = null
     public var eventSentAsyncInvokedCount: Int = 0
-    public var lastSavedCrash: EventMessage? = null
     public var lastSentCachedSession: String? = null
     public val sentSessionEnvelopes: Queue<Pair<Envelope<SessionPayload>, SessionSnapshotType>> =
         ConcurrentLinkedQueue()
@@ -61,11 +59,6 @@ public open class FakeDeliveryService : DeliveryService {
 
     override fun saveLogs(logEnvelope: Envelope<LogPayload>) {
         lastSavedLogPayloads.add(logEnvelope)
-    }
-
-    override fun sendCrash(crash: EventMessage, processTerminating: Boolean) {
-        lastSavedCrash = crash
-        lastSentCrash = crash
     }
 
     public fun getSentSessions(): List<Envelope<SessionPayload>> {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.internal.ndk.NdkService
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 
 public class FakeNdkService : NdkService {
-    public var checkForNativeCrashCount: Int = 0
     public val propUpdates: MutableList<Map<String, String>> = mutableListOf()
 
     public var sessionId: String? = null
@@ -36,11 +35,6 @@ public class FakeNdkService : NdkService {
         val data = nativeCrashData
         nativeCrashData = null
         return data
-    }
-
-    override fun getAndSendNativeCrash(): NativeCrashData? {
-        checkForNativeCrashCount++
-        return getNativeCrash()
     }
 
     override val symbolsForCurrentArch: Map<String, String>?


### PR DESCRIPTION
## Goal

The code appears to be making a HTTP request to the old `v1/log/events` endpoint for NDK crashes as well as to the new OTel log endpoint. This PR removes the legacy approach which was the last part of startup that performed I/O on the main thread.

## Profiling

This seems like a modest improvement but I've previously seen this call have very high variance as it performs I/O.

<img width="981" alt="Screenshot 2024-09-03 at 10 03 55" src="https://github.com/user-attachments/assets/80937911-5dfe-4c6b-8ddb-0a4e84de3925">
<img width="1116" alt="Screenshot 2024-09-03 at 10 04 06" src="https://github.com/user-attachments/assets/eefa70f3-23b9-4be5-b151-e6aaf0b917b2">

## Testing

Manually verified that crashes still show in the dashboard.