### PR TITLE
Move ResurrectionService to the CrashModule in the Features layer

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadModuleSupplier.kt
@@ -4,7 +4,8 @@ import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
- * Function that returns an instance of [PayloadSourceModule]. Matches the signature of the constructor for [PayloadSourceModuleImpl]
+ * Function that returns an instance of [PayloadSourceModule].
+ * Matches the signature of the constructor for [PayloadSourceModuleImpl]
  */
 typealias PayloadSourceModuleSupplier = (
     initModule: InitModule,
@@ -17,9 +18,11 @@ typealias PayloadSourceModuleSupplier = (
     nativeCoreModuleProvider: Provider<NativeCoreModule?>,
     nativeSymbolsProvider: Provider<Map<String, String>?>,
     otelModule: OpenTelemetryModule,
-    otelPayloadMapperProvider: Provider<OtelPayloadMapper>
+    otelPayloadMapperProvider: Provider<OtelPayloadMapper>,
+    deliveryModule: DeliveryModule,
 ) -> PayloadSourceModule
 
+@Suppress("LongParameterList")
 fun createPayloadSourceModule(
     initModule: InitModule,
     coreModule: CoreModule,
@@ -31,7 +34,8 @@ fun createPayloadSourceModule(
     nativeCoreModuleProvider: Provider<NativeCoreModule?>,
     nativeSymbolsProvider: Provider<Map<String, String>?>,
     otelModule: OpenTelemetryModule,
-    otelPayloadMapperProvider: Provider<OtelPayloadMapper>
+    otelPayloadMapperProvider: Provider<OtelPayloadMapper>,
+    deliveryModule: DeliveryModule,
 ): PayloadSourceModule = PayloadSourceModuleImpl(
     initModule,
     coreModule,
@@ -43,5 +47,6 @@ fun createPayloadSourceModule(
     nativeCoreModuleProvider,
     nativeSymbolsProvider,
     otelModule,
-    otelPayloadMapperProvider
+    otelPayloadMapperProvider,
+    deliveryModule,
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSource
+import io.embrace.android.embracesdk.internal.resurrection.PayloadResurrectionService
 
 /**
  * Modules containing classes that generate the payloads.
@@ -21,4 +22,5 @@ interface PayloadSourceModule {
     val metadataService: MetadataService
     val hostedSdkVersionInfo: HostedSdkVersionInfo
     val rnBundleIdTracker: RnBundleIdTracker
+    val payloadResurrectionService: PayloadResurrectionService?
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
@@ -10,6 +10,6 @@ fun Envelope<SessionPayload>.getSessionSpan(): Span? {
         ?: data.spanSnapshots?.singleOrNull { it.hasFixedAttribute(EmbType.Ux.Session) }
 }
 
-internal fun Envelope<SessionPayload>.getSessionId(): String? {
+fun Envelope<SessionPayload>.getSessionId(): String? {
     return getSessionSpan()?.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
@@ -62,7 +62,7 @@ fun Span.toOldPayload(): EmbraceSpanData {
     )
 }
 
-internal fun EmbraceSpanData.toFailedSpan(endTimeMs: Long): EmbraceSpanData {
+fun Span.toFailedSpan(endTimeMs: Long): Span {
     val newAttributes = mutableMapOf<String, String>().apply {
         setFixedAttribute(ErrorCodeAttribute.Failure)
         if (hasFixedAttribute(EmbType.Ux.Session)) {
@@ -72,22 +72,7 @@ internal fun EmbraceSpanData.toFailedSpan(endTimeMs: Long): EmbraceSpanData {
 
     return copy(
         endTimeNanos = endTimeMs.millisToNanos(),
-        status = StatusCode.ERROR,
-        attributes = attributes.plus(newAttributes)
-    )
-}
-
-internal fun Span.toFailedSpan(endTimeMs: Long): Span {
-    val newAttributes = mutableMapOf<String, String>().apply {
-        setFixedAttribute(ErrorCodeAttribute.Failure)
-        if (hasFixedAttribute(EmbType.Ux.Session)) {
-            setFixedAttribute(AppTerminationCause.Crash)
-        }
-    }
-
-    return copy(
-        endTimeNanos = endTimeMs.millisToNanos(),
-        parentSpanId = this.parentSpanId ?: SpanId.getInvalid(),
+        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
         status = Span.Status.ERROR,
         attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
     )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionService.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.resurrection
 
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
+import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * This service finds cached payloads from previous process launches & sends them to the
@@ -13,5 +15,5 @@ interface PayloadResurrectionService {
      * Resurrects any payloads that were cached in a previous process & sends them to the
      * [IntakeService].
      */
-    fun resurrectOldPayloads()
+    fun resurrectOldPayloads(nativeCrashServiceProvider: Provider<NativeCrashService?>)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -30,12 +30,11 @@ import kotlin.math.max
 internal class PayloadResurrectionServiceImpl(
     private val intakeService: IntakeService,
     private val payloadStorageService: PayloadStorageService,
-    private val nativeCrashServiceProvider: Provider<NativeCrashService?>,
     private val logger: EmbLogger,
     private val serializer: PlatformSerializer,
 ) : PayloadResurrectionService {
 
-    override fun resurrectOldPayloads() {
+    override fun resurrectOldPayloads(nativeCrashServiceProvider: Provider<NativeCrashService?>) {
         val nativeCrashService = nativeCrashServiceProvider()
         val nativeCrashes = nativeCrashService?.getNativeCrashes()?.associateBy { it.sessionId } ?: emptyMap()
         nativeCrashes.values.forEach { nativeCrash ->

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImplTest.kt
@@ -2,10 +2,13 @@ package io.embrace.android.embracesdk.internal.injection
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
+import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
+import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeCoreModule
@@ -14,6 +17,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
 import io.embrace.android.embracesdk.internal.capture.metadata.EmbraceMetadataService
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,10 +41,38 @@ internal class PayloadSourceModuleImplTest {
             ::HashMap,
             FakeOpenTelemetryModule(),
             ::FakeOtelPayloadMapper,
+            FakeDeliveryModule(),
         )
         assertTrue(module.metadataService is EmbraceMetadataService)
         assertNotNull(module.sessionEnvelopeSource)
         assertNotNull(module.logEnvelopeSource)
         assertTrue(module.deviceArchitecture is DeviceArchitectureImpl)
+        assertNull(module.payloadResurrectionService)
+    }
+
+    @Test
+    fun `payload resurrection service is created when v2 delivery layer is on`() {
+        val initModule = FakeInitModule()
+        val module = PayloadSourceModuleImpl(
+            initModule,
+            CoreModuleImpl(RuntimeEnvironment.getApplication(), FakeEmbLogger()),
+            FakeWorkerThreadModule(),
+            FakeSystemServiceModule(),
+            FakeAndroidServicesModule(),
+            FakeEssentialServiceModule(),
+            FakeConfigModule(
+                configService = FakeConfigService(
+                    autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
+                        v2StorageEnabled = true
+                    )
+                )
+            ),
+            ::FakeNativeCoreModule,
+            ::HashMap,
+            FakeOpenTelemetryModule(),
+            ::FakeOtelPayloadMapper,
+            FakeDeliveryModule(),
+        )
+        assertNotNull(module.payloadResurrectionService)
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -64,29 +63,6 @@ internal class SpanMapperTest {
         val attributesOfFailedSpan = failedSpan.attributes?.associate { it.key to it.data } ?: emptyMap()
         checkNotNull(snapshot.attributes).forEach {
             assertEquals(attributesOfFailedSpan[it.key], it.data)
-        }
-    }
-
-    @Test
-    fun `terminating span snapshot as old payload works as expected`() {
-        val snapshot = FakeSpanData.perfSpanSnapshot.toEmbraceSpanData()
-        val terminationTimeMs = snapshot.startTimeNanos.nanosToMillis() + 60000L
-        val failedSpan = snapshot.toFailedSpan(terminationTimeMs)
-
-        assertEquals(snapshot.traceId, failedSpan.traceId)
-        assertEquals(snapshot.spanId, failedSpan.spanId)
-        assertEquals(snapshot.parentSpanId, failedSpan.parentSpanId)
-        assertEquals(snapshot.name, failedSpan.name)
-        assertEquals(snapshot.startTimeNanos, failedSpan.startTimeNanos)
-        assertEquals(terminationTimeMs, failedSpan.endTimeNanos.nanosToMillis())
-        assertEquals(StatusCode.ERROR, checkNotNull(failedSpan.status))
-        assertEquals(snapshot.events.single(), failedSpan.events.single())
-        failedSpan.assertError(ErrorCode.FAILURE)
-        failedSpan.assertIsTypePerformance()
-        failedSpan.assertIsKeySpan()
-        failedSpan.assertNotPrivateSpan()
-        checkNotNull(snapshot.attributes).forEach {
-            assertEquals(failedSpan.attributes[it.key], it.value)
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -54,7 +54,6 @@ class PayloadResurrectionServiceImplTest {
         resurrectionService = PayloadResurrectionServiceImpl(
             intakeService = intakeService,
             payloadStorageService = payloadStorageService,
-            nativeCrashServiceProvider = { nativeCrashService },
             logger = logger,
             serializer = serializer,
         )
@@ -62,7 +61,7 @@ class PayloadResurrectionServiceImplTest {
 
     @Test
     fun `if no previous cached session then send previous cached sessions should not send anything`() {
-        resurrectionService.resurrectOldPayloads()
+        resurrectionService.resurrectOldPayloads({ nativeCrashService })
         assertTrue(intakeService.intakeList.isEmpty())
     }
 
@@ -166,7 +165,7 @@ class PayloadResurrectionServiceImplTest {
             data = deadSessionEnvelope
         )
         serializer.errorOnNextOperation()
-        resurrectionService.resurrectOldPayloads()
+        resurrectionService.resurrectOldPayloads({ nativeCrashService })
         assertResurrectionFailure()
     }
 
@@ -211,7 +210,7 @@ class PayloadResurrectionServiceImplTest {
             data = earlierDeadSession
         )
 
-        resurrectionService.resurrectOldPayloads()
+        resurrectionService.resurrectOldPayloads({ nativeCrashService })
 
         val sessionPayloads = intakeService.getIntakes<SessionPayload>(false)
         assertEquals(2, sessionPayloads.size)
@@ -243,7 +242,7 @@ class PayloadResurrectionServiceImplTest {
             metadata = sessionMetadata,
             data = this
         )
-        resurrectionService.resurrectOldPayloads()
+        resurrectionService.resurrectOldPayloads({ nativeCrashService })
     }
 
     private fun createNativeCrashData(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -46,7 +46,7 @@ internal class ModuleInitBootstrapper(
     private val momentsModuleSupplier: MomentsModuleSupplier = ::createMomentsModule,
     private val sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier = ::createSessionOrchestrationModule,
     private val crashModuleSupplier: CrashModuleSupplier = ::createCrashModule,
-    private val payloadSourceModuleSupplier: PayloadSourceModuleSupplier = ::createPayloadSourceModule
+    private val payloadSourceModuleSupplier: PayloadSourceModuleSupplier = ::createPayloadSourceModule,
 ) {
     lateinit var coreModule: CoreModule
         private set
@@ -329,7 +329,8 @@ internal class ModuleInitBootstrapper(
                             { nativeCoreModule },
                             { nativeFeatureModule.nativeThreadSamplerService?.getNativeSymbols() },
                             openTelemetryModule,
-                            { OtelPayloadMapperImpl(anrModule.anrOtelMapper, nativeFeatureModule.nativeAnrOtelMapper) }
+                            { OtelPayloadMapperImpl(anrModule.anrOtelMapper, nativeFeatureModule.nativeAnrOtelMapper) },
+                            deliveryModule
                         )
                     }
                     postInit(PayloadSourceModule::class) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -56,7 +56,8 @@ internal fun fakeModuleInitBootstrapper(
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier =
         { _, _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
     crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _, _ -> FakeCrashModule() },
-    payloadSourceModuleSupplier: PayloadSourceModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() }
+    payloadSourceModuleSupplier: PayloadSourceModuleSupplier =
+        { _, _, _, _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() },
 ) = ModuleInitBootstrapper(
     logger = fakeEmbLogger,
     initModule = fakeInitModule,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadResurrectionService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadResurrectionService.kt
@@ -1,12 +1,14 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.resurrection.PayloadResurrectionService
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 class FakePayloadResurrectionService : PayloadResurrectionService {
 
     var resurrectCount: Int = 0
 
-    override fun resurrectOldPayloads() {
+    override fun resurrectOldPayloads(nativeCrashServiceProvider: Provider<NativeCrashService?>) {
         resurrectCount++
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeLogEnvelopeSource
 import io.embrace.android.embracesdk.fakes.FakeLogPayloadSource
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
+import io.embrace.android.embracesdk.fakes.FakePayloadResurrectionService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeRnBundleIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionEnvelopeSource
@@ -18,6 +19,7 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersion
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPayloadSource
 import io.embrace.android.embracesdk.internal.injection.PayloadSourceModule
+import io.embrace.android.embracesdk.internal.resurrection.PayloadResurrectionService
 
 class FakePayloadSourceModule(
     override val metadataService: MetadataService = FakeMetadataService(),
@@ -26,6 +28,7 @@ class FakePayloadSourceModule(
     override val resourceSource: FakeEnvelopeResourceSource = FakeEnvelopeResourceSource(),
     override val metadataSource: FakeEnvelopeMetadataSource = FakeEnvelopeMetadataSource(),
     override val rnBundleIdTracker: FakeRnBundleIdTracker = FakeRnBundleIdTracker(),
+    override val payloadResurrectionService: PayloadResurrectionService = FakePayloadResurrectionService(),
     sessionPayloadSource: SessionPayloadSource = FakeSessionPayloadSource(),
     logPayloadSource: LogPayloadSource = FakeLogPayloadSource()
 ) : PayloadSourceModule {


### PR DESCRIPTION
## Goal

The PayloadResurrectionService, for now, depends on the NativeCrashService, which exists in the Features Layer, so I'm moving it there too (in the CrashModule, as it is resurrecting payloads generated sometimes by native crashes) so it can have access to it. 

## Testing
Change module tests to verify that the service is only initialized if the v2 feature flag is on.