### PR TITLE
Use version catalog where possible

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    `java-gradle-plugin`
     `kotlin-dsl`
+    `kotlin-dsl-precompiled-script-plugins`
 }
 
 repositories {
@@ -10,15 +10,14 @@ repositories {
     mavenCentral()
 }
 
+// NOTE: when updating any of these keep in sync with the version catalog
 dependencies {
-    compileOnly(gradleApi())
+    implementation(gradleApi())
 
     // Version of Kotlin used at build time
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
-
-    // NOTE: when updating any of these keep in sync with buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
     implementation("com.android.tools.build:gradle:8.5.2")
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.16.3")
     implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.8.3")
 }

--- a/buildSrc/src/main/kotlin/embrace-prod-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-prod-defaults.gradle.kts
@@ -70,21 +70,21 @@ android {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_EXPOSED}")
+    implementation(findLibrary("kotlin.stdlib"))
     add("lintChecks", project.project(":embrace-lint"))
 
-    testImplementation("junit:junit:${Versions.JUNIT}")
-    testImplementation("io.mockk:mockk:${Versions.MOCKK}")
-    testImplementation("androidx.test:core:${Versions.ANDROIDX_TEST}")
-    testImplementation("androidx.test.ext:junit:${Versions.ANDROIDX_JUNIT}")
-    testImplementation("org.robolectric:robolectric:${Versions.ROBOLECTRIC}")
-    testImplementation("com.squareup.okhttp3:mockwebserver:${Versions.MOCKWEBSERVER}")
+    testImplementation(findLibrary("junit"))
+    testImplementation(findLibrary("mockk"))
+    testImplementation(findLibrary("androidx.test.core"))
+    testImplementation(findLibrary("androidx.test.junit"))
+    testImplementation(findLibrary("robolectric"))
+    testImplementation(findLibrary("mockwebserver"))
     testImplementation(project(":embrace-test-common"))
     testImplementation(project(":embrace-test-fakes"))
 
-    androidTestImplementation("androidx.test:core:${Versions.ANDROIDX_TEST}")
-    androidTestImplementation("androidx.test:runner:${Versions.ANDROIDX_TEST}")
-    androidTestUtil("androidx.test:orchestrator:${Versions.ANDROIDX_TEST}")
+    androidTestImplementation(findLibrary("androidx.test.core"))
+    androidTestImplementation(findLibrary("androidx.test.runner"))
+    androidTestUtil(findLibrary("androidx.test.orchestrator"))
 }
 
 checkstyle {
@@ -174,3 +174,7 @@ signing {
 project.tasks.withType(Sign::class).configureEach {
     enabled = !project.version.toString().endsWith("-SNAPSHOT")
 }
+
+// workaround: see https://medium.com/@saulmm2/android-gradle-precompiled-scripts-tomls-kotlin-dsl-df3c27ea017c
+private fun Project.findLibrary(alias: String) =
+    project.extensions.getByType<VersionCatalogsExtension>().named("libs").findLibrary(alias).get()

--- a/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.DETEKT}")
+    add("detektPlugins", findLibrary("detekt.formatting"))
 }
 
 detekt {
@@ -70,3 +70,7 @@ project.tasks.withType(KotlinCompile::class.java).configureEach {
         allWarningsAsErrors = true
     }
 }
+
+// workaround: see https://medium.com/@saulmm2/android-gradle-precompiled-scripts-tomls-kotlin-dsl-df3c27ea017c
+private fun Project.findLibrary(alias: String) =
+    project.extensions.getByType<VersionCatalogsExtension>().named("libs").findLibrary(alias).get()

--- a/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/gradle/Versions.kt
@@ -7,20 +7,5 @@ object Versions {
     const val COMPILE_SDK = 34
     const val MIN_SDK = 21
     const val MIN_COMPILE_SDK = 34
-
-    const val JUNIT = "4.13.2"
-
-    // Kotlin stdlib version used
-    const val KOTLIN_EXPOSED = "1.8.22"
-
-    // NOTE: when updating keep this in sync with the version in buildSrc/build.gradle.kts
-    // kotlin 1.9 required before any further upgrades
-    const val DETEKT = "1.23.6"
-
     const val NDK = "22.1.7171670"
-    const val MOCKK = "1.12.2"
-    const val ANDROIDX_TEST = "1.5.0"
-    const val ANDROIDX_JUNIT = "1.1.3"
-    const val ROBOLECTRIC = "4.12.1"
-    const val MOCKWEBSERVER = "4.9.3"
 }

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.embrace.gradle.Versions
-
 plugins {
     id("embrace-test-defaults")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,10 @@ okhttp = "4.12.0"
 firebase = "23.1.0"
 compose = "1.0.5"
 robolectric = "4.12.1"
+mockk = "1.12.2"
+androidxTest = "1.5.0"
+androidxJunit = "1.1.3"
+mockwebserver = "4.9.3"
 
 [libraries]
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektGradlePlugin" }
@@ -45,5 +49,13 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging", version.ref = "firebase" }
 compose = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTest" }
+androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidxTest" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinExposed" }
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detektGradlePlugin" }
 
 [plugins]


### PR DESCRIPTION
## Goal

Uses a workaround in Gradle to use the version catalog in a precompiled build script. I've not been able to find a solution that would use the version catalog when setting the plugins yet, but this gets us 90% of the way there.

