### PR TITLE
[POC} alternative syntax for integration tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -133,6 +133,16 @@ internal class IntegrationTestRule(
         Embrace.getImpl().stop()
     }
 
+    fun runTest(
+        setupAction: Harness.() -> Unit,
+        testCaseAction: Harness.() -> Unit,
+        assertAction: Harness.() -> Unit,
+    ) {
+        setupAction(harness)
+        testCaseAction(harness)
+        assertAction(harness)
+    }
+
     /**
      * Test harness for which an instance is generated each test run and provided to the test by the Rule
      */

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.IntegrationTestRule
 import io.embrace.android.embracesdk.fakes.FakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.findSpansOfType
-import io.embrace.android.embracesdk.getSentSessions
 import io.embrace.android.embracesdk.getSingleSession
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -27,27 +26,33 @@ internal class ActivityFeatureTest {
 
     @Test
     fun `automatically capture activities`() {
-        with(testRule) {
-            harness.overriddenConfigService.breadcrumbBehavior = FakeBreadcrumbBehavior(
-                automaticActivityCaptureEnabled = true
-            )
-            startSdk()
-            var startTimeMs: Long = 0
-            harness.recordSession(simulateActivityCreation = true) {
-                startTimeMs = harness.overriddenClock.now()
+        var startTimeMs: Long = 0
+
+        testRule.runTest(
+            setupAction = {
+                overriddenConfigService.breadcrumbBehavior = FakeBreadcrumbBehavior(
+                    automaticActivityCaptureEnabled = true
+                )
+            },
+            testCaseAction = {
+                recordSession(simulateActivityCreation = true) {
+                    startTimeMs = overriddenClock.now()
+                }
+            },
+            assertAction = {
+                val message = getSingleSession()
+                val viewSpans = message.findSpansOfType(EmbType.Ux.View)
+                assertEquals(1, viewSpans.size)
+
+                with(viewSpans[0]) {
+                    assertEquals(
+                        "android.app.Activity",
+                        attributes?.findAttributeValue("view.name")
+                    )
+                    assertEquals(startTimeMs, startTimeNanos?.nanosToMillis())
+                    assertEquals(startTimeMs + 30000L, endTimeNanos?.nanosToMillis())
+                }
             }
-            val message = harness.getSingleSession()
-
-            val viewSpans = message.findSpansOfType(EmbType.Ux.View)
-            assertEquals(1, viewSpans.size)
-
-            val span1 = viewSpans[0]
-
-            with(span1) {
-                assertEquals("android.app.Activity", attributes?.findAttributeValue("view.name"))
-                assertEquals(startTimeMs, startTimeNanos?.nanosToMillis())
-                assertEquals(startTimeMs + 30000L, endTimeNanos?.nanosToMillis())
-            }
-        }
+        )
     }
 }


### PR DESCRIPTION
## Goal

A proposal for an alternative syntax used for writing integration tests. This DSL allows 3 actions to be declared: for configuring the SDK, invoking a function on the SDK to trigger the behavior, and then asserting the results. I believe this offers a few benefits:

1. It will make longer test cases easier to read
2. When a test fails it should be more obvious at what stage of the test case it failed
3. The `Harness` & `Bootstrapper` class are directly used in lots of places where they don't need to be. This syntax opens up the door to reducing that
