### PR TITLE
Github Actions improvements

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -32,9 +32,6 @@ jobs:
   release:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jdk-version: [ "17" ]
     steps:
       - name: Decode Keystore
         run: |
@@ -52,25 +49,14 @@ jobs:
         with:
           ref: release/${{ github.event.inputs.version_of_rc }}
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.m2/repository
-            ~/.sonar/cache
-          key: ${{ runner.os }}-gradle-jdk${{ matrix.jdk-version }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties', '**/libs.versions.toml', 'gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
-
-      - name: Install JDK ${{ matrix.jdk-version }}
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: ${{ matrix.jdk-version }}
+          java-version: 17
 
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Generate SDK RC - Publish and close Sonatype repository
         run: |
@@ -105,11 +91,3 @@ jobs:
           git push origin :refs/tags/${{ github.event.inputs.version_of_rc }}.${{ github.event.inputs.patch_number }}
           git tag -f ${{ github.event.inputs.version_of_rc }}.${{ github.event.inputs.patch_number }}
           git push origin --tags
-
-      - name: Cleanup Gradle Cache
-        # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches:
   release:
     types: [ released ]
 
@@ -14,36 +13,22 @@ concurrency:
 
 jobs:
   gradle-test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      matrix:
-        jdk-version: ["17"]
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.m2/repository
-            ~/.sonar/cache
-          key: ${{ runner.os }}-gradle-jdk${{ matrix.jdk-version }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties', '**/libs.versions.toml', 'gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
-
-      - name: Install JDK ${{ matrix.jdk-version }}
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: ${{ matrix.jdk-version }}
+          java-version: 17
 
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       # Build the entire project, run the tests, and run all static analysis
       - name: Gradle Build
@@ -64,11 +49,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           file: embrace-android-sdk/build/reports/kover/reportRelease.xml
-
-      - name: Cleanup Gradle Cache
-        # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@
 name: Dependency Review
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: '0 3 * * *'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -17,30 +17,31 @@ env:
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       matrix:
-        jdk-version: ["17"]
         api-level: [29]
         target: [default]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - uses: actions/cache@v4
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.m2/repository
-            ~/.sonar/cache
-          key: ${{ runner.os }}-gradle-jdk${{ matrix.jdk-version }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties', '**/libs.versions.toml', 'gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
+          distribution: 'adopt'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       # Cache the emulator
       - name: AVD cache
@@ -60,15 +61,6 @@ jobs:
           force-avd-creation: false
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
-
-      - name: Install JDK ${{ matrix.jdk-version }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'adopt'
-          java-version: ${{ matrix.jdk-version }}
-
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
 
       - name: Run Functional Tests
         uses: embrace-io/android-emulator-runner@v2
@@ -102,12 +94,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-      - name: Cleanup Gradle Cache
-        if: always()
-        # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -26,28 +26,26 @@ jobs:
   publish-api-docs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      matrix:
-        jdk-version: [ "17" ]
     steps:
       - name: Configure git
         run: |
           git config --global user.name 'embrace-ci[bot]'
           git config --global user.email 'embrace-ci@users.noreply.github.com'
+
       - name: Checkout SDK
         uses: actions/checkout@v4
         with:
           ref: release/${{ github.event.inputs.version_to_release }}
           fetch-depth: 0
 
-      - name: Set up JDK ${{ matrix.jdk-version }}
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.jdk-version }}
           distribution: 'adopt'
+          java-version: 17
 
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Generate Documentation
         run: ./gradlew dokkaHtmlMultiModule clean --no-build-cache --no-configuration-cache
@@ -70,11 +68,3 @@ jobs:
       - name: Record SDK Version History (${{ github.event.inputs.version_to_release }}.${{ github.event.inputs.patch_version_of_release }})
         run: |
           curl -X POST ${{ vars.SDK_VERSION_URL }}/android/version/ -H 'X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}' -H 'Content-Type: application/json' -d '{"version": "${{ github.event.inputs.version_to_release }}.${{ github.event.inputs.patch_version_of_release }}"}'
-
-      - name: Cleanup Gradle Cache
-        # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -23,34 +23,18 @@ jobs:
     needs: [functional, baseline-profile]
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      matrix:
-        jdk-version: ["17"]
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.m2/repository
-            ~/.sonar/cache
-          key: ${{ runner.os }}-gradle-jdk${{ matrix.jdk-version }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties', '**/libs.versions.toml', 'gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
-
-      - name: Install JDK ${{ matrix.jdk-version }}
+      - name: Install Java
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: ${{ matrix.jdk-version }}
+          java-version: 17
 
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       # Build the entire project, run the tests, and run all static analysis
       - name: Gradle Build
@@ -64,14 +48,12 @@ jobs:
           path: embrace-android-sdk/build/reports/tests/
 
       - name: Gradlew Release to internal Maven
-        run: |
-          ./gradlew clean publishReleasePublicationToSnapshotRepository --stacktrace
+        run: ./gradlew clean publishReleasePublicationToSnapshotRepository --stacktrace
 
       - name: Checkout Swazzler
         uses: actions/checkout@v4
         with:
           repository: embrace-io/embrace-swazzler3
-          ref: master
           path: ./embrace-swazzler3
           token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
@@ -79,11 +61,3 @@ jobs:
         run: |
           cd ./embrace-swazzler3
           ./gradlew clean publishPluginMavenPublicationToSnapshotRepository --stacktrace
-
-      - name: Cleanup Gradle Cache
-        # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/rc-release-branch.yml
+++ b/.github/workflows/rc-release-branch.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Checkout SDK
         uses: actions/checkout@v4
-        with:
-          ref: master
 
       - name: Create SDK Release Branch "release/${{ github.event.inputs.version_to_release }}"
         run: |
@@ -46,7 +44,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embrace-io/embrace-swazzler3
-          ref: master
           token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
       - name: Create Swazzler Release Branch "release/${{ github.event.inputs.version_to_release }}"

--- a/.github/workflows/rc-update-test-apps.yml
+++ b/.github/workflows/rc-update-test-apps.yml
@@ -31,12 +31,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ matrix.repo }}
-          ref: master
           token: ${{ secrets.GH_ANDROID_SDK_TOKEN }} # NOTE: write embrace-io/android-sdk-benchmark, embrace-io/android-test-suite, embrace-io/ndk-test-app-ndkbuild, embrace-io/ndk-test-app-custombuild, embrace-io/ndk-test-app, embrace-io/android-size-measure
 
       - name: Set next SDK version
         run: |
-          git checkout master
+          git checkout main
           sed -i -r "s#swazzler_version = ([^\']+)#swazzler_version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
           git add gradle.properties
           git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -27,9 +27,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      matrix:
-        jdk-version: [ "17" ]
     steps:
       - name: Checkout SDK
         uses: actions/checkout@v4
@@ -37,14 +34,14 @@ jobs:
           ref: release/${{ github.event.inputs.version_to_release }}
           fetch-depth: 0
 
-      - name: Set up JDK ${{ matrix.jdk-version }}
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.jdk-version }}
           distribution: 'adopt'
