### PR TITLE
Trigger initial delivery of stored payloads

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DeliveryConnectivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DeliveryConnectivityFeatureTest.kt
@@ -1,22 +1,13 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
-import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.fakeIncompleteSessionEnvelope
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
-import io.embrace.android.embracesdk.fixtures.fakeCachedSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata
-import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata2
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
-import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
-import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.payload.getSessionSpan
-import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -84,6 +75,27 @@ internal class DeliveryConnectivityFeatureTest {
                 recordSession()
                 simulateNetworkChange(NetworkStatus.WIFI)
             },
+            assertAction = {
+                assertEquals(2, getSessionEnvelopes(2).size)
+            }
+        )
+    }
+
+    @Test
+    fun `stored payload sent on startup`() {
+        val startMs = fakeSessionStoredTelemetryMetadata.timestamp
+        testRule.runTest(
+            setupAction = {
+                payloadStorageService.addPayload(
+                    fakeSessionStoredTelemetryMetadata,
+                    fakeSessionEnvelope(sessionId = "1", startMs = startMs))
+                payloadStorageService.addPayload(
+                    fakeSessionStoredTelemetryMetadata2,
+                    fakeSessionEnvelope(sessionId = "2", startMs = startMs + 1000)
+                )
+                payloadStorageServiceProvider = { payloadStorageService }
+            },
+            testCaseAction = {},
             assertAction = {
                 assertEquals(2, getSessionEnvelopes(2).size)
             }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
@@ -12,11 +12,13 @@ val fakeCachedSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
     complete = false
 )
 
-val fakeSessionStoredTelemetryMetadata =
-    fakeCachedSessionStoredTelemetryMetadata.copy(
-        timestamp = fakeCachedSessionStoredTelemetryMetadata.timestamp + 1000L,
-        complete = true
-    )
+val fakeSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
+    timestamp = DEFAULT_FAKE_CURRENT_TIME + 1000L,
+    uuid = "30690ad1-6b87-4e08-b72c-7deca14451d8",
+    processId = "8115ec91-3e5e-4d8a-816d-cc40306f9822",
+    envelopeType = SupportedEnvelopeType.SESSION,
+    true
+)
 
 val fakeSessionStoredTelemetryMetadata2 = StoredTelemetryMetadata(
     timestamp = DEFAULT_FAKE_CURRENT_TIME + 10_000L,


### PR DESCRIPTION
## Goal

When the SDK loaded there was nothing that triggered the delivery of completed payloads that were stored on disk. I've taken the approach of invoking the `SchedulingService` when the SDK initializes. We could add a more specific function if that's semantically desired but for now I just called `onPayloadIntake()`.

## Testing

Added an integration test

