### PR TITLE
Use mock web server in integration tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/StatefulSessionTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.assertions.hasSpanSnapshotsOfType
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.opentelemetry.embErrorLogCount
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionEndType
@@ -31,6 +32,10 @@ internal class StatefulSessionTest {
     @Test
     fun `session messages are recorded`() {
         testRule.runTest(
+            setupAction = {
+                useMockWebServer = true
+                overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(v2StorageEnabled = true)
+            },
             testCaseAction = {
                 recordSession {
                     embrace.addBreadcrumb("Hello, World!")
@@ -41,7 +46,7 @@ internal class StatefulSessionTest {
             },
             assertAction = {
                 // verify first session
-                val messages = getSessionEnvelopes(2)
+                val messages = getSessionEnvelopesFromMockServer(2)
                 val first = messages[0]
                 first.findSessionSpan().attributes?.assertMatches {
                     embSessionStartType.name to LifeEventType.STATE.name.lowercase(Locale.ENGLISH)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.EmbraceImpl
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
+import io.embrace.android.embracesdk.fakes.behavior.FakeSdkEndpointBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeDeliveryModule
 import io.embrace.android.embracesdk.internal.injection.CoreModule
@@ -21,6 +22,9 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceOtelExportAsse
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
+import io.embrace.android.embracesdk.testframework.server.FakeApiServer
+import okhttp3.Protocol
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.rules.ExternalResource
 
 /**
@@ -66,7 +70,7 @@ import org.junit.rules.ExternalResource
  * production.
  */
 internal class IntegrationTestRule(
-    private val embraceSetupInterfaceSupplier: Provider<EmbraceSetupInterface> = { EmbraceSetupInterface() }
+    private val embraceSetupInterfaceSupplier: Provider<EmbraceSetupInterface> = { EmbraceSetupInterface() },
 ) : ExternalResource() {
 
     /**
@@ -87,6 +91,7 @@ internal class IntegrationTestRule(
     lateinit var preSdkStart: EmbracePreSdkStartInterface
     private lateinit var otelAssertion: EmbraceOtelExportAssertionInterface
     private lateinit var spanExporter: FilteredSpanExporter
+    private lateinit var server: MockWebServer
 
     lateinit var bootstrapper: ModuleInitBootstrapper
 
@@ -125,11 +130,23 @@ internal class IntegrationTestRule(
      * Setup the Embrace SDK so it's ready for testing.
      */
     override fun before() {
+        val apiServer = FakeApiServer()
+        server = MockWebServer().apply {
+            protocols = listOf(Protocol.H2_PRIOR_KNOWLEDGE)
+            dispatcher = apiServer
+            start()
+        }
+        val baseUrl = server.url("api").toString()
+
         setup = embraceSetupInterfaceSupplier.invoke()
+        setup.overriddenConfigService.sdkEndpointBehavior = FakeSdkEndpointBehavior(
+            baseUrl,
+            baseUrl
+        )
         preSdkStart = EmbracePreSdkStartInterface(setup)
         bootstrapper = setup.createBootstrapper()
         action = EmbraceActionInterface(setup, bootstrapper)
-        payloadAssertion = EmbracePayloadAssertionInterface(bootstrapper)
+        payloadAssertion = EmbracePayloadAssertionInterface(bootstrapper, apiServer)
         spanExporter = FilteredSpanExporter()
         otelAssertion = EmbraceOtelExportAssertionInterface(spanExporter)
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
@@ -1,0 +1,84 @@
+package io.embrace.android.embracesdk.testframework.server
+
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.internal.TypeUtils
+import io.embrace.android.embracesdk.internal.comms.api.Endpoint
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.LogPayload
+import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.utils.threadLocal
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.zip.GZIPInputStream
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+/**
+ * Fake API server that is used to capture log/session requests made by the SDK in integration tests.
+ */
+internal class FakeApiServer : Dispatcher() {
+
+    private val serializer by threadLocal { TestPlatformSerializer() }
+    private val sessionRequests = ConcurrentLinkedQueue<Envelope<SessionPayload>>()
+    private val logRequests = ConcurrentLinkedQueue<Envelope<LogPayload>>()
+
+    /**
+     * Returns a list of session envelopes in the order in which the server received them.
+     */
+    fun getSessionEnvelopes(): List<Envelope<SessionPayload>> = sessionRequests.toList()
+
+    /**
+     * Returns a list of log envelopes in the order in which the server received them.
+     */
+    fun getLogEnvelopes(): List<Envelope<LogPayload>> = logRequests.toList()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun dispatch(request: RecordedRequest): MockResponse {
+        val endpoint = findRequestEndpoint(request)
+        val envelope = deserializeEnvelope(request, endpoint)
+        validateHeaders(request.headers.toMultimap().mapValues { it.value.joinToString() })
+
+        when (endpoint) {
+            Endpoint.SESSIONS_V2 -> sessionRequests.add(envelope as Envelope<SessionPayload>)
+            Endpoint.LOGS -> logRequests.add(envelope as Envelope<LogPayload>)
+            else -> error("Unsupported request type $endpoint")
+        }
+        return MockResponse().setResponseCode(200)
+    }
+
+    private fun validateHeaders(headers: Map<String, String>) {
+        with(headers) {
+            assertEquals("application/json", get("accept"))
+            assertNotNull(get("user-agent"))
+            assertEquals("application/json", get("content-type"))
+            assertNotNull(get("x-em-aid"))
+            assertNotNull(get("x-em-did"))
+        }
+    }
+
+    private fun findRequestEndpoint(request: RecordedRequest): Endpoint {
+        return when (val path = request.path?.removePrefix("/api/v2/")) {
+            Endpoint.LOGS.path -> Endpoint.LOGS
+            Endpoint.SESSIONS_V2.path -> Endpoint.SESSIONS_V2
+            else -> error("Unsupported path $path")
+        }
+    }
+
+    private fun deserializeEnvelope(request: RecordedRequest, endpoint: Endpoint): Envelope<*> {
+        try {
+            val type = when (endpoint) {
+                Endpoint.LOGS -> LogPayload::class
+                Endpoint.SESSIONS_V2 -> SessionPayload::class
+                else -> error("Unsupported endpoint $endpoint")
+            }
+            val envelopeType = TypeUtils.parameterizedType(Envelope::class, type)
+            GZIPInputStream(request.body.inputStream()).use { stream ->
+                return serializer.fromJson(stream, envelopeType)
+            }
+        } catch (exc: Exception) {
+            throw IllegalStateException("Failed to deserialize request envelope", exc)
+        }
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSdkEndpointBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSdkEndpointBehavior.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.SdkEndpointBehavior
+
+class FakeSdkEndpointBehavior(
+    private val dataEndpoint: String,
+    private val configEndpoint: String,
+) : SdkEndpointBehavior {
+    override fun getData(appId: String?): String = dataEndpoint
+    override fun getConfig(appId: String?): String = configEndpoint
+}


### PR DESCRIPTION
## Goal

Alters `StatefulSessionTest` to use mockwebserver rather than `FakeRequestExecutionService`. This exercises the whole of the SDK against a test harness & also opens the door for returning different responses (e.g. 429) to confirm the SDK can handle it properly.
