### PR TITLE
Make delivery services optional

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -112,6 +112,13 @@ interface ConfigService {
     val appId: String?
 
     /**
+     * Whether only OTel exporters should be used. If this returns true,
+     * the SDK should avoid enabling unnecessary systems (such as anything that creates requests
+     * to Embrace).
+     */
+    fun isOnlyUsingOtelExporters(): Boolean
+
+    /**
      * Adds a listener for changes to the [RemoteConfig]. The listeners will be notified when the
      * [ConfigService] refreshes its configuration.
      *

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -166,6 +166,8 @@ internal class EmbraceConfigService(
 
     override val appId: String? = resolveAppId(customAppId, openTelemetryCfg)
 
+    override fun isOnlyUsingOtelExporters(): Boolean = appId.isNullOrEmpty()
+
     /**
      * Loads the build information from resources provided by the config file packaged within the application by Gradle at
      * build-time.

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -97,6 +97,7 @@ internal class EmbraceConfigServiceTest {
         } returns fakeCachedConfig
         worker = fakeBackgroundWorker()
         service = createService(worker = worker, action = {})
+        assertFalse(service.isOnlyUsingOtelExporters())
     }
 
     /**
@@ -312,8 +313,9 @@ internal class EmbraceConfigServiceTest {
             SystemInfo()
         )
         cfg.addLogExporter(FakeLogRecordExporter())
-        val service = createService(worker = worker, appId = "abcdefoi", config = cfg)
+        val service = createService(worker = worker, appId = "", config = cfg)
         assertNotNull(service)
+        assertTrue(service.isOnlyUsingOtelExporters())
     }
 
     /**

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2.kt
@@ -8,11 +8,14 @@ import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServ
 
 /**
  * Contains dependencies that are required for delivering code to Embrace servers.
+ *
+ * Types are nullable because folks who are only exporting via OTel exporters do not need this
+ * functionality.
  */
 interface DeliveryModule2 {
-    val intakeService: IntakeService
-    val payloadResurrectionService: PayloadResurrectionService
-    val payloadCachingService: PayloadCachingService
-    val requestExecutionService: RequestExecutionService
-    val schedulingService: SchedulingService
+    val intakeService: IntakeService?
+    val payloadResurrectionService: PayloadResurrectionService?
+    val payloadCachingService: PayloadCachingService?
+    val requestExecutionService: RequestExecutionService?
+    val schedulingService: SchedulingService?
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
@@ -11,25 +11,42 @@ import io.embrace.android.embracesdk.internal.delivery.resurrection.PayloadResur
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServiceImpl
 
-internal class DeliveryModule2Impl : DeliveryModule2 {
+internal class DeliveryModule2Impl(
+    configModule: ConfigModule
+) : DeliveryModule2 {
 
-    override val intakeService: IntakeService by singleton {
-        IntakeServiceImpl(schedulingService)
+    override val intakeService: IntakeService? by singleton {
+        if (configModule.configService.isOnlyUsingOtelExporters()) {
+            return@singleton null
+        }
+        IntakeServiceImpl(checkNotNull(schedulingService))
     }
 
-    override val payloadResurrectionService: PayloadResurrectionService by singleton {
-        PayloadResurrectionServiceImpl(intakeService)
+    override val payloadResurrectionService: PayloadResurrectionService? by singleton {
+        if (configModule.configService.isOnlyUsingOtelExporters()) {
+            return@singleton null
+        }
+        PayloadResurrectionServiceImpl(checkNotNull(intakeService))
     }
 
-    override val payloadCachingService: PayloadCachingService by singleton {
+    override val payloadCachingService: PayloadCachingService? by singleton {
+        if (configModule.configService.isOnlyUsingOtelExporters()) {
+            return@singleton null
+        }
         PayloadCachingServiceImpl()
     }
 
-    override val requestExecutionService: RequestExecutionService by singleton {
+    override val requestExecutionService: RequestExecutionService? by singleton {
+        if (configModule.configService.isOnlyUsingOtelExporters()) {
+            return@singleton null
+        }
         RequestExecutionServiceImpl()
     }
 
-    override val schedulingService: SchedulingService by singleton {
-        SchedulingServiceImpl(requestExecutionService)
+    override val schedulingService: SchedulingService? by singleton {
+        if (configModule.configService.isOnlyUsingOtelExporters()) {
+            return@singleton null
+        }
+        SchedulingServiceImpl(checkNotNull(requestExecutionService))
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
@@ -4,6 +4,8 @@ package io.embrace.android.embracesdk.internal.injection
  * Function that returns an instance of [DeliveryModule2]. Matches the signature of the constructor
  * for [DeliveryModule2Impl]
  */
-typealias DeliveryModule2Supplier = () -> DeliveryModule2
+typealias DeliveryModule2Supplier = (configModule: ConfigModule) -> DeliveryModule2
 
-fun createDeliveryModule2(): DeliveryModule2 = DeliveryModule2Impl()
+fun createDeliveryModule2(
+    configModule: ConfigModule
+): DeliveryModule2 = DeliveryModule2Impl(configModule)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
@@ -1,18 +1,37 @@
 package io.embrace.android.embracesdk.internal.delivery
 
+import io.embrace.android.embracesdk.fakes.FakeConfigModule
+import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.internal.injection.DeliveryModule2Impl
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class DeliveryModule2ImplTest {
 
     @Test
     fun testModule() {
-        val module = DeliveryModule2Impl()
+        val module = DeliveryModule2Impl(
+            FakeConfigModule()
+        )
         assertNotNull(module)
         assertNotNull(module.intakeService)
         assertNotNull(module.payloadCachingService)
         assertNotNull(module.payloadResurrectionService)
         assertNotNull(module.requestExecutionService)
+        assertNotNull(module.schedulingService)
+    }
+
+    @Test
+    fun `test otel export only`() {
+        val module = DeliveryModule2Impl(
+            FakeConfigModule(configService = FakeConfigService(onlyUsingOtelExporters = true))
+        )
+        assertNotNull(module)
+        assertNull(module.intakeService)
+        assertNull(module.payloadCachingService)
+        assertNull(module.payloadResurrectionService)
+        assertNull(module.requestExecutionService)
+        assertNull(module.schedulingService)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -216,7 +216,7 @@ internal class ModuleInitBootstrapper(
                     }
 
                     deliveryModule2 = init(DeliveryModule2::class) {
-                        deliveryModule2Supplier()
+                        deliveryModule2Supplier(configModule)
                     }
 
                     anrModule = init(AnrModule::class) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -29,6 +29,7 @@ class FakeConfigService(
     override var appId: String = "abcde",
     var sdkDisabled: Boolean = false,
     var backgroundActivityCaptureEnabled: Boolean = false,
+    var onlyUsingOtelExporters: Boolean = false,
     private var hasValidRemoteConfig: Boolean = false,
     override var backgroundActivityBehavior: BackgroundActivityBehavior = createBackgroundActivityBehavior(),
     override var autoDataCaptureBehavior: AutoDataCaptureBehavior = createAutoDataCaptureBehavior(),
@@ -60,6 +61,7 @@ class FakeConfigService(
 
     override fun hasValidRemoteConfig(): Boolean = hasValidRemoteConfig
     override fun isAppExitInfoCaptureEnabled(): Boolean = appExitInfoBehavior.isAeiCaptureEnabled()
+    override fun isOnlyUsingOtelExporters(): Boolean = onlyUsingOtelExporters
 
     fun updateListeners() {
         listeners.forEach {


### PR DESCRIPTION
## Goal

Makes the `DeliveryModule2` return null if the SDK is configured to only send data to OTel exporters. This avoids unnecessary work.

## Testing

Added unit test coverage.
