### PR TITLE
Payload storage service implementation

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
@@ -14,9 +14,12 @@ import io.embrace.android.embracesdk.internal.worker.comparator.extractPriorityF
  * We considered the possibility of starvation & scoring payloads based on age, but we decided
  * that crashes/sessions are generally far more important so should always be delivered first.
  */
-internal val storedTelemetryComparator = Comparator { lhs: Runnable, rhs: Runnable ->
-    val (lhsPrio, rhsPrio) = extractPriorityFromRunnable<StoredTelemetryMetadata>(lhs, rhs)
-    return@Comparator compareBy<StoredTelemetryMetadata>(StoredTelemetryMetadata::envelopeType)
-        .thenBy<StoredTelemetryMetadata>(StoredTelemetryMetadata::timestamp)
-        .compare(lhsPrio, rhsPrio)
-}
+internal val storedTelemetryRunnableComparator =
+    Comparator<Runnable> { lhs: Runnable, rhs: Runnable ->
+        val (lhsPrio, rhsPrio) = extractPriorityFromRunnable<StoredTelemetryMetadata>(lhs, rhs)
+        return@Comparator storedTelemetryComparator.compare(lhsPrio, rhsPrio)
+    }
+
+internal val storedTelemetryComparator: java.util.Comparator<StoredTelemetryMetadata> =
+    compareBy(StoredTelemetryMetadata::envelopeType)
+        .thenBy(StoredTelemetryMetadata::timestamp)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
+import java.io.InputStream
 
 /**
  * Stores a completed payload to disk.
@@ -10,5 +12,15 @@ interface PayloadStorageService {
     /**
      * Stores a payload
      */
