### PR TITLE
Use mock web server by default

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -238,6 +238,9 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `set process as started by notification works as expected`() {
         testRule.runTest(
+            setupAction = {
+                useMockWebServer = false
+            },
             testCaseAction = {
                 embrace.internalInterface.setProcessStartedByNotification()
                 recordSession()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/MomentApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/MomentApiTest.kt
@@ -28,6 +28,9 @@ internal class MomentApiTest {
         var startTime: Long = -1
 
         testRule.runTest(
+            setupAction = {
+                useMockWebServer = false
+            },
             testCaseAction = {
                 // Send start moment
                 startTime = clock.now()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -94,6 +94,7 @@ internal class SessionApiTest {
                     "emb.usage.set_username" to "1",
                     "emb.usage.set_user_email" to "1",
                     "emb.usage.set_user_identifier" to "1",
+                    "emb.usage.get_trace_id_header" to "1",
                     "emb.private.sequence_id" to "4"
                 ).toSortedMap()
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -19,6 +19,7 @@ internal class ResurrectionFeatureTest {
     fun `resurrection attempt with v2 delivery layer off does not crash the SDK`() {
         testRule.runTest(
             setupAction = {
+                useMockWebServer = false
                 overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
                     v2StorageEnabled = false
                 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
@@ -36,6 +36,7 @@ internal class V1DeliveryFeatureTest {
     fun `v1 session delivery`() {
         testRule.runTest(
             setupAction = {
+                useMockWebServer = false
                 overriddenConfigService.autoDataCaptureBehavior = behavior
             },
             testCaseAction = {
@@ -54,6 +55,7 @@ internal class V1DeliveryFeatureTest {
     fun `v1 background activity delivery`() {
         testRule.runTest(
             setupAction = {
+                useMockWebServer = false
                 overriddenConfigService.autoDataCaptureBehavior = behavior
             },
             testCaseAction = {
@@ -71,6 +73,7 @@ internal class V1DeliveryFeatureTest {
     fun `v1 crash delivery`() {
         testRule.runTest(
             setupAction = {
+                useMockWebServer = false
                 overriddenConfigService.autoDataCaptureBehavior = behavior
             },
             testCaseAction = {
@@ -89,6 +92,7 @@ internal class V1DeliveryFeatureTest {
     fun `v1 log delivery`() {
         testRule.runTest(
             setupAction = {
+                useMockWebServer = false
                 overriddenConfigService.autoDataCaptureBehavior = behavior
                 setupFakeAeiData()
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/MomentBoundaryTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/MomentBoundaryTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getSessionId
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
@@ -25,8 +26,11 @@ internal class MomentBoundaryTest {
 
     @Test
     fun `startup moment completes within one session`() {
-
         testRule.runTest(
+            setupAction = {
+                useMockWebServer = false
+                overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(v2StorageEnabled = false)
+            },
             testCaseAction = {
                 recordSession {
                     embrace.endAppStartup()
@@ -35,7 +39,7 @@ internal class MomentBoundaryTest {
                 }
             },
             assertAction = {
-                val message = getSingleSessionEnvelope()
+                val message = getSessionEnvelopesV1(1).single()
 
                 val moments = getSentMoments(4)
                 assertEquals(4, moments.size)
@@ -66,6 +70,10 @@ internal class MomentBoundaryTest {
     @Test
     fun `startup moment completes within two sessions`() {
         testRule.runTest(
+            setupAction = {
+                useMockWebServer = false
+                overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(v2StorageEnabled = false)
+            },
             testCaseAction = {
                 recordSession {
                     embrace.startMoment(MOMENT_NAME)
@@ -76,7 +84,7 @@ internal class MomentBoundaryTest {
                 }
             },
             assertAction = {
-                val sessions = getSessionEnvelopes(2)
+                val sessions = getSessionEnvelopesV1(2)
                 val firstMessage = sessions[0]
                 val secondMessage = sessions[1]
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
@@ -9,7 +9,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-private const val SESSION_COUNT = 1000
+private const val SESSION_COUNT = 200
 
 @RunWith(AndroidJUnit4::class)
 internal class SessionSpamTest {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/StatefulSessionTest.kt
@@ -32,10 +32,6 @@ internal class StatefulSessionTest {
     @Test
     fun `session messages are recorded`() {
         testRule.runTest(
-            setupAction = {
-                useMockWebServer = true
-                overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(v2StorageEnabled = true)
-            },
             testCaseAction = {
                 recordSession {
                     embrace.addBreadcrumb("Hello, World!")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeoutException
  */
 internal class EmbracePayloadAssertionInterface(
     bootstrapper: ModuleInitBootstrapper,
-    private val apiServer: FakeApiServer,
+    private val apiServer: FakeApiServer?,
 ) {
 
     private val deliveryService by lazy { bootstrapper.deliveryModule.deliveryService as FakeDeliveryService }
@@ -60,14 +60,14 @@ internal class EmbracePayloadAssertionInterface(
         expectedSize: Int
     ): List<Envelope<LogPayload>> {
         return retrievePayload(expectedSize) {
-            apiServer.getLogEnvelopes()
+            checkNotNull(apiServer).getLogEnvelopes()
         }
     }
 
     private fun retrieveLogEnvelopes(
         expectedSize: Int
     ): List<Envelope<LogPayload>> {
-        val supplier = { requestExecutionService.getRequests<LogPayload>() }
+        val supplier = { checkNotNull(apiServer).getLogEnvelopes() }
         try {
             return retrievePayload(expectedSize, supplier)
         } catch (exc: TimeoutException) {
@@ -138,7 +138,7 @@ internal class EmbracePayloadAssertionInterface(
         state: ApplicationState = ApplicationState.FOREGROUND,
     ): List<Envelope<SessionPayload>> {
         return retrievePayload(expectedSize) {
-            apiServer.getSessionEnvelopes().filter { it.findAppState() == state }
+            checkNotNull(apiServer).getSessionEnvelopes().filter { it.findAppState() == state }
         }
     }
 
@@ -163,7 +163,7 @@ internal class EmbracePayloadAssertionInterface(
         expectedSize: Int, appState: ApplicationState,
     ): List<Envelope<SessionPayload>> {
         val supplier = {
-            requestExecutionService.getRequests<SessionPayload>()
+            checkNotNull(apiServer).getSessionEnvelopes()
                 .filter { it.findAppState() == appState }
         }
         try {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -29,7 +29,7 @@ import io.embrace.android.embracesdk.testframework.IntegrationTestRule
  */
 internal class EmbraceSetupInterface @JvmOverloads constructor(
     currentTimeMs: Long = IntegrationTestRule.DEFAULT_SDK_START_TIME_MS,
-    var useMockWebServer: Boolean = false,
+    var useMockWebServer: Boolean = true,
     @Suppress("DEPRECATION") val appFramework: Embrace.AppFramework = Embrace.AppFramework.NATIVE,
     val overriddenClock: FakeClock = FakeClock(currentTime = currentTimeMs),
     val overriddenInitModule: FakeInitModule = FakeInitModule(clock = overriddenClock, logger = FakeEmbLogger()),


### PR DESCRIPTION
## Goal

Updates the integration tests to use mockwebserver by default. This required using the previous approach for moments + the v1 delivery tests, so after 7.0 we should be able to remove all this code & just use mock web server. There isn't a noticeable difference in execution time between these two approaches which was my main concern starting out with this approach.

