### PR TITLE
Add lifecycle testing library

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -43,5 +43,6 @@ dependencies {
     testImplementation(libs.opentelemetry.semconv)
     testImplementation(libs.opentelemetry.semconv.incubating)
     testImplementation(libs.lifecycle.common.java8)
+    testImplementation(libs.lifecycle.testing)
     testImplementation(libs.kotlin.reflect)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriterImpl
@@ -35,6 +37,7 @@ class EssentialServiceModuleImpl(
     systemServiceModule: SystemServiceModule,
     androidServicesModule: AndroidServicesModule,
     storageModule: StorageModule,
+    lifecycleOwnerProvider: Provider<LifecycleOwner?>,
     networkConnectivityServiceProvider: Provider<NetworkConnectivityService?>
 ) : EssentialServiceModule {
 
@@ -44,7 +47,8 @@ class EssentialServiceModuleImpl(
 
     override val processStateService: ProcessStateService by singleton {
         Systrace.traceSynchronous("process-state-service-init") {
-            EmbraceProcessStateService(initModule.clock, initModule.logger)
+            val lifecycleOwner = lifecycleOwnerProvider() ?: ProcessLifecycleOwner.get()
+            EmbraceProcessStateService(initModule.clock, initModule.logger, lifecycleOwner)
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleSupplier.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import androidx.lifecycle.LifecycleOwner
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.utils.Provider
 
@@ -15,6 +16,7 @@ typealias EssentialServiceModuleSupplier = (
     systemServiceModule: SystemServiceModule,
     androidServicesModule: AndroidServicesModule,
     storageModule: StorageModule,
+    lifecycleOwnerProvider: Provider<LifecycleOwner?>,
     networkConnectivityServiceProvider: Provider<NetworkConnectivityService?>
 ) -> EssentialServiceModule
 
@@ -27,6 +29,7 @@ fun createEssentialServiceModule(
     systemServiceModule: SystemServiceModule,
     androidServicesModule: AndroidServicesModule,
     storageModule: StorageModule,
+    lifecycleOwnerProvider: Provider<LifecycleOwner?>,
     networkConnectivityServiceProvider: Provider<NetworkConnectivityService?>
 ): EssentialServiceModule = EssentialServiceModuleImpl(
     initModule,
@@ -37,5 +40,6 @@ fun createEssentialServiceModule(
     systemServiceModule,
     androidServicesModule,
     storageModule,
+    lifecycleOwnerProvider,
     networkConnectivityServiceProvider
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.session.lifecycle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.ProcessLifecycleOwner
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -19,7 +18,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 internal class EmbraceProcessStateService(
     private val clock: Clock,
     private val logger: EmbLogger,
-    private val lifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get()
+    private val lifecycleOwner: LifecycleOwner
 ) : ProcessStateService, LifecycleEventObserver {
 
     /**

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/EmbraceProcessStateServiceTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session
 import android.app.Application
 import android.os.Looper
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeProcessStateListener
@@ -64,7 +65,8 @@ internal class EmbraceProcessStateServiceTest {
         fakeEmbLogger = FakeEmbLogger()
         stateService = EmbraceProcessStateService(
             fakeClock,
-            fakeEmbLogger
+            fakeEmbLogger,
+            TestLifecycleOwner(Lifecycle.State.INITIALIZED)
         )
     }
 

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     testImplementation(libs.protobuf.java)
     testImplementation(libs.protobuf.java.util)
     testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.lifecycle.testing)
 
     androidTestImplementation(project(":embrace-test-fakes"))
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -2,6 +2,9 @@ package io.embrace.android.embracesdk.testframework.actions
 
 import android.app.Activity
 import android.content.Context
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.EmbraceHooks
 import io.embrace.android.embracesdk.fakes.FakeClock
@@ -54,19 +57,11 @@ internal class EmbraceActionInterface(
     }
 
     private fun onForeground() {
-        val processStateService = EmbraceHooks.getProcessStateService()
-        if (!processStateService.isInBackground) {
-            error("Unbalanced call to onForeground() within a test case. Please correct the test.")
-        }
-        processStateService.onForeground()
+        setup.lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
     }
 
     private fun onBackground() {
-        val processStateService = EmbraceHooks.getProcessStateService()
-        if (processStateService.isInBackground) {
-            error("Unbalanced call to onBackground() within a test case. Please correct the test.")
-        }
-        processStateService.onBackground()
+        setup.lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
     }
 
     fun simulateNetworkChange(status: NetworkStatus) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.testframework.actions
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -56,7 +58,8 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
     val fakeNativeFeatureModule: FakeNativeFeatureModule = FakeNativeFeatureModule(),
     var cacheStorageServiceProvider: Provider<PayloadStorageService?> = { null },
     var payloadStorageServiceProvider: Provider<PayloadStorageService?> = { null },
-    val networkConnectivityService: FakeNetworkConnectivityService = FakeNetworkConnectivityService()
+    val networkConnectivityService: FakeNetworkConnectivityService = FakeNetworkConnectivityService(),
+    val lifecycleOwner: TestLifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.INITIALIZED),
 ) {
     fun createBootstrapper(): ModuleInitBootstrapper = ModuleInitBootstrapper(
         initModule = overriddenInitModule,
@@ -64,7 +67,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
         coreModuleSupplier = { _, _ -> overriddenCoreModule },
         workerThreadModuleSupplier = { _ -> overriddenWorkerThreadModule },
         androidServicesModuleSupplier = { _, _, _ -> overriddenAndroidServicesModule },
-        essentialServiceModuleSupplier = { initModule, configModule, openTelemetryModule, coreModule, workerThreadModule, systemServiceModule, androidServicesModule, storageModule, _ ->
+        essentialServiceModuleSupplier = { initModule, configModule, openTelemetryModule, coreModule, workerThreadModule, systemServiceModule, androidServicesModule, storageModule, _, _ ->
             createEssentialServiceModule(
                 initModule,
                 configModule,
@@ -73,7 +76,8 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                 workerThreadModule,
                 systemServiceModule,
                 androidServicesModule,
-                storageModule
+                storageModule,
+                { lifecycleOwner }
             ) { networkConnectivityService }
         },
         deliveryModuleSupplier = { configModule, otelModule, initModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, _, _, requestExecutionServiceProvider, deliveryServiceProvider ->

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -183,8 +183,10 @@ internal class ModuleInitBootstrapper(
                             workerThreadModule,
                             systemServiceModule,
                             androidServicesModule,
-                            storageModule
-                        ) { null }
+                            storageModule,
+                            { null },
+                            { null }
+                        )
                     }
                     postInit(EssentialServiceModule::class) {
                         // Allow config service to start making HTTP requests

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -44,7 +44,7 @@ internal fun fakeModuleInitBootstrapper(
     androidServicesModuleSupplier: AndroidServicesModuleSupplier = { _, _, _ -> FakeAndroidServicesModule() },
     workerThreadModuleSupplier: WorkerThreadModuleSupplier = { _ -> FakeWorkerThreadModule() },
     storageModuleSupplier: StorageModuleSupplier = { _, _, _ -> FakeStorageModule() },
-    essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
+    essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import android.os.Looper
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
@@ -34,6 +35,7 @@ internal class EssentialServiceModuleImplTest {
             androidServicesModule = FakeAndroidServicesModule(),
             storageModule = FakeStorageModule(),
             configModule = FakeConfigModule(),
+            lifecycleOwnerProvider = { TestLifecycleOwner() },
             networkConnectivityServiceProvider = { null }
         )
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
@@ -23,7 +23,7 @@ internal class UserApiDelegateTest {
     @Before
     fun setUp() {
         val moduleInitBootstrapper = fakeModuleInitBootstrapper(
-            essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _ ->
+            essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ ->
                 FakeEssentialServiceModule().apply {
                     fakeUserService = userService as FakeUserService
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", vers
 lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "lifecycle" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 lifecycle-extensions = { group = "androidx.lifecycle", name = "lifecycle-extensions", version.ref = "lifecycle-extensions" }
+lifecycle-testing = { group = "androidx.lifecycle", name = "lifecycle-runtime-testing", version.ref = "lifecycle" }
 
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }


### PR DESCRIPTION
## Goal

Adds a test artefact from the lifecycle libraries that allows us to cover more of the SDK surface area in integration tests. Previously we were directly invoking callbacks on `ProcessStateService`. However, since 2.3.0 the androidx lifecycle library has provided an artefact that allows dispatching test events (effectively this just implements the `LifecycleOwner` interface).

I've added this library & updated the integration tests so that a dummy lifecycle owner is passed through during test initialization. This should make it more obvious if changes to this library ever break our SDK.

