### PR TITLE
Use v2 delivery layer by default

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashTeardownHandler.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashTeardownHandler.kt
@@ -3,6 +3,6 @@ package io.embrace.android.embracesdk.internal.capture.crash
 /**
  * Interface for handling crash teardown.
  */
-interface CrashTeardownHandler {
+fun interface CrashTeardownHandler {
     fun handleCrash(crashId: String)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -46,6 +46,6 @@ class AutoDataCaptureBehaviorImpl(
     override fun isDiskUsageCaptureEnabled(): Boolean = cfg.isDiskUsageCaptureEnabled()
 
     // this should remain immutable across the process lifecycle
-    private val v2StorageImpl by lazy { remote?.killSwitchConfig?.v2Storage ?: false }
+    private val v2StorageImpl by lazy { remote?.killSwitchConfig?.v2Storage ?: true }
     override fun isV2StorageEnabled(): Boolean = v2StorageImpl
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -34,7 +34,7 @@ internal class DeliveryModuleImpl(
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
     requestExecutionServiceProvider: Provider<RequestExecutionService>,
-    deliverServiceProvider: () -> DeliveryService = {
+    deliveryServiceProvider: () -> DeliveryService = {
         if (configModule.configService.isOnlyUsingOtelExporters()) {
             NoopDeliveryService()
         } else {
@@ -62,7 +62,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val deliveryService: DeliveryService by singleton {
-        deliverServiceProvider()
+        deliveryServiceProvider()
     }
 
     override val intakeService: IntakeService by singleton {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -34,7 +34,7 @@ internal class DeliveryModuleImpl(
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
     requestExecutionServiceProvider: Provider<RequestExecutionService>,
-    deliveryServiceProvider: () -> DeliveryService = {
+    deliverServiceProvider: () -> DeliveryService = {
         if (configModule.configService.isOnlyUsingOtelExporters()) {
             NoopDeliveryService()
         } else {
@@ -62,7 +62,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val deliveryService: DeliveryService by singleton {
-        deliveryServiceProvider()
+        deliverServiceProvider()
     }
 
     override val intakeService: IntakeService by singleton {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
@@ -38,7 +38,6 @@ internal class LogOrchestratorImpl(
 
     override fun handleCrash(crashId: String) {
         flush(true)
-        payloadStore.onCrash()
     }
 
     override fun onLogsAdded() {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/NoopPayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/NoopPayloadStore.kt
@@ -18,6 +18,6 @@ internal class NoopPayloadStore : PayloadStore {
     override fun storeLogPayload(envelope: Envelope<LogPayload>, attemptImmediateRequest: Boolean) {
     }
 
-    override fun onCrash() {
+    override fun handleCrash(crashId: String) {
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStore.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.internal.capture.crash.CrashTeardownHandler
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -9,7 +10,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
  * a shim that hides whether v1 or v2 of the storage implementation is used. Once we delete
  * v1, this interface can be deleted too.
  */
-interface PayloadStore {
+interface PayloadStore : CrashTeardownHandler {
 
     /**
      * Stores a final session payload that will have no further modifications
@@ -32,5 +33,5 @@ interface PayloadStore {
      * crash have been added. The legacy implementation ignores this but the v2 implementation
      * relies on it.
      */
-    fun onCrash()
+    override fun handleCrash(crashId: String)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -250,9 +250,6 @@ internal class SessionOrchestratorImpl(
     private fun processEndMessage(envelope: Envelope<SessionPayload>?, transitionType: TransitionType) {
         envelope?.let {
             payloadStore.storeSessionPayload(envelope, transitionType)
-            if (transitionType == TransitionType.CRASH) {
-                payloadStore.onCrash()
-            }
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1PayloadStore.kt
@@ -31,7 +31,7 @@ class V1PayloadStore(
         deliveryService.sendSession(envelope, SessionSnapshotType.PERIODIC_CACHE)
     }
 
-    override fun onCrash() {
+    override fun handleCrash(crashId: String) {
         // ignored - v1 couples this concept to storage
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
@@ -33,7 +33,9 @@ internal class V2PayloadStore(
         intakeService.take(envelope, createMetadata(type))
     }
 
-    override fun onCrash() = intakeService.shutdown()
+    override fun handleCrash(crashId: String) {
+        intakeService.shutdown()
+    }
 
     /**
      * Constructs a [StoredTelemetryMetadata] object from the given [Envelope].

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.worker.TaskPriority
 /**
  * Prioritises based on [TaskPriority]
  */
-val taskPriorityComparator: java.util.Comparator<Runnable> = Comparator { lhs: Runnable, rhs: Runnable ->
+val taskPriorityComparator: Comparator<Runnable> = Comparator { lhs: Runnable, rhs: Runnable ->
     val (lhsPrio, rhsPrio) = extractPriorityFromRunnable<TaskPriority>(lhs, rhs)
     return@Comparator lhsPrio.compareTo(rhsPrio)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/comparator/PriorityTaskComparators.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.worker.TaskPriority
 /**
  * Prioritises based on [TaskPriority]
  */
-internal val taskPriorityComparator = Comparator { lhs: Runnable, rhs: Runnable ->
+val taskPriorityComparator: java.util.Comparator<Runnable> = Comparator { lhs: Runnable, rhs: Runnable ->
     val (lhsPrio, rhsPrio) = extractPriorityFromRunnable<TaskPriority>(lhs, rhs)
     return@Comparator lhsPrio.compareTo(rhsPrio)
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -33,7 +33,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertTrue(isDiskUsageCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
-            assertFalse(isV2StorageEnabled())
+            assertTrue(isV2StorageEnabled())
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.internal.delivery.resurrection.NoopPayloadR
 import io.embrace.android.embracesdk.internal.delivery.scheduling.NoopSchedulingService
 import io.embrace.android.embracesdk.internal.delivery.storage.NoopPayloadStorageService
 import io.embrace.android.embracesdk.internal.session.orchestrator.NoopPayloadStore
-import io.embrace.android.embracesdk.internal.session.orchestrator.V1PayloadStore
 import io.embrace.android.embracesdk.internal.session.orchestrator.V2PayloadStore
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -57,7 +56,7 @@ class DeliveryModuleImplTest {
         assertNotNull(module.payloadResurrectionService)
         assertNotNull(module.requestExecutionService)
         assertNotNull(module.schedulingService)
-        assertTrue(module.payloadStore is V1PayloadStore)
+        assertTrue(module.payloadStore is V2PayloadStore)
     }
 
     @Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -50,9 +50,8 @@ class V2PayloadStoreTest {
         assertEquals(0, intakeService.shutdownCount)
     }
 
-    @Test
     fun `test shutdown`() {
-        store.onCrash()
+        store.handleCrash("fakeCrashId")
         assertEquals(1, intakeService.shutdownCount)
     }
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
@@ -23,6 +23,7 @@ val storedTelemetryRunnableComparator =
 internal val storedTelemetryComparator: java.util.Comparator<StoredTelemetryMetadata> =
     compareBy(StoredTelemetryMetadata::envelopeType)
         .thenBy(StoredTelemetryMetadata::timestamp)
+        .thenBy(StoredTelemetryMetadata::uuid)
 
 inline fun <reified T> extractPriorityFromRunnable(
     lhs: Runnable,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
@@ -84,6 +84,17 @@ internal class CrashDataSourceImplTest {
     }
 
     @Test
+    fun `test crash handler order`() {
+        setupForHandleCrash()
+        val observedOrder = mutableListOf<Int>()
+        crashDataSource.addCrashTeardownHandler(lazy { CrashTeardownHandler { observedOrder.add(1) } })
+        crashDataSource.addCrashTeardownHandler(lazy { CrashTeardownHandler { observedOrder.add(2) } })
+        crashDataSource.addCrashTeardownHandler(lazy { CrashTeardownHandler { observedOrder.add(3) } })
+        crashDataSource.handleCrash(testException)
+        assertEquals(listOf(1, 2, 3), observedOrder)
+    }
+
+    @Test
     fun `test SessionOrchestrator and LogOrchestrator are called when handleCrash is called`() {
         setupForHandleCrash()
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -45,7 +45,7 @@ internal class JvmCrashFeatureTest {
             },
             assertAction = {
                 val session = getSingleSessionEnvelope()
-                getSingleLogEnvelope(false).getLastLog().assertCrash(
+                getSingleLogEnvelope().getLastLog().assertCrash(
                     state = "foreground",
                     crashId = session.getCrashedId()
                 )
@@ -61,7 +61,7 @@ internal class JvmCrashFeatureTest {
             },
             assertAction = {
                 val ba = getSingleSessionEnvelope(ApplicationState.BACKGROUND)
-                getSingleLogEnvelope(false).getLastLog().assertCrash(
+                getSingleLogEnvelope().getLastLog().assertCrash(
                     crashId = ba.getCrashedId()
                 )
             }
@@ -86,7 +86,7 @@ internal class JvmCrashFeatureTest {
                 }
             },
             assertAction = {
-                val log = getSingleLogEnvelope(false).getLastLog()
+                val log = getSingleLogEnvelope().getLastLog()
                 assertOtelLogReceived(
                     logReceived = log,
                     expectedMessage = "",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
@@ -16,7 +16,7 @@ internal class UserFeaturesTest {
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
+        EmbraceSetupInterface()
     }
 
     @Test
@@ -30,7 +30,6 @@ internal class UserFeaturesTest {
                 }
             },
             testCaseAction = {
-                startSdk()
                 recordSession()
                 recordSession {
                     embrace.clearUserIdentifier()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
+import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -16,7 +16,7 @@ internal class UserFeaturesTest {
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface()
+        EmbraceSetupInterface(startImmediately = false)
     }
 
     @Test
@@ -30,6 +30,7 @@ internal class UserFeaturesTest {
                 }
             },
             testCaseAction = {
+                startSdk()
                 recordSession()
                 recordSession {
                     embrace.clearUserIdentifier()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -55,7 +55,7 @@ internal class PeriodicSessionCacheTest {
                 }
             },
             assertAction = {
-                val envelopes = getCachedSessionEnvelopes(3)
+                val envelopes = getCachedSessionEnvelopes(2)
                 val endMessage = envelopes[0]
                 val span = endMessage.findSpanSnapshotOfType(EmbType.Ux.Session)
                 assertNull(span.getSessionProperty("Test"))

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -447,6 +447,7 @@ internal class ModuleInitBootstrapper(
                             addCrashTeardownHandler(lazy { anrModule.anrService })
                             addCrashTeardownHandler(lazy { logModule.logOrchestrator })
                             addCrashTeardownHandler(lazy { sessionOrchestrationModule.sessionOrchestrator })
+                            addCrashTeardownHandler(lazy { deliveryModule.payloadStore })
                         }
                     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/CountdownLatchAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/CountdownLatchAssertions.kt
@@ -17,7 +17,7 @@ fun CountDownLatch.assertCountedDown(waitTimeMs: Long = 1000L) {
  */
 inline fun <T, R> returnIfConditionMet(
     desiredValueSupplier: Provider<T>,
-    waitTimeMs: Int = 1000,
+    waitTimeMs: Int = 10000,
     checkIntervalMs: Int = 10,
     dataProvider: () -> R,
     condition: (R) -> Boolean,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStore.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStore.kt
@@ -32,7 +32,7 @@ class FakePayloadStore(
         storedLogPayloads.add(Pair(envelope, attemptImmediateRequest))
     }
 
-    override fun onCrash() {
+    override fun handleCrash(crashId: String) {
         crashCount++
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
@@ -12,7 +12,7 @@ import java.util.zip.GZIPInputStream
 class FakeRequestExecutionService : RequestExecutionService {
 
     private val serializer = TestPlatformSerializer()
-    var constantResponse: ApiResponse = ApiResponse.None
+    var constantResponse: ApiResponse = ApiResponse.Success(null, null)
     var responseAction: (intake: Envelope<*>) -> ApiResponse = { _ -> constantResponse }
     var exceptionOnExecution: Throwable? = null
     val attemptedHttpRequests = mutableListOf<Envelope<*>>()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -13,7 +13,7 @@ class FakeAutoDataCaptureBehavior(
     private val sigHandlerDetectionEnabled: Boolean = true,
     private val ndkEnabled: Boolean = false,
     private val diskUsageReportingEnabled: Boolean = true,
-    private val v2StorageEnabled: Boolean = false
+    private val v2StorageEnabled: Boolean = true
 ) : AutoDataCaptureBehavior {
 
     override fun isMemoryWarningCaptureEnabled(): Boolean = memoryServiceEnabled


### PR DESCRIPTION
## Goal

Updates the SDK to use the v2 delivery layer by default. This mostly involved flipping a switch & updating assertions in the integration tests.
