### PR TITLE
Allow the SDK to be stopped when it's starting

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLoggerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLoggerImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.logging
 
 import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal const val EMBRACE_TAG = "[Embrace]"
 
@@ -10,6 +11,7 @@ internal const val EMBRACE_TAG = "[Embrace]"
  */
 class EmbLoggerImpl : EmbLogger {
 
+    private val loggedSdkNotStarted = AtomicBoolean(false)
     var errorHandler: InternalErrorHandler? = null
 
     override fun logDebug(msg: String, throwable: Throwable?) {
@@ -29,8 +31,10 @@ class EmbLoggerImpl : EmbLogger {
     }
 
     override fun logSdkNotInitialized(action: String) {
-        val msg = "Embrace SDK is not initialized yet, cannot $action."
-        log(msg, EmbLogger.Severity.WARNING, Throwable(msg))
+        if (!loggedSdkNotStarted.getAndSet(true)) {
+            val msg = "Embrace SDK is not initialized yet, cannot $action."
+            log(msg, EmbLogger.Severity.WARNING, Throwable(msg))
+        }
     }
 
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {
@@ -63,7 +67,7 @@ class EmbLoggerImpl : EmbLogger {
     private inline fun logcatImpl(
         throwable: Throwable?,
         severity: EmbLogger.Severity,
-        msg: String
+        msg: String,
     ) {
         when (severity) {
             EmbLogger.Severity.DEBUG -> Log.d(EMBRACE_TAG, msg, throwable)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.LogType
 import io.embrace.android.embracesdk.assertions.findEventOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.findSpansByName
+import io.embrace.android.embracesdk.fakes.behavior.FakeSdkModeBehavior
 import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
@@ -311,6 +312,18 @@ internal class EmbraceInternalInterfaceTest {
                     assertEquals(spans["tz-parent-span"]?.spanId, parentSpanId)
                 }
                 assertNotNull(spans["tz-old-span"])
+            }
+        )
+    }
+
+    @Test
+    fun `SDK will not start if feature flag has it being disabled`() {
+        testRule.runTest(
+            setupAction = {
+                overriddenConfigService.sdkModeBehavior = FakeSdkModeBehavior(sdkDisabled = true)
+            },
+            testCaseAction = {
+                assertFalse(embrace.isStarted)
             }
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -44,6 +44,7 @@ import io.embrace.android.embracesdk.internal.payload.EventType
 import io.embrace.android.embracesdk.internal.worker.TaskPriority
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.spans.TracingApi
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Implementation class of the SDK. Embrace.java forms our public API and calls functions in this
@@ -95,6 +96,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
     private val logger by lazy { bootstrapper.initModule.logger }
     private val customAppId: String?
         get() = sdkStateApiDelegate.customAppId
+    private val sdkShuttingDown = AtomicBoolean(false)
 
     /**
      * The application being instrumented by the SDK.
@@ -304,14 +306,16 @@ internal class EmbraceImpl @JvmOverloads constructor(
      * Shuts down the Embrace SDK.
      */
     fun stop() {
-        if (sdkCallChecker.started.compareAndSet(true, false)) {
-            logger.logInfo("Shutting down Embrace SDK")
-            runCatching {
-                application?.let {
-                    unregisterComposeActivityListener(it)
+        synchronized(sdkCallChecker) {
+            if (sdkShuttingDown.compareAndSet(false, true)) {
+                logger.logInfo("Shutting down Embrace SDK")
+                runCatching {
+                    application?.let {
+                        unregisterComposeActivityListener(it)
+                    }
+                    application = null
+                    bootstrapper.stopServices()
                 }
-                application = null
-                bootstrapper.stopServices()
             }
         }
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -163,7 +163,7 @@ internal class ModuleInitBootstrapper(
                             appFramework,
                             configServiceProvider,
                         ) {
-                            if (Embrace.getInstance().isStarted && isSdkDisabled()) {
+                            if (isSdkDisabled()) {
                                 Embrace.getInstance().internalInterface.stopSdk()
                             }
                         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -55,7 +55,7 @@ class FakeConfigService(
         listeners.add(configListener)
     }
 
-    override fun isSdkDisabled(): Boolean = sdkDisabled
+    override fun isSdkDisabled(): Boolean = sdkDisabled || sdkModeBehavior.isSdkDisabled()
 
     override fun isBackgroundActivityCaptureEnabled(): Boolean = backgroundActivityCaptureEnabled
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSdkModeBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeSdkModeBehavior.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
+
+class FakeSdkModeBehavior(
+    var sdkDisabled: Boolean
+) : SdkModeBehavior {
+    override fun isSdkDisabled() = sdkDisabled
+}


### PR DESCRIPTION
## Goal

We only ever stop the SDK while it's started, and we validate that the SDK is started before we try to stop it. Somewhere along the way, we messed up this logic to make the SDK impossible to stop. This addresses that now.

## Testing
Add integration test, and also make the FakeConfigService a bit smarter by taking into account the SdkModeBehavior when deciding whether the SDK is enabled.
