### PR TITLE
Add integration test for payload pruning

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -148,9 +148,11 @@ class PayloadStorageServiceImpl(
         if (removalCount < 0) {
             return false
         }
-        val removals = input
-            .sortedWith(storedTelemetryComparator)
-            .takeLast(removalCount)
+        val removals = input.sortedWith(
+            compareByDescending(StoredTelemetryMetadata::envelopeType)
+                .thenBy(StoredTelemetryMetadata::timestamp)
+        )
+            .take(removalCount)
         removals.forEach(::processDelete)
         logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, RuntimeException("Pruned payload storage"))
 
@@ -165,7 +167,7 @@ class PayloadStorageServiceImpl(
         fun createOutputDir(
             ctx: Context,
             outputType: OutputType,
-            logger: EmbLogger
+            logger: EmbLogger,
         ) = lazy {
             try {
                 File(ctx.filesDir, outputType.dir).apply(File::mkdirs)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
@@ -1,0 +1,86 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.internal.worker.Worker.Priority.DataPersistenceWorker
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
+import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
+import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
+import kotlin.math.log
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val STORAGE_LIMIT = 500
+private const val OVERAGE = 100
+
+@RunWith(AndroidJUnit4::class)
+internal class PruningFeatureTest {
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule {
+        val clock = FakeClock(0)
+        EmbraceSetupInterface(
+            overriddenClock = clock,
+            overriddenInitModule = FakeInitModule(
+                clock,
+                FakeEmbLogger(throwOnInternalError = false)
+            )
+        )
+    }
+
+    @Test
+    fun `stored payloads are pruned appropriately`() {
+        testRule.runTest(
+            setupAction = {
+                overriddenConfigService.backgroundActivityCaptureEnabled = false
+            },
+            testCaseAction = {
+                simulateNetworkChange(NetworkStatus.NOT_REACHABLE)
+                repeat(STORAGE_LIMIT + OVERAGE) { k ->
+                    recordSession {
+                        embrace.addBreadcrumb("$k")
+                    }
+                }
+                submitNetworkChange()
+            },
+            assertAction = {
+                val sessionEnvelopes = getSessionEnvelopes(STORAGE_LIMIT, waitTimeMs = 10000)
+                assertEquals(STORAGE_LIMIT, sessionEnvelopes.size)
+
+                val breadcrumbs = sessionEnvelopes.map { envelope ->
+                    val sessionSpan = envelope.findSessionSpan()
+                    val breadcrumbEvent = checkNotNull(sessionSpan.events?.single {
+                        it.name == "emb-breadcrumb"
+                    })
+                    checkNotNull(breadcrumbEvent.attributes?.findAttributeValue("message")).toInt()
+                }
+                val expected = List(STORAGE_LIMIT) { it + OVERAGE }
+                assertEquals(STORAGE_LIMIT, breadcrumbs.size)
+                assertEquals(expected, breadcrumbs)
+            }
+        )
+    }
+
+    /**
+     * Submits a network change AFTER all the sessions have been written to disk & triggered the
+     * pruning logic.
+     */
+    private fun EmbraceActionInterface.submitNetworkChange() {
+        val workerThreadModule = testRule.bootstrapper.workerThreadModule
+        val worker =
+            workerThreadModule.priorityWorker<StoredTelemetryMetadata>(DataPersistenceWorker)
+        worker.submit(fakeSessionStoredTelemetryMetadata) {
+            simulateNetworkChange(NetworkStatus.WIFI)
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
@@ -29,11 +29,11 @@ internal class SessionSpamTest {
                 }
             },
             assertAction = {
-                val messages = getSessionEnvelopes(SESSION_COUNT)
+                val messages = getSessionEnvelopes(SESSION_COUNT, waitTimeMs = 10000)
                 val ids = messages.map { it.getSessionId() }.toSet()
                 assertEquals(SESSION_COUNT, ids.size)
 
-                val bas = getSessionEnvelopes(SESSION_COUNT, ApplicationState.BACKGROUND)
+                val bas = getSessionEnvelopes(SESSION_COUNT, ApplicationState.BACKGROUND, waitTimeMs = 10000)
                 val baIds = bas.map { it.getSessionId() }.toSet()
                 assertEquals(SESSION_COUNT, baIds.size)
             }


### PR DESCRIPTION
## Goal

Adds an integration test that checks the priority in which payloads are pruned. This also fixes a bug where the most recent session was deleted due to the reuse of a comparator that isn't correct for this specific use-case.

