### PR TITLE
Create editorconfig file for formatting defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+insert_final_newline = true
+max_line_length = 120
+ij_continuation_indent_size = 4
+ij_visual_guides = 120
+
+[*.java]
+ij_java_class_count_to_use_import_on_demand = 99
+
+[{*.kt,*.kts}] 
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = false
+


### PR DESCRIPTION
## Goal

Codify our preferred code formatting default in an `.editorconfig` file for the SDK project so we don't have to manually apply it on IDE upgrades that don't simply take the previous version's settings.

