### PR TITLE
Move old payload classes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/DiskUsage.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/DiskUsage.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal.payload
+package io.embrace.android.embracesdk.internal.capture.metadata
 
 /**
  * Disk space used by the app and available memory on the device.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppInfo
 import io.embrace.android.embracesdk.internal.payload.DeviceInfo
-import io.embrace.android.embracesdk.internal.payload.DiskUsage
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.capture.metadata
 
 import io.embrace.android.embracesdk.internal.payload.AppInfo
 import io.embrace.android.embracesdk.internal.payload.DeviceInfo
-import io.embrace.android.embracesdk.internal.payload.DiskUsage
 
 interface MetadataService {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingService.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.delivery.caching
 import io.embrace.android.embracesdk.internal.delivery.Shutdownable
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 
 typealias SessionPayloadSupplier = (

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -6,9 +6,9 @@ import io.embrace.android.embracesdk.internal.buildinfo.BuildInfo
 import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTracker
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
+import io.embrace.android.embracesdk.internal.injection.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
-import io.embrace.android.embracesdk.internal.payload.PackageVersionInfo
 
 internal class EnvelopeResourceSourceImpl(
     private val hosted: HostedSdkVersionInfo,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Context
 import io.embrace.android.embracesdk.internal.AndroidResourcesService
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfoService
-import io.embrace.android.embracesdk.internal.payload.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.registry.ServiceRegistry
 
 /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.internal.buildinfo.BuildInfoService
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfoServiceImpl
 import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.payload.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.registry.ServiceRegistry
 
 class CoreModuleImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PackageVersionInfo.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PackageVersionInfo.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal.payload
+package io.embrace.android.embracesdk.internal.injection
 
 import android.content.pm.PackageInfo
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/DomainCount.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/DomainCount.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal.payload
+package io.embrace.android.embracesdk.internal.network.logging
 
 /**
  * Included in the payload when the network request capture limit has been exceeded for a

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceDomainCountLimiter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceDomainCountLimiter.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.network.logging
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.payload.DomainCount
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils
 import java.util.concurrent.ConcurrentHashMap

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionZygote.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionZygote.kt
@@ -1,4 +1,7 @@
-package io.embrace.android.embracesdk.internal.payload
+package io.embrace.android.embracesdk.internal.session
+
+import io.embrace.android.embracesdk.internal.payload.ApplicationState
+import io.embrace.android.embracesdk.internal.payload.LifeEventType
 
 /**
  * A precursor object that holds state associated with a newly started session.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/FinalEnvelopeParams.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.message
 
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
 /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.session.message
 
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 
 /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollator.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.session.message
 
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 
 interface PayloadMessageCollator {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
@@ -4,8 +4,8 @@ import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSo
 import io.embrace.android.embracesdk.internal.gating.GatingService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 
 /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 
 /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.internal.opentelemetry.embHeartbeatTimeUnix
 import io.embrace.android.embracesdk.internal.opentelemetry.embTerminated
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulator.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 
 /**
  * Populates the attributes of a session span.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
@@ -19,7 +19,7 @@ import io.embrace.android.embracesdk.internal.opentelemetry.embSessionStartupThr
 import io.embrace.android.embracesdk.internal.opentelemetry.embState
 import io.embrace.android.embracesdk.internal.opentelemetry.embTerminated
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import java.util.Locale
 
 internal class SessionSpanAttrPopulatorImpl(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceTest.kt
@@ -19,8 +19,8 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.resource.DeviceImpl
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSourceImpl
+import io.embrace.android.embracesdk.internal.injection.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.embrace.android.embracesdk.internal.payload.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.payload.UserInfo
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.fakes.FakeRnBundleIdTracker
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfo
 import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
+import io.embrace.android.embracesdk.internal.injection.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.embrace.android.embracesdk.internal.payload.PackageVersionInfo
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
@@ -28,7 +28,6 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import org.junit.Assert.assertEquals

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -9,9 +9,9 @@ import io.embrace.android.embracesdk.fakes.system.mockApplication
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfoService
 import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.injection.CoreModule
+import io.embrace.android.embracesdk.internal.injection.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.payload.PackageVersionInfo
 import io.embrace.android.embracesdk.internal.registry.ServiceRegistry
 import io.mockk.every
 import io.mockk.isMockKMock

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.capture.metadata.DiskUsage
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.payload.AppInfo
 import io.embrace.android.embracesdk.internal.payload.DeviceInfo
-import io.embrace.android.embracesdk.internal.payload.DiskUsage
 
 /**
  * Fake implementation of [MetadataService] that represents an Android device. A [UnsupportedOperationException] will be thrown

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCachingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCachingService.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
 import io.embrace.android.embracesdk.internal.delivery.caching.SessionPayloadSupplier
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 
 class FakePayloadCachingService : PayloadCachingService {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCollator.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.message.FinalEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.InitialEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollator

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessState
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -8,8 +8,8 @@ import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.opentelemetry.api.trace.SpanId
 
 fun fakeSessionZygote(): SessionZygote = SessionZygote(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionSpanAttrPopulator.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionSpanAttrPopulator.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSpanAttrPopulator
 
 class FakeSessionSpanAttrPopulator : SessionSpanAttrPopulator {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeV2PayloadCollator.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.SessionZygote
+import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.message.FinalEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.InitialEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollator


### PR DESCRIPTION
## Goal

Moves some classes out of `embrace-android-payload` that no longer require JSON adapters. 

## Testing

Relied on existing test coverage.
