### PR TITLE
Simplify session properties tests to not checked cached payload

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/features/SessionPropertiesTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.checkNextSavedBackgroundActivity
 import io.embrace.android.embracesdk.findSessionSpan
-import io.embrace.android.embracesdk.getLastSavedSession
 import io.embrace.android.embracesdk.getLastSentBackgroundActivity
 import io.embrace.android.embracesdk.getSentBackgroundActivities
 import io.embrace.android.embracesdk.getSessionId
@@ -168,19 +167,12 @@ internal class SessionPropertiesTest {
                 }
             )
 
-            harness.recordSession {
-                with(checkNotNull(harness.getLastSavedSession()?.getSessionSpan())) {
-                    assertNotEquals(lastSessionId, embrace.currentSessionId)
-                    assertPropertyExistence(
-                        exist = listOf("perm")
-                    )
-                    lastSessionId = checkNotNull(embrace.currentSessionId)
-                }
+            val session = checkNotNull(harness.recordSession {
                 embrace.addSessionProperty("perm2", "value", true)
-                checkNotNull(harness.getLastSavedSession()?.getSessionSpan()).assertPropertyExistence(
-                    exist = listOf("perm", "perm2")
-                )
-            }
+            })
+            checkNotNull(session.getSessionSpan()).assertPropertyExistence(
+                exist = listOf("perm", "perm2")
+            )
 
             harness.checkNextSavedBackgroundActivity(
                 action = {
@@ -197,15 +189,10 @@ internal class SessionPropertiesTest {
                 }
             )
 
-            harness.recordSession {
-                with(checkNotNull(harness.getLastSavedSession()?.getSessionSpan())) {
-                    assertNotEquals(lastSessionId, embrace.currentSessionId)
-                    assertPropertyExistence(
-                        exist = listOf("perm", "perm2", "perm3")
-                    )
-                    lastSessionId = checkNotNull(embrace.currentSessionId)
-                }
-            }
+            val session2 = checkNotNull(harness.recordSession())
+            checkNotNull(session2.getSessionSpan()).assertPropertyExistence(
+                exist = listOf("perm", "perm2", "perm3")
+            )
         }
     }
 
@@ -215,33 +202,19 @@ internal class SessionPropertiesTest {
             harness.overriddenConfigService.backgroundActivityCaptureEnabled = false
             startSdk()
             embrace.addSessionProperty("perm", "value", true)
-            var lastSessionId = checkNotNull(harness.recordSession()).getSessionId()
-            harness.recordSession {
-                with(checkNotNull(harness.getLastSavedSession()?.getSessionSpan())) {
-                    assertNotEquals(lastSessionId, embrace.currentSessionId)
-                    assertPropertyExistence(
-                        exist = listOf("perm")
-                    )
-                    lastSessionId = checkNotNull(embrace.currentSessionId)
-                }
+            val session = checkNotNull(harness.recordSession {
                 embrace.addSessionProperty("perm2", "value", true)
-                checkNotNull(harness.getLastSavedSession()?.getSessionSpan()).assertPropertyExistence(
-                    exist = listOf("perm", "perm2")
-                )
-            }
-            harness.recordSession {
-                with(checkNotNull(harness.getLastSavedSession()?.getSessionSpan())) {
-                    assertNotEquals(lastSessionId, embrace.currentSessionId)
-                    assertPropertyExistence(
-                        exist = listOf("perm", "perm2")
-                    )
-                    lastSessionId = checkNotNull(embrace.currentSessionId)
-                }
+            })
+            checkNotNull(session.getSessionSpan()).assertPropertyExistence(
+                exist = listOf("perm", "perm2")
+            )
+
+            val session2 = checkNotNull(harness.recordSession {
                 embrace.addSessionProperty("perm3", "value", true)
-                checkNotNull(harness.getLastSavedSession()?.getSessionSpan()).assertPropertyExistence(
-                    exist = listOf("perm", "perm2", "perm3")
-                )
-            }
+            })
+            checkNotNull(session2.getSessionSpan()).assertPropertyExistence(
+                exist = listOf("perm", "perm2", "perm3")
+            )
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryService.kt
@@ -61,30 +61,30 @@ open class FakeDeliveryService : DeliveryService {
         lastSavedLogPayloads.add(logEnvelope)
     }
 
-    fun getSentSessions(): List<Envelope<SessionPayload>> {
-        return sentSessionEnvelopes.filter { it.first.findAppState() == ApplicationState.FOREGROUND }.map { it.first }
-    }
+    fun getSentSessions(): List<Envelope<SessionPayload>> =
+        sentSessionEnvelopes.filterSessionEnvelopes(appState = ApplicationState.FOREGROUND)
 
-    fun getSentBackgroundActivities(): List<Envelope<SessionPayload>> {
-        return sentSessionEnvelopes.filter { it.first.findAppState() == ApplicationState.BACKGROUND }.map { it.first }
-    }
+    fun getSentBackgroundActivities(): List<Envelope<SessionPayload>> =
+        sentSessionEnvelopes.filterSessionEnvelopes(appState = ApplicationState.BACKGROUND)
 
-    fun getSavedBackgroundActivities(): List<Envelope<SessionPayload>> {
-        return savedSessionEnvelopes.filter { it.first.findAppState() == ApplicationState.BACKGROUND }.map { it.first }
-    }
+    fun getSavedSessions(): List<Envelope<SessionPayload>> =
+        savedSessionEnvelopes.filterSessionEnvelopes(appState = ApplicationState.FOREGROUND)
 
-    private fun Envelope<SessionPayload>.findAppState(): ApplicationState {
-        val value = findSessionSpan().attributes?.findAttributeValue(embState.name)?.uppercase(Locale.ENGLISH)
-        return ApplicationState.valueOf(checkNotNull(value))
-    }
+    fun getSavedBackgroundActivities(): List<Envelope<SessionPayload>> =
+        savedSessionEnvelopes.filterSessionEnvelopes(appState = ApplicationState.BACKGROUND)
 
     fun getLastSentSession(): Envelope<SessionPayload>? {
         return getSentSessions().lastOrNull()
     }
 
-    fun getLastSavedSession(): Envelope<SessionPayload>? {
-        return savedSessionEnvelopes.map { it.first }.lastOrNull {
-            it.findAppState() == ApplicationState.FOREGROUND
-        }
+    private fun Queue<Pair<Envelope<SessionPayload>, SessionSnapshotType>>.filterSessionEnvelopes(
+        appState: ApplicationState
+    ): List<Envelope<SessionPayload>> {
+        return filter { it.first.findAppState() == appState }.map { it.first }
+    }
+
+    private fun Envelope<SessionPayload>.findAppState(): ApplicationState {
+        val value = findSessionSpan().attributes?.findAttributeValue(embState.name)?.uppercase(Locale.ENGLISH)
+        return ApplicationState.valueOf(checkNotNull(value))
     }
 }


### PR DESCRIPTION
## Goal

Getting the last saved session was flakey in the same way getting the last saved background activity was flakey. Fixed this by just not checking that, but instead checking when the session is done, which is not flakey because that save happens on the main test thread.

At the same time, I made the non-flakey saved envelope payload validation function generic and usable for sessions, if we ever need it
