### PR TITLE
Add post-setup step to integration tests that allows for almost all tests to automatically start the SDK

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -19,10 +19,8 @@ import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import io.opentelemetry.semconv.HttpAttributes
-import java.net.SocketException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -32,6 +30,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.net.SocketException
 
 /**
  * Validation of the internal API
@@ -42,13 +41,12 @@ internal class EmbraceInternalInterfaceTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `no NPEs when SDK not started`() {
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 assertFalse(embrace.isStarted)
                 with(embrace.internalInterface) {
@@ -117,7 +115,6 @@ internal class EmbraceInternalInterfaceTest {
     fun `network recording methods work as expected`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     clock.tick()
                     configService.updateListeners()
@@ -172,7 +169,8 @@ internal class EmbraceInternalInterfaceTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 val spans = checkNotNull(session.data.spans)
-                val requests = checkNotNull(spans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key) != null })
+                val requests =
+                    checkNotNull(spans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key) != null })
                 assertEquals(
                     "Unexpected number of requests in sent session: ${requests.size}",
                     4,
@@ -190,7 +188,6 @@ internal class EmbraceInternalInterfaceTest {
 
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.internalInterface.logComposeTap(Pair(expectedX, expectedY), expectedElementName)
                 }
@@ -228,7 +225,6 @@ internal class EmbraceInternalInterfaceTest {
                     })
             },
             testCaseAction = {
-                startSdk()
                 recordSession {
                     assertTrue(embrace.internalInterface.shouldCaptureNetworkBody("capture.me", "GET"))
                     assertFalse(embrace.internalInterface.shouldCaptureNetworkBody("capture.me", "POST"))
@@ -243,7 +239,6 @@ internal class EmbraceInternalInterfaceTest {
     fun `set process as started by notification works as expected`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 embrace.internalInterface.setProcessStartedByNotification()
                 recordSession()
             },
@@ -258,7 +253,6 @@ internal class EmbraceInternalInterfaceTest {
     fun `test sdk time`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 assertEquals(clock.now(), embrace.internalInterface.getSdkCurrentTime())
                 clock.tick()
                 assertEquals(clock.now(), embrace.internalInterface.getSdkCurrentTime())
@@ -270,7 +264,6 @@ internal class EmbraceInternalInterfaceTest {
     fun `internal tracing APIs work as expected`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     with(embrace.internalInterface) {
                         val parentSpanId = checkNotNull(startSpan(name = "tz-parent-span"))
@@ -326,7 +319,6 @@ internal class EmbraceInternalInterfaceTest {
     fun `span logging across sessions`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 val internalInterface = checkNotNull(embrace.internalInterface)
                 var stoppedParentId = ""
                 var activeParentId = ""

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -46,7 +46,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `no NPEs when SDK not started`() {
         testRule.runTest(
-            startImmediately = false,
+            startSdk = false,
             testCaseAction = {
                 assertFalse(embrace.isStarted)
                 with(embrace.internalInterface) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -16,7 +16,7 @@ import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
-import io.embrace.android.embracesdk.testframework.actions.EmbracePostSetupInterface
+import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInterface
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -58,7 +58,7 @@ internal class ExternalTracerTest {
     @Test
     fun `check correctness of implementations used by Tracer`() {
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 setupExporter()
             },
             testCaseAction = {
@@ -90,7 +90,7 @@ internal class ExternalTracerTest {
         var parentContext: Context?
 
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 setupExporter()
             },
             testCaseAction = {
@@ -184,7 +184,7 @@ internal class ExternalTracerTest {
     @Test
     fun `opentelemetry instance can be used to log spans`() {
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 setupExporter()
             },
             testCaseAction = {
@@ -200,7 +200,7 @@ internal class ExternalTracerTest {
         )
     }
 
-    private fun EmbracePostSetupInterface.setupExporter() {
+    private fun EmbracePreSdkStartInterface.setupExporter() {
         embrace.addSpanExporter(spanExporter)
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
@@ -16,6 +14,7 @@ import io.embrace.android.embracesdk.internal.payload.toOldPayload
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
@@ -43,9 +42,7 @@ internal class ExternalTracerTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     private lateinit var spanExporter: FakeSpanExporter
     private lateinit var embOpenTelemetry: OpenTelemetry
@@ -67,6 +64,7 @@ internal class ExternalTracerTest {
     fun `check correctness of implementations used by Tracer`() {
         var tracer: Tracer? = null
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 setupSpanExporter()
                 tracer = embrace.getOpenTelemetry().getTracer("foo")
@@ -95,6 +93,7 @@ internal class ExternalTracerTest {
         var parentContext: Context?
 
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 setupSpanExporter()
                 recordSession {
@@ -186,6 +185,7 @@ internal class ExternalTracerTest {
     @Test
     fun `opentelemetry instance can be used to log spans`() {
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 setupSpanExporter()
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,22 +19,27 @@ import java.lang.Thread.sleep
 @RunWith(AndroidJUnit4::class)
 internal class LogRecordExporterTest {
 
+    private lateinit var fakeLogRecordExporter: FakeLogRecordExporter
+
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
+    @Before
+    fun setup() {
+        fakeLogRecordExporter = FakeLogRecordExporter()
+    }
+
     @Test
     fun `SDK can receive a LogRecordExporter`() {
-        val fakeLogRecordExporter = FakeLogRecordExporter()
-
         testRule.runTest(
-            startImmediately = false,
-            testCaseAction = {
+            postSetupAction = {
                 embrace.addLogRecordExporter(fakeLogRecordExporter)
-                startSdk()
-
+            },
+            testCaseAction = {
                 recordSession {
                     embrace.logMessage("test message", Severity.INFO)
+                    // TODO: get rid of this
                     sleep(3000)
                 }
             },
@@ -47,22 +53,17 @@ internal class LogRecordExporterTest {
     @Test
     fun `a LogRecordExporter added after initialization won't be used`() {
         val fake = FakeInternalErrorService()
-        val fakeLogRecordExporter = FakeLogRecordExporter()
-
         testRule.runTest(
-            startImmediately = false,
             setupAction = {
                 overriddenInitModule.logger.apply {
                     internalErrorService = fake
                 }
             },
             testCaseAction = {
-                startSdk()
                 embrace.addLogRecordExporter(fakeLogRecordExporter)
-
                 recordSession {
                     embrace.logMessage("test message", Severity.INFO)
-
+                    // TODO: get rid of this
                     sleep(3000)
                 }
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
@@ -2,18 +2,17 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
-import java.lang.Thread.sleep
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.lang.Thread.sleep
 
 @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
 @RunWith(AndroidJUnit4::class)
@@ -21,15 +20,14 @@ internal class LogRecordExporterTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `SDK can receive a LogRecordExporter`() {
         val fakeLogRecordExporter = FakeLogRecordExporter()
 
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 embrace.addLogRecordExporter(fakeLogRecordExporter)
                 startSdk()
@@ -52,6 +50,7 @@ internal class LogRecordExporterTest {
         val fakeLogRecordExporter = FakeLogRecordExporter()
 
         testRule.runTest(
+            startImmediately = false,
             setupAction = {
                 overriddenInitModule.logger.apply {
                     internalErrorService = fake

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
@@ -33,7 +33,7 @@ internal class LogRecordExporterTest {
     @Test
     fun `SDK can receive a LogRecordExporter`() {
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 embrace.addLogRecordExporter(fakeLogRecordExporter)
             },
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -41,7 +41,7 @@ internal class PublicApiTest {
     @Test
     fun `SDK can start`() {
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 assertFalse(embrace.isStarted)
             },
             testCaseAction = {
@@ -143,7 +143,7 @@ internal class PublicApiTest {
     @Test
     fun `getLastRunEndState() behave as expected`() {
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 assertEquals(LastRunEndState.INVALID, embrace.lastRunEndState)
             },
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -3,10 +3,10 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace.LastRunEndState
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.payload.AppFramework
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
+import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -32,7 +32,7 @@ internal class PublicApiTest {
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false).apply {
+        EmbraceSetupInterface().apply {
             overriddenConfigService.networkSpanForwardingBehavior =
                 FakeNetworkSpanForwardingBehavior(true)
         }
@@ -41,6 +41,7 @@ internal class PublicApiTest {
     @Test
     fun `SDK can start`() {
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 assertFalse(embrace.isStarted)
                 startSdk()
@@ -55,8 +56,6 @@ internal class PublicApiTest {
     fun `SDK start defaults to native app framework`() {
         testRule.runTest(
             testCaseAction = {
-                assertFalse(embrace.isStarted)
-                startSdk()
                 assertEquals(AppFramework.NATIVE, configService.appFramework)
                 assertTrue(embrace.isStarted)
             }
@@ -66,9 +65,10 @@ internal class PublicApiTest {
     @Test
     fun `SDK disabled via config cannot start`() {
         testRule.runTest(
+            setupAction = {
+                overriddenConfigService.sdkDisabled = true
+            },
             testCaseAction = {
-                configService.sdkDisabled = true
-                startSdk()
                 assertFalse(embrace.isStarted)
             }
         )
@@ -77,6 +77,7 @@ internal class PublicApiTest {
     @Test
     fun `custom appId must be valid`() {
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 assertFalse(embrace.setAppId(""))
                 assertFalse(embrace.setAppId("abcd"))
@@ -90,7 +91,6 @@ internal class PublicApiTest {
     fun `custom appId cannot be set after start`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 assertTrue(embrace.isStarted)
                 assertFalse(embrace.setAppId("xyz12"))
             }
@@ -100,6 +100,7 @@ internal class PublicApiTest {
     @Test
     fun `getCurrentSessionId returns null when SDK is not started`() {
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 assertNull(embrace.currentSessionId)
             }
@@ -110,7 +111,6 @@ internal class PublicApiTest {
     fun `getCurrentSessionId returns sessionId when SDK is started and foreground session is active`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     assertEquals(
                         embrace.currentSessionId,
@@ -128,7 +128,6 @@ internal class PublicApiTest {
         var backgroundSessionId: String? = null
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     foregroundSessionId = embrace.currentSessionId
                 }
@@ -144,6 +143,7 @@ internal class PublicApiTest {
     @Test
     fun `getLastRunEndState() behave as expected`() {
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 assertEquals(LastRunEndState.INVALID, embrace.lastRunEndState)
                 startSdk()
@@ -156,7 +156,6 @@ internal class PublicApiTest {
     fun `ensure all generated W3C traceparent conforms to the expected format`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 repeat(100) {
                     assertTrue(validPattern.matches(checkNotNull(embrace.generateW3cTraceparent())))
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -41,10 +41,10 @@ internal class PublicApiTest {
     @Test
     fun `SDK can start`() {
         testRule.runTest(
-            startImmediately = false,
-            testCaseAction = {
+            postSetupAction = {
                 assertFalse(embrace.isStarted)
-                startSdk()
+            },
+            testCaseAction = {
                 assertEquals(AppFramework.NATIVE, configService.appFramework)
                 assertFalse(configService.isSdkDisabled())
                 assertTrue(embrace.isStarted)
@@ -77,7 +77,7 @@ internal class PublicApiTest {
     @Test
     fun `custom appId must be valid`() {
         testRule.runTest(
-            startImmediately = false,
+            startSdk = false,
             testCaseAction = {
                 assertFalse(embrace.setAppId(""))
                 assertFalse(embrace.setAppId("abcd"))
@@ -100,7 +100,7 @@ internal class PublicApiTest {
     @Test
     fun `getCurrentSessionId returns null when SDK is not started`() {
         testRule.runTest(
-            startImmediately = false,
+            startSdk = false,
             testCaseAction = {
                 assertNull(embrace.currentSessionId)
             }
@@ -143,10 +143,10 @@ internal class PublicApiTest {
     @Test
     fun `getLastRunEndState() behave as expected`() {
         testRule.runTest(
-            startImmediately = false,
-            testCaseAction = {
+            postSetupAction = {
                 assertEquals(LastRunEndState.INVALID, embrace.lastRunEndState)
-                startSdk()
+            },
+            testCaseAction = {
                 assertEquals(LastRunEndState.CLEAN_EXIT, embrace.lastRunEndState)
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -23,15 +22,12 @@ internal class PushNotificationApiTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `log push notification and data type`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.logPushNotification("title", "body", "from", "id", 1, 2, true, true)
                 }
@@ -47,7 +43,6 @@ internal class PushNotificationApiTest {
     fun `log push data type`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.logPushNotification("title", "body", "from", "id", 1, 2, false, true)
                 }
@@ -63,7 +58,6 @@ internal class PushNotificationApiTest {
     fun `log push notification no data type`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.logPushNotification("title", "body", "from", "id", 1, 2, true, false)
                 }
@@ -79,7 +73,6 @@ internal class PushNotificationApiTest {
     fun `log push unknown type`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.logPushNotification("title", "body", "from", "id", 1, 2, false, false)
                 }
@@ -100,7 +93,6 @@ internal class PushNotificationApiTest {
                 )
             },
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.logPushNotification("title", "body", "from", "id", 1, 2, true, true)
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
@@ -2,14 +2,13 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertExpectedAttributes
 import io.embrace.android.embracesdk.assertions.assertHasEmbraceAttribute
 import io.embrace.android.embracesdk.fakes.FakeInternalErrorService
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.opentelemetry.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.opentelemetry.embSequenceId
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -23,13 +22,12 @@ import org.robolectric.annotation.Config
 internal class SpanExporterTest {
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `SDK can receive a SpanExporter`() {
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 val fakeSpanExporter = FakeSpanExporter()
                 embrace.addSpanExporter(fakeSpanExporter)
@@ -78,7 +76,6 @@ internal class SpanExporterTest {
                 }
             },
             testCaseAction = {
-                startSdk()
                 embrace.addSpanExporter(fakeSpanExporter)
 
                 recordSession {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SpanExporterTest.kt
@@ -35,7 +35,7 @@ internal class SpanExporterTest {
     @Test
     fun `SDK can receive a SpanExporter`() {
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 embrace.addSpanExporter(fakeSpanExporter)
             },
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -58,12 +58,12 @@ internal class TracingApiTest {
         val spanExporter = FakeSpanExporter()
 
         testRule.runTest(
-            startImmediately = false,
-            testCaseAction = {
+            postSetupAction = {
                 testStartTimeMs = clock.now()
                 clock.tick(100L)
                 embrace.addSpanExporter(spanExporter)
-                startSdk()
+            },
+            testCaseAction = {
                 results.add("\nSpans exported before session starts: ${spanExporter.exportedSpans.toList().map { it.name }}")
                 recordSession {
                     val parentSpan = checkNotNull(embrace.createSpan(name = "test-trace-root"))
@@ -306,13 +306,13 @@ internal class TracingApiTest {
     @Test
     fun `can only create span if there is a valid session`() {
         testRule.runTest(
-            startImmediately = false,
             setupAction = {
                 overriddenConfigService.backgroundActivityCaptureEnabled = false
             },
-            testCaseAction = {
+            postSetupAction = {
                 assertNull(embrace.startSpan("test"))
-                startSdk()
+            },
+            testCaseAction = {
                 recordSession {
                     assertNotNull(embrace.startSpan("test"))
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
@@ -19,11 +17,10 @@ import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceAssertionInterface
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.context.Context
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -35,15 +32,15 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
 internal class TracingApiTest {
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     private val results = mutableListOf<String>()
     private lateinit var executor: SingleThreadTestScheduledExecutor
@@ -61,6 +58,7 @@ internal class TracingApiTest {
         val spanExporter = FakeSpanExporter()
 
         testRule.runTest(
+            startImmediately = false,
             testCaseAction = {
                 testStartTimeMs = clock.now()
                 clock.tick(100L)
@@ -273,7 +271,6 @@ internal class TracingApiTest {
     fun `span can be parented by a span created on a different thread`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     val latch = CountDownLatch(1)
                     val parentThreadId = Thread.currentThread().id
@@ -309,6 +306,7 @@ internal class TracingApiTest {
     @Test
     fun `can only create span if there is a valid session`() {
         testRule.runTest(
+            startImmediately = false,
             setupAction = {
                 overriddenConfigService.backgroundActivityCaptureEnabled = false
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -58,7 +58,7 @@ internal class TracingApiTest {
         val spanExporter = FakeSpanExporter()
 
         testRule.runTest(
-            postSetupAction = {
+            preSdkStartAction = {
                 testStartTimeMs = clock.now()
                 clock.tick(100L)
                 embrace.addSpanExporter(spanExporter)
@@ -309,7 +309,7 @@ internal class TracingApiTest {
             setupAction = {
                 overriddenConfigService.backgroundActivityCaptureEnabled = false
             },
-            postSetupAction = {
+            preSdkStartAction = {
                 assertNull(embrace.startSpan("test"))
             },
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -21,7 +20,7 @@ internal class ActivityFeatureTest {
 
     @Rule
     @JvmField
-    val testRule = IntegrationTestRule { EmbraceSetupInterface(startImmediately = false) }
+    val testRule = IntegrationTestRule()
 
     @Test
     fun `automatically capture activities`() {
@@ -34,7 +33,6 @@ internal class ActivityFeatureTest {
                 )
             },
             testCaseAction = {
-                startSdk()
                 recordSession() {
                     startTimeMs = clock.now()
                     simulateActivityLifecycle()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -8,7 +8,6 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import io.embrace.android.embracesdk.testframework.assertions.getLastLog
 import io.mockk.every
@@ -27,7 +26,7 @@ internal class AeiFeatureTest {
 
     @Rule
     @JvmField
-    val testRule = IntegrationTestRule { EmbraceSetupInterface(startImmediately = false) }
+    val testRule = IntegrationTestRule()
 
     @Test
     fun `application exit info feature`() {
@@ -36,7 +35,6 @@ internal class AeiFeatureTest {
                 setupFakeAeiData()
             },
             testCaseAction = {
-                startSdk(context = ApplicationProvider.getApplicationContext())
                 recordSession()
             },
             assertAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
@@ -1,10 +1,9 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -14,9 +13,7 @@ import org.junit.runner.RunWith
 internal class PersonaFeaturesTest {
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `personas found in metadata`() {
@@ -25,7 +22,6 @@ internal class PersonaFeaturesTest {
                 overriddenAndroidServicesModule.preferencesService.userPersonas = setOf("preloaded")
             },
             testCaseAction = {
-                startSdk()
                 embrace.setUserAsPayer()
                 recordSession {
                     embrace.addUserPersona("test")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SensitiveKeysRedactionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SensitiveKeysRedactionFeatureTest.kt
@@ -5,10 +5,7 @@ import io.embrace.android.embracesdk.assertions.findSpanByName
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,9 +14,7 @@ import org.junit.runner.RunWith
 internal class SensitiveKeysRedactionFeatureTest {
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     private val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
         listOf("password")
@@ -32,7 +27,6 @@ internal class SensitiveKeysRedactionFeatureTest {
                 overriddenConfigService.sensitiveKeysBehavior = sensitiveKeysBehavior
             },
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.startSpan("test span")?.apply {
                         addAttribute("password", "1234")
@@ -59,7 +53,6 @@ internal class SensitiveKeysRedactionFeatureTest {
                 overriddenConfigService.sensitiveKeysBehavior = sensitiveKeysBehavior
             },
             testCaseAction = {
-                startSdk()
                 recordSession {
                     embrace.startSpan("test span")?.apply {
                         addEvent("event", null, mapOf("password" to "123456", "status" to "ok"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -22,15 +21,12 @@ internal class SessionPropertiesTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `session properties additions and removal works at all stages app state transition`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 embrace.addSessionProperty(PERM_KEY, PERM_VAL, true)
                 embrace.addSessionProperty(PERM_KEY_2, PERM_VAL, true)
                 recordSession {
@@ -75,7 +71,6 @@ internal class SessionPropertiesTest {
                 overriddenConfigService.backgroundActivityCaptureEnabled = false
             },
             testCaseAction = {
-                startSdk()
                 embrace.addSessionProperty(PERM_KEY, PERM_VAL, true)
                 embrace.addSessionProperty(TEMP_KEY, TEMP_VAL, false)
                 embrace.addSessionProperty(PERM_KEY_2, PERM_VAL, true)
@@ -113,7 +108,6 @@ internal class SessionPropertiesTest {
     fun `temp properties are cleared in next session`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 embrace.addSessionProperty(PERM_KEY, PERM_VAL, true)
                 recordSession {
                     embrace.addSessionProperty(TEMP_KEY, TEMP_VAL, false)
@@ -147,7 +141,6 @@ internal class SessionPropertiesTest {
     fun `adding properties in bg activity modifications change the cached payload`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession()
                 checkNextSavedBackgroundActivity(
                     action = {
@@ -173,7 +166,6 @@ internal class SessionPropertiesTest {
     fun `permanent properties are persisted in cached payloads`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 var lastSessionId: String? = null
                 recordSession {
                     lastSessionId = checkNotNull(embrace.currentSessionId)
@@ -235,7 +227,6 @@ internal class SessionPropertiesTest {
                 overriddenConfigService.backgroundActivityCaptureEnabled = false
             },
             testCaseAction = {
-                startSdk()
                 embrace.addSessionProperty("perm", "value", true)
                 recordSession {
                     embrace.addSessionProperty("perm2", "value", true)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -15,9 +14,7 @@ internal class UserFeaturesTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `user info setting and clearing`() {
@@ -30,7 +27,6 @@ internal class UserFeaturesTest {
                 }
             },
             testCaseAction = {
-                startSdk()
                 recordSession()
                 recordSession {
                     embrace.clearUserIdentifier()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpanTest.kt
@@ -1,9 +1,8 @@
 package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Rule
@@ -15,9 +14,7 @@ internal class SessionSpanTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(startImmediately = false)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `there is always a valid session when background activity is enabled`() {
@@ -25,7 +22,6 @@ internal class SessionSpanTest {
 
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     ids.add(embrace.currentSessionId)
                 }
@@ -46,7 +42,6 @@ internal class SessionSpanTest {
     fun `session span event limits do not affect logging maximum breadcrumbs`() {
         testRule.runTest(
             testCaseAction = {
-                startSdk()
                 recordSession {
                     repeat(101) {
                         embrace.addBreadcrumb("breadcrumb $it")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -88,11 +88,21 @@ internal class IntegrationTestRule(
      * the integration test suite.
      */
     inline fun runTest(
+        startImmediately: Boolean = true,
         setupAction: EmbraceSetupInterface.() -> Unit = {},
         testCaseAction: EmbraceActionInterface.() -> Unit,
         assertAction: EmbraceAssertionInterface.() -> Unit = {},
     ) {
         setupAction(setup)
+        with(setup) {
+            val embraceImpl = EmbraceImpl(bootstrapper)
+            EmbraceHooks.setImpl(embraceImpl)
+            if (startImmediately) {
+                embraceImpl.start(overriddenCoreModule.context, appFramework) {
+                    overriddenConfigService.apply { appFramework = it }
+                }
+            }
+        }
         testCaseAction(action)
         assertAction(assertion)
     }
