### PR TITLE
New abstraction for the result from an execution service attempt

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
@@ -1,0 +1,82 @@
+package io.embrace.android.embracesdk.internal.delivery.execution
+
+import io.embrace.android.embracesdk.internal.comms.api.Endpoint
+
+/**
+ * The result of an execution attempt on a [RequestExecutionService]
+ */
+sealed class ExecutionResult(
+    val shouldRetry: Boolean,
+) {
+    /**
+     * A completed HTTP request that returned a 2xx status code.
+     */
+    object Success : ExecutionResult(false)
+
+    /**
+     * A completed HTTP request that returned a 413 (Payload Too Large) status code.
+     */
+    object PayloadTooLarge : ExecutionResult(false)
+
+    /**
+     * A completed HTTP request that returned a 429 (Too Many Requests) status code.
+     */
+    data class TooManyRequests(val endpoint: Endpoint, val retryAfter: Long?) : ExecutionResult(true)
+
+    /**
+     * A completed HTTP request that with a status code that indicates it did not succeed (4xx and 5xx)
+     *
+     * Other than 413 and 429, which are modeled by [PayloadTooLarge] and [TooManyRequests] respectively, all properly
+     * received responses will be represented by this result.
+     */
+    data class Failure(val code: Int) : ExecutionResult(code in 500..599)
+
+    /**
+     * A completed HTTP request with a status code not explicitly covered by other [ExecutionResult]
+     *
+     * This indicates the request being completed but makes no assumption about whether the server would have handled
+     * it correctly. By default, this should be treated similarly as [Success].
+     */
+    data class Other(val code: Int) : ExecutionResult(false)
+
+    /**
+     * An execution that was interrupted by the given throwable. This result may be due to a failure before the request
+     * was queued for execution, during execution of the request, or in the job after the response was fully loaded.
+     */
+    data class Incomplete(val exception: Throwable, val retry: Boolean = true) : ExecutionResult(retry)
+
+    /**
+     * An execution attempt was not made for expected reasons.
+     */
+    object NotAttempted : ExecutionResult(false)
+
+    companion object {
+        private const val HTTP_OK = 200
+        private const val HTTP_ENTITY_TOO_LARGE = 413
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private val HTTP_FAILURES = 400..599
+
+        /**
+         * Given the inputs, return the [ExecutionResult] they map to
+         */
+        fun getResult(
+            endpoint: Endpoint,
+            responseCode: Int?,
+            headersProvider: () -> Map<String, String>,
+            clientError: Throwable? = null,
+        ): ExecutionResult {
+            return when (responseCode) {
+                null -> Incomplete(clientError ?: IllegalStateException("Unknown execution error"))
+                HTTP_OK -> Success
+                HTTP_ENTITY_TOO_LARGE -> PayloadTooLarge
+                HTTP_TOO_MANY_REQUESTS -> TooManyRequests(
+                    endpoint,
+                    headersProvider()["Retry-After"]?.toLongOrNull()
+                )
+
+                in HTTP_FAILURES -> Failure(responseCode)
+                else -> Other(responseCode)
+            }
+        }
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionService.kt
@@ -1,15 +1,13 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
 import io.embrace.android.embracesdk.internal.comms.api.ApiRequestV2
-import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult.Companion.getResult
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 
-private const val NO_HTTP_RESPONSE = -1
-private const val TOO_MANY_REQUESTS = 429
 private const val DEFAULT_TIMEOUT_MILLISECONDS = 10 * 1000
 
 class HttpUrlConnectionRequestExecutionService(
@@ -17,57 +15,48 @@ class HttpUrlConnectionRequestExecutionService(
     private val lazyDeviceId: Lazy<String>,
     private val appId: String,
     private val embraceVersionName: String,
-    private val connectionTimeoutMilliseconds: Int = DEFAULT_TIMEOUT_MILLISECONDS
+    private val connectionTimeoutMilliseconds: Int = DEFAULT_TIMEOUT_MILLISECONDS,
 ) : RequestExecutionService {
     override fun attemptHttpRequest(
         payloadStream: () -> InputStream,
         envelopeType: SupportedEnvelopeType,
-    ): ApiResponse {
+    ): ExecutionResult {
         val apiRequest = envelopeType.endpoint.getApiRequestFromEndpoint()
-
-        try {
+        var headersProvider = { emptyMap<String, String>() }
+        var failureReason: Throwable? = null
+        val responseCode = try {
             val httpUrlConnection = createUrlConnection(apiRequest)
-
             httpUrlConnection.outputStream?.use { outputStream ->
                 payloadStream().use { inputStream ->
                     inputStream.copyTo(outputStream)
                 }
             }
-
             httpUrlConnection.connect()
-
-            return handleHttpUrlConnectionResponse(httpUrlConnection, envelopeType.endpoint)
+            headersProvider = { readHttpResponseHeaders(httpUrlConnection) }
+            readResponseCode(httpUrlConnection)
         } catch (throwable: Throwable) {
-            return ApiResponse.Incomplete(throwable)
+            failureReason = throwable
+            null
         }
+
+        return getResult(
+            endpoint = envelopeType.endpoint,
+            responseCode = responseCode,
+            headersProvider = headersProvider,
+            clientError = failureReason,
+        )
     }
 
-    private fun handleHttpUrlConnectionResponse(httpUrlConnection: HttpURLConnection, endpoint: Endpoint): ApiResponse {
-        val responseCode = readResponseCode(httpUrlConnection)
-        val responseHeaders = readHttpResponseHeaders(httpUrlConnection)
-
-        return when (responseCode) {
-            HttpURLConnection.HTTP_OK -> ApiResponse.Success(null, null)
-            HttpURLConnection.HTTP_NOT_MODIFIED -> ApiResponse.NotModified
-            HttpURLConnection.HTTP_ENTITY_TOO_LARGE -> ApiResponse.PayloadTooLarge
-            TOO_MANY_REQUESTS -> ApiResponse.TooManyRequests(endpoint, responseHeaders["Retry-After"]?.toLongOrNull())
-
-            NO_HTTP_RESPONSE -> {
-                ApiResponse.Incomplete(IllegalStateException("Connection failed or unexpected response code"))
-            }
-
-            else -> ApiResponse.Failure(responseCode, responseHeaders)
-        }
-    }
-
-    private fun readResponseCode(httpUrlConnection: HttpURLConnection): Int = try {
+    private fun readResponseCode(httpUrlConnection: HttpURLConnection): Int? = try {
         httpUrlConnection.responseCode
     } catch (throwable: Throwable) {
-        NO_HTTP_RESPONSE
+        null
     }
 
-    private fun readHttpResponseHeaders(httpUrlConnection: HttpURLConnection): Map<String, String> {
-        return httpUrlConnection.headerFields?.mapValues { it.value.joinToString() } ?: emptyMap()
+    private fun readHttpResponseHeaders(httpUrlConnection: HttpURLConnection): Map<String, String> = try {
+        httpUrlConnection.headerFields?.mapValues { it.value.joinToString() } ?: emptyMap()
+    } catch (throwable: Throwable) {
+        emptyMap()
     }
 
     private fun createUrlConnection(apiRequest: ApiRequestV2): HttpURLConnection {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionService.kt
@@ -22,7 +22,7 @@ class HttpUrlConnectionRequestExecutionService(
         envelopeType: SupportedEnvelopeType,
     ): ExecutionResult {
         val apiRequest = envelopeType.endpoint.getApiRequestFromEndpoint()
-        var headersProvider = { emptyMap<String, String>() }
+        var headersProvider: (() -> Map<String, String>)? = null
         var failureReason: Throwable? = null
         val responseCode = try {
             val httpUrlConnection = createUrlConnection(apiRequest)
@@ -42,7 +42,7 @@ class HttpUrlConnectionRequestExecutionService(
         return getResult(
             endpoint = envelopeType.endpoint,
             responseCode = responseCode,
-            headersProvider = headersProvider,
+            headersProvider = headersProvider ?: { emptyMap() },
             clientError = failureReason,
         )
     }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
 import io.embrace.android.embracesdk.internal.comms.api.ApiRequestV2
-import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult.Companion.getResult
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -14,11 +14,8 @@ import okio.BufferedSink
 import okio.buffer
 import okio.source
 import java.io.InputStream
-import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
 
-private const val NO_HTTP_RESPONSE = -1
-private const val TOO_MANY_REQUESTS = 429
 private const val DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10L
 private const val DEFAULT_READ_TIMEOUT_SECONDS = 60L
 
@@ -41,44 +38,33 @@ class OkHttpRequestExecutionService(
     override fun attemptHttpRequest(
         payloadStream: () -> InputStream,
         envelopeType: SupportedEnvelopeType,
-    ): ApiResponse {
+    ): ExecutionResult {
         val apiRequest = envelopeType.endpoint.getApiRequestFromEndpoint()
-
         val requestBody = generateRequestBody(payloadStream)
-
         val request = Request.Builder()
             .url(apiRequest.url)
             .headers(apiRequest.getHeaders().toHeaders())
             .post(requestBody)
             .build()
 
+        var failureReason: Throwable? = null
         val httpCallResponse = try {
             okHttpClient.newCall(request).execute()
         } catch (throwable: Throwable) {
-            return ApiResponse.Incomplete(throwable)
+            failureReason = throwable
+            null
         }
 
-        httpCallResponse.use { response ->
-            return when (response.code) {
-                HttpURLConnection.HTTP_OK -> return ApiResponse.Success(null, null)
-                HttpURLConnection.HTTP_NOT_MODIFIED -> ApiResponse.NotModified
-                HttpURLConnection.HTTP_ENTITY_TOO_LARGE -> ApiResponse.PayloadTooLarge
-
-                TOO_MANY_REQUESTS -> {
-                    val retryAfter = response.headers["Retry-After"]?.toLongOrNull()
-                    ApiResponse.TooManyRequests(envelopeType.endpoint, retryAfter)
-                }
-
-                NO_HTTP_RESPONSE -> ApiResponse.Incomplete(
-                    IllegalStateException("Connection failed or unexpected response code")
-                )
-
-                else -> ApiResponse.Failure(
-                    response.code,
-                    response.headers.associate { it.first to it.second }
-                )
-            }
-        }
+        return getResult(
+            endpoint = envelopeType.endpoint,
+            responseCode = httpCallResponse?.code,
+            headersProvider = {
+                httpCallResponse?.run {
+                    httpCallResponse.headers.toMap()
+                } ?: emptyMap()
+            },
+            clientError = failureReason,
+        )
     }
 
     private val mediaType = "application/json".toMediaType()

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -58,11 +58,7 @@ class OkHttpRequestExecutionService(
         return getResult(
             endpoint = envelopeType.endpoint,
             responseCode = httpCallResponse?.code,
-            headersProvider = {
-                httpCallResponse?.run {
-                    httpCallResponse.headers.toMap()
-                } ?: emptyMap()
-            },
+            headersProvider = { httpCallResponse?.headers?.toMap() ?: emptyMap() },
             clientError = failureReason,
         )
     }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/RequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/RequestExecutionService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
-import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import java.io.InputStream
 
@@ -16,5 +15,5 @@ interface RequestExecutionService {
     fun attemptHttpRequest(
         payloadStream: () -> InputStream,
         envelopeType: SupportedEnvelopeType
-    ): ApiResponse
+    ): ExecutionResult
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionServiceTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
-import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.mockwebserver.MockResponse
@@ -73,7 +72,7 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         )
 
         // then the response should be incomplete
-        check(response is ApiResponse.Incomplete)
+        check(response is ExecutionResult.Incomplete)
         assertTrue(response.exception is UnknownHostException)
     }
 
@@ -89,11 +88,11 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         )
 
         // then the response should be successful
-        assertTrue(response is ApiResponse.Success)
+        assertTrue(response is ExecutionResult.Success)
     }
 
     @Test
-    fun `return not modified if the server returns a 304 response`() {
+    fun `return other result if 304 response received`() {
         // given a server that returns a 304 response
         server.enqueue(MockResponse().setResponseCode(304))
 
@@ -104,7 +103,7 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         )
 
         // then the response should be not modified
-        assertTrue(response is ApiResponse.NotModified)
+        assertTrue(response is ExecutionResult.Other)
     }
 
     @Test
@@ -119,7 +118,7 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         )
 
         // then the response should be payload too large
-        assertTrue(response is ApiResponse.PayloadTooLarge)
+        assertTrue(response is ExecutionResult.PayloadTooLarge)
     }
 
     @Test
@@ -138,7 +137,7 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         )
 
         // then the response should be too many requests
-        check(response is ApiResponse.TooManyRequests)
+        check(response is ExecutionResult.TooManyRequests)
         assertEquals(10L, response.retryAfter)
     }
 
@@ -154,7 +153,7 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         )
 
         // then the response should be incomplete
-        check(response is ApiResponse.Incomplete)
+        check(response is ExecutionResult.Incomplete)
         assertTrue(response.exception is IllegalStateException)
     }
 
@@ -174,9 +173,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         )
 
         // then the response should be failure
