### PR TITLE
Allow priority based execution using custom comparators

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
@@ -14,7 +14,6 @@ import io.embrace.android.embracesdk.internal.payload.EventMessage
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import java.lang.reflect.ParameterizedType
 import java.util.concurrent.Future
@@ -24,7 +23,7 @@ internal class EmbraceApiService(
     private val serializer: PlatformSerializer,
     private val cachedConfigProvider: (url: String, request: ApiRequest) -> CachedConfig,
     private val logger: EmbLogger,
-    private val priorityWorker: PriorityWorker,
+    private val priorityWorker: PriorityWorker<ApiRequest>,
     private val pendingApiCallsSender: PendingApiCallsSender,
     lazyDeviceId: Lazy<String>,
     appId: String,
@@ -160,11 +159,7 @@ internal class EmbraceApiService(
         request: ApiRequest,
         onComplete: ((response: ApiResponse) -> Unit),
     ): Future<*> {
-        val priority = when (request.isSessionRequest()) {
-            true -> TaskPriority.CRITICAL
-            else -> TaskPriority.NORMAL
-        }
-        return priorityWorker.submit(priority) {
+        return priorityWorker.submit(request) {
             var response: ApiResponse = ApiResponse.None
             try {
                 response = handleApiRequest(request, action)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModule.kt
@@ -19,7 +19,7 @@ interface WorkerThreadModule : Closeable {
     /**
      * Return a [PriorityWorker] matching the [worker]
      */
-    fun priorityWorker(worker: Worker.Priority): PriorityWorker
+    fun <T> priorityWorker(worker: Worker.Priority): PriorityWorker<T>
 
     /**
      * Returns the thread that monitors the main thread for ANRs

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -4,6 +4,10 @@ import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.PriorityThreadPoolExecutor
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import io.embrace.android.embracesdk.internal.worker.Worker
+import io.embrace.android.embracesdk.internal.worker.Worker.Priority.FileCacheWorker
+import io.embrace.android.embracesdk.internal.worker.Worker.Priority.NetworkRequestWorker
+import io.embrace.android.embracesdk.internal.worker.comparator.apiRequestComparator
+import io.embrace.android.embracesdk.internal.worker.comparator.taskPriorityComparator
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -20,17 +24,17 @@ internal class WorkerThreadModuleImpl(
     initModule: InitModule,
 ) : WorkerThreadModule, RejectedExecutionHandler {
 
-    private val clock = initModule.clock
     private val logger = initModule.logger
     private val executors: MutableMap<Worker, ExecutorService> = ConcurrentHashMap()
-    private val priorityWorkers: MutableMap<Worker, PriorityWorker> = ConcurrentHashMap()
+    private val priorityWorkers: MutableMap<Worker, PriorityWorker<*>> = ConcurrentHashMap()
     private val backgroundWorkers: MutableMap<Worker, BackgroundWorker> = ConcurrentHashMap()
     override val anrMonitorThread: AtomicReference<Thread> = AtomicReference<Thread>()
 
-    override fun priorityWorker(worker: Worker.Priority): PriorityWorker {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> priorityWorker(worker: Worker.Priority): PriorityWorker<T> {
         return priorityWorkers.getOrPut(worker) {
-            PriorityWorker(fetchExecutor(worker))
-        }
+            PriorityWorker<T>(fetchExecutor(worker))
+        } as PriorityWorker<T>
     }
 
     override fun backgroundWorker(worker: Worker.Background): BackgroundWorker {
@@ -48,12 +52,16 @@ internal class WorkerThreadModuleImpl(
             val threadFactory = createThreadFactory(worker)
 
             if (worker is Worker.Priority) {
+                val comparator = when (worker) {
+                    FileCacheWorker -> taskPriorityComparator
+                    NetworkRequestWorker -> apiRequestComparator
+                }
                 PriorityThreadPoolExecutor(
-                    clock,
                     threadFactory,
                     this,
                     1,
-                    1
+                    1,
+                    comparator
                 )
             } else {
                 ScheduledThreadPoolExecutor(1, threadFactory, this)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityCallable.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityCallable.kt
@@ -7,6 +7,6 @@ import java.util.concurrent.Callable
  * task is.
  */
 internal class PriorityCallable<T>(
-    val priority: TaskPriority,
+    val priorityInfo: Any,
     impl: Callable<T>
 ) : Callable<T> by impl

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityRunnable.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityRunnable.kt
@@ -5,6 +5,6 @@ package io.embrace.android.embracesdk.internal.worker
  * task is.
  */
 internal class PriorityRunnable(
-    val priority: TaskPriority,
+    val priorityInfo: Any,
     impl: Runnable
 ) : Runnable by impl

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityRunnableFuture.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityRunnableFuture.kt
@@ -6,8 +6,7 @@ import java.util.concurrent.RunnableFuture
  * An implementation of [RunnableFuture] that also contains priority information on how important
  * the task is.
  */
-internal class PriorityRunnableFuture<T> (
+internal class PriorityRunnableFuture<T>(
     val impl: RunnableFuture<T>,
-    val priority: TaskPriority,
-    val submitTime: Long
+    val priorityInfo: Any
 ) : RunnableFuture<T> by impl

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutor.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutor.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.worker
 
-import io.embrace.android.embracesdk.internal.clock.Clock
 import java.util.concurrent.Callable
 import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.RejectedExecutionHandler
@@ -10,29 +9,27 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 /**
- * A [ThreadPoolExecutor] that supports prioritisation of submitted tasks. Prioritisation
- * uses the following logic:
+ * A [ThreadPoolExecutor] that supports prioritisation of submitted tasks. Each task
+ * must have a priorityInfo object that is associated with the task. Prioritisation is then
+ * delegated to the supplied [Comparator].
  *
- * 1. Each [TaskPriority] defines a delay threshold in milliseconds.
- * 2. Higher task priorities have smaller delay thresholds.
- * 3. A score is calculated for each task by adding the submit time + delay threshold
- * 4. Tasks are executed in order of lowest score to highest score
- *
- * This helps mitigate against resource starvation scenarios where a large number of high priority
- * tasks prevent lower priority tasks from ever completing execution.
+ * This executor assumes that all tasks submitted are operations that have some sort of logical
+ * grouping that can be prioritised. Submitting all HTTP requests to the same executor will result
+ * in good prioritisation. Submitting a bunch of miscellaneous tasks that have no relation to each
+ * other will probably not.
  */
 internal class PriorityThreadPoolExecutor(
-    private val clock: Clock,
     threadFactory: ThreadFactory,
     handler: RejectedExecutionHandler,
     corePoolSize: Int,
-    maximumPoolSize: Int
+    maximumPoolSize: Int,
+    comparator: Comparator<Runnable>
 ) : ThreadPoolExecutor(
     corePoolSize,
     maximumPoolSize,
     60L,
     TimeUnit.SECONDS,
-    createPriorityQueue(),
+    PriorityBlockingQueue(100, comparator),
     threadFactory,
     handler
 ) {
@@ -42,7 +39,7 @@ internal class PriorityThreadPoolExecutor(
             "Callable must be PriorityCallable"
         }
         val runnableFuture = super.newTaskFor(callable)
-        return PriorityRunnableFuture(runnableFuture, callable.priority, clock.now())
+        return PriorityRunnableFuture<T>(runnableFuture, callable.priorityInfo)
     }
 
     override fun <T : Any?> newTaskFor(
@@ -53,19 +50,6 @@ internal class PriorityThreadPoolExecutor(
             "Runnable must be PriorityCallable"
         }
         val runnableFuture = super.newTaskFor(runnable, value)
-        return PriorityRunnableFuture(runnableFuture, runnable.priority, clock.now())
-    }
-
-    companion object {
-        fun createPriorityQueue(): PriorityBlockingQueue<Runnable> =
-            PriorityBlockingQueue(
-                100,
-                compareBy<Runnable> { runnable ->
-                    require(runnable is PriorityRunnableFuture<*>) {
-                        "Runnable must be PriorityRunnableFuture"
-                    }
-                    runnable.submitTime + runnable.priority.delayThresholdMs
-                }
-            )
+        return PriorityRunnableFuture<T>(runnableFuture, runnable.priorityInfo)
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityWorker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityWorker.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
  * This class is necessary because it hides aspects of the ExecutorService API that we don't want
  * to expose as part of the internal API.
  */
-class PriorityWorker(
+class PriorityWorker<T>(
     private val impl: ExecutorService
 ) {
 
@@ -19,20 +19,20 @@ class PriorityWorker(
      * Submits a task for execution and returns a [Future].
      */
     fun submit(
-        priority: TaskPriority = TaskPriority.NORMAL,
+        priorityInfo: T,
         runnable: Runnable
     ): Future<*> {
-        return impl.submit(PriorityRunnable(priority, runnable))
+        return impl.submit(PriorityRunnable(priorityInfo as Any, runnable))
     }
 
     /**
      * Submits a task for execution and returns a [Future].
      */
-    fun <T> submit(
-        priority: TaskPriority = TaskPriority.NORMAL,
-        callable: Callable<T>
-    ): Future<T> {
-        return impl.submit(PriorityCallable(priority, callable))
+    fun <R> submit(
+        priorityInfo: T,
+        callable: Callable<R>
+    ): Future<R> {
+        return impl.submit(PriorityCallable(priorityInfo as Any, callable))
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
@@ -1,0 +1,39 @@
+package io.embrace.android.embracesdk.internal.worker.comparator
+
+import io.embrace.android.embracesdk.internal.comms.api.ApiRequest
+import io.embrace.android.embracesdk.internal.comms.api.isSessionRequest
+import io.embrace.android.embracesdk.internal.worker.PriorityRunnableFuture
+import io.embrace.android.embracesdk.internal.worker.TaskPriority
+
+/**
+ * Prioritises based on [TaskPriority]
+ */
+internal val taskPriorityComparator = Comparator { lhs: Runnable, rhs: Runnable ->
+    val (lhsPrio, rhsPrio) = extractPriorityFromRunnable<TaskPriority>(lhs, rhs)
+    return@Comparator lhsPrio.compareTo(rhsPrio)
+}
+
+/**
+ * Prioritises based on whether the [ApiRequest] is a session or not.
+ */
+internal val apiRequestComparator = Comparator { lhs: Runnable, rhs: Runnable ->
+    val (lhsRequest, rhsRequest) = extractPriorityFromRunnable<ApiRequest>(lhs, rhs)
+    return@Comparator when {
+        lhsRequest.isSessionRequest() -> -1
+        rhsRequest.isSessionRequest() -> 1
+        else -> 0
+    }
+}
+
+private inline fun <reified T> extractPriorityFromRunnable(
+    lhs: Runnable,
+    rhs: Runnable
+): Pair<T, T> {
+    require(lhs is PriorityRunnableFuture<*> && rhs is PriorityRunnableFuture<*>) {
+        "Runnables must be PriorityRunnableFuture"
+    }
+    require(lhs.priorityInfo is T && rhs.priorityInfo is T) {
+        "PriorityInfo must be of type T"
+    }
+    return Pair(lhs.priorityInfo as T, rhs.priorityInfo as T)
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbraceDeliveryServiceTest.kt
@@ -40,6 +40,7 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
+import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
@@ -52,7 +53,7 @@ import org.junit.Test
 internal class EmbraceDeliveryServiceTest {
 
     private lateinit var fakeClock: FakeClock
-    private lateinit var worker: PriorityWorker
+    private lateinit var worker: PriorityWorker<TaskPriority>
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var apiService: FakeApiService
     private lateinit var fakeNativeCrashService: FakeNativeCrashService

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.internal.comms.api.ApiRequest
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
@@ -39,7 +41,8 @@ internal class WorkerThreadModuleImplTest {
     @Test
     fun `network request executor uses custom queue`() {
         val module = WorkerThreadModuleImpl(initModule)
-        assertNotNull(module.priorityWorker(Worker.Priority.NetworkRequestWorker))
+        assertNotNull(module.priorityWorker<ApiRequest>(Worker.Priority.NetworkRequestWorker))
+        assertNotNull(module.priorityWorker<TaskPriority>(Worker.Priority.FileCacheWorker))
     }
 
     @Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheCurrentAccessTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheCurrentAccessTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
+import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.mockk.clearAllMocks
 import io.mockk.spyk
 import io.mockk.verify
@@ -22,7 +23,7 @@ import java.util.concurrent.TimeUnit
 internal class EmbraceDeliveryCacheCurrentAccessTest {
 
     private val serializer = EmbraceSerializer()
-    private lateinit var worker: PriorityWorker
+    private lateinit var worker: PriorityWorker<TaskPriority>
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheManagerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceDeliveryCacheManagerTest.kt
@@ -23,6 +23,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapsh
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.NORMAL_END
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.PERIODIC_CACHE
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
+import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -46,7 +47,7 @@ internal class EmbraceDeliveryCacheManagerTest {
 
     private val prefix = "last_session"
     private val serializer = EmbraceSerializer()
-    private val worker = fakePriorityWorker()
+    private val worker = fakePriorityWorker<TaskPriority>()
     private lateinit var deliveryCacheManager: EmbraceDeliveryCacheManager
     private lateinit var storageService: StorageService
     private lateinit var cacheService: EmbraceCacheService

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.worker
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.Callable
@@ -83,26 +82,6 @@ internal class BackgroundWorkerTest {
         BackgroundWorker(impl).submit(callable)
         impl.runCurrentlyBlocked()
         assertTrue(ran)
-    }
-
-    @Test
-    fun `test runnable transformed`() {
-        val impl = DecoratedExecutorService()
-        val runnable = Runnable {}
-        val future = PriorityWorker(impl).submit(TaskPriority.LOW, runnable)
-        val submitted = impl.runnables.single() as PriorityRunnable
-        assertEquals(TaskPriority.LOW, submitted.priority)
-        assertNull(future.get())
-    }
-
-    @Test
-    fun `test callable transformed`() {
-        val impl = DecoratedExecutorService()
-        val callable = Callable { "test" }
-        val future = PriorityWorker(impl).submit(TaskPriority.HIGH, callable)
-        val submitted = impl.callables.single() as PriorityCallable<*>
-        assertEquals(TaskPriority.HIGH, submitted.priority)
-        assertEquals("test", future.get())
     }
 
     @Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutorTest.kt
@@ -1,31 +1,22 @@
 package io.embrace.android.embracesdk.internal.worker
 
-import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.internal.worker.comparator.taskPriorityComparator
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.FutureTask
 import java.util.concurrent.PriorityBlockingQueue
-import java.util.concurrent.RejectedExecutionHandler
 
 internal class PriorityThreadPoolExecutorTest {
 
-    private val clock = FakeClock()
-
     private val executor = PriorityThreadPoolExecutor(
-        clock,
         Executors.defaultThreadFactory(),
-        RejectedExecutionHandler { _, _ -> },
+        { _, _ -> },
         1,
-        1
+        1,
+        taskPriorityComparator
     )
-
-    @Before
-    fun setUp() {
-        clock.setCurrentTime(0)
-    }
 
     @Test(expected = IllegalArgumentException::class)
     fun `reject invalid runnable`() {
@@ -39,25 +30,28 @@ internal class PriorityThreadPoolExecutorTest {
 
     @Test
     fun `submit valid runnable`() {
-        val future = PriorityWorker(executor).submit {}
-        assertEquals(TaskPriority.NORMAL, (future as PriorityRunnableFuture<*>).priority)
+        val future = PriorityWorker<TaskPriority>(executor).submit(TaskPriority.NORMAL) {}
+        assertEquals(TaskPriority.NORMAL, (future as PriorityRunnableFuture<*>).priorityInfo)
     }
 
     @Test
     fun `submit valid callable`() {
-        val future = PriorityWorker(executor).submit(TaskPriority.HIGH, Callable {})
-        assertEquals(TaskPriority.HIGH, (future as PriorityRunnableFuture<*>).priority)
+        val future = PriorityWorker<TaskPriority>(executor).submit(TaskPriority.HIGH, Callable {})
+        assertEquals(TaskPriority.HIGH, (future as PriorityRunnableFuture<*>).priorityInfo)
     }
 
     @Test
     fun `tasks are processed in priority order when priority is different`() {
         val inputs = listOf(
-            createFuture(1, TaskPriority.LOW, 0),
-            createFuture(2, TaskPriority.NORMAL, 0),
-            createFuture(3, TaskPriority.CRITICAL, 0),
-            createFuture(4, TaskPriority.HIGH, 0)
+            createFuture(1, TaskPriority.LOW),
+            createFuture(2, TaskPriority.NORMAL),
+            createFuture(3, TaskPriority.CRITICAL),
+            createFuture(4, TaskPriority.HIGH)
         )
-        val queue = PriorityThreadPoolExecutor.createPriorityQueue()
+        val queue = PriorityBlockingQueue<Runnable>(
+            100,
+            taskPriorityComparator
+        )
         inputs.forEach(queue::add)
         queue.forEach(Runnable::run)
 
@@ -68,15 +62,18 @@ internal class PriorityThreadPoolExecutorTest {
     @Test
     fun `tasks are in random order when priority + submission time is same`() {
         val inputs = listOf(
-            createFuture("elephant", TaskPriority.NORMAL, 0),
-            createFuture("apple", TaskPriority.NORMAL, 0),
-            createFuture("cat", TaskPriority.NORMAL, 0),
-            createFuture("banana", TaskPriority.NORMAL, 0),
-            createFuture("zebra", TaskPriority.NORMAL, 0),
-            createFuture("dog", TaskPriority.NORMAL, 0),
-            createFuture("snake", TaskPriority.NORMAL, 0)
+            createFuture("elephant", TaskPriority.NORMAL),
+            createFuture("apple", TaskPriority.NORMAL),
+            createFuture("cat", TaskPriority.NORMAL),
+            createFuture("banana", TaskPriority.NORMAL),
+            createFuture("zebra", TaskPriority.NORMAL),
+            createFuture("dog", TaskPriority.NORMAL),
+            createFuture("snake", TaskPriority.NORMAL)
         )
-        val queue = PriorityThreadPoolExecutor.createPriorityQueue()
+        val queue = PriorityBlockingQueue<Runnable>(
+            100,
+            taskPriorityComparator
+        )
         inputs.forEach(queue::add)
         queue.forEach(Runnable::run)
 
@@ -95,102 +92,13 @@ internal class PriorityThreadPoolExecutorTest {
         )
     }
 
-    @Test
-    fun `tasks are processed in submission order when priority is same`() {
-        val inputs = listOf(
-            createFuture("elephant", TaskPriority.NORMAL, 0),
-            createFuture("apple", TaskPriority.NORMAL, 1),
-            createFuture("cat", TaskPriority.NORMAL, 2),
-            createFuture("banana", TaskPriority.NORMAL, 3),
-            createFuture("zebra", TaskPriority.NORMAL, 4),
-            createFuture("dog", TaskPriority.NORMAL, 5),
-            createFuture("snake", TaskPriority.NORMAL, 6)
-        )
-        val queue = PriorityThreadPoolExecutor.createPriorityQueue()
-        inputs.forEach(queue::add)
-        queue.forEach(Runnable::run)
-
-        val observed = queue.getResults()
-        assertEquals(
-            listOf(
-                "elephant",
-                "apple",
-                "cat",
-                "banana",
-                "zebra",
-                "dog",
-                "snake"
-            ),
-            observed
-        )
-    }
-
-    @Test
-    fun `tasks are processed with both submission + priority order`() {
-        val inputs = listOf(
-            createFuture("elephant", TaskPriority.NORMAL, 0),
-            createFuture("apple", TaskPriority.HIGH, 1),
-            createFuture("cat", TaskPriority.NORMAL, 2),
-            createFuture("banana", TaskPriority.LOW, 3),
-            createFuture("zebra", TaskPriority.CRITICAL, 4),
-            createFuture("dog", TaskPriority.NORMAL, 5),
-            createFuture("snake", TaskPriority.NORMAL, 6)
-        )
-        val queue = PriorityThreadPoolExecutor.createPriorityQueue()
-        inputs.forEach(queue::add)
-        queue.forEach(Runnable::run)
-
-        val observed = queue.getResults()
-        assertEquals(
-            listOf(
-                "zebra",
-                "apple",
-                "elephant",
-                "cat",
-                "dog",
-                "snake",
-                "banana",
-            ),
-            observed
-        )
-    }
-
-    @Test
-    fun `resource starvation is mitigated`() {
-        val inputs = listOf(
-            createFuture("a", TaskPriority.CRITICAL, 0),
-            createFuture("c", TaskPriority.HIGH, 1),
-            createFuture("b", TaskPriority.CRITICAL, 2),
-            createFuture("d", TaskPriority.HIGH, 3).also {
-                clock.tick(TaskPriority.HIGH.delayThresholdMs + 1000)
-            },
-            createFuture("e", TaskPriority.CRITICAL, clock.now()),
-        )
-        val queue = PriorityThreadPoolExecutor.createPriorityQueue()
-        inputs.forEach(queue::add)
-        queue.forEach(Runnable::run)
-
-        val observed = queue.getResults()
-        assertEquals(
-            listOf(
-                "a",
-                "b",
-                "c",
-                "d",
-                "e",
-            ),
-            observed
-        )
-    }
-
     /**
      * Syntactic sugar for creating a [PriorityRunnableFuture].
      */
     private fun <T> createFuture(
         value: T,
-        taskPriority: TaskPriority,
-        submitTime: Long
-    ) = PriorityRunnableFuture(FutureTask { value }, taskPriority, submitTime)
+        taskPriority: TaskPriority
+    ) = PriorityRunnableFuture(FutureTask { value }, taskPriority)
 
     /**
      * Drains the results from the queue & returns their Callable value.

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/PriorityWorkerTest.kt
@@ -1,0 +1,29 @@
+package io.embrace.android.embracesdk.internal.worker
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.concurrent.Callable
+
+internal class PriorityWorkerTest {
+
+    @Test
+    fun `test runnable transformed`() {
+        val impl = DecoratedExecutorService()
+        val runnable = Runnable {}
+        val future = PriorityWorker<TaskPriority>(impl).submit(TaskPriority.LOW, runnable)
+        val submitted = impl.runnables.single() as PriorityRunnable
+        assertEquals(TaskPriority.LOW, submitted.priorityInfo)
+        assertNull(future.get())
+    }
+
+    @Test
+    fun `test callable transformed`() {
+        val impl = DecoratedExecutorService()
+        val callable = Callable { "test" }
+        val future = PriorityWorker<TaskPriority>(impl).submit(TaskPriority.HIGH, callable)
+        val submitted = impl.callables.single() as PriorityCallable<*>
+        assertEquals(TaskPriority.HIGH, submitted.priorityInfo)
+        assertEquals("test", future.get())
+    }
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/comparator/TaskPriorityComparatorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/comparator/TaskPriorityComparatorTest.kt
@@ -1,0 +1,64 @@
+package io.embrace.android.embracesdk.internal.worker.comparator
+
+import io.embrace.android.embracesdk.internal.comms.api.ApiRequest
+import io.embrace.android.embracesdk.internal.comms.api.ApiRequestUrl
+import io.embrace.android.embracesdk.internal.worker.PriorityRunnableFuture
+import io.embrace.android.embracesdk.internal.worker.TaskPriority.CRITICAL
+import io.embrace.android.embracesdk.internal.worker.TaskPriority.HIGH
+import io.embrace.android.embracesdk.internal.worker.TaskPriority.LOW
+import io.embrace.android.embracesdk.internal.worker.TaskPriority.NORMAL
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TaskPriorityComparatorTest {
+
+    @Test
+    fun `test api request comparator`() {
+        val input = listOf(
+            createRequest("1", true),
+            createRequest("2", false),
+            createRequest("3", true),
+            createRequest("4", false)
+        )
+        val expected = listOf(
+            createRequest("3", true),
+            createRequest("1", true),
+            createRequest("2", false),
+            createRequest("4", false)
+        )
+        val observed = input.sortElements(apiRequestComparator)
+        assertEquals(expected.map { it.url.url }, observed.map { it.url.url })
+    }
+
+    @Test
+    fun `test task priority comparator`() {
+        val input = listOf(CRITICAL, NORMAL, LOW, HIGH, NORMAL, CRITICAL, LOW, HIGH)
+        val expected = listOf(CRITICAL, CRITICAL, HIGH, HIGH, NORMAL, NORMAL, LOW, LOW)
+        val observed = input.sortElements(taskPriorityComparator)
+        assertEquals(expected, observed)
+    }
+
+    private inline fun <reified T> List<T>.sortElements(comparator: Comparator<Runnable>): List<T> {
+        return map(::createRunnable)
+            .sortedWith(comparator)
+            .map {
+                require(it is PriorityRunnableFuture<*>) {
+                    "Runnable must be PriorityRunnableFuture"
+                }
+                it.priorityInfo as T
+            }
+    }
+
+    private inline fun <reified T> createRunnable(priority: T): Runnable {
+        return PriorityRunnableFuture<T>(mockk(relaxed = true), priority as Any)
+    }
+
+    private fun createRequest(path: String, isSession: Boolean): ApiRequest {
+        val suffix = if (isSession) "spans" else "log"
+        return ApiRequest(
+            userAgent = "",
+            url = ApiRequestUrl(url = "https://example.com/api/$path/$suffix"),
+        )
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -41,6 +41,7 @@ import io.embrace.android.embracesdk.internal.injection.embraceImplInject
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.EventType
+import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.spans.TracingApi
 
@@ -198,8 +199,8 @@ internal class EmbraceImpl @JvmOverloads constructor(
 
         // Send any sessions that were cached and not yet sent.
         startSynchronous("send-cached-sessions")
-        val worker = bootstrapper.workerThreadModule.priorityWorker(Worker.Priority.FileCacheWorker)
-        worker.submit {
+        val worker = bootstrapper.workerThreadModule.priorityWorker<TaskPriority>(Worker.Priority.FileCacheWorker)
+        worker.submit(TaskPriority.NORMAL) {
             val essentialServiceModule = bootstrapper.essentialServiceModule
             bootstrapper.deliveryModule.deliveryService.sendCachedSessions(
                 bootstrapper.nativeFeatureModule::nativeCrashService,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeWorkers.kt
@@ -5,5 +5,5 @@ import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorServic
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 
-fun fakePriorityWorker(): PriorityWorker = PriorityWorker(BlockableExecutorService())
+fun <T> fakePriorityWorker(): PriorityWorker<T> = PriorityWorker(BlockableExecutorService())
 fun fakeBackgroundWorker(): BackgroundWorker = BackgroundWorker(BlockingScheduledExecutorService(blockingMode = false))


### PR DESCRIPTION
## Goal

Adapts the existing `PriorityThreadPoolExecutor` so that instead of only supporting the `TaskPriority` enum, it supports arbitrary data types with a matching comparator. I've updated the implementation so that network requests are prioritised based on whether `ApiRequest` is a session, and so that the `DeliveryCacheManager` prioritises based on the supplied `TaskPriority`.

## Testing

Updated & added to unit tests.
