### PR TITLE
Update session ID in the native layer after init

### DIFF
--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
@@ -382,7 +382,7 @@ internal class EmbraceNdkServiceTest {
     fun `test initialization does not does not install signals and create directories if loadEmbraceNative is false`() {
         every { sharedObjectLoader.loadEmbraceNative() } returns false
         initializeService()
-        verify(exactly = 0) { embraceNdkService["installSignals"]() }
+        verify(exactly = 0) { embraceNdkService["installSignals"]({ "null" }) }
         verify(exactly = 0) { embraceNdkService["createCrashReportDirectory"]() }
     }
 


### PR DESCRIPTION
## Goal

The initialization of the native crash signal handler happens after the first session (or sessions) is created, so instead of always initializing with no session, we use the sessionId provider to provide the latest one.

## Testing
Did not a test because the current tests are not fit for purpose and I don't want to rewrite everything. We'll be doing this soon, so I'll leave it to whoever does it to check this. I ain't wasting my time mocking nothing.
