### PR TITLE
Download and cache NDK

### DIFF
--- a/.github/workflows/swazzler-tests-subset.yml
+++ b/.github/workflows/swazzler-tests-subset.yml
@@ -28,7 +28,15 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Cache NDK
+        id: ndk-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/lib/android/sdk/ndk/27.0.12077973
+          key: ndk-cache
+
       - name: Install NDK
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
         run: echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "ndk;27.0.12077973"
 
       # make sure version in gradle.properties matches the version of embrace-swazzler3 version

--- a/.github/workflows/swazzler-tests-subset.yml
+++ b/.github/workflows/swazzler-tests-subset.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Install NDK
+        run: echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;27.0.12077973"
+
       # make sure version in gradle.properties matches the version of embrace-swazzler3 version
       - name: "Publish SDK locally"
         run: ./gradlew publishToMavenLocal --no-daemon

--- a/.github/workflows/swazzler-tests-subset.yml
+++ b/.github/workflows/swazzler-tests-subset.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+      ANDROID_BUILD_TOOLS_HOME: "/usr/local/lib/android/sdk/build-tools/35.0.0"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -26,7 +29,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Install NDK
-        run: echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;27.0.12077973"
+        run: echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "ndk;27.0.12077973"
 
       # make sure version in gradle.properties matches the version of embrace-swazzler3 version
       - name: "Publish SDK locally"


### PR DESCRIPTION
Use a specific NDK version so we don't depend on the github runners having it pre installed