### PR TITLE
Implement getUndeliveredPayloads methods in PayloadStorageService

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
@@ -42,5 +42,5 @@ interface PayloadStorageService {
     /**
      * Return cached payloads from previous app instances
      */
-    fun getUndeliveredPayloads(): List<StoredTelemetryMetadata> = emptyList()
+    fun getUndeliveredPayloads(): List<StoredTelemetryMetadata>
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -31,6 +31,7 @@ class PayloadStorageServiceImplTest {
     private lateinit var outputDir: File
     private lateinit var logger: FakeEmbLogger
     private lateinit var worker: PriorityWorker<StoredTelemetryMetadata>
+    private lateinit var currentProcessId: String
 
     @Before
     fun setUp() {
@@ -38,7 +39,8 @@ class PayloadStorageServiceImplTest {
         outputDir.deleteRecursively()
         worker = PriorityWorker(BlockableExecutorService(false))
         logger = FakeEmbLogger(false)
-        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, logger)
+        currentProcessId = PROCESS_ID
+        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger)
     }
 
     @Test
@@ -88,7 +90,7 @@ class PayloadStorageServiceImplTest {
     @Test
     fun `test objects pruned past limit`() {
         assertNull(outputDir.listFiles())
-        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, logger, 4)
+        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger, 4)
 
         // exceed storage limit
         listOf(
@@ -121,5 +123,42 @@ class PayloadStorageServiceImplTest {
         assertEquals(expected, outputs)
         val msg = logger.internalErrorMessages.last().throwable?.message
         assertEquals("Pruned payload storage", msg)
+    }
+
+    @Test
+    fun `getUndeliveredPayloads only returns incomplete ones with a different process identifier than the current`() {
+        listOf("old_pid" to 100_000L, PROCESS_ID to 200_000L).forEach { appInstance ->
+            listOf(true, false).forEach { complete ->
+                listOf(CRASH, SESSION, LOG, NETWORK).forEach { type ->
+                    val metadata = StoredTelemetryMetadata(
+                        timestamp = appInstance.second,
+                        uuid = UUID,
+                        processId = appInstance.first,
+                        envelopeType = type,
+                        complete = complete,
+                    )
+                    service.store(metadata) { stream ->
+                        stream.write("test".toByteArray())
+                    }
+                }
+            }
+        }
+
+        with(service.getUndeliveredPayloads()) {
+            assertEquals(4, size)
+            assertEquals(0, filter { it.complete }.size)
+            assertEquals(0, filter { it.processId == PROCESS_ID }.size)
+        }
+    }
+
+    @Test
+    fun `incomplete payload becomes undelivered when process identifier changes`() {
+        service.store(metadata.copy(complete = false)) { stream ->
+            stream.write("test".toByteArray())
+        }
+
+        assertEquals(0, service.getUndeliveredPayloads().size)
+        currentProcessId = "new-pid"
+        assertEquals(1, service.getUndeliveredPayloads().size)
     }
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -148,6 +148,10 @@ class PayloadStorageServiceImplTest {
             assertEquals(4, size)
             assertEquals(0, filter { it.complete }.size)
             assertEquals(0, filter { it.processId == PROCESS_ID }.size)
+            assertNotNull(singleOrNull { it.envelopeType == CRASH })
+            assertNotNull(singleOrNull { it.envelopeType == SESSION })
+            assertNotNull(singleOrNull { it.envelopeType == LOG })
+            assertNotNull(singleOrNull { it.envelopeType == NETWORK })
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -13,7 +13,9 @@ import java.io.InputStream
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.GZIPOutputStream
 
-class FakePayloadStorageService : PayloadStorageService {
+class FakePayloadStorageService(
+    var currentProcessId: String = "pid"
+) : PayloadStorageService {
     private val serializer = TestPlatformSerializer()
     private val cachedPayloads = LinkedHashMap<StoredTelemetryMetadata, ByteArray>()
 
@@ -49,7 +51,7 @@ class FakePayloadStorageService : PayloadStorageService {
         cachedPayloads.filter { it.key.complete }.keys.toList()
 
     override fun getUndeliveredPayloads(): List<StoredTelemetryMetadata> =
-        cachedPayloads.filterNot { it.key.complete }.keys.toList()
+        cachedPayloads.filterNot { it.key.complete && it.key.processId != currentProcessId }.keys.toList()
 
     fun <T> addPayload(metadata: StoredTelemetryMetadata, data: T) {
         store(metadata) { stream ->


### PR DESCRIPTION
## Goal

Implement the getUndeliveredPayloads method which only returns payloads with a different process identifier than the current one and is incomplete. We won't try to resurrect payloads for the current app instance because it's not dead yet!
