### PR TITLE
Load the native library in NdkService before accessing the delegate methods

### DIFF
--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
@@ -114,6 +114,7 @@ internal class EmbraceNdkServiceTest {
         resources = mockk(relaxed = true)
         blockableExecutorService = BlockableExecutorService()
         every { sharedObjectLoader.loadEmbraceNative() } returns true
+        every { sharedObjectLoader.loaded.get() } returns true
     }
 
     @After


### PR DESCRIPTION
_updateAppState was accessed before the native library was loaded. I added some guards to the delegate methods so we always verify that the native library is loaded before we call them.