### PR TITLE
Implement prioritisation of stored telemetry

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.internal.delivery
+
+/**
+ * Compares [StoredTelemetryMetadata] in priority order. Our priority rules are:
+ *
+ * Crash > Session
+ * Session > Log
+ * Log > Network
+ * Otherwise, older timestamps take precedence as they are more likely to get deleted if the SDK
+ * runs out of disk space.
+ *
+ * We considered the possibility of starvation & scoring payloads based on age, but we decided
+ * that crashes/sessions are generally far more important so should always be delivered first.
+ */
+internal object StoredTelemetryComparator : Comparator<StoredTelemetryMetadata> {
+
+    override fun compare(lhs: StoredTelemetryMetadata, rhs: StoredTelemetryMetadata): Int {
+        return compareBy(StoredTelemetryMetadata::envelopeType)
+            .thenBy(StoredTelemetryMetadata::timestamp)
+            .compare(lhs, rhs)
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -10,8 +10,8 @@ import kotlin.Result.Companion.failure
 class StoredTelemetryMetadata(
     val timestamp: Long,
     val uuid: String,
-    val type: SupportedEnvelopeType,
-    val filename: String = "v1_${timestamp}_${type.description}_$uuid.json"
+    val envelopeType: SupportedEnvelopeType,
+    val filename: String = "v1_${timestamp}_${envelopeType.description}_$uuid.json"
 ) {
 
     companion object {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
@@ -7,12 +7,12 @@ import java.lang.reflect.Type
  * Enumerates the different types of telemetry that are supported when persisting to disk.
  */
 enum class SupportedEnvelopeType(
-    val type: Type,
+    val serializedType: Type,
     val description: String
 ) {
 
-    SESSION(Envelope.sessionEnvelopeType, "session"),
     CRASH(Envelope.logEnvelopeType, "crash"),
+    SESSION(Envelope.sessionEnvelopeType, "session"),
     LOG(Envelope.logEnvelopeType, "log"),
     NETWORK(Envelope.logEnvelopeType, "network");
 

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
@@ -1,0 +1,28 @@
+package io.embrace.android.embracesdk.internal.delivery
+
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StoredTelemetryComparatorTest {
+
+    private val crash = StoredTelemetryMetadata(1, "crash", CRASH)
+    private val session = StoredTelemetryMetadata(1, "session", SESSION)
+    private val session2 = StoredTelemetryMetadata(100, "session2", SESSION)
+    private val session3 = StoredTelemetryMetadata(1000, "session3", SESSION)
+    private val log = StoredTelemetryMetadata(1, "log", LOG)
+    private val network = StoredTelemetryMetadata(1, "network", NETWORK)
+
+    @Test
+    fun `sort values`() {
+        val result = listOf(network, log, session2, crash, session3, session)
+            .sortedWith(StoredTelemetryComparator)
+            .map(StoredTelemetryMetadata::uuid)
+        val expected = listOf(crash, session, session2, session3, log, network)
+            .map(StoredTelemetryMetadata::uuid)
+        assertEquals(expected, result)
+    }
+}

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -52,7 +52,7 @@ class StoredTelemetryMetadataTest {
                 assertEquals(input, filename)
                 assertEquals(TIMESTAMP, timestamp)
                 assertEquals(UUID, uuid)
-                assertEquals(type, this.type)
+                assertEquals(type, this.envelopeType)
             }
         }
     }


### PR DESCRIPTION
## Goal

Implements rules for how stored telemetry should be prioritised. This will be used when sending telemetry, but IMO we should also use this when persisting data to avoid the queue getting saturated. In both scenarios this should be possible by supplying a comparator to the executor in `BackgroundWorker` - I'll make this change in a follow-up PR.

## Testing

Added unit tests.

