### PR TITLE
Register services lazily

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -15,14 +15,13 @@ import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehavior
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import java.io.Closeable
 
 /**
  * Provides access to the configuration for the customer's app.
  *
  * Configuration is configured for the user's app, and exposed via the API.
  */
-public interface ConfigService : Closeable {
+public interface ConfigService {
 
     public var remoteConfigSource: RemoteConfigSource?
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -316,10 +316,6 @@ internal class EmbraceConfigService(
         return clock.now() > lastRefreshConfigAttempt + configRetrySafeWindow * 1000
     }
 
-    override fun close() {
-        logger.logDebug("Shutting down EmbraceConfigService")
-    }
-
     override fun hasValidRemoteConfig(): Boolean = !configRequiresRefresh()
     override fun isAppExitInfoCaptureEnabled(): Boolean {
         return appExitInfoBehavior.isEnabled()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -108,7 +108,6 @@ internal class EmbraceConfigServiceTest {
     @After
     fun tearDown() {
         clearAllMocks()
-        service.close()
     }
 
     @Suppress("DEPRECATION")

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
@@ -20,8 +20,8 @@ internal class ServiceRegistryTest {
     fun testServiceRegistration() {
         val registry = ServiceRegistry(EmbLoggerImpl())
         val service = FakeService()
-        val obj = "test_obj"
-        registry.registerServices(service, obj)
+        val obj = lazy { "test_obj" }
+        registry.registerServices(lazy { service }, obj, lazy { null })
 
         val expected = listOf(service)
         assertEquals(expected, registry.closeables)
@@ -35,7 +35,7 @@ internal class ServiceRegistryTest {
     fun testListeners() {
         val registry = ServiceRegistry(EmbLoggerImpl())
         val service = FakeService()
-        registry.registerService(service)
+        registry.registerService(lazy { service })
         val expected = listOf(service)
 
         val activityService = FakeProcessStateService()
@@ -61,7 +61,7 @@ internal class ServiceRegistryTest {
     fun testClosedRegistration() {
         val registry = ServiceRegistry(EmbLoggerImpl())
         registry.closeRegistration()
-        registry.registerService(FakeService())
+        registry.registerService(lazy { FakeService() })
     }
 
     private class FakeService :

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -59,8 +59,6 @@ public class FakeConfigService(
     override fun hasValidRemoteConfig(): Boolean = hasValidRemoteConfig
     override fun isAppExitInfoCaptureEnabled(): Boolean = appExitInfoBehavior.isEnabled()
 
-    override fun close() {}
-
     public fun updateListeners() {
         listeners.forEach {
             it()


### PR DESCRIPTION
## Goal

Adds objects to the `ServiceRegistry` using lazy initialization so they are only created at the end of startup, to make their impact more obvious. I also removed various objects that don't need to be registered anymore.

## Profiling

<img width="921" alt="Screenshot 2024-09-03 at 15 04 21" src="https://github.com/user-attachments/assets/28e21b78-3395-4e46-b1a9-b535f1c09762">
<img width="1052" alt="Screenshot 2024-09-03 at 15 04 15" src="https://github.com/user-attachments/assets/c2fbec23-b3b6-46fd-8b75-d6b1f8cbd060">
