### PR TITLE
Attaching activity listener conditional to the native library loading

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.ndk
 
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 
 interface NdkService {
     fun updateSessionId(newSessionId: String)
@@ -21,5 +22,5 @@ interface NdkService {
      */
     val symbolsForCurrentArch: Map<String, String>?
 
-    fun initializeService()
+    fun initializeService(sessionIdTracker: SessionIdTracker)
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
@@ -14,14 +14,13 @@ import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
-import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
-import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
@@ -75,17 +74,18 @@ internal class EmbraceNdkServiceTest {
     private lateinit var storageManager: FakeStorageService
     private lateinit var metadataService: MetadataService
     private lateinit var configService: FakeConfigService
-    private lateinit var activityService: FakeProcessStateService
+    private lateinit var processStateService: FakeProcessStateService
     private lateinit var deliveryService: FakeDeliveryService
-    private lateinit var userService: UserService
+    private lateinit var userService: FakeUserService
     private lateinit var preferencesService: FakePreferenceService
-    private lateinit var sessionPropertiesService: SessionPropertiesService
+    private lateinit var sessionPropertiesService: FakeSessionPropertiesService
     private lateinit var sharedObjectLoader: SharedObjectLoader
     private lateinit var logger: EmbLogger
     private lateinit var delegate: NdkServiceDelegate.NdkDelegate
     private lateinit var repository: EmbraceNdkServiceRepository
     private lateinit var resources: Resources
     private lateinit var blockableExecutorService: BlockableExecutorService
+    private lateinit var sessionIdTracker: FakeSessionIdTracker
     private val deviceArchitecture = FakeDeviceArchitecture()
     private val serializer = EmbraceSerializer()
 
@@ -102,7 +102,7 @@ internal class EmbraceNdkServiceTest {
         storageManager = FakeStorageService()
         metadataService = FakeMetadataService()
         configService = FakeConfigService(autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(ndkEnabled = true))
-        activityService = FakeProcessStateService()
+        processStateService = FakeProcessStateService()
         deliveryService = FakeDeliveryService()
         userService = FakeUserService()
         preferencesService = FakePreferenceService()
@@ -113,6 +113,7 @@ internal class EmbraceNdkServiceTest {
         repository = mockk(relaxUnitFun = true)
         resources = mockk(relaxed = true)
         blockableExecutorService = BlockableExecutorService()
+        sessionIdTracker = FakeSessionIdTracker()
         every { sharedObjectLoader.loadEmbraceNative() } returns true
         every { sharedObjectLoader.loaded.get() } returns true
     }
@@ -137,7 +138,7 @@ internal class EmbraceNdkServiceTest {
                 context,
                 storageManager,
                 metadataService,
-                activityService,
+                processStateService,
                 configService,
                 userService,
                 sessionPropertiesService,
@@ -152,8 +153,28 @@ internal class EmbraceNdkServiceTest {
             ),
             recordPrivateCalls = true
         ).apply {
-            initializeService()
+            initializeService(sessionIdTracker = sessionIdTracker)
         }
+    }
+
+    @Test
+    fun `successful initialization attaches appropriate listeners`() {
+        every { sharedObjectLoader.loadEmbraceNative() } returns true
+        initializeService()
+        assertEquals(1, userService.listeners.size)
+        assertEquals(1, sessionIdTracker.listeners.size)
+        assertEquals(1, sessionPropertiesService.listeners.size)
+        assertEquals(1, processStateService.listeners.size)
+    }
+
+    @Test
+    fun `failed native library loading attaches no listeners`() {
+        every { sharedObjectLoader.loadEmbraceNative() } returns false
+        initializeService()
+        assertEquals(0, userService.listeners.size)
+        assertEquals(0, sessionIdTracker.listeners.size)
+        assertEquals(0, sessionPropertiesService.listeners.size)
+        assertEquals(0, processStateService.listeners.size)
     }
 
     @Test
@@ -193,7 +214,7 @@ internal class EmbraceNdkServiceTest {
 
         configService.appFramework = AppFramework.UNITY
         initializeService()
-        assertEquals(1, activityService.listeners.size)
+        assertEquals(1, processStateService.listeners.size)
 
         val reportBasePath = storageManager.filesDirectory.absolutePath + "/ndk"
         val markerFilePath =
@@ -229,7 +250,7 @@ internal class EmbraceNdkServiceTest {
         every { Uuid.getEmbUuid() } returns "uuid"
 
         initializeService()
-        assertEquals(1, activityService.listeners.size)
+        assertEquals(1, processStateService.listeners.size)
 
         val reportBasePath = storageManager.filesDirectory.absolutePath + "/ndk"
         val markerFilePath =

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -341,14 +341,8 @@ internal class ModuleInitBootstrapper(
 
                         if (configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
                             val worker = workerThreadModule.backgroundWorker(WorkerName.SERVICE_INIT)
-
                             worker.submit(TaskPriority.HIGH) {
-                                ndkService.initializeService()
-                                with(essentialServiceModule) {
-                                    userService.addUserInfoListener(ndkService::onUserInfoUpdate)
-                                    sessionIdTracker.addListener { ndkService.updateSessionId(it ?: "") }
-                                    sessionPropertiesService.addChangeListener(ndkService::onSessionPropertiesUpdate)
-                                }
+                                ndkService.initializeService(essentialServiceModule.sessionIdTracker)
                             }
                         }
                     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.ndk.NdkService
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 
 class FakeNdkService : NdkService {
     val propUpdates: MutableList<Map<String, String>> = mutableListOf()
@@ -11,7 +12,7 @@ class FakeNdkService : NdkService {
     var lastUnityCrashId: String? = null
     private var nativeCrashData: NativeCrashData? = null
 
-    override fun initializeService() {
+    override fun initializeService(sessionIdTracker: SessionIdTracker) {
     }
 
     override fun updateSessionId(newSessionId: String) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
@@ -4,10 +4,12 @@ import io.embrace.android.embracesdk.internal.session.id.SessionData
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 
 class FakeSessionIdTracker : SessionIdTracker {
-
     var sessionData: SessionData? = null
+    var listeners: MutableList<(String?) -> Unit> = mutableListOf()
 
-    override fun addListener(listener: (String?) -> Unit) {}
+    override fun addListener(listener: (String?) -> Unit) {
+        listeners.add(listener)
+    }
 
     override fun getActiveSession(): SessionData? = sessionData
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPropertiesService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPropertiesService.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesS
 class FakeSessionPropertiesService : SessionPropertiesService {
 
     var props: MutableMap<String, String> = mutableMapOf()
+    var listeners: MutableList<(Map<String, String>) -> Unit> = mutableListOf()
 
     override fun addProperty(originalKey: String, originalValue: String, permanent: Boolean): Boolean {
         props[originalKey] = originalValue
@@ -23,5 +24,6 @@ class FakeSessionPropertiesService : SessionPropertiesService {
     }
 
     override fun addChangeListener(listener: (Map<String, String>) -> Unit) {
+        listeners.add(listener)
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUserService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUserService.kt
@@ -12,6 +12,7 @@ class FakeUserService : UserService {
     var payer: Boolean? = null
     var personas: MutableList<String> = mutableListOf()
     var clearedCount: Int = 0
+    var listeners: MutableList<() -> Unit> = mutableListOf()
 
     override fun getUserInfo(): UserInfo = obj
 
@@ -68,5 +69,6 @@ class FakeUserService : UserService {
     }
 
     override fun addUserInfoListener(listener: () -> Unit) {
+        listeners.add(listener)
     }
 }


### PR DESCRIPTION
## Goal

Attach various listeners only after native library loading is success to avoid calling methods on the delegate when the library is not loaded.

## Testing

Added unit tests to verify the listener attachment, and let the existing unit and functional tests validation functionality.