### PR TITLE
Default the anr monitor thread executor to non-blocking in integration tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -19,11 +19,11 @@ import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
-import java.util.concurrent.atomic.AtomicReference
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicReference
 
 private const val START_TIME_MS = 10000000000L
 private const val INTERVAL_MS = 100L
@@ -47,7 +47,7 @@ internal class AnrFeatureTest {
             FakeWorkerThreadModule(initModule, Worker.Background.AnrWatchdogWorker).apply {
                 anrMonitorThread = AtomicReference(Thread.currentThread())
             }
-        anrMonitorExecutor = workerThreadModule.executor
+        anrMonitorExecutor = workerThreadModule.executor.apply { blockingMode = false }
         val anrModule = createAnrModule(
             initModule,
             FakeConfigService(),


### PR DESCRIPTION
## Goal

Using a blockable executor for the ANR worker means a lot of jobs were stuck by default before we needed to block it to simulate ANR capture. Since we were already setting the executor to blocking mode before we capture the ANR, we can set it to default to non-blockable so we only block the thread (when we need to).

This speeds up the execution of the tests as something in the `recordSession` flow, in the background/foreground callbacks, were taking ~1s each. Something was probably waiting for the something to execute, and then timing out at the 1s mark? Anyway, didn't look further as this fixes this tests.

I suspect any long running integration tests have the same issue