### PR TITLE
Replace worker implementation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -37,7 +37,7 @@ internal class WorkerThreadModuleImpl(
 
     override fun backgroundWorker(worker: Worker): BackgroundWorker {
         return backgroundWorker.getOrPut(worker) {
-            BackgroundWorker(fetchExecutor(worker))
+            BackgroundWorker(fetchExecutor(worker) as ScheduledExecutorService)
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorker.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.worker
 
 import java.util.concurrent.Callable
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 /**
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
  * to expose as part of the internal API.
  */
 class BackgroundWorker(
-    private val impl: ExecutorService
+    private val impl: ScheduledExecutorService
 ) {
 
     /**

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/DataCaptureOrchestratorTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
@@ -19,7 +19,7 @@ internal class DataCaptureOrchestratorTest {
     private lateinit var orchestrator: DataCaptureOrchestrator
     private lateinit var dataSource: FakeDataSource
     private lateinit var configService: FakeConfigService
-    private lateinit var executorService: BlockableExecutorService
+    private lateinit var executorService: BlockingScheduledExecutorService
     private var enabled: Boolean = true
 
     private val syncDataSource = DataSourceState(
@@ -37,7 +37,7 @@ internal class DataCaptureOrchestratorTest {
     fun setUp() {
         dataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         configService = FakeConfigService()
-        executorService = BlockableExecutorService()
+        executorService = BlockingScheduledExecutorService(blockingMode = false)
         orchestrator = DataCaptureOrchestrator(
             configService,
             BackgroundWorker(executorService),
@@ -72,13 +72,13 @@ internal class DataCaptureOrchestratorTest {
 
         orchestrator.currentSessionType = SessionType.FOREGROUND
         assertEquals(0, dataSource.enableDataCaptureCount)
-        executorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertEquals(1, dataSource.enableDataCaptureCount)
 
         enabled = false
         configService.updateListeners()
         assertEquals(0, dataSource.disableDataCaptureCount)
-        executorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertEquals(1, dataSource.disableDataCaptureCount)
     }
 
@@ -90,7 +90,7 @@ internal class DataCaptureOrchestratorTest {
         assertEquals(0, dataSource.enableDataCaptureCount)
         orchestrator.currentSessionType = SessionType.FOREGROUND
         assertEquals(0, dataSource.enableDataCaptureCount)
-        executorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertEquals(1, dataSource.enableDataCaptureCount)
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
@@ -10,12 +10,12 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -24,7 +24,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 
 private const val MAX_SESSION_PROPERTIES_FROM_CONFIG = 5
 private const val MAX_SESSION_PROPERTIES_DEFAULT = 10
@@ -47,7 +46,7 @@ internal class EmbraceSessionPropertiesTest {
 
     @Before
     fun setUp() {
-        val worker = BackgroundWorker(Executors.newSingleThreadExecutor())
+        val worker = fakeBackgroundWorker()
         context = ApplicationProvider.getApplicationContext()
         logger = EmbLoggerImpl()
         val prefs = lazy { PreferenceManager.getDefaultSharedPreferences(context) }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.config
 
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
@@ -34,7 +35,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import org.robolectric.android.util.concurrent.PausedExecutorService
 
 internal class EmbraceConfigServiceTest {
 
@@ -271,13 +271,13 @@ internal class EmbraceConfigServiceTest {
         // Use ExecutorService that requires tasks to be explicitly run. This allows us to simulate the case
         // when the loading from the cache doesn't run before the config is read.
 
-        val pausableExecutorService = PausedExecutorService()
+        val executorService = BlockingScheduledExecutorService(blockingMode = true)
 
         every { mockApiService.getCachedConfig() } returns CachedConfig(null, null)
 
         // Create a new instance of the ConfigService where the value of the config is what it is when the config
         // variable is initialized, before the cached version is loaded.
-        val configService = createService(BackgroundWorker(pausableExecutorService))
+        val configService = createService(BackgroundWorker(executorService))
         assertFalse(configService.hasValidRemoteConfig())
 
         // call arbitrary function to trigger config refresh
@@ -285,11 +285,7 @@ internal class EmbraceConfigServiceTest {
 
         // Only run the task from the executor that loads the cached config to the ConfigService so the call to fetch
         // a new config from the server isn't run
-        pausableExecutorService.runNext()
-        assertFalse(configService.hasValidRemoteConfig())
-
-        // fetch config from the server
-        pausableExecutorService.runNext()
+        executorService.runCurrentlyBlocked()
         assertTrue(configService.hasValidRemoteConfig())
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
@@ -7,11 +7,10 @@ import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSharedPreferences
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -28,7 +27,7 @@ internal class EmbracePreferencesServiceTest {
     private lateinit var service: EmbracePreferencesService
     private lateinit var fakeClock: FakeClock
 
-    private val executorService = BackgroundWorker(BlockableExecutorService())
+    private val executorService = fakeBackgroundWorker()
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Before

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -18,6 +17,7 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeV2PayloadCollator
 import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
@@ -29,7 +29,6 @@ import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicBackgroundActivityCacher
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -369,7 +368,7 @@ internal class SessionOrchestratorTest {
         fakeDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         dataCaptureOrchestrator = DataCaptureOrchestrator(
             configService,
-            BackgroundWorker(BlockableExecutorService()),
+            fakeBackgroundWorker(),
             logger
         ).apply {
             add(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.worker
 
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -8,33 +8,33 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 internal class BackgroundWorkerTest {
 
     @Test
     fun testSubmitRunnable() {
-        val impl = BlockableExecutorService()
+        val impl = BlockingScheduledExecutorService(blockingMode = false)
         var ran = false
         val runnable = Runnable {
             ran = true
         }
         BackgroundWorker(impl).submit(runnable)
-        impl.runNext()
+        impl.runCurrentlyBlocked()
         assertTrue(ran)
     }
 
     @Test
     fun testSubmitCallable() {
-        val impl = BlockableExecutorService()
+        val impl = BlockingScheduledExecutorService(blockingMode = false)
         var ran = false
         val callable = Callable {
             ran = true
         }
         BackgroundWorker(impl).submit(callable)
-        impl.runNext()
+        impl.runCurrentlyBlocked()
         assertTrue(ran)
     }
 
@@ -97,8 +97,8 @@ internal class BackgroundWorkerTest {
     private class ShutdownAndWaitExecutorService(
         private val postShutdownAction: () -> Unit = {},
         private val postAwaitTerminationAction: () -> Unit = {},
-        private val impl: ExecutorService = Executors.newSingleThreadExecutor()
-    ) : ExecutorService by impl {
+        private val impl: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+    ) : ScheduledExecutorService by impl {
 
         override fun shutdown() {
             impl.shutdown()

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -4,10 +4,10 @@ import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.arch.assertDoesNotHaveEmbraceAttribute
 import io.embrace.android.embracesdk.arch.assertIsKeySpan
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.schema.KeySpan
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
@@ -49,7 +49,7 @@ internal class AppStartupTraceEmitterTest {
     fun setUp() {
         clock = FakeClock()
         val initModule = FakeInitModule(clock = clock)
-        backgroundWorker = BackgroundWorker(BlockableExecutorService())
+        backgroundWorker = fakeBackgroundWorker()
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
         spanService.initializeService(clock.now())

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImplTest.kt
@@ -3,8 +3,8 @@ package io.embrace.android.embracesdk.internal.capture.startup
 import io.embrace.android.embracesdk.arch.assertIsPrivateSpan
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.arch.assertSuccessful
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -29,7 +29,7 @@ internal class StartupServiceImplTest {
     fun setUp() {
         clock = FakeClock(10000000)
         val initModule = FakeInitModule(clock = clock)
-        backgroundWorker = BackgroundWorker(BlockableExecutorService())
+        backgroundWorker = fakeBackgroundWorker()
         spanSink = initModule.openTelemetryModule.spanSink
         spanService = initModule.openTelemetryModule.spanService
         spanService.initializeService(clock.now())

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSourceTest.kt
@@ -1,12 +1,11 @@
 package io.embrace.android.embracesdk.internal.capture.thermalstate
 
 import android.os.PowerManager
-import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -25,7 +24,7 @@ internal class ThermalStateDataSourceTest {
         dataSource = ThermalStateDataSource(
             spanWriter,
             EmbLoggerImpl(),
-            BackgroundWorker(BlockableExecutorService()),
+            fakeBackgroundWorker(),
             FakeClock(100),
         ) { mockPowerManager }
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
@@ -4,8 +4,6 @@ import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.PrioritizedWorker
-import io.embrace.android.embracesdk.internal.worker.ScheduledWorker
 
 fun fakePrioritizedWorker(): PrioritizedWorker = PrioritizedWorker(BlockableExecutorService())
-fun fakeBackgroundWorker(): BackgroundWorker = BackgroundWorker(BlockableExecutorService())
-fun fakeScheduledWorker(): ScheduledWorker = ScheduledWorker(BlockingScheduledExecutorService(blockingMode = false))
+fun fakeBackgroundWorker(): BackgroundWorker = BackgroundWorker(BlockingScheduledExecutorService(blockingMode = false))


### PR DESCRIPTION
## Goal

Alters `BackgroundWorker` to use `ScheduledExecutorService` and updates tests also. This should not functionally impact anything as it was always used under the hood anyway. This will allow combining BackgroundWorker/ScheduledWorker in future PRs.