-        check(response is ApiResponse.Failure)
+        check(response is ExecutionResult.Failure)
         assertEquals(500, response.code)
-        assertEquals("ouch", response.headers?.get("Custom-Error-Header"))
     }
 
     @Test

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
-import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.Protocol
@@ -72,14 +71,14 @@ class OkHttpRequestExecutionServiceTest {
         )
 
         // when attempting to make a request
-        val response = requestExecutionService.attemptHttpRequest(
+        val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION
         )
 
-        // then the response should be incomplete
-        check(response is ApiResponse.Incomplete)
-        assertTrue(response.exception is UnknownHostException)
+        // then the result should be incomplete
+        check(result is ExecutionResult.Incomplete)
+        assertTrue(result.exception is UnknownHostException)
     }
 
     @Test
@@ -88,28 +87,28 @@ class OkHttpRequestExecutionServiceTest {
         server.enqueue(MockResponse().setResponseCode(200))
 
         // when attempting to make a request
-        val response = requestExecutionService.attemptHttpRequest(
+        val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION
         )
 
-        // then the response should be successful
-        assertTrue(response is ApiResponse.Success)
+        // then the result should be successful
+        assertTrue(result is ExecutionResult.Success)
     }
 
     @Test
-    fun `return not modified if the server returns a 304 response`() {
+    fun `return other result if 304 result received`() {
         // given a server that returns a 304 response
         server.enqueue(MockResponse().setResponseCode(304))
 
         // when attempting to make a request
-        val response = requestExecutionService.attemptHttpRequest(
+        val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION
         )
 
-        // then the response should be not modified
-        assertTrue(response is ApiResponse.NotModified)
+        // then the result should be other
+        assertTrue(result is ExecutionResult.Other)
     }
 
     @Test
@@ -118,13 +117,13 @@ class OkHttpRequestExecutionServiceTest {
         server.enqueue(MockResponse().setResponseCode(413))
 
         // when attempting to make a request
-        val response = requestExecutionService.attemptHttpRequest(
+        val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION
         )
 
-        // then the response should be payload too large
-        assertTrue(response is ApiResponse.PayloadTooLarge)
+        // then the result should be payload too large
+        assertTrue(result is ExecutionResult.PayloadTooLarge)
     }
 
     @Test
@@ -137,14 +136,14 @@ class OkHttpRequestExecutionServiceTest {
         )
 
         // when attempting to make a request
-        val response = requestExecutionService.attemptHttpRequest(
+        val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION
         )
 
-        // then the response should be too many requests
-        check(response is ApiResponse.TooManyRequests)
-        assertEquals(10L, response.retryAfter)
+        // then the result should be too many requests
+        check(result is ExecutionResult.TooManyRequests)
+        assertEquals(10L, result.retryAfter)
     }
 
     @Test
