### PR TITLE
Initial implementation of intake service

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -2,23 +2,43 @@ package io.embrace.android.embracesdk.internal.delivery.intake
 
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import io.embrace.android.embracesdk.internal.telemetry.errors.InternalErrorService
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
-import io.embrace.android.embracesdk.internal.worker.TaskPriority
+import java.util.zip.GZIPOutputStream
 
-@Suppress("unused")
 internal class IntakeServiceImpl(
     private val schedulingService: SchedulingService,
+    private val payloadStorageService: PayloadStorageService,
+    private val internalErrorService: InternalErrorService,
     private val serializer: PlatformSerializer,
-    private val worker: PriorityWorker<TaskPriority>,
-    private val storageLimit: Int = 100,
+    private val worker: PriorityWorker<StoredTelemetryMetadata>,
+    @Suppress("unused") private val storageLimit: Int = 100,
     private val shutdownTimeoutMs: Long = 3000
 ) : IntakeService {
 
     override fun handleCrash(crashId: String) {
+        worker.shutdownAndWait(shutdownTimeoutMs)
     }
 
     override fun take(intake: Envelope<*>, metadata: StoredTelemetryMetadata) {
+        worker.submit(metadata) {
+            processIntake(intake, metadata)
+        }
+    }
+
+    private fun processIntake(intake: Envelope<*>, metadata: StoredTelemetryMetadata) {
+        try {
+            payloadStorageService.store(metadata.filename) { outputStream ->
+                GZIPOutputStream(outputStream).use { gzipStream ->
+                    serializer.toJson(intake, metadata.envelopeType.serializedType, gzipStream)
+                }
+            }
+            schedulingService.onPayloadIntake()
+        } catch (exc: Throwable) {
+            internalErrorService.handleInternalError(exc)
+        }
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.internal.delivery.storage
+
+import io.embrace.android.embracesdk.internal.injection.SerializationAction
+
+/**
+ * Stores a completed payload to disk.
+ */
+interface PayloadStorageService {
+
+    /**
+     * Stores a payload
+     */
+    fun store(filename: String, action: SerializationAction)
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.internal.delivery.storage
+
+import io.embrace.android.embracesdk.internal.comms.delivery.CacheService
+import io.embrace.android.embracesdk.internal.injection.SerializationAction
+
+internal class PayloadStorageServiceImpl(
+    private val cacheService: CacheService
+) : PayloadStorageService {
+
+    override fun store(filename: String, action: SerializationAction) {
+        cacheService.cachePayload(filename, action)
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutio
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 import io.embrace.android.embracesdk.internal.delivery.resurrection.PayloadResurrectionService
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 
 /**
  * Contains dependencies that are required for delivering code to Embrace servers.
@@ -16,6 +17,7 @@ interface DeliveryModule2 {
     val intakeService: IntakeService?
     val payloadResurrectionService: PayloadResurrectionService?
     val payloadCachingService: PayloadCachingService?
+    val payloadStorageService: PayloadStorageService?
     val requestExecutionService: RequestExecutionService?
     val schedulingService: SchedulingService?
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
@@ -7,15 +7,18 @@ package io.embrace.android.embracesdk.internal.injection
 typealias DeliveryModule2Supplier = (
     configModule: ConfigModule,
     initModule: InitModule,
-    workerThreadModule: WorkerThreadModule
+    workerThreadModule: WorkerThreadModule,
+    storageModule: StorageModule
 ) -> DeliveryModule2
 
 fun createDeliveryModule2(
     configModule: ConfigModule,
     initModule: InitModule,
-    workerThreadModule: WorkerThreadModule
+    workerThreadModule: WorkerThreadModule,
+    storageModule: StorageModule
 ): DeliveryModule2 = DeliveryModule2Impl(
     configModule,
     initModule,
-    workerThreadModule
+    workerThreadModule,
+    storageModule
 )

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
@@ -3,24 +3,37 @@ package io.embrace.android.embracesdk.internal.delivery
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
+import io.embrace.android.embracesdk.internal.injection.DeliveryModule2
 import io.embrace.android.embracesdk.internal.injection.DeliveryModule2Impl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 
 class DeliveryModule2ImplTest {
 
+    private lateinit var module: DeliveryModule2
+    private lateinit var configService: FakeConfigService
+
+    @Before
+    fun setUp() {
+        configService = FakeConfigService()
+        module = DeliveryModule2Impl(
+            FakeConfigModule(configService),
+            FakeInitModule(),
+            FakeWorkerThreadModule(),
+            FakeStorageModule()
+        )
+    }
+
     @Test
     fun testModule() {
-        val module = DeliveryModule2Impl(
-            FakeConfigModule(),
-            FakeInitModule(),
-            FakeWorkerThreadModule()
-        )
         assertNotNull(module)
         assertNotNull(module.intakeService)
         assertNotNull(module.payloadCachingService)
+        assertNotNull(module.payloadStorageService)
         assertNotNull(module.payloadResurrectionService)
         assertNotNull(module.requestExecutionService)
         assertNotNull(module.schedulingService)
@@ -28,14 +41,11 @@ class DeliveryModule2ImplTest {
 
     @Test
     fun `test otel export only`() {
-        val module = DeliveryModule2Impl(
-            FakeConfigModule(configService = FakeConfigService(onlyUsingOtelExporters = true)),
-            FakeInitModule(),
-            FakeWorkerThreadModule()
-        )
+        configService.onlyUsingOtelExporters = true
         assertNotNull(module)
         assertNull(module.intakeService)
         assertNull(module.payloadCachingService)
+        assertNull(module.payloadStorageService)
         assertNull(module.payloadResurrectionService)
         assertNull(module.requestExecutionService)
         assertNull(module.schedulingService)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -1,0 +1,201 @@
+package io.embrace.android.embracesdk.internal.delivery.intake
+
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
+import io.embrace.android.embracesdk.fakes.FakeSchedulingService
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
+import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.Log
+import io.embrace.android.embracesdk.internal.payload.LogPayload
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.worker.PriorityRunnable
+import io.embrace.android.embracesdk.internal.worker.PriorityThreadPoolExecutor
+import io.embrace.android.embracesdk.internal.worker.PriorityWorker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+
+class IntakeServiceImplTest {
+
+    private lateinit var intakeService: IntakeService
+    private lateinit var payloadStorageService: FakePayloadStorageService
+    private lateinit var schedulingService: FakeSchedulingService
+    private lateinit var executorService: BlockableExecutorService
+    private lateinit var internalErrorService: FakeInternalErrorService
+
+    private val sessionEnvelope = Envelope(
+        data = SessionPayload(spans = listOf(Span(name = "session-span")))
+    )
+    private val logEnvelope = Envelope(
+        data = LogPayload(logs = listOf(Log(body = "Log data")))
+    )
+    private val sessionDataExpected = mapOf(
+        "data" to mapOf(
+            "spans" to listOf(mapOf("name" to "session-span"))
+        )
+    )
+    private val logDataExpected = mapOf(
+        "data" to mapOf(
+            "logs" to listOf(mapOf("body" to "Log data"))
+        )
+    )
+
+    private val clock = FakeClock()
+    private val sessionMetadata = StoredTelemetryMetadata.fromEnvelope(clock, SESSION)
+    private val logMetadata = StoredTelemetryMetadata.fromEnvelope(clock, LOG)
+    private val networkMetadata = StoredTelemetryMetadata.fromEnvelope(clock, NETWORK)
+    private val crashMetadata = StoredTelemetryMetadata.fromEnvelope(clock, CRASH)
+
+    @Before
+    fun setUp() {
+        internalErrorService = FakeInternalErrorService()
+        payloadStorageService = FakePayloadStorageService()
+        schedulingService = FakeSchedulingService()
+        executorService = BlockableExecutorService(blockingMode = true)
+        intakeService = IntakeServiceImpl(
+            schedulingService,
+            payloadStorageService,
+            internalErrorService,
+            TestPlatformSerializer(),
+            PriorityWorker(executorService)
+        )
+    }
+
+    @Test
+    fun `graceful shutdown on crash`() {
+        with(intakeService) {
+            take(sessionEnvelope, sessionMetadata)
+            take(logEnvelope, logMetadata)
+            handleCrash("crash-id")
+            try {
+                take(sessionEnvelope, sessionMetadata)
+            } catch (ignored: RejectedExecutionException) {
+                // this is an artefact of testing - WorkerThreadModule typically passes in an
+                // executor that has a custom rejection handler
+            }
+        }
+
+        assertEquals(2, payloadStorageService.storedObjects.size)
+        val sessionObj = payloadStorageService.storedObjects[0]
+        val logObj = payloadStorageService.storedObjects[1]
+        assertEquals(sessionDataExpected, sessionObj)
+        assertEquals(logDataExpected, logObj)
+
+        // assert scheduling service was notified
+        assertEquals(2, schedulingService.payloadIntakeCount)
+    }
+
+    @Test
+    fun `take log`() {
+        intakeService.take(logEnvelope, logMetadata)
+        executorService.runCurrentlyBlocked()
+
+        // assert filename is valid & contains correct metadata
+        val filename = payloadStorageService.storedFilenames.single()
+        val metadata = StoredTelemetryMetadata.fromFilename(filename).getOrThrow()
+        assertEquals(LOG, metadata.envelopeType)
+
+        // assert payload was stored
+        val obj = payloadStorageService.storedObjects.single()
+        assertEquals(logDataExpected, obj)
+
+        // assert scheduling service was notified
+        assertEquals(1, schedulingService.payloadIntakeCount)
+    }
+
+    @Test
+    fun `take session`() {
+        intakeService.take(sessionEnvelope, sessionMetadata)
+        executorService.runCurrentlyBlocked()
+
+        // assert filename is valid & contains correct metadata
+        val filename = payloadStorageService.storedFilenames.single()
+        val metadata = StoredTelemetryMetadata.fromFilename(filename).getOrThrow()
+        assertEquals(SESSION, metadata.envelopeType)
+
+        // assert payload was stored
+        val obj = payloadStorageService.storedObjects.single()
+        assertEquals(sessionDataExpected, obj)
+
+        // assert scheduling service was notified
+        assertEquals(1, schedulingService.payloadIntakeCount)
+    }
+
+    @Test
+    fun `exception in payload storage`() {
+        payloadStorageService.failStorage = true
+        intakeService.take(logEnvelope, logMetadata)
+        executorService.runCurrentlyBlocked()
+
+        // assert nothing was stored but no exception was thrown
+        assertTrue(payloadStorageService.storedObjects.isEmpty())
+        assertTrue(payloadStorageService.storedFilenames.isEmpty())
+        val exc = internalErrorService.throwables.single()
+        assertTrue(exc is IOException)
+    }
+
+    @Test
+    fun `priority ordering`() {
+        // construct priority executor & wait with latch until all tasks submitted
+        val executor = PriorityThreadPoolExecutor(
+            Executors.defaultThreadFactory(),
+            { _, _ -> },
+            1,
+            1,
+            storedTelemetryComparator
+        )
+        val latch = CountDownLatch(1)
+        executor.submit(
+            PriorityRunnable(sessionMetadata) {
+                latch.await(1000, TimeUnit.MILLISECONDS)
+            }
+        )
+        val worker = PriorityWorker<StoredTelemetryMetadata>(executor)
+        intakeService = IntakeServiceImpl(
+            schedulingService,
+            payloadStorageService,
+            internalErrorService,
+            TestPlatformSerializer(),
+            worker
+        )
+        with(intakeService) {
+            take(sessionEnvelope, sessionMetadata)
+            take(logEnvelope, crashMetadata)
+            take(logEnvelope, networkMetadata)
+            take(logEnvelope, logMetadata)
+            clock.tick(1000)
+            take(logEnvelope, logMetadata)
+            take(logEnvelope, networkMetadata)
+            take(logEnvelope, crashMetadata)
+            take(sessionEnvelope, sessionMetadata)
+
+            // stop blocking the executor
+            latch.countDown()
+        }
+        worker.shutdownAndWait(1000)
+        assertEquals(8, payloadStorageService.storedFilenames.size)
+
+        // assert payloads were prioritised in the expected order
+        val observedTypes = payloadStorageService.storedFilenames.map {
+            val metadata = StoredTelemetryMetadata.fromFilename(it).getOrThrow()
+            metadata.envelopeType
+        }
+        val expected = listOf(CRASH, CRASH, SESSION, SESSION, LOG, LOG, NETWORK, NETWORK)
+        assertEquals(expected, observedTypes)
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -216,7 +216,12 @@ internal class ModuleInitBootstrapper(
                     }
 
                     deliveryModule2 = init(DeliveryModule2::class) {
-                        deliveryModule2Supplier(configModule, initModule, workerThreadModule)
+                        deliveryModule2Supplier(
+                            configModule,
+                            initModule,
+                            workerThreadModule,
+                            storageModule
+                        )
                     }
 
                     anrModule = init(AnrModule::class) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -58,7 +58,7 @@ internal fun fakeModuleInitBootstrapper(
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
     crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _, _ -> FakeCrashModule() },
     payloadSourceModuleSupplier: PayloadSourceModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() },
-    fakeDeliveryModule2Supplier: DeliveryModule2Supplier = { _, _, _ -> FakeDeliveryModule2() },
+    fakeDeliveryModule2Supplier: DeliveryModule2Supplier = { _, _, _, _ -> FakeDeliveryModule2() },
 ) = ModuleInitBootstrapper(
     logger = fakeEmbLogger,
     initModule = fakeInitModule,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -1,0 +1,29 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
+import io.embrace.android.embracesdk.internal.injection.SerializationAction
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.util.zip.GZIPInputStream
+
+class FakePayloadStorageService : PayloadStorageService {
+
+    private val serializer = TestPlatformSerializer()
+
+    val storedFilenames: MutableList<String> = mutableListOf()
+    val storedObjects: MutableList<Any> = mutableListOf()
+    var failStorage: Boolean = false
+
+    override fun store(filename: String, action: SerializationAction) {
+        if (failStorage) {
+            throw IOException("Failed to store payload")
+        }
+        storedFilenames.add(filename)
+        val baos = ByteArrayOutputStream()
+        action(baos)
+        val bytes = baos.toByteArray()
+        val inputStream = GZIPInputStream(ByteArrayInputStream(bytes))
+        storedObjects.add(serializer.fromJson(inputStream, Map::class.java))
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeDeliveryModule2.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeDeliveryModule2.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes.injection
 import io.embrace.android.embracesdk.fakes.FakeIntakeService
 import io.embrace.android.embracesdk.fakes.FakePayloadCachingService
 import io.embrace.android.embracesdk.fakes.FakePayloadResurrectionService
+import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.fakes.FakeSchedulingService
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
@@ -10,12 +11,14 @@ import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutio
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 import io.embrace.android.embracesdk.internal.delivery.resurrection.PayloadResurrectionService
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.injection.DeliveryModule2
 
 class FakeDeliveryModule2(
     override val intakeService: IntakeService = FakeIntakeService(),
     override val payloadResurrectionService: PayloadResurrectionService = FakePayloadResurrectionService(),
     override val payloadCachingService: PayloadCachingService = FakePayloadCachingService(),
+    override val payloadStorageService: PayloadStorageService = FakePayloadStorageService(),
     override val requestExecutionService: RequestExecutionService = FakeRequestExecutionService(),
     override val schedulingService: SchedulingService = FakeSchedulingService(),
 ) : DeliveryModule2


### PR DESCRIPTION
## Goal

Creates an initial implementation of `IntakeService` which stores everything in the existing `CacheService`. This changeset attempts to fulfil the following requirements of `IntakeService`:

- On a crash the SDK will block until pending tasks have finished persisting data
- Crashes/sessions/logs/network capture are prioritised for persistence in order of importance
- Payloads are stored gzip compressed
- The scheduling service is notified after a payload is persisted
- An internal error is logged if persistence fails for whatever reason

I have not implemented cleanup if disk usage exceeds a maximum limit.

I've wrapped `CacheService` with a `PayloadStorageService` interface. My initial thought is that in future PRs we probably want to extract the functionality we want out of `CacheService`, but I'm open to discussion on that. IMO it would be good if `PayloadStorageService` also handled most of the file operations that will be triggered from `SchedulingService`, as that should simplify our synchronisation strategy.

The next task on my list is to figure out the file structure in which we want to store data on disk.

## Testing

Added unit tests to match these requirements. We will add higher level integration tests later on.
