### PR TITLE
Avoid check not null in module bootstrapper

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -295,12 +295,13 @@ internal class ModuleInitBootstrapper(
                                 }
                             },
                             {
-                                if (configModule.configService.isOnlyUsingOtelExporters()) {
+                                val apiService = essentialServiceModule.apiService
+                                if (configModule.configService.isOnlyUsingOtelExporters() || apiService == null) {
                                     null
                                 } else {
                                     EmbraceDeliveryService(
                                         storageModule.deliveryCacheManager,
-                                        checkNotNull(essentialServiceModule.apiService),
+                                        apiService,
                                         initModule.jsonSerializer,
                                         initModule.logger
                                     )


### PR DESCRIPTION
## Goal

Avoids checkNotNull to prefer returning null in the `ModuleInitBootstrapper`. Functionally this should not make much different as `apiService` will always be null if only OTel export mode is enabled, but it can't hurt to alter this in case that assumption ever breaks.

