### PR TITLE
ci: Pre-fetch and cache robolectric dependencies.

### DIFF
--- a/.github/fetch-robolectric-dependencies.sh
+++ b/.github/fetch-robolectric-dependencies.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Based on suggestion from https://robolectric.org/blog/2023/11/11/improving-android-all-downloading/
+# and https://github.com/utzcoz/robolectric-android-all-fetcher
+
+VERSIONS="10-robolectric-5803371 11-robolectric-6757853 12-robolectric-7732740 12.1-robolectric-8229987 13-robolectric-9030017 14-robolectric-10818077 4.4_r1-robolectric-r2 5.0.2_r3-robolectric-r0 5.1.1_r9-robolectric-r2 6.0.1_r3-robolectric-r1 7.0.0_r1-robolectric-r1 7.1.0_r7-robolectric-r1 8.0.0_r4-robolectric-r1 8.1.0-robolectric-4611349 9-robolectric-4913185-2"
+
+for version in $VERSIONS; do
+  echo $(date): Fetching Robolectric ${version}
+  mvn dependency:get -Dartifact=org.robolectric:android-all:${version} --no-transfer-progress
+  mvn dependency:get -Dartifact=org.robolectric:android-all-instrumented:${version}-i6 --no-transfer-progress
+done

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository/org/robolectric
+          key: robolectric-${{ hashFiles('.github/fetch-robolectric-dependencies.sh') }}
+          restore-keys: |
+            robolectric-
+
+      - name: Fetch Robolectric dependencies
+        run: /bin/sh .github/fetch-robolectric-dependencies.sh
+
       # Build the entire project, run the tests, and run all static analysis
       - name: Gradle Build
         run: ./gradlew assembleRelease testReleaseUnitTest detekt lint apiCheck --stacktrace


### PR DESCRIPTION
## Goal

Prevent re-downloading of Robolectric jars from Maven Central.

## Testing

Run with cold cache

![image](https://github.com/user-attachments/assets/c5226d67-13d6-4bde-9415-b6bd8fa67b75)

Run with warm cache

![image](https://github.com/user-attachments/assets/bc88a472-f3d0-4fe7-a515-1c3dde5c0db0)

## Release Notes


