### PR TITLE
Make SessionApiTest not flakey

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.testcases
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
@@ -21,7 +22,11 @@ internal class SessionApiTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule()
+    val testRule: IntegrationTestRule = IntegrationTestRule {
+        IntegrationTestRule.Harness().apply {
+            overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(diskUsageReportingEnabled = false)
+        }
+    }
 
     /**
      * Verifies that a session end message is sent.

--- a/embrace-android-sdk/src/test/resources/v2_session_expected.json
+++ b/embrace-android-sdk/src/test/resources/v2_session_expected.json
@@ -32,10 +32,8 @@
     "os_version": "__EMBRACE_TEST_IGNORE__",
     "os_code": "__EMBRACE_TEST_IGNORE__",
     "screen_resolution": "__EMBRACE_TEST_IGNORE__",
-    "num_cores": "__EMBRACE_TEST_IGNORE__",
-    "disk_space": "__EMBRACE_TEST_IGNORE__"
+    "num_cores": "__EMBRACE_TEST_IGNORE__"
   },
-  "s": "__EMBRACE_TEST_IGNORE__",
   "type": "spans",
   "version": "0.1.0"
 }


### PR DESCRIPTION
## Goal

The SessionApiTest was flakey because whether the disk space attribute is written in the session is non-deterministic. So to make the payload predictable, I disabled that feature in this integration test verification, which is superfluous anyway since it working ought to be verified via unit tests anyway.