### PR TITLE
[DNM] Bump kotlin dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ fastlane/readme.md
 docs/
 
 .DS_Store
+.kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 }
 
 plugins {
-    id("com.google.devtools.ksp") version("1.9.24-1.0.20") apply false
+    id("com.google.devtools.ksp") version("2.0.21-1.0.25") apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
     id("com.android.library") apply false
     id("org.jetbrains.kotlin.android") apply false

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(gradleApi())
 
     // Version of Kotlin used at build time
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21")
     implementation("com.android.tools.build:gradle:8.7.1")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.16.3")

--- a/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-test-defaults.gradle.kts
@@ -1,6 +1,8 @@
 import io.embrace.gradle.Versions
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -28,6 +30,15 @@ android {
         checkReleaseBuilds = false // run on CI instead, speeds up release builds
         baseline = project.file("lint-baseline.xml")
         disable.addAll(mutableSetOf("GradleDependency", "NewerVersionAvailable"))
+    }
+
+    kotlin {
+        compilerOptions {
+            apiVersion.set(KotlinVersion.KOTLIN_1_8)
+            languageVersion.set(KotlinVersion.KOTLIN_1_8)
+            jvmTarget.set(JvmTarget.JVM_1_8)
+            allWarningsAsErrors = true
+        }
     }
 }
 
@@ -60,15 +71,6 @@ project.tasks.withType(DetektCreateBaselineTask::class.java).configureEach {
 
 project.tasks.withType(JavaCompile::class.java).configureEach {
     options.compilerArgs.addAll(listOf("-Xlint:unchecked", "-Xlint:deprecation"))
-}
-
-project.tasks.withType(KotlinCompile::class.java).configureEach {
-    kotlinOptions {
-        apiVersion = "1.8"
-        languageVersion = "1.8"
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-        allWarningsAsErrors = true
-    }
 }
 
 // workaround: see https://medium.com/@saulmm2/android-gradle-precompiled-scripts-tomls-kotlin-dsl-df3c27ea017c

--- a/buildSrc/src/main/kotlin/enable-explicit-api-mode.gradle.kts
+++ b/buildSrc/src/main/kotlin/enable-explicit-api-mode.gradle.kts
@@ -1,12 +1,12 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id("com.android.library") apply false
     id("kotlin-android") apply false
 }
 
-project.tasks.withType(KotlinCompile::class.java).configureEach {
-    kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs + "-Xexplicit-api=strict"
+android {
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.add("-Xexplicit-api=strict")
+        }
     }
 }

--- a/embrace-lint/build.gradle.kts
+++ b/embrace-lint/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("java-library")
@@ -11,9 +11,9 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-project.tasks.withType(KotlinCompile::class.java).configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 


### PR DESCRIPTION
## Goal

Bumps Kotlin to 2.0.21. We still maintain compatibility back to 1.8.22 by setting the `apiVersion/languageVersion` attributes, so it's not anticipated this change will affect any end-user experience.

## Testing

Relied on existing test coverage & reviewed [release notes](https://kotlinlang.org/docs/whatsnew20.html).
