### PR TITLE
Change the token encoded in a file name for envelope type to priority

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -57,7 +57,7 @@ internal class WorkerThreadModuleImpl(
 
             if (worker is Worker.Priority) {
                 val comparator = when (worker) {
-                    DataPersistenceWorker -> fileCacheWorkercomparator
+                    DataPersistenceWorker -> fileCacheWorkerComparator
                     NetworkRequestWorker -> apiRequestComparator
                 }
                 PriorityThreadPoolExecutor(
@@ -73,7 +73,7 @@ internal class WorkerThreadModuleImpl(
         }
     }
 
-    private val fileCacheWorkercomparator by lazy {
+    private val fileCacheWorkerComparator by lazy {
         when (configServiceProvider().autoDataCaptureBehavior.isV2StorageEnabled()) {
             true -> storedTelemetryRunnableComparator
             false -> taskPriorityComparator

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
@@ -48,7 +48,7 @@ internal class V2PayloadStore(
             System.NativeCrash.value -> SupportedEnvelopeType.CRASH
             System.ReactNativeCrash.value -> SupportedEnvelopeType.CRASH
             System.FlutterException.value -> SupportedEnvelopeType.CRASH
-            System.NetworkCapturedRequest.value -> SupportedEnvelopeType.NETWORK
+            System.NetworkCapturedRequest.value -> SupportedEnvelopeType.BLOB
             else -> SupportedEnvelopeType.LOG
         }
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -33,14 +33,22 @@ class V2PayloadStoreTest {
     fun `test store session`() {
         val envelope = fakeSessionEnvelope()
         store.storeSessionPayload(envelope, TransitionType.ON_BACKGROUND)
-        verifySessionIntake(envelope, intakeService.getIntakes(), "1692201601000_session_fakeuuid_fakeProcessId_true_v1.json")
+        verifySessionIntake(
+            envelope,
+            intakeService.getIntakes(),
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_v1.json"
+        )
     }
 
     @Test
     fun `test store session with crash`() {
         val envelope = fakeSessionEnvelope()
         store.storeSessionPayload(envelope, TransitionType.CRASH)
-        verifySessionIntake(envelope, intakeService.getIntakes(), "1692201601000_session_fakeuuid_fakeProcessId_true_v1.json")
+        verifySessionIntake(
+            envelope,
+            intakeService.getIntakes(),
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_v1.json"
+        )
     }
 
     @Test
@@ -50,7 +58,7 @@ class V2PayloadStoreTest {
 
         val intake = intakeService.getIntakes<LogPayload>().single()
         assertSame(envelope, intake.envelope)
-        assertEquals("1692201601000_log_fakeuuid_fakeProcessId_true_v1.json", intake.metadata.filename)
+        assertEquals("p5_1692201601000_fakeuuid_fakeProcessId_true_v1.json", intake.metadata.filename)
         assertEquals(0, intakeService.shutdownCount)
     }
 
@@ -64,7 +72,11 @@ class V2PayloadStoreTest {
     fun `test snapshot`() {
         val envelope = fakeSessionEnvelope()
         store.cacheSessionSnapshot(envelope)
-        verifySessionIntake(envelope, intakeService.getIntakes(false), "1692201601000_session_fakeuuid_fakeProcessId_false_v1.json")
+        verifySessionIntake(
+            envelope,
+            intakeService.getIntakes(false),
+            "p3_1692201601000_fakeuuid_fakeProcessId_false_v1.json"
+        )
     }
 
     @Test
@@ -92,7 +104,7 @@ class V2PayloadStoreTest {
 
         // network
         storeLogWithType(System.NetworkCapturedRequest)
-        assertEquals(SupportedEnvelopeType.NETWORK, getLastLogMetadata().envelopeType)
+        assertEquals(SupportedEnvelopeType.BLOB, getLastLogMetadata().envelopeType)
     }
 
     private fun storeLogWithType(type: TelemetryType) {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -13,7 +13,7 @@ data class StoredTelemetryMetadata(
     val processId: String,
     val envelopeType: SupportedEnvelopeType,
     val complete: Boolean = true,
-    val filename: String = "${timestamp}_${envelopeType.description}_${uuid}_${processId}_${complete}_v1.json",
+    val filename: String = "${envelopeType.priority}_${timestamp}_${uuid}_${processId}_${complete}_v1.json",
 ) {
 
     companion object {
@@ -27,18 +27,18 @@ data class StoredTelemetryMetadata(
             if (parts.size != 6) {
                 return failure(IllegalArgumentException("Invalid filename: $filename"))
             }
-            val timestamp = parts[0].toLongOrNull() ?: return failure(
-                IllegalArgumentException("Invalid timestamp: $filename")
+            val envelopeType = SupportedEnvelopeType.fromPriority(parts[0]) ?: return failure(
+                IllegalArgumentException("Invalid priority: $filename")
             )
-            val type = SupportedEnvelopeType.fromDescription(parts[1]) ?: return failure(
-                IllegalArgumentException("Invalid type: $filename")
+            val timestamp = parts[1].toLongOrNull() ?: return failure(
+                IllegalArgumentException("Invalid timestamp: $filename")
             )
             val uuid = parts[2]
             val processId = parts[3]
             val complete = parts[4].toBooleanStrictOrNull() ?: return failure(
                 IllegalArgumentException("Invalid completeness state: $filename")
             )
-            return Result.success(StoredTelemetryMetadata(timestamp, uuid, processId, type, complete, filename))
+            return Result.success(StoredTelemetryMetadata(timestamp, uuid, processId, envelopeType, complete, filename))
         }
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
@@ -9,22 +9,22 @@ import java.lang.reflect.Type
  */
 enum class SupportedEnvelopeType(
     val serializedType: Type,
-    val description: String,
+    val priority: String,
     val endpoint: Endpoint,
 ) {
 
-    CRASH(Envelope.logEnvelopeType, "crash", Endpoint.LOGS),
-    SESSION(Envelope.sessionEnvelopeType, "session", Endpoint.SESSIONS_V2),
-    LOG(Envelope.logEnvelopeType, "log", Endpoint.LOGS),
-    NETWORK(Envelope.logEnvelopeType, "network", Endpoint.LOGS);
+    CRASH(Envelope.logEnvelopeType, "p1", Endpoint.LOGS),
+    SESSION(Envelope.sessionEnvelopeType, "p3", Endpoint.SESSIONS_V2),
+    LOG(Envelope.logEnvelopeType, "p5", Endpoint.LOGS),
+    BLOB(Envelope.logEnvelopeType, "p7", Endpoint.LOGS);
 
     companion object {
         private val valueMap =
-            SupportedEnvelopeType.values().associateBy(SupportedEnvelopeType::description)
+            SupportedEnvelopeType.values().associateBy(SupportedEnvelopeType::priority)
 
         /**
-         * Returns the [SupportedEnvelopeType] that corresponds to the given description, if any.
+         * Returns the [SupportedEnvelopeType] that corresponds to the given priority, if any.
          */
-        fun fromDescription(description: String): SupportedEnvelopeType? = valueMap[description]
+        fun fromPriority(priority: String): SupportedEnvelopeType? = valueMap[priority]
     }
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.delivery
 
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.BLOB
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
-import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
 import io.embrace.android.embracesdk.internal.worker.PriorityRunnableFuture
 import io.mockk.mockk
@@ -16,7 +16,7 @@ class StoredTelemetryComparatorTest {
     private val session2 = StoredTelemetryMetadata(100, "session2", "pid", SESSION)
     private val session3 = StoredTelemetryMetadata(1000, "session3", "pid", SESSION)
     private val log = StoredTelemetryMetadata(1, "log", "pid", LOG)
-    private val network = StoredTelemetryMetadata(1, "network", "pid", NETWORK)
+    private val network = StoredTelemetryMetadata(1, "network", "pid", BLOB)
 
     @Test
     fun `sort values`() {

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -13,18 +13,18 @@ class StoredTelemetryMetadataTest {
     }
 
     private val typeNameMap = mapOf(
-        SupportedEnvelopeType.CRASH to "crash",
-        SupportedEnvelopeType.SESSION to "session",
-        SupportedEnvelopeType.LOG to "log",
-        SupportedEnvelopeType.NETWORK to "network"
+        SupportedEnvelopeType.CRASH to "p1",
+        SupportedEnvelopeType.SESSION to "p3",
+        SupportedEnvelopeType.LOG to "p5",
+        SupportedEnvelopeType.BLOB to "p7"
     )
 
     @Test
     fun `construct objects`() {
-        typeNameMap.entries.forEach { (type, description) ->
+        typeNameMap.entries.forEach { (type, priority) ->
             listOf(true, false).forEach { payloadComplete ->
                 assertEquals(
-                    "${TIMESTAMP}_${description}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json",
+                    "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json",
                     StoredTelemetryMetadata(TIMESTAMP, UUID, PROCESS_ID, type, payloadComplete).filename
                 )
             }
@@ -38,9 +38,10 @@ class StoredTelemetryMetadataTest {
             "foo",
             "my_session.json",
             "1234567890_session_v1.json",
-            "a_b_c_v1.json",
-            "${TIMESTAMP}_b_c_v1.json",
-            "${TIMESTAMP}_session_c_v1.json"
+            "p4_${TIMESTAMP}_b_c_true_v1.json",
+            "p1_b_c_false_v1.json",
+            "p3_${TIMESTAMP}_b_c_d_v1.json",
+            "p3_${TIMESTAMP}_c_d_v1.json"
         )
         badFilenames.forEach { filename ->
             val result = StoredTelemetryMetadata.fromFilename(filename)
@@ -50,9 +51,9 @@ class StoredTelemetryMetadataTest {
 
     @Test
     fun `from valid filename`() {
-        typeNameMap.entries.forEach { (type, description) ->
+        typeNameMap.entries.forEach { (type, priority) ->
             listOf(true, false).forEach { payloadComplete ->
-                val input = "${TIMESTAMP}_${description}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json"
+                val input = "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json"
                 with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
                     assertEquals(input, filename)
                     assertEquals(TIMESTAMP, timestamp)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -7,9 +7,9 @@ import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeSchedulingService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.BLOB
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
-import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryRunnableComparator
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -68,11 +68,11 @@ class IntakeServiceImplTest {
     private val clock = FakeClock()
     private val sessionMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, SESSION)
     private val logMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, LOG)
-    private val networkMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, NETWORK)
+    private val networkMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, BLOB)
     private val crashMetadata = StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, CRASH)
     private val sessionMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, SESSION)
     private val logMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, LOG)
-    private val networkMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, NETWORK)
+    private val networkMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, BLOB)
     private val crashMetadata2 = StoredTelemetryMetadata(clock.apply { tick(100L) }.now(), UUID, PROCESS_ID, CRASH)
 
     @Before
@@ -247,7 +247,7 @@ class IntakeServiceImplTest {
             val metadata = StoredTelemetryMetadata.fromFilename(it).getOrThrow()
             metadata.envelopeType
         }
-        val expected = listOf(CRASH, CRASH, SESSION, SESSION, LOG, LOG, NETWORK, NETWORK)
+        val expected = listOf(CRASH, CRASH, SESSION, SESSION, LOG, LOG, BLOB, BLOB)
         assertEquals(expected, observedTypes)
     }
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -3,9 +3,9 @@ package io.embrace.android.embracesdk.internal.delivery.storage
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.BLOB
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
-import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.NETWORK
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
@@ -97,11 +97,11 @@ class PayloadStorageServiceImplTest {
             Pair(0L, CRASH),
             Pair(0L, SESSION),
             Pair(0L, LOG),
-            Pair(0L, NETWORK),
+            Pair(0L, BLOB),
             Pair(1000L, CRASH),
             Pair(1000L, SESSION),
             Pair(1000L, LOG),
-            Pair(1000L, NETWORK)
+            Pair(1000L, BLOB)
         ).forEach {
             val metadata = StoredTelemetryMetadata(it.first, UUID, PROCESS_ID, it.second)
             service.store(metadata) { stream ->
@@ -129,7 +129,7 @@ class PayloadStorageServiceImplTest {
     fun `getUndeliveredPayloads only returns incomplete ones with a different process identifier than the current`() {
         listOf("old_pid" to 100_000L, PROCESS_ID to 200_000L).forEach { appInstance ->
             listOf(true, false).forEach { complete ->
-                listOf(CRASH, SESSION, LOG, NETWORK).forEach { type ->
+                listOf(CRASH, SESSION, LOG, BLOB).forEach { type ->
                     val metadata = StoredTelemetryMetadata(
                         timestamp = appInstance.second,
                         uuid = UUID,
@@ -151,7 +151,7 @@ class PayloadStorageServiceImplTest {
             assertNotNull(singleOrNull { it.envelopeType == CRASH })
             assertNotNull(singleOrNull { it.envelopeType == SESSION })
             assertNotNull(singleOrNull { it.envelopeType == LOG })
-            assertNotNull(singleOrNull { it.envelopeType == NETWORK })
+            assertNotNull(singleOrNull { it.envelopeType == BLOB })
         }
     }
 


### PR DESCRIPTION
## Goal

Change the token encoded in the payload filename to priority, move it to the front of the file, so the natural sort order of the file name will be the priority order

## Testing
Changed unit tests to verify the new scheme
