### PR TITLE
Make defensive copy of keyset

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationCaptureService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationCaptureService.kt
@@ -43,7 +43,7 @@ class PushNotificationCaptureService(
             }
 
         fun extractDeveloperDefinedPayload(bundle: Bundle): Map<String, String> {
-            val keySet = bundle.keySet() ?: return emptyMap()
+            val keySet = bundle.keySet()?.toSet() ?: return emptyMap()
             return keySet.filter {
                 // let's filter all google reserved words, leaving us with user defined keys
                 !it.startsWith(RESERVED_PREFIX_PAYLOAD_KEYS) &&


### PR DESCRIPTION
## Goal

Makes a defensive copy of a keyset in push notification capture to avoid the potential for ConcurrentModificationException.
