### PR TITLE
Hookup v2 delivery layer to dependency injection

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
@@ -18,6 +19,7 @@ import io.embrace.android.embracesdk.internal.delivery.scheduling.NoopScheduling
 import io.embrace.android.embracesdk.internal.delivery.storage.NoopPayloadStorageService
 import io.embrace.android.embracesdk.internal.session.orchestrator.NoopPayloadStore
 import io.embrace.android.embracesdk.internal.session.orchestrator.V1PayloadStore
+import io.embrace.android.embracesdk.internal.session.orchestrator.V2PayloadStore
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -68,5 +70,12 @@ class DeliveryModuleImplTest {
         assertTrue(module.requestExecutionService is NoopRequestExecutionService)
         assertTrue(module.schedulingService is NoopSchedulingService)
         assertTrue(module.payloadStore is NoopPayloadStore)
+    }
+
+    @Test
+    fun testV2Store() {
+        configService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(v2StorageEnabled = true)
+        assertNotNull(module)
+        assertTrue(module.payloadStore is V2PayloadStore)
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
-internal class SchedulingServiceImpl(
+class SchedulingServiceImpl(
     private val storageService: PayloadStorageService,
     private val executionService: RequestExecutionService,
     private val schedulingWorker: BackgroundWorker,


### PR DESCRIPTION
## Goal

Hooks up the v2 delivery layer via the `SchedulingServiceImpl`, so that if the flag is flipped the functionality is enabled.

## Testing

Added unit tests.
