### PR TITLE
Only take snapshots of session spans if we are doing a periodic payload cache

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/BackgroundActivityTest.kt
@@ -3,8 +3,10 @@ package io.embrace.android.embracesdk.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.findSessionSpan
+import io.embrace.android.embracesdk.findSpanSnapshotsOfType
 import io.embrace.android.embracesdk.getSentBackgroundActivities
 import io.embrace.android.embracesdk.getSessionId
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
@@ -39,6 +41,7 @@ internal class BackgroundActivityTest {
             val first = bgActivities[0]
             val firstAttrs = checkNotNull(first.findSessionSpan().attributes)
             assertEquals("1", firstAttrs.findAttributeValue(embSessionNumber.name))
+            assertEquals(0, first.findSpanSnapshotsOfType(EmbType.Ux.Session).size)
 
             // verify second bg activity
             val second = bgActivities[1]

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SequentialSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/SequentialSessionTest.kt
@@ -3,9 +3,11 @@ package io.embrace.android.embracesdk.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.findSessionSpan
-import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.findSpanSnapshotsOfType
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.opentelemetry.embColdStart
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.recordSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -34,14 +36,17 @@ internal class SequentialSessionTest {
             val firstAttrs = checkNotNull(first.findSessionSpan().attributes)
             assertEquals("1", firstAttrs.findAttributeValue(embSessionNumber.name))
             assertTrue(firstAttrs.findAttributeValue(embColdStart.name).toBoolean())
+            assertEquals(0, first.findSpanSnapshotsOfType(EmbType.Ux.Session).size)
 
             val secondAttrs = checkNotNull(second.findSessionSpan().attributes)
             assertEquals("2", secondAttrs.findAttributeValue(embSessionNumber.name))
             assertFalse(secondAttrs.findAttributeValue(embColdStart.name).toBoolean())
+            assertEquals(0, second.findSpanSnapshotsOfType(EmbType.Ux.Session).size)
 
             val thirdAttrs = checkNotNull(third.findSessionSpan().attributes)
             assertEquals("3", thirdAttrs.findAttributeValue(embSessionNumber.name))
             assertFalse(thirdAttrs.findAttributeValue(embColdStart.name).toBoolean())
+            assertEquals(0, third.findSpanSnapshotsOfType(EmbType.Ux.Session).size)
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/session/StatefulSessionTest.kt
@@ -3,8 +3,10 @@ package io.embrace.android.embracesdk.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.findSessionSpan
+import io.embrace.android.embracesdk.findSpanSnapshotsOfType
 import io.embrace.android.embracesdk.getSentSessions
 import io.embrace.android.embracesdk.getSessionId
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.opentelemetry.embErrorLogCount
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionEndType
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartType
@@ -60,6 +62,7 @@ internal class StatefulSessionTest {
                 )
             )
             assertEquals("0", attrs.findAttributeValue(embErrorLogCount.name))
+            assertEquals(0, first.findSpanSnapshotsOfType(EmbType.Ux.Session).size)
 
             // verify second session
             val second = messages[1]

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
-import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
@@ -11,7 +10,6 @@ import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.getSentBackgroundActivities
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -259,17 +257,6 @@ internal class TracingApiTest {
                     )
                 ),
                 key = true
-            )
-
-            val sessionSpanSnapshot = checkNotNull(snapshots["emb-session"])
-            sessionSpanSnapshot.assertIsType(EmbType.Ux.Session)
-            assertEmbraceSpanData(
-                span = sessionSpanSnapshot,
-                expectedStartTimeMs = 169220160100,
-                expectedEndTimeMs = null,
-                expectedParentId = SpanId.getInvalid(),
-                expectedStatus = Span.Status.UNSET,
-                private = false
             )
         }
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -24,13 +24,14 @@ import kotlin.random.Random
 class FakeSpanData(
     private var name: String = "fake-started-span",
     private var kind: SpanKind = SpanKind.INTERNAL,
+    private var type: EmbType = EmbType.Performance.Default,
     private var spanContext: SpanContext = newTraceRootContext(),
     private var parentSpanContext: SpanContext = SpanContext.getInvalid(),
     private var startEpochNanos: Long = DEFAULT_START_TIME_MS.millisToNanos(),
     private var attributes: Attributes =
         Attributes.builder().fromMap(
             attributes = mapOf(
-                EmbType.Performance.Default.toEmbraceKeyValuePair(),
+                type.toEmbraceKeyValuePair(),
                 KeySpan.toEmbraceKeyValuePair(),
                 Pair("my-key", "my-value")
             ),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.session.message.FinalEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.InitialEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollator
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import java.util.concurrent.atomic.AtomicInteger
 
 class FakeV2PayloadCollator(
@@ -44,5 +45,10 @@ class FakeV2PayloadCollator(
      */
     override fun buildFinalEnvelope(
         params: FinalEnvelopeParams
-    ): Envelope<SessionPayload> = Envelope(data = SessionPayload())
+    ): Envelope<SessionPayload> {
+        if (params.endType != SessionSnapshotType.PERIODIC_CACHE) {
+            currentSessionSpan.endSession(startNewSession = params.startNewSession)
+        }
+        return Envelope(data = SessionPayload())
+    }
 }


### PR DESCRIPTION
## Goal

Only snapshot session span if we know the session isn't ending, i.e. we are only caching the payload

## Testing
Added unit and integration tests to verify this. Also fixed related tests that were wrongly validating data on the fake CurrentSessionSpan. This caused a domino of fixes that ultimately results in better validation overall.
