### PR TITLE
Enforce use of default OTel SDK default ContextStorage

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
@@ -20,6 +20,11 @@ internal class OpenTelemetrySdk(
     openTelemetryClock: Clock,
     configuration: OpenTelemetryConfiguration
 ) {
+    init {
+        // Enforce the use of default ThreadLocal ContextStorage of the OTel Java to bypass SPI looking that violates Android strict mode
+        System.setProperty("io.opentelemetry.context.contextStorageProvider", "default")
+    }
+
     val sdkTracerProvider: SdkTracerProvider by lazy {
         Systrace.traceSynchronous("otel-tracer-provider-init") {
             SdkTracerProvider

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdkTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdkTest.kt
@@ -95,4 +95,9 @@ internal class OpenTelemetrySdkTest {
             assertEquals("url", schemaUrl)
         }
     }
+
+    @Test
+    fun `verify that the default StorageContext is used after OpenTelemetrySdk is initialized`() {
+        assertEquals("default", System.getProperty("io.opentelemetry.context.contextStorageProvider"))
+    }
 }


### PR DESCRIPTION
## Goal

Use default `ContextStorage` to short circuit service provider lookup for setting a custom `ContextStorageProvider` to avoid a disk read on SDK startup that violates strict mode.

## Testing
Add unit test to verify the system property that controls this is set properly.

