### PR TITLE
Update integration tests to use payload store

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/IntegrationTestRule.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
+import io.embrace.android.embracesdk.fakes.FakePayloadStore
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
@@ -28,7 +29,6 @@ import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.createAndroidServicesModule
 import io.embrace.android.embracesdk.internal.injection.createWorkerThreadModule
-import io.embrace.android.embracesdk.internal.session.orchestrator.V1PayloadStore
 import io.embrace.android.embracesdk.internal.utils.Provider
 import org.junit.rules.ExternalResource
 
@@ -163,7 +163,7 @@ internal class IntegrationTestRule(
         val overriddenDeliveryModule: FakeDeliveryModule =
             FakeDeliveryModule(
                 deliveryService = deliveryService,
-                payloadStore = V1PayloadStore(deliveryService)
+                payloadStore = FakePayloadStore(deliveryService)
             ),
         val fakeAnrModule: AnrModule = FakeAnrModule(),
         val fakeNativeFeatureModule: FakeNativeFeatureModule = FakeNativeFeatureModule()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/assertions/InternalErrorAssertions.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.assertions
 
-import io.embrace.android.embracesdk.fakes.FakeDeliveryService
+import io.embrace.android.embracesdk.fakes.FakePayloadStore
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.opentelemetry.semconv.ExceptionAttributes
@@ -15,8 +15,8 @@ internal fun assertInternalErrorLogged(
     errorMessage: String
 ) {
     bootstrapper.logModule.logOrchestrator.flush(false)
-    val deliveryService = bootstrapper.deliveryModule.deliveryService as FakeDeliveryService
-    val logs = deliveryService.lastSentLogPayloads.mapNotNull { it.data.logs }
+    val payloadStore = bootstrapper.deliveryModule.payloadStore as FakePayloadStore
+    val logs = payloadStore.storedLogPayloads.mapNotNull { it.first.data.logs }
         .flatten()
         .filter { log ->
             log.attributes?.findAttributeValue("emb.type") == "sys.internal"

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -8,6 +8,8 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.findSessionSpan
 import io.embrace.android.embracesdk.findSpanSnapshotsOfType
+import io.embrace.android.embracesdk.getSentSessions
+import io.embrace.android.embracesdk.getSingleSession
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
 import io.embrace.android.embracesdk.recordSession
@@ -64,7 +66,7 @@ internal class PeriodicSessionCacheTest {
                 assertEquals("Test", nextSpan.getSessionProperty("Test"))
             }
 
-            val endMessage = checkNotNull(deliveryService.savedSessionEnvelopes.last().first)
+            val endMessage = harness.getSingleSession()
             val span = endMessage.findSessionSpan()
             val attrs = checkNotNull(span.attributes)
             assertEquals(true, attrs.findAttributeValue("emb.clean_exit").toBoolean())

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStore.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStore.kt
@@ -4,9 +4,12 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.orchestrator.PayloadStore
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.session.orchestrator.TransitionType
 
-class FakePayloadStore : PayloadStore {
+class FakePayloadStore(
+    private val deliveryService: FakeDeliveryService = FakeDeliveryService()
+) : PayloadStore {
 
     val storedSessionPayloads = mutableListOf<Pair<Envelope<SessionPayload>, TransitionType>>()
     val storedLogPayloads = mutableListOf<Pair<Envelope<LogPayload>, Boolean>>()
@@ -22,6 +25,7 @@ class FakePayloadStore : PayloadStore {
 
     override fun cacheSessionSnapshot(envelope: Envelope<SessionPayload>) {
         cachedSessionPayloads.add(envelope)
+        deliveryService.sendSession(envelope, SessionSnapshotType.PERIODIC_CACHE)
     }
 
     override fun storeLogPayload(envelope: Envelope<LogPayload>, attemptImmediateRequest: Boolean) {


### PR DESCRIPTION
## Goal

Updates the integration tests to grab the payload from the `PayloadStore` rather than the `DeliveryService` (where applicable). Ultimately the tests should grab the payloads from a fake `RequestExecutionService` but that's not in place just yet, so this will act as an initial refactor.

