### PR TITLE
Don't queue a send for payloads being deleted

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
@@ -25,7 +25,7 @@ interface PayloadStorageService {
     /**
      * Deletes a payload
      */
-    fun delete(metadata: StoredTelemetryMetadata)
+    fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit = {})
 
     /**
      * Loads a payload as an [InputStream]

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -99,9 +99,10 @@ class PayloadStorageServiceImpl(
         }
     }
 
-    override fun delete(metadata: StoredTelemetryMetadata) {
+    override fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit) {
         worker.submit(metadata) {
             processDelete(metadata)
+            callback()
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/FakeCacheStorageService.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/FakeCacheStorageService.kt
@@ -17,8 +17,9 @@ internal class FakeCacheStorageService: PayloadStorageService {
         storedPayloads[metadata] = action
     }
 
-    override fun delete(metadata: StoredTelemetryMetadata) {
+    override fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit) {
         deletedPayloads.add(metadata)
+        callback()
     }
 
     override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -44,9 +44,10 @@ class FakePayloadStorageService(
         }
     }
 
-    override fun delete(metadata: StoredTelemetryMetadata) {
+    override fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit) {
         cachedPayloads.remove(metadata)
         deleteCount.getAndIncrement()
+        callback()
     }
 
     override fun getPayloadsByPriority(): List<StoredTelemetryMetadata> =


### PR DESCRIPTION
## Goal

Track payloads queued for deletion and only attempt to send payloads that aren't queued to be deleted. To support this, I added a basic callback to the `delete` function. Didn't want to complicate things.

Existing tests verify that this works.

