### PR TITLE
Avoid otel dep in delivery module

### DIFF
--- a/embrace-android-delivery/build.gradle.kts
+++ b/embrace-android-delivery/build.gradle.kts
@@ -13,10 +13,4 @@ apiValidation.validationDisabled = true
 dependencies {
     implementation(project(":embrace-android-payload"))
     implementation(project(":embrace-android-core"))
-    compileOnly(platform(libs.opentelemetry.bom))
-    compileOnly(libs.opentelemetry.api)
-    compileOnly(libs.opentelemetry.sdk)
-    testImplementation(platform(libs.opentelemetry.bom))
-    testImplementation(libs.opentelemetry.api)
-    testImplementation(libs.opentelemetry.sdk)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -24,7 +24,8 @@ class FakeInitModule(
         systemInfo = systemInfo
     )
 ) : InitModule by initModule {
-    val openTelemetryModule: OpenTelemetryModule = createOpenTelemetryModule(initModule)
+
+    val openTelemetryModule: OpenTelemetryModule by lazy { createOpenTelemetryModule(initModule) }
 
     fun getFakeClock(): FakeClock? = clock as? FakeClock
 }


### PR DESCRIPTION
## Goal

Avoids a runtime crash in our tests due to classloading issues. I've just delayed the classloading for the `openTelemetryModule` because we'll never use it from the delivery tests.