### PR TITLE
Send payload type as a header

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -36,7 +36,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(),
-            "p3_1692201601000_fakeuuid_fakeProcessId_true_v1.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_v1.json"
         )
     }
 
@@ -47,7 +47,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(),
-            "p3_1692201601000_fakeuuid_fakeProcessId_true_v1.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_v1.json"
         )
     }
 
@@ -58,7 +58,7 @@ class V2PayloadStoreTest {
 
         val intake = intakeService.getIntakes<LogPayload>().single()
         assertSame(envelope, intake.envelope)
-        assertEquals("p5_1692201601000_fakeuuid_fakeProcessId_true_v1.json", intake.metadata.filename)
+        assertEquals("p5_1692201601000_fakeuuid_fakeProcessId_true_unknown_v1.json", intake.metadata.filename)
         assertEquals(0, intakeService.shutdownCount)
     }
 
@@ -75,7 +75,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(false),
-            "p3_1692201601000_fakeuuid_fakeProcessId_false_v1.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_false_session_v1.json"
         )
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -90,6 +90,7 @@ class V2PayloadStoreTest {
         ).forEach { type ->
             storeLogWithType(type)
             assertEquals(SupportedEnvelopeType.CRASH, getLastLogMetadata().envelopeType)
+            assertEquals(type.value, getLastLogMetadata().payloadType.value)
         }
 
         // log
@@ -100,11 +101,13 @@ class V2PayloadStoreTest {
         ).forEach { type ->
             storeLogWithType(type)
             assertEquals(SupportedEnvelopeType.LOG, getLastLogMetadata().envelopeType)
+            assertEquals(type.value, getLastLogMetadata().payloadType.value)
         }
 
         // network
         storeLogWithType(System.NetworkCapturedRequest)
         assertEquals(SupportedEnvelopeType.BLOB, getLastLogMetadata().envelopeType)
