### PR TITLE
Genericize executor test helpers

### DIFF
--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/TestAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/TestAssertions.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.assertions
+
+import org.junit.Assert.assertEquals
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+fun CountDownLatch.assertCountedDown() {
+    await(1, TimeUnit.SECONDS)
+    assertEquals(0, count)
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import java.util.LinkedList
 import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Delayed
 import java.util.concurrent.Future
 import java.util.concurrent.FutureTask
@@ -97,6 +98,7 @@ class BlockingScheduledExecutorService(
     var submitCount: Int = 0
 
     override fun execute(command: Runnable?) {
+        submitCount++
         requireNotNull(command)
         delegateExecutorService.execute(command)
     }
@@ -199,6 +201,17 @@ class BlockingScheduledExecutorService(
         }
 
         return futureTask
+    }
+
+    /**
+     * Queue a task to run that returns a [CountDownLatch]
+     */
+    fun queueCompletionTask(): CountDownLatch {
+        val latch = CountDownLatch(1)
+        submit {
+            latch.countDown()
+        }
+        return latch
     }
 
     private fun <V> submitOrQueue(delay: Long, futureTask: BlockedFutureScheduledTask<V>) {


### PR DESCRIPTION
## Goal

Add helpers for testing work scheduled on a BlockingScheduledExecutorService that was previously private to a specific test classes. These will be used later to verify that all the tasks queued prior has been executed.

