### PR TITLE
Fixed RemoteConfig cache

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiResponseCache.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiResponseCache.kt
@@ -79,7 +79,7 @@ class ApiResponseCache(
             val uri = URI.create(url)
             val requestMethod = request.httpMethod.toString()
             val headerFields = request.getHeaders().mapValues { listOf(it.value) }
-            obj.get(uri, requestMethod, headerFields.plus("Accept-Encoding" to listOf("gzip")))
+            obj.get(uri, requestMethod, headerFields)
         } catch (exc: IOException) {
             null
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiService.kt
@@ -100,6 +100,7 @@ internal class EmbraceApiService(
         accept = "application/json",
         url = ApiRequestUrl(url),
         httpMethod = HttpMethod.GET,
+        acceptEncoding = "gzip",
     )
 
     override fun onNetworkConnectivityStatusChanged(status: NetworkStatus) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -70,7 +70,7 @@ internal class EmbraceConfigService(
     override var remoteConfigSource: RemoteConfigSource? = null
         set(value) {
             field = value
-            performInitialConfigLoad()
+            loadConfigFromCache()
             attemptConfigRefresh()
         }
 
@@ -186,14 +186,6 @@ internal class EmbraceConfigService(
                 " embrace.disableMappingFileUpload=true to gradle.properties."
         }
         return appId
-    }
-
-    /**
-     * Schedule an action that loads the config from the cache.
-     * This is deferred to lessen its impact upon startup.
-     */
-    private fun performInitialConfigLoad() {
-        backgroundWorker.submit(runnable = ::loadConfigFromCache)
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -47,11 +47,15 @@ class AutoDataCaptureBehaviorImpl(
     override fun isNativeCrashCaptureEnabled(): Boolean = cfg.isNativeCrashCaptureEnabled()
     override fun isDiskUsageCaptureEnabled(): Boolean = cfg.isDiskUsageCaptureEnabled()
 
-    override fun isV2StorageEnabled(): Boolean =
-        thresholdCheck.isBehaviorEnabled(remote?.killSwitchConfig?.v2StoragePct)
-            ?: V2_STORAGE_ENABLED_DEFAULT
+    private val v2StorageImpl by lazy {
+        thresholdCheck.isBehaviorEnabled(remote?.killSwitchConfig?.v2StoragePct) ?: V2_STORAGE_ENABLED_DEFAULT
+    }
 
-    override fun shouldUseOkHttp(): Boolean =
-        thresholdCheck.isBehaviorEnabled(remote?.killSwitchConfig?.useOkHttpPct)
-            ?: USE_OKHTTP_DEFAULT
+    override fun isV2StorageEnabled(): Boolean = v2StorageImpl
+
+    private val shouldUseOkHttpImpl by lazy {
+        thresholdCheck.isBehaviorEnabled(remote?.killSwitchConfig?.useOkHttpPct) ?: USE_OKHTTP_DEFAULT
+    }
+
+    override fun shouldUseOkHttp(): Boolean = shouldUseOkHttpImpl
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -90,11 +90,11 @@ internal class EmbraceConfigServiceTest {
     fun setup() {
         fakeClock.setCurrentTime(1000000000000)
         every { mockApiService.getConfig() } returns remoteConfig
-        fakePreferenceService =
-            FakePreferenceService(deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D07FF")
+        fakePreferenceService = FakePreferenceService(deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D07FF")
         every {
             mockCacheService.loadObject<RemoteConfig>("config.json", RemoteConfig::class.java)
         } returns fakeCachedConfig
+        every { mockApiService.getCachedConfig() } returns CachedConfig(fakeCachedConfig, null)
         worker = fakeBackgroundWorker()
         service = createService(worker = worker, action = {})
         assertFalse(service.isOnlyUsingOtelExporters())


### PR DESCRIPTION
We were storing config requests with HttpResponseCache but we were not using them. I added the necessary headers to hit the cache entries, and unzipped the result.

I also moved the initial config read to the main thread, to avoid race conditions where we try to read feature flags before they are initialized.