+        assertEquals(System.NetworkCapturedRequest.value, getLastLogMetadata().payloadType.value)
     }
 
     private fun storeLogWithType(type: TelemetryType) {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
@@ -1,0 +1,52 @@
+package io.embrace.android.embracesdk.internal.delivery
+
+enum class PayloadType(
+    val value: String,
+) {
+    SESSION("session"),
+    LOG("sys.log"),
+    CRASH("sys.android.crash"),
+    NATIVE_CRASH("sys.android.native_crash"),
+    REACT_NATIVE_CRASH("sys.android.react_native_crash"),
+    FLUTTER_EXCEPTION("sys.flutter_exception"),
+    AEI("sys.exit"),
+    EXCEPTION("sys.exception"),
+    NETWORK_CAPTURE("sys.network_capture"),
+    UNKNOWN("unknown");
+
+    companion object {
+        fun fromValue(value: String?): PayloadType {
+            return values().firstOrNull { it.value == value } ?: UNKNOWN
+        }
+
+        fun toFilenamePart(payloadType: PayloadType): String {
+            return when (payloadType) {
+                SESSION -> "session"
+                CRASH -> "crash"
+                LOG -> "log"
+                NATIVE_CRASH -> "native"
+                REACT_NATIVE_CRASH -> "react"
+                FLUTTER_EXCEPTION -> "flutter"
+                AEI -> "aei"
+                EXCEPTION -> "exception"
+                NETWORK_CAPTURE -> "network"
+                else -> "unknown"
+            }
+        }
+
+        fun fromFilenameComponent(component: String): PayloadType {
+            return when (component) {
+                "session" -> SESSION
+                "crash" -> CRASH
+                "log" -> LOG
+                "native" -> NATIVE_CRASH
+                "react" -> REACT_NATIVE_CRASH
+                "flutter" -> FLUTTER_EXCEPTION
+                "aei" -> AEI
+                "exception" -> EXCEPTION
+                "network" -> NETWORK_CAPTURE
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.delivery
 enum class PayloadType(
     val value: String,
 ) {
-    SESSION("session"),
+    SESSION("ux.session"),
     LOG("sys.log"),
     CRASH("sys.android.crash"),
     NATIVE_CRASH("sys.android.native_crash"),

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -23,7 +23,6 @@ data class StoredTelemetryMetadata(
 ) {
 
     companion object {
-
         /**
          * Parses a filename and constructs a [StoredTelemetryMetadata] object. This returns a
          * [Result] because the filename may be invalid.

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery
 
+import io.embrace.android.embracesdk.internal.delivery.PayloadType.Companion.toFilenamePart
 import kotlin.Result.Companion.failure
 
 /**
@@ -13,7 +14,12 @@ data class StoredTelemetryMetadata(
     val processId: String,
     val envelopeType: SupportedEnvelopeType,
     val complete: Boolean = true,
-    val filename: String = "${envelopeType.priority}_${timestamp}_${uuid}_${processId}_${complete}_v1.json",
+    val payloadType: PayloadType = PayloadType.UNKNOWN,
+    val filename: String = "${envelopeType.priority}_${timestamp}_${uuid}_${processId}_${complete}_${
+        toFilenamePart(
+            payloadType
+        )
+    }_v1.json",
 ) {
 
     companion object {
@@ -24,7 +30,7 @@ data class StoredTelemetryMetadata(
          */
         fun fromFilename(filename: String): Result<StoredTelemetryMetadata> {
             val parts = filename.split("_")
-            if (parts.size != 6) {
+            if (parts.size != 7) {
                 return failure(IllegalArgumentException("Invalid filename: $filename"))
             }
             val envelopeType = SupportedEnvelopeType.fromPriority(parts[0]) ?: return failure(
@@ -38,7 +44,18 @@ data class StoredTelemetryMetadata(
             val complete = parts[4].toBooleanStrictOrNull() ?: return failure(
                 IllegalArgumentException("Invalid completeness state: $filename")
             )
-            return Result.success(StoredTelemetryMetadata(timestamp, uuid, processId, envelopeType, complete, filename))
+            val payloadType = PayloadType.fromFilenameComponent(parts[5])
+            return Result.success(
+                StoredTelemetryMetadata(
+                    timestamp,
+                    uuid,
+                    processId,
+                    envelopeType,
+                    complete,
+                    payloadType,
+                    filename
+                )
+            )
         }
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -38,12 +38,18 @@ class OkHttpRequestExecutionService(
     override fun attemptHttpRequest(
         payloadStream: () -> InputStream,
         envelopeType: SupportedEnvelopeType,
+        payloadType: String,
     ): ExecutionResult {
         val apiRequest = envelopeType.endpoint.getApiRequestFromEndpoint()
         val requestBody = generateRequestBody(payloadStream)
         val request = Request.Builder()
             .url(apiRequest.url)
-            .headers(apiRequest.getHeaders().toHeaders())
+            .headers(
+                apiRequest
+                    .getHeaders()
+                    .plus("X-EM-TYPES" to payloadType)
+                    .toHeaders()
+            )
             .post(requestBody)
             .build()
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/RequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/RequestExecutionService.kt
@@ -14,6 +14,7 @@ interface RequestExecutionService {
      */
     fun attemptHttpRequest(
         payloadStream: () -> InputStream,
-        envelopeType: SupportedEnvelopeType
+        envelopeType: SupportedEnvelopeType,
+        payloadType: String
     ): ExecutionResult
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -115,7 +115,8 @@ class SchedulingServiceImpl(
                     payload.toStream()?.run {
                         executionService.attemptHttpRequest(
                             payloadStream = { this },
-                            envelopeType = payload.envelopeType
+                            envelopeType = payload.envelopeType,
+                            payloadType = payload.payloadType.value
                         )
                     } ?: ExecutionResult.NotAttempted
                 } catch (t: Throwable) {

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -24,8 +24,15 @@ class StoredTelemetryMetadataTest {
         typeNameMap.entries.forEach { (type, priority) ->
             listOf(true, false).forEach { payloadComplete ->
                 assertEquals(
-                    "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json",
-                    StoredTelemetryMetadata(TIMESTAMP, UUID, PROCESS_ID, type, payloadComplete).filename
+                    "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_aei_v1.json",
+                    StoredTelemetryMetadata(
+                        TIMESTAMP,
+                        UUID,
+                        PROCESS_ID,
+                        type,
+                        payloadComplete,
+                        payloadType = PayloadType.AEI
+                    ).filename
                 )
             }
         }
@@ -53,13 +60,14 @@ class StoredTelemetryMetadataTest {
     fun `from valid filename`() {
         typeNameMap.entries.forEach { (type, priority) ->
             listOf(true, false).forEach { payloadComplete ->
-                val input = "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_v1.json"
+                val input = "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_native_v1.json"
                 with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
                     assertEquals(input, filename)
                     assertEquals(TIMESTAMP, timestamp)
                     assertEquals(UUID, uuid)
                     assertEquals(type, envelopeType)
                     assertEquals(payloadComplete, complete)
+                    assertEquals(PayloadType.NATIVE_CRASH, payloadType)
                 }
             }
         }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionServiceTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
+import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.mockwebserver.MockResponse
@@ -68,7 +69,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         val response = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the response should be incomplete
@@ -84,7 +86,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         val response = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the response should be successful
@@ -99,7 +102,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         val response = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the response should be not modified
@@ -114,7 +118,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         val response = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the response should be payload too large
@@ -133,7 +138,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         val response = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the response should be too many requests
@@ -149,7 +155,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         val response = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the response should be incomplete
@@ -169,7 +176,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         val response = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the response should be failure
@@ -185,7 +193,8 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         // when attempting to make a request
         requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the request should include the expected headers
@@ -197,5 +206,24 @@ class HttpUrlConnectionRequestExecutionServiceTest {
         assertEquals("gzip", request.getHeader("Content-Encoding"))
         assertEquals(testAppId, request.getHeader("X-EM-AID"))
         assertEquals(testDeviceId, request.getHeader("X-EM-DID"))
+        assertEquals(PayloadType.SESSION.value, request.getHeader("X-EM-TYPES"))
+    }
+
+    @Test
+    fun `payload type header is sent correctly`() {
+        // given a server that returns a 200 response
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        // when attempting to make a request
+        requestExecutionService.attemptHttpRequest(
+            payloadStream = { testPostBody.byteInputStream() },
+            envelopeType = SupportedEnvelopeType.LOG,
+            payloadType = PayloadType.AEI.value
+        )
+
+        // then the request should include the expected headers
+        val request = server.takeRequest()
+
+        assertEquals(PayloadType.AEI.value, request.getHeader("X-EM-TYPES"))
     }
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
+import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.Protocol
@@ -73,7 +74,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the result should be incomplete
@@ -89,7 +91,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the result should be successful
@@ -104,7 +107,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the result should be other
@@ -119,7 +123,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the result should be payload too large
@@ -138,7 +143,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the result should be too many requests
@@ -154,7 +160,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the result should be incomplete
@@ -174,7 +181,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the result should be failure
@@ -190,7 +198,8 @@ class OkHttpRequestExecutionServiceTest {
         // when attempting to make a request
         requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
-            envelopeType = SupportedEnvelopeType.SESSION
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION.value
         )
 
         // then the request should include the expected headers
@@ -202,5 +211,24 @@ class OkHttpRequestExecutionServiceTest {
         assertEquals("gzip", request.getHeader("Content-Encoding"))
         assertEquals(testAppId, request.getHeader("X-EM-AID"))
         assertEquals(testDeviceId, request.getHeader("X-EM-DID"))
+        assertEquals(PayloadType.SESSION.value, request.getHeader("X-EM-TYPES"))
+    }
+
+    @Test
+    fun `payload type header is sent correctly`() {
+        // given a server that returns a 200 response
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        // when attempting to make a request
+        requestExecutionService.attemptHttpRequest(
+            payloadStream = { testPostBody.byteInputStream() },
+            envelopeType = SupportedEnvelopeType.LOG,
+            payloadType = PayloadType.AEI.value
+        )
+
+        // then the request should include the expected headers
+        val request = server.takeRequest()
+
+        assertEquals(PayloadType.AEI.value, request.getHeader("X-EM-TYPES"))
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
@@ -36,6 +36,7 @@ class FakeRequestExecutionService(
     override fun attemptHttpRequest(
         payloadStream: () -> InputStream,
         envelopeType: SupportedEnvelopeType,
+        payloadType: String,
     ): ExecutionResult {
         exceptionOnExecution?.run { throw this }
         val bufferedStream = GZIPInputStream(payloadStream())


### PR DESCRIPTION
Add `X-EM-TYPES` header to post requests with the type of payload we are sending. 

We are sending the following possible types: 

- "session"
- "sys.log"
- "sys.android.crash"
- "sys.android.native_crash"
- "sys.android.react_native_crash"
- "sys.flutter_exception"
- "sys.exit"
- "sys.exception"
- "sys.network_capture"
- "unknown"