@@ -153,14 +152,14 @@ class OkHttpRequestExecutionServiceTest {
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
 
         // when attempting to make a request
-        val response = requestExecutionService.attemptHttpRequest(
+        val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION
         )
 
-        // then the response should be incomplete
-        check(response is ApiResponse.Incomplete)
-        assertTrue(response.exception is SocketTimeoutException)
+        // then the result should be incomplete
+        check(result is ExecutionResult.Incomplete)
+        assertTrue(result.exception is SocketTimeoutException)
     }
 
     @Test
@@ -173,15 +172,14 @@ class OkHttpRequestExecutionServiceTest {
         )
 
         // when attempting to make a request
-        val response = requestExecutionService.attemptHttpRequest(
+        val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION
         )
 
-        // then the response should be failure
-        check(response is ApiResponse.Failure)
-        assertEquals(500, response.code)
-        assertEquals("ouch", response.headers?.get("custom-error-header"))
+        // then the result should be failure
+        check(result is ExecutionResult.Failure)
+        assertEquals(500, result.code)
     }
 
     @Test

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -9,9 +9,9 @@ import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.fixtures.fakeLogStoredTelemetryMetadata
 import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata2
-import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
+import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServiceImpl.Companion.INITIAL_DELAY_MS
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
@@ -159,7 +159,10 @@ internal class SchedulingServiceImplTest {
         val longBlockedDuration = 90_000L
         storageService.clearStorage()
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
-        executionService.constantResponse = ApiResponse.TooManyRequests(endpoint = Endpoint.SESSIONS_V2, longBlockedDuration)
+        executionService.constantResponse = ExecutionResult.TooManyRequests(
+            endpoint = Endpoint.SESSIONS_V2,
+            retryAfter = longBlockedDuration
+        )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
         assertEquals(1, executionService.sendAttempts())
@@ -177,7 +180,10 @@ internal class SchedulingServiceImplTest {
     fun `payloads that fail to deliver because of a 429 will be retried before the default delay if endpoint is unblocked earlier`() {
         storageService.clearStorage()
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
-        executionService.constantResponse = ApiResponse.TooManyRequests(endpoint = Endpoint.SESSIONS_V2, SHORT_BLOCKED_DURATION)
+        executionService.constantResponse = ExecutionResult.TooManyRequests(
+            endpoint = Endpoint.SESSIONS_V2,
+            retryAfter = SHORT_BLOCKED_DURATION
+        )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
         allSendsSucceed()
@@ -191,11 +197,14 @@ internal class SchedulingServiceImplTest {
     fun `payloads to unblocked endpoint will not affect other endpoints`() {
         storageService.clearStorage()
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
-        executionService.constantResponse = ApiResponse.TooManyRequests(endpoint = Endpoint.SESSIONS_V2, SHORT_BLOCKED_DURATION)
+        executionService.constantResponse = ExecutionResult.TooManyRequests(
+            endpoint = Endpoint.SESSIONS_V2,
+            retryAfter = SHORT_BLOCKED_DURATION
+        )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
         assertEquals(1, executionService.sendAttempts())
-        executionService.constantResponse = success
+        allSendsSucceed()
         storageService.addFakePayload(fakeLogStoredTelemetryMetadata)
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
@@ -208,7 +217,10 @@ internal class SchedulingServiceImplTest {
         storageService.clearStorage()
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata2)
-        executionService.constantResponse = ApiResponse.TooManyRequests(endpoint = Endpoint.SESSIONS_V2, SHORT_BLOCKED_DURATION)
+        executionService.constantResponse = ExecutionResult.TooManyRequests(
+            endpoint = Endpoint.SESSIONS_V2,
+            retryAfter = SHORT_BLOCKED_DURATION
+        )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
         assertEquals(1, executionService.sendAttempts())
@@ -221,7 +233,10 @@ internal class SchedulingServiceImplTest {
     fun `payloads to already blocked endpoint will not be sent`() {
         storageService.clearStorage()
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
-        executionService.constantResponse = ApiResponse.TooManyRequests(endpoint = Endpoint.SESSIONS_V2, SHORT_BLOCKED_DURATION)
+        executionService.constantResponse = ExecutionResult.TooManyRequests(
+            endpoint = Endpoint.SESSIONS_V2,
+            retryAfter = SHORT_BLOCKED_DURATION
+        )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata2)
@@ -313,7 +328,7 @@ internal class SchedulingServiceImplTest {
     }
 
     private fun allSendsSucceed() {
-        executionService.constantResponse = success
+        executionService.constantResponse = ExecutionResult.Success
     }
 
     private fun allSendsFail() {
@@ -322,7 +337,6 @@ internal class SchedulingServiceImplTest {
 
     private companion object {
         const val SHORT_BLOCKED_DURATION = 30_000L
-        val success = ApiResponse.Success(body = "", headers = emptyMap())
-        val failure = ApiResponse.Failure(code = 500, emptyMap())
+        val failure = ExecutionResult.Failure(code = 500)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -205,12 +205,12 @@ internal class EmbraceImpl @JvmOverloads constructor(
         // Send any sessions that were cached and not yet sent.
         startSynchronous("send-cached-sessions")
 
-        if (useLegacyResurrection(configModule.configService)) {
+        if (useV1DeliveryLayer(configModule.configService)) {
             bootstrapper
                 .workerThreadModule
                 .priorityWorker<TaskPriority>(Worker.Priority.DeliveryCacheWorker)
                 .submit(TaskPriority.NORMAL) {
-                    if (useLegacyResurrection(configModule.configService)) {
+                    if (useV1DeliveryLayer(configModule.configService)) {
                         val essentialServiceModule = bootstrapper.essentialServiceModule
                         bootstrapper.deliveryModule.deliveryService?.sendCachedSessions(
                             bootstrapper.nativeFeatureModule::nativeCrashService,
@@ -274,12 +274,12 @@ internal class EmbraceImpl @JvmOverloads constructor(
         )
         endSynchronous()
 
-        if (!useLegacyResurrection(configModule.configService)) {
+        if (!useV1DeliveryLayer(configModule.configService)) {
             val worker = bootstrapper
                 .workerThreadModule
                 .backgroundWorker(Worker.Background.IoRegWorker)
             worker.submit {
-                if (!useLegacyResurrection(configModule.configService)) {
+                if (!useV1DeliveryLayer(configModule.configService)) {
                     bootstrapper.payloadSourceModule.payloadResurrectionService?.resurrectOldPayloads(
                         nativeCrashServiceProvider = { bootstrapper.nativeFeatureModule.nativeCrashService }
                     )
@@ -382,7 +382,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
         }
     }
 
-    private fun useLegacyResurrection(cfgService: ConfigService?): Boolean {
+    private fun useV1DeliveryLayer(cfgService: ConfigService?): Boolean {
         return cfgService?.autoDataCaptureBehavior?.isV2StorageEnabled() != true
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.assertions.getSessionId
-import io.embrace.android.embracesdk.internal.comms.api.ApiResponse
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
@@ -18,8 +18,8 @@ class FakeRequestExecutionService(
 ) : RequestExecutionService {
 
     private val serializer = TestPlatformSerializer()
-    var constantResponse: ApiResponse = ApiResponse.Success(null, null)
-    var responseAction: (intake: Envelope<*>) -> ApiResponse = { _ -> constantResponse }
+    var constantResponse: ExecutionResult = ExecutionResult.Success
+    var responseAction: (intake: Envelope<*>) -> ExecutionResult = { _ -> constantResponse }
     var exceptionOnExecution: Throwable? = null
     val attemptedHttpRequests = ConcurrentLinkedQueue<Envelope<*>>()
     val sessionIds = mutableSetOf<String>()
@@ -36,7 +36,7 @@ class FakeRequestExecutionService(
     override fun attemptHttpRequest(
         payloadStream: () -> InputStream,
         envelopeType: SupportedEnvelopeType,
-    ): ApiResponse {
+    ): ExecutionResult {
         exceptionOnExecution?.run { throw this }
         val bufferedStream = GZIPInputStream(payloadStream())
         val envelope: Envelope<*> = serializer.fromJson(bufferedStream, envelopeType.serializedType)


### PR DESCRIPTION
## Goal

Created `ExecutionResult` to model the result... of the execution. It's a subset and simplified version of `ApiResponse` which was being used and contains a bunch of things that aren't necessary, as well as gaps that are now explicitly handled, e.g. non failure status codes, retry definition, etc.

This is laying the ground work to better handle various results in terms of whether we retry or log their failure.

## Testing

Existing tests should cover this. I changed the names in the tests for the OkHttp version but not the HttpUrl one because it'll be gone soon anyway...