### PR TITLE
Allow internal spans to have longer names

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -5,11 +5,11 @@ import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.isAttributeValid
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.logs.LogRecordBuilder
-import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.semconv.ExceptionAttributes
 
@@ -27,8 +27,8 @@ internal fun LogRecordBuilder.setFixedAttribute(fixedAttribute: FixedAttribute):
 /**
  * Populate an [AttributesBuilder] with String key-value pairs from a [Map]
  */
-fun AttributesBuilder.fromMap(attributes: Map<String, String>): AttributesBuilder {
-    attributes.filter { EmbraceSpanImpl.attributeValid(it.key, it.value) || it.key.isValidLongValueAttribute() }.forEach {
+fun AttributesBuilder.fromMap(attributes: Map<String, String>, internal: Boolean): AttributesBuilder {
+    attributes.filter { isAttributeValid(it.key, it.value, internal) || it.key.isValidLongValueAttribute() }.forEach {
         put(it.key, it.value)
     }
     return this

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanLimits.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanLimits.kt
@@ -7,7 +7,16 @@ object EmbraceSpanLimits {
     const val MAX_TOTAL_EVENT_COUNT: Int = 11000
     const val MAX_CUSTOM_ATTRIBUTE_COUNT: Int = 50
     const val MAX_TOTAL_ATTRIBUTE_COUNT: Int = 300
+    const val MAX_INTERNAL_ATTRIBUTE_KEY_LENGTH: Int = 1000
+    const val MAX_INTERNAL_ATTRIBUTE_VALUE_LENGTH: Int = 2000
     const val MAX_CUSTOM_ATTRIBUTE_KEY_LENGTH: Int = 50
     const val MAX_CUSTOM_ATTRIBUTE_VALUE_LENGTH: Int = 500
     const val EXCEPTION_EVENT_NAME: String = "exception"
+
+    internal fun String.isNameValid(internal: Boolean): Boolean =
+        isNotBlank() && ((internal && length <= MAX_INTERNAL_NAME_LENGTH) || length <= MAX_NAME_LENGTH)
+
+    internal fun isAttributeValid(key: String, value: String, internal: Boolean) =
+        ((internal && key.length <= MAX_INTERNAL_ATTRIBUTE_KEY_LENGTH) || key.length <= MAX_CUSTOM_ATTRIBUTE_KEY_LENGTH) &&
+            ((internal && value.length <= MAX_INTERNAL_ATTRIBUTE_VALUE_LENGTH) || value.length <= MAX_CUSTOM_ATTRIBUTE_VALUE_LENGTH)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanImpl.Companion.isValidName
+import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.isNameValid
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -134,7 +134,7 @@ internal class SpanServiceImpl(
         events: List<EmbraceSpanEvent>? = null,
         attributes: Map<String, String>? = null
     ): Boolean {
-        return (name.isValidName(internal)) &&
+        return (name.isNameValid(internal)) &&
             ((events == null) || (events.size <= EmbraceSpanLimits.MAX_CUSTOM_EVENT_COUNT)) &&
             ((attributes == null) || (attributes.size <= EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_COUNT))
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -4,10 +4,14 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_ATTRIBUTE_KEY
+import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN
 import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_ATTRIBUTE_VALUE
+import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN
 import io.embrace.android.embracesdk.fixtures.MAX_LENGTH_EVENT_NAME
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
+import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
+import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_EVENT_NAME
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_SPAN_NAME
 import io.embrace.android.embracesdk.fixtures.fakeContextKey
@@ -320,6 +324,21 @@ internal class EmbraceSpanImplTest {
                 assertTrue(addAttribute(key = "key$it", value = "value"))
             }
             assertFalse(addAttribute(key = "failedKey", value = "value"))
+        }
+    }
+
+    @Test
+    fun `check internal span attribute key and value limits`() {
+        embraceSpan = createEmbraceSpanImpl(
+            spanBuilder = createEmbraceSpanBuilder()
+        )
+        with(embraceSpan) {
+            assertTrue(start())
+            assertFalse(addAttribute(key = TOO_LONG_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN, value = "value"))
+            assertFalse(addAttribute(key = "key", value = TOO_LONG_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN))
+            assertTrue(addAttribute(key = MAX_LENGTH_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN, value = "value"))
+            assertTrue(addAttribute(key = "key", value = MAX_LENGTH_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN))
+            assertTrue(addAttribute(key = "Key", value = MAX_LENGTH_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN))
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -550,7 +550,8 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                events = events
+                events = events,
+                internal = false
             )
         )
 
@@ -594,7 +595,8 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                attributes = attributesMap
+                attributes = attributesMap,
+                internal = false
             )
         )
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -11,9 +11,9 @@ import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.recordSession
+import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
-import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -33,6 +33,21 @@ internal class NetworkRequestApiTest {
         assertSingleNetworkRequestInSession(
             EmbraceNetworkRequest.fromCompletedRequest(
                 URL,
+                HttpMethod.GET,
+                START_TIME,
+                END_TIME,
+                BYTES_SENT,
+                BYTES_RECEIVED,
+                200
+            )
+        )
+    }
+
+    @Test
+    fun `record completed GET request with long URL`() {
+        assertSingleNetworkRequestInSession(
+            EmbraceNetworkRequest.fromCompletedRequest(
+                LONG_URL,
                 HttpMethod.GET,
                 START_TIME,
                 END_TIME,
@@ -311,6 +326,7 @@ internal class NetworkRequestApiTest {
         private const val BYTES_RECEIVED = 500L
         private const val TRACE_ID = "rAnDoM-traceId"
         private const val TRACEPARENT = "00-c4ada96c31e1b6b9e351a1cffc99ae38-331f3a8acf49d295-01"
+        private val LONG_URL = "https://embrace.io/" + "s".repeat(1900)
 
         private val NETWORK_CAPTURE_DATA = NetworkCaptureData(
             requestHeaders = mapOf(Pair("x-emb-test", "holla")),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -29,11 +29,12 @@ class FakeSpanData(
     private var startEpochNanos: Long = DEFAULT_START_TIME_MS.millisToNanos(),
     private var attributes: Attributes =
         Attributes.builder().fromMap(
-            mapOf(
+            attributes = mapOf(
                 EmbType.Performance.Default.toEmbraceKeyValuePair(),
                 KeySpan.toEmbraceKeyValuePair(),
                 Pair("my-key", "my-value")
-            )
+            ),
+            internal = true,
         ).build(),
     private var events: MutableList<EventData> = mutableListOf(
         EventData.create(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -85,6 +85,10 @@ val MAX_LENGTH_ATTRIBUTE_KEY: String = "s".repeat(EmbraceSpanLimits.MAX_CUSTOM_A
 val TOO_LONG_ATTRIBUTE_KEY: String = "s".repeat(EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_KEY_LENGTH + 1)
 val MAX_LENGTH_ATTRIBUTE_VALUE: String = "s".repeat(EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_VALUE_LENGTH)
 val TOO_LONG_ATTRIBUTE_VALUE: String = "s".repeat(EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_VALUE_LENGTH + 1)
+val MAX_LENGTH_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN: String = "s".repeat(EmbraceSpanLimits.MAX_INTERNAL_ATTRIBUTE_KEY_LENGTH)
+val TOO_LONG_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN: String = "s".repeat(EmbraceSpanLimits.MAX_INTERNAL_ATTRIBUTE_KEY_LENGTH + 1)
+val MAX_LENGTH_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN: String = "s".repeat(EmbraceSpanLimits.MAX_INTERNAL_ATTRIBUTE_VALUE_LENGTH)
+val TOO_LONG_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN: String = "s".repeat(EmbraceSpanLimits.MAX_INTERNAL_ATTRIBUTE_VALUE_LENGTH + 1)
 
 val maxSizeAttributes: Map<String, String> = createMapOfSize(EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_COUNT)
 val tooBigAttributes: Map<String, String> = createMapOfSize(EmbraceSpanLimits.MAX_CUSTOM_ATTRIBUTE_COUNT + 1)


### PR DESCRIPTION
## Goal

Allow spans that the SDK logs as its out of the box instrumentation to have longer names as well as attribute values. This solves the problem of network requests having long names and attributes because of the URL being logged is greater than what was set as the ceiling for perf traces.

## Testing
Add unit tests and integration tests