### PR TITLE
Prevent JNI error on SIGQUIT when Google ANR capture enabled

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/EmbraceSigquitNdkDelegate.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/EmbraceSigquitNdkDelegate.kt
@@ -2,9 +2,12 @@ package io.embrace.android.embracesdk.internal.anr.sigquit
 
 // IMPORTANT: This class is referenced by emb_anr_manager.c. Move or rename both at the same time, or it will break.
 class EmbraceSigquitNdkDelegate : SigquitNdkDelegate {
-    external override fun installGoogleAnrHandler(googleThreadId: Int): Int
+    external override fun installGoogleAnrHandler(
+        googleThreadId: Int,
+        instance: SigquitDataSource
+    ): Int
 }
 
 internal interface SigquitNdkDelegate {
-    fun installGoogleAnrHandler(googleThreadId: Int): Int
+    fun installGoogleAnrHandler(googleThreadId: Int, instance: SigquitDataSource): Int
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/sigquit/SigquitDataSourceImpl.kt
@@ -43,7 +43,7 @@ internal class SigquitDataSourceImpl(
 
     private fun install(googleThreadId: Int): Int {
         return try {
-            val res = sigquitNdkDelegate.installGoogleAnrHandler(googleThreadId)
+            val res = sigquitNdkDelegate.installGoogleAnrHandler(googleThreadId, this)
             if (res > 0) {
                 googleAnrTrackerInstalled.set(false)
             }

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -19,6 +19,7 @@
 -keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrSample { *; }
 -keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrStackframe { *; }
 -keep class io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSource { *; }
+-keep class io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSourceImpl { *; }
 
 ## Keep classes with JNI calls to native code
 -keep class io.embrace.android.embracesdk.internal.capture.cpu.EmbraceCpuInfoNdkDelegate { *; }

--- a/embrace-android-sdk/src/main/cpp/anr/anr.h
+++ b/embrace-android-sdk/src/main/cpp/anr/anr.h
@@ -15,6 +15,6 @@
 #define EMB_ANR_INSTALL_HANDLER_FAIL 1 << 2
 #define EMB_ANR_INSTALL_REPORTING_CONFIGURATION_FAIL 1 << 3
 
-int emb_install_google_anr_handler(JNIEnv *env, jobject anr_service, jint _google_thread_id);
+int emb_install_google_anr_handler(JNIEnv *env, jobject sigquit_data_source, jint _google_thread_id);
 
 #endif //EMBRACE_ANDROID_SDK3_ANR_H

--- a/embrace-android-sdk/src/main/cpp/anr/emb_anr_manager.c
+++ b/embrace-android-sdk/src/main/cpp/anr/emb_anr_manager.c
@@ -12,9 +12,12 @@ extern "C" {
 
 JNIEXPORT jint JNICALL
 Java_io_embrace_android_embracesdk_internal_anr_sigquit_EmbraceSigquitNdkDelegate_installGoogleAnrHandler(
-        JNIEnv *env, jobject thiz,
-        jint google_thread_id) {
-    return emb_install_google_anr_handler(env, thiz, google_thread_id);
+        JNIEnv *env,
+        jobject thiz,
+        jint google_thread_id,
+        jobject sigquit_data_source
+        ) {
+    return emb_install_google_anr_handler(env, sigquit_data_source, google_thread_id);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Goal

Prevents a JNI error that is triggered by SIGQUIT when Google ANR capture is enabled (i.e. when an ANR happens). This feature is disabled by default & users would either need to set `sdk_config.anr.capture_google` to `true` in `embrace-config.json` _or_ have a remote config set that enables this behavior. The error looks like:

>JNI DETECTED ERROR IN APPLICATION: can't call void io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSourceImpl.saveSigquit(long) on instance of io.embrace.android.embracesdk.internal.anr.sigquit.EmbraceSigquitNdkDelegate

This was been introduced in #1214 so will be present in 6.10.0 upwards. The `anr_manager.c` code assumed that the caller would always be the object that would contain the `saveSigquit` function, but that assumption was invalidated in #1214. I've fixed this by explicitly passing a reference to the object that should be called from the JNI.

Additionally, I've added a Proguard keep rule as the class doesn't seem to have a suitable keep rule.

## Testing

Manually confirmed in a debug + release app that triggering an ANR with this feature enabled doesn't crash the process.