### PR TITLE
Add functionality for shutting down worker & waiting for tasks to complete

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorker.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.worker
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 /**
  * Submits tasks to a background thread pool.
@@ -32,5 +33,18 @@ class BackgroundWorker(
         callable: Callable<T>
     ): Future<T> {
         return impl.submit(PriorityCallable(priority, callable))
+    }
+
+    /**
+     * Shutdown the worker. If [timeoutMs] is greater than 0, the worker will
+     * block for the specified milliseconds if tasks are still enqueued or running.
+     */
+    fun shutdownAndWait(timeoutMs: Long = 0) {
+        runCatching {
+            with(impl) {
+                shutdown()
+                awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)
+            }
+        }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -2,10 +2,15 @@ package io.embrace.android.embracesdk.internal.worker
 
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 internal class BackgroundWorkerTest {
 
@@ -51,5 +56,59 @@ internal class BackgroundWorkerTest {
         val submitted = impl.callables.single() as PriorityCallable<*>
         assertEquals(TaskPriority.HIGH, submitted.priority)
         assertEquals("test", future.get())
+    }
+
+    @Test
+    fun `shutdown and wait within timeout`() {
+        val latch = CountDownLatch(1)
+        val worker = BackgroundWorker(
+            ShutdownAndWaitExecutorService(postShutdownAction = {
+                latch.countDown()
+            })
+        )
+
+        var ran = false
+        worker.submit(TaskPriority.NORMAL) {
+            latch.await(1000, TimeUnit.MILLISECONDS)
+            ran = true
+        }
+        worker.shutdownAndWait(100)
+        assertTrue(ran)
+    }
+
+    @Test
+    fun `shutdown and wait exceeds timeout`() {
+        val latch = CountDownLatch(1)
+        val worker = BackgroundWorker(
+            ShutdownAndWaitExecutorService(postAwaitTerminationAction = {
+                latch.countDown()
+            })
+        )
+
+        var ran = false
+        worker.submit(TaskPriority.NORMAL,) {
+            latch.await(1000, TimeUnit.MILLISECONDS)
+            ran = true
+        }
+        worker.shutdownAndWait(0)
+        assertFalse(ran)
+    }
+
+    private class ShutdownAndWaitExecutorService(
+        private val postShutdownAction: () -> Unit = {},
+        private val postAwaitTerminationAction: () -> Unit = {},
+        private val impl: ExecutorService = Executors.newSingleThreadExecutor()
+    ) : ExecutorService by impl {
+
+        override fun shutdown() {
+            impl.shutdown()
+            postShutdownAction()
+        }
+
+        override fun awaitTermination(timeout: Long, unit: TimeUnit?): Boolean {
+            val result = impl.awaitTermination(timeout, unit)
+            postAwaitTerminationAction()
+            return result
+        }
     }
 }


### PR DESCRIPTION
## Goal

Adds a function to `BackgroundWorker` that calls `shutdown` and then `awaitTermination` on the `ExecutorService` implementation. This is intended for use when payloads are being persisted but the process is about to terminate due to a JVM crash. However, it will likely become useful in other scenarios.

## Testing

Added unit test coverage.
