### PR TITLE
Replace scheduling worker

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -77,7 +77,7 @@ internal class DeliveryModuleImpl(
                 cacheStorageService,
                 initModule.logger,
                 initModule.jsonSerializer,
-                workerThreadModule.priorityWorker(Worker.Priority.FileCacheWorker)
+                workerThreadModule.priorityWorker(Worker.Priority.DataPersistenceWorker)
             )
         }
     }
@@ -140,8 +140,8 @@ internal class DeliveryModuleImpl(
             SchedulingServiceImpl(
                 payloadStorageService,
                 requestExecutionService,
-                workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
-                workerThreadModule.backgroundWorker(Worker.Background.DeliveryWorker),
+                workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
+                workerThreadModule.backgroundWorker(Worker.Background.HttpRequestWorker),
                 initModule.clock,
                 initModule.logger
             )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
@@ -44,7 +44,7 @@ internal class StorageModuleImpl(
     override val deliveryCacheManager: DeliveryCacheManager by singleton {
         EmbraceDeliveryCacheManager(
             cacheService,
-            workerThreadModule.priorityWorker(Worker.Priority.FileCacheWorker),
+            workerThreadModule.priorityWorker(Worker.Priority.DataPersistenceWorker),
             initModule.logger
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.internal.worker.PriorityThreadPoolExecutor
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import io.embrace.android.embracesdk.internal.worker.Worker
-import io.embrace.android.embracesdk.internal.worker.Worker.Priority.FileCacheWorker
+import io.embrace.android.embracesdk.internal.worker.Worker.Priority.DataPersistenceWorker
 import io.embrace.android.embracesdk.internal.worker.Worker.Priority.NetworkRequestWorker
 import io.embrace.android.embracesdk.internal.worker.comparator.apiRequestComparator
 import io.embrace.android.embracesdk.internal.worker.comparator.taskPriorityComparator
@@ -57,7 +57,7 @@ internal class WorkerThreadModuleImpl(
 
             if (worker is Worker.Priority) {
                 val comparator = when (worker) {
-                    FileCacheWorker -> fileCacheWorkercomparator
+                    DataPersistenceWorker -> fileCacheWorkercomparator
                     NetworkRequestWorker -> apiRequestComparator
                 }
                 PriorityThreadPoolExecutor(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
@@ -13,7 +13,7 @@ sealed class Worker(internal val threadName: String) {
         /**
          * Saves/loads request information from files cached on disk.
          */
-        object FileCacheWorker : Priority("file-cache")
+        object DataPersistenceWorker : Priority("data-persistence")
 
         /**
          * All HTTP requests are performed on this executor.
@@ -55,10 +55,8 @@ sealed class Worker(internal val threadName: String) {
         object AnrWatchdogWorker : Background("anr-watchdog")
 
         /**
-         * Delivery Worker
-         *
-         * TODO: Make this a PriorityWorker
+         * Worker that performs HTTP requests that push data to the server.
          */
-        object DeliveryWorker : Background("delivery")
+        object HttpRequestWorker : Background("http-request")
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
@@ -40,7 +40,7 @@ internal class WorkerThreadModuleImplTest {
     fun `network request executor uses custom queue`() {
         val module = WorkerThreadModuleImpl(initModule, ::FakeConfigService)
         assertNotNull(module.priorityWorker<ApiRequest>(Worker.Priority.NetworkRequestWorker))
-        assertNotNull(module.priorityWorker<TaskPriority>(Worker.Priority.FileCacheWorker))
+        assertNotNull(module.priorityWorker<TaskPriority>(Worker.Priority.DataPersistenceWorker))
     }
 
     @Test

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -198,7 +198,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
 
         // Send any sessions that were cached and not yet sent.
         startSynchronous("send-cached-sessions")
-        val worker = bootstrapper.workerThreadModule.priorityWorker<TaskPriority>(Worker.Priority.FileCacheWorker)
+        val worker = bootstrapper.workerThreadModule.priorityWorker<TaskPriority>(Worker.Priority.DataPersistenceWorker)
         worker.submit(TaskPriority.NORMAL) {
             val essentialServiceModule = bootstrapper.essentialServiceModule
             bootstrapper.deliveryModule.deliveryService?.sendCachedSessions(


### PR DESCRIPTION
## Goal

Replaces the worker used for the `SchedulingService` with one that can use I/O, as I/O will be triggered the first time the service attempts to read from the `PayloadStore`. Additionally renamed some workers to more appropriate names.

