### PR TITLE
Only write attributes for crashes if they contain valid values

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriter.kt
@@ -11,6 +11,7 @@ interface LogWriter {
         schemaType: SchemaType,
         severity: Severity,
         message: String,
-        isPrivate: Boolean = false
+        isPrivate: Boolean = false,
+        addCurrentSessionId: Boolean = true,
     )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.EmbraceProcessStateService.Companion.BACKGROUND_STATE
 import io.embrace.android.embracesdk.internal.session.lifecycle.EmbraceProcessStateService.Companion.FOREGROUND_STATE
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
+import io.embrace.android.embracesdk.internal.spans.setAttribute
 import io.embrace.android.embracesdk.internal.spans.setFixedAttribute
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.opentelemetry.api.common.AttributeKey
@@ -25,7 +26,8 @@ class LogWriterImpl(
         schemaType: SchemaType,
         severity: Severity,
         message: String,
-        isPrivate: Boolean
+        isPrivate: Boolean,
+        addCurrentSessionId: Boolean,
     ) {
         val builder = logger.logRecordBuilder()
             .setBody(message)
@@ -36,7 +38,9 @@ class LogWriterImpl(
 
         var sessionState: String? = null
         sessionIdTracker.getActiveSession()?.let { session ->
-            builder.setAttribute(SessionIncubatingAttributes.SESSION_ID, session.id)
+            if (addCurrentSessionId) {
+                builder.setAttribute(SessionIncubatingAttributes.SESSION_ID, session.id, false)
+            }
             sessionState = if (session.isForeground) {
                 FOREGROUND_STATE
             } else {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch.schema
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.utils.isBlankish
 import io.opentelemetry.api.common.AttributeKey
 
 /**
@@ -37,12 +38,14 @@ class TelemetryAttributes(
         return result
     }
 
-    fun setAttribute(key: EmbraceAttributeKey, value: String) {
-        setAttribute(key.attributeKey, value)
+    fun setAttribute(key: EmbraceAttributeKey, value: String, keepBlankishValues: Boolean = true) {
+        setAttribute(key.attributeKey, value, keepBlankishValues)
     }
 
-    fun setAttribute(key: AttributeKey<String>, value: String) {
-        map[key] = value
+    fun setAttribute(key: AttributeKey<String>, value: String, keepBlankishValues: Boolean = true) {
+        if (keepBlankishValues || !value.isBlankish()) {
+            map[key] = value
+        }
     }
 
     fun getAttribute(key: EmbraceAttributeKey): String? = map[key.attributeKey]

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.toSessionPropertyAttri
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanLimits.isAttributeValid
+import io.embrace.android.embracesdk.internal.utils.isBlankish
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.AttributesBuilder
@@ -21,6 +22,17 @@ import io.opentelemetry.semconv.ExceptionAttributes
 
 internal fun LogRecordBuilder.setFixedAttribute(fixedAttribute: FixedAttribute): LogRecordBuilder {
     setAttribute(fixedAttribute.key.attributeKey, fixedAttribute.value)
+    return this
+}
+
+internal fun LogRecordBuilder.setAttribute(
+    attributeKey: AttributeKey<String>,
+    value: String,
+    keepBlankishValues: Boolean = true,
+): LogRecordBuilder {
+    if (keepBlankishValues || !value.isBlankish()) {
+        setAttribute(attributeKey, value)
+    }
     return this
 }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/Extensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/Extensions.kt
@@ -1,0 +1,3 @@
+package io.embrace.android.embracesdk.internal.utils
+
+fun String.isBlankish(): Boolean = isBlank() || lowercase() == "null"

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/ExtensionsKtTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/ExtensionsKtTest.kt
@@ -1,0 +1,19 @@
+package io.embrace.android.embracesdk.internal.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class ExtensionsKtTest {
+
+    @Test
+    fun `blankish values return true when isBlankish invoked`() {
+        val blankishValues = listOf("", " ", "null", "NULL")
+
+        blankishValues.forEach { value ->
+            assertTrue(value.isBlankish())
+        }
+
+        assertFalse("test".isBlankish())
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
@@ -8,7 +8,13 @@ class FakeLogWriter : LogWriter {
 
     val logEvents: MutableList<LogEventData> = mutableListOf()
 
-    override fun addLog(schemaType: SchemaType, severity: Severity, message: String, isPrivate: Boolean) {
+    override fun addLog(
+        schemaType: SchemaType,
+        severity: Severity,
+        message: String,
+        isPrivate: Boolean,
+        addCurrentSessionId: Boolean,
+    ) {
         logEvents.add(LogEventData(schemaType, severity, message))
     }
 }


### PR DESCRIPTION
## Goal

The NDK and/or the serialization layer is returning values that are effectively null/empty but with non-null string value like "null", and we weren't filtering out those cases because we assumed it would just return null when those values didn't exist.

Add in the generic ability to detect string values like that, and to skip adding those values as OTel attributes, if you explicitly say that's what you wanted.

There was also some code in the native crash log generation layer that didn't check for empty collections before serializing their values - took care of those cases too.

## Testing
Units tests all the way down

