### PR TITLE
Added concurrency policy to pull_request Github actions

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [ released ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gradle-test:
     runs-on: macos-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
 

--- a/.github/workflows/swazzler-tests-subset.yml
+++ b/.github/workflows/swazzler-tests-subset.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   ANDROID_BUILD_TOOLS_HOME: "/usr/local/lib/android/sdk/build-tools/32.0.0"
 


### PR DESCRIPTION
This concurrency policy cancels in-progress runs when pushing new code to a specific branch.

Example: 

- Let's say we create a `branch_A`, and create a pull request. This will trigger the actions in this PR. 
- If we create a `branch_B`, the actions will also run, simultaneously.
- If we push new code to `branch_A`, the actions that were running on that branch will be canceled, and new ones will be triggered. 

This avoids running actions on stale code.