### PR TITLE
Remove startup trace recording callback once it's logged startup

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -98,6 +98,7 @@ internal class AppStartupTraceEmitter(
     private var sdkInitEndedInForeground: Boolean? = null
 
     private val startupRecorded = AtomicBoolean(false)
+    private val dataCollectionComplete = AtomicBoolean(false)
     private val endWithFrameDraw: Boolean = versionChecker.isAtLeast(VERSION_CODES.Q)
 
     override fun applicationInitStart(timestampMs: Long?) {
@@ -162,9 +163,9 @@ internal class AppStartupTraceEmitter(
      * Called when app startup is considered complete, i.e. the data can be used and any additional updates can be ignored
      */
     private fun dataCollectionComplete(callback: (() -> Unit)?) {
-        if (!startupRecorded.get()) {
-            synchronized(startupRecorded) {
-                if (!startupRecorded.get()) {
+        if (!dataCollectionComplete.get()) {
+            synchronized(dataCollectionComplete) {
+                if (!dataCollectionComplete.get()) {
                     backgroundWorker.submit {
                         recordStartup()
                         if (!startupRecorded.get()) {
@@ -175,6 +176,7 @@ internal class AppStartupTraceEmitter(
                         }
                     }
                     callback?.invoke()
+                    dataCollectionComplete.set(true)
                 }
             }
         }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -99,30 +100,6 @@ internal class StartupTrackerTest {
 
     @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
-    fun `cold start with activity instance recreated`() {
-        defaultActivityController.create()
-        clock.tick()
-        val recreateTime = clock.now()
-        defaultActivityController.recreate()
-        clock.tick()
-        val startTime = clock.now()
-        defaultActivityController.start()
-        clock.tick()
-        val resumeTime = clock.now()
-        defaultActivityController.resume()
-        clock.tick()
-
-        verifyTiming(
-            preCreateTime = recreateTime,
-            createTime = recreateTime,
-            postCreateTime = recreateTime,
-            startTime = startTime,
-            resumeTime = resumeTime
-        )
-    }
-
-    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
-    @Test
     fun `cold start with different activities being created and foregrounded first`() {
         defaultActivityController.create()
         clock.tick()
@@ -153,6 +130,16 @@ internal class StartupTrackerTest {
                 resumeTime = resumeTime
             )
         }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify startup tracker detached after trace recorded`() {
+        val firstLaunchTimes = launchActivity()
+        assertEquals(firstLaunchTimes.createTime, dataCollector.startupActivityInitStartMs)
+        clock.tick(500_000)
+        val secondLaunchTimes = launchActivity()
+        assertNotEquals(secondLaunchTimes.createTime, dataCollector.startupActivityInitStartMs)
     }
 
     private fun launchActivity(controller: ActivityController<*> = defaultActivityController): ActivityTiming {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -46,6 +46,7 @@ class FakeAppStartupDataCollector(
     ) {
         startupActivityName = activityName
         startupActivityResumedMs = timestampMs ?: clock.now()
+        collectionCompleteCallback?.invoke()
     }
 
     override fun firstFrameRendered(
@@ -55,6 +56,7 @@ class FakeAppStartupDataCollector(
     ) {
         startupActivityName = activityName
         firstFrameRenderedMs = timestampMs ?: clock.now()
+        collectionCompleteCallback?.invoke()
     }
 
     override fun addTrackedInterval(name: String, startTimeMs: Long, endTimeMs: Long) {


### PR DESCRIPTION
## Goal

Remove the startup tracing callback when it's done its job. That way, it can never conflict with the UI load activity lifecycle listener when it's attached in a subsequent PR.

## Testing
Add unit tests

