### PR TITLE
[DNM] Remove beta annotation from tracing api

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -306,7 +306,6 @@ public abstract interface class io/embrace/android/embracesdk/spans/TracingApi {
 	public abstract fun createSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public abstract fun getSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
-	public abstract fun isTracingAvailable ()Z
 	public abstract fun recordCompletedSpan (Ljava/lang/String;JJ)Z
 	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
 	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;)Z

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.spans
 
-import io.embrace.android.embracesdk.annotation.BetaApi
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanContext
 
@@ -8,8 +7,8 @@ import io.opentelemetry.api.trace.SpanContext
  * Represents a Span that can be started and stopped with the appropriate [ErrorCode] if applicable. This wraps the OpenTelemetry Span
  * by adding an additional layer for local validation
  */
-@BetaApi
 public interface EmbraceSpan {
+
     /**
      * The [SpanContext] for this [EmbraceSpan] instance. This is null if the span has not been started.
      */

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
@@ -1,12 +1,10 @@
 package io.embrace.android.embracesdk.spans
 
-import io.embrace.android.embracesdk.annotation.BetaApi
 import java.util.concurrent.TimeUnit
 
 /**
  * Represents an Event in an [EmbraceSpan]
  */
-@BetaApi
 public data class EmbraceSpanEvent internal constructor(
     /**
      * The name of the event

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/ErrorCode.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/ErrorCode.kt
@@ -1,11 +1,8 @@
 package io.embrace.android.embracesdk.spans
 
-import io.embrace.android.embracesdk.annotation.BetaApi
-
 /**
  * Categorize the broad reason a Span completed unsuccessfully.
  */
-@BetaApi
 public enum class ErrorCode {
     /**
      * An application failure caused the Span to terminate

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -1,12 +1,9 @@
 package io.embrace.android.embracesdk.spans
 
-import io.embrace.android.embracesdk.annotation.BetaApi
-
 /**
  * The public API used to add traces to your application. Note that [recordCompletedSpan] can be used before the SDK is initialized.
  * The actual trace won't be recorded until the SDK is started, but it's safe to use this prior to SDK initialization.
  */
-@BetaApi
 public interface TracingApi {
     /**
      * Create an [EmbraceSpan] with the given name that will be the root span of a new trace. Returns null if the [EmbraceSpan] cannot
@@ -14,7 +11,6 @@ public interface TracingApi {
      *
      * Note: the [EmbraceSpan] created will not be started. For a method that creates and starts the span, use [startSpan]
      */
-    @BetaApi
     public fun createSpan(
         name: String
     ): EmbraceSpan? = createSpan(name = name, parent = null)
@@ -26,7 +22,6 @@ public interface TracingApi {
      *
      * * Note: the [EmbraceSpan] created will not be started. For a method that creates and starts the span, use [startSpan]
      */
-    @BetaApi
     public fun createSpan(
         name: String,
         parent: EmbraceSpan?
@@ -36,7 +31,6 @@ public interface TracingApi {
      * Create, start, and return a new [EmbraceSpan] with the given name that will be the root span of a new trace. Returns null if the
      * [EmbraceSpan] cannot be created or started.
      */
-    @BetaApi
     public fun startSpan(
         name: String
     ): EmbraceSpan? = startSpan(name = name, parent = null)
@@ -45,7 +39,6 @@ public interface TracingApi {
      * Create, start, and return a new [EmbraceSpan] with the given name and parent. Returns null if the [EmbraceSpan] cannot be created
      * or started, like if the parent has been started.
      */
-    @BetaApi
     public fun startSpan(
         name: String,
         parent: EmbraceSpan?
@@ -59,7 +52,6 @@ public interface TracingApi {
      * Create, start, and return a new [EmbraceSpan] with the given name, parent, and start time (epoch time in milliseconds).
      * Returns null if the [EmbraceSpan] cannot be created or started, like if the parent has been started.
      */
-    @BetaApi
     public fun startSpan(
         name: String,
         parent: EmbraceSpan?,
@@ -71,7 +63,6 @@ public interface TracingApi {
      * return correctly. If an exception or error is thrown inside the block, the span will end at the point of the throw and the
      * [Throwable] will be rethrown.
      */
-    @BetaApi
     public fun <T> recordSpan(
         name: String,
         code: () -> T
@@ -83,7 +74,6 @@ public interface TracingApi {
      * return correctly. If an exception or error is thrown inside the block, the span will end at the point of the throw and the
      * [Throwable] will be rethrown.
      */
-    @BetaApi
     public fun <T> recordSpan(
         name: String,
         parent: EmbraceSpan?,
@@ -95,7 +85,6 @@ public interface TracingApi {
      * cannot be created, the block of code will still run and return correctly. If an exception or error is thrown inside the block,
      * the span will end at the point of the throw and the [Throwable] will be rethrown.
      */
-    @BetaApi
     public fun <T> recordSpan(
         name: String,
         attributes: Map<String, String>?,
@@ -110,7 +99,6 @@ public interface TracingApi {
      * the span will end at the point of the throw and the
      * [Throwable] will be rethrown.
      */
-    @BetaApi
     public fun <T> recordSpan(
         name: String,
         parent: EmbraceSpan?,
@@ -123,7 +111,6 @@ public interface TracingApi {
      * Record a span with the given name, start time, and end time (epoch time in milliseconds). The created span will be the root span of
      * a new trace.
      */
-    @BetaApi
     public fun recordCompletedSpan(
         name: String,
         startTimeMs: Long,
@@ -144,7 +131,6 @@ public interface TracingApi {
      * root span of a new trace. A non-null [ErrorCode] can be passed in to denote the operation the span represents was ended
      * unsuccessfully under the stated circumstances.
      */
-    @BetaApi
     public fun recordCompletedSpan(
         name: String,
         startTimeMs: Long,
@@ -165,7 +151,6 @@ public interface TracingApi {
      * Record a span with the given name, parent, start time, and end time (epoch time in milliseconds). Passing in a parent that is null
      * will result in a new trace with the new span as its root.
      */
-    @BetaApi
     public fun recordCompletedSpan(
         name: String,
         startTimeMs: Long,
@@ -187,7 +172,6 @@ public interface TracingApi {
      * that is null will result in a new trace with the new span as its root. A non-null [ErrorCode] can be passed in to denote the
      * operation the span represents was ended unsuccessfully under the stated circumstances.
      */
-    @BetaApi
     public fun recordCompletedSpan(
         name: String,
         startTimeMs: Long,
@@ -209,7 +193,6 @@ public interface TracingApi {
      * a new trace. You can also pass in a [Map] with [String] keys and values to be used as the attributes of the recorded span, or
      * a [List] of [EmbraceSpanEvent] to be used as the events of the recorded span.
      */
-    @BetaApi
     public fun recordCompletedSpan(
         name: String,
         startTimeMs: Long,
@@ -233,7 +216,6 @@ public interface TracingApi {
      * with [String] keys and values to be used as the attributes of the recorded span, or a [List] of [EmbraceSpanEvent] to be used
      * as the events of the recorded span.
      */
-    @BetaApi
     public fun recordCompletedSpan(
         name: String,
         startTimeMs: Long,
@@ -249,12 +231,5 @@ public interface TracingApi {
      * Returns null if a span corresponding to the given [spanId] cannot be found, which can happen if this span never existed or
      * if was completed in a prior session.
      */
-    @BetaApi
     public fun getSpan(spanId: String): EmbraceSpan?
-
-    /**
-     * @see [Embrace.isStarted]
-     */
-    @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
-    public fun isTracingAvailable(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -71,7 +71,4 @@ class EmbraceTracer(
      * in used for [recordCompletedSpan] so the timestamps will be in sync with those used by the SDK when a time is implicitly recorded.
      */
     fun getSdkCurrentTimeMs(): Long = clock.now()
-
-    @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
-    override fun isTracingAvailable(): Boolean = spanService.initialized()
 }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -54,7 +54,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun getTraceIdHeader ()Ljava/lang/String;
 	public fun getUnityInternalInterface ()Lio/embrace/android/embracesdk/UnityInternalInterface;
 	public fun isStarted ()Z
-	public fun isTracingAvailable ()Z
 	public fun logCustomStacktrace ([Ljava/lang/StackTraceElement;)V
 	public fun logCustomStacktrace ([Ljava/lang/StackTraceElement;Lio/embrace/android/embracesdk/Severity;)V
 	public fun logCustomStacktrace ([Ljava/lang/StackTraceElement;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -430,12 +430,6 @@ public final class Embrace implements SdkApi {
         return false;
     }
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public boolean isTracingAvailable() {
-        return impl.isTracingAvailable();
-    }
-
     @Nullable
     @Override
     public EmbraceSpan createSpan(@NonNull String name) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracingApi.kt
@@ -43,9 +43,4 @@ class FakeTracingApi : TracingApi {
     override fun getSpan(spanId: String): EmbraceSpan? {
         TODO("Not yet implemented")
     }
-
-    @Deprecated("Not required. Use Embrace.isStarted() to know when the full tracing API is available")
-    override fun isTracingAvailable(): Boolean {
-        TODO("Not yet implemented")
-    }
 }


### PR DESCRIPTION
## Goal

Removes the beta annotation from the tracing api. This should only be merged as part of 7.0.

