### PR TITLE
Tweak payload storage implementation

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -1,22 +1,37 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
+import android.content.Context
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import io.embrace.android.embracesdk.internal.telemetry.errors.InternalErrorService
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.InputStream
+import java.util.concurrent.ConcurrentSkipListSet
 import java.util.zip.GZIPOutputStream
 
 internal class PayloadStorageServiceImpl(
     private val internalErrorService: InternalErrorService,
     outputDir: Lazy<File>,
-    private val storageLimit: Int = 500 // TODO: check limit
+    private val storageLimit: Int = 500
 ) : PayloadStorageService {
 
-    private val payloadDir by outputDir
+    // maintain an in-memory list of payloads to avoid calling listFiles() every time we need
+    // to check the storage limit. This will always remain in sync with the actual files on disk
+    // as the files are only manipulated from within this class.
+    private val storedFiles: ConcurrentSkipListSet<StoredTelemetryMetadata> by lazy {
+        val result = runCatching { payloadDir.listFiles() }.getOrNull()
+        val files = result?.toList() ?: emptyList()
+        val metadata = files.mapNotNull {
+            StoredTelemetryMetadata.fromFilename(it.name).getOrNull()
+        }
+        ConcurrentSkipListSet(storedTelemetryComparator).apply<ConcurrentSkipListSet<StoredTelemetryMetadata>> {
+            addAll(metadata)
+        }
+    }
 
-    // TODO: synchronisation
+    private val payloadDir by outputDir
 
     override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
         try {
@@ -30,7 +45,9 @@ internal class PayloadStorageServiceImpl(
         metadata: StoredTelemetryMetadata,
         action: SerializationAction
     ) {
-        pruneIfNeeded()
+        if (pruneStorage(metadata)) {
+            return
+        }
 
         // write to a temporary file then rename it, to avoid sending incomplete files
         // to the backend (i.e. where the process terminates or there isn't any disk space).
@@ -41,14 +58,20 @@ internal class PayloadStorageServiceImpl(
 
         // move the complete file to its final location.
         metadata.asFile().parentFile?.mkdirs()
-        tmpFile.renameTo(metadata.asFile())
+        if (tmpFile.renameTo(metadata.asFile())) {
+            storedFiles.add(metadata)
+        }
     }
 
     override fun delete(metadata: StoredTelemetryMetadata) {
         try {
-            metadata.asFile().delete()
+            if (metadata.asFile().delete()) {
+                storedFiles.remove(metadata)
+            }
         } catch (exc: Throwable) {
-            internalErrorService.handleInternalError(exc)
+            if (exc !is FileNotFoundException) {
+                internalErrorService.handleInternalError(exc)
+            }
         }
     }
 
@@ -61,22 +84,42 @@ internal class PayloadStorageServiceImpl(
         }
     }
 
-    private fun pruneIfNeeded() {
-        // TODO: future: avoid calling listFiles() every time by retaining an in-memory list
-        val files = payloadDir.listFiles() ?: return
-        val metadataList = files.mapNotNull {
-            StoredTelemetryMetadata.fromFilename(it.name).getOrNull()
-        }.sortedWith(storedTelemetryComparator)
-
-        if (metadataList.size >= storageLimit) {
-            val excess = metadataList.size - storageLimit + 1
-            metadataList.takeLast(excess).forEach { it.asFile().delete() }
+    private fun pruneStorage(metadata: StoredTelemetryMetadata): Boolean {
+        val count = storedFiles.size
+        if (count < storageLimit) {
+            return false
         }
+        val input = storedFiles.plus(metadata)
+        val removalCount = input.size - storageLimit
+        if (removalCount < 0) {
+            return false
+        }
+        val removals = input
+            .sortedWith(storedTelemetryComparator)
+            .takeLast(removalCount)
+        removals.forEach(::delete)
+        internalErrorService.handleInternalError(RuntimeException("Pruned payload storage"))
+
+        // notify the caller whether the new payload should be dropped
+        val shouldNotPersist = removals.contains(metadata)
+        return shouldNotPersist
     }
 
     private fun StoredTelemetryMetadata.asFile(): File = File(payloadDir, filename)
 
     companion object {
-        internal const val OUTPUT_DIR_NAME = "embrace_payloads"
+        private const val OUTPUT_DIR_NAME = "embrace_payloads"
+
+        fun createOutputDir(
+            ctx: Context,
+            internalErrorService: InternalErrorService
+        ): Lazy<File> = lazy {
+            try {
+                File(ctx.filesDir, OUTPUT_DIR_NAME).apply(File::mkdirs)
+            } catch (exc: Throwable) {
+                internalErrorService.handleInternalError(exc)
+                ctx.cacheDir
+            }
+        }
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule2Impl.kt
@@ -12,9 +12,7 @@ import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServ
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServiceImpl
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageServiceImpl
-import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageServiceImpl.Companion.OUTPUT_DIR_NAME
 import io.embrace.android.embracesdk.internal.worker.Worker
-import java.io.File
 
 internal class DeliveryModule2Impl(
     configModule: ConfigModule,
@@ -54,9 +52,13 @@ internal class DeliveryModule2Impl(
         if (configModule.configService.isOnlyUsingOtelExporters()) {
             return@singleton null
         }
+        val internalErrorService = initModule.internalErrorService
         PayloadStorageServiceImpl(
-            initModule.internalErrorService,
-            lazy { File(coreModule.context.filesDir, OUTPUT_DIR_NAME) }
+            internalErrorService,
+            PayloadStorageServiceImpl.createOutputDir(
+                coreModule.context,
+                internalErrorService
+            )
         )
     }
 

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -81,6 +81,7 @@ class PayloadStorageServiceImplTest {
 
     @Test
     fun `test objects pruned past limit`() {
+        assertNull(outputDir.listFiles())
         service = PayloadStorageServiceImpl(internalErrorService, lazy { outputDir }, 4)
 
         // exceed storage limit
@@ -95,8 +96,8 @@ class PayloadStorageServiceImplTest {
             Pair(1000L, NETWORK)
         ).forEach {
             val metadata = StoredTelemetryMetadata(it.first, UUID, it.second)
-            service.store(metadata) {
-                it.write("test".toByteArray())
+            service.store(metadata) { stream ->
+                stream.write("test".toByteArray())
             }
         }
 
@@ -109,8 +110,10 @@ class PayloadStorageServiceImplTest {
             Pair(0L, CRASH),
             Pair(1000L, CRASH),
             Pair(0L, SESSION),
-            Pair(1000L, NETWORK)
+            Pair(1000L, SESSION)
         )
         assertEquals(expected, outputs)
+        val msg = internalErrorService.throwables.first().message
+        assertEquals("Pruned payload storage", msg)
     }
 }


### PR DESCRIPTION
## Goal

Makes some of the tweaks to the payload storage implementation that were discussed in #1427. Specifically:

- Create an in-memory list of files
- Fix prioritisation of stored telemetry deletion

## Testing

Mostly relied on existing unit tests.
