### PR TITLE
Record correct type when capturing logs

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
@@ -1,12 +1,15 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.Uuid
 
 internal class V2PayloadStore(
@@ -28,12 +31,26 @@ internal class V2PayloadStore(
     }
 
     override fun storeLogPayload(envelope: Envelope<LogPayload>, attemptImmediateRequest: Boolean) {
-        val type = SupportedEnvelopeType.LOG // TODO: distinguish between log/network/crash type
+        val type = findSupportedEnvelopeType(envelope.data.logs)
         intakeService.take(envelope, createMetadata(type))
     }
 
     override fun handleCrash(crashId: String) {
         intakeService.shutdown()
+    }
+
+    private fun findSupportedEnvelopeType(logs: List<Log>?): SupportedEnvelopeType {
+        // look at emb.type in the first log. This assumes logs are homogenous.
+        val embType: String? = logs?.firstOrNull()?.attributes?.findAttributeValue("emb.type")
+
+        return when (embType) {
+            System.Crash.value -> SupportedEnvelopeType.CRASH
+            System.NativeCrash.value -> SupportedEnvelopeType.CRASH
+            System.ReactNativeCrash.value -> SupportedEnvelopeType.CRASH
+            System.FlutterException.value -> SupportedEnvelopeType.CRASH
+            System.NetworkCapturedRequest.value -> SupportedEnvelopeType.NETWORK
+            else -> SupportedEnvelopeType.LOG
+        }
     }
 
     /**


### PR DESCRIPTION
## Goal

Records whether the log was a log, crash, or network capture when persisting to disk.

## Testing

Added unit tests.