### PR TITLE
Periodic cache bug fixes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionCacher.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionCacher.kt
@@ -26,7 +26,7 @@ class PeriodicSessionCacher(
             onPeriodicCache(provider),
             0,
             intervalMs,
-            TimeUnit.SECONDS
+            TimeUnit.MILLISECONDS
         )
     }
 


### PR DESCRIPTION
## Goal

Makes two changes to the periodic cache logic. Firstly, the correct unit is used for the caching interval (this was altered during our delivery refactor & hadn't shipped to prod). Secondly, if `delete` fails due to `RejectedExecution` it should be run on the current thread as in this condition the worker will have shutdown.

