### PR TITLE
Log situation when SDK starts up with orchestrator not hooked up

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 internal class EmbraceProcessStateService(
     private val clock: Clock,
     private val logger: EmbLogger,
-    private val lifecycleOwner: LifecycleOwner
+    private val lifecycleOwner: LifecycleOwner,
 ) : ProcessStateService, LifecycleEventObserver {
 
     /**
@@ -44,12 +44,9 @@ internal class EmbraceProcessStateService(
     init {
         // add lifecycle observer on main thread to avoid IllegalStateExceptions with
         // androidx.lifecycle
-        ThreadUtils.runOnMainThread(
-            logger,
-            Runnable {
-                lifecycleOwner.lifecycle.addObserver(this)
-            }
-        )
+        ThreadUtils.runOnMainThread(logger) {
+            lifecycleOwner.lifecycle.addObserver(this)
+        }
     }
 
     override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
@@ -127,6 +124,10 @@ internal class EmbraceProcessStateService(
     override fun getAppState(): String = when {
         isInBackground -> BACKGROUND_STATE
         else -> FOREGROUND_STATE
+    }
+
+    override fun isInitialized(): Boolean {
+        return sessionOrchestrator != null
     }
 
     companion object {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ProcessStateService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ProcessStateService.kt
@@ -41,4 +41,9 @@ interface ProcessStateService : LifecycleEventObserver, Closeable {
      * @return the current state of the app
      */
     fun getAppState(): String
+
+    /**
+     * Returns true if this is fully initialized
+     */
+    fun isInitialized(): Boolean
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -319,6 +319,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `SDK will not start if feature flag has it being disabled`() {
         testRule.runTest(
+            expectSdkToStart = false,
             setupAction = {
                 overriddenConfigService.sdkModeBehavior = FakeSdkModeBehavior(sdkDisabled = true)
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -62,6 +62,7 @@ internal class PublicApiTest {
     @Test
     fun `SDK disabled via config cannot start`() {
         testRule.runTest(
+            expectSdkToStart = false,
             setupAction = {
                 overriddenConfigService.sdkDisabled = true
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -25,6 +25,7 @@ import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import okhttp3.Protocol
 import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
 import org.junit.rules.ExternalResource
 
 /**
@@ -101,6 +102,7 @@ internal class IntegrationTestRule(
      */
     inline fun runTest(
         startSdk: Boolean = true,
+        expectSdkToStart: Boolean = startSdk,
         setupAction: EmbraceSetupInterface.() -> Unit = {},
         preSdkStartAction: EmbracePreSdkStartInterface.() -> Unit = {},
         testCaseAction: EmbraceActionInterface.() -> Unit,
@@ -118,6 +120,7 @@ internal class IntegrationTestRule(
                 embraceImpl.start(overriddenCoreModule.context, appFramework) {
                     overriddenConfigService.apply { appFramework = it }
                 }
+                assertEquals(expectSdkToStart, bootstrapper.essentialServiceModule.processStateService.isInitialized())
             }
         }
         testCaseAction(action)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.delivery.execution.HttpUrlConnecti
 import io.embrace.android.embracesdk.internal.delivery.execution.OkHttpRequestExecutionService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.network.http.HttpUrlConnectionTracker.registerFactory
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
@@ -493,6 +494,14 @@ internal class ModuleInitBootstrapper(
                         serviceRegistry.registerMemoryCleanerListeners(sessionOrchestrationModule.memoryCleanerService)
                         serviceRegistry.registerActivityLifecycleListeners(essentialServiceModule.activityLifecycleTracker)
                         serviceRegistry.registerStartupListener(essentialServiceModule.activityLifecycleTracker)
+                    }
+
+                    // Verify that the ProcessStateService is fully initialized at this point, and log otherwise.
+                    if (!essentialServiceModule.processStateService.isInitialized()) {
+                        logger.trackInternalError(
+                            type = InternalErrorType.PROCESS_STATE_CALLBACK_FAIL,
+                            throwable = IllegalStateException("ProcessStateService not initialized"),
+                        )
                     }
                     true
                 } else {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeProcessStateService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeProcessStateService.kt
@@ -33,4 +33,6 @@ class FakeProcessStateService(
         true -> "background"
         false -> "foreground"
     }
+
+    override fun isInitialized(): Boolean = true
 }


### PR DESCRIPTION
## Goal

The session orchestrator should be hooked up with after the SDK is initialized, so we'll log the case where it isn't true. The onForeground callback on it not being invoked can explain why some apps never get out of the background despite other callbacks being fired. This will help us narrow down the issue.

## Testing
Verified this on all integration tests

