### PR TITLE
Disable tap coordinate capture by default

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,7 @@ Version 7 of the Embrace Android SDK contains the following breaking changes:
 - `Embrace.LastRunEndState` is now its own top level class, `LastRunEndState`
 - Several public APIs are now implemented in Kotlin rather than Java. Generally this will not affect backwards compatibility but the following may have slight changes to their signatures:
   - `EmbraceNetworkRequest` Java overloads replaced with default parameters
+- View taps do not capture coordinates by default. Set `sdk_config.taps.capture_coordinates` to `true` in your `embrace-config.json` to enable this feature
 - Several internally used classes and symbols have been hidden from the public API
 
 ### Removed APIs

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
@@ -30,7 +30,7 @@ internal class BreadcrumbBehaviorImplTest {
             assertEquals(100, getViewBreadcrumbLimit())
             assertEquals(100, getWebViewBreadcrumbLimit())
             assertEquals(100, getFragmentBreadcrumbLimit())
-            assertTrue(isViewClickCoordinateCaptureEnabled())
+            assertFalse(isViewClickCoordinateCaptureEnabled())
             assertTrue(isActivityBreadcrumbCaptureEnabled())
             assertTrue(isWebViewBreadcrumbCaptureEnabled())
             assertTrue(isWebViewBreadcrumbQueryParamCaptureEnabled())

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/EnabledFeatureConfig.kt
@@ -40,7 +40,7 @@ object EnabledFeatureConfig {
      *
      * sdk_config.taps.capture_coordinates
      */
-    fun isViewClickCoordinateCaptureEnabled(): Boolean = true
+    fun isViewClickCoordinateCaptureEnabled(): Boolean = false
 
     /**
      * Gates memory warning capture


### PR DESCRIPTION
## Goal

Disables tap coordinate capture by default

## Testing

Updated existing test coverage.

