### PR TITLE
Added enable_network_span_forwarding local config flag

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkSpanForwardingBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkSpanForwardingBehaviorImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
 import io.embrace.android.embracesdk.internal.utils.Provider
 
@@ -16,11 +17,10 @@ class NetworkSpanForwardingBehaviorImpl(
          * Header name for the W3C traceparent
          */
         const val TRACEPARENT_HEADER_NAME: String = "traceparent"
-
-        private const val DEFAULT_PCT_ENABLED = 0.0f
     }
 
     override fun isNetworkSpanForwardingEnabled(): Boolean {
-        return thresholdCheck.isBehaviorEnabled(remote?.pctEnabled ?: DEFAULT_PCT_ENABLED)
+        return remote?.pctEnabled?.let { thresholdCheck.isBehaviorEnabled(it) }
+            ?: InstrumentedConfig.enabledFeatures.isNetworkSpanForwardingEnabled()
     }
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/EnabledFeatureConfig.kt
@@ -140,4 +140,11 @@ object EnabledFeatureConfig {
      * sdk_config.networking.enable_native_monitoring
      */
     fun isHttpUrlConnectionCaptureEnabled(): Boolean = true
+
+    /**
+     * Gates whether network span forwarding should be enabled
+     *
+     * sdk_config.networking.enable_network_span_forwarding
+     */
+    fun isNetworkSpanForwardingEnabled(): Boolean = false
 }


### PR DESCRIPTION
## Goal

This will allow to enable or disable network span forwarding from the embrace-config.json like the following:

```
{
  "app_id": ...
   ...
  "sdk_config": {
    "networking": {
      "enable_network_span_forwarding": true
    }
  }
}
```

If a remote config has been set, this will be ignored.

Depends on this Swazzler PR: https://github.com/embrace-io/embrace-swazzler3/pull/651