### PR TITLE
Use instrumented config classes to drive behavior

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -89,25 +89,22 @@ internal class EmbraceConfigService(
     override val backgroundActivityBehavior: BackgroundActivityBehavior =
         BackgroundActivityBehaviorImpl(
             thresholdCheck = thresholdCheck,
-            localSupplier = localConfig.sdkConfig::backgroundActivityConfig,
             remoteSupplier = { getConfig().backgroundActivityConfig }
         )
 
     override val autoDataCaptureBehavior: AutoDataCaptureBehavior =
         AutoDataCaptureBehaviorImpl(
             thresholdCheck = thresholdCheck,
-            localSupplier = { localConfig },
             remoteSupplier = remoteSupplier
         )
 
     override val breadcrumbBehavior: BreadcrumbBehavior =
         BreadcrumbBehaviorImpl(
             thresholdCheck,
-            localSupplier = localConfig::sdkConfig,
             remoteSupplier = remoteSupplier
         )
 
-    override val sensitiveKeysBehavior: SensitiveKeysBehavior = SensitiveKeysBehaviorImpl(localConfig.sdkConfig)
+    override val sensitiveKeysBehavior: SensitiveKeysBehavior = SensitiveKeysBehaviorImpl()
 
     override val logMessageBehavior: LogMessageBehavior =
         LogMessageBehaviorImpl(
@@ -118,51 +115,38 @@ internal class EmbraceConfigService(
     override val anrBehavior: AnrBehavior =
         AnrBehaviorImpl(
             thresholdCheck,
-            localSupplier = localConfig.sdkConfig::anr,
             remoteSupplier = { getConfig().anrConfig }
         )
 
-    override val sessionBehavior: SessionBehavior =
-        SessionBehaviorImpl(
-            thresholdCheck,
-            localSupplier = localConfig.sdkConfig::sessionConfig,
-            remoteSupplier = { getConfig() }
-        )
+    override val sessionBehavior: SessionBehavior = SessionBehaviorImpl(
+        thresholdCheck,
+        remoteSupplier = { getConfig() }
+    )
 
     override val networkBehavior: NetworkBehavior =
         NetworkBehaviorImpl(
             thresholdCheck = thresholdCheck,
-            localSupplier = localConfig::sdkConfig,
             remoteSupplier = remoteSupplier
         )
 
-    override val startupBehavior: StartupBehavior =
-        StartupBehaviorImpl(
-            thresholdCheck = thresholdCheck,
-            localSupplier = localConfig.sdkConfig::startupMoment
-        )
+    override val startupBehavior: StartupBehavior = StartupBehaviorImpl()
 
     override val dataCaptureEventBehavior: DataCaptureEventBehavior = DataCaptureEventBehaviorImpl(
         thresholdCheck = thresholdCheck,
         remoteSupplier = remoteSupplier
     )
 
-    override val sdkModeBehavior: SdkModeBehavior =
-        SdkModeBehaviorImpl(
-            thresholdCheck = thresholdCheck,
-            localSupplier = { localConfig },
-            remoteSupplier = remoteSupplier
-        )
+    override val sdkModeBehavior: SdkModeBehavior = SdkModeBehaviorImpl(
+        thresholdCheck = thresholdCheck,
+        remoteSupplier = remoteSupplier
+    )
 
-    override val sdkEndpointBehavior: SdkEndpointBehavior =
-        SdkEndpointBehaviorImpl(
-            thresholdCheck = thresholdCheck,
-            localSupplier = localConfig.sdkConfig::baseUrls,
-        )
+    override val sdkEndpointBehavior: SdkEndpointBehavior = SdkEndpointBehaviorImpl(
+        thresholdCheck = thresholdCheck
+    )
 
     override val appExitInfoBehavior: AppExitInfoBehavior = AppExitInfoBehaviorImpl(
         thresholdCheck = thresholdCheck,
-        localSupplier = localConfig.sdkConfig::appExitInfoConfig,
         remoteSupplier = remoteSupplier
     )
 
@@ -259,7 +243,8 @@ internal class EmbraceConfigService(
     private fun persistConfig() {
         // TODO: future get rid of these prefs from PrefService entirely?
         preferencesService.sdkDisabled = sdkModeBehavior.isSdkDisabled()
-        preferencesService.backgroundActivityEnabled = backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
+        preferencesService.backgroundActivityEnabled =
+            backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
     }
 
     // TODO: future extract these out to SdkBehavior interface

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.AnrLocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.AllowedNdkSampleMethod
 import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.Unwinder
@@ -12,16 +13,13 @@ import java.util.regex.Pattern
  */
 class AnrBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<AnrLocalConfig?>,
     remoteSupplier: Provider<AnrRemoteConfig?>
-) : AnrBehavior, MergedConfigBehavior<AnrLocalConfig, AnrRemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
+) : AnrBehavior, MergedConfigBehavior<UnimplementedConfig, AnrRemoteConfig>(
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
 
     private companion object {
-        private const val CAPTURE_GOOGLE_DEFAULT = false
         private const val DEFAULT_ANR_PCT_ENABLED = true
         private const val DEFAULT_ANR_PROCESS_ERRORS_PCT_ENABLED = false
         private const val DEFAULT_ANR_BG_PCT_ENABLED = false
@@ -37,7 +35,6 @@ class AnrBehaviorImpl(
         private const val DEFAULT_ANR_MIN_CAPTURE_DURATION = 1000
         private const val DEFAULT_ANR_MAIN_THREAD_ONLY = true
         private const val DEFAULT_NATIVE_THREAD_ANR_SAMPLING_FACTOR = 5
-        private const val DEFAULT_NATIVE_THREAD_ANR_SAMPLING_ENABLED = false
         private const val DEFAULT_NATIVE_THREAD_ANR_OFFSET_ENABLED = true
         private const val DEFAULT_IDLE_HANDLER_ENABLED = false
         private const val DEFAULT_STRICT_MODE_LISTENER_ENABLED = false
@@ -52,8 +49,7 @@ class AnrBehaviorImpl(
 
     override fun isSigquitCaptureEnabled(): Boolean {
         return thresholdCheck.isBehaviorEnabled(remote?.googlePctEnabled)
-            ?: local?.captureGoogle
-            ?: CAPTURE_GOOGLE_DEFAULT
+            ?: InstrumentedConfig.enabledFeatures.isSigquitCaptureEnabled()
     }
 
     override val allowPatternList: List<Pattern> by lazy {
@@ -127,8 +123,7 @@ class AnrBehaviorImpl(
 
     override fun isUnityAnrCaptureEnabled(): Boolean {
         return thresholdCheck.isBehaviorEnabled(remote?.pctNativeThreadAnrSamplingEnabled)
-            ?: local?.captureUnityThread
-            ?: DEFAULT_NATIVE_THREAD_ANR_SAMPLING_ENABLED
+            ?: InstrumentedConfig.enabledFeatures.isUnityAnrCaptureEnabled()
     }
 
     override fun isNativeThreadAnrSamplingOffsetEnabled(): Boolean =

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.AppExitInfoLocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
 
@@ -10,12 +11,10 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  */
 class AppExitInfoBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<AppExitInfoLocalConfig?>,
     remoteSupplier: Provider<RemoteConfig?>
-) : AppExitInfoBehavior, MergedConfigBehavior<AppExitInfoLocalConfig, RemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
+) : AppExitInfoBehavior, MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
     companion object {
         /**
@@ -23,18 +22,15 @@ class AppExitInfoBehaviorImpl(
          */
         private const val MAX_TRACE_SIZE_BYTES = 2097152 // 2MB
         const val AEI_MAX_NUM_DEFAULT: Int = 0 // 0 means no limit
-        const val AEI_ENABLED_DEFAULT: Boolean = true
     }
 
     override fun getTraceMaxLimit(): Int =
         remote?.appExitInfoConfig?.appExitInfoTracesLimit
-            ?: local?.appExitInfoTracesLimit
             ?: MAX_TRACE_SIZE_BYTES
 
     override fun isAeiCaptureEnabled(): Boolean {
         return thresholdCheck.isBehaviorEnabled(remote?.appExitInfoConfig?.pctAeiCaptureEnabled)
-            ?: local?.aeiCaptureEnabled
-            ?: AEI_ENABLED_DEFAULT
+            ?: InstrumentedConfig.enabledFeatures.isAeiCaptureEnabled()
     }
 
     override fun appExitInfoMaxNum(): Int = remote?.appExitInfoConfig?.aeiMaxNum ?: AEI_MAX_NUM_DEFAULT

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
 
@@ -10,74 +11,37 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  */
 class AutoDataCaptureBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<LocalConfig?>,
     remoteSupplier: Provider<RemoteConfig?>
-) : AutoDataCaptureBehavior, MergedConfigBehavior<LocalConfig, RemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
+) : AutoDataCaptureBehavior, MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
 
     private companion object {
-        const val MEMORY_SERVICE_ENABLED_DEFAULT = true
         const val THERMAL_STATUS_ENABLED_DEFAULT = true
-        const val POWER_SAVE_MODE_SERVICE_ENABLED_DEFAULT = true
-        const val NETWORK_CONNECTIVITY_SERVICE_ENABLED_DEFAULT = true
-        const val ANR_SERVICE_ENABLED_DEFAULT = true
-        const val CRASH_HANDLER_ENABLED_DEFAULT = true
-        const val CAPTURE_COMPOSE_ONCLICK_DEFAULT = false
-        const val REPORT_DISK_USAGE_DEFAULT = true
     }
 
-    override fun isMemoryWarningCaptureEnabled(): Boolean {
-        return local?.sdkConfig?.automaticDataCaptureConfig?.memoryServiceEnabled
-            ?: MEMORY_SERVICE_ENABLED_DEFAULT
-    }
+    private val cfg = InstrumentedConfig.enabledFeatures
+
+    override fun isMemoryWarningCaptureEnabled(): Boolean = cfg.isMemoryWarningCaptureEnabled()
 
     override fun isThermalStatusCaptureEnabled(): Boolean {
         return thresholdCheck.isBehaviorEnabled(remote?.dataConfig?.pctThermalStatusEnabled)
             ?: THERMAL_STATUS_ENABLED_DEFAULT
     }
 
-    override fun isPowerSaveModeCaptureEnabled(): Boolean {
-        return local?.sdkConfig?.automaticDataCaptureConfig?.powerSaveModeServiceEnabled
-            ?: POWER_SAVE_MODE_SERVICE_ENABLED_DEFAULT
-    }
+    override fun isPowerSaveModeCaptureEnabled(): Boolean = cfg.isPowerSaveModeCaptureEnabled()
+    override fun isNetworkConnectivityCaptureEnabled(): Boolean =
+        cfg.isNetworkConnectivityCaptureEnabled()
 
-    override fun isNetworkConnectivityCaptureEnabled(): Boolean {
-        return local?.sdkConfig?.automaticDataCaptureConfig?.networkConnectivityServiceEnabled
-            ?: NETWORK_CONNECTIVITY_SERVICE_ENABLED_DEFAULT
-    }
+    override fun isAnrCaptureEnabled(): Boolean = cfg.isAnrCaptureEnabled()
+    override fun isJvmCrashCaptureEnabled(): Boolean = cfg.isJvmCrashCaptureEnabled()
+    override fun isComposeClickCaptureEnabled(): Boolean =
+        remote?.killSwitchConfig?.jetpackCompose ?: cfg.isComposeClickCaptureEnabled()
 
-    override fun isAnrCaptureEnabled(): Boolean {
-        return local?.sdkConfig?.automaticDataCaptureConfig?.anrServiceEnabled
-            ?: ANR_SERVICE_ENABLED_DEFAULT
-    }
+    override fun is3rdPartySigHandlerDetectionEnabled(): Boolean =
+        remote?.killSwitchConfig?.sigHandlerDetection ?: cfg.is3rdPartySigHandlerDetectionEnabled()
 
-    override fun isJvmCrashCaptureEnabled(): Boolean =
-        local?.sdkConfig?.crashHandler?.enabled ?: CRASH_HANDLER_ENABLED_DEFAULT
-
-    override fun isComposeClickCaptureEnabled(): Boolean {
-        return when (remote?.killSwitchConfig?.jetpackCompose) {
-            null, true -> {
-                // no remote: use local
-                // remote is true: it can be explicitly disabled locally
-                local?.sdkConfig?.composeConfig?.captureComposeOnClick ?: CAPTURE_COMPOSE_ONCLICK_DEFAULT
-            }
-            false -> {
-                // remote is false: the killswitch ignores local
-                false
-            }
-        }
-    }
-
-    override fun is3rdPartySigHandlerDetectionEnabled(): Boolean {
-        return remote?.killSwitchConfig?.sigHandlerDetection
-            ?: local?.sdkConfig?.sigHandlerDetection ?: true
-    }
-
-    override fun isNativeCrashCaptureEnabled(): Boolean = local?.ndkEnabled ?: false
-
-    override fun isDiskUsageCaptureEnabled(): Boolean =
-        local?.sdkConfig?.app?.reportDiskUsage ?: REPORT_DISK_USAGE_DEFAULT
+    override fun isNativeCrashCaptureEnabled(): Boolean = cfg.isNativeCrashCaptureEnabled()
+    override fun isDiskUsageCaptureEnabled(): Boolean = cfg.isDiskUsageCaptureEnabled()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.BackgroundActivityLocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
 
@@ -9,36 +10,21 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  */
 class BackgroundActivityBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<BackgroundActivityLocalConfig?>,
     remoteSupplier: Provider<BackgroundActivityRemoteConfig?>
-) : BackgroundActivityBehavior, MergedConfigBehavior<BackgroundActivityLocalConfig, BackgroundActivityRemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
-) {
+) : BackgroundActivityBehavior,
+    MergedConfigBehavior<UnimplementedConfig, BackgroundActivityRemoteConfig>(
+        thresholdCheck = thresholdCheck,
+        remoteSupplier = remoteSupplier
+    ) {
 
-    private companion object {
-        const val BACKGROUND_ACTIVITY_CAPTURE_ENABLED_DEFAULT = false
-        const val MANUAL_BACKGROUND_ACTIVITY_LIMIT_DEFAULT = 100
-        const val MIN_BACKGROUND_ACTIVITY_DURATION_DEFAULT = 5000L
-        const val MAX_CACHED_ACTIVITIES_DEFAULT = 30
-    }
+    private val cfg = InstrumentedConfig.backgroundActivity
 
     override fun isBackgroundActivityCaptureEnabled(): Boolean {
         return remote?.threshold?.let(thresholdCheck::isBehaviorEnabled)
-            ?: local?.backgroundActivityCaptureEnabled
-            ?: BACKGROUND_ACTIVITY_CAPTURE_ENABLED_DEFAULT
+            ?: InstrumentedConfig.enabledFeatures.isBackgroundActivityCaptureEnabled()
     }
 
-    override fun getManualBackgroundActivityLimit(): Int {
-        return local?.manualBackgroundActivityLimit ?: MANUAL_BACKGROUND_ACTIVITY_LIMIT_DEFAULT
-    }
-
-    override fun getMinBackgroundActivityDuration(): Long {
-        return local?.minBackgroundActivityDuration ?: MIN_BACKGROUND_ACTIVITY_DURATION_DEFAULT
-    }
-
-    override fun getMaxCachedActivities(): Int {
-        return local?.maxCachedActivities ?: MAX_CACHED_ACTIVITIES_DEFAULT
-    }
+    override fun getManualBackgroundActivityLimit(): Int = cfg.getManualBackgroundActivityLimit()
+    override fun getMinBackgroundActivityDuration(): Long = cfg.getMinBackgroundActivityDuration()
+    override fun getMaxCachedActivities(): Int = cfg.getMaxCachedActivities()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
 
@@ -10,12 +11,10 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  */
 class BreadcrumbBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<SdkLocalConfig?>,
     remoteSupplier: Provider<RemoteConfig?>
-) : BreadcrumbBehavior, MergedConfigBehavior<SdkLocalConfig, RemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
+) : BreadcrumbBehavior, MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
 
     private companion object {
@@ -24,36 +23,32 @@ class BreadcrumbBehaviorImpl(
          * The default breadcrumbs capture limit.
          */
         const val DEFAULT_BREADCRUMB_LIMIT = 100
-        const val CAPTURE_TAP_COORDINATES_DEFAULT = true
-        const val ENABLE_AUTOMATIC_ACTIVITY_CAPTURE_DEFAULT = true
-        const val WEB_VIEW_CAPTURE_DEFAULT = true
-        const val WEB_VIEW_QUERY_PARAMS_CAPTURE_DEFAULT = true
     }
 
-    override fun getCustomBreadcrumbLimit(): Int = remote?.uiConfig?.breadcrumbs ?: DEFAULT_BREADCRUMB_LIMIT
-    override fun getFragmentBreadcrumbLimit(): Int = remote?.uiConfig?.fragments ?: DEFAULT_BREADCRUMB_LIMIT
+    private val cfg = InstrumentedConfig.enabledFeatures
+
+    override fun getCustomBreadcrumbLimit(): Int =
+        remote?.uiConfig?.breadcrumbs ?: DEFAULT_BREADCRUMB_LIMIT
+
+    override fun getFragmentBreadcrumbLimit(): Int =
+        remote?.uiConfig?.fragments ?: DEFAULT_BREADCRUMB_LIMIT
+
     override fun getTapBreadcrumbLimit(): Int = remote?.uiConfig?.taps ?: DEFAULT_BREADCRUMB_LIMIT
     override fun getViewBreadcrumbLimit(): Int = remote?.uiConfig?.views ?: DEFAULT_BREADCRUMB_LIMIT
-    override fun getWebViewBreadcrumbLimit(): Int = remote?.uiConfig?.webViews ?: DEFAULT_BREADCRUMB_LIMIT
+    override fun getWebViewBreadcrumbLimit(): Int =
+        remote?.uiConfig?.webViews ?: DEFAULT_BREADCRUMB_LIMIT
 
     override fun isViewClickCoordinateCaptureEnabled(): Boolean =
-        local?.taps?.captureCoordinates ?: CAPTURE_TAP_COORDINATES_DEFAULT
+        cfg.isViewClickCoordinateCaptureEnabled()
 
     override fun isActivityBreadcrumbCaptureEnabled(): Boolean =
-        local?.viewConfig?.enableAutomaticActivityCapture
-            ?: ENABLE_AUTOMATIC_ACTIVITY_CAPTURE_DEFAULT
+        cfg.isActivityBreadcrumbCaptureEnabled()
 
     override fun isWebViewBreadcrumbCaptureEnabled(): Boolean =
-        local?.webViewConfig?.captureWebViews ?: WEB_VIEW_CAPTURE_DEFAULT
+        cfg.isWebViewBreadcrumbCaptureEnabled()
 
     override fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean =
-        local?.webViewConfig?.captureQueryParams ?: WEB_VIEW_QUERY_PARAMS_CAPTURE_DEFAULT
+        cfg.isWebViewBreadcrumbQueryParamCaptureEnabled()
 
-    override fun isFcmPiiDataCaptureEnabled(): Boolean {
-        return try {
-            local?.captureFcmPiiData ?: false
-        } catch (ex: Exception) {
-            false
-        }
-    }
+    override fun isFcmPiiDataCaptureEnabled(): Boolean = cfg.isFcmPiiDataCaptureEnabled()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.instrumented.NetworkCaptureConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
@@ -13,25 +13,15 @@ import kotlin.math.min
  */
 class NetworkBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<SdkLocalConfig?>,
-    remoteSupplier: Provider<RemoteConfig?>
-) : NetworkBehavior, MergedConfigBehavior<SdkLocalConfig, RemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
+    remoteSupplier: Provider<RemoteConfig?>,
+    private val disabledUrlPatterns: List<String>? = null
+) : NetworkBehavior, MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
 
     companion object {
 
-        /**
-         * Capture request content length by default.
-         */
-        const val CAPTURE_REQUEST_CONTENT_LENGTH: Boolean = false
-
-        /**
-         * Enable native monitoring by default.
-         */
-        const val ENABLE_NATIVE_MONITORING_DEFAULT: Boolean = true
         const val DEFAULT_NETWORK_CALL_LIMIT: Int = 1000
 
         private val dirtyKeyList = listOf(
@@ -44,50 +34,43 @@ class NetworkBehaviorImpl(
         )
     }
 
-    override fun getTraceIdHeader(): String =
-        local?.networking?.traceIdHeader ?: NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
+    private val cfg = InstrumentedConfig.networkCapture
 
+    override fun getTraceIdHeader(): String = cfg.getTraceIdHeader()
     override fun isRequestContentLengthCaptureEnabled(): Boolean =
-        local?.networking?.captureRequestContentLength ?: CAPTURE_REQUEST_CONTENT_LENGTH
+        InstrumentedConfig.enabledFeatures.isRequestContentLengthCaptureEnabled()
 
     override fun isHttpUrlConnectionCaptureEnabled(): Boolean =
-        local?.networking?.enableNativeMonitoring ?: ENABLE_NATIVE_MONITORING_DEFAULT
+        InstrumentedConfig.enabledFeatures.isHttpUrlConnectionCaptureEnabled()
 
     override fun getLimitsByDomain(): Map<String, Int> {
-        val limitCeiling = getLimitCeiling()
-        val domainSuffixLimits: MutableMap<String, Int> = remote?.networkConfig?.domainLimits?.toMutableMap() ?: mutableMapOf()
+        val limits = remote?.networkConfig?.domainLimits ?: cfg.getLimitsByDomain()
+            .mapValues { it.value.toInt() }
+        val limitCeiling = getRequestLimitPerDomain()
 
-        local?.networking?.domains?.forEach { localLimit ->
-            val dom = localLimit.domain
-            val lim = localLimit.limit
-            if (dom != null && lim != null) {
-                domainSuffixLimits[dom] = domainSuffixLimits[dom]?.let { remoteLimit ->
-                    min(remoteLimit, lim)
-                } ?: min(limitCeiling, lim)
-            }
+        return limits.mapValues {
+            min(it.value, limitCeiling)
         }
-
-        return domainSuffixLimits
     }
 
-    override fun getRequestLimitPerDomain(): Int {
-        val remoteDefault = getLimitCeiling()
-        return min(remoteDefault, local?.networking?.defaultCaptureLimit ?: remoteDefault)
-    }
+    override fun getRequestLimitPerDomain(): Int = min(
+        remote?.networkConfig?.defaultCaptureLimit ?: DEFAULT_NETWORK_CALL_LIMIT,
+        cfg.getRequestLimitPerDomain()
+    )
 
     override fun isUrlEnabled(url: String): Boolean {
-        val patterns =
-            remote?.disabledUrlPatterns ?: local?.networking?.disabledUrlPatterns ?: emptySet()
+        val patterns = disabledUrlPatterns ?: remote?.disabledUrlPatterns ?: cfg.getIgnoredRequestPatternList()
         val regexes = patterns.mapNotNull {
             runCatching { Pattern.compile(it) }.getOrNull()
         }.toSet()
         return regexes.none { it.matcher(url).find() }
     }
 
-    override fun isCaptureBodyEncryptionEnabled(): Boolean = getNetworkBodyCapturePublicKey() != null
+    override fun isCaptureBodyEncryptionEnabled(): Boolean =
+        getNetworkBodyCapturePublicKey() != null
 
     override fun getNetworkBodyCapturePublicKey(): String? {
-        var keyToClean = local?.capturePublicKey
+        var keyToClean = cfg.getNetworkBodyCapturePublicKey()
         if (keyToClean != null) {
             for (dirty in dirtyKeyList) {
                 keyToClean = keyToClean?.replace(dirty.toRegex(), "")
@@ -96,10 +79,6 @@ class NetworkBehaviorImpl(
         return keyToClean
     }
 
-    override fun getNetworkCaptureRules(): Set<NetworkCaptureRuleRemoteConfig> = remote?.networkCaptureRules ?: emptySet()
-
-    /**
-     * Cap the default limit at whatever the default limit is that is set or implied by the remote config
-     */
-    private fun getLimitCeiling(): Int = remote?.networkConfig?.defaultCaptureLimit ?: DEFAULT_NETWORK_CALL_LIMIT
+    override fun getNetworkCaptureRules(): Set<NetworkCaptureRuleRemoteConfig> =
+        remote?.networkCaptureRules ?: emptySet()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkEndpointBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkEndpointBehaviorImpl.kt
@@ -1,18 +1,15 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
-import io.embrace.android.embracesdk.internal.config.local.BaseUrlLocalConfig
-import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 
 /**
  * Provides the behavior that the Background Activity feature should follow.
  */
 class SdkEndpointBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<BaseUrlLocalConfig?>,
-) : SdkEndpointBehavior, MergedConfigBehavior<BaseUrlLocalConfig, UnimplementedConfig>(
-    thresholdCheck,
-    localSupplier
+) : SdkEndpointBehavior, MergedConfigBehavior<UnimplementedConfig, UnimplementedConfig>(
+    thresholdCheck = thresholdCheck
 ) {
 
     companion object {
@@ -24,13 +21,13 @@ class SdkEndpointBehaviorImpl(
         if (appId == null) {
             return ""
         }
-        return local?.data ?: "https://a-$appId.$DATA_DEFAULT"
+        return InstrumentedConfig.baseUrls.getData() ?: "https://a-$appId.$DATA_DEFAULT"
     }
 
     override fun getConfig(appId: String?): String {
         if (appId == null) {
             return ""
         }
-        return local?.config ?: "https://a-$appId.$CONFIG_DEFAULT"
+        return InstrumentedConfig.baseUrls.getConfig() ?: "https://a-$appId.$CONFIG_DEFAULT"
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
 import kotlin.math.max
@@ -11,12 +11,10 @@ import kotlin.math.min
  */
 class SdkModeBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<LocalConfig?>,
     remoteSupplier: Provider<RemoteConfig?>
-) : SdkModeBehavior, MergedConfigBehavior<LocalConfig, RemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
+) : SdkModeBehavior, MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
 
     private companion object {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImpl.kt
@@ -1,17 +1,15 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 
 private const val SENSITIVE_KEY_MAX_LENGTH = 128
 private const val SENSITIVE_KEYS_LIST_MAX_SIZE = 10000
 
 const val REDACTED_LABEL: String = "<redacted>"
 
-class SensitiveKeysBehaviorImpl(
-    localConfig: SdkLocalConfig
-) : SensitiveKeysBehavior {
+class SensitiveKeysBehaviorImpl(denyList: List<String>? = null) : SensitiveKeysBehavior {
 
-    private val denyList = localConfig.sensitiveKeysDenylist?.take(SENSITIVE_KEYS_LIST_MAX_SIZE)
+    private val denyList = (denyList ?: InstrumentedConfig.redaction.getSensitiveKeysDenylist())?.take(SENSITIVE_KEYS_LIST_MAX_SIZE)
 
     override fun isSensitiveKey(key: String): Boolean {
         return denyList?.any { it.take(SENSITIVE_KEY_MAX_LENGTH) == key } ?: false

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.SessionLocalConfig
+import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.gating.SessionGatingKeys
 import io.embrace.android.embracesdk.internal.payload.EventMessage
@@ -13,12 +14,10 @@ import java.util.Locale
  */
 class SessionBehaviorImpl(
     thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<SessionLocalConfig?>,
     remoteSupplier: Provider<RemoteConfig?>
-) : SessionBehavior, MergedConfigBehavior<SessionLocalConfig, RemoteConfig>(
-    thresholdCheck,
-    localSupplier,
-    remoteSupplier
+) : SessionBehavior, MergedConfigBehavior<UnimplementedConfig, RemoteConfig>(
+    thresholdCheck = thresholdCheck,
+    remoteSupplier = remoteSupplier
 ) {
 
     companion object {
@@ -26,12 +25,12 @@ class SessionBehaviorImpl(
     }
 
     override fun getFullSessionEvents(): Set<String> {
-        val strings = remote?.sessionConfig?.fullSessionEvents ?: local?.fullSessionEvents ?: emptySet()
+        val strings = remote?.sessionConfig?.fullSessionEvents ?: InstrumentedConfig.session.getFullSessionEvents()
         return strings.map { it.lowercase(Locale.US) }.toSet()
     }
 
     override fun getSessionComponents(): Set<String>? =
-        remote?.sessionConfig?.sessionComponents ?: local?.sessionComponents
+        remote?.sessionConfig?.sessionComponents ?: InstrumentedConfig.session.getSessionComponents()
 
     override fun isGatingFeatureEnabled(): Boolean = getSessionComponents() != null
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImpl.kt
@@ -1,23 +1,12 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
-import io.embrace.android.embracesdk.internal.config.local.StartupMomentLocalConfig
-import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 
 /**
  * Provides the behavior that the Startup moment feature should follow.
  */
-class StartupBehaviorImpl(
-    thresholdCheck: BehaviorThresholdCheck,
-    localSupplier: Provider<StartupMomentLocalConfig?>
-) : StartupBehavior, MergedConfigBehavior<StartupMomentLocalConfig, UnimplementedConfig>(
-    thresholdCheck = thresholdCheck,
-    localSupplier = localSupplier
-) {
+class StartupBehaviorImpl : StartupBehavior {
 
-    private companion object {
-        const val AUTOMATICALLY_END_DEFAULT = true
-    }
-
-    override fun isStartupMomentAutoEndEnabled(): Boolean = local?.automaticallyEnd ?: AUTOMATICALLY_END_DEFAULT
+    override fun isStartupMomentAutoEndEnabled(): Boolean =
+        InstrumentedConfig.enabledFeatures.isStartupMomentAutoEndEnabled()
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/SessionPropertiesServiceImplTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -23,11 +22,7 @@ internal class SessionPropertiesServiceImplTest {
     fun setUp() {
         val fakeConfigService =
             FakeConfigService(
-                sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-                    SdkLocalConfig(
-                        sensitiveKeysDenylist = listOf("password")
-                    )
-                )
+                sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(listOf("password"))
             )
         fakeCurrentSessionSpan = FakeCurrentSessionSpan()
         service = SessionPropertiesServiceImpl(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.comms.api
 
 import io.embrace.android.embracesdk.fakes.createSdkEndpointBehavior
-import io.embrace.android.embracesdk.internal.config.local.BaseUrlLocalConfig
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -17,7 +16,7 @@ internal class EmbraceApiUrlBuilderTest {
 
     @Before
     fun setup() {
-        val baseUrlLocalConfig = createSdkEndpointBehavior { BaseUrlLocalConfig() }
+        val baseUrlLocalConfig = createSdkEndpointBehavior()
 
         apiUrlBuilder = EmbraceApiUrlBuilder(
             coreBaseUrl = baseUrlLocalConfig.getData(APP_ID),

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/LocalConfigTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/LocalConfigTest.kt
@@ -181,53 +181,6 @@ internal class LocalConfigTest {
     }
 
     @Test
-    fun testSessionOnlyConfig() {
-        var localConfig = LocalConfigParser.buildConfig(
-            "GrCPU",
-            false,
-            "{\"session\": {\"components\": [\"breadcrumbs_taps\"]}}",
-            serializer,
-            cfg,
-            logger
-        )
-        assertTrue(
-            checkNotNull(localConfig.sdkConfig.sessionConfig?.sessionComponents)
-                .contains("breadcrumbs_taps")
-        )
-
-        // full session for component list is empty
-        localConfig =
-            LocalConfigParser.buildConfig(
-                "GrCPU",
-                false,
-                "{\"session\": {\"send_full_for\": []}}",
-                serializer,
-                cfg,
-                logger
-            )
-        assertTrue(
-            checkNotNull(localConfig.sdkConfig.sessionConfig?.fullSessionEvents).isEmpty()
-        )
-
-        // receive a full session for component to restrict session messages
-        localConfig = LocalConfigParser.buildConfig(
-            "GrCPU",
-            false,
-            "{\"session\": {\"send_full_for\": [\"crashes\"]}}",
-            serializer,
-            cfg,
-            logger
-        )
-        val sessionConfig = localConfig.sdkConfig.sessionConfig
-        assertFalse(
-            checkNotNull(sessionConfig?.fullSessionEvents?.isEmpty())
-        )
-        assertTrue(
-            checkNotNull(sessionConfig?.fullSessionEvents?.contains("crashes"))
-        )
-    }
-
-    @Test
     fun testStartupMomentOnlyConfig() {
         val localConfig = LocalConfigParser.buildConfig(
             "GrCPU",

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AnrBehaviorImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createAnrBehavior
-import io.embrace.android.embracesdk.internal.config.local.AnrLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.AllowedNdkSampleMethod
 import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.Unwinder
@@ -12,11 +11,6 @@ import org.junit.Test
 import java.util.regex.Pattern
 
 internal class AnrBehaviorImplTest {
-
-    private val local = AnrLocalConfig(
-        captureGoogle = true,
-        captureUnityThread = true
-    )
 
     private val remote = AnrRemoteConfig(
         pctEnabled = 0,
@@ -90,16 +84,8 @@ internal class AnrBehaviorImplTest {
     }
 
     @Test
-    fun testLocalOnly() {
-        with(createAnrBehavior(localCfg = { local })) {
-            assertTrue(isSigquitCaptureEnabled())
-            assertTrue(isUnityAnrCaptureEnabled())
-        }
-    }
-
-    @Test
     fun testRemoteAndLocal() {
-        with(createAnrBehavior(localCfg = { local }, remoteCfg = { remote })) {
+        with(createAnrBehavior(remoteCfg = { remote })) {
             assertFalse(isSigquitCaptureEnabled())
             assertEquals(200L, getSamplingIntervalMs())
             assertFalse(shouldCaptureMainThreadOnly())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImplTest.kt
@@ -1,17 +1,13 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createAppExitInfoBehavior
-import io.embrace.android.embracesdk.internal.config.local.AppExitInfoLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class AppExitInfoBehaviorImplTest {
-
-    private val local = AppExitInfoLocalConfig(33792, false)
 
     private val remote = RemoteConfig(
         appExitInfoConfig = AppExitInfoConfig(55209, 100f)
@@ -26,16 +22,8 @@ internal class AppExitInfoBehaviorImplTest {
     }
 
     @Test
-    fun testLocalOnly() {
-        with(createAppExitInfoBehavior(localCfg = { local })) {
-            assertEquals(33792, getTraceMaxLimit())
-            assertFalse(isAeiCaptureEnabled())
-        }
-    }
-
-    @Test
     fun testLocalAndRemote() {
-        with(createAppExitInfoBehavior(localCfg = { local }, remoteCfg = { remote })) {
+        with(createAppExitInfoBehavior(remoteCfg = { remote })) {
             assertEquals(55209, getTraceMaxLimit())
             assertTrue(isAeiCaptureEnabled())
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -1,12 +1,6 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.internal.config.local.AppLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.AutomaticDataCaptureLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.ComposeLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.CrashHandlerLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.DataRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -15,22 +9,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class AutoDataCaptureBehaviorImplTest {
-
-    private val local = LocalConfig(
-        appId = "",
-        ndkEnabled = true,
-        sdkConfig = SdkLocalConfig(
-            automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(
-                memoryServiceEnabled = false,
-                powerSaveModeServiceEnabled = false,
-                networkConnectivityServiceEnabled = false,
-                anrServiceEnabled = false
-            ),
-            crashHandler = CrashHandlerLocalConfig(false),
-            composeConfig = ComposeLocalConfig(true),
-            app = AppLocalConfig(reportDiskUsage = false)
-        ),
-    )
 
     private val remote = RemoteConfig(
         killSwitchConfig = KillSwitchRemoteConfig(
@@ -57,23 +35,8 @@ internal class AutoDataCaptureBehaviorImplTest {
     }
 
     @Test
-    fun testLocalOnly() {
-        with(createAutoDataCaptureBehavior(localCfg = { local })) {
-            assertFalse(isMemoryWarningCaptureEnabled())
-            assertFalse(isPowerSaveModeCaptureEnabled())
-            assertFalse(isNetworkConnectivityCaptureEnabled())
-            assertFalse(isAnrCaptureEnabled())
-            assertFalse(isJvmCrashCaptureEnabled())
-            assertTrue(isComposeClickCaptureEnabled())
-            assertTrue(is3rdPartySigHandlerDetectionEnabled())
-            assertTrue(isNativeCrashCaptureEnabled())
-            assertFalse(isDiskUsageCaptureEnabled())
-        }
-    }
-
-    @Test
     fun testLocalAndRemote() {
-        with(createAutoDataCaptureBehavior(localCfg = { local }, remoteCfg = { remote })) {
+        with(createAutoDataCaptureBehavior(remoteCfg = { remote })) {
             assertFalse(is3rdPartySigHandlerDetectionEnabled())
             assertFalse(isComposeClickCaptureEnabled())
             assertFalse(isThermalStatusCaptureEnabled())
@@ -87,26 +50,10 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertFalse(isComposeClickCaptureEnabled())
         }
 
-        // Jetpack Compose is enabled locally, no remote config
-        with(createAutoDataCaptureBehavior(localCfg = { local })) {
-            assertTrue(isComposeClickCaptureEnabled())
-        }
-
-        // Jetpack Compose disabled remotely, overrides local: killswitch
-        with(createAutoDataCaptureBehavior(localCfg = { local }, remoteCfg = { remote })) {
+        // Jetpack Compose disabled remotely
+        with(createAutoDataCaptureBehavior(remoteCfg = { remote })) {
             assertFalse(isComposeClickCaptureEnabled())
         }
-
-        val localComposeOff = LocalConfig(
-            "abcde",
-            false,
-            SdkLocalConfig(
-                composeConfig = ComposeLocalConfig(
-                    false
-                )
-            )
-        )
-
         val remoteComposeKillSwitchOff = RemoteConfig(
             killSwitchConfig = KillSwitchRemoteConfig(
                 sigHandlerDetection = false,
@@ -114,20 +61,9 @@ internal class AutoDataCaptureBehaviorImplTest {
             )
         )
 
-        // Jetpack Compose enabled remotely, but explicit disabled locally, remote ignored
+        // Jetpack Compose enabled remotely
         with(
             createAutoDataCaptureBehavior(
-                localCfg = { localComposeOff },
-                remoteCfg = { remoteComposeKillSwitchOff }
-            )
-        ) {
-            assertFalse(isComposeClickCaptureEnabled())
-        }
-
-        // Jetpack Compose enabled remotely, and explicit enabled locally
-        with(
-            createAutoDataCaptureBehavior(
-                localCfg = { local },
                 remoteCfg = { remoteComposeKillSwitchOff }
             )
         ) {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImplTest.kt
@@ -1,21 +1,12 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
-import io.embrace.android.embracesdk.internal.config.local.BackgroundActivityLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class BackgroundActivityBehaviorImplTest {
-
-    private val local = BackgroundActivityLocalConfig(
-        true,
-        50,
-        3000L,
-        50
-    )
 
     private val remote = BackgroundActivityRemoteConfig(
         0f
@@ -32,22 +23,12 @@ internal class BackgroundActivityBehaviorImplTest {
     }
 
     @Test
-    fun testLocalOnly() {
-        with(createBackgroundActivityBehavior(localCfg = { local })) {
-            assertTrue(isBackgroundActivityCaptureEnabled())
-            assertEquals(50, getManualBackgroundActivityLimit())
-            assertEquals(3000L, getMinBackgroundActivityDuration())
-            assertEquals(50, getMaxCachedActivities())
-        }
-    }
-
-    @Test
     fun testRemoteAndLocal() {
-        with(createBackgroundActivityBehavior(localCfg = { local }, remoteCfg = { remote })) {
+        with(createBackgroundActivityBehavior(remoteCfg = { remote })) {
             assertFalse(isBackgroundActivityCaptureEnabled())
-            assertEquals(50, getManualBackgroundActivityLimit())
-            assertEquals(3000L, getMinBackgroundActivityDuration())
-            assertEquals(50, getMaxCachedActivities())
+            assertEquals(100, getManualBackgroundActivityLimit())
+            assertEquals(5000L, getMinBackgroundActivityDuration())
+            assertEquals(30, getMaxCachedActivities())
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
@@ -1,9 +1,5 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.TapsLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.ViewLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.WebViewLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.UiRemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Uuid
@@ -26,16 +22,9 @@ internal class BreadcrumbBehaviorImplTest {
 
     private val behaviorThresholdCheck = BehaviorThresholdCheck { Uuid.getEmbUuid() }
 
-    private val local = SdkLocalConfig(
-        taps = TapsLocalConfig(false),
-        viewConfig = ViewLocalConfig(false),
-        webViewConfig = WebViewLocalConfig(captureWebViews = false, captureQueryParams = false),
-        captureFcmPiiData = true
-    )
-
     @Test
     fun testDefaults() {
-        with(BreadcrumbBehaviorImpl(thresholdCheck = behaviorThresholdCheck, localSupplier = { null }) { null }) {
+        with(BreadcrumbBehaviorImpl(thresholdCheck = behaviorThresholdCheck) { null }) {
             assertEquals(100, getCustomBreadcrumbLimit())
             assertEquals(100, getTapBreadcrumbLimit())
             assertEquals(100, getViewBreadcrumbLimit())
@@ -50,19 +39,10 @@ internal class BreadcrumbBehaviorImplTest {
     }
 
     @Test
-    fun testLocalOnly() {
-        with(BreadcrumbBehaviorImpl(thresholdCheck = behaviorThresholdCheck, localSupplier = { local }) { null }) {
-            assertFalse(isViewClickCoordinateCaptureEnabled())
-            assertFalse(isActivityBreadcrumbCaptureEnabled())
-            assertFalse(isWebViewBreadcrumbCaptureEnabled())
-            assertFalse(isWebViewBreadcrumbQueryParamCaptureEnabled())
-            assertTrue(isFcmPiiDataCaptureEnabled())
-        }
-    }
-
-    @Test
     fun testRemoteAndLocal() {
-        with(BreadcrumbBehaviorImpl(thresholdCheck = behaviorThresholdCheck, localSupplier = { local }) { remote }) {
+        with(
+            BreadcrumbBehaviorImpl(thresholdCheck = behaviorThresholdCheck) { remote }
+        ) {
             assertEquals(99, getCustomBreadcrumbLimit())
             assertEquals(98, getTapBreadcrumbLimit())
             assertEquals(97, getViewBreadcrumbLimit())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
@@ -1,20 +1,9 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.createNetworkBehavior
-import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.internal.config.LocalConfigParser
-import io.embrace.android.embracesdk.internal.config.local.DomainLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.NetworkLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
-import io.embrace.android.embracesdk.internal.opentelemetry.OpenTelemetryConfiguration
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -22,34 +11,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class NetworkBehaviorImplTest {
-
-    companion object {
-        private const val testCleanPublicKey =
-            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQE" +
-                "AuAZAv5tzK9Ab/DsVpNaYiuslKQsOHjz4N4haZLT8VaVIrlVjtkd5nPrVgEKStQf6PKn" +
-                "Q+1C0Tp069b6aPUkG22UL96nCKQ1eCIwRUT+Da7ac2YVuL21+HTs1KxLEWgN7qGy1uYN" +
-                "onrpsiY3XqzDvYMo65oFzbBV+yctuGHDFaulULJiLL8cE3/Rg3T0RfHK+C5/PqC8FBj6" +
-                "kn3FP9FZJM4cty3nzbNWknj8r7+ikmOwma6CHEZz2u1gwPhIchNxNKuUF+4vxcBre9V/" +
-                "96LYOjSOGSDJmJN6ehUJjUpu7YSuGCki8YoLHAyoD/mYy7N/hYSeZwHiNjM+r44lZHNQ" +
-                "TpwIDAQAB"
-    }
-
-    private val local = SdkLocalConfig(
-        networking = NetworkLocalConfig(
-            traceIdHeader = "x-custom-trace",
-            captureRequestContentLength = true,
-            enableNativeMonitoring = false,
-            domains = listOf(
-                DomainLocalConfig(
-                    "google.com",
-                    100
-                )
-            ),
-            disabledUrlPatterns = listOf("google.com"),
-            defaultCaptureLimit = 720,
-        ),
-        capturePublicKey = "test"
-    )
 
     private val remote = RemoteConfig(
         networkConfig = NetworkRemoteConfig(
@@ -71,7 +32,7 @@ internal class NetworkBehaviorImplTest {
 
     @Test
     fun testDefaults() {
-        with(createNetworkBehavior(localCfg = { null }, remoteCfg = { null })) {
+        with(createNetworkBehavior(remoteCfg = { null })) {
             assertEquals("x-emb-trace-id", getTraceIdHeader())
             assertFalse(isRequestContentLengthCaptureEnabled())
             assertTrue(isHttpUrlConnectionCaptureEnabled())
@@ -85,41 +46,8 @@ internal class NetworkBehaviorImplTest {
     }
 
     @Test
-    fun testLocalOnly() {
-        with(createNetworkBehavior(localCfg = { local }, remoteCfg = { null })) {
-            assertEquals("x-custom-trace", getTraceIdHeader())
-            assertTrue(isRequestContentLengthCaptureEnabled())
-            assertFalse(isHttpUrlConnectionCaptureEnabled())
-            assertEquals(mapOf("google.com" to 100), getLimitsByDomain())
-            assertEquals(720, getRequestLimitPerDomain())
-            assertFalse(isUrlEnabled("google.com"))
-            assertTrue(isCaptureBodyEncryptionEnabled())
-            assertEquals("test", getNetworkBodyCapturePublicKey())
-        }
-    }
-
-    @Test
     fun testRemoteOnly() {
-        with(createNetworkBehavior(localCfg = { null }, remoteCfg = { remote })) {
-            assertEquals(409, getRequestLimitPerDomain())
-            assertEquals(mapOf("google.com" to 50), getLimitsByDomain())
-            assertTrue(isUrlEnabled("google.com"))
-            assertFalse(isUrlEnabled("example.com"))
-            assertEquals(
-                NetworkCaptureRuleRemoteConfig(
-                    "test",
-                    5000,
-                    "GET",
-                    "google.com",
-                ),
-                getNetworkCaptureRules().single()
-            )
-        }
-    }
-
-    @Test
-    fun testRemoteAndLocal() {
-        with(createNetworkBehavior(localCfg = { local }, remoteCfg = { remote })) {
+        with(createNetworkBehavior(remoteCfg = { remote })) {
             assertEquals(409, getRequestLimitPerDomain())
             assertEquals(mapOf("google.com" to 50), getLimitsByDomain())
             assertTrue(isUrlEnabled("google.com"))
@@ -138,26 +66,8 @@ internal class NetworkBehaviorImplTest {
 
     @Test
     fun testNetworkingInvalidDisabledRegexIgnored() {
-        val cfg = SdkLocalConfig(
-            networking = NetworkLocalConfig(
-                disabledUrlPatterns = listOf("a.b.c", "invalid[}regex")
-            )
-        )
-        with(createNetworkBehavior(localCfg = { cfg })) {
+        with(createNetworkBehavior(disabledUrlPatterns = listOf("a.b.c", "invalid[}regex"))) {
             assertTrue(isUrlEnabled("invalid[}regex"))
         }
-    }
-
-    @Test
-    fun testGetNetworkBodyCapturePublicKey() {
-        val otelCfg = OpenTelemetryConfiguration(
-            SpanSinkImpl(),
-            LogSinkImpl(),
-            SystemInfo()
-        )
-        val json = ResourceReader.readResourceAsText("public_key_config.json")
-        val localConfig = LocalConfigParser.buildConfig("aaa", false, json, EmbraceSerializer(), otelCfg, EmbLoggerImpl())
-        val behavior = createNetworkBehavior(localCfg = localConfig::sdkConfig)
-        assertEquals(testCleanPublicKey, behavior.getNetworkBodyCapturePublicKey())
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SdkEndpointBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SdkEndpointBehaviorImplTest.kt
@@ -1,31 +1,16 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createSdkEndpointBehavior
-import io.embrace.android.embracesdk.internal.config.local.BaseUrlLocalConfig
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class SdkEndpointBehaviorImplTest {
-
-    private val local = BaseUrlLocalConfig(
-        "https://config.example.com",
-        "https://data.example.com",
-        "https://images.example.com"
-    )
 
     @Test
     fun testDefaults() {
         with(createSdkEndpointBehavior()) {
             assertEquals("https://a-12345.config.emb-api.com", getConfig("12345"))
             assertEquals("https://a-12345.data.emb-api.com", getData("12345"))
-        }
-    }
-
-    @Test
-    fun testLocalOnly() {
-        with(createSdkEndpointBehavior(localCfg = { local })) {
-            assertEquals("https://config.example.com", getConfig("12345"))
-            assertEquals("https://data.example.com", getData("12345"))
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -10,7 +9,7 @@ internal class SensitiveKeysBehaviorImplTest {
     @Test
     fun `keys are not sensitive if they are not in the sensitive keys list`() {
         // given an empty sensitive list
-        val behavior = getBehaviorWithSensitiveList(emptyList())
+        val behavior = SensitiveKeysBehaviorImpl(emptyList())
 
         // when checking if a key is sensitive
         val isSensitive = behavior.isSensitiveKey("password")
@@ -22,7 +21,7 @@ internal class SensitiveKeysBehaviorImplTest {
     @Test
     fun `keys are not sensitive with a null sensitive keys list`() {
         // given a null sensitive list
-        val behavior = getBehaviorWithSensitiveList(null)
+        val behavior = SensitiveKeysBehaviorImpl(null)
 
         // when checking if a key is sensitive
         val isSensitive = behavior.isSensitiveKey("password")
@@ -34,7 +33,7 @@ internal class SensitiveKeysBehaviorImplTest {
     @Test
     fun `keys are sensitive when found in the sensitive keys list`() {
         // given a sensitive list with a key
-        val behavior = getBehaviorWithSensitiveList(listOf("password"))
+        val behavior = SensitiveKeysBehaviorImpl(listOf("password"))
 
         // when checking if a key present in the list is sensitive
         val isSensitive = behavior.isSensitiveKey("password")
@@ -46,7 +45,7 @@ internal class SensitiveKeysBehaviorImplTest {
     @Test
     fun `keys in the sensitive list are truncated to 128 characters`() {
         // given a sensitive list with a long key
-        val behavior = getBehaviorWithSensitiveList(listOf("a".repeat(200)))
+        val behavior = SensitiveKeysBehaviorImpl(listOf("a".repeat(200)))
 
         // when checking if a key present in the list is sensitive
         val sensitiveKey = behavior.isSensitiveKey("a".repeat(128))
@@ -60,7 +59,7 @@ internal class SensitiveKeysBehaviorImplTest {
     @Test
     fun `sensitive list is truncated to 10000 keys`() {
         // given a sensitive list with more than 10000 keys
-        val behavior = getBehaviorWithSensitiveList(
+        val behavior = SensitiveKeysBehaviorImpl(
             List(10000) { it.toString() } + "password"
         )
 
@@ -74,7 +73,7 @@ internal class SensitiveKeysBehaviorImplTest {
     @Test
     fun `sensitive list with multiple keys`() {
         // given a sensitive list with multiple keys
-        val behavior = getBehaviorWithSensitiveList(
+        val behavior = SensitiveKeysBehaviorImpl(
             listOf(
                 "password",
                 "passkey"
@@ -90,13 +89,5 @@ internal class SensitiveKeysBehaviorImplTest {
         assertTrue(sensitiveKey)
         assertTrue(anotherSensitiveKey)
         assertFalse(notSensitiveKey)
-    }
-
-    private fun getBehaviorWithSensitiveList(list: List<String>?): SensitiveKeysBehaviorImpl {
-        return SensitiveKeysBehaviorImpl(
-            SdkLocalConfig(
-                sensitiveKeysDenylist = list
-            )
-        )
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImplImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImplImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createSessionBehavior
-import io.embrace.android.embracesdk.internal.config.local.SessionLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
 import org.junit.Assert.assertEquals
@@ -11,11 +10,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionBehaviorImplImplTest {
-
-    private val local = SessionLocalConfig(
-        sessionComponents = setOf("breadcrumbs"),
-        fullSessionEvents = setOf("crash")
-    )
 
     private val remote = RemoteConfig(
         sessionConfig = SessionRemoteConfig(
@@ -38,17 +32,8 @@ internal class SessionBehaviorImplImplTest {
     }
 
     @Test
-    fun testLocalOnly() {
-        with(createSessionBehavior(localCfg = { local })) {
-            assertEquals(setOf("breadcrumbs"), getSessionComponents())
-            assertEquals(setOf("crash"), getFullSessionEvents())
-            assertTrue(isGatingFeatureEnabled())
-        }
-    }
-
-    @Test
     fun testRemoteAndLocal() {
-        with(createSessionBehavior(localCfg = { local }, remoteCfg = { remote })) {
+        with(createSessionBehavior(remoteCfg = { remote })) {
             assertTrue(isGatingFeatureEnabled())
             assertTrue(isSessionControlEnabled())
             assertEquals(setOf("test"), getSessionComponents())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/StartupBehaviorImplTest.kt
@@ -1,28 +1,15 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.fakes.createStartupBehavior
-import io.embrace.android.embracesdk.internal.config.local.StartupMomentLocalConfig
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class StartupBehaviorImplTest {
 
-    private val local = StartupMomentLocalConfig(
-        automaticallyEnd = false
-    )
-
     @Test
     fun testDefaults() {
         with(createStartupBehavior()) {
             assertTrue(isStartupMomentAutoEndEnabled())
-        }
-    }
-
-    @Test
-    fun testLocalOnly() {
-        with(createStartupBehavior(localCfg = { local })) {
-            assertFalse(isStartupMomentAutoEndEnabled())
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
@@ -21,7 +21,6 @@ import io.embrace.android.embracesdk.internal.capture.user.EmbraceUserService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.gating.EmbraceGatingService
 import io.embrace.android.embracesdk.internal.gating.GatingService
@@ -86,11 +85,7 @@ internal class EmbraceEventServiceTest {
         configService = FakeConfigService(
             startupBehavior = FakeStartupBehavior(true),
             dataCaptureEventBehavior = createDataCaptureEventBehavior { remoteConfig },
-            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-                SdkLocalConfig(
-                    sensitiveKeysDenylist = listOf("password")
-                )
-            )
+            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(listOf("password"))
         )
         sessionPropertiesService = FakeSessionPropertiesService()
         gatingService = FakeGatingService(EmbraceGatingService(configService, FakeLogService(), FakeEmbLogger()))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.fakes.createSessionBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embExceptionHandling
@@ -44,11 +43,7 @@ internal class EmbraceLogServiceTest {
     @Before
     fun setUp() {
         fakeConfigService = FakeConfigService(
-            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-                SdkLocalConfig(
-                    sensitiveKeysDenylist = listOf("password")
-                )
-            )
+            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(listOf("password"))
         )
         fakeSessionPropertiesService = FakeSessionPropertiesService()
         fakeLogWriter = FakeLogWriter()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -5,76 +5,38 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureDataSource
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.createNetworkBehavior
-import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.internal.config.LocalConfigParser
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
-import io.embrace.android.embracesdk.internal.opentelemetry.OpenTelemetryConfiguration
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
-import io.mockk.clearAllMocks
-import io.mockk.unmockkAll
-import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
 
 internal class EmbraceNetworkCaptureServiceTest {
 
     private lateinit var preferenceService: FakePreferenceService
     private lateinit var networkCaptureDataSource: FakeNetworkCaptureDataSource
-
-    companion object {
-        private var cfg: RemoteConfig = RemoteConfig()
-        private val sessionIdTracker: FakeSessionIdTracker = FakeSessionIdTracker()
-        private val configService: FakeConfigService = FakeConfigService(
-            networkBehavior = createNetworkBehavior { cfg }
-        )
-        private lateinit var mockLocalConfig: LocalConfig
-        private val networkCaptureData: NetworkCaptureData = NetworkCaptureData(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        )
-
-        @BeforeClass
-        @JvmStatic
-        fun beforeClass() {
-            val otelCfg = OpenTelemetryConfiguration(
-                SpanSinkImpl(),
-                LogSinkImpl(),
-                SystemInfo()
-            )
-            mockLocalConfig =
-                LocalConfigParser.buildConfig(
-                    "GrCPU",
-                    false,
-                    "{\"base_urls\": {\"data\": \"https://data.emb-api.com\"}}",
-                    EmbraceSerializer(),
-                    otelCfg,
-                    EmbLoggerImpl()
-                )
-        }
-
-        @AfterClass
-        @JvmStatic
-        fun afterClass() {
-            unmockkAll()
-        }
-    }
+    private lateinit var cfg: RemoteConfig
+    private val sessionIdTracker: FakeSessionIdTracker = FakeSessionIdTracker()
+    private lateinit var configService: FakeConfigService
+    private val networkCaptureData: NetworkCaptureData = NetworkCaptureData(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+    )
 
     @Before
     fun setUp() {
-        clearAllMocks()
+        cfg = RemoteConfig()
+        configService = FakeConfigService(
+            networkBehavior = createNetworkBehavior(remoteCfg = { cfg })
+        )
         preferenceService = FakePreferenceService()
         networkCaptureDataSource = FakeNetworkCaptureDataSource()
         sessionIdTracker.setActiveSession("session-123", true)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -32,11 +31,7 @@ internal class EmbraceSpanFactoryImplTest {
             tracer = tracer,
             openTelemetryClock = initModule.openTelemetryModule.openTelemetryClock,
             spanRepository = spanRepository,
-            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-                SdkLocalConfig(
-                    sensitiveKeysDenylist = listOf("password")
-                )
-            )
+            sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(listOf("password"))
         )
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
@@ -49,11 +48,7 @@ internal class EmbraceSpanImplTest {
         .setTracerProvider(SdkTracerProvider.builder().build()).build()
         .getTracer(EmbraceSpanImplTest::class.java.name)
 
-    private val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-        SdkLocalConfig(
-            sensitiveKeysDenylist = listOf("password")
-        )
-    )
+    private val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(listOf("password"))
 
     @Before
     fun setup() {

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/InstrumentedConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/InstrumentedConfig.kt
@@ -18,4 +18,5 @@ object InstrumentedConfig {
     val networkCapture: NetworkCaptureConfig = NetworkCaptureConfig
     val project: ProjectConfig = ProjectConfig
     val redaction: RedactionConfig = RedactionConfig
+    val session: SessionConfig = SessionConfig
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/SessionConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/SessionConfig.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.internal.config.instrumented
+
+import com.squareup.moshi.Json
+
+/**
+ * Declares metadata about the app project
+ */
+@Suppress("FunctionOnlyReturningConstant")
+@Swazzled
+object SessionConfig {
+
+    /**
+     * A whitelist of session components (i.e. Breadcrumbs, Session properties, etc) that should be
+     * included in the session payload. The presence of this property denotes that the gating
+     * feature is enabled.
+     *
+     * sdk_config.session.components
+     */
+    @Json(name = "components")
+    fun getSessionComponents(): Set<String>? = null
+
+    /**
+     * A list of events (crashes, errors, etc) allowed to send a full session payload if the
+     * gating feature is enabled.
+     *
+     * sdk_config.session.send_full_for
+     */
+    @Json(name = "send_full_for")
+    fun getFullSessionEvents(): Set<String> = emptySet()
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -11,17 +11,11 @@ import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
-import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.NetworkLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.internal.injection.AnrModule
 import io.embrace.android.embracesdk.internal.injection.CoreModule
@@ -156,10 +150,6 @@ internal class IntegrationTestRule(
         val overriddenWorkerThreadModule: WorkerThreadModule = createWorkerThreadModule(overriddenInitModule),
         val overriddenConfigService: FakeConfigService = FakeConfigService(
             backgroundActivityCaptureEnabled = true,
-            networkBehavior = createNetworkBehavior(
-                localCfg = { DEFAULT_SDK_LOCAL_CONFIG },
-                remoteCfg = { DEFAULT_SDK_REMOTE_CONFIG }
-            ),
             networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior(true),
             autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(thermalStatusCaptureEnabled = false)
         ),
@@ -182,31 +172,5 @@ internal class IntegrationTestRule(
 
     companion object {
         const val DEFAULT_SDK_START_TIME_MS = 169220160000L
-
-        private val DEFAULT_SDK_LOCAL_CONFIG = SdkLocalConfig(
-            networking = NetworkLocalConfig(
-                enableNativeMonitoring = false
-            ),
-            betaFeaturesEnabled = false
-        )
-
-        private val DEFAULT_SDK_REMOTE_CONFIG = RemoteConfig(
-            disabledUrlPatterns = setOf("dontlogmebro.pizza"),
-            networkCaptureRules = setOf(
-                NetworkCaptureRuleRemoteConfig(
-                    id = "test",
-                    duration = 10000,
-                    method = "GET",
-                    urlRegex = "capture.me",
-                    expiresIn = 10000
-                )
-            )
-        )
-
-        val DEFAULT_LOCAL_CONFIG = LocalConfig(
-            appId = "CoYh3",
-            ndkEnabled = false,
-            sdkConfig = DEFAULT_SDK_LOCAL_CONFIG
-        )
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SensitiveKeysRedactionFeatureTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -24,9 +23,7 @@ internal class SensitiveKeysRedactionFeatureTest {
     @Before
     fun setUp() {
         testRule.harness.overriddenConfigService.sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-            localConfig = SdkLocalConfig(
-                sensitiveKeysDenylist = listOf("password")
-            )
+            listOf("password")
         )
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -6,10 +6,13 @@ import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.LogType
+import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.findEventOfType
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.findSpansByName
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
@@ -193,6 +196,22 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `access check methods work as expected`() {
         with(testRule) {
+            harness.overriddenConfigService.networkBehavior =
+                createNetworkBehavior(remoteCfg = {
+                    RemoteConfig(
+                        disabledUrlPatterns = setOf("dontlogmebro.pizza"),
+                        networkCaptureRules = setOf(
+                            NetworkCaptureRuleRemoteConfig(
+                                id = "test",
+                                duration = 10000,
+                                method = "GET",
+                                urlRegex = "capture.me",
+                                expiresIn = 10000
+                            )
+                        )
+                    )
+                })
+
             startSdk(context = harness.overriddenCoreModule.context)
             harness.recordSession {
                 assertTrue(embrace.internalInterface.shouldCaptureNetworkBody("capture.me", "GET"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -3,8 +3,11 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
+import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.getLastSentSession
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
@@ -162,6 +165,22 @@ internal class NetworkRequestApiTest {
 
     @Test
     fun `disabled URLs not recorded`() {
+        testRule.harness.overriddenConfigService.networkBehavior =
+            createNetworkBehavior(remoteCfg = {
+                RemoteConfig(
+                    disabledUrlPatterns = setOf("dontlogmebro.pizza"),
+                    networkCaptureRules = setOf(
+                        NetworkCaptureRuleRemoteConfig(
+                            id = "test",
+                            duration = 10000,
+                            method = "GET",
+                            urlRegex = "capture.me",
+                            expiresIn = 10000
+                        )
+                    )
+                )
+            })
+
         with(testRule) {
             harness.recordSession {
                 harness.overriddenConfigService.updateListeners()
@@ -233,7 +252,8 @@ internal class NetworkRequestApiTest {
 
             val session = checkNotNull(testRule.harness.getLastSentSession())
 
-            val spans = checkNotNull(session.data.spans?.filter { it.attributes?.findAttributeValue("http.request.method") != null })
+            val spans =
+                checkNotNull(session.data.spans?.filter { it.attributes?.findAttributeValue("http.request.method") != null })
             assertEquals(
                 "Unexpected number of requests in sent session: ${spans.size}",
                 2,
@@ -258,30 +278,61 @@ internal class NetworkRequestApiTest {
             with(networkSpan) {
                 val attrs = checkNotNull(attributes)
                 assertEquals(expectedRequest.url, attrs.findAttributeValue("url.full"))
-                assertEquals(expectedRequest.httpMethod, attrs.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key))
+                assertEquals(
+                    expectedRequest.httpMethod,
+                    attrs.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key)
+                )
                 assertEquals(expectedRequest.startTime.millisToNanos(), startTimeNanos)
                 assertEquals(expectedRequest.endTime.millisToNanos(), endTimeNanos)
                 assertEquals(expectedRequest.traceId, attrs.findAttributeValue("emb.trace_id"))
-                assertEquals(expectedRequest.w3cTraceparent, attrs.findAttributeValue("emb.w3c_traceparent"))
+                assertEquals(
+                    expectedRequest.w3cTraceparent,
+                    attrs.findAttributeValue("emb.w3c_traceparent")
+                )
                 if (completed) {
-                    assertEquals(expectedRequest.responseCode.toString(), attrs.findAttributeValue(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key))
-                    assertEquals(expectedRequest.bytesSent.toString(), attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key))
-                    assertEquals(expectedRequest.bytesReceived.toString(), attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key))
+                    assertEquals(
+                        expectedRequest.responseCode.toString(),
+                        attrs.findAttributeValue(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key)
+                    )
+                    assertEquals(
+                        expectedRequest.bytesSent.toString(),
+                        attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key)
+                    )
+                    assertEquals(
+                        expectedRequest.bytesReceived.toString(),
+                        attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key)
+                    )
                     assertEquals(null, attrs.findAttributeValue("error.type"))
-                    assertEquals(null, attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_MESSAGE.key))
+                    assertEquals(
+                        null,
+                        attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_MESSAGE.key)
+                    )
                     val statusCode = expectedRequest.responseCode
-                    val expectedStatus = if (statusCode != null && statusCode >= 200 && statusCode < 400) {
-                        Span.Status.UNSET
-                    } else {
-                        Span.Status.ERROR
-                    }
+                    val expectedStatus =
+                        if (statusCode != null && statusCode >= 200 && statusCode < 400) {
+                            Span.Status.UNSET
+                        } else {
+                            Span.Status.ERROR
+                        }
                     assertEquals(expectedStatus, status)
                 } else {
-                    assertEquals(null, attrs.findAttributeValue(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key))
-                    assertEquals(null, attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key))
-                    assertEquals(null, attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key))
+                    assertEquals(
+                        null,
+                        attrs.findAttributeValue(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key)
+                    )
+                    assertEquals(
+                        null,
+                        attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key)
+                    )
+                    assertEquals(
+                        null,
+                        attrs.findAttributeValue(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key)
+                    )
                     assertEquals(expectedRequest.errorType, attrs.findAttributeValue("error.type"))
-                    assertEquals(expectedRequest.errorMessage, attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_MESSAGE.key))
+                    assertEquals(
+                        expectedRequest.errorMessage,
+                        attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_MESSAGE.key)
+                    )
                     assertEquals(Span.Status.ERROR, status)
                 }
             }
@@ -292,7 +343,8 @@ internal class NetworkRequestApiTest {
         val session = checkNotNull(testRule.harness.getLastSentSession())
 
         val unfilteredSpans = checkNotNull(session.data.spans)
-        val spans = checkNotNull(unfilteredSpans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key) != null })
+        val spans =
+            checkNotNull(unfilteredSpans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key) != null })
         assertEquals(
             "Unexpected number of requests in sent session: ${spans.size}",
             1,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -28,14 +28,6 @@ import io.embrace.android.embracesdk.internal.config.behavior.StartupBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.StartupBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.WebViewVitalsBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.local.AnrLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.AppExitInfoLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.BackgroundActivityLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.BaseUrlLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.LocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SdkLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.SessionLocalConfig
-import io.embrace.android.embracesdk.internal.config.local.StartupMomentLocalConfig
 import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.LogRemoteConfig
@@ -51,45 +43,41 @@ private val behaviorThresholdCheck = BehaviorThresholdCheck(Uuid::getEmbUuid)
  */
 fun createAnrBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<AnrLocalConfig?> = { null },
     remoteCfg: Provider<AnrRemoteConfig?> = { null }
-): AnrBehavior = AnrBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
+): AnrBehavior = AnrBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [SessionBehaviorImpl] that returns default values.
  */
 fun createSessionBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<SessionLocalConfig?> = { null },
     remoteCfg: Provider<RemoteConfig?> = { null }
-): SessionBehavior = SessionBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
+): SessionBehavior = SessionBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [NetworkBehaviorImpl] that returns default values.
  */
 fun createNetworkBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<SdkLocalConfig?> = { null },
-    remoteCfg: Provider<RemoteConfig?> = { null }
-): NetworkBehavior = NetworkBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
+    remoteCfg: Provider<RemoteConfig?> = { null },
+    disabledUrlPatterns: List<String>? = null
+): NetworkBehavior = NetworkBehaviorImpl(thresholdCheck, remoteCfg, disabledUrlPatterns)
 
 /**
  * A [BackgroundActivityBehaviorImpl] that returns default values.
  */
 fun createBackgroundActivityBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<BackgroundActivityLocalConfig?> = { null },
     remoteCfg: Provider<BackgroundActivityRemoteConfig?> = { null }
-): BackgroundActivityBehavior = BackgroundActivityBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
+): BackgroundActivityBehavior = BackgroundActivityBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [AutoDataCaptureBehaviorImpl] that returns default values.
  */
 fun createAutoDataCaptureBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<LocalConfig?> = { null },
     remoteCfg: Provider<RemoteConfig?> = { null }
-): AutoDataCaptureBehavior = AutoDataCaptureBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
+): AutoDataCaptureBehavior = AutoDataCaptureBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [LogMessageBehaviorImpl] that returns default values.
@@ -102,10 +90,7 @@ fun createLogMessageBehavior(
 /**
  * A [StartupBehaviorImpl] that returns default values.
  */
-fun createStartupBehavior(
-    thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<StartupMomentLocalConfig?> = { null }
-): StartupBehavior = StartupBehaviorImpl(thresholdCheck, localCfg)
+fun createStartupBehavior(): StartupBehavior = StartupBehaviorImpl()
 
 /**
  * A [DataCaptureEventBehaviorImpl] that returns default values.
@@ -120,26 +105,23 @@ fun createDataCaptureEventBehavior(
  */
 fun createSdkModeBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<LocalConfig?> = { null },
     remoteCfg: Provider<RemoteConfig?> = { null }
-): SdkModeBehavior = SdkModeBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
+): SdkModeBehavior = SdkModeBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [SdkModeBehaviorImpl] that returns default values.
  */
 fun createSdkEndpointBehavior(
-    thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<BaseUrlLocalConfig?> = { null },
-): SdkEndpointBehavior = SdkEndpointBehaviorImpl(thresholdCheck, localCfg)
+    thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck
+): SdkEndpointBehavior = SdkEndpointBehaviorImpl(thresholdCheck)
 
 /**
  * A [AppExitInfoBehavior] that returns default values.
  */
 fun createAppExitInfoBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
-    localCfg: Provider<AppExitInfoLocalConfig?> = { null },
     remoteCfg: Provider<RemoteConfig?> = { null },
-): AppExitInfoBehavior = AppExitInfoBehaviorImpl(thresholdCheck, localCfg, remoteCfg)
+): AppExitInfoBehavior = AppExitInfoBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [NetworkSpanForwardingBehaviorImpl] that returns default values.
@@ -160,6 +142,4 @@ fun createWebViewVitalsBehavior(
 /**
  * A [SensitiveKeysBehaviorImpl] that returns default values.
  */
-internal fun createSensitiveKeysBehavior() = SensitiveKeysBehaviorImpl(
-    SdkLocalConfig()
-)
+internal fun createSensitiveKeysBehavior() = SensitiveKeysBehaviorImpl()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkBehavior.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
+import io.embrace.android.embracesdk.internal.config.instrumented.NetworkCaptureConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
+
+class FakeNetworkBehavior(
+    private val captureLimit: Int = 1000,
+    private val domains: Map<String, Int> = emptyMap()
+) : NetworkBehavior {
+    override fun getTraceIdHeader(): String = NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
+    override fun isRequestContentLengthCaptureEnabled(): Boolean = false
+    override fun isHttpUrlConnectionCaptureEnabled(): Boolean = true
+    override fun getLimitsByDomain(): Map<String, Int> = domains
+    override fun getRequestLimitPerDomain(): Int = captureLimit
+    override fun isUrlEnabled(url: String): Boolean = true
+    override fun isCaptureBodyEncryptionEnabled(): Boolean = false
+    override fun getNetworkBodyCapturePublicKey(): String? = null
+    override fun getNetworkCaptureRules(): Set<NetworkCaptureRuleRemoteConfig> = emptySet()
+}


### PR DESCRIPTION
## Goal

Updates the SDK implementation so that instead of `LocalConfig` the `InstrumentedConfig` drives the behavior of features. This builds on #1323 which adds the new class that will be swazzled with the contents of the config file.

## Testing

Updated existing test coverage.

