### PR TITLE
Alter assertion of flaky test

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -78,7 +78,7 @@ internal class BackgroundWorkerTest {
 
     @Test
     fun `shutdown and wait exceeds timeout`() {
-        val latch = CountDownLatch(1)
+        val latch = CountDownLatch(2)
         val worker = BackgroundWorker(
             ShutdownAndWaitExecutorService(postAwaitTerminationAction = {
                 latch.countDown()
@@ -91,6 +91,7 @@ internal class BackgroundWorkerTest {
             ran = true
         }
         worker.shutdownAndWait(0)
+        assertEquals(1, latch.count)
         assertFalse(ran)
     }
 


### PR DESCRIPTION
## Goal

The test case assumed that the job would not complete after the latch was released, but internally `BackgroundWorker` calls `shutdown` which allows completion of tasks that are already executing.

My fix is to increase the number of latches required to 2 so the `Runnable` never completes. I've added an assertion to check the latch was counted down instead.