### PR TITLE
Moved scheduled retry after send method setup

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
@@ -47,7 +47,7 @@ internal class EmbraceApiService(
 
     init {
         Systrace.traceSynchronous("api-service-init-block") {
-            pendingApiCallsSender.setSendMethod(this::executePost)
+            pendingApiCallsSender.initializeRetrySchedule(this::executePost)
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSender.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSender.kt
@@ -31,12 +31,9 @@ internal class EmbracePendingApiCallsSender(
     private var lastNetworkStatus: NetworkStatus = NetworkStatus.UNKNOWN
     private val sendMethodRef: AtomicReference<SendMethod?> = AtomicReference(null)
 
-    init {
-        scheduledWorker.submit(this::scheduleApiCallsDelivery)
-    }
-
-    override fun setSendMethod(sendMethod: SendMethod) {
+    override fun initializeRetrySchedule(sendMethod: SendMethod) {
         sendMethodRef.set(sendMethod)
+        scheduledWorker.submit(this::scheduleApiCallsDelivery)
     }
 
     override fun savePendingApiCall(request: ApiRequest, action: SerializationAction, sync: Boolean) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/PendingApiCallsSender.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/delivery/PendingApiCallsSender.kt
@@ -11,9 +11,9 @@ import io.embrace.android.embracesdk.internal.injection.SerializationAction
 public interface PendingApiCallsSender : NetworkConnectivityListener {
 
     /**
-     * Sets the method to be used when sending an [ApiRequest].
+     * Initializes the retry scheduling with a method to be used when sending an [ApiRequest].
      */
-    public fun setSendMethod(sendMethod: (request: ApiRequest, action: SerializationAction) -> ApiResponse)
+    public fun initializeRetrySchedule(sendMethod: (request: ApiRequest, action: SerializationAction) -> ApiResponse)
 
     /**
      * Save an API call to be sent later.

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -334,7 +334,7 @@ internal class EmbracePendingApiCallsSenderTest {
         )
 
         if (sendMethod != null) {
-            pendingApiCallsSender.setSendMethod(mockRetryMethod)
+            pendingApiCallsSender.initializeRetrySchedule(mockRetryMethod)
         }
 
         if (loadFailedRequest) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePendingApiCallsSender.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePendingApiCallsSender.kt
@@ -20,7 +20,7 @@ public class FakePendingApiCallsSender : PendingApiCallsSender {
         didScheduleApiCall = true
     }
 
-    override fun setSendMethod(sendMethod: (request: ApiRequest, action: SerializationAction) -> ApiResponse) {
+    override fun initializeRetrySchedule(sendMethod: (request: ApiRequest, action: SerializationAction) -> ApiResponse) {
         this.sendMethod = sendMethod
     }
 


### PR DESCRIPTION
Defer the submission of the api calls delivery to the scheduledWorker until `sendMethodRef` (which we will use to execute the delivery) is set
