### PR TITLE
Register scheduling service as network connectivity listener

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingService.kt
@@ -1,12 +1,13 @@
 package io.embrace.android.embracesdk.internal.delivery.scheduling
 
+import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityListener
 import io.embrace.android.embracesdk.internal.delivery.Shutdownable
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 
 /**
  * This service is responsible for scheduling HTTP requests to the Embrace backend.
  */
-interface SchedulingService : Shutdownable {
+interface SchedulingService : Shutdownable, NetworkConnectivityListener {
 
     /**
      * Called when a new payload has been stored by the [IntakeService] and is ready for scheduling.

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.delivery.scheduling
 
-import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityListener
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
@@ -27,7 +26,7 @@ class SchedulingServiceImpl(
     private val deliveryWorker: BackgroundWorker,
     private val clock: Clock,
     private val logger: EmbLogger,
-) : SchedulingService, NetworkConnectivityListener {
+) : SchedulingService {
 
     private val blockedEndpoints: MutableMap<Endpoint, Long> = ConcurrentHashMap()
     private val hasNetwork = AtomicBoolean(true)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -209,6 +209,7 @@ internal class ModuleInitBootstrapper(
                                 Systrace.traceSynchronous("network-connectivity-listeners") {
                                     networkConnectivityService.addNetworkConnectivityListener(pendingApiCallsSender)
                                     apiService?.let(networkConnectivityService::addNetworkConnectivityListener)
+                                    deliveryModule.schedulingService?.let(networkConnectivityService::addNetworkConnectivityListener)
                                 }
                             }
                         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSchedulingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSchedulingService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
 
 class FakeSchedulingService : SchedulingService {
@@ -13,5 +14,8 @@ class FakeSchedulingService : SchedulingService {
 
     override fun onPayloadIntake() {
         payloadIntakeCount++
+    }
+
+    override fun onNetworkConnectivityStatusChanged(status: NetworkStatus) {
     }
 }


### PR DESCRIPTION
## Goal

Registers this class as a listener so that it can react to changes in network connectivity.

