### PR TITLE
Add moshi rules to prevent adapters failing in minified build

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.clock.SystemClock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.serialization.DecoratedSerializer
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.telemetry.EmbraceTelemetryService
@@ -32,6 +33,6 @@ internal class InitModuleImpl(
     }
 
     override val jsonSerializer: PlatformSerializer by singleton {
-        EmbraceSerializer()
+        DecoratedSerializer(EmbraceSerializer(), logger)
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/DecoratedSerializer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/DecoratedSerializer.kt
@@ -1,0 +1,57 @@
+package io.embrace.android.embracesdk.internal.serialization
+
+import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import java.io.InputStream
+import java.io.OutputStream
+import java.lang.reflect.Type
+
+internal class DecoratedSerializer(
+    private val impl: PlatformSerializer,
+    private val logger: EmbLogger
+) : PlatformSerializer {
+
+    override fun <T> toJson(src: T): String {
+        return serializerAction { impl.toJson(src) }
+    }
+
+    override fun <T> toJson(src: T, clz: Class<T>): String {
+        return serializerAction { impl.toJson(src, clz) }
+    }
+
+    override fun <T> toJson(src: T, type: Type): String {
+        return serializerAction { impl.toJson(src, type) }
+    }
+
+    override fun <T> toJson(any: T, clazz: Class<T>, outputStream: OutputStream) {
+        return serializerAction { impl.toJson(any, clazz, outputStream) }
+    }
+
+    override fun <T> toJson(any: T, type: Type, outputStream: OutputStream) {
+        return serializerAction { impl.toJson(any, type, outputStream) }
+    }
+
+    override fun <T> fromJson(json: String, clz: Class<T>): T {
+        return serializerAction { impl.fromJson(json, clz) }
+    }
+
+    override fun <T> fromJson(json: String, type: Type): T {
+        return serializerAction { impl.fromJson(json, type) }
+    }
+
+    override fun <T> fromJson(inputStream: InputStream, clz: Class<T>): T {
+        return serializerAction { impl.fromJson(inputStream, clz) }
+    }
+
+    override fun <T> fromJson(inputStream: InputStream, type: Type): T {
+        return serializerAction { impl.fromJson(inputStream, type) }
+    }
+
+    private fun <T> serializerAction(action: () -> T): T {
+        try {
+            return action()
+        } catch (exc: Exception) {
+            logger.logError("JSON serializer failed", exc)
+            throw exc
+        }
+    }
+}

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/Endpoint.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/Endpoint.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.internal.comms.api
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 public enum class Endpoint(
     public val path: String,
     public val version: String

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/Unwinder.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/Unwinder.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.internal.config.remote
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 public enum class Unwinder(public val code: Int) {
     LIBUNWIND(0),
     LIBUNWINDSTACK(1)

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/AnrInterval.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/AnrInterval.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.payload
 
+import com.squareup.moshi.JsonClass
+
 /**
  * Intervals during which the UI thread was blocked for more than 1 second, which
  * determines that the application is not responding (ANR).
@@ -40,6 +42,7 @@ public data class AnrInterval @JvmOverloads constructor(
     /**
      * The type of thread not responding. Currently only the UI thread is monitored.
      */
+    @JsonClass(generateAdapter = false)
     public enum class Type {
         UI
     }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/ApplicationState.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/ApplicationState.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.internal.payload
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 public enum class ApplicationState {
 
     /**

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/PushNotificationBreadcrumb.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/PushNotificationBreadcrumb.kt
@@ -1,7 +1,10 @@
 package io.embrace.android.embracesdk.internal.payload
 
+import com.squareup.moshi.JsonClass
+
 public class PushNotificationBreadcrumb {
 
+    @JsonClass(generateAdapter = false)
     public enum class NotificationType(public val type: String) {
         NOTIFICATION("notif"),
         DATA("data"),

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/ThreadState.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/ThreadState.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.internal.payload
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 public enum class ThreadState(public val code: Int) {
     NEW(0),
     RUNNABLE(1),

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/WebVitalType.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/WebVitalType.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.payload
 
+import com.squareup.moshi.JsonClass
+
 /**
  * Web Core Vital type.
  *
@@ -9,6 +11,7 @@ package io.embrace.android.embracesdk.internal.payload
  * FCP = First Contentful Paint: Indicates the time it takes for the first content element to appear on the screen.
  *
  */
+@JsonClass(generateAdapter = false)
 public enum class WebVitalType {
     FID, LCP, CLS, FCP
 }

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -1,7 +1,15 @@
 -keepattributes LineNumberTable, SourceFile
 
-## Keep classes used by hosted SDKs
+## Keep public API including enums
 -keep class io.embrace.android.embracesdk.Embrace { *; }
+-keep class io.embrace.android.embracesdk.network.http.HttpMethod { *; }
+-keep class io.embrace.android.embracesdk.network.EmbraceNetworkRequest { *; }
+-keep class io.embrace.android.embracesdk.Severity { *; }
+-keep class io.embrace.android.embracesdk.LogType { *; }
+-keep class io.embrace.android.embracesdk.LogExceptionType { *; }
+-keep class io.embrace.android.embracesdk.spans.ErrorCode { *; }
+
+## Keep classes used by hosted SDKs
 -keep class io.embrace.android.embracesdk.Embrace$AppFramework { *; }
 -keep class io.embrace.android.embracesdk.Embrace$LastRunEndState { *; }
 -keep class io.embrace.android.embracesdk.Severity { *; }


### PR DESCRIPTION
## Goal

Moshi requires enums to be annotated to prevent R8/ProGuard from stripping their values. Several enums in our codebase were not annotated in this way, which worked fine until we changed the ProGuard rules to be more specific in #1043.

This change adds the `JsonClass` annotation to enums [as recommended](https://github.com/square/moshi?tab=readme-ov-file#r8--proguard).

## Testing

Manually verified against the `release` build variant of a minified test app that no errors show up in Logcat related to serialization.
