### PR TITLE
Fail integration test when the same span is exported more than once

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -16,9 +16,9 @@ import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
-import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceOtelExportAssertionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
+import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import org.junit.rules.ExternalResource
@@ -118,6 +118,7 @@ internal class IntegrationTestRule(
         }
         testCaseAction(action)
         assertAction(payloadAssertion)
+        spanExporter.failOnDuplicate()
         otelExportAssertion(otelAssertion)
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
@@ -35,6 +35,23 @@ internal class FilteredSpanExporter : SpanExporter {
         }, expectedCount)
     }
 
+    fun failOnDuplicate() {
+        val exportedSpans = spanData.toList()
+        val seen = exportedSpans.map { it.spanId }.distinct()
+        val duplicates = exportedSpans
+            .filterNot {
+                seen.contains(it.spanId)
+            }.map {
+                Pair(
+                    "spanId" to it.spanId,
+                    "name" to it.name,
+                )
+            }.distinct()
+        if (duplicates.isNotEmpty()) {
+            error("Duplicate spans exported: $duplicates")
+        }
+    }
+
     private fun awaitSpanExport(
         spanFilter: (SpanData) -> Boolean,
         expectedCount: Int,


### PR DESCRIPTION
## Goal

If the count of the distinct spans IDs exported is less than the total count of spans exported, fail an integration test.
