### PR TITLE
[DNM] Move nested classes into top level classes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,8 +1,15 @@
 # Upgrade guide
 
+# Upgrading from 6.x to 7.x
+
+Version 7 of the Embrace Android SDK contains the following breaking changes:
+
+- `Embrace.AppFramework` is now its own top level class, `AppFramework`
+- `Embrace.LastRunEndState` is now its own top level class, `LastRunEndState`
+
 # Upgrading from 5.x to 6.x
 
-Version X of the Embrace <platform> SDK renames some functions. This has been done to reduce
+Version 6 of the Embrace Android SDK renames some functions. This has been done to reduce
 confusion & increase consistency across our SDKs.
 
 Functions that have been marked as deprecated will still work as before, but will be removed in

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -1,3 +1,13 @@
+public final class io/embrace/android/embracesdk/AppFramework : java/lang/Enum {
+	public static final field FLUTTER Lio/embrace/android/embracesdk/AppFramework;
+	public static final field NATIVE Lio/embrace/android/embracesdk/AppFramework;
+	public static final field REACT_NATIVE Lio/embrace/android/embracesdk/AppFramework;
+	public static final field UNITY Lio/embrace/android/embracesdk/AppFramework;
+	public fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/AppFramework;
+	public static fun values ()[Lio/embrace/android/embracesdk/AppFramework;
+}
+
 public final class io/embrace/android/embracesdk/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
@@ -36,7 +46,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun getFlutterInternalInterface ()Lio/embrace/android/embracesdk/FlutterInternalInterface;
 	public static fun getInstance ()Lio/embrace/android/embracesdk/Embrace;
 	public fun getInternalInterface ()Lio/embrace/android/embracesdk/internal/EmbraceInternalInterface;
-	public fun getLastRunEndState ()Lio/embrace/android/embracesdk/Embrace$LastRunEndState;
+	public fun getLastRunEndState ()Lio/embrace/android/embracesdk/LastRunEndState;
 	public fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
 	public fun getReactNativeInternalInterface ()Lio/embrace/android/embracesdk/ReactNativeInternalInterface;
 	public fun getSessionProperties ()Ljava/util/Map;
@@ -78,9 +88,9 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun setUserIdentifier (Ljava/lang/String;)V
 	public fun setUsername (Ljava/lang/String;)V
 	public fun start (Landroid/content/Context;)V
-	public fun start (Landroid/content/Context;Lio/embrace/android/embracesdk/Embrace$AppFramework;)V
+	public fun start (Landroid/content/Context;Lio/embrace/android/embracesdk/AppFramework;)V
 	public fun start (Landroid/content/Context;Z)V
-	public fun start (Landroid/content/Context;ZLio/embrace/android/embracesdk/Embrace$AppFramework;)V
+	public fun start (Landroid/content/Context;ZLio/embrace/android/embracesdk/AppFramework;)V
 	public fun startMoment (Ljava/lang/String;)V
 	public fun startMoment (Ljava/lang/String;Ljava/lang/String;)V
 	public fun startMoment (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
@@ -92,31 +102,21 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun trackWebViewPerformance (Ljava/lang/String;Ljava/lang/String;)V
 }
 
-public final class io/embrace/android/embracesdk/Embrace$AppFramework : java/lang/Enum {
-	public static final field FLUTTER Lio/embrace/android/embracesdk/Embrace$AppFramework;
-	public static final field NATIVE Lio/embrace/android/embracesdk/Embrace$AppFramework;
-	public static final field REACT_NATIVE Lio/embrace/android/embracesdk/Embrace$AppFramework;
-	public static final field UNITY Lio/embrace/android/embracesdk/Embrace$AppFramework;
-	public fun getValue ()I
-	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/Embrace$AppFramework;
-	public static fun values ()[Lio/embrace/android/embracesdk/Embrace$AppFramework;
-}
-
-public final class io/embrace/android/embracesdk/Embrace$LastRunEndState : java/lang/Enum {
-	public static final field CLEAN_EXIT Lio/embrace/android/embracesdk/Embrace$LastRunEndState;
-	public static final field CRASH Lio/embrace/android/embracesdk/Embrace$LastRunEndState;
-	public static final field INVALID Lio/embrace/android/embracesdk/Embrace$LastRunEndState;
-	public fun getValue ()I
-	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/Embrace$LastRunEndState;
-	public static fun values ()[Lio/embrace/android/embracesdk/Embrace$LastRunEndState;
-}
-
 public final class io/embrace/android/embracesdk/EmbraceSamples {
 	public static final field INSTANCE Lio/embrace/android/embracesdk/EmbraceSamples;
 	public static final fun causeNdkIllegalInstruction ()V
 	public static final fun throwJvmException ()V
 	public static final fun triggerAnr ()V
 	public static final fun triggerLongAnr ()V
+}
+
+public final class io/embrace/android/embracesdk/LastRunEndState : java/lang/Enum {
+	public static final field CLEAN_EXIT Lio/embrace/android/embracesdk/LastRunEndState;
+	public static final field CRASH Lio/embrace/android/embracesdk/LastRunEndState;
+	public static final field INVALID Lio/embrace/android/embracesdk/LastRunEndState;
+	public fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/LastRunEndState;
+	public static fun values ()[Lio/embrace/android/embracesdk/LastRunEndState;
 }
 
 public final class io/embrace/android/embracesdk/ViewSwazzledHooks {
@@ -141,9 +141,9 @@ public final class io/embrace/android/embracesdk/WebViewClientSwazzledHooks {
 public abstract interface class io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi {
 	public abstract fun endView (Ljava/lang/String;)Z
 	public abstract fun start (Landroid/content/Context;)V
-	public abstract fun start (Landroid/content/Context;Lio/embrace/android/embracesdk/Embrace$AppFramework;)V
+	public abstract fun start (Landroid/content/Context;Lio/embrace/android/embracesdk/AppFramework;)V
 	public abstract fun start (Landroid/content/Context;Z)V
-	public abstract fun start (Landroid/content/Context;ZLio/embrace/android/embracesdk/Embrace$AppFramework;)V
+	public abstract fun start (Landroid/content/Context;ZLio/embrace/android/embracesdk/AppFramework;)V
 	public abstract fun startView (Ljava/lang/String;)Z
 }
 
@@ -167,7 +167,7 @@ public final class io/embrace/android/embracesdk/internal/api/SdkApi$DefaultImpl
 public abstract interface class io/embrace/android/embracesdk/internal/api/SdkStateApi {
 	public abstract fun getCurrentSessionId ()Ljava/lang/String;
 	public abstract fun getDeviceId ()Ljava/lang/String;
-	public abstract fun getLastRunEndState ()Lio/embrace/android/embracesdk/Embrace$LastRunEndState;
+	public abstract fun getLastRunEndState ()Lio/embrace/android/embracesdk/LastRunEndState;
 	public abstract fun isStarted ()Z
 	public abstract fun setAppId (Ljava/lang/String;)Z
 }

--- a/embrace-android-sdk/lint-baseline.xml
+++ b/embrace-android-sdk/lint-baseline.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.5.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.2)" variant="all" version="8.5.2">
+<issues format="6" by="lint 8.7.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.7.1">
+
+    <issue
+        id="EmbracePublicApiPackageRule"
+        message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
+        errorLine1="public enum AppFramework {"
+        errorLine2="            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/io/embrace/android/embracesdk/AppFramework.java"
+            line="7"
+            column="13"/>
+    </issue>
 
     <issue
         id="EmbracePublicApiPackageRule"
@@ -10,6 +21,17 @@
             file="src/main/java/io/embrace/android/embracesdk/EmbraceSamples.kt"
             line="14"
             column="15"/>
+    </issue>
+
+    <issue
+        id="EmbracePublicApiPackageRule"
+        message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
+        errorLine1="public enum LastRunEndState {"
+        errorLine2="            ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/io/embrace/android/embracesdk/LastRunEndState.java"
+            line="6"
+            column="13"/>
     </issue>
 
     <issue

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -1,8 +1,10 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.AppFramework.FLUTTER
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -30,14 +32,13 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 internal class FlutterInternalInterfaceTest {
 
-    @Suppress("DEPRECATION")
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
         val clock = FakeClock(IntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
         val fakeInitModule = FakeInitModule(clock = clock)
         EmbraceSetupInterface(
-            appFramework = Embrace.AppFramework.FLUTTER,
+            appFramework = FLUTTER,
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,
             overriddenWorkerThreadModule = FakeWorkerThreadModule(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.Embrace.LastRunEndState
+import io.embrace.android.embracesdk.LastRunEndState
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
@@ -1,8 +1,10 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.AppFramework.REACT_NATIVE
 import io.embrace.android.embracesdk.assertions.findSpanOfType
 import io.embrace.android.embracesdk.assertions.findSpanSnapshotOfType
 import io.embrace.android.embracesdk.assertions.findSpansByName
@@ -26,11 +28,10 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 internal class ReactNativeInternalInterfaceTest {
 
-    @Suppress("DEPRECATION")
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(appFramework = Embrace.AppFramework.REACT_NATIVE)
+        EmbraceSetupInterface(appFramework = REACT_NATIVE)
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
@@ -1,8 +1,10 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.AppFramework.UNITY
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.internal.payload.AppFramework
@@ -20,11 +22,10 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 internal class UnityInternalInterfaceTest {
 
-    @Suppress("DEPRECATION")
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(appFramework = Embrace.AppFramework.UNITY)
+        EmbraceSetupInterface(appFramework = UNITY)
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -1,8 +1,10 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.testframework.actions
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
-import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.AppFramework
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
@@ -34,7 +36,7 @@ import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 internal class EmbraceSetupInterface @JvmOverloads constructor(
     currentTimeMs: Long = IntegrationTestRule.DEFAULT_SDK_START_TIME_MS,
     var useMockWebServer: Boolean = true,
-    @Suppress("DEPRECATION") val appFramework: Embrace.AppFramework = Embrace.AppFramework.NATIVE,
+    val appFramework: AppFramework = AppFramework.NATIVE,
     val overriddenClock: FakeClock = FakeClock(currentTime = currentTimeMs),
     val overriddenInitModule: FakeInitModule = FakeInitModule(clock = overriddenClock, logger = FakeEmbLogger()),
     val overriddenOpenTelemetryModule: OpenTelemetryModule = overriddenInitModule.openTelemetryModule,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/AppFramework.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/AppFramework.java
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk;
+
+/**
+ * The AppFramework that is in use.
+ */
+@Deprecated
+public enum AppFramework {
+    NATIVE(1),
+    REACT_NATIVE(2),
+    UNITY(3),
+    FLUTTER(4);
+
+    private final int value;
+
+    AppFramework(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.java
@@ -67,6 +67,7 @@ public final class Embrace implements SdkApi {
     Embrace() {
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void start(@NonNull Context context) {
         if (verifyNonNullParameters("start", context)) {
@@ -676,54 +677,4 @@ public final class Embrace implements SdkApi {
         return true;
     }
 
-    /**
-     * The AppFramework that is in use.
-     */
-    @Deprecated
-    public enum AppFramework {
-        NATIVE(1),
-        REACT_NATIVE(2),
-        UNITY(3),
-        FLUTTER(4);
-
-        private final int value;
-
-        AppFramework(int value) {
-            this.value = value;
-        }
-
-        public int getValue() {
-            return value;
-        }
-    }
-
-    /**
-     * Enum representing the end state of the last run of the application.
-     */
-    public enum LastRunEndState {
-        /**
-         * The SDK has not been started yet.
-         */
-        INVALID(0),
-
-        /**
-         * The last run resulted in a crash.
-         */
-        CRASH(1),
-
-        /**
-         * The last run did not result in a crash.
-         */
-        CLEAN_EXIT(2);
-
-        private final int value;
-
-        LastRunEndState(int value) {
-            this.value = value;
-        }
-
-        public int getValue() {
-            return value;
-        }
-    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -118,21 +118,21 @@ internal class EmbraceImpl @JvmOverloads constructor(
     }
 
     @Suppress("DEPRECATION")
-    override fun start(context: Context) = start(context, Embrace.AppFramework.NATIVE) { null }
+    override fun start(context: Context) = start(context, io.embrace.android.embracesdk.AppFramework.NATIVE) { null }
 
     @Suppress("DEPRECATION")
     @Deprecated("Use {@link #start(Context)} instead.")
-    override fun start(context: Context, appFramework: Embrace.AppFramework) =
+    override fun start(context: Context, appFramework: io.embrace.android.embracesdk.AppFramework) =
         start(context, appFramework) { null }
 
     @Suppress("DEPRECATION")
     @Deprecated("Use {@link #start(Context)} instead. The isDevMode parameter has no effect.")
     override fun start(context: Context, isDevMode: Boolean) =
-        start(context, Embrace.AppFramework.NATIVE) { null }
+        start(context, io.embrace.android.embracesdk.AppFramework.NATIVE) { null }
 
     @Suppress("DEPRECATION")
     @Deprecated("Use {@link #start(Context, Embrace.AppFramework)} instead. The isDevMode parameter has no effect.")
-    override fun start(context: Context, isDevMode: Boolean, appFramework: Embrace.AppFramework) =
+    override fun start(context: Context, isDevMode: Boolean, appFramework: io.embrace.android.embracesdk.AppFramework) =
         start(context, appFramework) { null }
 
     /**
@@ -150,7 +150,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
     @Suppress("DEPRECATION")
     fun start(
         context: Context,
-        appFramework: Embrace.AppFramework,
+        appFramework: io.embrace.android.embracesdk.AppFramework,
         configServiceProvider: (framework: AppFramework) -> ConfigService? = { null },
     ) {
         try {
@@ -171,7 +171,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
     @Suppress("DEPRECATION", "CyclomaticComplexMethod", "ComplexMethod")
     private fun startImpl(
         context: Context,
-        framework: Embrace.AppFramework,
+        framework: io.embrace.android.embracesdk.AppFramework,
         configServiceProvider: (framework: AppFramework) -> ConfigService?,
     ) {
         if (application != null) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LastRunEndState.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/LastRunEndState.java
@@ -1,0 +1,31 @@
+package io.embrace.android.embracesdk;
+
+/**
+ * Enum representing the end state of the last run of the application.
+ */
+public enum LastRunEndState {
+    /**
+     * The SDK has not been started yet.
+     */
+    INVALID(0),
+
+    /**
+     * The last run resulted in a crash.
+     */
+    CRASH(1),
+
+    /**
+     * The last run did not result in a crash.
+     */
+    CLEAN_EXIT(2);
+
+    private final int value;
+
+    LastRunEndState(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/AppFrameworkExt.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/AppFrameworkExt.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal
 
-import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.AppFramework.FLUTTER
 import io.embrace.android.embracesdk.internal.payload.AppFramework.NATIVE
@@ -8,9 +7,11 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework.REACT_NATIVE
 import io.embrace.android.embracesdk.internal.payload.AppFramework.UNITY
 
 @Suppress("DEPRECATION")
-internal fun fromFramework(appFramework: Embrace.AppFramework): AppFramework = when (appFramework) {
-    Embrace.AppFramework.NATIVE -> NATIVE
-    Embrace.AppFramework.REACT_NATIVE -> REACT_NATIVE
-    Embrace.AppFramework.UNITY -> UNITY
-    Embrace.AppFramework.FLUTTER -> FLUTTER
+internal fun fromFramework(
+    appFramework: io.embrace.android.embracesdk.AppFramework
+): AppFramework = when (appFramework) {
+    io.embrace.android.embracesdk.AppFramework.NATIVE -> NATIVE
+    io.embrace.android.embracesdk.AppFramework.REACT_NATIVE -> REACT_NATIVE
+    io.embrace.android.embracesdk.AppFramework.UNITY -> UNITY
+    io.embrace.android.embracesdk.AppFramework.FLUTTER -> FLUTTER
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi.kt
@@ -1,6 +1,9 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.api
 
 import android.content.Context
+import io.embrace.android.embracesdk.AppFramework
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.annotation.InternalApi
 
@@ -40,7 +43,7 @@ public interface EmbraceAndroidApi {
     @Deprecated("Use {@link #start(Context)} instead.")
     public fun start(
         context: Context,
-        appFramework: Embrace.AppFramework
+        appFramework: AppFramework
     )
 
     /**
@@ -80,7 +83,7 @@ public interface EmbraceAndroidApi {
     public fun start(
         context: Context,
         isDevMode: Boolean,
-        appFramework: Embrace.AppFramework
+        appFramework: AppFramework
     )
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.api
 
-import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.LastRunEndState
 import io.embrace.android.embracesdk.annotation.InternalApi
 
 @InternalApi
@@ -26,5 +26,5 @@ public interface SdkStateApi {
 
     public val currentSessionId: String?
 
-    public val lastRunEndState: Embrace.LastRunEndState
+    public val lastRunEndState: LastRunEndState
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.api.delegate
 
-import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.LastRunEndState
 import io.embrace.android.embracesdk.internal.api.SdkStateApi
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.embraceImplInject
@@ -83,16 +83,16 @@ internal class SdkStateApiDelegate(
             return null
         }
 
-    override val lastRunEndState: Embrace.LastRunEndState
+    override val lastRunEndState: LastRunEndState
         get() {
             return if (isStarted && crashVerifier != null) {
                 if (crashVerifier?.didLastRunCrash() == true) {
-                    Embrace.LastRunEndState.CRASH
+                    LastRunEndState.CRASH
                 } else {
-                    Embrace.LastRunEndState.CLEAN_EXIT
+                    LastRunEndState.CLEAN_EXIT
                 }
             } else {
-                Embrace.LastRunEndState.INVALID
+                LastRunEndState.INVALID
             }
         }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.Embrace.LastRunEndState
+import io.embrace.android.embracesdk.LastRunEndState
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeLogService
 import io.embrace.android.embracesdk.fakes.FakePreferenceService

--- a/embrace-test-fakes/lint-baseline.xml
+++ b/embrace-test-fakes/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.5.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.2)" variant="all" version="8.5.2">
+<issues format="6" by="lint 8.7.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.7.1">
 
     <issue
         id="StopShip"
@@ -455,17 +455,6 @@
     <issue
         id="StopShip"
         message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="            TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt"
-            line="43"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -909,17 +898,6 @@
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt"
             line="28"
             column="44"/>
-    </issue>
-
-    <issue
-        id="UseTomlInstead"
-        message="Use version catalog instead"
-        errorLine1="    implementation(&quot;org.robolectric:robolectric:${Versions.ROBOLECTRIC}&quot;)"
-        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle.kts"
-            line="26"
-            column="20"/>
     </issue>
 
 </issues>


### PR DESCRIPTION
## Goal

Moves the `AppFramework` and `LastRunEndState` into top level classes. This is a breaking change so should be shipped as part of 7.0.

