### PR TITLE
Fix manual session control enablement

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehavior.kt
@@ -24,9 +24,9 @@ interface SessionBehavior {
     fun isGatingFeatureEnabled(): Boolean
 
     /**
-     * Whether session control is enabled, meaning that features should be gated.
+     * Whether session control is disabled, meaning that can't end sessions manually.
      */
-    fun isSessionControlEnabled(): Boolean
+    fun isSessionControlDisabled(): Boolean
 
     /**
      * Returns the maximum number of properties that can be attached to a session

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImpl.kt
@@ -34,7 +34,7 @@ class SessionBehaviorImpl(
 
     override fun isGatingFeatureEnabled(): Boolean = getSessionComponents() != null
 
-    override fun isSessionControlEnabled(): Boolean = remote?.sessionConfig?.isEnabled ?: true
+    override fun isSessionControlDisabled(): Boolean = remote?.disableSessionControl ?: false
 
     override fun getMaxSessionProperties(): Int = remote?.maxSessionProperties ?: SESSION_PROPERTY_LIMIT
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImpl.kt
@@ -34,7 +34,7 @@ class SessionBehaviorImpl(
 
     override fun isGatingFeatureEnabled(): Boolean = getSessionComponents() != null
 
-    override fun isSessionControlEnabled(): Boolean = remote?.sessionConfig?.isEnabled ?: false
+    override fun isSessionControlEnabled(): Boolean = remote?.sessionConfig?.isEnabled ?: true
 
     override fun getMaxSessionProperties(): Int = remote?.maxSessionProperties ?: SESSION_PROPERTY_LIMIT
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -22,13 +22,13 @@ internal fun shouldEndManualSession(
 ): Boolean {
     if (state == ProcessState.BACKGROUND) {
         logger.logWarning("Cannot manually end session while in background.")
-        return true
+        return false
     }
-    if (configService.sessionBehavior.isSessionControlEnabled()) {
-        logger.logWarning("Cannot manually end session while session control is enabled.")
-        return true
+    if (!configService.sessionBehavior.isSessionControlEnabled()) {
+        logger.logWarning("Cannot manually end session while session control is disabled.")
+        return false
     }
-    val initial = activeSession ?: return true
+    val initial = activeSession ?: return false
     val startTime = initial.startTime
     val delta = clock.now() - startTime
     if (delta < MIN_SESSION_MS) {
@@ -37,9 +37,9 @@ internal fun shouldEndManualSession(
                 "This protects against instrumentation unintentionally creating too" +
                 "many sessions"
         )
-        return true
+        return false
     }
-    return false
+    return true
 }
 
 internal fun shouldRunOnBackground(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -24,7 +24,7 @@ internal fun shouldEndManualSession(
         logger.logWarning("Cannot manually end session while in background.")
         return false
     }
-    if (!configService.sessionBehavior.isSessionControlEnabled()) {
+    if (configService.sessionBehavior.isSessionControlDisabled()) {
         logger.logWarning("Cannot manually end session while session control is disabled.")
         return false
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -111,7 +111,7 @@ internal class SessionOrchestratorImpl(
                 payloadFactory.startSessionWithManual(timestamp)
             },
             earlyTerminationCondition = {
-                return@transitionState shouldEndManualSession(
+                return@transitionState !shouldEndManualSession(
                     configService,
                     clock,
                     activeSession,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -89,7 +89,7 @@ internal class EmbraceApiServiceTest {
 
         // verify a few fields were serialized correctly.
         checkNotNull(remoteConfig)
-        assertTrue(checkNotNull(remoteConfig.sessionConfig?.isEnabled))
+        assertFalse(checkNotNull(remoteConfig.disableSessionControl))
         assertEquals(100, remoteConfig.threshold)
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImplImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImplImplTest.kt
@@ -12,8 +12,8 @@ import org.junit.Test
 internal class SessionBehaviorImplImplTest {
 
     private val remote = RemoteConfig(
+        disableSessionControl = true,
         sessionConfig = SessionRemoteConfig(
-            isEnabled = false,
             sessionComponents = setOf("test"),
             fullSessionEvents = setOf("test2")
         ),
@@ -26,7 +26,7 @@ internal class SessionBehaviorImplImplTest {
             assertEquals(emptySet<String>(), getFullSessionEvents())
             assertNull(getSessionComponents())
             assertFalse(isGatingFeatureEnabled())
-            assertTrue(isSessionControlEnabled())
+            assertFalse(isSessionControlDisabled())
             assertEquals(10, getMaxSessionProperties())
         }
     }
@@ -35,7 +35,7 @@ internal class SessionBehaviorImplImplTest {
     fun testRemoteAndLocal() {
         with(createSessionBehavior(remoteCfg = { remote })) {
             assertTrue(isGatingFeatureEnabled())
-            assertFalse(isSessionControlEnabled())
+            assertTrue(isSessionControlDisabled())
             assertEquals(setOf("test"), getSessionComponents())
             assertEquals(setOf("test2"), getFullSessionEvents())
             assertEquals(57, getMaxSessionProperties())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImplImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/SessionBehaviorImplImplTest.kt
@@ -13,7 +13,7 @@ internal class SessionBehaviorImplImplTest {
 
     private val remote = RemoteConfig(
         sessionConfig = SessionRemoteConfig(
-            isEnabled = true,
+            isEnabled = false,
             sessionComponents = setOf("test"),
             fullSessionEvents = setOf("test2")
         ),
@@ -26,7 +26,7 @@ internal class SessionBehaviorImplImplTest {
             assertEquals(emptySet<String>(), getFullSessionEvents())
             assertNull(getSessionComponents())
             assertFalse(isGatingFeatureEnabled())
-            assertFalse(isSessionControlEnabled())
+            assertTrue(isSessionControlEnabled())
             assertEquals(10, getMaxSessionProperties())
         }
     }
@@ -35,7 +35,7 @@ internal class SessionBehaviorImplImplTest {
     fun testRemoteAndLocal() {
         with(createSessionBehavior(remoteCfg = { remote })) {
             assertTrue(isGatingFeatureEnabled())
-            assertTrue(isSessionControlEnabled())
+            assertFalse(isSessionControlEnabled())
             assertEquals(setOf("test"), getSessionComponents())
             assertEquals(setOf("test2"), getFullSessionEvents())
             assertEquals(57, getMaxSessionProperties())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/gating/EmbraceGatingServiceV2PayloadTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/event/gating/EmbraceGatingServiceV2PayloadTest.kt
@@ -71,8 +71,8 @@ internal class EmbraceGatingServiceV2PayloadTest {
 
     private fun buildCustomRemoteConfig(components: Set<String>?, fullSessionEvents: Set<String>?) =
         RemoteConfig(
+            disableSessionControl = false,
             sessionConfig = SessionRemoteConfig(
-                isEnabled = true,
                 sessionComponents = components,
                 fullSessionEvents = fullSessionEvents
             )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -128,7 +128,6 @@ internal class EmbraceLogServiceTest {
                 remoteCfg = {
                     RemoteConfig(
                         sessionConfig = SessionRemoteConfig(
-                            isEnabled = true,
                             sessionComponents = emptySet() // empty set will gate everything
                         )
                     )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -203,7 +203,7 @@ internal class SessionOrchestratorTest {
     @Test
     fun `test manual session end disabled`() {
         configService = FakeConfigService(
-            sessionBehavior = FakeSessionBehavior(sessionControlEnabled = false)
+            sessionBehavior = FakeSessionBehavior(sessionControlDisabled = true)
         )
         createOrchestrator(false)
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -201,9 +201,9 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
-    fun `test manual session end disabled for session gating`() {
+    fun `test manual session end disabled`() {
         configService = FakeConfigService(
-            sessionBehavior = FakeSessionBehavior(sessionControlEnabled = true)
+            sessionBehavior = FakeSessionBehavior(sessionControlEnabled = false)
         )
         createOrchestrator(false)
 

--- a/embrace-android-core/src/test/resources/remote_config_response.json
+++ b/embrace-android-core/src/test/resources/remote_config_response.json
@@ -3,8 +3,8 @@
   "event_limits": {},
   "offset": 0,
   "personas": [],
+  "disable_session_control": false,
   "session_control": {
-    "enable": true,
     "async_end": false
   },
   "threshold": 100,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
@@ -66,6 +66,12 @@ data class RemoteConfig(
     val sessionConfig: SessionRemoteConfig? = null,
 
     /**
+     * Settings defining if session control is disabled or not
+     */
+    @Json(name = "disable_session_control")
+    val disableSessionControl: Boolean? = null,
+
+    /**
      * Settings defining the log configuration.
      */
     @Json(name = "logs")

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/SessionRemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/SessionRemoteConfig.kt
@@ -10,9 +10,6 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class SessionRemoteConfig(
-    @Json(name = "enable")
-    val isEnabled: Boolean? = null,
-
     /**
      * A list of session components (i.e. Breadcrumbs, Session properties, etc) that will be
      * included in the session payload. If components list exists, the services should restrict

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -51,9 +51,9 @@ internal class ManualSessionTest {
     }
 
     @Test
-    fun `calling endSession when session control enabled does not end sessions`() {
+    fun `calling endSession when session control disabled does not end sessions`() {
         with(testRule) {
-            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlEnabled = true)
+            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlEnabled = false)
             harness.recordSession {
                 harness.overriddenClock.tick(10000)
                 embrace.endSession()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/ManualSessionTest.kt
@@ -53,7 +53,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when session control disabled does not end sessions`() {
         with(testRule) {
-            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlEnabled = false)
+            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlDisabled = true)
             harness.recordSession {
                 harness.overriddenClock.tick(10000)
                 embrace.endSession()
@@ -66,7 +66,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when state session is below 5s has no effect`() {
         with(testRule) {
-            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlEnabled = true)
+            harness.overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlDisabled = true)
             harness.recordSession {
                 harness.overriddenClock.tick(1000) // not enough to trigger new session
                 embrace.endSession()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSessionBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSessionBehavior.kt
@@ -4,13 +4,13 @@ import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 
 class FakeSessionBehavior(
     private val maxSessionProperties: Int = 100,
-    private val sessionControlEnabled: Boolean = false
+    private val sessionControlDisabled: Boolean = false
 ) : SessionBehavior {
 
     override fun getFullSessionEvents(): Set<String> = emptySet()
     override fun getSessionComponents(): Set<String>? = null
     override fun isGatingFeatureEnabled(): Boolean = false
-    override fun isSessionControlEnabled(): Boolean = sessionControlEnabled
+    override fun isSessionControlDisabled(): Boolean = sessionControlDisabled
     override fun getMaxSessionProperties(): Int = maxSessionProperties
     override fun shouldGateMoment(): Boolean = false
     override fun shouldGateInfoLog(): Boolean = false


### PR DESCRIPTION
## Goal

Have a kill switch to disable ending sessions manually. There was a confused implementation with the previous key.

## Testing

Manual and Unit test.
