### PR TITLE
Remove unused build id function from project config

### DIFF
--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/ProjectConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/ProjectConfig.kt
@@ -20,9 +20,4 @@ object ProjectConfig {
      * sdk_config.app_framework
      */
     fun getAppFramework(): String? = null
-
-    /**
-     * The ID of the particular build, generated at compile-time
-     */
-    fun getBuildId(): String = ""
 }


### PR DESCRIPTION
## Goal

This function is not instrumented by the swazzler yet & `BuildInfo` is used in the SDK still. This changeset removes it for now to avoid confusion.

