### PR TITLE
Extract further payload caching

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/NoopPayloadCachingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/NoopPayloadCachingService.kt
@@ -1,12 +1,15 @@
 package io.embrace.android.embracesdk.internal.delivery.caching
 
-import io.embrace.android.embracesdk.internal.payload.Envelope
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 
 class NoopPayloadCachingService : PayloadCachingService {
 
-    override fun startCaching(state: ProcessState, supplier: () -> Envelope<SessionPayload>?) {
+    override fun startCaching(
+        initial: SessionZygote,
+        state: ProcessState,
+        supplier: SessionPayloadSupplier,
+    ) {
     }
 
     override fun stopCaching() {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingService.kt
@@ -3,7 +3,14 @@ package io.embrace.android.embracesdk.internal.delivery.caching
 import io.embrace.android.embracesdk.internal.delivery.Shutdownable
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
+
+typealias SessionPayloadSupplier = (
+    state: ProcessState,
+    timestamp: Long,
+    initial: SessionZygote,
+) -> Envelope<SessionPayload>?
 
 /**
  * This service caches in-memory data in case the process terminates. Cached data from terminated processes will be
@@ -14,7 +21,11 @@ interface PayloadCachingService : Shutdownable {
     /**
      * Starts caching a payload.
      */
-    fun startCaching(state: ProcessState, supplier: () -> Envelope<SessionPayload>?)
+    fun startCaching(
+        initial: SessionZygote,
+        state: ProcessState,
+        supplier: SessionPayloadSupplier,
+    )
 
     /**
      * Stops caching a payload.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
@@ -1,13 +1,21 @@
 package io.embrace.android.embracesdk.internal.delivery.caching
 
+import io.embrace.android.embracesdk.internal.Systrace
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
+import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
+import io.embrace.android.embracesdk.internal.session.orchestrator.PayloadStore
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class PayloadCachingServiceImpl(
-    private val periodicSessionCacher: PeriodicSessionCacher
+    private val periodicSessionCacher: PeriodicSessionCacher,
+    private val clock: Clock,
+    private val sessionIdTracker: SessionIdTracker,
+    private val payloadStore: PayloadStore
 ) : PayloadCachingService {
 
     private var stateChanged: AtomicBoolean = AtomicBoolean(true)
@@ -21,18 +29,34 @@ internal class PayloadCachingServiceImpl(
     }
 
     override fun startCaching(
+        initial: SessionZygote,
         state: ProcessState,
-        supplier: () -> Envelope<SessionPayload>?,
+        supplier: SessionPayloadSupplier,
     ) {
         periodicSessionCacher.start {
-            return@start if (state == ProcessState.BACKGROUND) {
+            if (state == ProcessState.BACKGROUND) {
                 if (stateChanged.getAndSet(false)) {
-                    supplier()
+                    onSessionCache(initial, state, supplier)
                 } else {
                     null
                 }
             } else {
-                supplier()
+                onSessionCache(initial, state, supplier)
+            }
+        }
+    }
+
+    private fun onSessionCache(
+        initial: SessionZygote,
+        endProcessState: ProcessState,
+        supplier: SessionPayloadSupplier
+    ): Envelope<SessionPayload>? {
+        Systrace.traceSynchronous("on-session-cache") {
+            if (initial.sessionId != sessionIdTracker.getActiveSessionId()) {
+                return null
+            }
+            return supplier(endProcessState, clock.now(), initial)?.apply {
+                payloadStore.cacheSessionSnapshot(this)
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -88,7 +88,12 @@ internal class DeliveryModuleImpl(
         if (configModule.configService.isOnlyUsingOtelExporters()) {
             NoopPayloadCachingService()
         } else {
-            PayloadCachingServiceImpl(periodicSessionCacher)
+            PayloadCachingServiceImpl(
+                periodicSessionCacher,
+                initModule.clock,
+                essentialServiceModule.sessionIdTracker,
+                payloadStore
+            )
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
@@ -3,7 +3,10 @@ package io.embrace.android.embracesdk.internal.delivery.caching
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakePayloadStore
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
+import io.embrace.android.embracesdk.fakes.fakeSessionZygote
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
@@ -18,24 +21,48 @@ class PayloadCachingServiceImplTest {
 
     private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var service: PayloadCachingService
+    private lateinit var sessionIdTracker: FakeSessionIdTracker
+    private val zygote = fakeSessionZygote()
 
     @Before
     fun setUp() {
         executorService = BlockingScheduledExecutorService(FakeClock())
         val cacher = PeriodicSessionCacher(BackgroundWorker(executorService), FakeEmbLogger(), INTERVAL)
-        service = PayloadCachingServiceImpl(cacher)
+        sessionIdTracker = FakeSessionIdTracker()
+        sessionIdTracker.setActiveSession(zygote.sessionId, true)
+
+        service = PayloadCachingServiceImpl(
+            cacher,
+            FakeClock(),
+            sessionIdTracker,
+            FakePayloadStore()
+        )
     }
 
     @Test(expected = RejectedExecutionException::class)
     fun rejection() {
         service.shutdown()
-        service.startCaching(ProcessState.FOREGROUND) { null }
+        service.startCaching(zygote, ProcessState.FOREGROUND) { _, _, _ ->
+            null
+        }
+    }
+
+    @Test
+    fun `session id mismatch does not cache`() {
+        sessionIdTracker.setActiveSession("someOtherId", true)
+        var count = 0
+        service.startCaching(zygote, ProcessState.FOREGROUND) { _, _, _ ->
+            count++
+            fakeSessionEnvelope()
+        }
+        executorService.moveForwardAndRunBlocked(INTERVAL)
+        assertEquals(0, count)
     }
 
     @Test
     fun `start caching`() {
         var count = 0
-        service.startCaching(ProcessState.FOREGROUND) {
+        service.startCaching(zygote, ProcessState.FOREGROUND) { _, _, _ ->
             count++
             fakeSessionEnvelope()
         }
@@ -46,7 +73,7 @@ class PayloadCachingServiceImplTest {
     @Test
     fun `stop caching`() {
         var count = 0
-        service.startCaching(ProcessState.FOREGROUND) {
+        service.startCaching(zygote, ProcessState.FOREGROUND) { _, _, _ ->
             count++
             fakeSessionEnvelope()
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -362,7 +362,10 @@ internal class SessionOrchestratorTest {
             PeriodicSessionCacher(
                 BackgroundWorker(sessionCacheExecutor),
                 logger
-            )
+            ),
+            clock,
+            sessionIdTracker,
+            store
         )
         fakeDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         dataCaptureOrchestrator = DataCaptureOrchestrator(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCachingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCachingService.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
-import io.embrace.android.embracesdk.internal.payload.Envelope
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.delivery.caching.SessionPayloadSupplier
+import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 
 class FakePayloadCachingService : PayloadCachingService {
@@ -13,7 +13,11 @@ class FakePayloadCachingService : PayloadCachingService {
     override fun shutdown() {
     }
 
-    override fun startCaching(state: ProcessState, supplier: () -> Envelope<SessionPayload>?) {
+    override fun startCaching(
+        initial: SessionZygote,
+        state: ProcessState,
+        supplier: SessionPayloadSupplier,
+    ) {
     }
 
     override fun stopCaching() {


### PR DESCRIPTION
## Goal

Moves further payload caching logic out of `SessionOrchestratorImpl` so that it's isolated in a single class that will make future changes easier.

## Testing

Updated test coverage.

