### PR TITLE
Create fake behavior implementations

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -54,7 +54,6 @@ internal class EmbraceConfigService(
     private val clock: Clock,
     private val logger: EmbLogger,
     private val backgroundWorker: BackgroundWorker,
-    isDebug: Boolean,
     suppliedFramework: AppFramework,
     private val foregroundAction: ConfigService.() -> Unit,
     val thresholdCheck: BehaviorThresholdCheck =
@@ -150,7 +149,6 @@ internal class EmbraceConfigService(
 
     override val sdkModeBehavior: SdkModeBehavior =
         SdkModeBehaviorImpl(
-            isDebug = isDebug,
             thresholdCheck = thresholdCheck,
             localSupplier = { localConfig },
             remoteSupplier = remoteSupplier

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehavior.kt
@@ -3,13 +3,6 @@ package io.embrace.android.embracesdk.internal.config.behavior
 interface SdkModeBehavior {
 
     /**
-     * Checks if beta features are enabled for this device.
-     *
-     * @return true if beta features should run for this device, otherwise false.
-     */
-    fun isBetaFeaturesEnabled(): Boolean
-
-    /**
      * Given a Config instance, computes if the SDK is enabled based on the threshold and the offset.
      *
      * @return true if the sdk is enabled, false otherwise

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
@@ -10,7 +10,6 @@ import kotlin.math.min
  * Provides whether the SDK should enable certain 'behavior' modes, such as 'integration mode'
  */
 class SdkModeBehaviorImpl(
-    private val isDebug: Boolean,
     thresholdCheck: BehaviorThresholdCheck,
     localSupplier: Provider<LocalConfig?>,
     remoteSupplier: Provider<RemoteConfig?>
@@ -23,13 +22,6 @@ class SdkModeBehaviorImpl(
     private companion object {
 
         /**
-         * The percentage of devices which should have beta features initialized.
-         *
-         * The range of allowed values is 0.0f to 100.0f, and the default is 1.0f (1% of devices).
-         */
-        private const val DEFAULT_BETA_FEATURES_PCT = 1.0f
-
-        /**
          * The default percentage of devices for which the SDK is enabled.
          */
         private const val DEFAULT_THRESHOLD = 100
@@ -38,19 +30,6 @@ class SdkModeBehaviorImpl(
          * The default percentage offset of devices for which the SDK is enabled.
          */
         private const val DEFAULT_OFFSET = 0
-    }
-
-    override fun isBetaFeaturesEnabled(): Boolean {
-        if (local?.sdkConfig?.betaFeaturesEnabled == false) {
-            return false
-        }
-
-        if (isDebug) {
-            return true
-        }
-
-        val pct = remote?.pctBetaFeaturesEnabled ?: DEFAULT_BETA_FEATURES_PCT
-        return thresholdCheck.isBehaviorEnabled(pct)
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
@@ -41,7 +41,6 @@ internal class ConfigModuleImpl(
                     initModule.clock,
                     initModule.logger,
                     workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
-                    coreModule.isDebug,
                     framework,
                     foregroundAction
                 )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -13,12 +13,8 @@ import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeRnBundleIdTracker
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.createSdkModeBehavior
 import io.embrace.android.embracesdk.internal.BuildInfo
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.resource.DeviceImpl
@@ -101,19 +97,7 @@ internal class EmbraceMetadataServiceTest {
         }
     }
 
-    private val configService: FakeConfigService =
-        FakeConfigService(
-            autoDataCaptureBehavior = createAutoDataCaptureBehavior(
-                localCfg = {
-                    LocalConfig("appId", true, SdkLocalConfig())
-                }
-            ),
-            sdkModeBehavior = createSdkModeBehavior(
-                localCfg = {
-                    LocalConfig("appId", false, SdkLocalConfig())
-                }
-            )
-        )
+    private val configService: FakeConfigService = FakeConfigService()
 
     @Before
     fun setUp() {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
@@ -9,9 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
-import io.embrace.android.embracesdk.fakes.createSessionBehavior
-import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
@@ -44,8 +42,7 @@ internal class EmbraceSessionPropertiesTest {
     private lateinit var sessionProperties: EmbraceSessionProperties
     private lateinit var context: Context
     private lateinit var logger: EmbLogger
-    private lateinit var configService: ConfigService
-    private lateinit var config: RemoteConfig
+    private lateinit var configService: FakeConfigService
     private lateinit var writer: FakeCurrentSessionSpan
 
     @Before
@@ -57,11 +54,8 @@ internal class EmbraceSessionPropertiesTest {
         preferencesService =
             EmbracePreferencesService(worker, prefs, fakeClock, EmbraceSerializer())
 
-        config = RemoteConfig()
         configService = FakeConfigService(
-            sessionBehavior = createSessionBehavior {
-                config
-            }
+            sessionBehavior = FakeSessionBehavior(MAX_SESSION_PROPERTIES_DEFAULT)
         )
         writer = FakeCurrentSessionSpan()
         sessionProperties = EmbraceSessionProperties(
@@ -185,7 +179,7 @@ internal class EmbraceSessionPropertiesTest {
 
     @Test
     fun addPropertyTooManyWithRemoteConfigMax() {
-        config = RemoteConfig(maxSessionProperties = MAX_SESSION_PROPERTIES_FROM_CONFIG)
+        configService.sessionBehavior = FakeSessionBehavior(maxSessionProperties = MAX_SESSION_PROPERTIES_FROM_CONFIG)
         var isPermanent = true
         for (i in 0 until MAX_SESSION_PROPERTIES_FROM_CONFIG) {
             assertTrue(sessionProperties.add("prop$i", VALUE_VALID, isPermanent))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -312,7 +312,6 @@ internal class EmbraceConfigServiceTest {
             fakeClock,
             logger,
             worker,
-            false,
             AppFramework.NATIVE,
             action
         ).apply {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
@@ -1,22 +1,12 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createSdkModeBehavior
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SdkModeBehaviorImplTest {
-
-    private val local = LocalConfig(
-        "",
-        false,
-        SdkLocalConfig(
-            betaFeaturesEnabled = true
-        )
-    )
 
     // 100% enabled
     private val enabled = BehaviorThresholdCheck { "07D85B44E4E245F4A30E559BFC000000" }
@@ -34,73 +24,8 @@ internal class SdkModeBehaviorImplTest {
                 thresholdCheck = disabled
             )
         ) {
-            assertFalse(isBetaFeaturesEnabled())
             assertFalse(isSdkDisabled())
         }
-    }
-
-    @Test
-    fun testLocalOnly() {
-        with(
-            createSdkModeBehavior(
-                thresholdCheck = enabled,
-                localCfg = { local }
-            )
-        ) {
-            assertTrue(isBetaFeaturesEnabled())
-        }
-    }
-
-    @Test
-    fun testBetaFeaturesEnabled() {
-        var behavior = createSdkModeBehavior(
-            thresholdCheck = enabled
-        )
-        assertTrue(behavior.isBetaFeaturesEnabled())
-
-        behavior = createSdkModeBehavior(
-            thresholdCheck = disabled
-        )
-        assertFalse(behavior.isBetaFeaturesEnabled())
-
-        behavior = createSdkModeBehavior(
-            thresholdCheck = enabled,
-            localCfg = { LocalConfig("", false, SdkLocalConfig(betaFeaturesEnabled = false)) }
-        )
-        assertFalse(behavior.isBetaFeaturesEnabled())
-
-        behavior =
-            createSdkModeBehavior(
-                thresholdCheck = enabled,
-                localCfg = { local },
-                remoteCfg = { RemoteConfig(pctBetaFeaturesEnabled = 100f) }
-            )
-        assertTrue(behavior.isBetaFeaturesEnabled())
-
-        behavior =
-            createSdkModeBehavior(
-                thresholdCheck = disabled,
-                localCfg = { local },
-                remoteCfg = { RemoteConfig(pctBetaFeaturesEnabled = 0f) }
-            )
-        assertFalse(behavior.isBetaFeaturesEnabled())
-    }
-
-    @Test
-    fun testMetadataDebug() {
-        val behaviorNotDebug =
-            createSdkModeBehavior(
-                isDebug = false,
-                thresholdCheck = disabled
-            )
-        assertFalse(behaviorNotDebug.isBetaFeaturesEnabled())
-
-        val behaviorDebug =
-            createSdkModeBehavior(
-                isDebug = true,
-                thresholdCheck = disabled
-            )
-        assertTrue(behaviorDebug.isBetaFeaturesEnabled())
     }
 
     @Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -5,10 +5,8 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureDataSource
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.createNetworkBehavior
-import io.embrace.android.embracesdk.fakes.createSdkEndpointBehavior
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.config.LocalConfigParser
-import io.embrace.android.embracesdk.internal.config.local.BaseUrlLocalConfig
 import io.embrace.android.embracesdk.internal.config.local.LocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -36,8 +34,7 @@ internal class EmbraceNetworkCaptureServiceTest {
         private var cfg: RemoteConfig = RemoteConfig()
         private val sessionIdTracker: FakeSessionIdTracker = FakeSessionIdTracker()
         private val configService: FakeConfigService = FakeConfigService(
-            networkBehavior = createNetworkBehavior { cfg },
-            sdkEndpointBehavior = createSdkEndpointBehavior { BaseUrlLocalConfig() }
+            networkBehavior = createNetworkBehavior { cfg }
         )
         private lateinit var mockLocalConfig: LocalConfig
         private val networkCaptureData: NetworkCaptureData = NetworkCaptureData(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
@@ -17,16 +17,10 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeUserService
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.createDataCaptureEventBehavior
 import io.embrace.android.embracesdk.fakes.createSessionBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionZygote
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SessionLocalConfig
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPayloadSourceImpl
 import io.embrace.android.embracesdk.internal.gating.EmbraceGatingService
@@ -66,9 +60,6 @@ internal class SessionHandlerTest {
     private lateinit var preferencesService: FakePreferenceService
     private lateinit var sessionIdTracker: FakeSessionIdTracker
     private lateinit var metadataService: FakeMetadataService
-    private lateinit var localConfig: LocalConfig
-    private lateinit var remoteConfig: RemoteConfig
-    private lateinit var sessionLocalConfig: SessionLocalConfig
     private lateinit var deliveryService: FakeDeliveryService
     private lateinit var gatingService: FakeGatingService
     private lateinit var configService: FakeConfigService
@@ -93,26 +84,8 @@ internal class SessionHandlerTest {
         metadataService = FakeMetadataService()
         sessionIdTracker = FakeSessionIdTracker()
         memoryCleanerService = FakeMemoryCleanerService()
-
-        localConfig = LocalConfig(
-            appId = "abcde",
-            ndkEnabled = true,
-            sdkConfig = SdkLocalConfig()
-        )
-        sessionLocalConfig = SessionLocalConfig()
-        remoteConfig = RemoteConfig()
         configService = FakeConfigService(
-            autoDataCaptureBehavior = createAutoDataCaptureBehavior(
-                localCfg = { localConfig },
-                remoteCfg = { remoteConfig }
-            ),
-            sessionBehavior = createSessionBehavior(
-                localCfg = { sessionLocalConfig },
-                remoteCfg = { remoteConfig }
-            ),
-            dataCaptureEventBehavior = createDataCaptureEventBehavior(
-                remoteCfg = { remoteConfig }
-            )
+            sessionBehavior = createSessionBehavior()
         )
         gatingService = FakeGatingService(EmbraceGatingService(configService, FakeLogService(), FakeEmbLogger()))
         preferencesService = FakePreferenceService()
@@ -147,7 +120,6 @@ internal class SessionHandlerTest {
     fun `onSession started successfully with no preference service session number`() {
         // return absent session number
         sessionNumber = 0
-        sessionLocalConfig = SessionLocalConfig()
         // this is needed so session handler creates automatic session stopper
 
         payloadFactory.startPayloadWithState(ProcessState.FOREGROUND, NOW, true)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -17,13 +17,11 @@ import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeV2PayloadCollator
-import io.embrace.android.embracesdk.fakes.createSessionBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
 import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
@@ -205,13 +203,7 @@ internal class SessionOrchestratorTest {
     @Test
     fun `test manual session end disabled for session gating`() {
         configService = FakeConfigService(
-            sessionBehavior = createSessionBehavior {
-                RemoteConfig(
-                    sessionConfig = SessionRemoteConfig(
-                        isEnabled = true
-                    ),
-                )
-            }
+            sessionBehavior = FakeSessionBehavior(sessionControlEnabled = true)
         )
         createOrchestrator(false)
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
@@ -177,8 +177,7 @@ internal class FeatureModuleImpl(
         DataSourceState(
             factory = { thermalService },
             configGate = {
-                configService.autoDataCaptureBehavior.isThermalStatusCaptureEnabled() &&
-                    configService.sdkModeBehavior.isBetaFeaturesEnabled()
+                configService.autoDataCaptureBehavior.isThermalStatusCaptureEnabled()
             }
         )
     }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceRule.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceRule.kt
@@ -3,12 +3,11 @@ package io.embrace.android.embracesdk.internal.anr
 import android.os.Looper
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.createAnrBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.internal.anr.detection.BlockedThreadDetector
 import io.embrace.android.embracesdk.internal.anr.detection.LivenessCheckScheduler
 import io.embrace.android.embracesdk.internal.anr.detection.TargetThreadHandler
 import io.embrace.android.embracesdk.internal.anr.detection.ThreadMonitoringState
-import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
@@ -34,7 +33,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
     lateinit var livenessCheckScheduler: LivenessCheckScheduler
     lateinit var state: ThreadMonitoringState
     lateinit var blockedThreadDetector: BlockedThreadDetector
-    lateinit var cfg: AnrRemoteConfig
+    lateinit var anrBehavior: FakeAnrBehavior
     lateinit var anrExecutorService: T
     lateinit var targetThreadHandler: TargetThreadHandler
     lateinit var anrMonitorThread: AtomicReference<Thread>
@@ -42,9 +41,9 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
     override fun before() {
         clock.setCurrentTime(0)
         val looper: Looper = mockk(relaxed = true)
-        cfg = AnrRemoteConfig()
+        anrBehavior = FakeAnrBehavior()
         anrMonitorThread = AtomicReference(Thread.currentThread())
-        fakeConfigService = FakeConfigService(anrBehavior = createAnrBehavior { cfg })
+        fakeConfigService = FakeConfigService(anrBehavior = anrBehavior)
         anrExecutorService = scheduledExecutorSupplier.invoke()
         state = ThreadMonitoringState(clock)
         val worker = ScheduledWorker(anrExecutorService)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
@@ -287,7 +287,7 @@ internal class EmbraceAnrServiceTest {
     fun testProcessAnrTickDisabled() {
         with(rule) {
             // create an ANR service with config that disables ANR capture
-            cfg = cfg.copy(pctEnabled = 0)
+            rule.anrBehavior.anrCaptureEnabled = false
             clock.setCurrentTime(15020000L)
             anrService.processAnrTick(clock.now())
             assertEquals(0, anrService.stacktraceSampler.size())
@@ -301,7 +301,7 @@ internal class EmbraceAnrServiceTest {
     @Test
     fun testReachedAnrCaptureLimit() {
         with(rule) {
-            cfg = cfg.copy(anrPerSession = 3)
+            rule.anrBehavior.anrPerSessionImpl = 3
             val state = anrService.stacktraceSampler
             assertFalse(state.reachedAnrStacktraceCaptureLimit())
 
@@ -398,7 +398,7 @@ internal class EmbraceAnrServiceTest {
     fun `test handleCrash stops ANR tracking but samples can still be retrieved`() {
         with(rule) {
             clock.setCurrentTime(14000000L)
-            cfg = cfg.copy(pctBgEnabled = 100)
+            rule.anrBehavior.bgAnrCaptureEnabled = true
             anrService.onForeground(true, clock.now())
             anrExecutorService.submit {
                 assertTrue(state.started.get())

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/NativeThreadSamplerInstallerTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/NativeThreadSamplerInstallerTest.kt
@@ -1,12 +1,11 @@
 package io.embrace.android.embracesdk.internal.anr
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.createAnrBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.anr.ndk.EmbraceNativeThreadSamplerService
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerInstaller
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -23,7 +22,6 @@ internal class NativeThreadSamplerInstallerTest {
     private lateinit var configService: ConfigService
     private lateinit var anrService: AnrService
     private lateinit var delegate: EmbraceNativeThreadSamplerService.NdkDelegate
-    private lateinit var cfg: AnrRemoteConfig
     private lateinit var installer: NativeThreadSamplerInstaller
 
     @Before
@@ -32,9 +30,7 @@ internal class NativeThreadSamplerInstallerTest {
         anrService = mockk(relaxed = true)
         delegate = mockk(relaxed = true)
         sampler = mockk(relaxed = true)
-
-        cfg = AnrRemoteConfig(pctNativeThreadAnrSamplingEnabled = 100f)
-        configService = FakeConfigService(anrBehavior = createAnrBehavior { cfg })
+        configService = FakeConfigService(anrBehavior = FakeAnrBehavior(nativeThreadAnrSamplingEnabled = true))
         installer = NativeThreadSamplerInstaller(sharedObjectLoader = sharedObjectLoader, mockk(relaxed = true))
         every { sharedObjectLoader.loadEmbraceNative() } returns true
     }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/ThreadInfoCollectorTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/ThreadInfoCollectorTest.kt
@@ -1,9 +1,8 @@
 package io.embrace.android.embracesdk.internal.anr
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.createAnrBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.internal.payload.ThreadInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -15,6 +14,7 @@ import java.lang.Thread.MIN_PRIORITY
 import java.lang.Thread.NORM_PRIORITY
 import java.lang.Thread.State.RUNNABLE
 import java.lang.Thread.currentThread
+import java.util.regex.Pattern
 
 internal class ThreadInfoCollectorTest {
 
@@ -28,12 +28,10 @@ internal class ThreadInfoCollectorTest {
     @Before
     fun setUp() {
         configService = FakeConfigService(
-            anrBehavior = createAnrBehavior {
-                AnrRemoteConfig(
-                    allowList = listOf(currentThread().name),
-                    blockList = listOf("Finalizer")
-                )
-            }
+            anrBehavior = FakeAnrBehavior(
+                allowPatternList = listOf(currentThread().name).map(Pattern::compile),
+                blockPatternList = listOf("Finalizer").map(Pattern::compile)
+            )
         )
         threadInfoCollector = ThreadInfoCollector(currentThread())
     }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/detection/TargetThreadHandlerTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/detection/TargetThreadHandlerTest.kt
@@ -4,9 +4,8 @@ import android.os.Message
 import android.os.MessageQueue
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.createAnrBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import io.mockk.mockk
@@ -118,9 +117,7 @@ internal class TargetThreadHandlerTest {
     fun testStartIdleHandlerEnabled() {
         val messageQueue = mockk<MessageQueue>(relaxed = true)
         configService = FakeConfigService(
-            anrBehavior = createAnrBehavior {
-                AnrRemoteConfig(pctIdleHandlerEnabled = 100f)
-            }
+            anrBehavior = FakeAnrBehavior(idleHandlerEnabled = true)
         )
         handler = createHandler(messageQueue)
         handler.start()
@@ -131,9 +128,7 @@ internal class TargetThreadHandlerTest {
     fun testStartIdleHandlerDisabled() {
         val messageQueue = mockk<MessageQueue>(relaxed = true)
         configService = FakeConfigService(
-            anrBehavior = createAnrBehavior {
-                AnrRemoteConfig(pctIdleHandlerEnabled = 0f)
-            }
+            anrBehavior = FakeAnrBehavior(idleHandlerEnabled = false)
         )
         handler = createHandler(messageQueue)
         handler.start()

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSourceImplTest.kt
@@ -1,11 +1,10 @@
 package io.embrace.android.embracesdk.internal.anr.sigquit
 
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
-import io.embrace.android.embracesdk.fakes.createAnrBehavior
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -14,27 +13,34 @@ internal class SigquitDataSourceImplTest {
 
     private lateinit var dataSource: SigquitDataSourceImpl
     private lateinit var sessionSpan: FakeCurrentSessionSpan
-    private lateinit var config: AnrRemoteConfig
 
     @Before
     fun setUp() {
-        val logger = EmbLoggerImpl()
         sessionSpan = FakeCurrentSessionSpan()
-        config = AnrRemoteConfig()
         dataSource = SigquitDataSourceImpl(
-            SharedObjectLoader(logger),
+            SharedObjectLoader(FakeEmbLogger()),
             AnrThreadIdDelegate(),
-            createAnrBehavior(remoteCfg = { config }),
-            logger,
+            FakeAnrBehavior(),
+            FakeEmbLogger(),
             sessionSpan
         )
     }
 
     @Test
-    fun `test save google anr`() {
+    fun `test google anr not saved`() {
         assertEquals(0, sessionSpan.addedEvents.size)
         dataSource.saveSigquit(100)
-        config = config.copy(googlePctEnabled = 100)
+    }
+
+    @Test
+    fun `test save google anr`() {
+        dataSource = SigquitDataSourceImpl(
+            SharedObjectLoader(FakeEmbLogger()),
+            AnrThreadIdDelegate(),
+            FakeAnrBehavior(googleAnrCaptureEnabled = true),
+            FakeEmbLogger(),
+            sessionSpan
+        )
         dataSource.saveSigquit(200)
         assertEquals(1, sessionSpan.addedEvents.size)
         val event = sessionSpan.addedEvents.single()

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
@@ -7,10 +7,8 @@ import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.fakes.createAppExitInfoBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.every
@@ -21,6 +19,7 @@ import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import java.io.IOException
 
@@ -39,15 +38,9 @@ internal class AeiDataSourceImplTest {
 
     private lateinit var applicationExitInfoService: AeiDataSourceImpl
     private lateinit var logWriter: FakeLogWriter
+    private lateinit var configService: FakeConfigService
 
     private val worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
-
-    private var appExitInfoConfig = AppExitInfoConfig(pctAeiCaptureEnabled = 100.0f)
-    private val configService = FakeConfigService(
-        appExitInfoBehavior = createAppExitInfoBehavior {
-            RemoteConfig(appExitInfoConfig = appExitInfoConfig)
-        }
-    )
 
     private val preferenceService = FakePreferenceService()
     private val logger = EmbLoggerImpl()
@@ -87,6 +80,13 @@ internal class AeiDataSourceImplTest {
             logWriter,
             logger
         ).apply(AeiDataSourceImpl::enableDataCapture)
+    }
+
+    @Before
+    fun setUp() {
+        configService = FakeConfigService(
+            appExitInfoBehavior = FakeAppExitInfoBehavior(enabled = true)
+        )
     }
 
     @Test
@@ -300,8 +300,7 @@ internal class AeiDataSourceImplTest {
         // given a trace that exceeds the limit
         every { mockAppExitInfo.traceInputStream } returns "a".repeat(500).byteInputStream()
 
-        appExitInfoConfig =
-            AppExitInfoConfig(pctAeiCaptureEnabled = 100.0f, appExitInfoTracesLimit = 100)
+        configService.appExitInfoBehavior = FakeAppExitInfoBehavior(enabled = true, traceMaxLimit = 100)
         every {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiNdkCrashProtobufSendTest.kt
@@ -7,9 +7,8 @@ import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.fakes.createAppExitInfoBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.TypeUtils
-import io.embrace.android.embracesdk.internal.config.local.AppExitInfoLocalConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
@@ -136,11 +135,7 @@ internal class AeiNdkCrashProtobufSendTest {
         val logWriter = FakeLogWriter()
         AeiDataSourceImpl(
             BackgroundWorker(MoreExecutors.newDirectExecutorService()),
-            createAppExitInfoBehavior(localCfg = {
-                AppExitInfoLocalConfig(
-                    aeiCaptureEnabled = true
-                )
-            }),
+            FakeAppExitInfoBehavior(enabled = true),
             activityManager,
             FakePreferenceService(),
             logWriter,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
@@ -10,11 +10,8 @@ import io.embrace.android.embracesdk.fakes.FakeNdkService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.config.local.CrashHandlerLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.JsException
@@ -68,15 +65,7 @@ internal class CrashDataSourceImplTest {
 
     private fun setupForHandleCrash(crashHandlerEnabled: Boolean = false) {
         configService = FakeConfigService(
-            autoDataCaptureBehavior = createAutoDataCaptureBehavior(
-                localCfg = {
-                    LocalConfig(
-                        "",
-                        false,
-                        SdkLocalConfig(crashHandler = CrashHandlerLocalConfig(crashHandlerEnabled))
-                    )
-                }
-            )
+            autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uncaughtExceptionHandlerEnabled = crashHandlerEnabled)
         )
         crashDataSource = CrashDataSourceImpl(
             sessionPropertiesService,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/webview/EmbraceWebViewServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/webview/EmbraceWebViewServiceTest.kt
@@ -5,12 +5,9 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
-import io.embrace.android.embracesdk.fakes.createWebViewVitalsBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeWebViewVitalsBehavior
 import io.embrace.android.embracesdk.internal.TypeUtils
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.WebViewVitals
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.WebVital
 import io.embrace.android.embracesdk.internal.payload.WebVitalType
@@ -40,17 +37,15 @@ internal class EmbraceWebViewServiceTest {
     private lateinit var serializer: EmbraceSerializer
     private lateinit var writer: FakeCurrentSessionSpan
     private lateinit var openTelemetryModule: FakeOpenTelemetryModule
-    private lateinit var configService: ConfigService
+    private lateinit var configService: FakeConfigService
     private lateinit var embraceWebViewService: EmbraceWebViewService
-    private var cfg: RemoteConfig? = RemoteConfig()
 
     @Before
     fun setup() {
         serializer = EmbraceSerializer()
         writer = FakeCurrentSessionSpan()
         openTelemetryModule = FakeOpenTelemetryModule(writer)
-        cfg = RemoteConfig(webViewVitals = WebViewVitals(100f, 50))
-        configService = FakeConfigService(webViewVitalsBehavior = createWebViewVitalsBehavior { cfg })
+        configService = FakeConfigService(webViewVitalsBehavior = FakeWebViewVitalsBehavior(50, true))
         embraceWebViewService = EmbraceWebViewService(
             configService,
             serializer,
@@ -180,14 +175,14 @@ internal class EmbraceWebViewServiceTest {
 
     @Test
     fun `test limit collect web vital by maxVitals remote config`() {
-        cfg = RemoteConfig(webViewVitals = WebViewVitals(100f, 1))
+        configService.webViewVitalsBehavior = FakeWebViewVitalsBehavior(1, true)
 
         embraceWebViewService.collectWebData("webViewMock", expectedCompleteData)
         embraceWebViewService.collectWebData("webViewMock", expectedCompleteData2)
         Assert.assertEquals(1, writer.addedEvents.size)
 
         // same but bigger max vitals limit
-        cfg = RemoteConfig(webViewVitals = WebViewVitals(100f, 10))
+        configService.webViewVitalsBehavior = FakeWebViewVitalsBehavior(10, true)
 
         embraceWebViewService.collectWebData("webViewMock", expectedCompleteData)
         embraceWebViewService.collectWebData("webViewMock", expectedCompleteData2)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/AnrModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/AnrModuleImplTest.kt
@@ -3,13 +3,10 @@ package io.embrace.android.embracesdk.internal.injection
 import android.os.Looper
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.anr.NoOpAnrService
-import io.embrace.android.embracesdk.internal.config.local.AutomaticDataCaptureLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -42,25 +39,13 @@ internal class AnrModuleImplTest {
     fun testBehaviorDisabled() {
         val module = AnrModuleImpl(
             FakeInitModule(),
-            createConfigServiceWithAnrDisabled(),
+            FakeConfigService(
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(anrServiceEnabled = false)
+            ),
             FakeWorkerThreadModule(),
             FakeOpenTelemetryModule()
         )
         assertTrue(module.anrService is NoOpAnrService)
         assertNotNull(module.anrOtelMapper)
     }
-
-    private fun createConfigServiceWithAnrDisabled() = FakeConfigService(
-        autoDataCaptureBehavior = createAutoDataCaptureBehavior(localCfg = {
-            LocalConfig(
-                "",
-                false,
-                SdkLocalConfig(
-                    automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(
-                        anrServiceEnabled = false
-                    )
-                )
-            )
-        })
-    )
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/CrashModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/CrashModuleImplTest.kt
@@ -3,21 +3,17 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 internal class CrashModuleImplTest {
 
-    private val autoDataCaptureBehaviorWithNdkEnabled = createAutoDataCaptureBehavior(
-        localCfg = { LocalConfig(appId = "xYxYx", ndkEnabled = true, sdkConfig = SdkLocalConfig()) }
-    )
+    private val autoDataCaptureBehaviorWithNdkEnabled = FakeAutoDataCaptureBehavior(ndkEnabled = true)
 
     @Test
     fun testDefaultImplementations() {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
@@ -3,11 +3,9 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeFeatureModule
 import io.embrace.android.embracesdk.fakes.FakeVersionChecker
-import io.embrace.android.embracesdk.fakes.createAnrBehavior
-import io.embrace.android.embracesdk.fakes.createSdkModeBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
-import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
@@ -21,7 +19,9 @@ internal class DataCaptureServiceModuleImplTest {
         val module = DataCaptureServiceModuleImpl(
             initModule,
             openTelemetryModule,
-            createEnabledBehavior(),
+            FakeConfigService(
+                anrBehavior = FakeAnrBehavior(strictModeListenerEnabled = true)
+            ),
             FakeWorkerThreadModule(),
             FakeVersionChecker(false),
             FakeFeatureModule()
@@ -32,14 +32,5 @@ internal class DataCaptureServiceModuleImplTest {
         assertNotNull(module.appStartupDataCollector)
         assertNotNull(module.pushNotificationService)
         assertNotNull(module.startupService)
-    }
-
-    private fun createEnabledBehavior(): FakeConfigService {
-        return FakeConfigService(
-            anrBehavior = createAnrBehavior { AnrRemoteConfig(pctStrictModeListenerEnabled = 100f) },
-            sdkModeBehavior = createSdkModeBehavior(
-                isDebug = true
-            )
-        )
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -9,10 +9,9 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.createNetworkBehavior
-import io.embrace.android.embracesdk.fakes.createNetworkSpanForwardingBehavior
-import io.embrace.android.embracesdk.fakes.createSdkModeBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
@@ -21,9 +20,7 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.local.LocalConfig
 import io.embrace.android.embracesdk.internal.config.local.NetworkLocalConfig
 import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.internal.config.remote.DataRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.internal.injection.AnrModule
@@ -159,25 +156,12 @@ internal class IntegrationTestRule(
         val overriddenWorkerThreadModule: WorkerThreadModule = createWorkerThreadModule(overriddenInitModule),
         val overriddenConfigService: FakeConfigService = FakeConfigService(
             backgroundActivityCaptureEnabled = true,
-            sdkModeBehavior = createSdkModeBehavior(
-                isDebug = overriddenCoreModule.isDebug,
-                localCfg = { DEFAULT_LOCAL_CONFIG }
-            ),
             networkBehavior = createNetworkBehavior(
                 localCfg = { DEFAULT_SDK_LOCAL_CONFIG },
                 remoteCfg = { DEFAULT_SDK_REMOTE_CONFIG }
             ),
-            networkSpanForwardingBehavior = createNetworkSpanForwardingBehavior {
-                NetworkSpanForwardingRemoteConfig(pctEnabled = 100.0f)
-            },
-            autoDataCaptureBehavior = createAutoDataCaptureBehavior(
-                remoteCfg = {
-                    DEFAULT_SDK_REMOTE_CONFIG.copy(
-                        // disable thermal status capture as it interferes with unit tests
-                        dataConfig = DataRemoteConfig(pctThermalStatusEnabled = 0.0f)
-                    )
-                }
-            )
+            networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior(true),
+            autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(thermalStatusCaptureEnabled = false)
         ),
         val overriddenAndroidServicesModule: AndroidServicesModule = createAndroidServicesModule(
             initModule = overriddenInitModule,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/ThermalStateTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/ThermalStateTest.kt
@@ -4,14 +4,11 @@ import android.os.Build
 import android.os.PowerManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.createSdkModeBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.findSpanSnapshotsOfType
 import io.embrace.android.embracesdk.findSpansOfType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.config.remote.DataRemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
@@ -32,7 +29,8 @@ internal class ThermalStateFeatureTest {
 
     @Before
     fun setUp() {
-        setUpThermalCapture()
+        testRule.harness.overriddenConfigService.autoDataCaptureBehavior =
+            FakeAutoDataCaptureBehavior(thermalStatusCaptureEnabled = true)
     }
 
     @Test
@@ -54,7 +52,10 @@ internal class ThermalStateFeatureTest {
             val attrs = checkNotNull(snapshot.attributes)
             assertEquals("emb-thermal-state", snapshot.name)
             assertEquals("perf.thermal_state", attrs.findAttributeValue("emb.type"))
-            assertEquals(PowerManager.THERMAL_STATUS_NONE.toString(), attrs.findAttributeValue("status"))
+            assertEquals(
+                PowerManager.THERMAL_STATUS_NONE.toString(),
+                attrs.findAttributeValue("status")
+            )
             assertEquals(startTimeMs, snapshot.startTimeNanos?.nanosToMillis())
         }
     }
@@ -84,11 +85,17 @@ internal class ThermalStateFeatureTest {
                 assertEquals("perf.thermal_state", it.attributes?.findAttributeValue("emb.type"))
             }
             val firstSpan = spans.first()
-            assertEquals(PowerManager.THERMAL_STATUS_CRITICAL.toString(), firstSpan.attributes?.findAttributeValue("status"))
+            assertEquals(
+                PowerManager.THERMAL_STATUS_CRITICAL.toString(),
+                firstSpan.attributes?.findAttributeValue("status")
+            )
             assertEquals(startTimeMs, firstSpan.startTimeNanos?.nanosToMillis())
             assertEquals(startTimeMs + tickTimeMs, firstSpan.endTimeNanos?.nanosToMillis())
             val secondSpan = spans.last()
-            assertEquals(PowerManager.THERMAL_STATUS_MODERATE.toString(), secondSpan.attributes?.findAttributeValue("status"))
+            assertEquals(
+                PowerManager.THERMAL_STATUS_MODERATE.toString(),
+                secondSpan.attributes?.findAttributeValue("status")
+            )
             assertEquals(startTimeMs + tickTimeMs, secondSpan.startTimeNanos?.nanosToMillis())
             assertEquals(startTimeMs + tickTimeMs * 2, secondSpan.endTimeNanos?.nanosToMillis())
 
@@ -98,27 +105,12 @@ internal class ThermalStateFeatureTest {
             val snapshot = snapshots.single()
             assertEquals("emb-thermal-state", snapshot.name)
             assertEquals("perf.thermal_state", snapshot.attributes?.findAttributeValue("emb.type"))
-            assertEquals(PowerManager.THERMAL_STATUS_NONE.toString(), snapshot.attributes?.findAttributeValue("status"))
+            assertEquals(
+                PowerManager.THERMAL_STATUS_NONE.toString(),
+                snapshot.attributes?.findAttributeValue("status")
+            )
             assertEquals(startTimeMs + tickTimeMs * 2, snapshot.startTimeNanos?.nanosToMillis())
         }
     }
 
-    private fun setUpThermalCapture() {
-        testRule.harness.overriddenConfigService.autoDataCaptureBehavior =
-            createAutoDataCaptureBehavior(
-                remoteCfg = {
-                    RemoteConfig(
-                        dataConfig = DataRemoteConfig(pctThermalStatusEnabled = 100.0f)
-                    )
-                }
-            )
-        testRule.harness.overriddenConfigService.sdkModeBehavior =
-            createSdkModeBehavior(
-                remoteCfg = {
-                    RemoteConfig(
-                        pctBetaFeaturesEnabled = 100.0f
-                    )
-                }
-            )
-    }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/WebviewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/WebviewFeatureTest.kt
@@ -4,16 +4,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.moshi.Types
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.WebViewVitals
-import io.embrace.android.embracesdk.fakes.createWebViewVitalsBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeWebViewVitalsBehavior
 import io.embrace.android.embracesdk.findEventsOfType
 import io.embrace.android.embracesdk.findSessionSpan
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.WebVital
 import io.embrace.android.embracesdk.internal.payload.WebVitalType
+import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
 import io.opentelemetry.semconv.UrlAttributes.URL_FULL
 import org.junit.Assert.assertEquals
@@ -35,10 +33,7 @@ internal class WebviewFeatureTest {
 
     @Before
     fun setup() {
-        testRule.harness.overriddenConfigService.webViewVitalsBehavior =
-            createWebViewVitalsBehavior(remoteCfg = {
-                RemoteConfig(webViewVitals = WebViewVitals(100f, 50))
-            })
+        testRule.harness.overriddenConfigService.webViewVitalsBehavior = FakeWebViewVitalsBehavior(50, true)
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -2,13 +2,11 @@ package io.embrace.android.embracesdk.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
-import io.embrace.android.embracesdk.fakes.createSessionBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getSentSessions
-import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -55,9 +53,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when session control enabled does not end sessions`() {
         with(testRule) {
-            harness.overriddenConfigService.sessionBehavior = createSessionBehavior {
-                RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true))
-            }
+            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlEnabled = true)
             harness.recordSession {
                 harness.overriddenClock.tick(10000)
                 embrace.endSession()
@@ -70,9 +66,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when state session is below 5s has no effect`() {
         with(testRule) {
-            harness.overriddenConfigService.sessionBehavior = createSessionBehavior {
-                RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true))
-            }
+            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlEnabled = true)
             harness.recordSession {
                 harness.overriddenClock.tick(1000) // not enough to trigger new session
                 embrace.endSession()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace.AppFramework
 import io.embrace.android.embracesdk.Embrace.LastRunEndState
 import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.createNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.recordSession
@@ -36,10 +37,7 @@ internal class PublicApiTest {
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
         IntegrationTestRule.Harness(startImmediately = false).apply {
-            overriddenConfigService.networkSpanForwardingBehavior =
-                createNetworkSpanForwardingBehavior {
-                    NetworkSpanForwardingRemoteConfig(100f)
-                }
+            overriddenConfigService.networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior(true)
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
@@ -13,15 +13,11 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureService
-import io.embrace.android.embracesdk.fakes.createAnrBehavior
-import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.createNetworkSpanForwardingBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.api.delegate.EmbraceInternalInterfaceImpl
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
@@ -216,25 +212,23 @@ internal class EmbraceInternalInterfaceImplTest {
     @Test
     fun `check isNetworkSpanForwardingEnabled`() {
         assertFalse(internalImpl.isNetworkSpanForwardingEnabled())
-        fakeConfigService.networkSpanForwardingBehavior =
-            createNetworkSpanForwardingBehavior(remoteConfig = { NetworkSpanForwardingRemoteConfig(pctEnabled = 100.0f) })
+        fakeConfigService.networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior(true)
         assertTrue(internalImpl.isNetworkSpanForwardingEnabled())
     }
 
     @Test
     fun `check isAnrCaptureEnabled`() {
         assertTrue(internalImpl.isAnrCaptureEnabled())
-        fakeConfigService.anrBehavior = createAnrBehavior(remoteCfg = { AnrRemoteConfig(pctEnabled = 0) })
+        fakeConfigService.anrBehavior = FakeAnrBehavior(anrCaptureEnabled = false)
         assertFalse(internalImpl.isAnrCaptureEnabled())
-        fakeConfigService.anrBehavior = createAnrBehavior(remoteCfg = { AnrRemoteConfig(pctEnabled = 100) })
+        fakeConfigService.anrBehavior = FakeAnrBehavior(anrCaptureEnabled = true)
         assertTrue(internalImpl.isAnrCaptureEnabled())
     }
 
     @Test
     fun `check isNdkEnabled`() {
         assertFalse(internalImpl.isNdkEnabled())
-        fakeConfigService.autoDataCaptureBehavior =
-            createAutoDataCaptureBehavior(localCfg = { LocalConfig("abcde", true, SdkLocalConfig()) })
+        fakeConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(ndkEnabled = true)
         assertTrue(internalImpl.isNdkEnabled())
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
@@ -7,9 +7,8 @@ import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
-import io.embrace.android.embracesdk.fakes.createNetworkSpanForwardingBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
-import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
@@ -64,9 +63,7 @@ internal class NetworkRequestApiDelegateTest {
 
     @Test
     fun testGenerateW3cTraceparentEnabled() {
-        configService.networkSpanForwardingBehavior = createNetworkSpanForwardingBehavior {
-            NetworkSpanForwardingRemoteConfig(100f)
-        }
+        configService.networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior(true)
         assertNotNull(delegate.generateW3cTraceparent())
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -119,11 +119,10 @@ fun createDataCaptureEventBehavior(
  * A [SdkModeBehaviorImpl] that returns default values.
  */
 fun createSdkModeBehavior(
-    isDebug: Boolean = false,
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     localCfg: Provider<LocalConfig?> = { null },
     remoteCfg: Provider<RemoteConfig?> = { null }
-): SdkModeBehavior = SdkModeBehaviorImpl(isDebug, thresholdCheck, localCfg, remoteCfg)
+): SdkModeBehavior = SdkModeBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
 
 /**
  * A [SdkModeBehaviorImpl] that returns default values.

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAnrBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAnrBehavior.kt
@@ -1,0 +1,49 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.AnrBehavior
+import io.embrace.android.embracesdk.internal.config.remote.AllowedNdkSampleMethod
+import io.embrace.android.embracesdk.internal.config.remote.Unwinder
+import java.util.regex.Pattern
+
+class FakeAnrBehavior(
+    var strictModeListenerEnabled: Boolean = false,
+    var nativeThreadAnrSamplingEnabled: Boolean = false,
+    var idleHandlerEnabled: Boolean = false,
+    var anrCaptureEnabled: Boolean = true,
+    var googleAnrCaptureEnabled: Boolean = false,
+    var bgAnrCaptureEnabled: Boolean = false,
+    var nativeThreadAnrSamplingAllowlistIgnored: Boolean = true,
+    var monitorThreadPriorityImpl: Int = 5,
+    var sampleIntervalMsImpl: Long = 5,
+    var anrPerSessionImpl: Int = 5,
+    override val allowPatternList: List<Pattern> = emptyList(),
+    override val blockPatternList: List<Pattern> = emptyList(),
+    var nativeThreadAnrSamplingAllowlistImpl: List<AllowedNdkSampleMethod> = emptyList(),
+) : AnrBehavior {
+
+    override fun isGoogleAnrCaptureEnabled(): Boolean = googleAnrCaptureEnabled
+    override fun isAnrCaptureEnabled(): Boolean = anrCaptureEnabled
+    override fun isAnrProcessErrorsCaptureEnabled(): Boolean = false
+    override fun getMonitorThreadPriority(): Int = monitorThreadPriorityImpl
+    override fun isBgAnrCaptureEnabled(): Boolean = bgAnrCaptureEnabled
+    override fun getSamplingIntervalMs(): Long = sampleIntervalMsImpl
+    override fun getAnrProcessErrorsIntervalMs(): Long = 100
+    override fun getAnrProcessErrorsDelayMs(): Long = 0
+    override fun getAnrProcessErrorsSchedulerExtraTimeAllowanceMs(): Long = 100
+    override fun getMaxStacktracesPerInterval(): Int = 80
+    override fun getStacktraceFrameLimit(): Int = 256
+    override fun getMaxAnrIntervalsPerSession(): Int = anrPerSessionImpl
+    override fun getMinThreadPriority(): Int = 6
+    override fun getMinDuration(): Int = 1000
+    override fun shouldCaptureMainThreadOnly(): Boolean = true
+    override fun getNativeThreadAnrSamplingFactor(): Int = 10
+    override fun getNativeThreadAnrSamplingUnwinder(): Unwinder = Unwinder.LIBUNWIND
+    override fun isNativeThreadAnrSamplingEnabled(): Boolean = nativeThreadAnrSamplingEnabled
+    override fun isNativeThreadAnrSamplingOffsetEnabled(): Boolean = false
+    override fun isIdleHandlerEnabled(): Boolean = idleHandlerEnabled
+    override fun isStrictModeListenerEnabled(): Boolean = strictModeListenerEnabled
+    override fun getStrictModeViolationLimit(): Int = 10
+    override fun isNativeThreadAnrSamplingAllowlistIgnored(): Boolean = nativeThreadAnrSamplingAllowlistIgnored
+    override fun getNativeThreadAnrSamplingAllowlist(): List<AllowedNdkSampleMethod> = nativeThreadAnrSamplingAllowlistImpl
+    override fun getNativeThreadAnrSamplingIntervalMs(): Long = 1000
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAppExitInfoBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAppExitInfoBehavior.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.AppExitInfoBehavior
+
+class FakeAppExitInfoBehavior(
+    private val traceMaxLimit: Int = 20000000,
+    private val enabled: Boolean = true,
+    private val appExitInfoMaxNum: Int = 0
+) : AppExitInfoBehavior {
+
+    override fun getTraceMaxLimit(): Int = traceMaxLimit
+    override fun isEnabled(): Boolean = enabled
+    override fun appExitInfoMaxNum(): Int = appExitInfoMaxNum
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -1,0 +1,28 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.AutoDataCaptureBehavior
+
+class FakeAutoDataCaptureBehavior(
+    private val memoryServiceEnabled: Boolean = true,
+    private val thermalStatusCaptureEnabled: Boolean = true,
+    private val powerSaveModeServiceEnabled: Boolean = true,
+    private val networkConnectivityServiceEnabled: Boolean = true,
+    private val anrServiceEnabled: Boolean = true,
+    private val uncaughtExceptionHandlerEnabled: Boolean = true,
+    private val composeOnClickEnabled: Boolean = true,
+    private val sigHandlerDetectionEnabled: Boolean = true,
+    private val ndkEnabled: Boolean = false,
+    private val diskUsageReportingEnabled: Boolean = true
+) : AutoDataCaptureBehavior {
+
+    override fun isMemoryServiceEnabled(): Boolean = memoryServiceEnabled
+    override fun isThermalStatusCaptureEnabled(): Boolean = thermalStatusCaptureEnabled
+    override fun isPowerSaveModeServiceEnabled(): Boolean = powerSaveModeServiceEnabled
+    override fun isNetworkConnectivityServiceEnabled(): Boolean = networkConnectivityServiceEnabled
+    override fun isAnrServiceEnabled(): Boolean = anrServiceEnabled
+    override fun isUncaughtExceptionHandlerEnabled(): Boolean = uncaughtExceptionHandlerEnabled
+    override fun isComposeOnClickEnabled(): Boolean = composeOnClickEnabled
+    override fun isSigHandlerDetectionEnabled(): Boolean = sigHandlerDetectionEnabled
+    override fun isNdkEnabled(): Boolean = ndkEnabled
+    override fun isDiskUsageReportingEnabled(): Boolean = diskUsageReportingEnabled
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeLogMessageBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeLogMessageBehavior.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehavior
+
+class FakeLogMessageBehavior(
+    private val logMessageMaximumAllowedLength: Int = 128,
+    private val infoLogLimit: Int = 100,
+    private val warnLogLimit: Int = 100,
+    private val errorLogLimit: Int = 100
+) : LogMessageBehavior {
+
+    override fun getLogMessageMaximumAllowedLength(): Int = logMessageMaximumAllowedLength
+    override fun getInfoLogLimit(): Int = infoLogLimit
+    override fun getWarnLogLimit(): Int = warnLogLimit
+    override fun getErrorLogLimit(): Int = errorLogLimit
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkSpanForwardingBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkSpanForwardingBehavior.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
+
+class FakeNetworkSpanForwardingBehavior(
+    private val networkSpanForwardingEnabled: Boolean = false
+) : NetworkSpanForwardingBehavior {
+
+    override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwardingEnabled
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSessionBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSessionBehavior.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
+
+class FakeSessionBehavior(
+    private val maxSessionProperties: Int = 100,
+    private val sessionControlEnabled: Boolean = false
+) : SessionBehavior {
+
+    override fun getFullSessionEvents(): Set<String> = emptySet()
+    override fun getSessionComponents(): Set<String>? = null
+    override fun isGatingFeatureEnabled(): Boolean = false
+    override fun isSessionControlEnabled(): Boolean = sessionControlEnabled
+    override fun getMaxSessionProperties(): Int = maxSessionProperties
+    override fun shouldGateMoment(): Boolean = false
+    override fun shouldGateInfoLog(): Boolean = false
+    override fun shouldGateWarnLog(): Boolean = false
+    override fun shouldGateStartupMoment(): Boolean = false
+    override fun shouldSendFullForCrash(): Boolean = false
+    override fun shouldSendFullForErrorLog(): Boolean = false
+    override fun shouldGateSessionProperties(): Boolean = false
+    override fun shouldGateLogProperties(): Boolean = false
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeStartupBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeStartupBehavior.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
+
+class FakeStartupBehavior(
+    private val automaticEndEnabled: Boolean = true
+) : StartupBehavior {
+
+    override fun isAutomaticEndEnabled(): Boolean = automaticEndEnabled
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeWebViewVitalsBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeWebViewVitalsBehavior.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehavior
+
+class FakeWebViewVitalsBehavior(
+    private val maxWebViewVitals: Int = 100,
+    private val webViewVitalsEnabled: Boolean = true
+) : WebViewVitalsBehavior {
+
+    override fun getMaxWebViewVitals(): Int = maxWebViewVitals
+    override fun isWebViewVitalsEnabled(): Boolean = webViewVitalsEnabled
+}


### PR DESCRIPTION
## Goal

Test code is quite often constructing a real instance of the behavior implementations, when in the majority of cases the test only wants to disable/enable a feature or tweak one setting. I've gone through our test code & created fakes that will make it easier. Where tests are genuinely testing the existing config implementation I've left things as is.

