### PR TITLE
Register connectivity listener after delivery module init

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -209,7 +209,6 @@ internal class ModuleInitBootstrapper(
                                 Systrace.traceSynchronous("network-connectivity-listeners") {
                                     networkConnectivityService.addNetworkConnectivityListener(pendingApiCallsSender)
                                     apiService?.let(networkConnectivityService::addNetworkConnectivityListener)
-                                    deliveryModule.schedulingService?.let(networkConnectivityService::addNetworkConnectivityListener)
                                 }
                             }
                         }
@@ -308,6 +307,11 @@ internal class ModuleInitBootstrapper(
                                     )
                                 }
                             }
+                        )
+                    }
+                    postInit(DeliveryModule::class) {
+                        deliveryModule.schedulingService?.let(
+                            essentialServiceModule.networkConnectivityService::addNetworkConnectivityListener
                         )
                     }
 


### PR DESCRIPTION
## Goal

Register a connectivity listener after delivery module init, as otherwise scheduling service isn't initialized.