@@ -105,16 +115,6 @@ internal class IntegrationTestRule(
         bootstrapper = setup.createBootstrapper()
         action = EmbraceActionInterface(setup, bootstrapper)
         assertion = EmbraceAssertionInterface(bootstrapper)
-
-        with(setup) {
-            val embraceImpl = EmbraceImpl(bootstrapper)
-            EmbraceHooks.setImpl(embraceImpl)
-            if (startImmediately) {
-                embraceImpl.start(overriddenCoreModule.context, appFramework) {
-                    overriddenConfigService.apply { appFramework = it }
-                }
-            }
-        }
     }
 
     /**

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceAssertionInterface
-import io.embrace.android.embracesdk.testframework.actions.EmbracePostSetupInterface
+import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.rules.ExternalResource
 
@@ -81,7 +81,7 @@ internal class IntegrationTestRule(
      * Instance of the test harness that is recreating on every test iteration
      */
     lateinit var setup: EmbraceSetupInterface
-    lateinit var postSetup: EmbracePostSetupInterface
+    lateinit var preSdkStart: EmbracePreSdkStartInterface
     lateinit var bootstrapper: ModuleInitBootstrapper
 
     /**
@@ -92,7 +92,7 @@ internal class IntegrationTestRule(
     inline fun runTest(
         startSdk: Boolean = true,
         setupAction: EmbraceSetupInterface.() -> Unit = {},
-        postSetupAction: EmbracePostSetupInterface.() -> Unit = {},
+        preSdkStartAction: EmbracePreSdkStartInterface.() -> Unit = {},
         testCaseAction: EmbraceActionInterface.() -> Unit,
         assertAction: EmbraceAssertionInterface.() -> Unit = {},
     ) {
@@ -100,7 +100,7 @@ internal class IntegrationTestRule(
         with(setup) {
             val embraceImpl = EmbraceImpl(bootstrapper)
             EmbraceHooks.setImpl(embraceImpl)
-            postSetupAction(postSetup)
+            preSdkStartAction(preSdkStart)
             if (startSdk) {
                 embraceImpl.start(overriddenCoreModule.context, appFramework) {
                     overriddenConfigService.apply { appFramework = it }
@@ -116,7 +116,7 @@ internal class IntegrationTestRule(
      */
     override fun before() {
         setup = embraceSetupInterfaceSupplier.invoke()
-        postSetup = EmbracePostSetupInterface(setup)
+        preSdkStart = EmbracePreSdkStartInterface(setup)
         bootstrapper = setup.createBootstrapper()
         action = EmbraceActionInterface(setup, bootstrapper)
         assertion = EmbraceAssertionInterface(bootstrapper)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -15,7 +15,6 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import org.robolectric.Robolectric
-import org.robolectric.RuntimeEnvironment
 
 /**
  * Interface for performing actions on the [Embrace] instance under test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePostSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePostSetupInterface.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.testframework.actions
+
+import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.fakes.FakeClock
+
+internal class EmbracePostSetupInterface(
+    private val setup: EmbraceSetupInterface,
+) {
+    val embrace = Embrace.getInstance()
+
+    val clock: FakeClock
+        get() = setup.overriddenClock
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePreSdkStartInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePreSdkStartInterface.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testframework.actions
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.fakes.FakeClock
 
-internal class EmbracePostSetupInterface(
+internal class EmbracePreSdkStartInterface(
     private val setup: EmbraceSetupInterface,
 ) {
     val embrace = Embrace.getInstance()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -26,7 +26,6 @@ import io.embrace.android.embracesdk.testframework.IntegrationTestRule
  */
 internal class EmbraceSetupInterface @JvmOverloads constructor(
     currentTimeMs: Long = IntegrationTestRule.DEFAULT_SDK_START_TIME_MS,
-    val startImmediately: Boolean = true,
     @Suppress("DEPRECATION") val appFramework: Embrace.AppFramework = Embrace.AppFramework.NATIVE,
     val overriddenClock: FakeClock = FakeClock(currentTime = currentTimeMs),
     val overriddenInitModule: FakeInitModule = FakeInitModule(clock = overriddenClock),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import java.io.InputStream
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.zip.GZIPInputStream
 
 class FakeRequestExecutionService : RequestExecutionService {
@@ -15,7 +16,7 @@ class FakeRequestExecutionService : RequestExecutionService {
     var constantResponse: ApiResponse = ApiResponse.Success(null, null)
     var responseAction: (intake: Envelope<*>) -> ApiResponse = { _ -> constantResponse }
     var exceptionOnExecution: Throwable? = null
-    val attemptedHttpRequests = mutableListOf<Envelope<*>>()
+    val attemptedHttpRequests = ConcurrentLinkedQueue<Envelope<*>>()
 
     @Suppress("UNCHECKED_CAST")
     inline fun <reified T : Any> getRequests(): List<Envelope<T>> {


### PR DESCRIPTION
## Goal

Simplify integration test by adding a step to do something before setting up the test harness, and then only starting the SDK after that runs. This makes it not necessary to manually start the SDK, and also exposes a proper place to "do and verify stuff" before the SDK starts without manually needing to do so.

With this, `startImmediately` has been removed as a parameter of the harness, and `startSdk` was introduced as a parameter of `runTest` for those select tests that don't require the SDK to be started automatically.
