### PR TITLE
Optimize performance of v2 delivery layer

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -285,10 +285,19 @@ internal class EmbraceImpl @JvmOverloads constructor(
                     )
                 }
             }
-            worker.submit {
+            worker.submit { // potentially trigger first delivery attempt by firing network status callback
+                registerDeliveryNetworkListener()
                 bootstrapper.deliveryModule.schedulingService?.onPayloadIntake()
             }
+        } else {
+            registerDeliveryNetworkListener()
         }
+    }
+
+    private fun registerDeliveryNetworkListener() {
+        bootstrapper.deliveryModule.schedulingService?.let(
+            bootstrapper.essentialServiceModule.networkConnectivityService::addNetworkConnectivityListener
+        )
     }
 
     /**

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -319,11 +319,6 @@ internal class ModuleInitBootstrapper(
                             }
                         )
                     }
-                    postInit(DeliveryModule::class) {
-                        deliveryModule.schedulingService?.let(
-                            essentialServiceModule.networkConnectivityService::addNetworkConnectivityListener
-                        )
-                    }
 
                     postInit(AnrModule::class) {
                         serviceRegistry.registerServices(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
@@ -3,13 +3,14 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityListener
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
+import java.util.concurrent.CopyOnWriteArrayList
 
 class FakeNetworkConnectivityService(
     initialNetworkStatus: NetworkStatus = NetworkStatus.UNKNOWN,
     override var ipAddress: String = defaultIpAddress
 ) : NetworkConnectivityService {
 
-    private val networkConnectivityListeners = mutableListOf<NetworkConnectivityListener>()
+    private val networkConnectivityListeners = CopyOnWriteArrayList<NetworkConnectivityListener>()
     var networkStatus: NetworkStatus = initialNetworkStatus
         set(value) {
             field = value


### PR DESCRIPTION
## Goal

The v2 delivery layer was setting a network connectivity listener early in the bootstrapping which led to initializing OkHttp on the main thread, which is an expensive operation. To fix this I've set the listener at the end of SDK init on a background thread as it's not essential.

## Testing

Relied on existing test coverage.

## Profiling

<img width="948" alt="Screenshot 2024-10-23 at 09 37 25" src="https://github.com/user-attachments/assets/30dfe7c0-fe93-446c-838d-c032d3e75ebd">
<img width="984" alt="Screenshot 2024-10-23 at 09 37 33" src="https://github.com/user-attachments/assets/4bd27683-4f62-436a-8b0f-bbc2af539cee">


