### PR TITLE
Avoid mixing workers between different delivery systems

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/StorageModuleImpl.kt
@@ -44,7 +44,7 @@ internal class StorageModuleImpl(
     override val deliveryCacheManager: DeliveryCacheManager by singleton {
         EmbraceDeliveryCacheManager(
             cacheService,
-            workerThreadModule.priorityWorker(Worker.Priority.DataPersistenceWorker),
+            workerThreadModule.priorityWorker(Worker.Priority.DeliveryCacheWorker),
             initModule.logger
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleSupplier.kt
@@ -1,17 +1,12 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.utils.Provider
-
 /**
  * Function that returns an instance of [WorkerThreadModule]. Matches the signature of the constructor for [WorkerThreadModuleImpl]
  */
 typealias WorkerThreadModuleSupplier = (
     initModule: InitModule,
-    configServiceProvider: Provider<ConfigService>
 ) -> WorkerThreadModule
 
 fun createWorkerThreadModule(
-    initModule: InitModule,
-    configServiceProvider: Provider<ConfigService>
-): WorkerThreadModule = WorkerThreadModuleImpl(initModule, configServiceProvider)
+    initModule: InitModule
+): WorkerThreadModule = WorkerThreadModuleImpl(initModule)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
@@ -16,6 +16,11 @@ sealed class Worker(internal val threadName: String) {
         object DataPersistenceWorker : Priority("data-persistence")
 
         /**
+         * Delivery cache worker for v1 delivery
+         */
+        object DeliveryCacheWorker : Priority("delivery-cache")
+
+        /**
          * All HTTP requests are performed on this executor.
          */
         object NetworkRequestWorker : Priority("network-request")

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImplTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.mockk.mockk
@@ -16,7 +15,7 @@ internal class AndroidServicesModuleImplTest {
         val module = AndroidServicesModuleImpl(
             initModule = initModule,
             coreModule = coreModule,
-            workerThreadModule = WorkerThreadModuleImpl(initModule, ::FakeConfigService)
+            workerThreadModule = WorkerThreadModuleImpl(initModule)
         )
 
         assertTrue(module.preferencesService is EmbracePreferencesService)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImplTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.comms.api.ApiRequest
 import io.embrace.android.embracesdk.internal.worker.TaskPriority
@@ -23,7 +22,7 @@ internal class WorkerThreadModuleImplTest {
 
     @Test
     fun testModule() {
-        val module = WorkerThreadModuleImpl(initModule, ::FakeConfigService)
+        val module = WorkerThreadModuleImpl(initModule)
         assertNotNull(module)
 
         val backgroundExecutor = module.backgroundWorker(Worker.Background.PeriodicCacheWorker)
@@ -38,14 +37,14 @@ internal class WorkerThreadModuleImplTest {
 
     @Test
     fun `network request executor uses custom queue`() {
-        val module = WorkerThreadModuleImpl(initModule, ::FakeConfigService)
+        val module = WorkerThreadModuleImpl(initModule)
         assertNotNull(module.priorityWorker<ApiRequest>(Worker.Priority.NetworkRequestWorker))
         assertNotNull(module.priorityWorker<TaskPriority>(Worker.Priority.DataPersistenceWorker))
     }
 
     @Test
     fun `rejected execution policy`() {
-        val module = WorkerThreadModuleImpl(initModule, ::FakeConfigService)
+        val module = WorkerThreadModuleImpl(initModule)
         val worker = module.backgroundWorker(Worker.Background.PeriodicCacheWorker)
         module.close()
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
@@ -34,7 +34,7 @@ inline fun <reified T> extractPriorityFromRunnable(
         "Runnables must be PriorityRunnableFuture"
     }
     require(lhs.priorityInfo is T && rhs.priorityInfo is T) {
-        "PriorityInfo must be of type ${T::class.java.simpleName}"
+        "PriorityInfo must be of type ${T::class.java.simpleName}, got ${lhs.priorityInfo::class} and ${rhs.priorityInfo::class}"
     }
     return Pair(lhs.priorityInfo as T, rhs.priorityInfo as T)
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -41,7 +41,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
     ),
     val overriddenWorkerThreadModule: WorkerThreadModule = createWorkerThreadModule(
         overriddenInitModule
-    ) { overriddenConfigService },
+    ),
     val overriddenAndroidServicesModule: AndroidServicesModule = createAndroidServicesModule(
         initModule = overriddenInitModule,
         coreModule = overriddenCoreModule,
@@ -53,7 +53,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
         initModule = overriddenInitModule,
         openTelemetryModule = overriddenInitModule.openTelemetryModule,
         coreModuleSupplier = { _, _ -> overriddenCoreModule },
-        workerThreadModuleSupplier = { _, _ -> overriddenWorkerThreadModule },
+        workerThreadModuleSupplier = { _ -> overriddenWorkerThreadModule },
         androidServicesModuleSupplier = { _, _, _ -> overriddenAndroidServicesModule },
         deliveryModuleSupplier = { configModule, otelModule, initModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, _, _ ->
             createDeliveryModule(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -208,7 +208,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
         if (useLegacyResurrection()) {
             bootstrapper
                 .workerThreadModule
-                .priorityWorker<TaskPriority>(Worker.Priority.DataPersistenceWorker)
+                .priorityWorker<TaskPriority>(Worker.Priority.DeliveryCacheWorker)
                 .submit(TaskPriority.NORMAL) {
                     if (useLegacyResurrection()) {
                         val essentialServiceModule = bootstrapper.essentialServiceModule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -132,7 +132,7 @@ internal class ModuleInitBootstrapper(
 
                     val serviceRegistry = coreModule.serviceRegistry
                     workerThreadModule = init(WorkerThreadModule::class) {
-                        workerThreadModuleSupplier(initModule) { configModule.configService }
+                        workerThreadModuleSupplier(initModule)
                     }
 
                     postInit(OpenTelemetryModule::class) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -42,7 +42,7 @@ internal fun fakeModuleInitBootstrapper(
     coreModuleSupplier: CoreModuleSupplier = { _, _ -> FakeCoreModule() },
     systemServiceModuleSupplier: SystemServiceModuleSupplier = { _, _ -> FakeSystemServiceModule() },
     androidServicesModuleSupplier: AndroidServicesModuleSupplier = { _, _, _ -> FakeAndroidServicesModule() },
-    workerThreadModuleSupplier: WorkerThreadModuleSupplier = { _, _ -> FakeWorkerThreadModule() },
+    workerThreadModuleSupplier: WorkerThreadModuleSupplier = { _ -> FakeWorkerThreadModule() },
     storageModuleSupplier: StorageModuleSupplier = { _, _, _ -> FakeStorageModule() },
     essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeConfigModule() },

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeWorkerThreadModule.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.createWorkerThreadModule
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
@@ -13,7 +12,7 @@ class FakeWorkerThreadModule(
     fakeInitModule: FakeInitModule = FakeInitModule(),
     private val testWorkerName: Worker? = null,
     private val anotherTestWorkerName: Worker? = null,
-    private val base: WorkerThreadModule = createWorkerThreadModule(fakeInitModule, ::FakeConfigService)
+    private val base: WorkerThreadModule = createWorkerThreadModule(fakeInitModule)
 ) : WorkerThreadModule by base {
 
     val executorClock: FakeClock = fakeInitModule.getFakeClock() ?: FakeClock()


### PR DESCRIPTION
## Goal

Uses a separate worker for the v1/v2 delivery systems to avoid the possibility of undesired behavior if the wrong type information is submitted with a `Runnable`. This shouldn't add a thread in practice as only 1 system will be active at a time. As part of this change I also correctly gated a v1 delivery call in SDK bootstrapping behind the v2 storage feature flag.

## Testing

Relied on existing test coverage.
