### PR TITLE
ci: Don't need to use internal android-emulator-runner fork.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: embrace-io/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           force-avd-creation: false
@@ -63,7 +63,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run Functional Tests
-        uses: embrace-io/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
## Goal

It's not necessary to use our own fork inside public repos.

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Do not put any customer information here. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>

