### PR TITLE
Encode process id in filename

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 typealias DeliveryModuleSupplier = (
     configModule: ConfigModule,
     initModule: InitModule,
+    otelModule: OpenTelemetryModule,
     workerThreadModule: WorkerThreadModule,
     coreModule: CoreModule,
     storageModule: StorageModule,
@@ -21,6 +22,7 @@ typealias DeliveryModuleSupplier = (
 fun createDeliveryModule(
     configModule: ConfigModule,
     initModule: InitModule,
+    otelModule: OpenTelemetryModule,
     workerThreadModule: WorkerThreadModule,
     coreModule: CoreModule,
     storageModule: StorageModule,
@@ -30,6 +32,7 @@ fun createDeliveryModule(
 ): DeliveryModule = DeliveryModuleImpl(
     configModule,
     initModule,
+    otelModule,
     workerThreadModule,
     coreModule,
     storageModule,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfiguration.kt
@@ -48,7 +48,7 @@ class OpenTelemetryConfiguration(
      * This allows us to explicitly relate all the sessions associated with a particular app launch rather than having the backend figure
      * this out by proximity for stitched sessions.
      */
-    private val processIdentifier: String by lazy {
+    val processIdentifier: String by lazy {
         Systrace.traceSynchronous("process-identifier-init", IdGenerator.Companion::generateLaunchInstanceId)
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.utils.Uuid
 internal class V2PayloadStore(
     private val intakeService: IntakeService,
     private val clock: Clock,
+    private val processIdProvider: () -> String,
     private val uuidProvider: () -> String = { Uuid.getEmbUuid() },
 ) : PayloadStore {
 
@@ -39,6 +40,6 @@ internal class V2PayloadStore(
      * Constructs a [StoredTelemetryMetadata] object from the given [Envelope].
      */
     private fun createMetadata(type: SupportedEnvelopeType, complete: Boolean = true): StoredTelemetryMetadata {
-        return StoredTelemetryMetadata(clock.now(), uuidProvider(), type, complete)
+        return StoredTelemetryMetadata(clock.now(), uuidProvider(), processIdProvider(), type, complete)
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -33,6 +34,7 @@ class DeliveryModuleImplTest {
         module = DeliveryModuleImpl(
             FakeConfigModule(configService),
             FakeInitModule(),
+            FakeOpenTelemetryModule(),
             FakeWorkerThreadModule(),
             CoreModuleImpl(ApplicationProvider.getApplicationContext(), FakeEmbLogger()),
             FakeStorageModule(),

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -201,6 +201,7 @@ class PayloadResurrectionServiceImplTest {
         val earlierDeadSessionMetadata = StoredTelemetryMetadata(
             timestamp = earlierDeadSession.getStartTime(),
             uuid = "fake-uuid",
+            processId = "fakePid",
             envelopeType = SupportedEnvelopeType.SESSION,
             complete = false
         )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -20,21 +20,21 @@ class V2PayloadStoreTest {
     @Before
     fun setUp() {
         intakeService = FakeIntakeService()
-        store = V2PayloadStore(intakeService, FakeClock()) { "fakeuuid" }
+        store = V2PayloadStore(intakeService, FakeClock(), { "fakeProcessId" }) { "fakeuuid" }
     }
 
     @Test
     fun `test store session`() {
         val envelope = fakeSessionEnvelope()
         store.storeSessionPayload(envelope, TransitionType.ON_BACKGROUND)
-        verifySessionIntake(envelope, intakeService.getIntakes(), "1692201601000_session_fakeuuid_true_v1.json")
+        verifySessionIntake(envelope, intakeService.getIntakes(), "1692201601000_session_fakeuuid_fakeProcessId_true_v1.json")
     }
 
     @Test
     fun `test store session with crash`() {
         val envelope = fakeSessionEnvelope()
         store.storeSessionPayload(envelope, TransitionType.CRASH)
-        verifySessionIntake(envelope, intakeService.getIntakes(), "1692201601000_session_fakeuuid_true_v1.json")
+        verifySessionIntake(envelope, intakeService.getIntakes(), "1692201601000_session_fakeuuid_fakeProcessId_true_v1.json")
     }
 
     @Test
@@ -44,7 +44,7 @@ class V2PayloadStoreTest {
 
         val intake = intakeService.getIntakes<LogPayload>().single()
         assertSame(envelope, intake.envelope)
-        assertEquals("1692201601000_log_fakeuuid_true_v1.json", intake.metadata.filename)
+        assertEquals("1692201601000_log_fakeuuid_fakeProcessId_true_v1.json", intake.metadata.filename)
         assertEquals(0, intakeService.shutdownCount)
     }
 
@@ -58,7 +58,7 @@ class V2PayloadStoreTest {
     fun `test snapshot`() {
         val envelope = fakeSessionEnvelope()
         store.cacheSessionSnapshot(envelope)
-        verifySessionIntake(envelope, intakeService.getIntakes(false), "1692201601000_session_fakeuuid_false_v1.json")
+        verifySessionIntake(envelope, intakeService.getIntakes(false), "1692201601000_session_fakeuuid_fakeProcessId_false_v1.json")
     }
 
     private fun verifySessionIntake(

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -10,9 +10,10 @@ import kotlin.Result.Companion.failure
 data class StoredTelemetryMetadata(
     val timestamp: Long,
     val uuid: String,
+    val processId: String,
     val envelopeType: SupportedEnvelopeType,
     val complete: Boolean = true,
-    val filename: String = "${timestamp}_${envelopeType.description}_${uuid}_${complete}_v1.json",
+    val filename: String = "${timestamp}_${envelopeType.description}_${uuid}_${processId}_${complete}_v1.json",
 ) {
 
     companion object {
@@ -23,7 +24,7 @@ data class StoredTelemetryMetadata(
          */
         fun fromFilename(filename: String): Result<StoredTelemetryMetadata> {
             val parts = filename.split("_")
-            if (parts.size != 5) {
+            if (parts.size != 6) {
                 return failure(IllegalArgumentException("Invalid filename: $filename"))
             }
             val timestamp = parts[0].toLongOrNull() ?: return failure(
@@ -33,10 +34,11 @@ data class StoredTelemetryMetadata(
                 IllegalArgumentException("Invalid type: $filename")
             )
             val uuid = parts[2]
-            val complete = parts[3].toBooleanStrictOrNull() ?: return failure(
+            val processId = parts[3]
+            val complete = parts[4].toBooleanStrictOrNull() ?: return failure(
                 IllegalArgumentException("Invalid completeness state: $filename")
             )
-            return Result.success(StoredTelemetryMetadata(timestamp, uuid, type, complete, filename))
+            return Result.success(StoredTelemetryMetadata(timestamp, uuid, processId, type, complete, filename))
         }
     }
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
@@ -11,12 +11,12 @@ import org.junit.Test
 
 class StoredTelemetryComparatorTest {
 
-    private val crash = StoredTelemetryMetadata(1, "crash", CRASH)
-    private val session = StoredTelemetryMetadata(1, "session", SESSION)
-    private val session2 = StoredTelemetryMetadata(100, "session2", SESSION)
-    private val session3 = StoredTelemetryMetadata(1000, "session3", SESSION)
-    private val log = StoredTelemetryMetadata(1, "log", LOG)
-    private val network = StoredTelemetryMetadata(1, "network", NETWORK)
+    private val crash = StoredTelemetryMetadata(1, "crash", "pid", CRASH)
+    private val session = StoredTelemetryMetadata(1, "session", "pid", SESSION)
+    private val session2 = StoredTelemetryMetadata(100, "session2", "pid", SESSION)
+    private val session3 = StoredTelemetryMetadata(1000, "session3", "pid", SESSION)
+    private val log = StoredTelemetryMetadata(1, "log", "pid", LOG)
+    private val network = StoredTelemetryMetadata(1, "network", "pid", NETWORK)
 
     @Test
     fun `sort values`() {

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -9,6 +9,7 @@ class StoredTelemetryMetadataTest {
     companion object {
         private const val TIMESTAMP = 1726739283136
         private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
+        private const val PROCESS_ID = "fakeProcessId"
     }
 
     private val typeNameMap = mapOf(
@@ -23,8 +24,8 @@ class StoredTelemetryMetadataTest {
         typeNameMap.entries.forEach { (type, description) ->
             listOf(true, false).forEach { payloadComplete ->
                 assertEquals(
-                    "${TIMESTAMP}_${description}_${UUID}_${payloadComplete}_v1.json",
-                    StoredTelemetryMetadata(TIMESTAMP, UUID, type, payloadComplete).filename
+                    "${TIMESTAMP}_${description}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json",
+                    StoredTelemetryMetadata(TIMESTAMP, UUID, PROCESS_ID, type, payloadComplete).filename
                 )
             }
         }
@@ -51,7 +52,7 @@ class StoredTelemetryMetadataTest {
     fun `from valid filename`() {
         typeNameMap.entries.forEach { (type, description) ->
             listOf(true, false).forEach { payloadComplete ->
-                val input = "${TIMESTAMP}_${description}_${UUID}_${payloadComplete}_v1.json"
+                val input = "${TIMESTAMP}_${description}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json"
                 with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
                     assertEquals(input, filename)
                     assertEquals(TIMESTAMP, timestamp)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -37,6 +37,7 @@ class IntakeServiceImplTest {
 
     companion object {
         private const val UUID = "uuid"
+        private const val PROCESS_ID = "pid"
     }
 
     private lateinit var intakeService: IntakeService
@@ -65,14 +66,14 @@ class IntakeServiceImplTest {
     }
 
     private val clock = FakeClock()
-    private val sessionMetadata = StoredTelemetryMetadata(clock.now(), UUID, SESSION)
-    private val logMetadata = StoredTelemetryMetadata(clock.now(), UUID, LOG)
-    private val networkMetadata = StoredTelemetryMetadata(clock.now(), UUID, NETWORK)
-    private val crashMetadata = StoredTelemetryMetadata(clock.now(), UUID, CRASH)
-    private val sessionMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, SESSION)
-    private val logMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, LOG)
-    private val networkMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, NETWORK)
-    private val crashMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, CRASH)
+    private val sessionMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, SESSION)
+    private val logMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, LOG)
+    private val networkMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, NETWORK)
+    private val crashMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, CRASH)
+    private val sessionMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, SESSION)
+    private val logMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, LOG)
+    private val networkMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, NETWORK)
+    private val crashMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, CRASH)
 
     @Before
     fun setUp() {

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -21,9 +21,10 @@ class PayloadStorageServiceImplTest {
     companion object {
         private const val TIMESTAMP = 1500000000L
         private const val UUID = "uuid"
+        private const val PROCESS_ID = "pid"
     }
 
-    private val metadata = StoredTelemetryMetadata(TIMESTAMP, UUID, SESSION)
+    private val metadata = StoredTelemetryMetadata(TIMESTAMP, UUID, PROCESS_ID, SESSION)
     private lateinit var service: PayloadStorageService
     private lateinit var outputDir: File
     private lateinit var logger: FakeEmbLogger
@@ -96,7 +97,7 @@ class PayloadStorageServiceImplTest {
             Pair(1000L, LOG),
             Pair(1000L, NETWORK)
         ).forEach {
-            val metadata = StoredTelemetryMetadata(it.first, UUID, it.second)
+            val metadata = StoredTelemetryMetadata(it.first, UUID, PROCESS_ID, it.second)
             service.store(metadata) { stream ->
                 stream.write("test".toByteArray())
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -56,9 +56,10 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
         coreModuleSupplier = { _, _ -> overriddenCoreModule },
         workerThreadModuleSupplier = { _, _ -> overriddenWorkerThreadModule },
         androidServicesModuleSupplier = { _, _, _ -> overriddenAndroidServicesModule },
-        deliveryModuleSupplier = { configModule, initModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, _, _ ->
+        deliveryModuleSupplier = { configModule, otelModule, initModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, _, _ ->
             createDeliveryModule(
                 configModule,
+                otelModule,
                 initModule,
                 workerThreadModule,
                 coreModule,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -282,6 +282,7 @@ internal class ModuleInitBootstrapper(
                         deliveryModuleSupplier(
                             configModule,
                             initModule,
+                            openTelemetryModule,
                             workerThreadModule,
                             coreModule,
                             storageModule,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -48,7 +48,7 @@ internal fun fakeModuleInitBootstrapper(
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
-    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
+    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _ -> FakeNativeCoreModule() },

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 val fakeCachedSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
     timestamp = DEFAULT_FAKE_CURRENT_TIME + 1000L,
     uuid = "30690ad1-6b87-4e08-b72c-7deca14451d8",
+    processId = "8115ec91-3e5e-4d8a-816d-cc40306f9822",
     envelopeType = SupportedEnvelopeType.SESSION,
     complete = false
 )
@@ -20,11 +21,13 @@ val fakeSessionStoredTelemetryMetadata =
 val fakeSessionStoredTelemetryMetadata2 = StoredTelemetryMetadata(
     timestamp = DEFAULT_FAKE_CURRENT_TIME + 10_000L,
     uuid = "e6cfe01a-990e-4af7-b30e-f862947cef9b",
+    processId = "8115ec91-3e5e-4d8a-816d-cc40306f9822",
     envelopeType = SupportedEnvelopeType.SESSION
 )
 
 val fakeLogStoredTelemetryMetadata = StoredTelemetryMetadata(
     timestamp = DEFAULT_FAKE_CURRENT_TIME + 500L,
     uuid = "6bda3896-d4fd-42ce-89f6-47bec86f1c80",
+    processId = "8115ec91-3e5e-4d8a-816d-cc40306f9822",
     envelopeType = SupportedEnvelopeType.LOG
 )


### PR DESCRIPTION
## Goal

Encodes the process ID in the filename so that it's simpler to find sessions belonging to a given process.

## Testing

Updated unit tests.

