### PR TITLE
Add kill switch for v2 storage

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
@@ -56,4 +56,9 @@ interface AutoDataCaptureBehavior {
      * for apps with a lot of local files.
      */
     fun isDiskUsageCaptureEnabled(): Boolean
+
+    /**
+     * Gates whether the SDK should use the v2 storage implementation or the legacy one.
+     */
+    fun isV2StorageEnabled(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -44,4 +44,8 @@ class AutoDataCaptureBehaviorImpl(
 
     override fun isNativeCrashCaptureEnabled(): Boolean = cfg.isNativeCrashCaptureEnabled()
     override fun isDiskUsageCaptureEnabled(): Boolean = cfg.isDiskUsageCaptureEnabled()
+
+    // this should remain immutable across the process lifecycle
+    private val v2StorageImpl by lazy { remote?.killSwitchConfig?.v2Storage ?: false }
+    override fun isV2StorageEnabled(): Boolean = v2StorageImpl
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrches
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulatorImpl
+import io.embrace.android.embracesdk.internal.session.orchestrator.V1SessionPayloadStore
 import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class SessionOrchestrationModuleImpl(
@@ -102,7 +103,7 @@ internal class SessionOrchestrationModuleImpl(
             configModule.configService,
             essentialServiceModule.sessionIdTracker,
             boundaryDelegate,
-            deliveryModule.deliveryService,
+            V1SessionPayloadStore(deliveryModule.deliveryService),
             periodicSessionCacher,
             periodicBackgroundActivityCacher,
             dataSourceModule.dataCaptureOrchestrator,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPayloadStore.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+
+/**
+ * Interface that hides the details of how session payloads are stored to callers. This is
+ * a shim that hides whether v1 or v2 of the storage implementation is used. Once we delete
+ * v1, this interface can be deleted too.
+ */
+interface SessionPayloadStore {
+
+    /**
+     * Stores a final session payload that will have no further modifications
+     * (i.e. the session ended or crashed)
+     */
+    fun storeSessionPayload(envelope: Envelope<SessionPayload>, transitionType: TransitionType)
+
+    /**
+     * Stores a session snapshot that is likely to have further modifications.
+     */
+    fun cacheSessionSnapshot(envelope: Envelope<SessionPayload>)
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 
-internal enum class TransitionType {
+enum class TransitionType {
     INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH;
 
     fun endState(currentState: ProcessState): ProcessState = when (this) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1SessionPayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1SessionPayloadStore.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.JVM_CRASH
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.NORMAL_END
+
+internal class V1SessionPayloadStore(
+    private val deliveryService: DeliveryService
+) : SessionPayloadStore {
+
+    override fun storeSessionPayload(envelope: Envelope<SessionPayload>, transitionType: TransitionType) {
+        val type = when (transitionType) {
+            TransitionType.CRASH -> JVM_CRASH
+            else -> NORMAL_END
+        }
+        deliveryService.sendSession(envelope, type)
+    }
+
+    override fun cacheSessionSnapshot(envelope: Envelope<SessionPayload>) {
+        deliveryService.sendSession(envelope, SessionSnapshotType.PERIODIC_CACHE)
+    }
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -13,7 +13,8 @@ internal class AutoDataCaptureBehaviorImplTest {
     private val remote = RemoteConfig(
         killSwitchConfig = KillSwitchRemoteConfig(
             sigHandlerDetection = false,
-            jetpackCompose = false
+            jetpackCompose = false,
+            v2Storage = true
         ),
         dataConfig = DataRemoteConfig(pctThermalStatusEnabled = 0.0f)
     )
@@ -31,6 +32,8 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertFalse(isNativeCrashCaptureEnabled())
             assertTrue(isDiskUsageCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
+            assertTrue(isThermalStatusCaptureEnabled())
+            assertFalse(isV2StorageEnabled())
         }
     }
 
@@ -40,6 +43,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertFalse(is3rdPartySigHandlerDetectionEnabled())
             assertFalse(isComposeClickCaptureEnabled())
             assertFalse(isThermalStatusCaptureEnabled())
+            assertTrue(isV2StorageEnabled())
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -397,7 +397,7 @@ internal class SessionOrchestratorTest {
                 userService,
                 sessionPropertiesService
             ),
-            deliveryService,
+            V1SessionPayloadStore(deliveryService),
             periodicSessionCacher,
             periodicBackgroundActivityCacher,
             dataCaptureOrchestrator,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/KillSwitchRemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/KillSwitchRemoteConfig.kt
@@ -12,5 +12,8 @@ data class KillSwitchRemoteConfig(
     @Json(name = "sig_handler_detection")
     val sigHandlerDetection: Boolean? = null,
     @Json(name = "jetpack_compose")
-    val jetpackCompose: Boolean? = null
+    val jetpackCompose: Boolean? = null,
+
+    @Json(name = "v2_storage")
+    val v2Storage: Boolean? = null
 )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -12,7 +12,8 @@ class FakeAutoDataCaptureBehavior(
     private val composeOnClickEnabled: Boolean = true,
     private val sigHandlerDetectionEnabled: Boolean = true,
     private val ndkEnabled: Boolean = false,
-    private val diskUsageReportingEnabled: Boolean = true
+    private val diskUsageReportingEnabled: Boolean = true,
+    private val v2StorageEnabled: Boolean = false
 ) : AutoDataCaptureBehavior {
 
     override fun isMemoryWarningCaptureEnabled(): Boolean = memoryServiceEnabled
@@ -25,4 +26,5 @@ class FakeAutoDataCaptureBehavior(
     override fun is3rdPartySigHandlerDetectionEnabled(): Boolean = sigHandlerDetectionEnabled
     override fun isNativeCrashCaptureEnabled(): Boolean = ndkEnabled
     override fun isDiskUsageCaptureEnabled(): Boolean = diskUsageReportingEnabled
+    override fun isV2StorageEnabled(): Boolean = v2StorageEnabled
 }


### PR DESCRIPTION
## Goal

Adds a kill switch in remote config that can be used to disable the v2 storage system if so required.

