### PR TITLE
Fix race condition in scheduling service

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImplTest.kt
@@ -47,11 +47,11 @@ internal class PayloadSourceModuleImplTest {
         assertNotNull(module.sessionEnvelopeSource)
         assertNotNull(module.logEnvelopeSource)
         assertTrue(module.deviceArchitecture is DeviceArchitectureImpl)
-        assertNull(module.payloadResurrectionService)
+        assertNotNull(module.payloadResurrectionService)
     }
 
     @Test
-    fun `payload resurrection service is created when v2 delivery layer is on`() {
+    fun `payload resurrection service is created when v2 delivery layer is off`() {
         val initModule = FakeInitModule()
         val module = PayloadSourceModuleImpl(
             initModule,
@@ -63,7 +63,7 @@ internal class PayloadSourceModuleImplTest {
             FakeConfigModule(
                 configService = FakeConfigService(
                     autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
-                        v2StorageEnabled = true
+                        v2StorageEnabled = false
                     )
                 )
             ),
@@ -73,6 +73,6 @@ internal class PayloadSourceModuleImplTest {
             ::FakeOtelPayloadMapper,
             FakeDeliveryModule(),
         )
-        assertNotNull(module.payloadResurrectionService)
+        assertNull(module.payloadResurrectionService)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
@@ -1,13 +1,12 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
-import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
@@ -17,11 +16,11 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.testframework.assertions.JsonComparator
+import org.json.JSONObject
+import org.junit.Assert
 import java.io.IOException
 import java.util.Locale
 import java.util.concurrent.TimeoutException
-import org.json.JSONObject
-import org.junit.Assert
 
 /**
  * Provides assertions that can be used in integration tests to validate the behavior of the SDK,
@@ -55,8 +54,19 @@ internal class EmbracePayloadAssertionInterface(
     private fun retrieveLogEnvelopes(
         expectedSize: Int
     ): List<Envelope<LogPayload>> {
-        return retrievePayload(expectedSize) {
-            requestExecutionService.getRequests<LogPayload>()
+        val supplier = { requestExecutionService.getRequests<LogPayload>() }
+        try {
+            return retrievePayload(expectedSize, supplier)
+        } catch (exc: TimeoutException) {
+            val envelopes: List<Map<String, String?>> = supplier().map { envelope ->
+                mapOf(
+                    "type" to envelope.type,
+                    "logCount" to envelope.data.logs?.size.toString(),
+                    "hashCodes" to envelope.data.logs?.map { it.hashCode() }?.joinToString { ", " }
+                )
+            }
+            throw IllegalStateException("Expected $expectedSize envelopes, but got ${envelopes.size}. " +
+                "Envelopes: $envelopes", exc)
         }
     }
 
@@ -115,7 +125,6 @@ internal class EmbracePayloadAssertionInterface(
             }
             throw IllegalStateException("Expected $expectedSize sessions, but got ${sessions.size}. Sessions: $sessions", exc)
         }
-
     }
 
     private fun Envelope<SessionPayload>.findAppState(): ApplicationState {


### PR DESCRIPTION
## Goal

Fix race condition in scheduling service where a payload is removed from the active send list too early, resulting in a new delivery queue instance that contains it, because the payload was not deleted from disk when the initial query was made, and we needed the active state to filter it out
