### PR TITLE
Handle shutdown in scheduling service

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -41,7 +41,10 @@ class SchedulingServiceImpl(
     }
 
     override fun shutdown() {
-        // TODO: get ready to die
+        // shutdown workers from further scheduling but don't wait for completion as
+        // we can just retry in the next process
+        schedulingWorker.shutdownAndWait(0)
+        deliveryWorker.shutdownAndWait(0)
     }
 
     override fun onNetworkConnectivityStatusChanged(status: NetworkStatus) {

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.RejectedExecutionException
 
 internal class SchedulingServiceImplTest {
 
@@ -269,6 +270,18 @@ internal class SchedulingServiceImplTest {
         deliveryExecutor.awaitExecutionCompletion()
         assertEquals(2, executionService.sendAttempts())
         assertEquals(0, storageService.storedPayloadCount())
+    }
+
+    @Test(expected = RejectedExecutionException::class)
+    fun `test shutdown`() {
+        logger.throwOnInternalError = false
+        schedulingService.onPayloadIntake()
+        schedulingService.shutdown()
+
+        // Throws RejectedExecutionException. Note that this is a consequence of the
+        // test setup & the real executor has its own rejection handler,
+        // meaning the exception will never get thrown in prod.
+        schedulingService.onPayloadIntake()
     }
 
     private fun waitForOnPayloadIntakeTaskCompletion() {


### PR DESCRIPTION
## Goal

Implements shutdown in the `SchedulingService`. I've taken the approach of just shutting the scheduling + delivery executors & not waiting, as we don't want to block on HTTP requests or I/O operations as these can just be retried on the next process, but we do want to prevent adding any further work when the process is terminating.

## Testing

Added unit test.

