### PR TITLE
Avoid binder transaction when starting session

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -25,20 +25,13 @@ internal class EmbraceNetworkConnectivityService(
     private val networkConnectivityListeners = mutableListOf<NetworkConnectivityListener>()
     override val ipAddress: String? by lazy { calculateIpAddress() }
 
-    override fun onReceive(context: Context, intent: Intent): Unit = handleNetworkStatus(true)
-
-    override fun networkStatusOnSessionStarted(startTime: Long): Unit = handleNetworkStatus(false)
-
-    private fun handleNetworkStatus(notifyListeners: Boolean) {
+    override fun onReceive(context: Context, intent: Intent) {
         try {
             val networkStatus = getCurrentNetworkStatus()
             if (didNetworkStatusChange(networkStatus)) {
                 lastNetworkStatus = networkStatus
-
-                if (notifyListeners) {
-                    logger.logInfo("Network status changed to: " + networkStatus.name)
-                    notifyNetworkConnectivityListeners(networkStatus)
-                }
+                logger.logInfo("Network status changed to: " + networkStatus.name)
+                notifyNetworkConnectivityListeners(networkStatus)
             }
         } catch (ex: Exception) {
             logger.logWarning("Failed to record network connectivity", ex)
@@ -77,7 +70,8 @@ internal class EmbraceNetworkConnectivityService(
         return networkStatus
     }
 
-    private fun didNetworkStatusChange(newNetworkStatus: NetworkStatus) = lastNetworkStatus != newNetworkStatus
+    private fun didNetworkStatusChange(newNetworkStatus: NetworkStatus) =
+        lastNetworkStatus != newNetworkStatus
 
     override fun register() {
         backgroundWorker.submit {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkConnectivityService.kt
@@ -9,14 +9,6 @@ import java.io.Closeable
 public interface NetworkConnectivityService : Closeable {
 
     /**
-     * Record the connection type at the start of the session and open a connectivity interval with it,
-     * with a start time that matches the session start time.
-     *
-     * @param startTime of the session
-     */
-    public fun networkStatusOnSessionStarted(startTime: Long)
-
-    /**
      * Adds a listener for changes in the connectivity status.
      */
     public fun addNetworkConnectivityListener(listener: NetworkConnectivityListener)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -20,7 +20,6 @@ import io.embrace.android.embracesdk.internal.payload.AppInfo
 import io.embrace.android.embracesdk.internal.payload.DeviceInfo
 import io.embrace.android.embracesdk.internal.payload.DiskUsage
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
-import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 /**
@@ -37,7 +36,7 @@ internal class EmbraceMetadataService(
     private val metadataBackgroundWorker: BackgroundWorker,
     private val clock: Clock,
     private val logger: EmbLogger
-) : MetadataService, StartupListener {
+) : MetadataService {
 
     private val res by lazy { resourceSource.value.getEnvelopeResource() }
     private val meta by lazy(metadataSource::getEnvelopeMetadata)
@@ -66,6 +65,13 @@ internal class EmbraceMetadataService(
      */
     override fun precomputeValues() {
         metadataBackgroundWorker.submit {
+            with(preferencesService) {
+                appVersion = res.appVersion
+                osVersion = res.osVersion
+                if (installDate == null) {
+                    installDate = clock.now()
+                }
+            }
             val free = statFs.freeBytes
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && configService.autoDataCaptureBehavior.isDiskUsageReportingEnabled()) {
                 val deviceDiskAppUsage = getDeviceDiskAppUsage(
@@ -152,14 +158,4 @@ internal class EmbraceMetadataService(
     }
 
     override fun getDiskUsage(): DiskUsage? = diskUsage
-
-    override fun applicationStartupComplete() {
-        with(preferencesService) {
-            appVersion = res.appVersion
-            osVersion = res.osVersion
-            if (installDate == null) {
-                installDate = clock.now()
-            }
-        }
-    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -15,14 +15,13 @@ import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehavior
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import java.io.Closeable
 
 /**
  * Provides access to the configuration for the customer's app.
  *
  * Configuration is configured for the user's app, and exposed via the API.
  */
-public interface ConfigService : Closeable {
+public interface ConfigService {
 
     public var remoteConfigSource: RemoteConfigSource?
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -316,10 +316,6 @@ internal class EmbraceConfigService(
         return clock.now() > lastRefreshConfigAttempt + configRetrySafeWindow * 1000
     }
 
-    override fun close() {
-        logger.logDebug("Shutting down EmbraceConfigService")
-    }
-
     override fun hasValidRemoteConfig(): Boolean = !configRequiresRefresh()
     override fun isAppExitInfoCaptureEnabled(): Boolean {
         return appExitInfoBehavior.isEnabled()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
@@ -79,8 +79,7 @@ internal class SessionOrchestrationModuleImpl(
         OrchestratorBoundaryDelegate(
             memoryCleanerService,
             essentialServiceModule.userService,
-            essentialServiceModule.sessionPropertiesService,
-            essentialServiceModule.networkConnectivityService
+            essentialServiceModule.sessionPropertiesService
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorBoundaryDelegate.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorBoundaryDelegate.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
-import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerService
@@ -16,25 +15,19 @@ import io.embrace.android.embracesdk.internal.session.MemoryCleanerService
 internal class OrchestratorBoundaryDelegate(
     private val memoryCleanerService: MemoryCleanerService,
     private val userService: UserService,
-    private val sessionPropertiesService: SessionPropertiesService,
-    private val networkConnectivityService: NetworkConnectivityService
+    private val sessionPropertiesService: SessionPropertiesService
 ) {
 
     /**
      * Prepares all services/state for a new session. Practically this involves
      * resetting collections in services etc.
      */
-    public fun prepareForNewSession(clearUserInfo: Boolean = false) {
+    fun prepareForNewSession(clearUserInfo: Boolean = false) {
         memoryCleanerService.cleanServicesCollections()
         sessionPropertiesService.prepareForNewSession()
 
         if (clearUserInfo) {
             userService.clearAllUserInfo()
         }
-    }
-
-    public fun onSessionStarted(startTime: Long) {
-        // Record the connection type at the start of the session.
-        networkConnectivityService.networkStatusOnSessionStarted(startTime)
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -244,9 +244,6 @@ internal class SessionOrchestratorImpl(
             Systrace.endSynchronous()
 
             // et voila! a new session is born
-            Systrace.startSynchronous("boundary-delegate")
-            boundaryDelegate.onSessionStarted(timestamp)
-            Systrace.endSynchronous()
             Systrace.endSynchronous()
         }
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -189,7 +189,7 @@ internal class EmbraceMetadataServiceTest {
     @Test
     fun `test startup complete`() {
         every { preferencesService.installDate }.returns(null)
-        getMetadataService().applicationStartupComplete()
+        getMetadataService()
 
         verify(exactly = 1) { preferencesService.appVersion = any() }
         verify(exactly = 1) { preferencesService.osVersion = any() }
@@ -199,7 +199,7 @@ internal class EmbraceMetadataServiceTest {
     @Test
     fun `test startup complete if it is not the first time`() {
         every { preferencesService.installDate }.returns(1234L)
-        getMetadataService().applicationStartupComplete()
+        getMetadataService()
         verify(exactly = 0) { preferencesService.installDate = any() }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -108,7 +108,6 @@ internal class EmbraceConfigServiceTest {
     @After
     fun tearDown() {
         clearAllMocks()
-        service.close()
     }
 
     @Suppress("DEPRECATION")

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
@@ -20,8 +20,8 @@ internal class ServiceRegistryTest {
     fun testServiceRegistration() {
         val registry = ServiceRegistry(EmbLoggerImpl())
         val service = FakeService()
-        val obj = "test_obj"
-        registry.registerServices(service, obj)
+        val obj = lazy { "test_obj" }
+        registry.registerServices(lazy { service }, obj, lazy { null })
 
         val expected = listOf(service)
         assertEquals(expected, registry.closeables)
@@ -35,7 +35,7 @@ internal class ServiceRegistryTest {
     fun testListeners() {
         val registry = ServiceRegistry(EmbLoggerImpl())
         val service = FakeService()
-        registry.registerService(service)
+        registry.registerService(lazy { service })
         val expected = listOf(service)
 
         val activityService = FakeProcessStateService()
@@ -61,7 +61,7 @@ internal class ServiceRegistryTest {
     fun testClosedRegistration() {
         val registry = ServiceRegistry(EmbLoggerImpl())
         registry.closeRegistration()
-        registry.registerService(FakeService())
+        registry.registerService(lazy { FakeService() })
     }
 
     private class FakeService :

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
-import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
@@ -15,7 +14,6 @@ internal class OrchestratorBoundaryDelegateTest {
     private lateinit var memoryCleanerService: FakeMemoryCleanerService
     private lateinit var userService: FakeUserService
     private lateinit var sessionPropertiesService: SessionPropertiesService
-    private lateinit var networkConnectivityService: FakeNetworkConnectivityService
 
     @Before
     fun setUp() {
@@ -24,12 +22,10 @@ internal class OrchestratorBoundaryDelegateTest {
         sessionPropertiesService = FakeSessionPropertiesService().apply {
             addProperty("key", "value", false)
         }
-        networkConnectivityService = FakeNetworkConnectivityService()
         delegate = OrchestratorBoundaryDelegate(
             memoryCleanerService,
             userService,
-            sessionPropertiesService,
-            networkConnectivityService
+            sessionPropertiesService
         )
     }
 
@@ -47,11 +43,5 @@ internal class OrchestratorBoundaryDelegateTest {
         assertEquals(1, memoryCleanerService.callCount)
         assertEquals(0, sessionPropertiesService.getProperties().size)
         assertEquals(0, userService.clearedCount)
-    }
-
-    @Test
-    fun `on session started`() {
-        delegate.onSessionStarted(1000)
-        assertEquals(1, networkConnectivityService.networkStatusOnSessionStartedCount)
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeLogService
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
@@ -398,8 +397,7 @@ internal class SessionOrchestratorTest {
             OrchestratorBoundaryDelegate(
                 memoryCleanerService,
                 userService,
-                sessionPropertiesService,
-                FakeNetworkConnectivityService()
+                sessionPropertiesService
             ),
             deliveryService,
             periodicSessionCacher,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/NetworkStatusFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/NetworkStatusFeatureTest.kt
@@ -43,7 +43,7 @@ internal class NetworkStatusFeatureTest {
             val attrs = checkNotNull(span.attributes)
             assertEquals("emb-network-status", span.name)
             assertEquals("sys.network_status", attrs.findAttributeValue("emb.type"))
-            assertEquals("wan", attrs.findAttributeValue("network"))
+            assertEquals("unknown", attrs.findAttributeValue("network"))
             assertEquals(startTimeMs, span.startTimeNanos?.nanosToMillis())
             assertEquals(startTimeMs + tickTimeMs, span.endTimeNanos?.nanosToMillis())
 
@@ -74,7 +74,7 @@ internal class NetworkStatusFeatureTest {
             assertEquals("emb-network-status", snapshot.name)
             val snapshotAttrs = checkNotNull(snapshot.attributes)
             assertEquals("sys.network_status", snapshotAttrs.findAttributeValue("emb.type"))
-            assertEquals("wan", snapshotAttrs.findAttributeValue("network"))
+            assertEquals("unknown", snapshotAttrs.findAttributeValue("network"))
             assertEquals(startTimeMs, snapshot.startTimeNanos?.nanosToMillis())
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -201,8 +201,7 @@ internal class ModuleInitBootstrapper(
                             serviceRegistry.registerServices(
                                 processStateService,
                                 activityLifecycleTracker,
-                                networkConnectivityService,
-                                userService
+                                networkConnectivityService
                             )
 
                             val networkBehavior = configModule.configService.networkBehavior
@@ -324,7 +323,6 @@ internal class ModuleInitBootstrapper(
                         )
                     }
                     postInit(PayloadSourceModule::class) {
-                        serviceRegistry.registerServices(payloadSourceModule.metadataService)
                         payloadSourceModule.metadataService.precomputeValues()
                     }
 
@@ -379,11 +377,7 @@ internal class ModuleInitBootstrapper(
                     }
 
                     postInit(LogModule::class) {
-                        serviceRegistry.registerServices(
-                            logModule.logService,
-                            logModule.networkCaptureService,
-                            logModule.networkLoggingService
-                        )
+                        serviceRegistry.registerServices(logModule.logService)
                         // Start the log orchestrator
                         logModule.logOrchestrator
                     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -213,6 +213,9 @@ internal class ModuleInitBootstrapper(
                             }
                             workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit {
                                 Systrace.traceSynchronous("network-connectivity-registration") {
+                                    essentialServiceModule.networkConnectivityService.register()
+                                }
+                                Systrace.traceSynchronous("network-connectivity-listeners") {
                                     networkConnectivityService.addNetworkConnectivityListener(pendingApiCallsSender)
                                     apiService?.let(networkConnectivityService::addNetworkConnectivityListener)
                                 }
@@ -253,9 +256,6 @@ internal class ModuleInitBootstrapper(
                     }
                     postInit(FeatureModule::class) {
                         featureModule.registerFeatures()
-                    }
-                    Systrace.traceSynchronous("network-connectivity-registration") {
-                        essentialServiceModule.networkConnectivityService.register()
                     }
                     initModule.internalErrorService.handler =
                         { featureModule.internalErrorDataSource.dataSource }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -59,8 +59,6 @@ public class FakeConfigService(
     override fun hasValidRemoteConfig(): Boolean = hasValidRemoteConfig
     override fun isAppExitInfoCaptureEnabled(): Boolean = appExitInfoBehavior.isEnabled()
 
-    override fun close() {}
-
     public fun updateListeners() {
         listeners.forEach {
             it()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
@@ -22,13 +22,6 @@ public class FakeNetworkConnectivityService(
             notifyListeners()
         }
 
-    public var networkStatusOnSessionStartedCount: Int = 0
-
-    override fun networkStatusOnSessionStarted(startTime: Long) {
-        notifyListeners()
-        networkStatusOnSessionStartedCount += 1
-    }
-
     override fun addNetworkConnectivityListener(listener: NetworkConnectivityListener) {
         networkConnectivityListeners.add(listener)
     }
@@ -58,8 +51,6 @@ public class FakeNetworkConnectivityService(
 
 public class NoOpNetworkConnectivityService : NetworkConnectivityService {
     override fun close() {}
-
-    override fun networkStatusOnSessionStarted(startTime: Long) {}
 
     override fun addNetworkConnectivityListener(listener: NetworkConnectivityListener) {}
 


### PR DESCRIPTION
## Goal

Avoids a binder transaction when starting a session. The network connectivity service no longer needs to be informed of a session start as it uses spans, whereas in the legacy data model it did.


## Profiling

<img width="804" alt="Screenshot 2024-09-03 at 13 41 23" src="https://github.com/user-attachments/assets/d1882863-ba36-4377-af45-580301d01536">
<img width="794" alt="Screenshot 2024-09-03 at 13 41 17" src="https://github.com/user-attachments/assets/500972a5-02fb-471c-9060-1477dc4c3ae8">

