### PR TITLE
Filter invalid ANR samples

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrStacktraceSampler.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrStacktraceSampler.kt
@@ -52,12 +52,13 @@ internal class AnrStacktraceSampler(
     override fun onThreadUnblocked(thread: Thread, timestamp: Long) {
         // Finalize AnrInterval
         val responseMs = lastUnblockedMs
+        val sanitizedSamples = samples.filter { it.timestamp in responseMs..timestamp }
         val anrInterval = AnrInterval(
             responseMs,
             null,
             timestamp,
             AnrInterval.Type.UI,
-            AnrSampleList(samples.toList())
+            AnrSampleList(sanitizedSamples)
         )
 
         synchronized(anrIntervals) {


### PR DESCRIPTION
## Goal

Filters out any invalid ANR samples (i.e. any samples that have a timestamp outside of the interval range). Once we eventually migrate this feature over to be captured via pure OTel this problem should go away entirely.

## Testing

Relied on existing test coverage.
