### PR TITLE
Initialize OTel on main thread to avoid thread contention

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
@@ -181,7 +181,7 @@ internal class BackgroundActivityDisabledTest {
                 startMs = session2StartMs,
                 endMs = session2EndMs,
                 sessionNumber = 2,
-                sequenceId = 5,
+                sequenceId = 4,
                 coldStart = false,
             )
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
@@ -39,8 +39,8 @@ internal class SpanExporterTest {
                 "Timed out waiting for the span to be exported: ${fakeSpanExporter.exportedSpans.map { it.name }}",
                 fakeSpanExporter.awaitSpanExport(1)
             )
-            // Verify that 4 spans have been logged - the exported ones and 3 private diagnostic traces
-            assertEquals(3, harness.overriddenOpenTelemetryModule.spanSink.completedSpans().size)
+            // Verify that 2 spans have been logged - the exported ones and 1 private diagnostic traces
+            assertEquals(2, harness.overriddenOpenTelemetryModule.spanSink.completedSpans().size)
 
             harness.recordSession {
                 assertTrue(
@@ -51,7 +51,7 @@ internal class SpanExporterTest {
                 assertEquals(2, fakeSpanExporter.exportedSpans.size)
                 val exportedSpans = fakeSpanExporter.exportedSpans.associateBy { it.name }
                 val testSpan = checkNotNull(exportedSpans["test"])
-                testSpan.assertHasEmbraceAttribute(embSequenceId, "5")
+                testSpan.assertHasEmbraceAttribute(embSequenceId, "4")
                 assertNotNull(testSpan.attributes.get(embProcessIdentifier.attributeKey))
                 testSpan.resource.assertExpectedAttributes(
                     expectedServiceName = harness.overriddenOpenTelemetryModule.openTelemetryConfiguration.embraceSdkName,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -258,10 +258,6 @@ internal class EmbraceImpl @JvmOverloads constructor(
         startSynchronous("startup-tracking")
         dataCaptureServiceModule.startupService.setSdkStartupInfo(startTimeMs, endTimeMs, inForeground, Thread.currentThread().name)
         endSynchronous()
-
-        // This should return immediately given that EmbraceSpansService initialization should be finished at this point
-        // Put in emergency timeout just in case something unexpected happens so as to fail the SDK startup.
-        bootstrapper.waitForAsyncInit()
     }
 
     /**

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -2,27 +2,20 @@ package io.embrace.android.embracesdk.injection
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
-import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.embrace.android.embracesdk.internal.worker.WorkerName
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
 @RunWith(AndroidJUnit4::class)
 internal class ModuleInitBootstrapperTest {
@@ -91,7 +84,7 @@ internal class ModuleInitBootstrapperTest {
     }
 
     @Test
-    fun `async init returns normally and without failure`() {
+    fun `init returns normally and without failure`() {
         assertTrue(
             moduleInitBootstrapper.init(
                 context = context,
@@ -99,34 +92,6 @@ internal class ModuleInitBootstrapperTest {
                 sdkStartTimeMs = 0L,
             )
         )
-        moduleInitBootstrapper.waitForAsyncInit()
-    }
-
-    @Test
-    fun `async init throws exception if it waiting for too long`() {
-        val fakeInitModule = FakeInitModule(clock = FakeClock())
-        val fakeCoreModule = FakeCoreModule(logger = logger)
-        val fakeWorkerThreadModule = FakeWorkerThreadModule(
-            fakeInitModule = fakeInitModule,
-            name = WorkerName.BACKGROUND_REGISTRATION
-        )
-        val bootstrapper = ModuleInitBootstrapper(
-            initModule = fakeInitModule,
-            coreModuleSupplier = { _, _ -> fakeCoreModule },
-            workerThreadModuleSupplier = { _ -> fakeWorkerThreadModule },
-            nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
-            logger = EmbLoggerImpl()
-        )
-        assertTrue(
-            bootstrapper.init(
-                context = context,
-                appFramework = AppFramework.NATIVE,
-                sdkStartTimeMs = 0L,
-            )
-        )
-        assertThrows(TimeoutException::class.java) {
-            bootstrapper.waitForAsyncInit(500L, TimeUnit.MILLISECONDS)
-        }
     }
 
     @Test


### PR DESCRIPTION
## Goal

OTel & the span service are initialized on a background thread with the intention of reducing impact on startup times. However, Perfetto tracing shows contention in a couple of places, notably `emb-config-init` and `emb-otel-logger-init`.

IMO it's preferable to always initialize on the main thread as it avoids the unpredictable real-world effects of the main thread waiting on a background thread. This does slightly impact performance in our benchmarks but I believe we've got some budget to use after all the other improvements. It's also worth noting we haven't yet attempted to optimize the OTel initialisation process or updated the baseline profile, which likely makes the trace look worse than it should be.

## Profiling

I profiled before & after on a OnePlus Pro 7 running Android 10.

<img width="1187" alt="Screenshot 2024-09-03 at 10 37 17" src="https://github.com/user-attachments/assets/3a9157c3-10f2-4e9d-aa9e-202bd49c1c66">

Initializing on the main thread adds ~20% onto startup time for this iteration. But as previously mentioned, the baseline profile has not been updated & we've attempted no additional optimizations yet.

<img width="1168" alt="Screenshot 2024-09-03 at 10 38 31" src="https://github.com/user-attachments/assets/5db12eba-e6d6-4eb2-997e-40cb41e935b4">


## Testing

Relied on existing test coverage.

