### PR TITLE
Add boilerplate for intake service

### DIFF
--- a/embrace-android-delivery/build.gradle.kts
+++ b/embrace-android-delivery/build.gradle.kts
@@ -13,4 +13,10 @@ apiValidation.validationDisabled = true
 dependencies {
     implementation(project(":embrace-android-payload"))
     implementation(project(":embrace-android-core"))
+    compileOnly(platform(libs.opentelemetry.bom))
+    compileOnly(libs.opentelemetry.api)
+    compileOnly(libs.opentelemetry.sdk)
+    testImplementation(platform(libs.opentelemetry.bom))
+    testImplementation(libs.opentelemetry.api)
+    testImplementation(libs.opentelemetry.sdk)
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -3,9 +3,17 @@ package io.embrace.android.embracesdk.internal.delivery.intake
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
 import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import io.embrace.android.embracesdk.internal.worker.PriorityWorker
+import io.embrace.android.embracesdk.internal.worker.TaskPriority
 
+@Suppress("unused")
 internal class IntakeServiceImpl(
-    @Suppress("unused") private val schedulingService: SchedulingService
+    private val schedulingService: SchedulingService,
+    private val serializer: PlatformSerializer,
+    private val worker: PriorityWorker<TaskPriority>,
+    private val storageLimit: Int = 100,
+    private val shutdownTimeoutMs: Long = 3000
 ) : IntakeService {
 
     override fun handleCrash(crashId: String) {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
@@ -10,16 +10,23 @@ import io.embrace.android.embracesdk.internal.delivery.resurrection.PayloadResur
 import io.embrace.android.embracesdk.internal.delivery.resurrection.PayloadResurrectionServiceImpl
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServiceImpl
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class DeliveryModule2Impl(
-    configModule: ConfigModule
+    configModule: ConfigModule,
+    initModule: InitModule,
+    workerThreadModule: WorkerThreadModule
 ) : DeliveryModule2 {
 
     override val intakeService: IntakeService? by singleton {
         if (configModule.configService.isOnlyUsingOtelExporters()) {
             return@singleton null
         }
-        IntakeServiceImpl(checkNotNull(schedulingService))
+        IntakeServiceImpl(
+            checkNotNull(schedulingService),
+            initModule.jsonSerializer,
+            workerThreadModule.priorityWorker(Worker.Priority.FileCacheWorker)
+        )
     }
 
     override val payloadResurrectionService: PayloadResurrectionService? by singleton {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
@@ -4,8 +4,18 @@ package io.embrace.android.embracesdk.internal.injection
  * Function that returns an instance of [DeliveryModule2]. Matches the signature of the constructor
  * for [DeliveryModule2Impl]
  */
-typealias DeliveryModule2Supplier = (configModule: ConfigModule) -> DeliveryModule2
+typealias DeliveryModule2Supplier = (
+    configModule: ConfigModule,
+    initModule: InitModule,
+    workerThreadModule: WorkerThreadModule
+) -> DeliveryModule2
 
 fun createDeliveryModule2(
-    configModule: ConfigModule
-): DeliveryModule2 = DeliveryModule2Impl(configModule)
+    configModule: ConfigModule,
+    initModule: InitModule,
+    workerThreadModule: WorkerThreadModule
+): DeliveryModule2 = DeliveryModule2Impl(
+    configModule,
+    initModule,
+    workerThreadModule
+)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.internal.delivery
 
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.DeliveryModule2Impl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -12,7 +14,9 @@ class DeliveryModule2ImplTest {
     @Test
     fun testModule() {
         val module = DeliveryModule2Impl(
-            FakeConfigModule()
+            FakeConfigModule(),
+            FakeInitModule(),
+            FakeWorkerThreadModule()
         )
         assertNotNull(module)
         assertNotNull(module.intakeService)
@@ -25,7 +29,9 @@ class DeliveryModule2ImplTest {
     @Test
     fun `test otel export only`() {
         val module = DeliveryModule2Impl(
-            FakeConfigModule(configService = FakeConfigService(onlyUsingOtelExporters = true))
+            FakeConfigModule(configService = FakeConfigService(onlyUsingOtelExporters = true)),
+            FakeInitModule(),
+            FakeWorkerThreadModule()
         )
         assertNotNull(module)
         assertNull(module.intakeService)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -216,7 +216,7 @@ internal class ModuleInitBootstrapper(
                     }
 
                     deliveryModule2 = init(DeliveryModule2::class) {
-                        deliveryModule2Supplier(configModule)
+                        deliveryModule2Supplier(configModule, initModule, workerThreadModule)
                     }
 
                     anrModule = init(AnrModule::class) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -58,7 +58,7 @@ internal fun fakeModuleInitBootstrapper(
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
     crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _, _ -> FakeCrashModule() },
     payloadSourceModuleSupplier: PayloadSourceModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() },
-    fakeDeliveryModule2Supplier: DeliveryModule2Supplier = { FakeDeliveryModule2() },
+    fakeDeliveryModule2Supplier: DeliveryModule2Supplier = { _, _, _ -> FakeDeliveryModule2() },
 ) = ModuleInitBootstrapper(
     logger = fakeEmbLogger,
     initModule = fakeInitModule,


### PR DESCRIPTION
## Goal

Adds the boilerplate of constructor parameters & dependency injection code that `IntakeService` will require. I've also added a dependency on OTel as it'll be necessary to access the `Clock` implementation.
