### PR TITLE
Create internal api module

### DIFF
--- a/embrace-android-compose/build.gradle.kts
+++ b/embrace-android-compose/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.lifecycle.runtime)
     implementation(libs.lifecycle.process)
     compileOnly(libs.compose)
+    compileOnly(project(":embrace-internal-api"))
     compileOnly(project(":embrace-android-sdk"))
     testImplementation(project(":embrace-android-sdk"))
 }

--- a/embrace-android-fcm/build.gradle.kts
+++ b/embrace-android-fcm/build.gradle.kts
@@ -11,5 +11,6 @@ android {
 dependencies {
     compileOnly(libs.firebase.messaging)
     compileOnly(project(":embrace-android-sdk"))
+    compileOnly(project(":embrace-internal-api"))
     testImplementation(project(":embrace-android-sdk"))
 }

--- a/embrace-android-okhttp3/build.gradle.kts
+++ b/embrace-android-okhttp3/build.gradle.kts
@@ -13,7 +13,9 @@ dependencies {
     compileOnly(project(":embrace-android-core"))
     compileOnly(project(":embrace-android-infra"))
     compileOnly(project(":embrace-android-sdk"))
+    compileOnly(project(":embrace-internal-api"))
     testImplementation(project(":embrace-android-core"))
     testImplementation(project(":embrace-android-infra"))
     testImplementation(project(":embrace-android-sdk"))
+    testImplementation(project(":embrace-internal-api"))
 }

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(project(":embrace-android-features"))
     implementation(project(":embrace-android-payload"))
     implementation(project(":embrace-android-delivery"))
+    implementation(project(":embrace-internal-api"))
 
     implementation(platform(libs.opentelemetry.bom))
 

--- a/embrace-internal-api/build.gradle.kts
+++ b/embrace-internal-api/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("embrace-prod-defaults")
+}
+
+description = "Embrace Android SDK: Internal API"
+
+apiValidation.validationDisabled = true
+
+android {
+    namespace = "io.embrace.android.embracesdk.api.internal"
+}
+
+dependencies {
+    compileOnly(project(":embrace-android-api"))
+}

--- a/embrace-internal-api/lint-baseline.xml
+++ b/embrace-internal-api/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.7.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.7.1">
+
+</issues>

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalApi.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalApi.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.internal
+
+/**
+ * Provides access to internal Embrace SDK APIs. This is intended for use by Embrace's SDKs only and is subject
+ * to breaking changes without warning.
+ */
+class EmbraceInternalApi private constructor() {
+
+    companion object {
+        private val instance = EmbraceInternalApi()
+
+        @JvmStatic
+        fun getInstance(): EmbraceInternalApi = instance
+    }
+}

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     compileOnly(project(":embrace-android-payload"))
     compileOnly(project(":embrace-android-features"))
     compileOnly(project(":embrace-android-delivery"))
+    compileOnly(project(":embrace-internal-api"))
 
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 include(
     ":embrace-android-api",
+    ":embrace-internal-api",
     ":embrace-android-sdk",
     ":embrace-android-core",
     ":embrace-android-infra",


### PR DESCRIPTION
## Goal

Creates a new module for our internal API. This is not pulled in by default - our hosted SDKs will have to explicitly add the dependency to access internal APIs. This should reduce the amount of unwanted symbols that are currently exposed to end-users.