-    fun store(filename: String, action: SerializationAction)
+    fun store(metadata: StoredTelemetryMetadata, action: SerializationAction)
+
+    /**
+     * Deletes a payload
+     */
+    fun delete(metadata: StoredTelemetryMetadata)
+
+    /**
+     * Loads a payload as an [InputStream]
+     */
+    fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream?
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -1,13 +1,82 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
-import io.embrace.android.embracesdk.internal.comms.delivery.CacheService
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
+import io.embrace.android.embracesdk.internal.telemetry.errors.InternalErrorService
+import java.io.File
+import java.io.InputStream
+import java.util.zip.GZIPOutputStream
 
 internal class PayloadStorageServiceImpl(
-    private val cacheService: CacheService
+    private val internalErrorService: InternalErrorService,
+    outputDir: Lazy<File>,
+    private val storageLimit: Int = 500 // TODO: check limit
 ) : PayloadStorageService {
 
-    override fun store(filename: String, action: SerializationAction) {
-        cacheService.cachePayload(filename, action)
+    private val payloadDir by outputDir
+
+    // TODO: synchronisation
+
+    override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
+        try {
+            storeImpl(metadata, action)
+        } catch (exc: Throwable) {
+            internalErrorService.handleInternalError(exc)
+        }
+    }
+
+    private fun storeImpl(
+        metadata: StoredTelemetryMetadata,
+        action: SerializationAction
+    ) {
+        pruneIfNeeded()
+
+        // write to a temporary file then rename it, to avoid sending incomplete files
+        // to the backend (i.e. where the process terminates or there isn't any disk space).
+        val tmpFile = File.createTempFile(metadata.filename, ".tmp")
+        GZIPOutputStream(tmpFile.outputStream().buffered()).use { stream ->
+            action(stream)
+        }
+
+        // move the complete file to its final location.
+        metadata.asFile().parentFile?.mkdirs()
+        tmpFile.renameTo(metadata.asFile())
+    }
+
+    override fun delete(metadata: StoredTelemetryMetadata) {
+        try {
+            metadata.asFile().delete()
+        } catch (exc: Throwable) {
+            internalErrorService.handleInternalError(exc)
+        }
+    }
+
+    override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? {
+        return try {
+            metadata.asFile().inputStream().buffered()
+        } catch (exc: Throwable) {
+            internalErrorService.handleInternalError(exc)
+            null
+        }
+    }
+
+    private fun pruneIfNeeded() {
+        // TODO: future: avoid calling listFiles() every time by retaining an in-memory list
+        val files = payloadDir.listFiles() ?: return
+        val metadataList = files.mapNotNull {
+            StoredTelemetryMetadata.fromFilename(it.name).getOrNull()
+        }.sortedWith(storedTelemetryComparator)
+
+        if (metadataList.size >= storageLimit) {
+            val excess = metadataList.size - storageLimit + 1
+            metadataList.takeLast(excess).forEach { it.asFile().delete() }
+        }
+    }
+
+    private fun StoredTelemetryMetadata.asFile(): File = File(payloadDir, filename)
+
+    companion object {
+        internal const val OUTPUT_DIR_NAME = "embrace_payloads"
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
@@ -12,13 +12,15 @@ import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServ
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServiceImpl
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageServiceImpl
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageServiceImpl.Companion.OUTPUT_DIR_NAME
 import io.embrace.android.embracesdk.internal.worker.Worker
+import java.io.File
 
 internal class DeliveryModule2Impl(
     configModule: ConfigModule,
     initModule: InitModule,
     workerThreadModule: WorkerThreadModule,
-    storageModule: StorageModule
+    coreModule: CoreModule
 ) : DeliveryModule2 {
 
     override val intakeService: IntakeService? by singleton {
@@ -52,7 +54,10 @@ internal class DeliveryModule2Impl(
         if (configModule.configService.isOnlyUsingOtelExporters()) {
             return@singleton null
         }
-        PayloadStorageServiceImpl(storageModule.cacheService)
+        PayloadStorageServiceImpl(
+            initModule.internalErrorService,
+            lazy { File(coreModule.context.filesDir, OUTPUT_DIR_NAME) }
+        )
     }
 
     override val requestExecutionService: RequestExecutionService? by singleton {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2ImplSupplier.kt
@@ -8,17 +8,17 @@ typealias DeliveryModule2Supplier = (
     configModule: ConfigModule,
     initModule: InitModule,
     workerThreadModule: WorkerThreadModule,
-    storageModule: StorageModule
+    coreModule: CoreModule
 ) -> DeliveryModule2
 
 fun createDeliveryModule2(
     configModule: ConfigModule,
     initModule: InitModule,
     workerThreadModule: WorkerThreadModule,
-    storageModule: StorageModule
+    coreModule: CoreModule
 ): DeliveryModule2 = DeliveryModule2Impl(
     configModule,
     initModule,
     workerThreadModule,
-    storageModule
+    coreModule
 )

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/DeliveryModule2ImplTest.kt
@@ -1,17 +1,22 @@
 package io.embrace.android.embracesdk.internal.delivery
 
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
+import io.embrace.android.embracesdk.internal.injection.CoreModuleImpl
 import io.embrace.android.embracesdk.internal.injection.DeliveryModule2
 import io.embrace.android.embracesdk.internal.injection.DeliveryModule2Impl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class DeliveryModule2ImplTest {
 
     private lateinit var module: DeliveryModule2
@@ -24,7 +29,7 @@ class DeliveryModule2ImplTest {
             FakeConfigModule(configService),
             FakeInitModule(),
             FakeWorkerThreadModule(),
-            FakeStorageModule()
+            CoreModuleImpl(ApplicationProvider.getApplicationContext(), FakeEmbLogger())
         )
     }
 

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
@@ -22,7 +22,7 @@ class StoredTelemetryComparatorTest {
     fun `sort values`() {
         val result = listOf(network, log, session2, crash, session3, session)
             .map { PriorityRunnableFuture<StoredTelemetryMetadata>(mockk(relaxed = true), it) }
-            .sortedWith(storedTelemetryComparator)
+            .sortedWith(storedTelemetryRunnableComparator)
             .map { it.priorityInfo as StoredTelemetryMetadata }
             .map(StoredTelemetryMetadata::uuid)
         val expected = listOf(crash, session, session2, session3, log, network)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRA
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
-import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
+import io.embrace.android.embracesdk.internal.delivery.storedTelemetryRunnableComparator
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
@@ -157,7 +157,7 @@ class IntakeServiceImplTest {
             { _, _ -> },
             1,
             1,
-            storedTelemetryComparator
+            storedTelemetryRunnableComparator
         )
         val latch = CountDownLatch(1)
         executor.submit(

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -1,0 +1,116 @@
+package io.embrace.android.embracesdk.internal.delivery.storage
+
+import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
+import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.GZIPInputStream
+
+class PayloadStorageServiceImplTest {
+
+    companion object {
+        private const val TIMESTAMP = 1500000000L
+        private const val UUID = "uuid"
+    }
+
+    private val metadata = StoredTelemetryMetadata(TIMESTAMP, UUID, SESSION)
+    private lateinit var service: PayloadStorageService
+    private lateinit var internalErrorService: FakeInternalErrorService
+    private lateinit var outputDir: File
+
+    @Before
+    fun setUp() {
+        internalErrorService = FakeInternalErrorService()
+        outputDir = Files.createTempDirectory("output").toFile()
+        outputDir.deleteRecursively()
+        service = PayloadStorageServiceImpl(internalErrorService, lazy { outputDir })
+    }
+
+    @Test
+    fun `test store and load object`() {
+        val fileContents = "test"
+
+        // store file
+        service.store(metadata) {
+            it.write(fileContents.toByteArray())
+        }
+        val files = outputDir.listFiles()
+        val file = files?.single() ?: error("File not found")
+        assertEquals(fileContents, GZIPInputStream(file.inputStream()).bufferedReader().readText())
+
+        // read file
+        val observed =
+            GZIPInputStream(service.loadPayloadAsStream(metadata)).bufferedReader().readText()
+        assertEquals(fileContents, observed)
+
+        // delete file
+        service.delete(metadata)
+        assertEquals(0, outputDir.listFiles()?.size)
+        assertNull(service.loadPayloadAsStream(metadata))
+    }
+
+    @Test
+    fun `delete non existent file`() {
+        service.delete(metadata) // no exception thrown
+        assertNull(outputDir.listFiles())
+    }
+
+    @Test
+    fun `load non existent file`() {
+        assertNull(service.loadPayloadAsStream(metadata))
+        assertNotNull(internalErrorService.throwables.single())
+    }
+
+    @Test
+    fun `exception in serialization action when storing`() {
+        service.store(metadata) {
+            error("Whoops!")
+        }
+        assertNotNull(internalErrorService.throwables.single())
+    }
+
+    @Test
+    fun `test objects pruned past limit`() {
+        service = PayloadStorageServiceImpl(internalErrorService, lazy { outputDir }, 4)
+
+        // exceed storage limit
+        listOf(
+            Pair(0L, CRASH),
+            Pair(0L, SESSION),
+            Pair(0L, LOG),
+            Pair(0L, NETWORK),
+            Pair(1000L, CRASH),
+            Pair(1000L, SESSION),
+            Pair(1000L, LOG),
+            Pair(1000L, NETWORK)
+        ).forEach {
+            val metadata = StoredTelemetryMetadata(it.first, UUID, it.second)
+            service.store(metadata) {
+                it.write("test".toByteArray())
+            }
+        }
+
+        val files = outputDir.listFiles() ?: error("No files found")
+        val outputs = files.map { StoredTelemetryMetadata.fromFilename(it.name).getOrThrow() }
+            .sortedWith(storedTelemetryComparator)
+            .map { Pair(it.timestamp, it.envelopeType) }
+
+        val expected = listOf(
+            Pair(0L, CRASH),
+            Pair(1000L, CRASH),
+            Pair(0L, SESSION),
+            Pair(1000L, NETWORK)
+        )
+        assertEquals(expected, outputs)
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -220,7 +220,7 @@ internal class ModuleInitBootstrapper(
                             configModule,
                             initModule,
                             workerThreadModule,
-                            storageModule
+                            coreModule
                         )
                     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -1,11 +1,12 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
-import java.util.zip.GZIPInputStream
+import java.io.InputStream
 
 class FakePayloadStorageService : PayloadStorageService {
 
@@ -15,15 +16,22 @@ class FakePayloadStorageService : PayloadStorageService {
     val storedObjects: MutableList<Any> = mutableListOf()
     var failStorage: Boolean = false
 
-    override fun store(filename: String, action: SerializationAction) {
+    override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
         if (failStorage) {
             throw IOException("Failed to store payload")
         }
-        storedFilenames.add(filename)
+        storedFilenames.add(metadata.filename)
         val baos = ByteArrayOutputStream()
         action(baos)
         val bytes = baos.toByteArray()
-        val inputStream = GZIPInputStream(ByteArrayInputStream(bytes))
+        val inputStream = ByteArrayInputStream(bytes)
         storedObjects.add(serializer.fromJson(inputStream, Map::class.java))
+    }
+
+    override fun delete(metadata: StoredTelemetryMetadata) {
+    }
+
+    override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? {
+        return null
     }
 }


### PR DESCRIPTION
## Goal

Creates an initial implementation of `PayloadStorageService`. Ultimately this will fulfil a similar function that `CacheService` did in the old approach, except right now it only persists final payloads (and not cache attempts).

I added functions to store, delete, and load a payload. Payloads are stored using gzip compression & there is a total limit on the number of files stored on disk, after which less important payloads (assessed by type + age) are deleted.

I also altered the atomic file write logic somewhat compared to the `EmbraceCacheService` implementation as there isn't any possibility these files will be overwritten. 

## Discussion

1. If we detect an exception that indicates disk space has run out, should we attempt to delete old/less important payloads in favour of the new one?
2.  Is the storage limit sensible?
3. `pruneFilesIfNeeded` calls `listFiles()` every time - is it worth maintaining an in-memory list of files to avoid this?
4. How should we capture telemetry about files that are dropped in `pruneFilesIfNeeded`, if at all?
5. The `EmbraceCacheService` was falling back to the cache directory if the file directory wasn't writable. I haven't copied that logic here. Is that something that could bite us - i.e. should I include a fallback option in this PR?
6. I haven't implemented a synchronisation strategy yet - I can see value in synchronising `store()`, but I'm less certain it makes sense to add any synchronisation for other functions. These will be called from other threads that will have no way of knowing when a payload might be deleted (i.e. if the storage limit is reached)

## Testing

Added new unit tests.

