### PR TITLE
Restore session api assertions

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -5,10 +5,12 @@ import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.opentelemetry.embFreeDiskBytes
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
+import io.embrace.android.embracesdk.testframework.assertions.toMap
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -68,27 +70,34 @@ internal class SessionApiTest {
                 assertEquals(startTime, sessionSpan.startTimeNanos?.nanosToMillis())
                 assertNotNull(sessionSpan.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
 
-                sessionSpan.attributes?.assertMatches {
-                    "emb.cold_start" to true
-                    "emb.state" to "foreground"
-                    "emb.clean_exit" to true
-                    "emb.session_start_type" to "state"
-                    "emb.terminated" to false
-                    "emb.session_end_type" to "state"
-                    "emb.heartbeat_time_unix_nano" to startTime.millisToNanos()
-                    "emb.session_number" to 1
-                    "emb.type" to "ux.session"
-                    "emb.error_log_count" to 0
-                    "emb.usage.set_username" to 1
-                    "emb.usage.set_user_email" to 1
-                    "emb.usage.set_user_identifier" to 1
-                    "emb.private.sequence_id" to 4
-                }
                 val attrs = checkNotNull(sessionSpan.attributes)
                 val attributeKeys = attrs.map { it.key }
                 validateExistenceOnly.forEach { key ->
                     attributeKeys.contains(key)
                 }
+
+                val attributesToCheck = attrs.filterNot {
+                    ignoredAttributes.contains(it.key)
+                }.toMap().toSortedMap()
+
+                val expected = mapOf(
+                    "emb.cold_start" to "true",
+                    "emb.state" to "foreground",
+                    "emb.clean_exit" to "true",
+                    "emb.session_start_type" to "state",
+                    "emb.terminated" to "false",
+                    "emb.session_end_type" to "state",
+                    "emb.heartbeat_time_unix_nano" to "${startTime.millisToNanos()}",
+                    "emb.session_number" to "1",
+                    "emb.type" to "ux.session",
+                    "emb.error_log_count" to "0",
+                    "emb.usage.set_username" to "1",
+                    "emb.usage.set_user_email" to "1",
+                    "emb.usage.set_user_identifier" to "1",
+                    "emb.private.sequence_id" to "4"
+                ).toSortedMap()
+
+                assertEquals(expected, attributesToCheck)
             }
         )
     }
@@ -103,5 +112,10 @@ internal class SessionApiTest {
             "emb.is_emulator",
             "emb.okhttp3_on_classpath",
         )
+
+        // Attributes that are unstable that we should not try to verify
+        val ignoredAttributes = setOf(
+            embFreeDiskBytes.attributeKey.key
+        ).plus(validateExistenceOnly)
     }
 }


### PR DESCRIPTION
## Goal

Restores assertions in `SessionApiTest` that were altered in #1453.

