### PR TITLE
Improve threading model for log capture

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -51,7 +51,8 @@ internal class DeliveryModuleImpl(
             if (configService.autoDataCaptureBehavior.isV2StorageEnabled()) {
                 V2PayloadStore(intakeService, initModule.clock)
             } else {
-                V1PayloadStore(deliveryService)
+                val worker = workerThreadModule.backgroundWorker(Worker.Background.LogMessageWorker)
+                V1PayloadStore(worker, deliveryService)
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -62,7 +62,6 @@ internal class LogModuleImpl(
             essentialServiceModule.logWriter,
             configModule.configService,
             essentialServiceModule.sessionPropertiesService,
-            workerThreadModule.backgroundWorker(Worker.Background.LogMessageWorker),
             initModule.logger,
             initModule.jsonSerializer
         )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
@@ -16,6 +16,7 @@ internal class LogOrchestratorImpl(
     private val payloadStore: PayloadStore?,
     private val logEnvelopeSource: LogEnvelopeSource,
 ) : LogOrchestrator {
+
     @Volatile
     private var lastLogTime: AtomicLong = AtomicLong(0)
 
@@ -45,9 +46,7 @@ internal class LogOrchestratorImpl(
             if (logRequest.defer) {
                 payloadStore?.storeLogPayload(logRequest.payload, false)
             } else {
-                worker.submit {
-                    payloadStore?.storeLogPayload(logRequest.payload, true)
-                }
+                payloadStore?.storeLogPayload(logRequest.payload, true)
             }
         }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1PayloadStore.kt
@@ -6,8 +6,10 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.JVM_CRASH
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType.NORMAL_END
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 class V1PayloadStore(
+    private val worker: BackgroundWorker,
     private val deliveryService: DeliveryService
 ) : PayloadStore {
 
@@ -23,7 +25,9 @@ class V1PayloadStore(
         if (attemptImmediateRequest) {
             deliveryService.sendLogs(envelope)
         } else {
-            deliveryService.saveLogs(envelope)
+            worker.submit {
+                deliveryService.saveLogs(envelope)
+            }
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.behavior.FakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.createSessionBehavior
-import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
@@ -35,7 +34,6 @@ internal class EmbraceLogServiceTest {
     private lateinit var fakeSessionPropertiesService: FakeSessionPropertiesService
     private lateinit var fakeConfigService: FakeConfigService
 
-    private val backgroundWorker = fakeBackgroundWorker()
     private val fakeEmbLogger = FakeEmbLogger()
     private val embraceSerializer = EmbraceSerializer()
 
@@ -54,7 +52,6 @@ internal class EmbraceLogServiceTest {
         logWriter = fakeLogWriter,
         configService = fakeConfigService,
         sessionPropertiesService = fakeSessionPropertiesService,
-        backgroundWorker = backgroundWorker,
         logger = fakeEmbLogger,
         serializer = embraceSerializer,
     )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureDataSource
 import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureService
 import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
-import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.injection.LogModule
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogService
@@ -25,7 +24,6 @@ class FakeLogModule(
         FakeLogWriter(),
         FakeConfigService(),
         FakeSessionPropertiesService(),
-        fakeBackgroundWorker(),
         EmbLoggerImpl(),
         EmbraceSerializer()
     )


### PR DESCRIPTION
## Goal

Improves the threading model for log capture + delivery. This makes the following changes to improve deliverability:

1. `V1PayloadStore` is now responsible for the background worker that stores log payloads, not `LogOrchestrator`. This means when enabled `V2PayloadStore` is consistently called from the same thread for all log payloads
2. Log capture now happens on the main thread which avoids the complexity of 2-3 worker threads interacting with each other. This does not affect log persistence which still happens on a background thread for v1/v2. In principle I can't see any operations that would be very expensive when capturing a log, but this is something we could profile if it needs optimizing

## Testing

Relied on existing test coverage.

