### PR TITLE
Fix periodic session cache test case

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -29,6 +29,7 @@ internal class DeliveryModuleImpl(
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
     requestExecutionServiceProvider: Provider<RequestExecutionService?>,
+    cacheStorageServiceProvider: Provider<PayloadStorageService?>,
     deliveryServiceProvider: () -> DeliveryService? = {
         val apiService = essentialServiceModule.apiService
         if (configModule.configService.isOnlyUsingOtelExporters() || apiService == null) {
@@ -124,7 +125,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val cacheStorageService: PayloadStorageService? by singleton {
-        if (configModule.configService.isOnlyUsingOtelExporters()) {
+        cacheStorageServiceProvider() ?: if (configModule.configService.isOnlyUsingOtelExporters()) {
             null
         } else {
             PayloadStorageServiceImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
@@ -15,6 +16,7 @@ typealias DeliveryModuleSupplier = (
     coreModule: CoreModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    cacheStorageServiceProvider: Provider<PayloadStorageService?>,
     requestExecutionServiceProvider: Provider<RequestExecutionService?>,
     deliveryServiceProvider: Provider<DeliveryService?>
 ) -> DeliveryModule
@@ -27,6 +29,7 @@ fun createDeliveryModule(
     coreModule: CoreModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    cacheStorageServiceProvider: Provider<PayloadStorageService?>,
     requestExecutionServiceProvider: Provider<RequestExecutionService?>,
     deliveryServiceProvider: Provider<DeliveryService?>
 ): DeliveryModule = DeliveryModuleImpl(
@@ -38,5 +41,6 @@ fun createDeliveryModule(
     storageModule,
     essentialServiceModule,
     requestExecutionServiceProvider,
+    cacheStorageServiceProvider,
     deliveryServiceProvider
 )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
@@ -40,6 +40,7 @@ class DeliveryModuleImplTest {
             FakeStorageModule(),
             FakeEssentialServiceModule(),
             ::FakeRequestExecutionService,
+            { null },
             ::FakeDeliveryService
         )
     }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparator.kt
@@ -20,7 +20,7 @@ val storedTelemetryRunnableComparator =
         return@Comparator storedTelemetryComparator.compare(lhsPrio, rhsPrio)
     }
 
-internal val storedTelemetryComparator: java.util.Comparator<StoredTelemetryMetadata> =
+val storedTelemetryComparator: java.util.Comparator<StoredTelemetryMetadata> =
     compareBy(StoredTelemetryMetadata::envelopeType)
         .thenBy(StoredTelemetryMetadata::timestamp)
         .thenBy(StoredTelemetryMetadata::uuid)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -3,17 +3,28 @@ package io.embrace.android.embracesdk.testcases.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.findSpanSnapshotOfType
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.spans.getSessionProperty
+import io.embrace.android.embracesdk.internal.worker.PriorityWorker
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.internal.worker.Worker.Background.PeriodicCacheWorker
+import io.embrace.android.embracesdk.internal.worker.Worker.Priority.DataPersistenceWorker
+import io.embrace.android.embracesdk.testframework.FakeCacheStorageService
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,46 +35,54 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class PeriodicSessionCacheTest {
 
+    private lateinit var workerThreadModule: FakeWorkerThreadModule
+    private lateinit var executor: BlockingScheduledExecutorService
+
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
         val clock = FakeClock(IntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
         val fakeInitModule = FakeInitModule(clock = clock)
+        executor = BlockingScheduledExecutorService(fakeClock = clock)
+
+        workerThreadModule = FakeWorkerThreadModule(
+            fakeInitModule = fakeInitModule,
+            testWorkerName = PeriodicCacheWorker,
+            priorityWorkerSupplier = { worker ->
+                when (worker) {
+                    Worker.Priority.DeliveryCacheWorker -> PriorityWorker<StoredTelemetryMetadata>(executor)
+                    else -> null
+                }
+            }
+        )
         EmbraceSetupInterface(
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,
-            overriddenWorkerThreadModule = FakeWorkerThreadModule(
-                fakeInitModule = fakeInitModule,
-                testWorkerName = PeriodicCacheWorker
-            )
+            overriddenWorkerThreadModule = workerThreadModule
         )
     }
 
     @Test
     fun `session is periodically cached`() {
         testRule.runTest(
+            setupAction = {
+                cacheStorageServiceProvider = ::FakeCacheStorageService
+            },
             testCaseAction = {
-                val executor =
-                    (testRule.bootstrapper.workerThreadModule as FakeWorkerThreadModule).executor
-
                 recordSession {
-                    executor.runCurrentlyBlocked()
                     embrace.addSessionProperty("Test", "Test", true)
-
-                    // trigger another periodic cache
-                    executor.moveForwardAndRunBlocked(2000)
+                    allowPeriodicCacheExecution()
                 }
+                allowPeriodicCacheExecution()
             },
             assertAction = {
-                val envelopes = getCachedSessionEnvelopes(2)
-                val endMessage = envelopes[0]
+                val endMessage = getCachedSessionEnvelopes(2).first()
                 val span = endMessage.findSpanSnapshotOfType(EmbType.Ux.Session)
-                assertNull(span.getSessionProperty("Test"))
+                assertNotNull(span.getSessionProperty("Test"))
                 span.attributes?.assertMatches {
                     "emb.clean_exit" to false
                     "emb.terminated" to true
                 }
-
                 val completedMessage = getSingleSessionEnvelope()
                 val completedSpan = completedMessage.findSessionSpan()
                 assertEquals("Test", completedSpan.getSessionProperty("Test"))
@@ -73,5 +92,23 @@ internal class PeriodicSessionCacheTest {
                 }
             }
         )
+    }
+
+    private fun loadSnapshot(cacheStorageService: FakeCacheStorageService): Envelope<SessionPayload> {
+        val metadata = cacheStorageService.storedPayloads.keys.single()
+        val inputStream = checkNotNull(cacheStorageService.loadPayloadAsStream(metadata))
+        return TestPlatformSerializer().fromJson(
+            inputStream,
+            SupportedEnvelopeType.SESSION.serializedType
+        )
+    }
+
+    private fun allowPeriodicCacheExecution() {
+        workerThreadModule.executor.runCurrentlyBlocked()
+        executor.runCurrentlyBlocked()
+    }
+
+    private fun getCacheStorageService(): FakeCacheStorageService {
+        return testRule.bootstrapper.deliveryModule.cacheStorageService as FakeCacheStorageService
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/FakeCacheStorageService.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/FakeCacheStorageService.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.testframework
+
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
+import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
+import io.embrace.android.embracesdk.internal.injection.SerializationAction
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+internal class FakeCacheStorageService: PayloadStorageService {
+
+    val storedPayloads = mutableMapOf<StoredTelemetryMetadata, SerializationAction>()
+    val deletedPayloads = mutableListOf<StoredTelemetryMetadata>()
+
+    override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
+        storedPayloads[metadata] = action
+    }
+
+    override fun delete(metadata: StoredTelemetryMetadata) {
+        deletedPayloads.add(metadata)
+    }
+
+    override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? {
+        val action = storedPayloads[metadata] ?: return null
+        val baos = ByteArrayOutputStream()
+        action(baos)
+        return ByteArrayInputStream(baos.toByteArray())
+    }
+
+    override fun getPayloadsByPriority(): List<StoredTelemetryMetadata> {
+        return storedPayloads.keys.sortedWith(storedTelemetryComparator)
+    }
+
+    override fun getUndeliveredPayloads(): List<StoredTelemetryMetadata> {
+        return emptyList()
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBeh
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.internal.injection.AnrModule
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
@@ -20,6 +21,7 @@ import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.createAndroidServicesModule
 import io.embrace.android.embracesdk.internal.injection.createDeliveryModule
 import io.embrace.android.embracesdk.internal.injection.createWorkerThreadModule
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 
 /**
@@ -47,7 +49,8 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
         coreModule = overriddenCoreModule,
         workerThreadModule = overriddenWorkerThreadModule
     ),
-    val fakeAnrModule: AnrModule = FakeAnrModule()
+    val fakeAnrModule: AnrModule = FakeAnrModule(),
+    var cacheStorageServiceProvider: Provider<PayloadStorageService?> = { null },
 ) {
     fun createBootstrapper(): ModuleInitBootstrapper = ModuleInitBootstrapper(
         initModule = overriddenInitModule,
@@ -55,7 +58,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
         coreModuleSupplier = { _, _ -> overriddenCoreModule },
         workerThreadModuleSupplier = { _ -> overriddenWorkerThreadModule },
         androidServicesModuleSupplier = { _, _, _ -> overriddenAndroidServicesModule },
-        deliveryModuleSupplier = { configModule, otelModule, initModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, _, _ ->
+        deliveryModuleSupplier = { configModule, otelModule, initModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, _, _, _ ->
             createDeliveryModule(
                 configModule,
                 otelModule,
@@ -64,6 +67,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                 coreModule,
                 storageModule,
                 essentialServiceModule,
+                cacheStorageServiceProvider = cacheStorageServiceProvider,
                 requestExecutionServiceProvider = { FakeRequestExecutionService() },
                 deliveryServiceProvider = { FakeDeliveryService() }
             )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -287,6 +287,7 @@ internal class ModuleInitBootstrapper(
                             coreModule,
                             storageModule,
                             essentialServiceModule,
+                            { null },
                             {
                                 if (configModule.configService.isOnlyUsingOtelExporters()) {
                                     null

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -48,7 +48,7 @@ internal fun fakeModuleInitBootstrapper(
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
-    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
+    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _ -> FakeNativeCoreModule() },


### PR DESCRIPTION
## Goal

Alters the periodic session cache test case so that it won't fail when run against the v2 delivery layer. I've not flipped the switch as part of this PR but have instead opted to create lots of the necessary functions etc.

