### PR TITLE
Extract prioritised executor

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestrator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestrator.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -71,7 +70,7 @@ class DataCaptureOrchestrator(
 
     private fun DataSourceState<*>.dispatchStateChange(action: () -> Unit) {
         if (asyncInit) {
-            worker.submit(TaskPriority.HIGH, action)
+            worker.submit(action)
         } else {
             action()
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.EventMessage
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import java.lang.reflect.ParameterizedType
@@ -24,7 +24,7 @@ internal class EmbraceApiService(
     private val serializer: PlatformSerializer,
     private val cachedConfigProvider: (url: String, request: ApiRequest) -> CachedConfig,
     private val logger: EmbLogger,
-    private val backgroundWorker: BackgroundWorker,
+    private val prioritizedWorker: PrioritizedWorker,
     private val pendingApiCallsSender: PendingApiCallsSender,
     lazyDeviceId: Lazy<String>,
     appId: String,
@@ -164,7 +164,7 @@ internal class EmbraceApiService(
             true -> TaskPriority.CRITICAL
             else -> TaskPriority.NORMAL
         }
-        return backgroundWorker.submit(priority) {
+        return prioritizedWorker.submit(priority) {
             var response: ApiResponse = ApiResponse.None
             try {
                 response = handleApiRequest(request, action)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -112,7 +112,7 @@ class EssentialServiceModuleImpl(
                     }
                 },
                 logger = initModule.logger,
-                backgroundWorker = workerThreadModule.backgroundWorker(Worker.NetworkRequestWorker),
+                prioritizedWorker = workerThreadModule.prioritizedWorker(Worker.NetworkRequestWorker),
                 pendingApiCallsSender = pendingApiCallsSender,
                 lazyDeviceId = lazyDeviceId,
                 appId = appId,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
@@ -44,7 +44,7 @@ internal class StorageModuleImpl(
     override val deliveryCacheManager: DeliveryCacheManager by singleton {
         EmbraceDeliveryCacheManager(
             cacheService,
-            workerThreadModule.backgroundWorker(Worker.FileCacheWorker),
+            workerThreadModule.prioritizedWorker(Worker.FileCacheWorker),
             initModule.logger
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import io.embrace.android.embracesdk.internal.worker.Worker
 import java.io.Closeable
@@ -15,6 +16,11 @@ interface WorkerThreadModule : Closeable {
      * Return a [BackgroundWorker] matching the [worker]
      */
     fun backgroundWorker(worker: Worker): BackgroundWorker
+
+    /**
+     * Return a [PrioritizedWorker] matching the [worker]
+     */
+    fun prioritizedWorker(worker: Worker): PrioritizedWorker
 
     /**
      * Return the [ScheduledWorker] given the [worker]

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PrioritizedWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PrioritizedWorker.kt
@@ -11,22 +11,28 @@ import java.util.concurrent.TimeUnit
  * This class is necessary because it hides aspects of the ExecutorService API that we don't want
  * to expose as part of the internal API.
  */
-class BackgroundWorker(
+class PrioritizedWorker(
     private val impl: ExecutorService
 ) {
 
     /**
      * Submits a task for execution and returns a [Future].
      */
-    fun submit(runnable: Runnable): Future<*> {
-        return impl.submit(runnable)
+    fun submit(
+        priority: TaskPriority = TaskPriority.NORMAL,
+        runnable: Runnable
+    ): Future<*> {
+        return impl.submit(PriorityRunnable(priority, runnable))
     }
 
     /**
      * Submits a task for execution and returns a [Future].
      */
-    fun <T> submit(callable: Callable<T>): Future<T> {
-        return impl.submit(callable)
+    fun <T> submit(
+        priority: TaskPriority = TaskPriority.NORMAL,
+        callable: Callable<T>
+    ): Future<T> {
+        return impl.submit(PriorityCallable(priority, callable))
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/ScheduledWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/ScheduledWorker.kt
@@ -59,4 +59,17 @@ class ScheduledWorker(
         intervalMs: Long,
         unit: TimeUnit
     ): ScheduledFuture<*> = impl.scheduleAtFixedRate(runnable, initialDelay, intervalMs, unit)
+
+    /**
+     * Shutdown the worker. If [timeoutMs] is greater than 0, the worker will
+     * block for the specified milliseconds if tasks are still enqueued or running.
+     */
+    fun shutdownAndWait(timeoutMs: Long = 0) {
+        runCatching {
+            with(impl) {
+                shutdown()
+                awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)
+            }
+        }
+    }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import org.junit.After
@@ -455,7 +455,7 @@ internal class EmbraceApiServiceTest {
             serializer = serializer,
             cachedConfigProvider = { _, _ -> cachedConfig },
             logger = EmbLoggerImpl(),
-            backgroundWorker = BackgroundWorker(testScheduledExecutor),
+            prioritizedWorker = PrioritizedWorker(testScheduledExecutor),
             pendingApiCallsSender = fakePendingApiCallsSender,
             lazyDeviceId = lazy { fakeDeviceId },
             appId = fakeAppId,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -11,8 +11,8 @@ import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSpanData.Companion.perfSpanSnapshot
 import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
-import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.fakeIncompleteSessionEnvelope
+import io.embrace.android.embracesdk.fakes.fakePrioritizedWorker
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.getLastHeartbeatTimeMs
@@ -39,7 +39,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapsh
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
@@ -52,7 +52,7 @@ import org.junit.Test
 internal class EmbraceDeliveryServiceTest {
 
     private lateinit var fakeClock: FakeClock
-    private lateinit var worker: BackgroundWorker
+    private lateinit var worker: PrioritizedWorker
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var apiService: FakeApiService
     private lateinit var fakeNativeCrashService: FakeNativeCrashService
@@ -67,7 +67,7 @@ internal class EmbraceDeliveryServiceTest {
     @Before
     fun setUp() {
         fakeClock = FakeClock()
-        worker = fakeBackgroundWorker()
+        worker = fakePrioritizedWorker()
         apiService = FakeApiService()
         fakeNativeCrashService = FakeNativeCrashService()
         gatingService = FakeGatingService()
@@ -82,7 +82,7 @@ internal class EmbraceDeliveryServiceTest {
         )
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService = cacheService,
-            backgroundWorker = worker,
+            prioritizedWorker = worker,
             logger = logger,
         )
         deliveryService = EmbraceDeliveryService(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
@@ -42,7 +42,7 @@ internal class WorkerThreadModuleImplTest {
     @Test
     fun `network request executor uses custom queue`() {
         val module = WorkerThreadModuleImpl(initModule)
-        assertNotNull(module.backgroundWorker(Worker.NetworkRequestWorker))
+        assertNotNull(module.prioritizedWorker(Worker.NetworkRequestWorker))
     }
 
     @Test(expected = IllegalStateException::class)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheCurrentAccessTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheCurrentAccessTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.mockk.clearAllMocks
 import io.mockk.spyk
 import io.mockk.verify
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 internal class EmbraceDeliveryCacheCurrentAccessTest {
 
     private val serializer = EmbraceSerializer()
-    private lateinit var worker: BackgroundWorker
+    private lateinit var worker: PrioritizedWorker
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService
@@ -34,7 +34,7 @@ internal class EmbraceDeliveryCacheCurrentAccessTest {
         fakeClock = FakeClock(clockInit)
         logger = EmbLoggerImpl()
         storageService = FakeStorageService()
-        worker = BackgroundWorker(SingleThreadTestScheduledExecutor())
+        worker = PrioritizedWorker(SingleThreadTestScheduledExecutor())
         cacheService = spyk(
             EmbraceCacheService(
                 storageService = storageService,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheManagerTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeStorageService
-import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
+import io.embrace.android.embracesdk.fakes.fakePrioritizedWorker
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.fixtures.testSessionEnvelope
 import io.embrace.android.embracesdk.fixtures.testSessionEnvelopeOneMinuteLater
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.JVM_CRASH
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.NORMAL_END
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.PERIODIC_CACHE
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -46,7 +46,7 @@ internal class EmbraceDeliveryCacheManagerTest {
 
     private val prefix = "last_session"
     private val serializer = EmbraceSerializer()
-    private val worker = fakeBackgroundWorker()
+    private val worker = fakePrioritizedWorker()
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService
@@ -339,7 +339,7 @@ internal class EmbraceDeliveryCacheManagerTest {
     fun `save payload sync`() {
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService,
-            BackgroundWorker(BlockableExecutorService(blockingMode = true)),
+            PrioritizedWorker(BlockableExecutorService(blockingMode = true)),
             logger
         )
         val expected = "test".toByteArray()
@@ -362,7 +362,7 @@ internal class EmbraceDeliveryCacheManagerTest {
         val executorService = BlockableExecutorService(blockingMode = true)
         deliveryCacheManager = EmbraceDeliveryCacheManager(
             cacheService,
-            BackgroundWorker(executorService),
+            PrioritizedWorker(executorService),
             logger
         )
         val expected = "test".toByteArray()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -21,7 +21,7 @@ internal class BackgroundWorkerTest {
         val runnable = Runnable {
             ran = true
         }
-        BackgroundWorker(impl).submit(TaskPriority.NORMAL, runnable)
+        BackgroundWorker(impl).submit(runnable)
         impl.runNext()
         assertTrue(ran)
     }
@@ -33,7 +33,7 @@ internal class BackgroundWorkerTest {
         val callable = Callable {
             ran = true
         }
-        BackgroundWorker(impl).submit(TaskPriority.NORMAL, callable)
+        BackgroundWorker(impl).submit(callable)
         impl.runNext()
         assertTrue(ran)
     }
@@ -42,7 +42,7 @@ internal class BackgroundWorkerTest {
     fun `test runnable transformed`() {
         val impl = DecoratedExecutorService()
         val runnable = Runnable {}
-        val future = BackgroundWorker(impl).submit(TaskPriority.LOW, runnable)
+        val future = PrioritizedWorker(impl).submit(TaskPriority.LOW, runnable)
         val submitted = impl.runnables.single() as PriorityRunnable
         assertEquals(TaskPriority.LOW, submitted.priority)
         assertNull(future.get())
@@ -52,7 +52,7 @@ internal class BackgroundWorkerTest {
     fun `test callable transformed`() {
         val impl = DecoratedExecutorService()
         val callable = Callable { "test" }
-        val future = BackgroundWorker(impl).submit(TaskPriority.HIGH, callable)
+        val future = PrioritizedWorker(impl).submit(TaskPriority.HIGH, callable)
         val submitted = impl.callables.single() as PriorityCallable<*>
         assertEquals(TaskPriority.HIGH, submitted.priority)
         assertEquals("test", future.get())
@@ -68,7 +68,7 @@ internal class BackgroundWorkerTest {
         )
 
         var ran = false
-        worker.submit(TaskPriority.NORMAL) {
+        worker.submit {
             latch.await(1000, TimeUnit.MILLISECONDS)
             ran = true
         }
@@ -86,7 +86,7 @@ internal class BackgroundWorkerTest {
         )
 
         var ran = false
-        worker.submit(TaskPriority.NORMAL,) {
+        worker.submit {
             latch.await(1000, TimeUnit.MILLISECONDS)
             ran = true
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutorTest.kt
@@ -39,13 +39,13 @@ internal class PriorityThreadPoolExecutorTest {
 
     @Test
     fun `submit valid runnable`() {
-        val future = BackgroundWorker(executor).submit {}
+        val future = PrioritizedWorker(executor).submit {}
         assertEquals(TaskPriority.NORMAL, (future as PriorityRunnableFuture<*>).priority)
     }
 
     @Test
     fun `submit valid callable`() {
-        val future = BackgroundWorker(executor).submit(TaskPriority.HIGH, Callable {})
+        val future = PrioritizedWorker(executor).submit(TaskPriority.HIGH, Callable {})
         assertEquals(TaskPriority.HIGH, (future as PriorityRunnableFuture<*>).priority)
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSource.kt
@@ -14,7 +14,6 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import java.util.concurrent.Executor
 
@@ -41,7 +40,7 @@ class ThermalStateDataSource(
     private var span: EmbraceSpan? = null
 
     override fun enableDataCapture() {
-        backgroundWorker.submit(TaskPriority.LOW) {
+        backgroundWorker.submit {
             Systrace.traceSynchronous("thermal-service-registration") {
                 thermalStatusListener = PowerManager.OnThermalStatusChangedListener {
                     handleThermalStateChange(it)
@@ -63,7 +62,7 @@ class ThermalStateDataSource(
     }
 
     override fun disableDataCapture() {
-        backgroundWorker.submit(TaskPriority.LOW) {
+        backgroundWorker.submit {
             thermalStatusListener?.let {
                 powerManager?.removeThermalStatusListener(it)
                 thermalStatusListener = null

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -41,7 +41,6 @@ import io.embrace.android.embracesdk.internal.injection.embraceImplInject
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.EventType
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.spans.TracingApi
 
@@ -199,8 +198,8 @@ internal class EmbraceImpl @JvmOverloads constructor(
 
         // Send any sessions that were cached and not yet sent.
         startSynchronous("send-cached-sessions")
-        val worker = bootstrapper.workerThreadModule.backgroundWorker(Worker.FileCacheWorker)
-        worker.submit(TaskPriority.HIGH) {
+        val worker = bootstrapper.workerThreadModule.prioritizedWorker(Worker.FileCacheWorker)
+        worker.submit {
             val essentialServiceModule = bootstrapper.essentialServiceModule
             bootstrapper.deliveryModule.deliveryService.sendCachedSessions(
                 bootstrapper.nativeFeatureModule::nativeCrashService,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
@@ -336,7 +335,7 @@ internal class ModuleInitBootstrapper(
 
                         if (configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
                             val worker = workerThreadModule.backgroundWorker(Worker.IoRegWorker)
-                            worker.submit(TaskPriority.HIGH) {
+                            worker.submit {
                                 ndkService.initializeService(essentialServiceModule.sessionIdTracker)
                             }
                         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSourceModule.kt
@@ -1,16 +1,14 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.internal.arch.EmbraceFeatureRegistry
 import io.embrace.android.embracesdk.internal.injection.DataSourceModule
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 class FakeDataSourceModule : DataSourceModule {
     override val dataCaptureOrchestrator: DataCaptureOrchestrator =
         DataCaptureOrchestrator(
             FakeConfigService(),
-            BackgroundWorker(BlockableExecutorService()),
+            fakeBackgroundWorker(),
             FakeEmbLogger()
         )
     override val embraceFeatureRegistry: EmbraceFeatureRegistry = dataCaptureOrchestrator

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
@@ -3,7 +3,9 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 
+fun fakePrioritizedWorker(): PrioritizedWorker = PrioritizedWorker(BlockableExecutorService())
 fun fakeBackgroundWorker(): BackgroundWorker = BackgroundWorker(BlockableExecutorService())
 fun fakeScheduledWorker(): ScheduledWorker = ScheduledWorker(BlockingScheduledExecutorService(blockingMode = false))


### PR DESCRIPTION
## Goal

Extracts a `PrioritizedWorker` class that is capable of setting a priority, and removes the possibility to set `TaskPriority` on `BackgroundWorker` as the field was ignored for every worker apart from the network request queue.

This is an intermediate stage in the refactor - I plan on combining `BackgroundWorker` and `ScheduledWorker` next as they now effectively fulfil the same function. 

## Testing

Relied on existing unit tests.