### PR TITLE
Fix integration test infra for validating saved background activities

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk
 
 import android.app.Activity
+import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.EventMessage
 import io.embrace.android.embracesdk.internal.payload.Log
@@ -19,44 +20,43 @@ import java.util.concurrent.TimeoutException
 /*** Extension functions that are syntactic sugar for retrieving information from the SDK. ***/
 
 /**
- * Wait for there to at least be [minSize] number of log envelopes to be sent and return all the ones sent. Times out at 1 second.
+ * Returns the list of log payload envelops that have been sent. If [minSize] is specified, it will wait a maximum of 1 second for
+ * the number of payloads that exist to equal to or exceed that before returning, timing out if it doesn't.
  */
 internal fun IntegrationTestRule.Harness.getSentLogPayloads(minSize: Int? = null): List<Envelope<LogPayload>> {
-    val logs = overriddenDeliveryModule.deliveryService.lastSentLogPayloads
-    return when (minSize) {
-        null -> logs
-        else -> returnIfConditionMet({ logs }) {
-            logs.size >= minSize
+    with(overriddenDeliveryModule.deliveryService) {
+        return when (minSize) {
+            null -> lastSentLogPayloads
+            else ->
+                returnIfConditionMet(
+                    desiredValueSupplier = { lastSentLogPayloads },
+                    dataProvider = { lastSentLogPayloads },
+                    condition = { data ->
+                        data.size >= minSize
+                    }
+                )
         }
     }
 }
 
 /**
- *  Returns a list of [Log]s that were sent by the SDK since the last logs flush.
- */
-internal fun IntegrationTestRule.Harness.getSentLogs(expectedSize: Int? = null): List<Log>? {
-    val logPayloads = overriddenDeliveryModule.deliveryService.lastSentLogPayloads
-    val logs = logPayloads.last().data.logs
-    return when (expectedSize) {
-        null -> logs
-        else -> returnIfConditionMet({ logs }) {
-            logs?.size == expectedSize
-        }
-    }
-}
-
-/**
- * Returns a list of [EventMessage] moments that were sent by the SDK since startup. If [expectedSize] is specified, it will wait up to
- * 1 second to validate the number of sent moments equal that size. If a second passes that the size requirement is not met, a
- * [TimeoutException] will be thrown. If [expectedSize] is null or not specified, the correct sent moments will be returned right
- * away.
+ * Returns the list of Moments that have been sent. If [expectedSize] is specified, it will wait a maximum of 1 second for
+ * the number of payloads that exist to equal that before returning, timing out if it doesn't.
  */
 internal fun IntegrationTestRule.Harness.getSentMoments(expectedSize: Int? = null): List<EventMessage> {
-    val logs = overriddenDeliveryModule.deliveryService.sentMoments
-    return when (expectedSize) {
-        null -> logs
-        else -> returnIfConditionMet({ logs }) {
-            logs.size == expectedSize
+    with(overriddenDeliveryModule.deliveryService) {
+        return when (expectedSize) {
+            null -> sentMoments
+            else ->
+                with(overriddenDeliveryModule.deliveryService) {
+                    returnIfConditionMet(
+                        desiredValueSupplier = { sentMoments },
+                        dataProvider = { sentMoments },
+                        condition = { data ->
+                            data.size == expectedSize
+                        }
+                    )
+                }
         }
     }
 }
@@ -64,14 +64,14 @@ internal fun IntegrationTestRule.Harness.getSentMoments(expectedSize: Int? = nul
 /**
  * Returns the last [Log] that was sent to the delivery service.
  */
-internal fun IntegrationTestRule.Harness.getLastSentLog(expectedSize: Int? = null): Log? {
-    return getSentLogs(expectedSize)?.last()
+internal fun IntegrationTestRule.Harness.getLastSentLog(): Log {
+    return checkNotNull(getSentLogPayloads(1).last().data.logs).last()
 }
 
 /**
  * Returns the last [Log] that was saved by the delivery service.
  */
-internal fun IntegrationTestRule.Harness.getLastSavedLogPayload(): Envelope<LogPayload>? {
+internal fun IntegrationTestRule.Harness.getLastSavedLogPayload(): Envelope<LogPayload> {
     return overriddenDeliveryModule.deliveryService.lastSavedLogPayloads.last()
 }
 
@@ -98,11 +98,42 @@ internal fun IntegrationTestRule.Harness.getLastSavedSession(): Envelope<Session
 }
 
 /**
- * Returns the last background activity that was saved by the SDK.
+ * Run some [action] and the validate the next saved background activity using [validationFn]. If no background activity is saved with
+ * 1 second, this fails.
  */
-internal fun IntegrationTestRule.Harness.getLastSavedBackgroundActivity(): Envelope<SessionPayload>? {
-    return overriddenDeliveryModule.deliveryService.getLastSavedBackgroundActivity()
+internal fun IntegrationTestRule.Harness.checkNextSavedBackgroundActivity(
+    action: () -> Unit,
+    validationFn: (Envelope<SessionPayload>) -> Unit
+): Envelope<SessionPayload> {
+    with(overriddenDeliveryModule.deliveryService) {
+        val startingSize = getSavedBackgroundActivities().size
+        overriddenClock.tick(10_000L)
+        action()
+        return when (getSavedBackgroundActivities().size) {
+            startingSize -> {
+                returnIfConditionMet(
+                    desiredValueSupplier = {
+                        getNthBackgroundActivity(startingSize)
+                    },
+                    condition = { data ->
+                        data.size > startingSize
+                    },
+                    dataProvider = ::getSavedBackgroundActivities
+                )
+            }
+            else -> {
+                getNthBackgroundActivity(startingSize)
+            }
+        }.apply {
+            validationFn(this)
+        }
+    }
 }
+
+private fun FakeDeliveryService.getNthBackgroundActivity(n: Int) =
+    getSavedBackgroundActivities().filterIndexed { index, _ ->
+        index == n
+    }.single()
 
 /**
  * Returns the last session that was sent by the SDK.
@@ -184,12 +215,17 @@ internal fun internalErrorService(): InternalErrorService? = Embrace.getImpl().i
 /**
  * Return the result of [desiredValueSupplier] if [condition] is true before [waitTimeMs] elapses. Otherwise, throws [TimeoutException]
  */
-internal fun <T> returnIfConditionMet(desiredValueSupplier: Provider<T>, waitTimeMs: Int = 1000, condition: () -> Boolean): T {
+internal fun <T, R> returnIfConditionMet(
+    desiredValueSupplier: Provider<T>,
+    waitTimeMs: Int = 1000,
+    dataProvider: () -> R,
+    condition: (R) -> Boolean
+): T {
     val tries: Int = waitTimeMs / CHECK_INTERVAL_MS
     val countDownLatch = CountDownLatch(1)
 
     repeat(tries) {
-        if (!condition()) {
+        if (!condition(dataProvider())) {
             countDownLatch.await(CHECK_INTERVAL_MS.toLong(), TimeUnit.MILLISECONDS)
         } else {
             return desiredValueSupplier.invoke()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRuleExtensions.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeoutException
 /*** Extension functions that are syntactic sugar for retrieving information from the SDK. ***/
 
 /**
- * Returns the list of log payload envelops that have been sent. If [minSize] is specified, it will wait a maximum of 1 second for
+ * Returns the list of log payload envelopes that have been sent. If [minSize] is specified, it will wait a maximum of 1 second for
  * the number of payloads that exist to equal to or exceed that before returning, timing out if it doesn't.
  */
 internal fun IntegrationTestRule.Harness.getSentLogPayloads(minSize: Int? = null): List<Envelope<LogPayload>> {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/JvmCrashFeatureTest.kt
@@ -50,7 +50,7 @@ internal class JvmCrashFeatureTest {
         with(testRule) {
             harness.recordSession {
                 handleException()
-                checkNotNull(harness.getLastSavedLogPayload()?.data?.logs).single().assertCrash(
+                checkNotNull(harness.getLastSavedLogPayload().data.logs).single().assertCrash(
                     state = "foreground",
                     crashId = checkNotNull(harness.getLastSentSession()?.getCrashedId())
                 )
@@ -62,7 +62,7 @@ internal class JvmCrashFeatureTest {
     fun `app crash in the background generates a crash log`() {
         with(testRule) {
             handleException()
-            checkNotNull(harness.getLastSavedLogPayload()?.data?.logs).single().assertCrash(
+            checkNotNull(harness.getLastSavedLogPayload().data.logs).single().assertCrash(
                 crashId = checkNotNull(harness.getLastSentBackgroundActivity()?.getCrashedId())
             )
         }
@@ -86,7 +86,7 @@ internal class JvmCrashFeatureTest {
             }
         }
 
-        val log = checkNotNull(testRule.harness.getLastSavedLogPayload()?.data?.logs).single()
+        val log = checkNotNull(testRule.harness.getLastSavedLogPayload().data.logs).single()
         assertOtelLogReceived(
             logReceived = log,
             expectedMessage = "",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityDisabledTest.kt
@@ -7,9 +7,9 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.findEventsOfType
 import io.embrace.android.embracesdk.findSessionSpan
+import io.embrace.android.embracesdk.getLastSentLog
 import io.embrace.android.embracesdk.getSentBackgroundActivities
 import io.embrace.android.embracesdk.getSentLogPayloads
-import io.embrace.android.embracesdk.getSentLogs
 import io.embrace.android.embracesdk.getSentSessions
 import io.embrace.android.embracesdk.getSessionId
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -84,7 +84,7 @@ internal class BackgroundActivityDisabledTest {
 
             embrace.addBreadcrumb("not-logged")
             harness.overriddenClock.tick(10_000L)
-            with(checkNotNull(harness.getSentLogPayloads(1).single().data.logs?.single())) {
+            with(checkNotNull(harness.getSentLogPayloads(1).single().data.logs).single()) {
                 assertEquals("error", body)
                 assertEquals("background", attributes?.findAttributeValue(embState.attributeKey.key))
                 assertNull(attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
@@ -124,8 +124,7 @@ internal class BackgroundActivityDisabledTest {
             checkNotNull(session)
 
             flushLogBatch()
-
-            with(checkNotNull(harness.getSentLogs(1)?.single())) {
+            checkNotNull(harness.getLastSentLog()).run {
                 assertEquals("sent-after-session", body)
                 assertEquals("foreground", attributes?.findAttributeValue(embState.attributeKey.key))
                 assertEquals(session.getSessionId(), attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryService.kt
@@ -34,10 +34,10 @@ open class FakeDeliveryService : DeliveryService {
         ConcurrentLinkedQueue()
 
     override fun sendSession(envelope: Envelope<SessionPayload>, snapshotType: SessionSnapshotType) {
+        savedSessionEnvelopes.add(envelope to snapshotType)
         if (snapshotType != SessionSnapshotType.PERIODIC_CACHE) {
             sentSessionEnvelopes.add(envelope to snapshotType)
         }
-        savedSessionEnvelopes.add(envelope to snapshotType)
     }
 
     override fun sendCachedSessions(
@@ -69,6 +69,10 @@ open class FakeDeliveryService : DeliveryService {
         return sentSessionEnvelopes.filter { it.first.findAppState() == ApplicationState.BACKGROUND }.map { it.first }
     }
 
+    fun getSavedBackgroundActivities(): List<Envelope<SessionPayload>> {
+        return savedSessionEnvelopes.filter { it.first.findAppState() == ApplicationState.BACKGROUND }.map { it.first }
+    }
+
     private fun Envelope<SessionPayload>.findAppState(): ApplicationState {
         val value = findSessionSpan().attributes?.findAttributeValue(embState.name)?.uppercase(Locale.ENGLISH)
         return ApplicationState.valueOf(checkNotNull(value))
@@ -78,19 +82,9 @@ open class FakeDeliveryService : DeliveryService {
         return getSentSessions().lastOrNull()
     }
 
-    fun getLastSentBackgroundActivity(): Envelope<SessionPayload>? {
-        return getSentBackgroundActivities().lastOrNull()
-    }
-
     fun getLastSavedSession(): Envelope<SessionPayload>? {
         return savedSessionEnvelopes.map { it.first }.lastOrNull {
             it.findAppState() == ApplicationState.FOREGROUND
-        }
-    }
-
-    fun getLastSavedBackgroundActivity(): Envelope<SessionPayload>? {
-        return savedSessionEnvelopes.map { it.first }.lastOrNull {
-            it.findAppState() == ApplicationState.BACKGROUND
         }
     }
 }


### PR DESCRIPTION
## Goal

Background activities are saved in a background thread, triggered explicitly by certain public API method calls. In order to control the order of execution and taking care of both the case when the background thread save runs before or after the validation code hits on the main test thread, I added `checkNextSavedBackgroundActivity` which takes in a lambda that will trigger an action that in turn triggers a save, as well as one that runs some validation code on the NEXT background activity that is saved. 

Along the way, I tweaked the implementation of `returnIfConditionMet` to separate the data being used to check the condition that is being continuously checked. TBH, I'm not sure if that's really needed - the initial failures were due to the background save not being triggered because there wasn't enough time that have lapsed before the previous save. But this is working and I don't want to change it back again, so lets go with this to see if the races are addresed.

