### PR TITLE
Rename workers and alter queue for some tasks

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestrator.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -71,7 +70,7 @@ class DataCaptureOrchestrator(
 
     private fun DataSourceState<*>.dispatchStateChange(action: () -> Unit) {
         if (asyncInit) {
-            worker.submit(TaskPriority.HIGH, action)
+            worker.submit(action)
         } else {
             action()
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.EventMessage
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import java.lang.reflect.ParameterizedType
@@ -24,7 +24,7 @@ internal class EmbraceApiService(
     private val serializer: PlatformSerializer,
     private val cachedConfigProvider: (url: String, request: ApiRequest) -> CachedConfig,
     private val logger: EmbLogger,
-    private val backgroundWorker: BackgroundWorker,
+    private val prioritizedWorker: PrioritizedWorker,
     private val pendingApiCallsSender: PendingApiCallsSender,
     lazyDeviceId: Lazy<String>,
     appId: String,
@@ -164,7 +164,7 @@ internal class EmbraceApiService(
             true -> TaskPriority.CRITICAL
             else -> TaskPriority.NORMAL
         }
-        return backgroundWorker.submit(priority) {
+        return prioritizedWorker.submit(priority) {
             var response: ApiResponse = ApiResponse.None
             try {
                 response = handleApiRequest(request, action)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/event/EmbraceEventService.kt
@@ -18,7 +18,7 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.utils.stream
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.ConcurrentMap
@@ -72,10 +72,10 @@ internal class EmbraceEventService(
             deliveryService,
             logger,
             clock,
-            workerThreadModule.scheduledWorker(WorkerName.BACKGROUND_REGISTRATION)
+            workerThreadModule.scheduledWorker(Worker.NonIoRegWorker)
         )
         backgroundWorker =
-            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
+            workerThreadModule.backgroundWorker(Worker.NonIoRegWorker)
     }
 
     override fun onForeground(coldStart: Boolean, timestamp: Long) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImpl.kt
@@ -5,7 +5,7 @@ package io.embrace.android.embracesdk.internal.injection
 import android.preference.PreferenceManager
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class AndroidServicesModuleImpl(
     initModule: InitModule,
@@ -20,7 +20,7 @@ internal class AndroidServicesModuleImpl(
             )
         }
         EmbracePreferencesService(
-            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+            workerThreadModule.backgroundWorker(Worker.IoRegWorker),
             lazyPrefs,
             initModule.clock,
             initModule.jsonSerializer

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.EmbraceConfigService
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class ConfigModuleImpl(
     initModule: InitModule,
@@ -26,7 +26,7 @@ internal class ConfigModuleImpl(
                     androidServicesModule.preferencesService,
                     initModule.clock,
                     initModule.logger,
-                    workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                    workerThreadModule.backgroundWorker(Worker.IoRegWorker),
                     framework,
                     foregroundAction
                 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImpl.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.internal.arch.EmbraceFeatureRegistry
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class DataSourceModuleImpl(
     initModule: InitModule,
@@ -14,7 +14,7 @@ internal class DataSourceModuleImpl(
     override val dataCaptureOrchestrator: DataCaptureOrchestrator by singleton {
         DataCaptureOrchestrator(
             configService,
-            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+            workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
             initModule.logger
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -23,7 +23,7 @@ import io.embrace.android.embracesdk.internal.session.id.SessionIdTrackerImpl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.EmbraceProcessStateService
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 class EssentialServiceModuleImpl(
     initModule: InitModule,
@@ -82,7 +82,7 @@ class EssentialServiceModuleImpl(
         Systrace.traceSynchronous("network-connectivity-service-init") {
             EmbraceNetworkConnectivityService(
                 coreModule.context,
-                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
                 initModule.logger,
                 systemServiceModule.connectivityManager
             )
@@ -92,7 +92,7 @@ class EssentialServiceModuleImpl(
     override val pendingApiCallsSender: PendingApiCallsSender by singleton {
         Systrace.traceSynchronous("pending-call-sender-init") {
             EmbracePendingApiCallsSender(
-                workerThreadModule.scheduledWorker(WorkerName.BACKGROUND_REGISTRATION),
+                workerThreadModule.scheduledWorker(Worker.IoRegWorker),
                 storageModule.deliveryCacheManager,
                 initModule.clock,
                 initModule.logger
@@ -112,7 +112,7 @@ class EssentialServiceModuleImpl(
                     }
                 },
                 logger = initModule.logger,
-                backgroundWorker = workerThreadModule.backgroundWorker(WorkerName.NETWORK_REQUEST),
+                backgroundWorker = workerThreadModule.backgroundWorker(Worker.NetworkRequestWorker),
                 pendingApiCallsSender = pendingApiCallsSender,
                 lazyDeviceId = lazyDeviceId,
                 appId = appId,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -112,7 +112,7 @@ class EssentialServiceModuleImpl(
                     }
                 },
                 logger = initModule.logger,
-                backgroundWorker = workerThreadModule.backgroundWorker(Worker.NetworkRequestWorker),
+                prioritizedWorker = workerThreadModule.prioritizedWorker(Worker.NetworkRequestWorker),
                 pendingApiCallsSender = pendingApiCallsSender,
                 lazyDeviceId = lazyDeviceId,
                 appId = appId,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.network.logging.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.network.logging.NetworkCaptureDataSourceImpl
 import io.embrace.android.embracesdk.internal.network.logging.NetworkCaptureService
 import io.embrace.android.embracesdk.internal.network.logging.NetworkLoggingService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class LogModuleImpl(
     initModule: InitModule,
@@ -62,7 +62,7 @@ internal class LogModuleImpl(
             essentialServiceModule.logWriter,
             configModule.configService,
             essentialServiceModule.sessionPropertiesService,
-            workerThreadModule.backgroundWorker(WorkerName.REMOTE_LOGGING),
+            workerThreadModule.backgroundWorker(Worker.LogMessageWorker),
             initModule.logger,
             initModule.jsonSerializer
         )
@@ -70,7 +70,7 @@ internal class LogModuleImpl(
 
     override val logOrchestrator: LogOrchestrator by singleton {
         LogOrchestratorImpl(
-            workerThreadModule.scheduledWorker(WorkerName.REMOTE_LOGGING),
+            workerThreadModule.scheduledWorker(Worker.LogMessageWorker),
             initModule.clock,
             openTelemetryModule.logSink,
             deliveryModule.deliveryService,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSo
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPayloadSourceImpl
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class PayloadSourceModuleImpl(
     initModule: InitModule,
@@ -42,7 +42,7 @@ internal class PayloadSourceModuleImpl(
             coreModule.context,
             configModule.configService,
             androidServicesModule.preferencesService,
-            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+            workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
             initModule.logger
         )
     }
@@ -96,7 +96,7 @@ internal class PayloadSourceModuleImpl(
                     DeviceImpl(
                         systemServiceModule.windowManager,
                         androidServicesModule.preferencesService,
-                        workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                        workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
                         initModule.systemInfo,
                         { nativeCoreModuleProvider()?.cpuInfoDelegate },
                         initModule.logger
@@ -122,7 +122,7 @@ internal class PayloadSourceModuleImpl(
                 lazy { systemServiceModule.storageManager },
                 configModule.configService,
                 androidServicesModule.preferencesService,
-                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
                 initModule.clock,
                 initModule.logger
             )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrches
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulatorImpl
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class SessionOrchestrationModuleImpl(
     initModule: InitModule,
@@ -55,7 +55,7 @@ internal class SessionOrchestrationModuleImpl(
 
     private val periodicSessionCacher: PeriodicSessionCacher by singleton {
         PeriodicSessionCacher(
-            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE),
+            workerThreadModule.scheduledWorker(Worker.PeriodicCacheWorker),
             initModule.logger
         )
     }
@@ -63,7 +63,7 @@ internal class SessionOrchestrationModuleImpl(
     private val periodicBackgroundActivityCacher: PeriodicBackgroundActivityCacher by singleton {
         PeriodicBackgroundActivityCacher(
             initModule.clock,
-            workerThreadModule.scheduledWorker(WorkerName.PERIODIC_CACHE),
+            workerThreadModule.scheduledWorker(Worker.PeriodicCacheWorker),
             initModule.logger
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.comms.delivery.EmbraceDeliveryCach
 import io.embrace.android.embracesdk.internal.storage.EmbraceStorageService
 import io.embrace.android.embracesdk.internal.storage.StatFsAvailabilityChecker
 import io.embrace.android.embracesdk.internal.storage.StorageService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.concurrent.TimeUnit
 
 internal class StorageModuleImpl(
@@ -44,14 +44,14 @@ internal class StorageModuleImpl(
     override val deliveryCacheManager: DeliveryCacheManager by singleton {
         EmbraceDeliveryCacheManager(
             cacheService,
-            workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE),
+            workerThreadModule.backgroundWorker(Worker.FileCacheWorker),
             initModule.logger
         )
     }
 
     init {
         workerThreadModule
-            .scheduledWorker(WorkerName.BACKGROUND_REGISTRATION)
+            .scheduledWorker(Worker.IoRegWorker)
             .schedule<Unit>({ storageService.logStorageTelemetry() }, 1, TimeUnit.MINUTES)
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
@@ -44,7 +44,7 @@ internal class StorageModuleImpl(
     override val deliveryCacheManager: DeliveryCacheManager by singleton {
         EmbraceDeliveryCacheManager(
             cacheService,
-            workerThreadModule.backgroundWorker(Worker.FileCacheWorker),
+            workerThreadModule.prioritizedWorker(Worker.FileCacheWorker),
             initModule.logger
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import io.embrace.android.embracesdk.internal.worker.Worker
 import java.io.Closeable
@@ -15,6 +16,11 @@ interface WorkerThreadModule : Closeable {
      * Return a [BackgroundWorker] matching the [worker]
      */
     fun backgroundWorker(worker: Worker): BackgroundWorker
+
+    /**
+     * Return a [PrioritizedWorker] matching the [worker]
+     */
+    fun prioritizedWorker(worker: Worker): PrioritizedWorker
 
     /**
      * Return the [ScheduledWorker] given the [worker]

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicReference
 
@@ -12,14 +12,14 @@ import java.util.concurrent.atomic.AtomicReference
 interface WorkerThreadModule : Closeable {
 
     /**
-     * Return a [BackgroundWorker] matching the [workerName]
+     * Return a [BackgroundWorker] matching the [worker]
      */
-    fun backgroundWorker(workerName: WorkerName): BackgroundWorker
+    fun backgroundWorker(worker: Worker): BackgroundWorker
 
     /**
-     * Return the [ScheduledWorker] given the [workerName]
+     * Return the [ScheduledWorker] given the [worker]
      */
-    fun scheduledWorker(workerName: WorkerName): ScheduledWorker
+    fun scheduledWorker(worker: Worker): ScheduledWorker
 
     /**
      * Returns the thread that monitors the main thread for ANRs

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -37,7 +37,7 @@ internal class WorkerThreadModuleImpl(
 
     override fun backgroundWorker(worker: Worker): BackgroundWorker {
         return backgroundWorker.getOrPut(worker) {
-            BackgroundWorker(fetchExecutor(worker))
+            BackgroundWorker(fetchExecutor(worker) as ScheduledExecutorService)
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.PriorityThreadPoolExecutor
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -22,23 +22,23 @@ internal class WorkerThreadModuleImpl(
 
     private val clock = initModule.clock
     private val logger = initModule.logger
-    private val executors: MutableMap<WorkerName, ExecutorService> = ConcurrentHashMap()
-    private val backgroundWorkers: MutableMap<WorkerName, BackgroundWorker> = ConcurrentHashMap()
-    private val scheduledWorkers: MutableMap<WorkerName, ScheduledWorker> = ConcurrentHashMap()
+    private val executors: MutableMap<Worker, ExecutorService> = ConcurrentHashMap()
+    private val backgroundWorker: MutableMap<Worker, BackgroundWorker> = ConcurrentHashMap()
+    private val scheduledWorker: MutableMap<Worker, ScheduledWorker> = ConcurrentHashMap()
     override val anrMonitorThread: AtomicReference<Thread> = AtomicReference<Thread>()
 
-    override fun backgroundWorker(workerName: WorkerName): BackgroundWorker {
-        return backgroundWorkers.getOrPut(workerName) {
-            BackgroundWorker(fetchExecutor(workerName))
+    override fun backgroundWorker(worker: Worker): BackgroundWorker {
+        return backgroundWorker.getOrPut(worker) {
+            BackgroundWorker(fetchExecutor(worker))
         }
     }
 
-    override fun scheduledWorker(workerName: WorkerName): ScheduledWorker {
-        if (workerName == WorkerName.NETWORK_REQUEST) {
+    override fun scheduledWorker(worker: Worker): ScheduledWorker {
+        if (worker == Worker.NetworkRequestWorker) {
             error("Network request executor is not a scheduled executor")
         }
-        return scheduledWorkers.getOrPut(workerName) {
-            ScheduledWorker(fetchExecutor(workerName) as ScheduledExecutorService)
+        return scheduledWorker.getOrPut(worker) {
+            ScheduledWorker(fetchExecutor(worker) as ScheduledExecutorService)
         }
     }
 
@@ -46,12 +46,12 @@ internal class WorkerThreadModuleImpl(
         executors.values.forEach(ExecutorService::shutdown)
     }
 
-    private fun fetchExecutor(workerName: WorkerName): ExecutorService {
-        return executors.getOrPut(workerName) {
-            val threadFactory = createThreadFactory(workerName)
+    private fun fetchExecutor(worker: Worker): ExecutorService {
+        return executors.getOrPut(worker) {
+            val threadFactory = createThreadFactory(worker)
 
-            when (workerName) {
-                WorkerName.NETWORK_REQUEST -> PriorityThreadPoolExecutor(clock, threadFactory, this, 1, 1)
+            when (worker) {
+                Worker.NetworkRequestWorker -> PriorityThreadPoolExecutor(clock, threadFactory, this, 1, 1)
                 else -> ScheduledThreadPoolExecutor(1, threadFactory, this)
             }
         }
@@ -72,10 +72,10 @@ internal class WorkerThreadModuleImpl(
         )
     }
 
-    private fun createThreadFactory(name: WorkerName): ThreadFactory {
+    private fun createThreadFactory(name: Worker): ThreadFactory {
         return ThreadFactory { runnable: Runnable ->
             Executors.defaultThreadFactory().newThread(runnable).apply {
-                if (name == WorkerName.ANR_MONITOR) {
+                if (name == Worker.AnrWatchdogWorker) {
                     anrMonitorThread.set(this)
                 }
                 this.name = "emb-${name.threadName}"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorker.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.worker
 
 import java.util.concurrent.Callable
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 /**
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
  * to expose as part of the internal API.
  */
 class BackgroundWorker(
-    private val impl: ExecutorService
+    private val impl: ScheduledExecutorService
 ) {
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PrioritizedWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PrioritizedWorker.kt
@@ -11,22 +11,28 @@ import java.util.concurrent.TimeUnit
  * This class is necessary because it hides aspects of the ExecutorService API that we don't want
  * to expose as part of the internal API.
  */
-class BackgroundWorker(
+class PrioritizedWorker(
     private val impl: ExecutorService
 ) {
 
     /**
      * Submits a task for execution and returns a [Future].
      */
-    fun submit(runnable: Runnable): Future<*> {
-        return impl.submit(runnable)
+    fun submit(
+        priority: TaskPriority = TaskPriority.NORMAL,
+        runnable: Runnable
+    ): Future<*> {
+        return impl.submit(PriorityRunnable(priority, runnable))
     }
 
     /**
      * Submits a task for execution and returns a [Future].
      */
-    fun <T> submit(callable: Callable<T>): Future<T> {
-        return impl.submit(callable)
+    fun <T> submit(
+        priority: TaskPriority = TaskPriority.NORMAL,
+        callable: Callable<T>
+    ): Future<T> {
+        return impl.submit(PriorityCallable(priority, callable))
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/ScheduledWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/ScheduledWorker.kt
@@ -59,4 +59,17 @@ class ScheduledWorker(
         intervalMs: Long,
         unit: TimeUnit
     ): ScheduledFuture<*> = impl.scheduleAtFixedRate(runnable, initialDelay, intervalMs, unit)
+
+    /**
+     * Shutdown the worker. If [timeoutMs] is greater than 0, the worker will
+     * block for the specified milliseconds if tasks are still enqueued or running.
+     */
+    fun shutdownAndWait(timeoutMs: Long = 0) {
+        runCatching {
+            with(impl) {
+                shutdown()
+                awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)
+            }
+        }
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
@@ -3,42 +3,43 @@ package io.embrace.android.embracesdk.internal.worker
 /**
  * The key used to reference a specific shared [BackgroundWorker] or the [ScheduledWorker] that uses it
  */
-enum class WorkerName(internal val threadName: String) {
+enum class Worker(internal val threadName: String) {
 
     /**
-     * Used primarily to perform short-lived tasks that need to execute only once, or
-     * recurring tasks that don't use I/O or block for long periods of time.
+     * Used to perform miscellaneous tasks that don't involve I/O & don't require guarantees about
+     * running on a specific thread or in a specific order.
      */
-    BACKGROUND_REGISTRATION("background-reg"),
+    NonIoRegWorker("non-io-reg"),
+
+    /**
+     * Used to perform miscellaneous tasks that _do_ involve I/O & don't require guarantees about
+     * running on a specific thread or in a specific order.
+     */
+    IoRegWorker("non-io-reg"),
 
     /**
      * Saves/loads request information from files cached on disk.
      */
-    DELIVERY_CACHE("delivery-cache"),
+    FileCacheWorker("file-cache"),
 
     /**
      * All HTTP requests are performed on this executor.
      */
-    NETWORK_REQUEST("network-request"),
+    NetworkRequestWorker("network-request"),
 
     /**
      * Used for periodic writing of session/background activity payloads to disk.
      */
-    PERIODIC_CACHE("periodic-cache"),
+    PeriodicCacheWorker("periodic-cache"),
 
     /**
      * Used to construct log messages. Log messages are sent to the server on a separate thread -
      * the intention behind this is to offload unnecessary CPU work from the main thread.
      */
-    REMOTE_LOGGING("remote-logging"),
+    LogMessageWorker("log-message"),
 
     /**
      * Monitor thread that checks the main thread for ANRs.
      */
-    ANR_MONITOR("anr-monitor"),
-
-    /**
-     * Initialize services asynchronously
-     */
-    SERVICE_INIT("service-init"),
+    AnrWatchdogWorker("anr-watchdog")
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestratorTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
@@ -19,7 +19,7 @@ internal class DataCaptureOrchestratorTest {
     private lateinit var orchestrator: DataCaptureOrchestrator
     private lateinit var dataSource: FakeDataSource
     private lateinit var configService: FakeConfigService
-    private lateinit var executorService: BlockableExecutorService
+    private lateinit var executorService: BlockingScheduledExecutorService
     private var enabled: Boolean = true
 
     private val syncDataSource = DataSourceState(
@@ -37,7 +37,7 @@ internal class DataCaptureOrchestratorTest {
     fun setUp() {
         dataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         configService = FakeConfigService()
-        executorService = BlockableExecutorService()
+        executorService = BlockingScheduledExecutorService(blockingMode = false)
         orchestrator = DataCaptureOrchestrator(
             configService,
             BackgroundWorker(executorService),
@@ -72,13 +72,13 @@ internal class DataCaptureOrchestratorTest {
 
         orchestrator.currentSessionType = SessionType.FOREGROUND
         assertEquals(0, dataSource.enableDataCaptureCount)
-        executorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertEquals(1, dataSource.enableDataCaptureCount)
 
         enabled = false
         configService.updateListeners()
         assertEquals(0, dataSource.disableDataCaptureCount)
-        executorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertEquals(1, dataSource.disableDataCaptureCount)
     }
 
@@ -90,7 +90,7 @@ internal class DataCaptureOrchestratorTest {
         assertEquals(0, dataSource.enableDataCaptureCount)
         orchestrator.currentSessionType = SessionType.FOREGROUND
         assertEquals(0, dataSource.enableDataCaptureCount)
-        executorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertEquals(1, dataSource.enableDataCaptureCount)
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityServiceTest.kt
@@ -4,8 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
@@ -45,7 +45,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
             logger = EmbLoggerImpl()
             mockConnectivityManager = mockk()
             fakeClock = FakeClock()
-            worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
+            worker = fakeBackgroundWorker()
         }
 
         /**

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.pm.PackageInfo
 import android.os.Environment
 import android.view.WindowManager
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -13,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeRnBundleIdTracker
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSourceImpl
@@ -24,7 +24,6 @@ import io.embrace.android.embracesdk.internal.payload.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.payload.UserInfo
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -127,7 +126,7 @@ internal class EmbraceMetadataServiceTest {
                     DeviceImpl(
                         mockk(relaxed = true),
                         preferencesService,
-                        BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+                        fakeBackgroundWorker(),
                         SystemInfo(),
                         Companion::cpuInfoDelegate,
                         FakeEmbLogger()
@@ -140,7 +139,7 @@ internal class EmbraceMetadataServiceTest {
             lazy { storageStatsManager },
             configService,
             preferencesService,
-            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            fakeBackgroundWorker(),
             fakeClock,
             FakeEmbLogger()
         )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
@@ -3,16 +3,15 @@ package io.embrace.android.embracesdk.internal.capture.metadata
 import android.content.Context
 import android.content.res.AssetManager
 import android.view.WindowManager
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfo
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -59,7 +58,7 @@ internal class EmbraceRnBundleIdTrackerTest {
         context,
         configService,
         preferencesService,
-        BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+        fakeBackgroundWorker(),
         FakeEmbLogger()
     )
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
@@ -10,12 +10,12 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -24,7 +24,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 
 private const val MAX_SESSION_PROPERTIES_FROM_CONFIG = 5
 private const val MAX_SESSION_PROPERTIES_DEFAULT = 10
@@ -47,7 +46,7 @@ internal class EmbraceSessionPropertiesTest {
 
     @Before
     fun setUp() {
-        val worker = BackgroundWorker(Executors.newSingleThreadExecutor())
+        val worker = fakeBackgroundWorker()
         context = ApplicationProvider.getApplicationContext()
         logger = EmbLoggerImpl()
         val prefs = lazy { PreferenceManager.getDefaultSharedPreferences(context) }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import org.junit.After
@@ -455,7 +455,7 @@ internal class EmbraceApiServiceTest {
             serializer = serializer,
             cachedConfigProvider = { _, _ -> cachedConfig },
             logger = EmbLoggerImpl(),
-            backgroundWorker = BackgroundWorker(testScheduledExecutor),
+            prioritizedWorker = PrioritizedWorker(testScheduledExecutor),
             pendingApiCallsSender = fakePendingApiCallsSender,
             lazyDeviceId = lazy { fakeDeviceId },
             appId = fakeAppId,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.comms.delivery
 
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fakes.FakeApiService
 import io.embrace.android.embracesdk.fakes.FakeClock
@@ -13,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.FakeSpanData.Companion.perfSpanSnapsh
 import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.fakeIncompleteSessionEnvelope
+import io.embrace.android.embracesdk.fakes.fakePrioritizedWorker
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getLastHeartbeatTimeMs
@@ -39,7 +39,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapsh
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
@@ -52,7 +52,7 @@ import org.junit.Test
 internal class EmbraceDeliveryServiceTest {
 
     private lateinit var fakeClock: FakeClock
-    private lateinit var worker: BackgroundWorker
+    private lateinit var worker: PrioritizedWorker
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var apiService: FakeApiService
     private lateinit var fakeNativeCrashService: FakeNativeCrashService
@@ -67,7 +67,7 @@ internal class EmbraceDeliveryServiceTest {
     @Before
     fun setUp() {
         fakeClock = FakeClock()
-        worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
+        worker = fakePrioritizedWorker()
         apiService = FakeApiService()
         fakeNativeCrashService = FakeNativeCrashService()
         gatingService = FakeGatingService()
@@ -82,7 +82,7 @@ internal class EmbraceDeliveryServiceTest {
         )
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService = cacheService,
-            backgroundWorker = worker,
+            prioritizedWorker = worker,
             logger = logger,
         )
         deliveryService = EmbraceDeliveryService(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.internal.config
 
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.comms.api.CachedConfig
@@ -95,7 +95,7 @@ internal class EmbraceConfigServiceTest {
         every {
             mockCacheService.loadObject<RemoteConfig>("config.json", RemoteConfig::class.java)
         } returns fakeCachedConfig
-        worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
+        worker = fakeBackgroundWorker()
         service = createService(worker = worker, action = {})
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.config
 
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
@@ -34,7 +35,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import org.robolectric.android.util.concurrent.PausedExecutorService
 
 internal class EmbraceConfigServiceTest {
 
@@ -271,13 +271,13 @@ internal class EmbraceConfigServiceTest {
         // Use ExecutorService that requires tasks to be explicitly run. This allows us to simulate the case
         // when the loading from the cache doesn't run before the config is read.
 
-        val pausableExecutorService = PausedExecutorService()
+        val executorService = BlockingScheduledExecutorService(blockingMode = true)
 
         every { mockApiService.getCachedConfig() } returns CachedConfig(null, null)
 
         // Create a new instance of the ConfigService where the value of the config is what it is when the config
         // variable is initialized, before the cached version is loaded.
-        val configService = createService(BackgroundWorker(pausableExecutorService))
+        val configService = createService(BackgroundWorker(executorService))
         assertFalse(configService.hasValidRemoteConfig())
 
         // call arbitrary function to trigger config refresh
@@ -285,11 +285,7 @@ internal class EmbraceConfigServiceTest {
 
         // Only run the task from the executor that loads the cached config to the ConfigService so the call to fetch
         // a new config from the server isn't run
-        pausableExecutorService.runNext()
-        assertFalse(configService.hasValidRemoteConfig())
-
-        // fetch config from the server
-        pausableExecutorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertTrue(configService.hasValidRemoteConfig())
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImplTest.kt
@@ -2,12 +2,11 @@ package io.embrace.android.embracesdk.internal.envelope.resource
 
 import android.os.Environment
 import android.view.WindowManager
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeCpuInfoDelegate
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -62,7 +61,7 @@ internal class DeviceImplTest {
         val device = DeviceImpl(
             windowManager,
             preferencesService,
-            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            fakeBackgroundWorker(),
             SystemInfo(),
             Companion::cpuInfoDelegate,
             EmbLoggerImpl(),
@@ -76,7 +75,7 @@ internal class DeviceImplTest {
         val device = DeviceImpl(
             windowManager,
             preferencesService,
-            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            fakeBackgroundWorker(),
             SystemInfo(),
             Companion::cpuInfoDelegate,
             EmbLoggerImpl(),
@@ -90,7 +89,7 @@ internal class DeviceImplTest {
         val device = DeviceImpl(
             windowManager,
             preferencesService,
-            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            fakeBackgroundWorker(),
             SystemInfo(),
             Companion::cpuInfoDelegate,
             EmbLoggerImpl(),

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/EmbraceEventServiceTest.kt
@@ -29,7 +29,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -90,7 +90,7 @@ internal class EmbraceEventServiceTest {
         sessionPropertiesService = FakeSessionPropertiesService()
         gatingService = FakeGatingService(EmbraceGatingService(configService, FakeLogService(), FakeEmbLogger()))
         val initModule = FakeInitModule(clock = fakeClock)
-        fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = initModule, name = WorkerName.BACKGROUND_REGISTRATION)
+        fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = initModule, name = Worker.NonIoRegWorker)
         eventHandler = EventHandler(
             metadataService = metadataService,
             sessionIdTracker = sessionIdTracker,
@@ -100,7 +100,7 @@ internal class EmbraceEventServiceTest {
             logger = logger,
             clock = fakeClock,
             processStateService = processStateService,
-            scheduledWorker = fakeWorkerThreadModule.scheduledWorker(WorkerName.BACKGROUND_REGISTRATION)
+            scheduledWorker = fakeWorkerThreadModule.scheduledWorker(Worker.NonIoRegWorker)
         )
         eventService = EmbraceEventService(
             1,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -18,7 +18,7 @@ internal class DataSourceModuleImplTest {
             FakeConfigService(),
             FakeWorkerThreadModule(
                 fakeInitModule = fakeInitModule,
-                name = WorkerName.BACKGROUND_REGISTRATION
+                name = Worker.NonIoRegWorker
             ),
         )
         assertSame(module.dataCaptureOrchestrator, module.embraceFeatureRegistry)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Before
@@ -26,14 +26,14 @@ internal class WorkerThreadModuleImplTest {
         val module = WorkerThreadModuleImpl(initModule)
         assertNotNull(module)
 
-        val backgroundExecutor = module.backgroundWorker(WorkerName.PERIODIC_CACHE)
+        val backgroundExecutor = module.backgroundWorker(Worker.PeriodicCacheWorker)
         assertNotNull(backgroundExecutor)
-        val scheduledExecutor = module.scheduledWorker(WorkerName.PERIODIC_CACHE)
+        val scheduledExecutor = module.scheduledWorker(Worker.PeriodicCacheWorker)
         assertNotNull(scheduledExecutor)
 
         // test caching
-        assertSame(backgroundExecutor, module.backgroundWorker(WorkerName.PERIODIC_CACHE))
-        assertSame(scheduledExecutor, module.scheduledWorker(WorkerName.PERIODIC_CACHE))
+        assertSame(backgroundExecutor, module.backgroundWorker(Worker.PeriodicCacheWorker))
+        assertSame(scheduledExecutor, module.scheduledWorker(Worker.PeriodicCacheWorker))
 
         // test shutting down module
         module.close()
@@ -42,19 +42,19 @@ internal class WorkerThreadModuleImplTest {
     @Test
     fun `network request executor uses custom queue`() {
         val module = WorkerThreadModuleImpl(initModule)
-        assertNotNull(module.backgroundWorker(WorkerName.NETWORK_REQUEST))
+        assertNotNull(module.backgroundWorker(Worker.NetworkRequestWorker))
     }
 
     @Test(expected = IllegalStateException::class)
     fun `network request scheduled executor fails`() {
         val module = WorkerThreadModuleImpl(initModule)
-        module.scheduledWorker(WorkerName.NETWORK_REQUEST)
+        module.scheduledWorker(Worker.NetworkRequestWorker)
     }
 
     @Test
     fun `rejected execution policy`() {
         val module = WorkerThreadModuleImpl(initModule)
-        val worker = module.backgroundWorker(WorkerName.PERIODIC_CACHE)
+        val worker = module.backgroundWorker(Worker.PeriodicCacheWorker)
         module.close()
 
         val future = worker.submit {}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
@@ -42,7 +42,7 @@ internal class WorkerThreadModuleImplTest {
     @Test
     fun `network request executor uses custom queue`() {
         val module = WorkerThreadModuleImpl(initModule)
-        assertNotNull(module.backgroundWorker(Worker.NetworkRequestWorker))
+        assertNotNull(module.prioritizedWorker(Worker.NetworkRequestWorker))
     }
 
     @Test(expected = IllegalStateException::class)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.logs
 
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -9,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.behavior.FakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.createSessionBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.internal.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
@@ -36,7 +35,7 @@ internal class EmbraceLogServiceTest {
     private lateinit var fakeSessionPropertiesService: FakeSessionPropertiesService
     private lateinit var fakeConfigService: FakeConfigService
 
-    private val backgroundWorker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
+    private val backgroundWorker = fakeBackgroundWorker()
     private val fakeEmbLogger = FakeEmbLogger()
     private val embraceSerializer = EmbraceSerializer()
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
@@ -7,11 +7,10 @@ import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSharedPreferences
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -28,7 +27,7 @@ internal class EmbracePreferencesServiceTest {
     private lateinit var service: EmbracePreferencesService
     private lateinit var fakeClock: FakeClock
 
-    private val executorService = BackgroundWorker(BlockableExecutorService())
+    private val executorService = fakeBackgroundWorker()
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Before

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionOrchestrationModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionOrchestrationModuleImplTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.SessionOrchestrationModuleImpl
 import io.embrace.android.embracesdk.internal.injection.createDataSourceModule
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -23,7 +23,7 @@ internal class SessionOrchestrationModuleImplTest {
     private val configService = FakeConfigService()
     private val workerThreadModule = FakeWorkerThreadModule(
         fakeInitModule = initModule,
-        name = WorkerName.BACKGROUND_REGISTRATION
+        name = Worker.NonIoRegWorker
     )
 
     @Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -18,6 +17,7 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeV2PayloadCollator
 import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
@@ -29,7 +29,6 @@ import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -369,7 +368,7 @@ internal class SessionOrchestratorTest {
         fakeDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         dataCaptureOrchestrator = DataCaptureOrchestrator(
             configService,
-            BackgroundWorker(BlockableExecutorService()),
+            fakeBackgroundWorker(),
             logger
         ).apply {
             add(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheCurrentAccessTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheCurrentAccessTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.mockk.clearAllMocks
 import io.mockk.spyk
 import io.mockk.verify
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 internal class EmbraceDeliveryCacheCurrentAccessTest {
 
     private val serializer = EmbraceSerializer()
-    private lateinit var worker: BackgroundWorker
+    private lateinit var worker: PrioritizedWorker
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService
@@ -34,7 +34,7 @@ internal class EmbraceDeliveryCacheCurrentAccessTest {
         fakeClock = FakeClock(clockInit)
         logger = EmbLoggerImpl()
         storageService = FakeStorageService()
-        worker = BackgroundWorker(SingleThreadTestScheduledExecutor())
+        worker = PrioritizedWorker(SingleThreadTestScheduledExecutor())
         cacheService = spyk(
             EmbraceCacheService(
                 storageService = storageService,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheManagerTest.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.internal.storage
 
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeStorageService
+import io.embrace.android.embracesdk.fakes.fakePrioritizedWorker
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.fixtures.testSessionEnvelope
 import io.embrace.android.embracesdk.fixtures.testSessionEnvelopeOneMinuteLater
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.JVM_CRASH
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.NORMAL_END
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.PERIODIC_CACHE
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -46,7 +46,7 @@ internal class EmbraceDeliveryCacheManagerTest {
 
     private val prefix = "last_session"
     private val serializer = EmbraceSerializer()
-    private val worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
+    private val worker = fakePrioritizedWorker()
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService
@@ -339,7 +339,7 @@ internal class EmbraceDeliveryCacheManagerTest {
     fun `save payload sync`() {
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService,
-            BackgroundWorker(BlockableExecutorService(blockingMode = true)),
+            PrioritizedWorker(BlockableExecutorService(blockingMode = true)),
             logger
         )
         val expected = "test".toByteArray()
@@ -362,7 +362,7 @@ internal class EmbraceDeliveryCacheManagerTest {
         val executorService = BlockableExecutorService(blockingMode = true)
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService,
-            BackgroundWorker(executorService),
+            PrioritizedWorker(executorService),
             logger
         )
         val expected = "test".toByteArray()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -21,7 +21,7 @@ internal class BackgroundWorkerTest {
         val runnable = Runnable {
             ran = true
         }
-        BackgroundWorker(impl).submit(TaskPriority.NORMAL, runnable)
+        BackgroundWorker(impl).submit(runnable)
         impl.runNext()
         assertTrue(ran)
     }
@@ -33,7 +33,7 @@ internal class BackgroundWorkerTest {
         val callable = Callable {
             ran = true
         }
-        BackgroundWorker(impl).submit(TaskPriority.NORMAL, callable)
+        BackgroundWorker(impl).submit(callable)
         impl.runNext()
         assertTrue(ran)
     }
@@ -42,7 +42,7 @@ internal class BackgroundWorkerTest {
     fun `test runnable transformed`() {
         val impl = DecoratedExecutorService()
         val runnable = Runnable {}
-        val future = BackgroundWorker(impl).submit(TaskPriority.LOW, runnable)
+        val future = PrioritizedWorker(impl).submit(TaskPriority.LOW, runnable)
         val submitted = impl.runnables.single() as PriorityRunnable
         assertEquals(TaskPriority.LOW, submitted.priority)
         assertNull(future.get())
@@ -52,7 +52,7 @@ internal class BackgroundWorkerTest {
     fun `test callable transformed`() {
         val impl = DecoratedExecutorService()
         val callable = Callable { "test" }
-        val future = BackgroundWorker(impl).submit(TaskPriority.HIGH, callable)
+        val future = PrioritizedWorker(impl).submit(TaskPriority.HIGH, callable)
         val submitted = impl.callables.single() as PriorityCallable<*>
         assertEquals(TaskPriority.HIGH, submitted.priority)
         assertEquals("test", future.get())
@@ -68,7 +68,7 @@ internal class BackgroundWorkerTest {
         )
 
         var ran = false
-        worker.submit(TaskPriority.NORMAL) {
+        worker.submit {
             latch.await(1000, TimeUnit.MILLISECONDS)
             ran = true
         }
@@ -86,7 +86,7 @@ internal class BackgroundWorkerTest {
         )
 
         var ran = false
-        worker.submit(TaskPriority.NORMAL,) {
+        worker.submit {
             latch.await(1000, TimeUnit.MILLISECONDS)
             ran = true
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.worker
 
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -8,33 +8,33 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 internal class BackgroundWorkerTest {
 
     @Test
     fun testSubmitRunnable() {
-        val impl = BlockableExecutorService()
+        val impl = BlockingScheduledExecutorService(blockingMode = false)
         var ran = false
         val runnable = Runnable {
             ran = true
         }
         BackgroundWorker(impl).submit(runnable)
-        impl.runNext()
+        impl.runCurrentlyBlocked()
         assertTrue(ran)
     }
 
     @Test
     fun testSubmitCallable() {
-        val impl = BlockableExecutorService()
+        val impl = BlockingScheduledExecutorService(blockingMode = false)
         var ran = false
         val callable = Callable {
             ran = true
         }
         BackgroundWorker(impl).submit(callable)
-        impl.runNext()
+        impl.runCurrentlyBlocked()
         assertTrue(ran)
     }
 
@@ -97,8 +97,8 @@ internal class BackgroundWorkerTest {
     private class ShutdownAndWaitExecutorService(
         private val postShutdownAction: () -> Unit = {},
         private val postAwaitTerminationAction: () -> Unit = {},
-        private val impl: ExecutorService = Executors.newSingleThreadExecutor()
-    ) : ExecutorService by impl {
+        private val impl: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+    ) : ScheduledExecutorService by impl {
 
         override fun shutdown() {
             impl.shutdown()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutorTest.kt
@@ -39,13 +39,13 @@ internal class PriorityThreadPoolExecutorTest {
 
     @Test
     fun `submit valid runnable`() {
-        val future = BackgroundWorker(executor).submit {}
+        val future = PrioritizedWorker(executor).submit {}
         assertEquals(TaskPriority.NORMAL, (future as PriorityRunnableFuture<*>).priority)
     }
 
     @Test
     fun `submit valid callable`() {
-        val future = BackgroundWorker(executor).submit(TaskPriority.HIGH, Callable {})
+        val future = PrioritizedWorker(executor).submit(TaskPriority.HIGH, Callable {})
         assertEquals(TaskPriority.HIGH, (future as PriorityRunnableFuture<*>).priority)
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSource.kt
@@ -14,7 +14,6 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import java.util.concurrent.Executor
 
@@ -41,7 +40,7 @@ class ThermalStateDataSource(
     private var span: EmbraceSpan? = null
 
     override fun enableDataCapture() {
-        backgroundWorker.submit(TaskPriority.LOW) {
+        backgroundWorker.submit {
             Systrace.traceSynchronous("thermal-service-registration") {
                 thermalStatusListener = PowerManager.OnThermalStatusChangedListener {
                     handleThermalStateChange(it)
@@ -63,7 +62,7 @@ class ThermalStateDataSource(
     }
 
     override fun disableDataCapture() {
-        backgroundWorker.submit(TaskPriority.LOW) {
+        backgroundWorker.submit {
             thermalStatusListener?.let {
                 powerManager?.removeThermalStatusListener(it)
                 thermalStatusListener = null

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.internal.anr.sigquit.AnrThreadIdDelegate
 import io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSource
 import io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSourceImpl
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class AnrModuleImpl(
     initModule: InitModule,
@@ -23,7 +23,7 @@ internal class AnrModuleImpl(
     otelModule: OpenTelemetryModule
 ) : AnrModule {
 
-    private val anrMonitorWorker = workerModule.scheduledWorker(WorkerName.ANR_MONITOR)
+    private val anrMonitorWorker = workerModule.scheduledWorker(Worker.AnrWatchdogWorker)
 
     override val anrService: AnrService by singleton {
         if (configService.autoDataCaptureBehavior.isAnrCaptureEnabled()) {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.capture.webview.WebViewService
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     initModule: InitModule,
@@ -45,7 +45,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     override val startupService: StartupService by singleton {
         StartupServiceImpl(
             spanService = openTelemetryModule.spanService,
-            backgroundWorker = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
+            backgroundWorker = workerThreadModule.backgroundWorker(Worker.NonIoRegWorker)
         )
     }
 
@@ -54,7 +54,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
             clock = openTelemetryModule.openTelemetryClock,
             startupServiceProvider = { startupService },
             spanService = openTelemetryModule.spanService,
-            backgroundWorker = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+            backgroundWorker = workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
             versionChecker = versionChecker,
             logger = initModule.logger
         )

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
@@ -25,7 +25,7 @@ import io.embrace.android.embracesdk.internal.capture.webview.WebViewDataSource
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class FeatureModuleImpl(
     private val featureRegistry: EmbraceFeatureRegistry,
@@ -148,7 +148,7 @@ internal class FeatureModuleImpl(
             factory = {
                 LowPowerDataSource(
                     context = coreModule.context,
-                    backgroundWorker = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                    backgroundWorker = workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
                     clock = initModule.clock,
                     provider = { systemServiceModule.powerManager },
                     spanService = otelModule.spanService,
@@ -164,7 +164,7 @@ internal class FeatureModuleImpl(
             ThermalStateDataSource(
                 spanService = otelModule.spanService,
                 logger = initModule.logger,
-                backgroundWorker = workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                backgroundWorker = workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
                 clock = initModule.clock,
                 powerManagerProvider = { systemServiceModule.powerManager }
             )
@@ -185,7 +185,7 @@ internal class FeatureModuleImpl(
     private val aeiService: AeiDataSourceImpl? by singleton {
         if (BuildVersionChecker.isAtLeast(Build.VERSION_CODES.R)) {
             AeiDataSourceImpl(
-                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                workerThreadModule.backgroundWorker(Worker.NonIoRegWorker),
                 configService.appExitInfoBehavior,
                 systemServiceModule.activityManager,
                 androidServicesModule.preferencesService,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.ndk.NdkDelegateImpl
 import io.embrace.android.embracesdk.internal.ndk.NdkService
 import io.embrace.android.embracesdk.internal.ndk.NoopNativeCrashService
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class NativeFeatureModuleImpl(
     initModule: InitModule,
@@ -41,7 +41,7 @@ internal class NativeFeatureModuleImpl(
                 initModule.logger,
                 embraceNdkServiceRepository,
                 NdkDelegateImpl(),
-                workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION),
+                workerThreadModule.backgroundWorker(Worker.IoRegWorker),
                 payloadSourceModule.deviceArchitecture,
                 initModule.jsonSerializer
             )
@@ -55,7 +55,7 @@ internal class NativeFeatureModuleImpl(
                     configService = configModule.configService,
                     symbols = lazy { ndkService.symbolsForCurrentArch },
                     logger = initModule.logger,
-                    scheduledWorker = workerThreadModule.scheduledWorker(WorkerName.BACKGROUND_REGISTRATION),
+                    scheduledWorker = workerThreadModule.scheduledWorker(Worker.NonIoRegWorker),
                     deviceArchitecture = payloadSourceModule.deviceArchitecture,
                     sharedObjectLoader = nativeCoreModule.sharedObjectLoader,
                 )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
@@ -2,15 +2,14 @@ package io.embrace.android.embracesdk.internal.capture.aei
 
 import android.app.ActivityManager
 import android.app.ApplicationExitInfo
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -40,7 +39,7 @@ internal class AeiDataSourceImplTest {
     private lateinit var logWriter: FakeLogWriter
     private lateinit var configService: FakeConfigService
 
-    private val worker = BackgroundWorker(MoreExecutors.newDirectExecutorService())
+    private val worker = fakeBackgroundWorker()
 
     private val preferenceService = FakePreferenceService()
     private val logger = EmbLoggerImpl()

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiNdkCrashProtobufSendTest.kt
@@ -3,16 +3,15 @@ package io.embrace.android.embracesdk.internal.capture.aei
 import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import com.android.server.os.TombstoneProtos
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.TypeUtils
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -134,7 +133,7 @@ internal class AeiNdkCrashProtobufSendTest {
         )
         val logWriter = FakeLogWriter()
         AeiDataSourceImpl(
-            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            fakeBackgroundWorker(),
             FakeAppExitInfoBehavior(enabled = true),
             activityManager,
             FakePreferenceService(),

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/powersave/LowPowerDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/powersave/LowPowerDataSourceTest.kt
@@ -5,12 +5,11 @@ import android.content.Intent
 import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -31,7 +30,7 @@ internal class LowPowerDataSourceTest {
             ApplicationProvider.getApplicationContext(),
             spanService,
             EmbLoggerImpl(),
-            BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+            fakeBackgroundWorker(),
             FakeClock()
         ) { mockk(relaxed = true) }.apply {
             enableDataCapture()

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -4,10 +4,10 @@ import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.arch.assertDoesNotHaveEmbraceAttribute
 import io.embrace.android.embracesdk.arch.assertIsKeySpan
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.schema.KeySpan
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
@@ -49,7 +49,7 @@ internal class AppStartupTraceEmitterTest {
     fun setUp() {
         clock = FakeClock()
         val initModule = FakeInitModule(clock = clock)
-        backgroundWorker = BackgroundWorker(BlockableExecutorService())
+        backgroundWorker = fakeBackgroundWorker()
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
         spanService.initializeService(clock.now())

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImplTest.kt
@@ -3,8 +3,8 @@ package io.embrace.android.embracesdk.internal.capture.startup
 import io.embrace.android.embracesdk.arch.assertIsPrivateSpan
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.arch.assertSuccessful
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -29,7 +29,7 @@ internal class StartupServiceImplTest {
     fun setUp() {
         clock = FakeClock(10000000)
         val initModule = FakeInitModule(clock = clock)
-        backgroundWorker = BackgroundWorker(BlockableExecutorService())
+        backgroundWorker = fakeBackgroundWorker()
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
         spanService.initializeService(clock.now())

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSourceTest.kt
@@ -1,12 +1,11 @@
 package io.embrace.android.embracesdk.internal.capture.thermalstate
 
 import android.os.PowerManager
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -25,7 +24,7 @@ internal class ThermalStateDataSourceTest {
         dataSource = ThermalStateDataSource(
             spanWriter,
             EmbLoggerImpl(),
-            BackgroundWorker(BlockableExecutorService()),
+            fakeBackgroundWorker(),
             FakeClock(100),
         ) { mockPowerManager }
     }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -25,8 +25,8 @@ internal class LastRunCrashVerifierTest {
     fun setUp() {
         mockCrashFileMarker = mockk()
         lastRunCrashVerifier = LastRunCrashVerifier(mockCrashFileMarker, EmbLoggerImpl())
-        fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), name = WorkerName.BACKGROUND_REGISTRATION)
-        worker = fakeWorkerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
+        fakeWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), name = Worker.NonIoRegWorker)
+        worker = fakeWorkerThreadModule.backgroundWorker(Worker.NonIoRegWorker)
     }
 
     @After

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
@@ -5,7 +5,6 @@ import android.content.res.Resources
 import android.os.Build
 import android.os.Handler
 import android.util.Base64
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -19,6 +18,7 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
@@ -29,7 +29,6 @@ import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.NativeCrashMetadata
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -146,7 +145,7 @@ internal class EmbraceNdkServiceTest {
                 logger,
                 repository,
                 delegate,
-                BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+                fakeBackgroundWorker(),
                 deviceArchitecture,
                 EmbraceSerializer(),
                 handler

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/AnrFeatureTest.kt
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.recordSession
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.Assert.assertEquals
@@ -42,7 +42,7 @@ internal class AnrFeatureTest {
         val clock = FakeClock(currentTime = START_TIME_MS)
         val initModule = FakeInitModule(clock)
         val workerThreadModule =
-            FakeWorkerThreadModule(initModule, WorkerName.ANR_MONITOR).apply {
+            FakeWorkerThreadModule(initModule, Worker.AnrWatchdogWorker).apply {
                 anrMonitorThread = AtomicReference(Thread.currentThread())
             }
         anrMonitorExecutor = workerThreadModule.executor

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/EmbraceLoggingFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/EmbraceLoggingFeatureTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.getLastSentLog
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.recordSession
 import io.opentelemetry.api.logs.Severity
 import org.junit.Rule
@@ -26,7 +26,7 @@ internal class EmbraceLoggingFeatureTest {
         IntegrationTestRule.Harness(
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,
-            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = WorkerName.REMOTE_LOGGING)
+            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = Worker.LogMessageWorker)
         )
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
@@ -25,7 +25,7 @@ import io.embrace.android.embracesdk.internal.opentelemetry.embState
 import io.embrace.android.embracesdk.internal.opentelemetry.embTerminated
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.recordSession
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
@@ -49,7 +49,7 @@ internal class BackgroundActivityDisabledTest {
     val testRule: IntegrationTestRule = IntegrationTestRule {
         val clock = FakeClock()
         val initModule = FakeInitModule(clock)
-        val workerThreadModule = FakeWorkerThreadModule(initModule, WorkerName.REMOTE_LOGGING)
+        val workerThreadModule = FakeWorkerThreadModule(initModule, Worker.LogMessageWorker)
 
         IntegrationTestRule.Harness(
             overriddenClock = clock,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/PeriodicSessionCacheTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.findSpanSnapshotsOfType
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.recordSession
-import io.embrace.android.embracesdk.internal.worker.WorkerName.PERIODIC_CACHE
+import io.embrace.android.embracesdk.internal.worker.Worker.PeriodicCacheWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -32,7 +32,7 @@ internal class PeriodicSessionCacheTest {
         IntegrationTestRule.Harness(
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,
-            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = PERIODIC_CACHE)
+            overriddenWorkerThreadModule = FakeWorkerThreadModule(fakeInitModule = fakeInitModule, name = PeriodicCacheWorker)
         )
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.getLastSentLog
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.recordSession
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.semconv.ExceptionAttributes
@@ -42,7 +42,7 @@ internal class FlutterInternalInterfaceTest {
             overriddenInitModule = fakeInitModule,
             overriddenWorkerThreadModule = FakeWorkerThreadModule(
                 fakeInitModule = fakeInitModule,
-                name = WorkerName.REMOTE_LOGGING
+                name = Worker.LogMessageWorker
             )
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -41,7 +41,6 @@ import io.embrace.android.embracesdk.internal.injection.embraceImplInject
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.EventType
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.spans.TracingApi
 
@@ -199,8 +198,8 @@ internal class EmbraceImpl @JvmOverloads constructor(
 
         // Send any sessions that were cached and not yet sent.
         startSynchronous("send-cached-sessions")
-        val worker = bootstrapper.workerThreadModule.backgroundWorker(Worker.FileCacheWorker)
-        worker.submit(TaskPriority.HIGH) {
+        val worker = bootstrapper.workerThreadModule.prioritizedWorker(Worker.FileCacheWorker)
+        worker.submit {
             val essentialServiceModule = bootstrapper.essentialServiceModule
             bootstrapper.deliveryModule.deliveryService.sendCachedSessions(
                 bootstrapper.nativeFeatureModule::nativeCrashService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -42,7 +42,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.worker.TaskPriority
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.spans.TracingApi
 
 /**
@@ -199,7 +199,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
 
         // Send any sessions that were cached and not yet sent.
         startSynchronous("send-cached-sessions")
-        val worker = bootstrapper.workerThreadModule.backgroundWorker(WorkerName.DELIVERY_CACHE)
+        val worker = bootstrapper.workerThreadModule.backgroundWorker(Worker.FileCacheWorker)
         worker.submit(TaskPriority.HIGH) {
             val essentialServiceModule = bootstrapper.essentialServiceModule
             bootstrapper.deliveryModule.deliveryService.sendCachedSessions(
@@ -210,7 +210,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
         endSynchronous()
 
         crashModule.lastRunCrashVerifier.readAndCleanMarkerAsync(
-            bootstrapper.workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION)
+            bootstrapper.workerThreadModule.backgroundWorker(Worker.IoRegWorker)
         )
 
         val internalInterfaceModuleImpl =

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.worker.TaskPriority
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.reflect.KClass
@@ -200,7 +200,7 @@ internal class ModuleInitBootstrapper(
                                     registerFactory(networkBehavior.isRequestContentLengthCaptureEnabled())
                                 }
                             }
-                            workerThreadModule.backgroundWorker(WorkerName.BACKGROUND_REGISTRATION).submit {
+                            workerThreadModule.backgroundWorker(Worker.NonIoRegWorker).submit {
                                 Systrace.traceSynchronous("network-connectivity-registration") {
                                     essentialServiceModule.networkConnectivityService.register()
                                 }
@@ -335,7 +335,7 @@ internal class ModuleInitBootstrapper(
                         )
 
                         if (configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
-                            val worker = workerThreadModule.backgroundWorker(WorkerName.SERVICE_INIT)
+                            val worker = workerThreadModule.backgroundWorker(Worker.IoRegWorker)
                             worker.submit(TaskPriority.HIGH) {
                                 ndkService.initializeService(essentialServiceModule.sessionIdTracker)
                             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
@@ -336,7 +335,7 @@ internal class ModuleInitBootstrapper(
 
                         if (configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
                             val worker = workerThreadModule.backgroundWorker(Worker.IoRegWorker)
-                            worker.submit(TaskPriority.HIGH) {
+                            worker.submit {
                                 ndkService.initializeService(essentialServiceModule.sessionIdTracker)
                             }
                         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
@@ -1,16 +1,14 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.internal.arch.EmbraceFeatureRegistry
 import io.embrace.android.embracesdk.internal.injection.DataSourceModule
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 class FakeDataSourceModule : DataSourceModule {
     override val dataCaptureOrchestrator: DataCaptureOrchestrator =
         DataCaptureOrchestrator(
             FakeConfigService(),
-            BackgroundWorker(BlockableExecutorService()),
+            fakeBackgroundWorker(),
             FakeEmbLogger()
         )
     override val embraceFeatureRegistry: EmbraceFeatureRegistry = dataCaptureOrchestrator

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
@@ -4,8 +4,6 @@ import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
-import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 
 fun fakePrioritizedWorker(): PrioritizedWorker = PrioritizedWorker(BlockableExecutorService())
-fun fakeBackgroundWorker(): BackgroundWorker = BackgroundWorker(BlockableExecutorService())
-fun fakeScheduledWorker(): ScheduledWorker = ScheduledWorker(BlockingScheduledExecutorService(blockingMode = false))
+fun fakeBackgroundWorker(): BackgroundWorker = BackgroundWorker(BlockingScheduledExecutorService(blockingMode = false))

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
@@ -3,7 +3,9 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 
+fun fakePrioritizedWorker(): PrioritizedWorker = PrioritizedWorker(BlockableExecutorService())
 fun fakeBackgroundWorker(): BackgroundWorker = BackgroundWorker(BlockableExecutorService())
 fun fakeScheduledWorker(): ScheduledWorker = ScheduledWorker(BlockingScheduledExecutorService(blockingMode = false))

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.fakes.injection
 
-import com.google.common.util.concurrent.MoreExecutors
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
@@ -8,6 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureDataSource
 import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureService
 import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.injection.LogModule
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogService
@@ -17,7 +17,6 @@ import io.embrace.android.embracesdk.internal.network.logging.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.network.logging.NetworkCaptureService
 import io.embrace.android.embracesdk.internal.network.logging.NetworkLoggingService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 class FakeLogModule(
     override val networkLoggingService: NetworkLoggingService = FakeNetworkLoggingService(),
@@ -26,7 +25,7 @@ class FakeLogModule(
         FakeLogWriter(),
         FakeConfigService(),
         FakeSessionPropertiesService(),
-        BackgroundWorker(MoreExecutors.newDirectExecutorService()),
+        fakeBackgroundWorker(),
         EmbLoggerImpl(),
         EmbraceSerializer()
     )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
@@ -6,12 +6,12 @@ import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.createWorkerThreadModule
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
-import io.embrace.android.embracesdk.internal.worker.WorkerName
+import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.concurrent.atomic.AtomicReference
 
 class FakeWorkerThreadModule(
     fakeInitModule: FakeInitModule = FakeInitModule(),
-    private val name: WorkerName? = null,
+    private val name: Worker? = null,
     private val base: WorkerThreadModule = createWorkerThreadModule(fakeInitModule)
 ) : WorkerThreadModule by base {
 
@@ -21,17 +21,17 @@ class FakeWorkerThreadModule(
     private val backgroundWorker = BackgroundWorker(executor)
     private val scheduledWorker = ScheduledWorker(executor)
 
-    override fun backgroundWorker(workerName: WorkerName): BackgroundWorker {
-        return when (workerName) {
+    override fun backgroundWorker(worker: Worker): BackgroundWorker {
+        return when (worker) {
             name -> backgroundWorker
-            else -> base.backgroundWorker(workerName)
+            else -> base.backgroundWorker(worker)
         }
     }
 
-    override fun scheduledWorker(workerName: WorkerName): ScheduledWorker {
-        return when (workerName) {
+    override fun scheduledWorker(worker: Worker): ScheduledWorker {
+        return when (worker) {
             name -> scheduledWorker
-            else -> base.scheduledWorker(workerName)
+            else -> base.scheduledWorker(worker)
         }
     }
 


### PR DESCRIPTION
## Goal

Renames `WorkerName` in preparation for a future changeset that will separate the background/scheduled workers into a sealed class hierarchy. This will be necessary as we want to supply a comparator to the priority queue in the executor implementation, but that wouldn't make sense for `ScheduledWorker`.

In this changeset I altered the case of the constants & also renamed several to better reflect what they are doing.

Additionally I took tasks submitted to the background registration worker that performed I/O & put them on a separate queue.

## Testing

Relied on existing test coverage.