+          java-version: 17
 
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Gradlew Release SDK to Maven Central
         run: |
@@ -57,20 +54,9 @@ jobs:
           ref: release/${{ github.event.inputs.version_to_release }}
           token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
-
       - name: Gradlew Release Swazzler to Maven Central
         run: |
           ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
-
-      - name: Cleanup Gradle Cache
-        # Based on https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle#caching-dependencies
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
 
   publish-api-docs:
     name: Publish API Docs

--- a/.github/workflows/swazzler-tests-subset.yml
+++ b/.github/workflows/swazzler-tests-subset.yml
@@ -8,9 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  ANDROID_BUILD_TOOLS_HOME: "/usr/local/lib/android/sdk/build-tools/32.0.0"
-
 jobs:
   runSwazzlerTests:
     name: "Run Gradle Tests"
@@ -25,6 +22,9 @@ jobs:
           distribution: 'adopt'
           java-version: 17
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       # make sure version in gradle.properties matches the version of embrace-swazzler3 version
       - name: "Publish SDK locally"
         run: ./gradlew publishToMavenLocal --no-daemon
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embrace-io/swazzler-test
-          ref: master
           path: ./swazzler-test
           submodules: recursive
           token: ${{ secrets.GH_ANDROID_SDK_TOKEN || secrets.token }}
@@ -42,20 +41,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embrace-io/embrace-swazzler3
-          ref: master
           path: ./swazzler-test/embrace-swazzler3
           token: ${{ secrets.GH_ANDROID_SDK_TOKEN }}
 
       - name: "Publish Swazzler locally"
-        run: |
-          cd ./swazzler-test/embrace-swazzler3
-          ./gradlew publishToMavenLocal --no-daemon
+        working-directory: ./swazzler-test/embrace-swazzler3
+        run: ./gradlew publishToMavenLocal --no-daemon
 
       - name: "Run Gradle Tests"
-        run: |
-          echo "Running Gradle tests"
-          cd ./swazzler-test
-          ./gradlew :functional-tests:swazzlerTests --tests "io.embrace.android.gradle.swazzler.tests.MinimumSurvivalTests" --stacktrace
+        working-directory: ./swazzler-test
+        run: ./gradlew :functional-tests:swazzlerTests --tests "io.embrace.android.gradle.swazzler.tests.MinimumSurvivalTests" --stacktrace
 
       - name: "Test Results"
         if: ${{ always() }}

--- a/.github/workflows/update-main-versions.yml
+++ b/.github/workflows/update-main-versions.yml
@@ -28,12 +28,10 @@ jobs:
 
       - name: Checkout SDK
         uses: actions/checkout@v4
-        with:
-          ref: master
 
       - name: Set next SDK version
         run: |
-          git checkout master
+          git checkout main
           sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
           git add gradle.properties
           git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"
@@ -43,12 +41,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: embrace-io/embrace-swazzler3
-          ref: master
           token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
       - name: Set Next Swazzler Version
         run: |
-          git checkout master
+          git checkout main
           sed -i -r "s#version = ([^\']+)#version = ${{ github.event.inputs.next_version }}.0-SNAPSHOT#" gradle.properties
           git add gradle.properties
           git commit -m "CI/CD: set next version: ${{ github.event.inputs.next_version }}.0-SNAPSHOT"


### PR DESCRIPTION
- Stop using matrix for jdk-version
- Use setup-gradle instead of cache and wrapper_validation
- Use ubuntu-latest instead of macos
- Don't use fetch-depth: 0 when it's not necessary
- Add KVM group permissions for emulator
- Use working-directory instead of cd
- Remove unnecessary refs to default branches
- Replaced references to "master" with "main"
