### PR TITLE
Rename config functions

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -73,7 +73,7 @@ internal class EmbraceMetadataService(
                 }
             }
             val free = statFs.freeBytes
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && configService.autoDataCaptureBehavior.isDiskUsageReportingEnabled()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && configService.autoDataCaptureBehavior.isDiskUsageCaptureEnabled()) {
                 val deviceDiskAppUsage = getDeviceDiskAppUsage(
                     storageStatsManager.value,
                     context.packageManager,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -259,7 +259,7 @@ internal class EmbraceConfigService(
     private fun persistConfig() {
         // TODO: future get rid of these prefs from PrefService entirely?
         preferencesService.sdkDisabled = sdkModeBehavior.isSdkDisabled()
-        preferencesService.backgroundActivityEnabled = backgroundActivityBehavior.isEnabled()
+        preferencesService.backgroundActivityEnabled = backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
     }
 
     // TODO: future extract these out to SdkBehavior interface
@@ -320,7 +320,7 @@ internal class EmbraceConfigService(
 
     override fun hasValidRemoteConfig(): Boolean = !configRequiresRefresh()
     override fun isAppExitInfoCaptureEnabled(): Boolean {
-        return appExitInfoBehavior.isEnabled()
+        return appExitInfoBehavior.isAeiCaptureEnabled()
     }
 
     private companion object {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AnrBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AnrBehavior.kt
@@ -7,9 +7,9 @@ import java.util.regex.Pattern
 interface AnrBehavior {
 
     /**
-     * Control whether Google ANR capture is enabled.
+     * Control whether SIGQUIT capture is enabled.
      */
-    fun isGoogleAnrCaptureEnabled(): Boolean
+    fun isSigquitCaptureEnabled(): Boolean
 
     /**
      * Allow listed threads by pattern
@@ -106,9 +106,9 @@ interface AnrBehavior {
     fun getNativeThreadAnrSamplingUnwinder(): Unwinder
 
     /**
-     * Whether native thread ANR sampling is enabled
+     * Whether Unity ANR capture is enabled
      */
-    fun isNativeThreadAnrSamplingEnabled(): Boolean
+    fun isUnityAnrCaptureEnabled(): Boolean
 
     /**
      * Whether offsets are enabled for native thread ANR stacktrace sampling.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImpl.kt
@@ -50,7 +50,7 @@ class AnrBehaviorImpl(
             android.os.Process.THREAD_PRIORITY_DEFAULT
     }
 
-    override fun isGoogleAnrCaptureEnabled(): Boolean {
+    override fun isSigquitCaptureEnabled(): Boolean {
         return thresholdCheck.isBehaviorEnabled(remote?.googlePctEnabled)
             ?: local?.captureGoogle
             ?: CAPTURE_GOOGLE_DEFAULT
@@ -125,7 +125,7 @@ class AnrBehaviorImpl(
         }.getOrDefault(Unwinder.LIBUNWIND)
     }
 
-    override fun isNativeThreadAnrSamplingEnabled(): Boolean {
+    override fun isUnityAnrCaptureEnabled(): Boolean {
         return thresholdCheck.isBehaviorEnabled(remote?.pctNativeThreadAnrSamplingEnabled)
             ?: local?.captureUnityThread
             ?: DEFAULT_NATIVE_THREAD_ANR_SAMPLING_ENABLED

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehavior.kt
@@ -7,7 +7,7 @@ interface AppExitInfoBehavior {
     /**
      * Whether the feature is enabled or not.
      */
-    fun isEnabled(): Boolean
+    fun isAeiCaptureEnabled(): Boolean
 
     fun appExitInfoMaxNum(): Int
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImpl.kt
@@ -31,7 +31,7 @@ class AppExitInfoBehaviorImpl(
             ?: local?.appExitInfoTracesLimit
             ?: MAX_TRACE_SIZE_BYTES
 
-    override fun isEnabled(): Boolean {
+    override fun isAeiCaptureEnabled(): Boolean {
         return thresholdCheck.isBehaviorEnabled(remote?.appExitInfoConfig?.pctAeiCaptureEnabled)
             ?: local?.aeiCaptureEnabled
             ?: AEI_ENABLED_DEFAULT

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
@@ -6,7 +6,7 @@ interface AutoDataCaptureBehavior {
      * Returns true if [io.embrace.android.embracesdk.MemoryService] should
      * automatically capture data.
      */
-    fun isMemoryServiceEnabled(): Boolean
+    fun isMemoryWarningCaptureEnabled(): Boolean
 
     /**
      * Returns true if SDK should automatically capture thermal status data
@@ -17,43 +17,43 @@ interface AutoDataCaptureBehavior {
      * Returns true if [io.embrace.android.embracesdk.PowerSaveModeService] should
      * automatically capture data.
      */
-    fun isPowerSaveModeServiceEnabled(): Boolean
+    fun isPowerSaveModeCaptureEnabled(): Boolean
 
     /**
      * Returns true if [io.embrace.android.embracesdk.NetworkConnectivityService] should
      * automatically capture data.
      */
-    fun isNetworkConnectivityServiceEnabled(): Boolean
+    fun isNetworkConnectivityCaptureEnabled(): Boolean
 
     /**
      * Returns true if [io.embrace.android.embracesdk.anr.AnrService] should
      * automatically capture data.
      */
-    fun isAnrServiceEnabled(): Boolean
+    fun isAnrCaptureEnabled(): Boolean
 
     /**
      * Control whether the Embrace SDK automatically attaches to the uncaught exception handler.
      */
-    fun isUncaughtExceptionHandlerEnabled(): Boolean
+    fun isJvmCrashCaptureEnabled(): Boolean
 
     /**
      * Whether Jetpack Compose click events should be captured
      */
-    fun isComposeOnClickEnabled(): Boolean
+    fun isComposeClickCaptureEnabled(): Boolean
 
     /**
      * Whether embrace should attempt to overwrite other signal handlers
      */
-    fun isSigHandlerDetectionEnabled(): Boolean
+    fun is3rdPartySigHandlerDetectionEnabled(): Boolean
 
     /**
      * Whether NDK error capture is enabled
      */
-    fun isNdkEnabled(): Boolean
+    fun isNativeCrashCaptureEnabled(): Boolean
 
     /**
      * Control whether we scan for and report app disk usage. This can be a costly operation
      * for apps with a lot of local files.
      */
-    fun isDiskUsageReportingEnabled(): Boolean
+    fun isDiskUsageCaptureEnabled(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -29,7 +29,7 @@ class AutoDataCaptureBehaviorImpl(
         const val REPORT_DISK_USAGE_DEFAULT = true
     }
 
-    override fun isMemoryServiceEnabled(): Boolean {
+    override fun isMemoryWarningCaptureEnabled(): Boolean {
         return local?.sdkConfig?.automaticDataCaptureConfig?.memoryServiceEnabled
             ?: MEMORY_SERVICE_ENABLED_DEFAULT
     }
@@ -39,25 +39,25 @@ class AutoDataCaptureBehaviorImpl(
             ?: THERMAL_STATUS_ENABLED_DEFAULT
     }
 
-    override fun isPowerSaveModeServiceEnabled(): Boolean {
+    override fun isPowerSaveModeCaptureEnabled(): Boolean {
         return local?.sdkConfig?.automaticDataCaptureConfig?.powerSaveModeServiceEnabled
             ?: POWER_SAVE_MODE_SERVICE_ENABLED_DEFAULT
     }
 
-    override fun isNetworkConnectivityServiceEnabled(): Boolean {
+    override fun isNetworkConnectivityCaptureEnabled(): Boolean {
         return local?.sdkConfig?.automaticDataCaptureConfig?.networkConnectivityServiceEnabled
             ?: NETWORK_CONNECTIVITY_SERVICE_ENABLED_DEFAULT
     }
 
-    override fun isAnrServiceEnabled(): Boolean {
+    override fun isAnrCaptureEnabled(): Boolean {
         return local?.sdkConfig?.automaticDataCaptureConfig?.anrServiceEnabled
             ?: ANR_SERVICE_ENABLED_DEFAULT
     }
 
-    override fun isUncaughtExceptionHandlerEnabled(): Boolean =
+    override fun isJvmCrashCaptureEnabled(): Boolean =
         local?.sdkConfig?.crashHandler?.enabled ?: CRASH_HANDLER_ENABLED_DEFAULT
 
-    override fun isComposeOnClickEnabled(): Boolean {
+    override fun isComposeClickCaptureEnabled(): Boolean {
         return when (remote?.killSwitchConfig?.jetpackCompose) {
             null, true -> {
                 // no remote: use local
@@ -71,13 +71,13 @@ class AutoDataCaptureBehaviorImpl(
         }
     }
 
-    override fun isSigHandlerDetectionEnabled(): Boolean {
+    override fun is3rdPartySigHandlerDetectionEnabled(): Boolean {
         return remote?.killSwitchConfig?.sigHandlerDetection
             ?: local?.sdkConfig?.sigHandlerDetection ?: true
     }
 
-    override fun isNdkEnabled(): Boolean = local?.ndkEnabled ?: false
+    override fun isNativeCrashCaptureEnabled(): Boolean = local?.ndkEnabled ?: false
 
-    override fun isDiskUsageReportingEnabled(): Boolean =
+    override fun isDiskUsageCaptureEnabled(): Boolean =
         local?.sdkConfig?.app?.reportDiskUsage ?: REPORT_DISK_USAGE_DEFAULT
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehavior.kt
@@ -5,7 +5,7 @@ interface BackgroundActivityBehavior {
     /**
      * Whether the feature is enabled or not.
      */
-    fun isEnabled(): Boolean
+    fun isBackgroundActivityCaptureEnabled(): Boolean
 
     /**
      * Specify a maximum number of client defined background activities.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImpl.kt
@@ -24,7 +24,7 @@ class BackgroundActivityBehaviorImpl(
         const val MAX_CACHED_ACTIVITIES_DEFAULT = 30
     }
 
-    override fun isEnabled(): Boolean {
+    override fun isBackgroundActivityCaptureEnabled(): Boolean {
         return remote?.threshold?.let(thresholdCheck::isBehaviorEnabled)
             ?: local?.backgroundActivityCaptureEnabled
             ?: BACKGROUND_ACTIVITY_CAPTURE_ENABLED_DEFAULT

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehavior.kt
@@ -11,12 +11,12 @@ interface BreadcrumbBehavior {
     /**
      * Controls whether tap coordinates are captured in breadcrumbs
      */
-    fun isTapCoordinateCaptureEnabled(): Boolean
+    fun isViewClickCoordinateCaptureEnabled(): Boolean
 
     /**
      * Controls whether activity lifecycle changes are captured in breadcrumbs
      */
-    fun isAutomaticActivityCaptureEnabled(): Boolean
+    fun isActivityBreadcrumbCaptureEnabled(): Boolean
 
     /**
      * Controls whether webviews are captured.
@@ -26,7 +26,7 @@ interface BreadcrumbBehavior {
     /**
      * Control whether query params for webviews are captured.
      */
-    fun isQueryParamCaptureEnabled(): Boolean
+    fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean
 
-    fun isCaptureFcmPiiDataEnabled(): Boolean
+    fun isFcmPiiDataCaptureEnabled(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImpl.kt
@@ -36,20 +36,20 @@ class BreadcrumbBehaviorImpl(
     override fun getViewBreadcrumbLimit(): Int = remote?.uiConfig?.views ?: DEFAULT_BREADCRUMB_LIMIT
     override fun getWebViewBreadcrumbLimit(): Int = remote?.uiConfig?.webViews ?: DEFAULT_BREADCRUMB_LIMIT
 
-    override fun isTapCoordinateCaptureEnabled(): Boolean =
+    override fun isViewClickCoordinateCaptureEnabled(): Boolean =
         local?.taps?.captureCoordinates ?: CAPTURE_TAP_COORDINATES_DEFAULT
 
-    override fun isAutomaticActivityCaptureEnabled(): Boolean =
+    override fun isActivityBreadcrumbCaptureEnabled(): Boolean =
         local?.viewConfig?.enableAutomaticActivityCapture
             ?: ENABLE_AUTOMATIC_ACTIVITY_CAPTURE_DEFAULT
 
     override fun isWebViewBreadcrumbCaptureEnabled(): Boolean =
         local?.webViewConfig?.captureWebViews ?: WEB_VIEW_CAPTURE_DEFAULT
 
-    override fun isQueryParamCaptureEnabled(): Boolean =
+    override fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean =
         local?.webViewConfig?.captureQueryParams ?: WEB_VIEW_QUERY_PARAMS_CAPTURE_DEFAULT
 
-    override fun isCaptureFcmPiiDataEnabled(): Boolean {
+    override fun isFcmPiiDataCaptureEnabled(): Boolean {
         return try {
             local?.captureFcmPiiData ?: false
         } catch (ex: Exception) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehavior.kt
@@ -17,7 +17,7 @@ interface NetworkBehavior {
     /**
      * Enable the native monitoring.
      */
-    fun isNativeNetworkingMonitoringEnabled(): Boolean
+    fun isHttpUrlConnectionCaptureEnabled(): Boolean
 
     /**
      * Map of limits being enforced for each domain suffix for the maximum number of requests that are logged given that suffix. The
@@ -28,12 +28,12 @@ interface NetworkBehavior {
      * - For suffixes with only a local entry, apply the local limit or the ceiling defined by the default limit on the remote,
      *   which ever is smaller.
      */
-    fun getNetworkCallLimitsPerDomainSuffix(): Map<String, Int>
+    fun getLimitsByDomain(): Map<String, Int>
 
     /**
      * Gets the default limit for network calls for all domains where the limit is not specified.
      */
-    fun getNetworkCaptureLimit(): Int
+    fun getRequestLimitPerDomain(): Int
 
     /**
      * Checks if the url is allowed to be reported based on the specified disabled pattern.
@@ -51,7 +51,7 @@ interface NetworkBehavior {
     /**
      * Supplies the public key used for network capture
      */
-    fun getCapturePublicKey(): String?
+    fun getNetworkBodyCapturePublicKey(): String?
 
     /**
      * Gets the rules for capturing network call bodies

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
@@ -54,10 +54,10 @@ class NetworkBehaviorImpl(
     override fun isRequestContentLengthCaptureEnabled(): Boolean =
         local?.networking?.captureRequestContentLength ?: CAPTURE_REQUEST_CONTENT_LENGTH
 
-    override fun isNativeNetworkingMonitoringEnabled(): Boolean =
+    override fun isHttpUrlConnectionCaptureEnabled(): Boolean =
         local?.networking?.enableNativeMonitoring ?: ENABLE_NATIVE_MONITORING_DEFAULT
 
-    override fun getNetworkCallLimitsPerDomainSuffix(): Map<String, Int> {
+    override fun getLimitsByDomain(): Map<String, Int> {
         val limitCeiling = getLimitCeiling()
         val domainSuffixLimits: MutableMap<String, Int> = remote?.networkConfig?.domainLimits?.toMutableMap() ?: mutableMapOf()
 
@@ -74,7 +74,7 @@ class NetworkBehaviorImpl(
         return domainSuffixLimits
     }
 
-    override fun getNetworkCaptureLimit(): Int {
+    override fun getRequestLimitPerDomain(): Int {
         val remoteDefault = getLimitCeiling()
         return min(remoteDefault, local?.networking?.defaultCaptureLimit ?: remoteDefault)
     }
@@ -88,9 +88,9 @@ class NetworkBehaviorImpl(
         return regexes.none { it.matcher(url).find() }
     }
 
-    override fun isCaptureBodyEncryptionEnabled(): Boolean = getCapturePublicKey() != null
+    override fun isCaptureBodyEncryptionEnabled(): Boolean = getNetworkBodyCapturePublicKey() != null
 
-    override fun getCapturePublicKey(): String? {
+    override fun getNetworkBodyCapturePublicKey(): String? {
         var keyToClean = local?.capturePublicKey
         if (keyToClean != null) {
             for (dirty in dirtyKeyList) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/StartupBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/StartupBehavior.kt
@@ -5,5 +5,5 @@ interface StartupBehavior {
     /**
      * Controls whether the startup moment is automatically ended.
      */
-    fun isAutomaticEndEnabled(): Boolean
+    fun isStartupMomentAutoEndEnabled(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImpl.kt
@@ -19,5 +19,5 @@ class StartupBehaviorImpl(
         const val AUTOMATICALLY_END_DEFAULT = true
     }
 
-    override fun isAutomaticEndEnabled(): Boolean = local?.automaticallyEnd ?: AUTOMATICALLY_END_DEFAULT
+    override fun isStartupMomentAutoEndEnabled(): Boolean = local?.automaticallyEnd ?: AUTOMATICALLY_END_DEFAULT
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
@@ -91,7 +91,7 @@ internal class EmbraceEventService(
     override fun applicationStartupComplete() {
         if (processStartedByNotification) {
             activeEvents.remove(STARTUP_EVENT_NAME)
-        } else if (configService.startupBehavior.isAutomaticEndEnabled()) {
+        } else if (configService.startupBehavior.isStartupMomentAutoEndEnabled()) {
             endEvent(STARTUP_EVENT_NAME)
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceDomainCountLimiter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceDomainCountLimiter.kt
@@ -17,8 +17,8 @@ internal class EmbraceDomainCountLimiter(
     private val callsPerDomainSuffix = ConcurrentHashMap<String, DomainCount>()
     private val ipAddressNetworkCallCount = AtomicInteger(0)
     private val untrackedNetworkCallCount = AtomicInteger(0)
-    private var defaultPerDomainSuffixCallLimit = configService.networkBehavior.getNetworkCaptureLimit()
-    private var domainSuffixCallLimits = configService.networkBehavior.getNetworkCallLimitsPerDomainSuffix()
+    private var defaultPerDomainSuffixCallLimit = configService.networkBehavior.getRequestLimitPerDomain()
+    private var domainSuffixCallLimits = configService.networkBehavior.getLimitsByDomain()
 
     private val lock = Any()
 
@@ -80,8 +80,8 @@ internal class EmbraceDomainCountLimiter(
         synchronized(lock) {
             clearNetworkCalls()
             // re-fetch limits in case they changed since they last time they were fetched
-            defaultPerDomainSuffixCallLimit = configService.networkBehavior.getNetworkCaptureLimit()
-            domainSuffixCallLimits = configService.networkBehavior.getNetworkCallLimitsPerDomainSuffix()
+            defaultPerDomainSuffixCallLimit = configService.networkBehavior.getRequestLimitPerDomain()
+            domainSuffixCallLimits = configService.networkBehavior.getLimitsByDomain()
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureService.kt
@@ -134,7 +134,7 @@ internal class EmbraceNetworkCaptureService(
     }
 
     private fun encryptNetworkCall(capturedNetworkCall: NetworkCapturedCall): String? {
-        val capturePublicKey = configService.networkBehavior.getCapturePublicKey() ?: return null
+        val capturePublicKey = configService.networkBehavior.getNetworkBodyCapturePublicKey() ?: return null
         return networkCaptureEncryptionManager.value.encrypt(
             serializer.toJson(capturedNetworkCall),
             capturePublicKey

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImplTest.kt
@@ -55,7 +55,7 @@ internal class AnrBehaviorImplTest {
     @Test
     fun testDefaults() {
         with(createAnrBehavior()) {
-            assertFalse(isGoogleAnrCaptureEnabled())
+            assertFalse(isSigquitCaptureEnabled())
             assertEquals(100L, getSamplingIntervalMs())
             assertTrue(shouldCaptureMainThreadOnly())
             assertEquals(25, getStrictModeViolationLimit())
@@ -73,7 +73,7 @@ internal class AnrBehaviorImplTest {
             assertFalse(isIdleHandlerEnabled())
             assertFalse(isStrictModeListenerEnabled())
             assertFalse(isBgAnrCaptureEnabled())
-            assertFalse(isNativeThreadAnrSamplingEnabled())
+            assertFalse(isUnityAnrCaptureEnabled())
             assertFalse(isAnrProcessErrorsCaptureEnabled())
             assertTrue(isAnrCaptureEnabled())
             assertEquals(Unwinder.LIBUNWIND, getNativeThreadAnrSamplingUnwinder())
@@ -92,15 +92,15 @@ internal class AnrBehaviorImplTest {
     @Test
     fun testLocalOnly() {
         with(createAnrBehavior(localCfg = { local })) {
-            assertTrue(isGoogleAnrCaptureEnabled())
-            assertTrue(isNativeThreadAnrSamplingEnabled())
+            assertTrue(isSigquitCaptureEnabled())
+            assertTrue(isUnityAnrCaptureEnabled())
         }
     }
 
     @Test
     fun testRemoteAndLocal() {
         with(createAnrBehavior(localCfg = { local }, remoteCfg = { remote })) {
-            assertFalse(isGoogleAnrCaptureEnabled())
+            assertFalse(isSigquitCaptureEnabled())
             assertEquals(200L, getSamplingIntervalMs())
             assertFalse(shouldCaptureMainThreadOnly())
             assertEquals(209, getStrictModeViolationLimit())
@@ -118,7 +118,7 @@ internal class AnrBehaviorImplTest {
             assertTrue(isIdleHandlerEnabled())
             assertTrue(isStrictModeListenerEnabled())
             assertTrue(isBgAnrCaptureEnabled())
-            assertTrue(isNativeThreadAnrSamplingEnabled())
+            assertTrue(isUnityAnrCaptureEnabled())
             assertTrue(isAnrProcessErrorsCaptureEnabled())
             assertFalse(isAnrCaptureEnabled())
             assertEquals(Unwinder.LIBUNWINDSTACK, getNativeThreadAnrSamplingUnwinder())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImplTest.kt
@@ -21,7 +21,7 @@ internal class AppExitInfoBehaviorImplTest {
     fun testDefaults() {
         with(createAppExitInfoBehavior()) {
             assertEquals(2097152, getTraceMaxLimit())
-            assertTrue(isEnabled())
+            assertTrue(isAeiCaptureEnabled())
         }
     }
 
@@ -29,7 +29,7 @@ internal class AppExitInfoBehaviorImplTest {
     fun testLocalOnly() {
         with(createAppExitInfoBehavior(localCfg = { local })) {
             assertEquals(33792, getTraceMaxLimit())
-            assertFalse(isEnabled())
+            assertFalse(isAeiCaptureEnabled())
         }
     }
 
@@ -37,7 +37,7 @@ internal class AppExitInfoBehaviorImplTest {
     fun testLocalAndRemote() {
         with(createAppExitInfoBehavior(localCfg = { local }, remoteCfg = { remote })) {
             assertEquals(55209, getTraceMaxLimit())
-            assertTrue(isEnabled())
+            assertTrue(isAeiCaptureEnabled())
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -43,15 +43,15 @@ internal class AutoDataCaptureBehaviorImplTest {
     @Test
     fun testDefaults() {
         with(createAutoDataCaptureBehavior()) {
-            assertTrue(isMemoryServiceEnabled())
-            assertTrue(isPowerSaveModeServiceEnabled())
-            assertTrue(isNetworkConnectivityServiceEnabled())
-            assertTrue(isAnrServiceEnabled())
-            assertTrue(isUncaughtExceptionHandlerEnabled())
-            assertFalse(isComposeOnClickEnabled())
-            assertTrue(isSigHandlerDetectionEnabled())
-            assertFalse(isNdkEnabled())
-            assertTrue(isDiskUsageReportingEnabled())
+            assertTrue(isMemoryWarningCaptureEnabled())
+            assertTrue(isPowerSaveModeCaptureEnabled())
+            assertTrue(isNetworkConnectivityCaptureEnabled())
+            assertTrue(isAnrCaptureEnabled())
+            assertTrue(isJvmCrashCaptureEnabled())
+            assertFalse(isComposeClickCaptureEnabled())
+            assertTrue(is3rdPartySigHandlerDetectionEnabled())
+            assertFalse(isNativeCrashCaptureEnabled())
+            assertTrue(isDiskUsageCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
         }
     }
@@ -59,23 +59,23 @@ internal class AutoDataCaptureBehaviorImplTest {
     @Test
     fun testLocalOnly() {
         with(createAutoDataCaptureBehavior(localCfg = { local })) {
-            assertFalse(isMemoryServiceEnabled())
-            assertFalse(isPowerSaveModeServiceEnabled())
-            assertFalse(isNetworkConnectivityServiceEnabled())
-            assertFalse(isAnrServiceEnabled())
-            assertFalse(isUncaughtExceptionHandlerEnabled())
-            assertTrue(isComposeOnClickEnabled())
-            assertTrue(isSigHandlerDetectionEnabled())
-            assertTrue(isNdkEnabled())
-            assertFalse(isDiskUsageReportingEnabled())
+            assertFalse(isMemoryWarningCaptureEnabled())
+            assertFalse(isPowerSaveModeCaptureEnabled())
+            assertFalse(isNetworkConnectivityCaptureEnabled())
+            assertFalse(isAnrCaptureEnabled())
+            assertFalse(isJvmCrashCaptureEnabled())
+            assertTrue(isComposeClickCaptureEnabled())
+            assertTrue(is3rdPartySigHandlerDetectionEnabled())
+            assertTrue(isNativeCrashCaptureEnabled())
+            assertFalse(isDiskUsageCaptureEnabled())
         }
     }
 
     @Test
     fun testLocalAndRemote() {
         with(createAutoDataCaptureBehavior(localCfg = { local }, remoteCfg = { remote })) {
-            assertFalse(isSigHandlerDetectionEnabled())
-            assertFalse(isComposeOnClickEnabled())
+            assertFalse(is3rdPartySigHandlerDetectionEnabled())
+            assertFalse(isComposeClickCaptureEnabled())
             assertFalse(isThermalStatusCaptureEnabled())
         }
     }
@@ -84,17 +84,17 @@ internal class AutoDataCaptureBehaviorImplTest {
     fun testJetpackCompose() {
         // Jetpack Compose is disabled by default
         with(createAutoDataCaptureBehavior()) {
-            assertFalse(isComposeOnClickEnabled())
+            assertFalse(isComposeClickCaptureEnabled())
         }
 
         // Jetpack Compose is enabled locally, no remote config
         with(createAutoDataCaptureBehavior(localCfg = { local })) {
-            assertTrue(isComposeOnClickEnabled())
+            assertTrue(isComposeClickCaptureEnabled())
         }
 
         // Jetpack Compose disabled remotely, overrides local: killswitch
         with(createAutoDataCaptureBehavior(localCfg = { local }, remoteCfg = { remote })) {
-            assertFalse(isComposeOnClickEnabled())
+            assertFalse(isComposeClickCaptureEnabled())
         }
 
         val localComposeOff = LocalConfig(
@@ -121,7 +121,7 @@ internal class AutoDataCaptureBehaviorImplTest {
                 remoteCfg = { remoteComposeKillSwitchOff }
             )
         ) {
-            assertFalse(isComposeOnClickEnabled())
+            assertFalse(isComposeClickCaptureEnabled())
         }
 
         // Jetpack Compose enabled remotely, and explicit enabled locally
@@ -131,7 +131,7 @@ internal class AutoDataCaptureBehaviorImplTest {
                 remoteCfg = { remoteComposeKillSwitchOff }
             )
         ) {
-            assertTrue(isComposeOnClickEnabled())
+            assertTrue(isComposeClickCaptureEnabled())
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImplTest.kt
@@ -24,7 +24,7 @@ internal class BackgroundActivityBehaviorImplTest {
     @Test
     fun testDefaults() {
         with(createBackgroundActivityBehavior()) {
-            assertFalse(isEnabled())
+            assertFalse(isBackgroundActivityCaptureEnabled())
             assertEquals(100, getManualBackgroundActivityLimit())
             assertEquals(5000L, getMinBackgroundActivityDuration())
             assertEquals(30, getMaxCachedActivities())
@@ -34,7 +34,7 @@ internal class BackgroundActivityBehaviorImplTest {
     @Test
     fun testLocalOnly() {
         with(createBackgroundActivityBehavior(localCfg = { local })) {
-            assertTrue(isEnabled())
+            assertTrue(isBackgroundActivityCaptureEnabled())
             assertEquals(50, getManualBackgroundActivityLimit())
             assertEquals(3000L, getMinBackgroundActivityDuration())
             assertEquals(50, getMaxCachedActivities())
@@ -44,7 +44,7 @@ internal class BackgroundActivityBehaviorImplTest {
     @Test
     fun testRemoteAndLocal() {
         with(createBackgroundActivityBehavior(localCfg = { local }, remoteCfg = { remote })) {
-            assertFalse(isEnabled())
+            assertFalse(isBackgroundActivityCaptureEnabled())
             assertEquals(50, getManualBackgroundActivityLimit())
             assertEquals(3000L, getMinBackgroundActivityDuration())
             assertEquals(50, getMaxCachedActivities())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
@@ -41,22 +41,22 @@ internal class BreadcrumbBehaviorImplTest {
             assertEquals(100, getViewBreadcrumbLimit())
             assertEquals(100, getWebViewBreadcrumbLimit())
             assertEquals(100, getFragmentBreadcrumbLimit())
-            assertTrue(isTapCoordinateCaptureEnabled())
-            assertTrue(isAutomaticActivityCaptureEnabled())
+            assertTrue(isViewClickCoordinateCaptureEnabled())
+            assertTrue(isActivityBreadcrumbCaptureEnabled())
             assertTrue(isWebViewBreadcrumbCaptureEnabled())
-            assertTrue(isQueryParamCaptureEnabled())
-            assertFalse(isCaptureFcmPiiDataEnabled())
+            assertTrue(isWebViewBreadcrumbQueryParamCaptureEnabled())
+            assertFalse(isFcmPiiDataCaptureEnabled())
         }
     }
 
     @Test
     fun testLocalOnly() {
         with(BreadcrumbBehaviorImpl(thresholdCheck = behaviorThresholdCheck, localSupplier = { local }) { null }) {
-            assertFalse(isTapCoordinateCaptureEnabled())
-            assertFalse(isAutomaticActivityCaptureEnabled())
+            assertFalse(isViewClickCoordinateCaptureEnabled())
+            assertFalse(isActivityBreadcrumbCaptureEnabled())
             assertFalse(isWebViewBreadcrumbCaptureEnabled())
-            assertFalse(isQueryParamCaptureEnabled())
-            assertTrue(isCaptureFcmPiiDataEnabled())
+            assertFalse(isWebViewBreadcrumbQueryParamCaptureEnabled())
+            assertTrue(isFcmPiiDataCaptureEnabled())
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
@@ -74,12 +74,12 @@ internal class NetworkBehaviorImplTest {
         with(createNetworkBehavior(localCfg = { null }, remoteCfg = { null })) {
             assertEquals("x-emb-trace-id", getTraceIdHeader())
             assertFalse(isRequestContentLengthCaptureEnabled())
-            assertTrue(isNativeNetworkingMonitoringEnabled())
-            assertEquals(1000, getNetworkCaptureLimit())
-            assertEquals(emptyMap<String, Int>(), getNetworkCallLimitsPerDomainSuffix())
+            assertTrue(isHttpUrlConnectionCaptureEnabled())
+            assertEquals(1000, getRequestLimitPerDomain())
+            assertEquals(emptyMap<String, Int>(), getLimitsByDomain())
             assertTrue(isUrlEnabled("google.com"))
             assertFalse(isCaptureBodyEncryptionEnabled())
-            assertNull(getCapturePublicKey())
+            assertNull(getNetworkBodyCapturePublicKey())
             assertEquals(emptySet<NetworkCaptureRuleRemoteConfig>(), getNetworkCaptureRules())
         }
     }
@@ -89,20 +89,20 @@ internal class NetworkBehaviorImplTest {
         with(createNetworkBehavior(localCfg = { local }, remoteCfg = { null })) {
             assertEquals("x-custom-trace", getTraceIdHeader())
             assertTrue(isRequestContentLengthCaptureEnabled())
-            assertFalse(isNativeNetworkingMonitoringEnabled())
-            assertEquals(mapOf("google.com" to 100), getNetworkCallLimitsPerDomainSuffix())
-            assertEquals(720, getNetworkCaptureLimit())
+            assertFalse(isHttpUrlConnectionCaptureEnabled())
+            assertEquals(mapOf("google.com" to 100), getLimitsByDomain())
+            assertEquals(720, getRequestLimitPerDomain())
             assertFalse(isUrlEnabled("google.com"))
             assertTrue(isCaptureBodyEncryptionEnabled())
-            assertEquals("test", getCapturePublicKey())
+            assertEquals("test", getNetworkBodyCapturePublicKey())
         }
     }
 
     @Test
     fun testRemoteOnly() {
         with(createNetworkBehavior(localCfg = { null }, remoteCfg = { remote })) {
-            assertEquals(409, getNetworkCaptureLimit())
-            assertEquals(mapOf("google.com" to 50), getNetworkCallLimitsPerDomainSuffix())
+            assertEquals(409, getRequestLimitPerDomain())
+            assertEquals(mapOf("google.com" to 50), getLimitsByDomain())
             assertTrue(isUrlEnabled("google.com"))
             assertFalse(isUrlEnabled("example.com"))
             assertEquals(
@@ -120,8 +120,8 @@ internal class NetworkBehaviorImplTest {
     @Test
     fun testRemoteAndLocal() {
         with(createNetworkBehavior(localCfg = { local }, remoteCfg = { remote })) {
-            assertEquals(409, getNetworkCaptureLimit())
-            assertEquals(mapOf("google.com" to 50), getNetworkCallLimitsPerDomainSuffix())
+            assertEquals(409, getRequestLimitPerDomain())
+            assertEquals(mapOf("google.com" to 50), getLimitsByDomain())
             assertTrue(isUrlEnabled("google.com"))
             assertFalse(isUrlEnabled("example.com"))
             assertEquals(
@@ -149,7 +149,7 @@ internal class NetworkBehaviorImplTest {
     }
 
     @Test
-    fun testGetCapturePublicKey() {
+    fun testGetNetworkBodyCapturePublicKey() {
         val otelCfg = OpenTelemetryConfiguration(
             SpanSinkImpl(),
             LogSinkImpl(),
@@ -158,6 +158,6 @@ internal class NetworkBehaviorImplTest {
         val json = ResourceReader.readResourceAsText("public_key_config.json")
         val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), otelCfg, EmbLoggerImpl())
         val behavior = createNetworkBehavior(localCfg = localConfig::sdkConfig)
-        assertEquals(testCleanPublicKey, behavior.getCapturePublicKey())
+        assertEquals(testCleanPublicKey, behavior.getNetworkBodyCapturePublicKey())
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImplTest.kt
@@ -15,14 +15,14 @@ internal class StartupBehaviorImplTest {
     @Test
     fun testDefaults() {
         with(createStartupBehavior()) {
-            assertTrue(isAutomaticEndEnabled())
+            assertTrue(isStartupMomentAutoEndEnabled())
         }
     }
 
     @Test
     fun testLocalOnly() {
         with(createStartupBehavior(localCfg = { local })) {
-            assertFalse(isAutomaticEndEnabled())
+            assertFalse(isStartupMomentAutoEndEnabled())
         }
     }
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/ndk/EmbraceNativeThreadSamplerService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/ndk/EmbraceNativeThreadSamplerService.kt
@@ -105,7 +105,7 @@ class EmbraceNativeThreadSamplerService @JvmOverloads constructor(
             return
         }
 
-        if (ignored || !configService.anrBehavior.isNativeThreadAnrSamplingEnabled()) {
+        if (ignored || !configService.anrBehavior.isUnityAnrCaptureEnabled()) {
             return
         }
         if (count % factor == 0) {
@@ -157,13 +157,13 @@ class EmbraceNativeThreadSamplerService @JvmOverloads constructor(
 
     private fun shouldSkipNewSample(anrBehavior: AnrBehavior): Boolean {
         val sessionLimit = anrBehavior.getMaxAnrIntervalsPerSession()
-        return !configService.anrBehavior.isNativeThreadAnrSamplingEnabled() || intervals.size >= sessionLimit
+        return !configService.anrBehavior.isUnityAnrCaptureEnabled() || intervals.size >= sessionLimit
     }
 
     override fun getNativeSymbols(): Map<String, String>? = symbols.value
 
     override fun getCapturedIntervals(receivedTermination: Boolean?): List<NativeThreadAnrInterval>? {
-        if (!configService.anrBehavior.isNativeThreadAnrSamplingEnabled()) {
+        if (!configService.anrBehavior.isUnityAnrCaptureEnabled()) {
             return null
         }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/ndk/NativeThreadSamplerInstaller.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/ndk/NativeThreadSamplerInstaller.kt
@@ -57,7 +57,7 @@ class NativeThreadSamplerInstaller(
         }
         prepareTargetHandler()
 
-        if (configService.anrBehavior.isNativeThreadAnrSamplingEnabled()) {
+        if (configService.anrBehavior.isUnityAnrCaptureEnabled()) {
             monitorCurrentThread(sampler, anrService)
         }
 
@@ -79,7 +79,7 @@ class NativeThreadSamplerInstaller(
     ) {
         targetHandler?.post(
             Runnable {
-                if (configService.anrBehavior.isNativeThreadAnrSamplingEnabled() && !isMonitoring.get()) {
+                if (configService.anrBehavior.isUnityAnrCaptureEnabled() && !isMonitoring.get()) {
                     monitorCurrentThread(sampler, anrService)
                 }
             }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSourceImpl.kt
@@ -34,7 +34,7 @@ internal class SigquitDataSourceImpl(
 
     // IMPORTANT: This class and method are referenced by anr.c. Move or rename both at the same time, or it will break.
     override fun saveSigquit(timestamp: Long) {
-        if (anrBehavior.isGoogleAnrCaptureEnabled()) {
+        if (anrBehavior.isSigquitCaptureEnabled()) {
             captureData(NoInputValidation) {
                 addEvent(SchemaType.Sigquit, timestamp)
             }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
@@ -48,7 +48,7 @@ internal class CrashDataSourceImpl(
     private var jsException: JsException? = null
 
     init {
-        if (configService.autoDataCaptureBehavior.isUncaughtExceptionHandlerEnabled()) {
+        if (configService.autoDataCaptureBehavior.isJvmCrashCaptureEnabled()) {
             registerExceptionHandler()
         }
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/ActivityBreadcrumbTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/ActivityBreadcrumbTracker.kt
@@ -27,7 +27,7 @@ class ActivityBreadcrumbTracker(
     }
 
     override fun onActivityStarted(activity: Activity) {
-        if (configService.breadcrumbBehavior.isAutomaticActivityCaptureEnabled()) {
+        if (configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled()) {
             logView(activity.javaClass.name)
         }
     }
@@ -36,7 +36,7 @@ class ActivityBreadcrumbTracker(
      * Close all open fragments when the activity closes
      */
     override fun onActivityStopped(activity: Activity) {
-        if (configService.breadcrumbBehavior.isAutomaticActivityCaptureEnabled()) {
+        if (configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled()) {
             viewDataSourceProvider()?.onViewClose()
         }
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationDataSource.kt
@@ -35,7 +35,7 @@ class PushNotificationDataSource(
         captureData(
             inputValidation = NoInputValidation,
             captureAction = {
-                val captureFcmPiiData = breadcrumbBehavior.isCaptureFcmPiiDataEnabled()
+                val captureFcmPiiData = breadcrumbBehavior.isFcmPiiDataCaptureEnabled()
                 addEvent(
                     SchemaType.PushNotification(
                         title = if (captureFcmPiiData) title else null,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/TapDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/TapDataSource.kt
@@ -32,7 +32,7 @@ class TapDataSource(
             inputValidation = NoInputValidation,
             captureAction = {
                 val finalPoint = when {
-                    breadcrumbBehavior.isTapCoordinateCaptureEnabled() -> point
+                    breadcrumbBehavior.isViewClickCoordinateCaptureEnabled() -> point
                     else -> Pair(0.0f, 0.0f)
                 }
                 val coords = run {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/WebViewUrlDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/WebViewUrlDataSource.kt
@@ -33,7 +33,7 @@ class WebViewUrlDataSource(
                 captureAction = {
                     // Check if web view query params should be captured.
                     var parsedUrl: String = url ?: ""
-                    if (!breadcrumbBehavior.isQueryParamCaptureEnabled()) {
+                    if (!breadcrumbBehavior.isWebViewBreadcrumbQueryParamCaptureEnabled()) {
                         val queryOffset = url?.indexOf(QUERY_PARAMETER_DELIMITER) ?: 0
                         if (queryOffset > 0) {
                             parsedUrl = url?.substring(0, queryOffset) ?: ""

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
@@ -26,7 +26,7 @@ internal class AnrModuleImpl(
     private val anrMonitorWorker = workerModule.scheduledWorker(WorkerName.ANR_MONITOR)
 
     override val anrService: AnrService by singleton {
-        if (configService.autoDataCaptureBehavior.isAnrServiceEnabled()) {
+        if (configService.autoDataCaptureBehavior.isAnrCaptureEnabled()) {
             // the customer didn't enable early ANR detection, so construct the service
             // as part of normal initialization.
             EmbraceAnrService(

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
@@ -50,7 +50,7 @@ internal class FeatureModuleImpl(
                     logger = initModule.logger,
                 )
             },
-            configGate = { configService.autoDataCaptureBehavior.isMemoryServiceEnabled() },
+            configGate = { configService.autoDataCaptureBehavior.isMemoryWarningCaptureEnabled() },
         )
     }
 
@@ -155,7 +155,7 @@ internal class FeatureModuleImpl(
                     logger = initModule.logger
                 )
             },
-            configGate = { configService.autoDataCaptureBehavior.isPowerSaveModeServiceEnabled() }
+            configGate = { configService.autoDataCaptureBehavior.isPowerSaveModeCaptureEnabled() }
         )
     }
 
@@ -226,7 +226,7 @@ internal class FeatureModuleImpl(
                 )
             },
             configGate = {
-                configService.autoDataCaptureBehavior.isNetworkConnectivityServiceEnabled()
+                configService.autoDataCaptureBehavior.isNetworkConnectivityCaptureEnabled()
             }
         )
     }
@@ -234,7 +234,7 @@ internal class FeatureModuleImpl(
     override val sigquitDataSource: DataSourceState<SigquitDataSource> by dataSourceState {
         DataSourceState(
             factory = anrModule::sigquitDataSource,
-            configGate = { configService.anrBehavior.isGoogleAnrCaptureEnabled() }
+            configGate = { configService.anrBehavior.isSigquitCaptureEnabled() }
         )
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
@@ -83,7 +83,7 @@ internal class NativeFeatureModuleImpl(
     }
 
     override val nativeCrashService: NativeCrashService by singleton {
-        if (!configModule.configService.autoDataCaptureBehavior.isNdkEnabled()) {
+        if (!configModule.configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
             NoopNativeCrashService()
         } else {
             NativeCrashDataSourceImpl(
@@ -98,7 +98,8 @@ internal class NativeFeatureModuleImpl(
         }
     }
 
-    private fun nativeThreadSamplingEnabled(configService: ConfigService) = configService.autoDataCaptureBehavior.isNdkEnabled()
+    private fun nativeThreadSamplingEnabled(configService: ConfigService) =
+        configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()
 
     private val embraceNdkServiceRepository by singleton {
         EmbraceNdkServiceRepository(

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
@@ -118,7 +118,7 @@ internal class EmbraceNdkService(
     }
 
     private fun checkSignalHandlersOverwritten() {
-        if (configService.autoDataCaptureBehavior.isSigHandlerDetectionEnabled()) {
+        if (configService.autoDataCaptureBehavior.is3rdPartySigHandlerDetectionEnabled()) {
             val culprit = delegate._checkForOverwrittenHandlers()
             if (culprit != null) {
                 if (shouldIgnoreOverriddenHandler(culprit)) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -190,7 +190,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
             return
         }
 
-        if (configModule.configService.autoDataCaptureBehavior.isComposeOnClickEnabled()) {
+        if (configModule.configService.autoDataCaptureBehavior.isComposeClickCaptureEnabled()) {
             registerComposeActivityListener(coreModule.application)
         }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
@@ -176,7 +176,7 @@ internal class EmbraceInternalInterfaceImpl(
 
     override fun isAnrCaptureEnabled(): Boolean = configService.anrBehavior.isAnrCaptureEnabled()
 
-    override fun isNdkEnabled(): Boolean = configService.autoDataCaptureBehavior.isNdkEnabled()
+    override fun isNdkEnabled(): Boolean = configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()
 
     override fun logInternalError(message: String?, details: String?) {
         if (message == null) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -196,7 +196,7 @@ internal class ModuleInitBootstrapper(
                             )
 
                             val networkBehavior = configModule.configService.networkBehavior
-                            if (networkBehavior.isNativeNetworkingMonitoringEnabled()) {
+                            if (networkBehavior.isHttpUrlConnectionCaptureEnabled()) {
                                 Systrace.traceSynchronous("network-monitoring-installation") {
                                     registerFactory(networkBehavior.isRequestContentLengthCaptureEnabled())
                                 }
@@ -339,7 +339,7 @@ internal class ModuleInitBootstrapper(
                             lazy { nativeFeatureModule.nativeThreadSamplerService }
                         )
 
-                        if (configService.autoDataCaptureBehavior.isNdkEnabled()) {
+                        if (configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
                             val worker = workerThreadModule.backgroundWorker(WorkerName.SERVICE_INIT)
 
                             worker.submit(TaskPriority.HIGH) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeBreadcrumbBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeBreadcrumbBehavior.kt
@@ -19,9 +19,9 @@ class FakeBreadcrumbBehavior(
     override fun getTapBreadcrumbLimit(): Int = tapBreadcrumbLimitImpl
     override fun getViewBreadcrumbLimit(): Int = viewBreadcrumbLimitImpl
     override fun getWebViewBreadcrumbLimit(): Int = webviewBreadcrumbLimitImpl
-    override fun isTapCoordinateCaptureEnabled(): Boolean = tapCoordinateCaptureEnabled
-    override fun isAutomaticActivityCaptureEnabled(): Boolean = automaticActivityCaptureEnabled
+    override fun isViewClickCoordinateCaptureEnabled(): Boolean = tapCoordinateCaptureEnabled
+    override fun isActivityBreadcrumbCaptureEnabled(): Boolean = automaticActivityCaptureEnabled
     override fun isWebViewBreadcrumbCaptureEnabled(): Boolean = webViewBreadcrumbCaptureEnabled
-    override fun isQueryParamCaptureEnabled(): Boolean = queryParamCaptureEnabled
-    override fun isCaptureFcmPiiDataEnabled(): Boolean = captureFcmPiiDataEnabled
+    override fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean = queryParamCaptureEnabled
+    override fun isFcmPiiDataCaptureEnabled(): Boolean = captureFcmPiiDataEnabled
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -59,7 +59,7 @@ class FakeConfigService(
     override fun isBackgroundActivityCaptureEnabled(): Boolean = backgroundActivityCaptureEnabled
 
     override fun hasValidRemoteConfig(): Boolean = hasValidRemoteConfig
-    override fun isAppExitInfoCaptureEnabled(): Boolean = appExitInfoBehavior.isEnabled()
+    override fun isAppExitInfoCaptureEnabled(): Boolean = appExitInfoBehavior.isAeiCaptureEnabled()
 
     fun updateListeners() {
         listeners.forEach {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAnrBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAnrBehavior.kt
@@ -21,7 +21,7 @@ class FakeAnrBehavior(
     var nativeThreadAnrSamplingAllowlistImpl: List<AllowedNdkSampleMethod> = emptyList(),
 ) : AnrBehavior {
 
-    override fun isGoogleAnrCaptureEnabled(): Boolean = googleAnrCaptureEnabled
+    override fun isSigquitCaptureEnabled(): Boolean = googleAnrCaptureEnabled
     override fun isAnrCaptureEnabled(): Boolean = anrCaptureEnabled
     override fun isAnrProcessErrorsCaptureEnabled(): Boolean = false
     override fun getMonitorThreadPriority(): Int = monitorThreadPriorityImpl
@@ -38,7 +38,7 @@ class FakeAnrBehavior(
     override fun shouldCaptureMainThreadOnly(): Boolean = true
     override fun getNativeThreadAnrSamplingFactor(): Int = 10
     override fun getNativeThreadAnrSamplingUnwinder(): Unwinder = Unwinder.LIBUNWIND
-    override fun isNativeThreadAnrSamplingEnabled(): Boolean = nativeThreadAnrSamplingEnabled
+    override fun isUnityAnrCaptureEnabled(): Boolean = nativeThreadAnrSamplingEnabled
     override fun isNativeThreadAnrSamplingOffsetEnabled(): Boolean = false
     override fun isIdleHandlerEnabled(): Boolean = idleHandlerEnabled
     override fun isStrictModeListenerEnabled(): Boolean = strictModeListenerEnabled

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAppExitInfoBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAppExitInfoBehavior.kt
@@ -9,6 +9,6 @@ class FakeAppExitInfoBehavior(
 ) : AppExitInfoBehavior {
 
     override fun getTraceMaxLimit(): Int = traceMaxLimit
-    override fun isEnabled(): Boolean = enabled
+    override fun isAeiCaptureEnabled(): Boolean = enabled
     override fun appExitInfoMaxNum(): Int = appExitInfoMaxNum
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -15,14 +15,14 @@ class FakeAutoDataCaptureBehavior(
     private val diskUsageReportingEnabled: Boolean = true
 ) : AutoDataCaptureBehavior {
 
-    override fun isMemoryServiceEnabled(): Boolean = memoryServiceEnabled
+    override fun isMemoryWarningCaptureEnabled(): Boolean = memoryServiceEnabled
     override fun isThermalStatusCaptureEnabled(): Boolean = thermalStatusCaptureEnabled
-    override fun isPowerSaveModeServiceEnabled(): Boolean = powerSaveModeServiceEnabled
-    override fun isNetworkConnectivityServiceEnabled(): Boolean = networkConnectivityServiceEnabled
-    override fun isAnrServiceEnabled(): Boolean = anrServiceEnabled
-    override fun isUncaughtExceptionHandlerEnabled(): Boolean = uncaughtExceptionHandlerEnabled
-    override fun isComposeOnClickEnabled(): Boolean = composeOnClickEnabled
-    override fun isSigHandlerDetectionEnabled(): Boolean = sigHandlerDetectionEnabled
-    override fun isNdkEnabled(): Boolean = ndkEnabled
-    override fun isDiskUsageReportingEnabled(): Boolean = diskUsageReportingEnabled
+    override fun isPowerSaveModeCaptureEnabled(): Boolean = powerSaveModeServiceEnabled
+    override fun isNetworkConnectivityCaptureEnabled(): Boolean = networkConnectivityServiceEnabled
+    override fun isAnrCaptureEnabled(): Boolean = anrServiceEnabled
+    override fun isJvmCrashCaptureEnabled(): Boolean = uncaughtExceptionHandlerEnabled
+    override fun isComposeClickCaptureEnabled(): Boolean = composeOnClickEnabled
+    override fun is3rdPartySigHandlerDetectionEnabled(): Boolean = sigHandlerDetectionEnabled
+    override fun isNativeCrashCaptureEnabled(): Boolean = ndkEnabled
+    override fun isDiskUsageCaptureEnabled(): Boolean = diskUsageReportingEnabled
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeStartupBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeStartupBehavior.kt
@@ -6,5 +6,5 @@ class FakeStartupBehavior(
     private val automaticEndEnabled: Boolean = true
 ) : StartupBehavior {
 
-    override fun isAutomaticEndEnabled(): Boolean = automaticEndEnabled
+    override fun isStartupMomentAutoEndEnabled(): Boolean = automaticEndEnabled
 }


### PR DESCRIPTION
## Goal

Renames functions in the behavior classes for more consistency with the `InstrumentedConfig` naming scheme.

