### PR TITLE
Save crashes synchronously and process other unbatched log requests in background thread

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbType.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.arch.schema
 public sealed class EmbType(type: String, subtype: String?) : TelemetryType {
     override val key: EmbraceAttributeKey = EmbraceAttributeKey(id = "type")
     override val value: String = type + (subtype?.run { ".$this" } ?: "")
-    override val sendImmediately: Boolean = false
+    override val sendMode: SendMode = SendMode.DEFAULT
 
     /**
      * Keys that track how fast a time interval is. Only applies to spans.
@@ -48,7 +48,7 @@ public sealed class EmbType(type: String, subtype: String?) : TelemetryType {
      */
     public sealed class System(
         subtype: String,
-        override val sendImmediately: Boolean = false
+        override val sendMode: SendMode = SendMode.DEFAULT
     ) : EmbType("sys", subtype) {
 
         public object Breadcrumb : System("breadcrumb")
@@ -71,11 +71,11 @@ public sealed class EmbType(type: String, subtype: String?) : TelemetryType {
             public val embFlutterExceptionLibrary: EmbraceAttributeKey = EmbraceAttributeKey("exception.library")
         }
 
-        public object Exit : System("exit", true)
+        public object Exit : System("exit", SendMode.IMMEDIATE)
 
         public object PushNotification : System("push_notification")
 
-        public object Crash : System("android.crash", true) {
+        public object Crash : System("android.crash", SendMode.DEFER) {
             /**
              * The list of [Throwable] that caused the exception responsible for a crash
              */
@@ -83,7 +83,7 @@ public sealed class EmbType(type: String, subtype: String?) : TelemetryType {
                 EmbraceAttributeKey("android.crash.exception_cause")
         }
 
-        public object ReactNativeCrash : System("android.react_native_crash", true) {
+        public object ReactNativeCrash : System("android.react_native_crash", SendMode.DEFER) {
             /**
              * The JavaScript unhandled exception from the ReactNative layer
              */
@@ -92,9 +92,9 @@ public sealed class EmbType(type: String, subtype: String?) : TelemetryType {
             )
         }
 
-        public object ReactNativeAction : System("rn_action", true)
+        public object ReactNativeAction : System("rn_action")
 
-        public object NativeCrash : System("android.native_crash", true) {
+        public object NativeCrash : System("android.native_crash", SendMode.DEFER) {
             /**
              * Exception coming from the native layer
              */
@@ -122,7 +122,7 @@ public sealed class EmbType(type: String, subtype: String?) : TelemetryType {
 
         public object Sigquit : System("sigquit")
 
-        public object NetworkCapturedRequest : System("network_capture", true)
+        public object NetworkCapturedRequest : System("network_capture", SendMode.IMMEDIATE)
 
         public object NetworkStatus : System("network_status")
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.arch.schema
 
+import io.embrace.android.embracesdk.internal.opentelemetry.embSendMode
 import io.embrace.android.embracesdk.internal.payload.AppExitInfoData
 import io.embrace.android.embracesdk.internal.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
@@ -23,8 +24,8 @@ public sealed class SchemaType(
     protected abstract val schemaAttributes: Map<String, String>
 
     private val commonAttributes: Map<String, String> = mutableMapOf<String, String>().apply {
-        if (telemetryType.sendImmediately) {
-            plusAssign(SendImmediately.toEmbraceKeyValuePair())
+        if (telemetryType.sendMode != SendMode.DEFAULT) {
+            plusAssign(embSendMode.name to telemetryType.sendMode.name)
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendImmediately.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendImmediately.kt
@@ -1,6 +1,0 @@
-package io.embrace.android.embracesdk.internal.arch.schema
-
-public object SendImmediately : FixedAttribute {
-    override val key: EmbraceAttributeKey = EmbraceAttributeKey(id = "send_immediately")
-    override val value: String = "true"
-}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendMode.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendMode.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.internal.arch.schema
+
+import io.embrace.android.embracesdk.internal.arch.schema.SendMode.DEFAULT
+import io.embrace.android.embracesdk.internal.arch.schema.SendMode.DEFER
+import io.embrace.android.embracesdk.internal.arch.schema.SendMode.IMMEDIATE
+
+public enum class SendMode {
+    DEFAULT, IMMEDIATE, DEFER
+}
+
+public fun String.toSendMode(): SendMode {
+    return when (lowercase()) {
+        "immediate" -> IMMEDIATE
+        "defer" -> DEFER
+        else -> DEFAULT
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendMode.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendMode.kt
@@ -4,8 +4,24 @@ import io.embrace.android.embracesdk.internal.arch.schema.SendMode.DEFAULT
 import io.embrace.android.embracesdk.internal.arch.schema.SendMode.DEFER
 import io.embrace.android.embracesdk.internal.arch.schema.SendMode.IMMEDIATE
 
+/**
+ * How a given payload should be delivered to the Embrace server
+ */
 public enum class SendMode {
-    DEFAULT, IMMEDIATE, DEFER
+    /**
+     * Use the default delivery semantics - no customization required
+     */
+    DEFAULT,
+
+    /**
+     * If supported for that signal/payload type, deliver this as soon as possible and do not batch
+     */
+    IMMEDIATE,
+
+    /**
+     * Queue for delivery at the next convenient time. Used when the delivery environment is unstable, e.g. when an app is about to crash.
+     */
+    DEFER
 }
 
 public fun String.toSendMode(): SendMode {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryType.kt
@@ -6,5 +6,5 @@ package io.embrace.android.embracesdk.internal.arch.schema
  * backend that it can assume the data in the event follows a particular schema.
  */
 public interface TelemetryType : FixedAttribute {
-    public val sendImmediately: Boolean
+    public val sendMode: SendMode
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSource.kt
@@ -1,10 +1,11 @@
 package io.embrace.android.embracesdk.internal.envelope.log
 
+import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
 public interface LogEnvelopeSource {
     public fun getBatchedLogEnvelope(): Envelope<LogPayload>
 
-    public fun getNonbatchedEnvelope(): List<Envelope<LogPayload>>
+    public fun getNonbatchedEnvelope(): List<LogRequest<Envelope<LogPayload>>>
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSource.kt
@@ -7,5 +7,5 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 public interface LogEnvelopeSource {
     public fun getBatchedLogEnvelope(): Envelope<LogPayload>
 
-    public fun getNonbatchedEnvelope(): List<LogRequest<Envelope<LogPayload>>>
+    public fun getSingleLogEnvelopes(): List<LogRequest<Envelope<LogPayload>>>
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
@@ -14,8 +14,8 @@ internal class LogEnvelopeSourceImpl(
 
     override fun getBatchedLogEnvelope(): Envelope<LogPayload> = getLogEnvelope(logPayloadSource.getBatchedLogPayload())
 
-    override fun getNonbatchedEnvelope(): List<LogRequest<Envelope<LogPayload>>> {
-        val payloads = logPayloadSource.getNonbatchedLogPayloads()
+    override fun getSingleLogEnvelopes(): List<LogRequest<Envelope<LogPayload>>> {
+        val payloads = logPayloadSource.getSingleLogPayloads()
         return if (payloads.isNotEmpty()) {
             payloads.map { LogRequest(payload = getLogEnvelope(it.payload), defer = it.defer) }
         } else {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.envelope.log
 
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
+import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
@@ -13,10 +14,10 @@ internal class LogEnvelopeSourceImpl(
 
     override fun getBatchedLogEnvelope(): Envelope<LogPayload> = getLogEnvelope(logPayloadSource.getBatchedLogPayload())
 
-    override fun getNonbatchedEnvelope(): List<Envelope<LogPayload>> {
+    override fun getNonbatchedEnvelope(): List<LogRequest<Envelope<LogPayload>>> {
         val payloads = logPayloadSource.getNonbatchedLogPayloads()
         return if (payloads.isNotEmpty()) {
-            payloads.map { getLogEnvelope(it) }
+            payloads.map { LogRequest(payload = getLogEnvelope(it.payload), defer = it.defer) }
         } else {
             emptyList()
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSource.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.envelope.log
 
+import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
 public interface LogPayloadSource {
@@ -12,5 +13,5 @@ public interface LogPayloadSource {
     /**
      * Returns a list of [LogPayload] that each contain a single high priority log
      */
-    public fun getNonbatchedLogPayloads(): List<LogPayload>
+    public fun getNonbatchedLogPayloads(): List<LogRequest<LogPayload>>
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSource.kt
@@ -13,5 +13,5 @@ public interface LogPayloadSource {
     /**
      * Returns a list of [LogPayload] that each contain a single high priority log
      */
-    public fun getNonbatchedLogPayloads(): List<LogRequest<LogPayload>>
+    public fun getSingleLogPayloads(): List<LogRequest<LogPayload>>
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImpl.kt
@@ -10,29 +10,29 @@ internal class LogPayloadSourceImpl(
 
     override fun getBatchedLogPayload(): LogPayload {
         return LogPayload(
-            logs = logSink.flushLogs()
+            logs = logSink.flushBatch()
         )
     }
 
-    override fun getNonbatchedLogPayloads(): List<LogRequest<LogPayload>> {
-        val nonbatchedLogs = mutableListOf<LogRequest<LogPayload>>()
-        var logRequest = logSink.pollNonbatchedLog()
+    override fun getSingleLogPayloads(): List<LogRequest<LogPayload>> {
+        val logRequests = mutableListOf<LogRequest<LogPayload>>()
+        var logRequest = logSink.pollUnbatchedLog()
 
         while (logRequest != null) {
-            nonbatchedLogs.add(
+            logRequests.add(
                 LogRequest(
                     payload = LogPayload(logs = listOf(logRequest.payload)),
                     defer = logRequest.defer
                 )
             )
-            logRequest = if (nonbatchedLogs.size < MAX_PAYLOADS) {
-                logSink.pollNonbatchedLog()
+            logRequest = if (logRequests.size < MAX_PAYLOADS) {
+                logSink.pollUnbatchedLog()
             } else {
                 null
             }
         }
 
-        return nonbatchedLogs
+        return logRequests
     }
 
     private companion object {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.envelope.log
 
+import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.logs.LogSink
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
@@ -13,13 +14,18 @@ internal class LogPayloadSourceImpl(
         )
     }
 
-    override fun getNonbatchedLogPayloads(): List<LogPayload> {
-        val nonbatchedLogs = mutableListOf<LogPayload>()
-        var log = logSink.pollNonbatchedLog()
+    override fun getNonbatchedLogPayloads(): List<LogRequest<LogPayload>> {
+        val nonbatchedLogs = mutableListOf<LogRequest<LogPayload>>()
+        var logRequest = logSink.pollNonbatchedLog()
 
-        while (log != null) {
-            nonbatchedLogs.add(LogPayload(logs = listOf(log)))
-            log = if (nonbatchedLogs.size < MAX_PAYLOADS) {
+        while (logRequest != null) {
+            nonbatchedLogs.add(
+                LogRequest(
+                    payload = LogPayload(logs = listOf(logRequest.payload)),
+                    defer = logRequest.defer
+                )
+            )
+            logRequest = if (nonbatchedLogs.size < MAX_PAYLOADS) {
                 logSink.pollNonbatchedLog()
             } else {
                 null

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
@@ -49,7 +49,7 @@ internal class LogOrchestratorImpl(
     }
 
     private fun onLogsAdded() {
-        logEnvelopeSource.getNonbatchedEnvelope().forEach { logRequest ->
+        logEnvelopeSource.getSingleLogEnvelopes().forEach { logRequest ->
             if (logRequest.defer) {
                 deliveryService.saveLogs(logRequest.payload)
             } else {
@@ -99,7 +99,7 @@ internal class LogOrchestratorImpl(
     }
 
     private fun isMaxLogsPerBatchReached(): Boolean =
-        sink.completedLogs().size >= MAX_LOGS_PER_BATCH
+        sink.logsForNextBatch().size >= MAX_LOGS_PER_BATCH
 
     private fun isMaxInactivityTimeReached(now: Long): Boolean =
         now - lastLogTime.get() >= MAX_INACTIVITY_TIME

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogRequest.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogRequest.kt
@@ -1,0 +1,6 @@
+package io.embrace.android.embracesdk.internal.logs
+
+/**
+ * A wrapper for a log payload that stipulates whether its delivery should be deferred or sent immediately
+ */
+public data class LogRequest<T>(val payload: T, val defer: Boolean = false)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSink.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSink.kt
@@ -18,18 +18,18 @@ public interface LogSink {
     /**
      * Returns the list of currently stored [Log] objects, waiting to be sent in the next batch
      */
-    public fun completedLogs(): List<Log>
+    public fun logsForNextBatch(): List<Log>
 
     /**
      * Returns and clears the currently stored [Log] objects, to be used when the next batch is to be sent.
      * Implementations of this method must make sure the clearing and returning is atomic, i.e. logs cannot be added during this operation.
      */
-    public fun flushLogs(): List<Log>
+    public fun flushBatch(): List<Log>
 
     /**
      * Return a [Log] that is to be delivered in its own request
      */
-    public fun pollNonbatchedLog(): LogRequest<Log>?
+    public fun pollUnbatchedLog(): LogRequest<Log>?
 
     /**
      * Registers a callback to be called after new logs are stored.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSink.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSink.kt
@@ -27,9 +27,9 @@ public interface LogSink {
     public fun flushLogs(): List<Log>
 
     /**
-     * Return a [Log] that is to be sent immediately rather than batched
+     * Return a [Log] that is to be delivered in its own request
      */
-    public fun pollNonbatchedLog(): Log?
+    public fun pollNonbatchedLog(): LogRequest<Log>?
 
     /**
      * Registers a callback to be called after new logs are stored.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -39,11 +39,11 @@ public class LogSinkImpl : LogSink {
         return CompletableResultCode.ofSuccess()
     }
 
-    override fun completedLogs(): List<Log> {
+    override fun logsForNextBatch(): List<Log> {
         return storedLogs.toList()
     }
 
-    override fun flushLogs(): List<Log> {
+    override fun flushBatch(): List<Log> {
         synchronized(flushLock) {
             val batchSize = minOf(storedLogs.size, MAX_LOGS_PER_BATCH)
             val flushedLogs = storedLogs.threadSafeTake(batchSize)
@@ -52,7 +52,7 @@ public class LogSinkImpl : LogSink {
         }
     }
 
-    override fun pollNonbatchedLog(): LogRequest<Log>? = logRequests.poll()
+    override fun pollUnbatchedLog(): LogRequest<Log>? = logRequests.poll()
 
     override fun registerLogStoredCallback(onLogsStored: () -> Unit) {
         this.onLogsStored = onLogsStored

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbraceAttributeKeys.kt
@@ -97,3 +97,8 @@ public val embErrorLogCount: EmbraceAttributeKey = EmbraceAttributeKey("error_lo
  * Attribute name that identifies the number of free bytes on disk
  */
 public val embFreeDiskBytes: EmbraceAttributeKey = EmbraceAttributeKey("disk_free_bytes")
+
+/**
+ * Attribute name that identifies how a signal should be delivered to the Embrace backend
+ */
+public val embSendMode: EmbraceAttributeKey = EmbraceAttributeKey(id = "send_mode", isPrivate = true)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -23,8 +23,6 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import io.embrace.android.embracesdk.network.http.HttpMethod
-import io.mockk.mockk
-import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -37,7 +35,6 @@ import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
-import java.util.concurrent.ScheduledExecutorService
 
 internal class EmbraceApiServiceTest {
 
@@ -48,7 +45,7 @@ internal class EmbraceApiServiceTest {
     private lateinit var apiUrlBuilder: ApiUrlBuilder
     private lateinit var fakeApiClient: FakeApiClient
     private lateinit var fakeCacheManager: DeliveryCacheManager
-    private lateinit var testScheduledExecutor: ScheduledExecutorService
+    private lateinit var testScheduledExecutor: BlockingScheduledExecutorService
     private lateinit var cachedConfig: CachedConfig
     private lateinit var apiService: EmbraceApiService
     private lateinit var fakePendingApiCallsSender: FakePendingApiCallsSender
@@ -79,7 +76,6 @@ internal class EmbraceApiServiceTest {
         }
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun `test getConfig returns correct values in Response`() {
         fakeApiClient.queueResponse(
@@ -260,11 +256,10 @@ internal class EmbraceApiServiceTest {
 
     @Test
     fun `network request runnable is used`() {
-        testScheduledExecutor = mockk(relaxed = true)
         initApiService()
         val payload = "{}".toByteArray(Charsets.UTF_8)
         apiService.sendSession({ it.write(payload) }) {}
-        verify(exactly = 1) { testScheduledExecutor.submit(any<Runnable>()) }
+        assertEquals(1, testScheduledExecutor.submitCount)
     }
 
     @Test
@@ -376,14 +371,13 @@ internal class EmbraceApiServiceTest {
 
     @Test
     fun `test that requests to rate limited endpoint, do not execute the request and save a pending api call`() {
-        val callback = mockk<() -> Unit>(relaxed = true)
         val endpoint = Endpoint.LOGS
         with(endpoint.limiter) {
             updateRateLimitStatus()
             scheduleRetry(
                 scheduledWorker = ScheduledWorker(testScheduledExecutor),
                 retryAfter = 3,
-                retryMethod = callback
+                retryMethod = { }
             )
         }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeLogPayloadSource
 import io.embrace.android.embracesdk.fixtures.nonbatchableLog
+import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -31,10 +32,10 @@ internal class LogEnvelopeSourceImplTest {
 
     @Test
     fun getNonbatchedLogEnvelopes() {
-        with(source.getNonbatchedEnvelope().single()) {
+        with(source.getNonbatchedEnvelope().single().payload) {
             assertEquals(metadataSource.metadata, metadata)
             assertEquals(resourceSource.resource, resource)
-            assertEquals(logSource.nonbatchedLogs.single(), data)
+            assertEquals(logSource.nonbatchedLogs.single().payload, data)
             assertEquals("logs", type)
             assertEquals("0.1.0", version)
         }
@@ -43,9 +44,9 @@ internal class LogEnvelopeSourceImplTest {
     @Test
     fun `check maximum number of envelopes returned`() {
         val fakeLogPayloadSource = FakeLogPayloadSource()
-        val nonbatchedLogs = mutableListOf<LogPayload>()
+        val nonbatchedLogs = mutableListOf<LogRequest<LogPayload>>()
         repeat(5) {
-            nonbatchedLogs.add(LogPayload(listOf(nonbatchableLog.copy(body = "$it"))))
+            nonbatchedLogs.add(LogRequest(LogPayload(listOf(nonbatchableLog.copy(body = "$it")))))
         }
 
         fakeLogPayloadSource.nonbatchedLogs = nonbatchedLogs

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
@@ -3,8 +3,8 @@ package io.embrace.android.embracesdk.internal.envelope.log
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fixtures.deferredLog
 import io.embrace.android.embracesdk.fixtures.deferredLogRecordData
-import io.embrace.android.embracesdk.fixtures.nonbatchableLog
-import io.embrace.android.embracesdk.fixtures.unbatchableLogRecordData
+import io.embrace.android.embracesdk.fixtures.sendImmediatelyLog
+import io.embrace.android.embracesdk.fixtures.sendImmediatelyLogRecordData
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import org.junit.Assert.assertEquals
@@ -32,7 +32,7 @@ internal class LogPayloadSourceImplTest {
         sink.storeLogs(listOf(fakeLog))
         val payload = impl.getBatchedLogPayload()
         val log = checkNotNull(payload.logs?.single())
-        assertEquals(0, sink.completedLogs().size)
+        assertEquals(0, sink.logsForNextBatch().size)
         assertEquals(1, payload.logs?.size)
         assertEquals(fakeLog.timestampEpochNanos, log.timeUnixNano)
         assertEquals(fakeLog.severityText, log.severityText)
@@ -43,42 +43,42 @@ internal class LogPayloadSourceImplTest {
 
     @Test
     fun `log to with IMMEDIATE SendMode returns correctly`() {
-        sink.storeLogs(listOf(unbatchableLogRecordData))
-        val payloads = impl.getNonbatchedLogPayloads()
+        sink.storeLogs(listOf(sendImmediatelyLogRecordData))
+        val payloads = impl.getSingleLogPayloads()
         val logRequest = checkNotNull(payloads.single())
-        assertNull(sink.pollNonbatchedLog())
-        assertEquals(LogPayload(logs = listOf(nonbatchableLog)), logRequest.payload)
+        assertNull(sink.pollUnbatchedLog())
+        assertEquals(LogPayload(logs = listOf(sendImmediatelyLog)), logRequest.payload)
         assertFalse(logRequest.defer)
     }
 
     @Test
     fun `log to with DEFER SendMode returns correctly`() {
         sink.storeLogs(listOf(deferredLogRecordData))
-        val payloads = impl.getNonbatchedLogPayloads()
+        val payloads = impl.getSingleLogPayloads()
         val logRequest = checkNotNull(payloads.single())
-        assertNull(sink.pollNonbatchedLog())
+        assertNull(sink.pollUnbatchedLog())
         assertEquals(LogPayload(logs = listOf(deferredLog)), logRequest.payload)
         assertTrue(logRequest.defer)
     }
 
     @Test
-    fun `getNonbatchedLogPayloads returns the correct payload`() {
-        sink.storeLogs(listOf(unbatchableLogRecordData))
-        val payloads = impl.getNonbatchedLogPayloads()
+    fun `getSingleLogPayloads returns the correct payload`() {
+        sink.storeLogs(listOf(sendImmediatelyLogRecordData))
+        val payloads = impl.getSingleLogPayloads()
         val log = checkNotNull(payloads.single())
-        assertNull(sink.pollNonbatchedLog())
-        assertEquals(LogPayload(logs = listOf(nonbatchableLog)), log.payload)
+        assertNull(sink.pollUnbatchedLog())
+        assertEquals(LogPayload(logs = listOf(sendImmediatelyLog)), log.payload)
     }
 
     @Test
-    fun `getNonbatchedLogPayloads returns the maximum number of payloads`() {
+    fun `getSingleLogPayloads returns the maximum number of payloads`() {
         repeat(11) {
-            sink.storeLogs(listOf(unbatchableLogRecordData))
+            sink.storeLogs(listOf(sendImmediatelyLogRecordData))
         }
 
-        val payloads = impl.getNonbatchedLogPayloads()
+        val payloads = impl.getSingleLogPayloads()
         assertEquals(10, payloads.size)
-        assertNotNull(sink.pollNonbatchedLog())
-        assertNull(sink.pollNonbatchedLog())
+        assertNotNull(sink.pollUnbatchedLog())
+        assertNull(sink.pollUnbatchedLog())
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
@@ -1,13 +1,17 @@
 package io.embrace.android.embracesdk.internal.envelope.log
 
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
+import io.embrace.android.embracesdk.fixtures.deferredLog
+import io.embrace.android.embracesdk.fixtures.deferredLogRecordData
 import io.embrace.android.embracesdk.fixtures.nonbatchableLog
 import io.embrace.android.embracesdk.fixtures.unbatchableLogRecordData
 import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -19,15 +23,13 @@ internal class LogPayloadSourceImplTest {
 
     @Before
     fun setUp() {
-        sink = LogSinkImpl().apply {
-            storeLogs(listOf(fakeLog))
-            storeLogs(listOf(unbatchableLogRecordData))
-        }
+        sink = LogSinkImpl()
         impl = LogPayloadSourceImpl(sink)
     }
 
     @Test
     fun `getBatchedLogPayload returns a correct payload`() {
+        sink.storeLogs(listOf(fakeLog))
         val payload = impl.getBatchedLogPayload()
         val log = checkNotNull(payload.logs?.single())
         assertEquals(0, sink.completedLogs().size)
@@ -40,16 +42,37 @@ internal class LogPayloadSourceImplTest {
     }
 
     @Test
+    fun `log to with IMMEDIATE SendMode returns correctly`() {
+        sink.storeLogs(listOf(unbatchableLogRecordData))
+        val payloads = impl.getNonbatchedLogPayloads()
+        val logRequest = checkNotNull(payloads.single())
+        assertNull(sink.pollNonbatchedLog())
+        assertEquals(LogPayload(logs = listOf(nonbatchableLog)), logRequest.payload)
+        assertFalse(logRequest.defer)
+    }
+
+    @Test
+    fun `log to with DEFER SendMode returns correctly`() {
+        sink.storeLogs(listOf(deferredLogRecordData))
+        val payloads = impl.getNonbatchedLogPayloads()
+        val logRequest = checkNotNull(payloads.single())
+        assertNull(sink.pollNonbatchedLog())
+        assertEquals(LogPayload(logs = listOf(deferredLog)), logRequest.payload)
+        assertTrue(logRequest.defer)
+    }
+
+    @Test
     fun `getNonbatchedLogPayloads returns the correct payload`() {
+        sink.storeLogs(listOf(unbatchableLogRecordData))
         val payloads = impl.getNonbatchedLogPayloads()
         val log = checkNotNull(payloads.single())
         assertNull(sink.pollNonbatchedLog())
-        assertEquals(LogPayload(logs = listOf(nonbatchableLog)), log)
+        assertEquals(LogPayload(logs = listOf(nonbatchableLog)), log.payload)
     }
 
     @Test
     fun `getNonbatchedLogPayloads returns the maximum number of payloads`() {
-        repeat(10) {
+        repeat(11) {
             sink.storeLogs(listOf(unbatchableLogRecordData))
         }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporterTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporterTest.kt
@@ -22,8 +22,8 @@ internal class EmbraceLogRecordExporterTest {
 
         embraceLogRecordExporter.export(listOf(logRecordData))
 
-        assertFalse(logSink.completedLogs().isEmpty())
-        assertEquals(logRecordData.toNewPayload(), logSink.completedLogs()[0])
+        assertFalse(logSink.logsForNextBatch().isEmpty())
+        assertEquals(logRecordData.toNewPayload(), logSink.logsForNextBatch()[0])
     }
 
     @Test
@@ -46,9 +46,9 @@ internal class EmbraceLogRecordExporterTest {
 
         embraceLogRecordExporter.export(listOf(logRecordData, privateLogRecordData))
 
-        assertEquals(2, logSink.completedLogs().size)
-        assertEquals(logRecordData.toNewPayload(), logSink.completedLogs()[0])
-        assertEquals(privateLogRecordData.toNewPayload(), logSink.completedLogs()[1])
+        assertEquals(2, logSink.logsForNextBatch().size)
+        assertEquals(logRecordData.toNewPayload(), logSink.logsForNextBatch()[0])
+        assertEquals(privateLogRecordData.toNewPayload(), logSink.logsForNextBatch()[1])
 
         assertEquals(1, externalExporter.exportedLogs?.size)
         assertEquals(logRecordData, externalExporter.exportedLogs?.first())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
@@ -188,7 +188,7 @@ internal class LogOrchestratorTest {
     }
 
     @Test
-    fun `logs with DEFER SendMode are saved by not sent`() {
+    fun `logs with DEFER SendMode are saved but not sent`() {
         logSink.storeLogs(listOf(deferredLogRecordData))
         executorService.runCurrentlyBlocked()
         // Verify the log is not in the LogSink but is saved

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogSinkImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogSinkImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.logs
 
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fixtures.deferredLogRecordData
-import io.embrace.android.embracesdk.fixtures.unbatchableLogRecordData
+import io.embrace.android.embracesdk.fixtures.sendImmediatelyLogRecordData
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.opentelemetry.sdk.common.CompletableResultCode
 import org.junit.Assert.assertEquals
@@ -23,8 +23,8 @@ internal class LogSinkImplTest {
 
     @Test
     fun `verify default state`() {
-        assertEquals(0, logSink.completedLogs().size)
-        assertEquals(0, logSink.flushLogs().size)
+        assertEquals(0, logSink.logsForNextBatch().size)
+        assertEquals(0, logSink.flushBatch().size)
         assertEquals(CompletableResultCode.ofSuccess(), logSink.storeLogs(listOf()))
     }
 
@@ -32,22 +32,22 @@ internal class LogSinkImplTest {
     fun `storing logs adds to stored logs`() {
         val resultCode = logSink.storeLogs(listOf(FakeLogRecordData()))
         assertEquals(CompletableResultCode.ofSuccess(), resultCode)
-        assertEquals(1, logSink.completedLogs().size)
-        assertEquals(FakeLogRecordData().toNewPayload(), logSink.completedLogs().first())
+        assertEquals(1, logSink.logsForNextBatch().size)
+        assertEquals(FakeLogRecordData().toNewPayload(), logSink.logsForNextBatch().first())
     }
 
     @Test
     fun `flushing clears stored logs`() {
         logSink.storeLogs(listOf(FakeLogRecordData(), FakeLogRecordData()))
-        val snapshot = logSink.completedLogs()
+        val snapshot = logSink.logsForNextBatch()
         assertEquals(2, snapshot.size)
 
-        val flushedLogs = logSink.flushLogs()
+        val flushedLogs = logSink.flushBatch()
         assertEquals(2, flushedLogs.size)
         repeat(2) {
             assertSame(snapshot[it], flushedLogs[it])
         }
-        assertEquals(0, logSink.completedLogs().size)
+        assertEquals(0, logSink.logsForNextBatch().size)
     }
 
     @Test
@@ -60,32 +60,32 @@ internal class LogSinkImplTest {
 
     @Test
     fun `logs with IMMEDIATE SendMode are stored in priority log queue`() {
-        val resultCode = logSink.storeLogs(listOf(unbatchableLogRecordData))
+        val resultCode = logSink.storeLogs(listOf(sendImmediatelyLogRecordData))
         assertEquals(CompletableResultCode.ofSuccess(), resultCode)
-        assertEquals(0, logSink.completedLogs().size)
-        val logRequest = checkNotNull(logSink.pollNonbatchedLog())
-        assertEquals(unbatchableLogRecordData.log, logRequest.payload)
+        assertEquals(0, logSink.logsForNextBatch().size)
+        val logRequest = checkNotNull(logSink.pollUnbatchedLog())
+        assertEquals(sendImmediatelyLogRecordData.log, logRequest.payload)
         assertFalse(logRequest.defer)
-        assertNull(logSink.pollNonbatchedLog())
+        assertNull(logSink.pollUnbatchedLog())
     }
 
     @Test
     fun `logs with DEFER SendMode are stored in priority log queue`() {
         val resultCode = logSink.storeLogs(listOf(deferredLogRecordData))
         assertEquals(CompletableResultCode.ofSuccess(), resultCode)
-        assertEquals(0, logSink.completedLogs().size)
-        val logRequest = checkNotNull(logSink.pollNonbatchedLog())
+        assertEquals(0, logSink.logsForNextBatch().size)
+        val logRequest = checkNotNull(logSink.pollUnbatchedLog())
         assertEquals(deferredLogRecordData.log, logRequest.payload)
         assertTrue(logRequest.defer)
-        assertNull(logSink.pollNonbatchedLog())
+        assertNull(logSink.pollUnbatchedLog())
     }
 
     @Test
-    fun `unbatchable logs are stored in priority log queue`() {
-        val resultCode = logSink.storeLogs(listOf(unbatchableLogRecordData))
+    fun `unbatchable logs are stored in the unbatched log queue`() {
+        val resultCode = logSink.storeLogs(listOf(sendImmediatelyLogRecordData))
         assertEquals(CompletableResultCode.ofSuccess(), resultCode)
-        assertEquals(0, logSink.completedLogs().size)
-        assertEquals(unbatchableLogRecordData.log, checkNotNull(logSink.pollNonbatchedLog()).payload)
-        assertNull(logSink.pollNonbatchedLog())
+        assertEquals(0, logSink.logsForNextBatch().size)
+        assertEquals(sendImmediatelyLogRecordData.log, checkNotNull(logSink.pollUnbatchedLog()).payload)
+        assertNull(logSink.pollUnbatchedLog())
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -69,6 +69,14 @@ internal fun IntegrationTestRule.Harness.getLastSentLog(expectedSize: Int? = nul
 }
 
 /**
+ * Returns the last [Log] that was saved by the delivery service.
+ */
+internal fun IntegrationTestRule.Harness.getLastSavedLogPayload(): Envelope<LogPayload>? {
+    return overriddenDeliveryModule.deliveryService.lastSavedLogPayloads.last()
+}
+
+
+/**
  * Returns a list of session that were sent by the SDK since startup.
  */
 internal fun IntegrationTestRule.Harness.getSentSessions(): List<Envelope<SessionPayload>> {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/JvmCrashFeatureTest.kt
@@ -4,8 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
+import io.embrace.android.embracesdk.getLastSavedLogPayload
 import io.embrace.android.embracesdk.getLastSentBackgroundActivity
-import io.embrace.android.embracesdk.getLastSentLog
 import io.embrace.android.embracesdk.getLastSentSession
 import io.embrace.android.embracesdk.getSentSessions
 import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
@@ -50,7 +50,7 @@ internal class JvmCrashFeatureTest {
         with(testRule) {
             harness.recordSession {
                 handleException()
-                checkNotNull(harness.getLastSentLog()).assertCrash(
+                checkNotNull(harness.getLastSavedLogPayload()?.data?.logs).single().assertCrash(
                     state = "foreground",
                     crashId = checkNotNull(harness.getLastSentSession()?.getCrashedId())
                 )
@@ -62,7 +62,7 @@ internal class JvmCrashFeatureTest {
     fun `app crash in the background generates a crash log`() {
         with(testRule) {
             handleException()
-            checkNotNull(harness.getLastSentLog()).assertCrash(
+            checkNotNull(harness.getLastSavedLogPayload()?.data?.logs).single().assertCrash(
                 crashId = checkNotNull(harness.getLastSentBackgroundActivity()?.getCrashedId())
             )
         }
@@ -86,7 +86,7 @@ internal class JvmCrashFeatureTest {
             }
         }
 
-        val log = checkNotNull(testRule.harness.getLastSentLog())
+        val log = checkNotNull(testRule.harness.getLastSavedLogPayload()?.data?.logs).single()
         assertOtelLogReceived(
             logReceived = log,
             expectedMessage = "",

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogEnvelopeSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogEnvelopeSource.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSource
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
+import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
@@ -15,10 +16,10 @@ public class FakeLogEnvelopeSource(
 
     override fun getBatchedLogEnvelope(): Envelope<LogPayload> = getLogEnvelope(logPayloadSource.getBatchedLogPayload())
 
-    override fun getNonbatchedEnvelope(): List<Envelope<LogPayload>> {
+    override fun getNonbatchedEnvelope(): List<LogRequest<Envelope<LogPayload>>> {
         val payloads = logPayloadSource.getNonbatchedLogPayloads()
         return if (payloads.isNotEmpty()) {
-            payloads.map { getLogEnvelope(it) }
+            payloads.map { LogRequest(payload = getLogEnvelope(it.payload), defer = it.defer) }
         } else {
             emptyList()
         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogEnvelopeSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogEnvelopeSource.kt
@@ -16,8 +16,8 @@ public class FakeLogEnvelopeSource(
 
     override fun getBatchedLogEnvelope(): Envelope<LogPayload> = getLogEnvelope(logPayloadSource.getBatchedLogPayload())
 
-    override fun getNonbatchedEnvelope(): List<LogRequest<Envelope<LogPayload>>> {
-        val payloads = logPayloadSource.getNonbatchedLogPayloads()
+    override fun getSingleLogEnvelopes(): List<LogRequest<Envelope<LogPayload>>> {
+        val payloads = logPayloadSource.getSingleLogPayloads()
         return if (payloads.isNotEmpty()) {
             payloads.map { LogRequest(payload = getLogEnvelope(it.payload), defer = it.defer) }
         } else {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogPayloadSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogPayloadSource.kt
@@ -2,14 +2,16 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.fixtures.nonbatchableLog
 import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSource
+import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
 public class FakeLogPayloadSource : LogPayloadSource {
 
     public var logs: LogPayload = LogPayload()
-    public var nonbatchedLogs: List<LogPayload> = listOf(LogPayload(logs = listOf(nonbatchableLog)))
+    public var nonbatchedLogs: List<LogRequest<LogPayload>> =
+        listOf(LogRequest(LogPayload(logs = listOf(nonbatchableLog))))
 
     override fun getBatchedLogPayload(): LogPayload = logs
 
-    override fun getNonbatchedLogPayloads(): List<LogPayload> = nonbatchedLogs
+    override fun getNonbatchedLogPayloads(): List<LogRequest<LogPayload>> = nonbatchedLogs
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogPayloadSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogPayloadSource.kt
@@ -1,17 +1,17 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.fixtures.nonbatchableLog
+import io.embrace.android.embracesdk.fixtures.sendImmediatelyLog
 import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSource
 import io.embrace.android.embracesdk.internal.logs.LogRequest
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 
 public class FakeLogPayloadSource : LogPayloadSource {
 
-    public var logs: LogPayload = LogPayload()
-    public var nonbatchedLogs: List<LogRequest<LogPayload>> =
-        listOf(LogRequest(LogPayload(logs = listOf(nonbatchableLog))))
+    public var singleLogPayloadsSource: List<LogRequest<LogPayload>> =
+        listOf(LogRequest(LogPayload(logs = listOf(sendImmediatelyLog))))
+    private val batchedLogPayload: LogPayload = LogPayload()
 
-    override fun getBatchedLogPayload(): LogPayload = logs
+    override fun getBatchedLogPayload(): LogPayload = batchedLogPayload
 
-    override fun getNonbatchedLogPayloads(): List<LogRequest<LogPayload>> = nonbatchedLogs
+    override fun getSingleLogPayloads(): List<LogRequest<LogPayload>> = singleLogPayloadsSource
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.fixtures
 
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
-import io.embrace.android.embracesdk.internal.arch.schema.SendImmediately
-import io.embrace.android.embracesdk.internal.arch.schema.toPayload
+import io.embrace.android.embracesdk.internal.arch.schema.SendMode
+import io.embrace.android.embracesdk.internal.opentelemetry.embSendMode
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
@@ -25,10 +25,22 @@ public val nonbatchableLog: Log = Log(
     severityNumber = 9,
     severityText = "INFO",
     body = "unbatchable",
-    attributes = listOf(SendImmediately.toPayload())
+    attributes = listOf(Attribute(embSendMode.name, SendMode.IMMEDIATE.name))
+)
+
+public val deferredLog: Log = Log(
+    traceId = null,
+    spanId = null,
+    timeUnixNano = 1681972471807000000L,
+    severityNumber = 9,
+    severityText = "INFO",
+    body = "deferred",
+    attributes = listOf(Attribute(embSendMode.name, SendMode.DEFER.name))
 )
 
 public val unbatchableLogRecordData: FakeLogRecordData = FakeLogRecordData(log = nonbatchableLog)
+
+public val deferredLogRecordData: FakeLogRecordData = FakeLogRecordData(log = deferredLog)
 
 public val testNativeCrashData: NativeCrashData = NativeCrashData(
     nativeCrashId = "nativeCrashId",

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
@@ -18,13 +18,13 @@ public val testLog: Log = Log(
     attributes = listOf(Attribute(key = "test1", data = "value1"), Attribute(key = "test2", data = "value2"))
 )
 
-public val nonbatchableLog: Log = Log(
+public val sendImmediatelyLog: Log = Log(
     traceId = null,
     spanId = null,
     timeUnixNano = 1681972471806000000L,
     severityNumber = 9,
     severityText = "INFO",
-    body = "unbatchable",
+    body = "sendImmediately",
     attributes = listOf(Attribute(embSendMode.name, SendMode.IMMEDIATE.name))
 )
 
@@ -38,7 +38,7 @@ public val deferredLog: Log = Log(
     attributes = listOf(Attribute(embSendMode.name, SendMode.DEFER.name))
 )
 
-public val unbatchableLogRecordData: FakeLogRecordData = FakeLogRecordData(log = nonbatchableLog)
+public val sendImmediatelyLogRecordData: FakeLogRecordData = FakeLogRecordData(log = sendImmediatelyLog)
 
 public val deferredLogRecordData: FakeLogRecordData = FakeLogRecordData(log = deferredLog)
 


### PR DESCRIPTION
## Goal

Changed the `SendImmediately` designation to a `SendMode` enum to additionally allow logs to be saved instead of sent, and use this to save crash logs rather than send them. This ensures they will be delivered on the next app startup in a consistent matter, rather than rely on our existing, flakey mechanism to attempt to send synchronously, and only if it fails, save the payload.

Bundled with this change is the need to serialize the log payload and create the request for other unbatched logs off the calling thread. Right now, they are not being done on a background thread - only sent through it - so this could be problematic depending on where it's being invoked. Instead, we will run them on the same scheduler that we use to run the log batching job.

## Testing

Added unit tests everywhere to ensure this SendMode concept is passed down. Also added integration test to ensure that this works.