### PR TITLE
Create intake service interface

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.internal.delivery
+
+import kotlin.Result.Companion.failure
+
+/**
+ * Metadata about the telemetry payload.
+ *
+ * This information is encoded in the filename.
+ */
+class StoredTelemetryMetadata(
+    val timestamp: Long,
+    val uuid: String,
+    val type: SupportedEnvelopeType,
+    val filename: String = "v1_${timestamp}_${type.description}_$uuid.json"
+) {
+
+    companion object {
+
+        /**
+         * Parses a filename and constructs a [StoredTelemetryMetadata] object. This returns a
+         * [Result] because the filename may be invalid.
+         */
+        fun fromFilename(filename: String): Result<StoredTelemetryMetadata> {
+            val parts = filename.split("_")
+            if (parts.size != 4) {
+                return failure(IllegalArgumentException("Invalid filename: $filename"))
+            }
+            val timestamp = parts[1].toLongOrNull() ?: return failure(
+                IllegalArgumentException("Invalid timestamp: $filename")
+            )
+            val type = SupportedEnvelopeType.fromDescription(parts[2]) ?: return failure(
+                IllegalArgumentException("Invalid type: $filename")
+            )
+            val uuid = parts[3].removeSuffix(".json")
+            return Result.success(StoredTelemetryMetadata(timestamp, uuid, type, filename))
+        }
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
@@ -1,0 +1,28 @@
+package io.embrace.android.embracesdk.internal.delivery
+
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import java.lang.reflect.Type
+
+/**
+ * Enumerates the different types of telemetry that are supported when persisting to disk.
+ */
+enum class SupportedEnvelopeType(
+    val type: Type,
+    val description: String
+) {
+
+    SESSION(Envelope.sessionEnvelopeType, "session"),
+    CRASH(Envelope.logEnvelopeType, "crash"),
+    LOG(Envelope.logEnvelopeType, "log"),
+    NETWORK(Envelope.logEnvelopeType, "network");
+
+    companion object {
+        private val valueMap =
+            SupportedEnvelopeType.values().associateBy(SupportedEnvelopeType::description)
+
+        /**
+         * Returns the [SupportedEnvelopeType] that corresponds to the given description, if any.
+         */
+        fun fromDescription(description: String): SupportedEnvelopeType? = valueMap[description]
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeService.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.internal.delivery.intake
+
+import io.embrace.android.embracesdk.internal.capture.crash.CrashTeardownHandler
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.payload.Envelope
+
+/**
+ * IntakeService is responsible for storing telemetry payloads to disk and notifying the
+ * scheduling service whenever a payload is ready for sending. It has the following responsibilities:
+ *
+ * 1. Cache arbitrary payload types to disk (encoding priority & other metadata in the filename)
+ * 2. Clean up any telemetry that exceeds our max disk usage policy
+ * 3. Notify the scheduling service after a payload is stored to disk & is ready to send
+ * 4. Handle process termination gracefully by waiting until all payloads in the queue have been
+ * written to disk
+ */
+interface IntakeService : CrashTeardownHandler {
+
+    /**
+     * Stores a payload on disk as its JSON representation.
+     */
+    fun take(intake: Envelope<*>, metadata: StoredTelemetryMetadata)
+}

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -1,0 +1,59 @@
+package io.embrace.android.embracesdk.internal.delivery
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StoredTelemetryMetadataTest {
+
+    companion object {
+        private const val TIMESTAMP = 1726739283136
+        private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
+    }
+
+    private val typeNameMap = mapOf(
+        SupportedEnvelopeType.CRASH to "crash",
+        SupportedEnvelopeType.SESSION to "session",
+        SupportedEnvelopeType.LOG to "log",
+        SupportedEnvelopeType.NETWORK to "network"
+    )
+
+    @Test
+    fun `construct objects`() {
+        typeNameMap.entries.forEach { (type, description) ->
+            assertEquals(
+                "v1_${TIMESTAMP}_${description}_$UUID.json",
+                StoredTelemetryMetadata(TIMESTAMP, UUID, type).filename
+            )
+        }
+    }
+
+    @Test
+    fun `from invalid filename`() {
+        val badFilenames = listOf(
+            "",
+            "foo",
+            "my_session.json",
+            "v1_1234567890_session.json",
+            "v1_a_b_c.json",
+            "v1_${TIMESTAMP}_b_c.json"
+        )
+        badFilenames.forEach { filename ->
+            val result = StoredTelemetryMetadata.fromFilename(filename)
+            assertTrue("Filename failed: $filename", result.isFailure)
+        }
+    }
+
+    @Test
+    fun `from valid filename`() {
+        typeNameMap.entries.forEach { (type, description) ->
+            val input = "v1_${TIMESTAMP}_${description}_$UUID.json"
+            with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
+                assertEquals(input, filename)
+                assertEquals(TIMESTAMP, timestamp)
+                assertEquals(UUID, uuid)
+                assertEquals(type, this.type)
+            }
+        }
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeIntakeService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeIntakeService.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
+import io.embrace.android.embracesdk.internal.payload.Envelope
+
+class FakeIntakeService : IntakeService {
+
+    var crashId: String? = null
+    var intakeList: MutableList<Pair<Envelope<*>, StoredTelemetryMetadata>> =
+        mutableListOf()
+
+    override fun handleCrash(crashId: String) {
+        this.crashId = crashId
+    }
+
+    override fun take(intake: Envelope<*>, metadata: StoredTelemetryMetadata) {
+        intakeList.add(Pair(intake, metadata))
+    }
+}


### PR DESCRIPTION
## Goal

Creates an initial interface for the `IntakeService`, an initial implementation for the file metadata, and a fake service implementation.

## Discussion

1. Should we distinguish between different log payloads (log/crash/network) in the file metadata?
2. Do we want to rename the supported log payload types in the file metadata at all?
3. Are there additional types to support (e.g. AEI)?
4. Does the filename metadata structure look correct? Is there anything else we want to encode?

## Testing

Added unit test coverage
