### PR TITLE
Add the notion of completeness to payload storage

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -46,7 +46,7 @@ class V2PayloadStoreTest {
 
         val intake = intakeService.getIntakes<LogPayload>().single()
         assertSame(envelope, intake.envelope)
-        assertEquals("1692201601000_log_fakeuuid_v1.json", intake.metadata.filename)
+        assertEquals("1692201601000_log_fakeuuid_true_v1.json", intake.metadata.filename)
         assertEquals(0, intakeService.shutdownCount)
     }
 
@@ -65,7 +65,7 @@ class V2PayloadStoreTest {
     private fun verifySessionIntake(envelope: Envelope<SessionPayload>) {
         val intake = intakeService.getIntakes<SessionPayload>().single()
         assertSame(envelope, intake.envelope)
-        assertEquals("1692201601000_session_fakeuuid_v1.json", intake.metadata.filename)
+        assertEquals("1692201601000_session_fakeuuid_true_v1.json", intake.metadata.filename)
         assertEquals(0, intakeService.shutdownCount)
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
@@ -24,6 +24,7 @@ internal val storedTelemetryComparator: java.util.Comparator<StoredTelemetryMeta
     compareBy(StoredTelemetryMetadata::envelopeType)
         .thenBy(StoredTelemetryMetadata::timestamp)
         .thenBy(StoredTelemetryMetadata::uuid)
+        .thenBy(StoredTelemetryMetadata::complete)
 
 inline fun <reified T> extractPriorityFromRunnable(
     lhs: Runnable,

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -11,7 +11,8 @@ data class StoredTelemetryMetadata(
     val timestamp: Long,
     val uuid: String,
     val envelopeType: SupportedEnvelopeType,
-    val filename: String = "${timestamp}_${envelopeType.description}_${uuid}_v1.json"
+    val complete: Boolean = true,
+    val filename: String = "${timestamp}_${envelopeType.description}_${uuid}_${complete}_v1.json",
 ) {
 
     companion object {
@@ -22,7 +23,7 @@ data class StoredTelemetryMetadata(
          */
         fun fromFilename(filename: String): Result<StoredTelemetryMetadata> {
             val parts = filename.split("_")
-            if (parts.size != 4) {
+            if (parts.size != 5) {
                 return failure(IllegalArgumentException("Invalid filename: $filename"))
             }
             val timestamp = parts[0].toLongOrNull() ?: return failure(
@@ -31,8 +32,11 @@ data class StoredTelemetryMetadata(
             val type = SupportedEnvelopeType.fromDescription(parts[1]) ?: return failure(
                 IllegalArgumentException("Invalid type: $filename")
             )
-            val uuid = parts[2].removeSuffix(".json")
-            return Result.success(StoredTelemetryMetadata(timestamp, uuid, type, filename))
+            val uuid = parts[2]
+            val complete = parts[3].toBooleanStrictOrNull() ?: return failure(
+                IllegalArgumentException("Invalid completeness state: $filename")
+            )
+            return Result.success(StoredTelemetryMetadata(timestamp, uuid, type, complete, filename))
         }
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
@@ -39,4 +39,9 @@ interface PayloadStorageService {
      * Return stored payloads as a list sorted in priority order
      */
     fun getPayloadsByPriority(): List<StoredTelemetryMetadata>
+
+    /**
+     * Return cached payloads from previous app instances
+     */
+    fun getUndeliveredPayloads(): List<StoredTelemetryMetadata> = emptyList()
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -21,10 +21,12 @@ class StoredTelemetryMetadataTest {
     @Test
     fun `construct objects`() {
         typeNameMap.entries.forEach { (type, description) ->
-            assertEquals(
-                "${TIMESTAMP}_${description}_${UUID}_v1.json",
-                StoredTelemetryMetadata(TIMESTAMP, UUID, type).filename
-            )
+            listOf(true, false).forEach { payloadComplete ->
+                assertEquals(
+                    "${TIMESTAMP}_${description}_${UUID}_${payloadComplete}_v1.json",
+                    StoredTelemetryMetadata(TIMESTAMP, UUID, type, payloadComplete).filename
+                )
+            }
         }
     }
 
@@ -36,7 +38,8 @@ class StoredTelemetryMetadataTest {
             "my_session.json",
             "1234567890_session_v1.json",
             "a_b_c_v1.json",
-            "${TIMESTAMP}_b_c_v1.json"
+            "${TIMESTAMP}_b_c_v1.json",
+            "${TIMESTAMP}_session_c_v1.json"
         )
         badFilenames.forEach { filename ->
             val result = StoredTelemetryMetadata.fromFilename(filename)
@@ -47,12 +50,15 @@ class StoredTelemetryMetadataTest {
     @Test
     fun `from valid filename`() {
         typeNameMap.entries.forEach { (type, description) ->
-            val input = "${TIMESTAMP}_${description}_${UUID}_v1.json"
-            with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
-                assertEquals(input, filename)
-                assertEquals(TIMESTAMP, timestamp)
-                assertEquals(UUID, uuid)
-                assertEquals(type, this.envelopeType)
+            listOf(true, false).forEach { payloadComplete ->
+                val input = "${TIMESTAMP}_${description}_${UUID}_${payloadComplete}_v1.json"
+                with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
+                    assertEquals(input, filename)
+                    assertEquals(TIMESTAMP, timestamp)
+                    assertEquals(UUID, uuid)
+                    assertEquals(type, envelopeType)
+                    assertEquals(payloadComplete, complete)
+                }
             }
         }
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
@@ -4,15 +4,22 @@ import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURR
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 
-val fakeSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
-    timestamp = DEFAULT_FAKE_CURRENT_TIME + 2000L,
+val fakeCachedSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
+    timestamp = DEFAULT_FAKE_CURRENT_TIME + 1000L,
     uuid = "30690ad1-6b87-4e08-b72c-7deca14451d8",
-    envelopeType = SupportedEnvelopeType.SESSION
+    envelopeType = SupportedEnvelopeType.SESSION,
+    complete = false
 )
+
+val fakeSessionStoredTelemetryMetadata =
+    fakeCachedSessionStoredTelemetryMetadata.copy(
+        timestamp = fakeCachedSessionStoredTelemetryMetadata.timestamp + 1000L,
+        complete = true
+    )
 
 val fakeSessionStoredTelemetryMetadata2 = StoredTelemetryMetadata(
     timestamp = DEFAULT_FAKE_CURRENT_TIME + 10_000L,
-    uuid = "30690ad1-6b87-4e08-b72c-7deca14451d8",
+    uuid = "e6cfe01a-990e-4af7-b30e-f862947cef9b",
     envelopeType = SupportedEnvelopeType.SESSION
 )
 


### PR DESCRIPTION
## Goal

Make `StoredTelemetryMetadata` be aware of whether it contains a payload that is complete and ready to be delivered. This is so we can load and delete them during payload resurrection. Putting in the filename isn't the most efficient but it gets the job done. 

I avoided added to the interface more than I have to so that store/delete/load methods don't have to know about this.
