### PR TITLE
Alter stored telemetry comparator

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityRunnableFuture.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityRunnableFuture.kt
@@ -6,7 +6,7 @@ import java.util.concurrent.RunnableFuture
  * An implementation of [RunnableFuture] that also contains priority information on how important
  * the task is.
  */
-internal class PriorityRunnableFuture<T>(
+class PriorityRunnableFuture<T>(
     val impl: RunnableFuture<T>,
     val priorityInfo: Any
 ) : RunnableFuture<T> by impl

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
@@ -25,7 +25,7 @@ internal val apiRequestComparator = Comparator { lhs: Runnable, rhs: Runnable ->
     }
 }
 
-private inline fun <reified T> extractPriorityFromRunnable(
+inline fun <reified T> extractPriorityFromRunnable(
     lhs: Runnable,
     rhs: Runnable
 ): Pair<T, T> {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery
 
+import io.embrace.android.embracesdk.internal.worker.comparator.extractPriorityFromRunnable
+
 /**
  * Compares [StoredTelemetryMetadata] in priority order. Our priority rules are:
  *
@@ -12,11 +14,9 @@ package io.embrace.android.embracesdk.internal.delivery
  * We considered the possibility of starvation & scoring payloads based on age, but we decided
  * that crashes/sessions are generally far more important so should always be delivered first.
  */
-internal object StoredTelemetryComparator : Comparator<StoredTelemetryMetadata> {
-
-    override fun compare(lhs: StoredTelemetryMetadata, rhs: StoredTelemetryMetadata): Int {
-        return compareBy(StoredTelemetryMetadata::envelopeType)
-            .thenBy(StoredTelemetryMetadata::timestamp)
-            .compare(lhs, rhs)
-    }
+internal val storedTelemetryComparator = Comparator { lhs: Runnable, rhs: Runnable ->
+    val (lhsPrio, rhsPrio) = extractPriorityFromRunnable<StoredTelemetryMetadata>(lhs, rhs)
+    return@Comparator compareBy(StoredTelemetryMetadata::envelopeType)
+        .thenBy(StoredTelemetryMetadata::timestamp)
+        .compare(lhsPrio, rhsPrio)
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
@@ -4,6 +4,8 @@ import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRA
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
+import io.embrace.android.embracesdk.internal.worker.PriorityRunnableFuture
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -19,7 +21,9 @@ class StoredTelemetryComparatorTest {
     @Test
     fun `sort values`() {
         val result = listOf(network, log, session2, crash, session3, session)
-            .sortedWith(StoredTelemetryComparator)
+            .map { PriorityRunnableFuture<StoredTelemetryMetadata>(mockk(relaxed = true), it) }
+            .sortedWith(storedTelemetryComparator)
+            .map { it.priorityInfo as StoredTelemetryMetadata }
             .map(StoredTelemetryMetadata::uuid)
         val expected = listOf(crash, session, session2, session3, log, network)
             .map(StoredTelemetryMetadata::uuid)


### PR DESCRIPTION
## Goal

Refactors the comparator that will be used to prioritise telemetry to match the pattern used in `taskPriorityComparator` and others.

