### PR TITLE
Alter project dependency structure

### DIFF
--- a/embrace-android-delivery/build.gradle.kts
+++ b/embrace-android-delivery/build.gradle.kts
@@ -12,5 +12,5 @@ apiValidation.validationDisabled = true
 
 dependencies {
     implementation(project(":embrace-android-payload"))
-    testImplementation(project(":embrace-android-payload"))
+    implementation(project(":embrace-android-core"))
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Envelope.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Envelope.kt
@@ -33,5 +33,6 @@ data class Envelope<T>(
 
     companion object {
         val sessionEnvelopeType: ParameterizedType = Types.newParameterizedType(Envelope::class.java, SessionPayload::class.java)
+        val logEnvelopeType: ParameterizedType = Types.newParameterizedType(Envelope::class.java, LogPayload::class.java)
     }
 }

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     compileOnly(project(":embrace-android-sdk"))
     compileOnly(project(":embrace-android-payload"))
     compileOnly(project(":embrace-android-features"))
+    compileOnly(project(":embrace-android-delivery"))
 
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)


### PR DESCRIPTION
## Goal

Alters the dependencies in `embrace-android-delivery` so that the core module + test fakes can be accessed. Additionally defines the serialized type that should be used for log payloads.
