### PR TITLE
Create callback mechanism to run code post app startup

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
@@ -40,12 +40,20 @@ interface AppStartupDataCollector {
     /**
      * Set the time for when the startup Activity begins to render as well as its name
      */
-    fun startupActivityResumed(activityName: String, timestampMs: Long? = null)
+    fun startupActivityResumed(
+        activityName: String,
+        collectionCompleteCallback: (() -> Unit)? = null,
+        timestampMs: Long? = null,
+    )
 
     /**
      * Set the time for when the startup Activity has finished rendering its first frame as well as its name
      */
-    fun firstFrameRendered(activityName: String, timestampMs: Long? = null)
+    fun firstFrameRendered(
+        activityName: String,
+        collectionCompleteCallback: (() -> Unit)? = null,
+        timestampMs: Long? = null,
+    )
 
     /**
      * Set an arbitrary time interval during startup that is of note

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -128,19 +128,27 @@ internal class AppStartupTraceEmitter(
         startupActivityInitEndMs = timestampMs ?: nowMs()
     }
 
-    override fun startupActivityResumed(activityName: String, timestampMs: Long?) {
+    override fun startupActivityResumed(
+        activityName: String,
+        collectionCompleteCallback: (() -> Unit)?,
+        timestampMs: Long?
+    ) {
         startupActivityName = activityName
         startupActivityResumedMs = timestampMs ?: nowMs()
         if (!endWithFrameDraw) {
-            dataCollectionComplete()
+            dataCollectionComplete(collectionCompleteCallback)
         }
     }
 
-    override fun firstFrameRendered(activityName: String, timestampMs: Long?) {
+    override fun firstFrameRendered(
+        activityName: String,
+        collectionCompleteCallback: (() -> Unit)?,
+        timestampMs: Long?
+    ) {
         startupActivityName = activityName
         firstFrameRenderedMs = timestampMs ?: nowMs()
         if (endWithFrameDraw) {
-            dataCollectionComplete()
+            dataCollectionComplete(collectionCompleteCallback)
         }
     }
 
@@ -153,7 +161,7 @@ internal class AppStartupTraceEmitter(
     /**
      * Called when app startup is considered complete, i.e. the data can be used and any additional updates can be ignored
      */
-    private fun dataCollectionComplete() {
+    private fun dataCollectionComplete(callback: (() -> Unit)?) {
         if (!startupRecorded.get()) {
             synchronized(startupRecorded) {
                 if (!startupRecorded.get()) {
@@ -166,6 +174,7 @@ internal class AppStartupTraceEmitter(
                             )
                         }
                     }
+                    callback?.invoke()
                 }
             }
         }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -64,8 +64,11 @@ class StartupTracker(
                             decorView.onNextDraw {
                                 if (!isFirstDraw) {
                                     isFirstDraw = true
-                                    val callback =
-                                        { appStartupDataCollector.firstFrameRendered(activityName = activityName) }
+                                    val callback = {
+                                        appStartupDataCollector.firstFrameRendered(
+                                            activityName = activityName
+                                        )
+                                    }
                                     decorView.viewTreeObserver.registerFrameCommitCallback(callback)
                                 }
                             }
@@ -98,7 +101,9 @@ class StartupTracker(
 
     override fun onActivityResumed(activity: Activity) {
         if (activity.observeForStartup()) {
-            appStartupDataCollector.startupActivityResumed(activityName = activity.localClassName)
+            appStartupDataCollector.startupActivityResumed(
+                activityName = activity.localClassName
+            )
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -39,12 +39,20 @@ class FakeAppStartupDataCollector(
         startupActivityInitEndMs = timestampMs ?: clock.now()
     }
 
-    override fun startupActivityResumed(activityName: String, timestampMs: Long?) {
+    override fun startupActivityResumed(
+        activityName: String,
+        collectionCompleteCallback: (() -> Unit)?,
+        timestampMs: Long?
+    ) {
         startupActivityName = activityName
         startupActivityResumedMs = timestampMs ?: clock.now()
     }
 
-    override fun firstFrameRendered(activityName: String, timestampMs: Long?) {
+    override fun firstFrameRendered(
+        activityName: String,
+        collectionCompleteCallback: (() -> Unit)?,
+        timestampMs: Long?
+    ) {
         startupActivityName = activityName
         firstFrameRenderedMs = timestampMs ?: clock.now()
     }


### PR DESCRIPTION
## Goal

Add the ability to invoke a callback when an app startup trace is ready to be logged. This mechanism will be used to hook up the `UiLoadEventEmitter` in a subsequent PR
