### PR TITLE
Add additional worker to test in FakeWorkerModule 

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
@@ -90,7 +90,7 @@ internal class EmbraceEventServiceTest {
         sessionPropertiesService = FakeSessionPropertiesService()
         gatingService = FakeGatingService(EmbraceGatingService(configService, FakeLogService(), FakeEmbLogger()))
         val initModule = FakeInitModule(clock = fakeClock)
-        fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = initModule, name = Worker.Background.NonIoRegWorker)
+        fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = initModule, testWorkerName = Worker.Background.NonIoRegWorker)
         eventHandler = EventHandler(
             metadataService = metadataService,
             sessionIdTracker = sessionIdTracker,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImplTest.kt
@@ -18,7 +18,7 @@ internal class DataSourceModuleImplTest {
             FakeConfigService(),
             FakeWorkerThreadModule(
                 fakeInitModule = fakeInitModule,
-                name = Worker.Background.NonIoRegWorker
+                testWorkerName = Worker.Background.NonIoRegWorker
             ),
         )
         assertSame(module.dataCaptureOrchestrator, module.embraceFeatureRegistry)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionOrchestrationModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionOrchestrationModuleImplTest.kt
@@ -23,7 +23,7 @@ internal class SessionOrchestrationModuleImplTest {
     private val configService = FakeConfigService()
     private val workerThreadModule = FakeWorkerThreadModule(
         fakeInitModule = initModule,
-        name = Worker.Background.NonIoRegWorker
+        testWorkerName = Worker.Background.NonIoRegWorker
     )
 
     @Test

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
@@ -25,7 +25,8 @@ internal class LastRunCrashVerifierTest {
     fun setUp() {
         mockCrashFileMarker = mockk()
         lastRunCrashVerifier = LastRunCrashVerifier(mockCrashFileMarker, EmbLoggerImpl())
-        fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), name = Worker.Background.NonIoRegWorker)
+        fakeWorkerThreadModule =
+            FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), testWorkerName = Worker.Background.NonIoRegWorker)
         worker = fakeWorkerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/EmbraceLoggingFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/EmbraceLoggingFeatureTest.kt
@@ -26,7 +26,7 @@ internal class EmbraceLoggingFeatureTest {
         IntegrationTestRule.Harness(
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,
-            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = Worker.Background.LogMessageWorker)
+            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, testWorkerName = Worker.Background.LogMessageWorker)
         )
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
@@ -32,7 +32,7 @@ internal class PeriodicSessionCacheTest {
         IntegrationTestRule.Harness(
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,
-            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = PeriodicCacheWorker)
+            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, testWorkerName = PeriodicCacheWorker)
         )
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -42,7 +42,7 @@ internal class FlutterInternalInterfaceTest {
             overriddenInitModule = fakeInitModule,
             overriddenWorkerThreadModule = FakeWorkerThreadModule(
                 fakeInitModule = fakeInitModule,
-                name = Worker.Background.LogMessageWorker
+                testWorkerName = Worker.Background.LogMessageWorker
             )
         )
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
@@ -10,19 +10,22 @@ import java.util.concurrent.atomic.AtomicReference
 
 class FakeWorkerThreadModule(
     fakeInitModule: FakeInitModule = FakeInitModule(),
-    private val name: Worker? = null,
+    private val testWorkerName: Worker? = null,
+    private val anotherTestWorkerName: Worker? = null,
     private val base: WorkerThreadModule = createWorkerThreadModule(fakeInitModule)
 ) : WorkerThreadModule by base {
 
     val executorClock: FakeClock = fakeInitModule.getFakeClock() ?: FakeClock()
-    val executor: BlockingScheduledExecutorService =
-        BlockingScheduledExecutorService(fakeClock = executorClock)
+    val executor: BlockingScheduledExecutorService = BlockingScheduledExecutorService(fakeClock = executorClock)
+    val anotherExecutor: BlockingScheduledExecutorService = BlockingScheduledExecutorService(fakeClock = executorClock)
 
     private val backgroundWorker = BackgroundWorker(executor)
+    private val anotherBackgroundWorker = BackgroundWorker(anotherExecutor)
 
     override fun backgroundWorker(worker: Worker.Background): BackgroundWorker {
         return when (worker) {
-            name -> backgroundWorker
+            testWorkerName -> backgroundWorker
+            anotherTestWorkerName -> anotherBackgroundWorker
             else -> base.backgroundWorker(worker)
         }
     }


### PR DESCRIPTION
## Goal

Add an additional worker that we can tweak the execution via a blocking executor. This is needed for testing the delivery service components

This PR was hijacked for this as the actual scheduling service code in previous revisions that were under discussion will come in subsequent PRs.