### PR TITLE
Provide no-op implementations of internal interface

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.payload.TapBreadcrumb
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 
 @SuppressLint("EmbracePublicApiPackageRule")
-internal class UninitializedSdkInternalInterfaceImpl(
+internal class NoopEmbraceInternalInterface(
     internalTracer: InternalTracingApi
 ) : EmbraceInternalInterface, InternalTracingApi by internalTracer {
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopFlutterInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopFlutterInternalInterface.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import io.embrace.android.embracesdk.FlutterInternalInterface
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+
+internal class NoopFlutterInternalInterface(
+    private val delegate: EmbraceInternalInterface,
+) : FlutterInternalInterface, EmbraceInternalInterface by delegate {
+
+    override fun setEmbraceFlutterSdkVersion(version: String?) {
+    }
+
+    override fun setDartVersion(version: String?) {
+    }
+
+    override fun logHandledDartException(
+        stack: String?,
+        name: String?,
+        message: String?,
+        context: String?,
+        library: String?,
+    ) {
+    }
+
+    override fun logUnhandledDartException(
+        stack: String?,
+        name: String?,
+        message: String?,
+        context: String?,
+        library: String?,
+    ) {
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopReactNativeInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopReactNativeInternalInterface.kt
@@ -1,0 +1,42 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import android.content.Context
+import io.embrace.android.embracesdk.ReactNativeInternalInterface
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+
+internal class NoopReactNativeInternalInterface(
+    private val delegate: EmbraceInternalInterface,
+) : ReactNativeInternalInterface, EmbraceInternalInterface by delegate {
+
+    override fun logUnhandledJsException(name: String, message: String, type: String?, stacktrace: String?) {}
+
+    override fun logHandledJsException(
+        name: String,
+        message: String,
+        properties: Map<String, Any>,
+        stacktrace: String?,
+    ) {
+    }
+
+    override fun setJavaScriptPatchNumber(number: String?) {}
+
+    override fun setReactNativeSdkVersion(version: String?) {}
+
+    override fun setReactNativeVersionNumber(version: String?) {}
+
+    override fun setJavaScriptBundleUrl(context: Context, url: String) {}
+
+    override fun setCacheableJavaScriptBundleUrl(context: Context, url: String, didUpdate: Boolean) {}
+
+    override fun logRnAction(
+        name: String,
+        startTime: Long,
+        endTime: Long,
+        properties: Map<String?, Any?>,
+        bytesSent: Int,
+        output: String,
+    ) {
+    }
+
+    override fun logRnView(screen: String) {}
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopUnityInternalInterface.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NoopUnityInternalInterface.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import io.embrace.android.embracesdk.UnityInternalInterface
+import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
+
+internal class NoopUnityInternalInterface(
+    private val delegate: EmbraceInternalInterface,
+) : UnityInternalInterface, EmbraceInternalInterface by delegate {
+
+    override fun setUnityMetaData(unityVersion: String?, buildGuid: String?, unitySdkVersion: String?) {
+    }
+
+    override fun logUnhandledUnityException(name: String, message: String, stacktrace: String?) {
+    }
+
+    override fun logHandledUnityException(name: String, message: String, stacktrace: String?) {
+    }
+
+    override fun recordIncompleteNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        errorType: String?,
+        errorMessage: String?,
+        traceId: String?,
+    ) {
+    }
+
+    override fun recordCompletedNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        bytesSent: Long,
+        bytesReceived: Long,
+        statusCode: Int,
+        traceId: String?,
+    ) {
+    }
+
+    override fun installUnityThreadSampler() {
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopEmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopEmbraceInternalInterfaceTest.kt
@@ -5,7 +5,7 @@ package io.embrace.android.embracesdk.internal.api
 import io.embrace.android.embracesdk.LogType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.internal.api.delegate.UninitializedSdkInternalInterfaceImpl
+import io.embrace.android.embracesdk.internal.api.delegate.NoopEmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
@@ -16,9 +16,9 @@ import org.junit.Before
 import org.junit.Test
 import java.net.SocketException
 
-internal class UninitializedSdkInternalInterfaceImplTest {
+internal class NoopEmbraceInternalInterfaceTest {
 
-    private lateinit var impl: UninitializedSdkInternalInterfaceImpl
+    private lateinit var impl: NoopEmbraceInternalInterface
     private lateinit var initModule: FakeInitModule
     private lateinit var openTelemetryModule: OpenTelemetryModule
 
@@ -26,7 +26,7 @@ internal class UninitializedSdkInternalInterfaceImplTest {
     fun setUp() {
         initModule = FakeInitModule(clock = FakeClock(currentTime = beforeObjectInitTime))
         openTelemetryModule = initModule.openTelemetryModule
-        impl = UninitializedSdkInternalInterfaceImpl(
+        impl = NoopEmbraceInternalInterface(
             InternalTracer(
                 openTelemetryModule.spanRepository,
                 openTelemetryModule.embraceTracer

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopFlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopFlutterInternalInterfaceTest.kt
@@ -1,0 +1,49 @@
+package io.embrace.android.embracesdk.internal.api
+
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.api.delegate.NoopEmbraceInternalInterface
+import io.embrace.android.embracesdk.internal.api.delegate.NoopFlutterInternalInterface
+import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
+import io.embrace.android.embracesdk.internal.spans.InternalTracer
+import org.junit.Before
+import org.junit.Test
+
+internal class NoopFlutterInternalInterfaceTest {
+
+    private lateinit var impl: NoopFlutterInternalInterface
+    private lateinit var initModule: FakeInitModule
+    private lateinit var openTelemetryModule: OpenTelemetryModule
+
+    @Before
+    fun setUp() {
+        initModule = FakeInitModule()
+        openTelemetryModule = initModule.openTelemetryModule
+        impl = NoopFlutterInternalInterface(
+            NoopEmbraceInternalInterface(
+                InternalTracer(
+                    openTelemetryModule.spanRepository,
+                    openTelemetryModule.embraceTracer
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `check no errors thrown when invoked`() {
+        impl.setEmbraceFlutterSdkVersion("version")
+        impl.logHandledDartException(
+            "stack",
+            "name",
+            "message",
+            "context",
+            "library"
+        )
+        impl.logUnhandledDartException(
+            "stack",
+            "name",
+            "message",
+            "context",
+            "library"
+        )
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopReactNativeInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopReactNativeInternalInterfaceTest.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.internal.api
+
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.api.delegate.NoopEmbraceInternalInterface
+import io.embrace.android.embracesdk.internal.api.delegate.NoopReactNativeInternalInterface
+import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
+import io.embrace.android.embracesdk.internal.spans.InternalTracer
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+
+internal class NoopReactNativeInternalInterfaceTest {
+
+    private lateinit var impl: NoopReactNativeInternalInterface
+    private lateinit var initModule: FakeInitModule
+    private lateinit var openTelemetryModule: OpenTelemetryModule
+
+    @Before
+    fun setUp() {
+        initModule = FakeInitModule()
+        openTelemetryModule = initModule.openTelemetryModule
+        impl = NoopReactNativeInternalInterface(
+            NoopEmbraceInternalInterface(
+                InternalTracer(
+                    openTelemetryModule.spanRepository,
+                    openTelemetryModule.embraceTracer
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `check no errors thrown when invoked`() {
+        impl.logUnhandledJsException("name", "message", "type", "stacktrace")
+        impl.logHandledJsException("name", "message", emptyMap(), "stacktrace")
+        impl.setJavaScriptPatchNumber("number")
+        impl.setReactNativeSdkVersion("version")
+        impl.setReactNativeVersionNumber("version")
+        impl.setJavaScriptBundleUrl(mockk(relaxed = true), "url")
+        impl.setCacheableJavaScriptBundleUrl(mockk(relaxed = true), "url", true)
+        impl.logRnAction("name", 1L, 2L, emptyMap(), 3, "output")
+        impl.logRnView("screen")
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopUnityInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/NoopUnityInternalInterfaceTest.kt
@@ -1,0 +1,57 @@
+package io.embrace.android.embracesdk.internal.api
+
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.api.delegate.NoopEmbraceInternalInterface
+import io.embrace.android.embracesdk.internal.api.delegate.NoopUnityInternalInterface
+import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
+import io.embrace.android.embracesdk.internal.spans.InternalTracer
+import org.junit.Before
+import org.junit.Test
+
+internal class NoopUnityInternalInterfaceTest {
+
+    private lateinit var impl: NoopUnityInternalInterface
+    private lateinit var initModule: FakeInitModule
+    private lateinit var openTelemetryModule: OpenTelemetryModule
+
+    @Before
+    fun setUp() {
+        initModule = FakeInitModule()
+        openTelemetryModule = initModule.openTelemetryModule
+        impl = NoopUnityInternalInterface(
+            NoopEmbraceInternalInterface(
+                InternalTracer(
+                    openTelemetryModule.spanRepository,
+                    openTelemetryModule.embraceTracer
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `check no errors thrown when invoked`() {
+        impl.setUnityMetaData("unityVersion", "buildGuid", "unitySdkVersion")
+        impl.logUnhandledUnityException("name", "message", "stacktrace")
+        impl.logHandledUnityException("name", "message", "stacktrace")
+        impl.recordIncompleteNetworkRequest(
+            "https://google.com",
+            "get",
+            15092342340,
+            15092342799,
+            "errorType",
+            "errorMessage",
+            "traceId"
+        )
+        impl.recordCompletedNetworkRequest(
+            "https://google.com",
+            "get",
+            15092342340,
+            15092342799,
+            140,
+            2509,
+            200,
+            "traceId"
+        )
+        impl.installUnityThreadSampler()
+    }
+}


### PR DESCRIPTION
## Goal

Provides no-op implementations of the internal interfaces if the SDK is not initialized yet. This should hopefully avoid NPEs on the hosted SDK side of things & make it easier to move this functionality in future.

## Testing

Added unit tests.
