### PR TITLE
Delete custom traceId header name support

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,7 @@ Version 7 of the Embrace Android SDK contains the following breaking changes:
   - `EmbraceNetworkRequest` Java overloads replaced with default parameters
 - View taps do not capture coordinates by default. Set `sdk_config.taps.capture_coordinates` to `true` in your `embrace-config.json` to enable this feature
 - Several internally used classes and symbols have been hidden from the public API
+- Recording a custom trace ID for an HTTP request from a custom request header is no longer supported. IDs in the `x-emb-trace-id` header will still be recorded and displayed on the dashboard.
 - Removed several obsolete remote config + local config properties. If you specify the below in your `embrace-config.json` they will be ignored:
   - `sdk_config.beta_features_enabled`
   - `sdk_config.anr.capture_google`
@@ -18,6 +19,7 @@ Version 7 of the Embrace Android SDK contains the following breaking changes:
   - `sdk_config.background_activity.min_background_activity_duration`
   - `sdk_config.background_activity.max_cached_activities`
   - `sdk_config.base_urls.images`
+  - `sdk_config.networking.trace_id_header`
   - `sdk_config.startup_moment.automatically_end`
 
 ### Removed APIs
@@ -27,6 +29,7 @@ The following deprecated APIs have been removed:
 | Old API                                                       | New API                                    |
 |---------------------------------------------------------------|--------------------------------------------|
 | `Embrace.getInstance().getSessionProperties()`                | N/A                                        |
+| `Embrace.getInstance().getTraceIdHeader()`                    | N/A                                        |
 | `Embrace.getInstance().isTracingAvailable()`                  | `Embrace.getInstance().isStarted()`        |
 | `Embrace.getInstance().start(Context, boolean)`               | `Embrace.getInstance().start(Context)`     |
 | `Embrace.getInstance().start(Context, boolean, AppFramework)` | `Embrace.getInstance().isStarted(Context)` |

--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -66,7 +66,6 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/LogsA
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/NetworkRequestApi {
 	public abstract fun generateW3cTraceparent ()Ljava/lang/String;
-	public abstract fun getTraceIdHeader ()Ljava/lang/String;
 	public abstract fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 }
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
@@ -17,7 +17,5 @@ public interface NetworkRequestApi {
      */
     public fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest)
 
-    public val traceIdHeader: String
-
     public fun generateW3cTraceparent(): String?
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehavior.kt
@@ -5,11 +5,6 @@ import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRe
 interface NetworkBehavior {
 
     /**
-     * The Trace ID Header that can be used to trace a particular request.
-     */
-    fun getTraceIdHeader(): String
-
-    /**
      * Control whether request size for native Android requests is captured.
      */
     fun isRequestContentLengthCaptureEnabled(): Boolean

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
@@ -36,7 +36,6 @@ class NetworkBehaviorImpl(
 
     private val cfg = InstrumentedConfig.networkCapture
 
-    override fun getTraceIdHeader(): String = cfg.getTraceIdHeader()
     override fun isRequestContentLengthCaptureEnabled(): Boolean =
         InstrumentedConfig.enabledFeatures.isRequestContentLengthCaptureEnabled()
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
@@ -33,7 +33,6 @@ internal class NetworkBehaviorImplTest {
     @Test
     fun testDefaults() {
         with(createNetworkBehavior(remoteCfg = { null })) {
-            assertEquals("x-emb-trace-id", getTraceIdHeader())
             assertFalse(isRequestContentLengthCaptureEnabled())
             assertTrue(isHttpUrlConnectionCaptureEnabled())
             assertEquals(1000, getRequestLimitPerDomain())

--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3ApplicationInterceptor.kt
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3ApplicationInterceptor.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.okhttp3
 
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
+import io.embrace.android.embracesdk.internal.EmbraceInternalApi.Companion.CUSTOM_TRACE_ID_HEADER_NAME
 import io.embrace.android.embracesdk.internal.network.http.EmbraceHttpPathOverride
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
@@ -45,7 +46,7 @@ class EmbraceOkHttp3ApplicationInterceptor(
                         embraceInternalApi.internalInterface.getSdkCurrentTime(),
                         causeName(e, UNKNOWN_EXCEPTION),
                         causeMessage(e, UNKNOWN_MESSAGE),
-                        request.header(embrace.traceIdHeader),
+                        request.header(CUSTOM_TRACE_ID_HEADER_NAME),
                         if (embraceInternalApi.internalInterface.isNetworkSpanForwardingEnabled()) {
                             request.header(
                                 TRACEPARENT_HEADER_NAME
@@ -72,7 +73,7 @@ class EmbraceOkHttp3ApplicationInterceptor(
                         embraceInternalApi.internalInterface.getSdkCurrentTime(),
                         errorType ?: UNKNOWN_EXCEPTION,
                         errorMessage ?: UNKNOWN_MESSAGE,
-                        request.header(embrace.traceIdHeader),
+                        request.header(CUSTOM_TRACE_ID_HEADER_NAME),
                         if (embraceInternalApi.internalInterface.isNetworkSpanForwardingEnabled()) {
                             request.header(
                                 TRACEPARENT_HEADER_NAME

--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.okhttp3
 
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
+import io.embrace.android.embracesdk.internal.EmbraceInternalApi.Companion.CUSTOM_TRACE_ID_HEADER_NAME
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.network.http.EmbraceHttpPathOverride
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
@@ -118,7 +119,7 @@ class EmbraceOkHttp3NetworkInterceptor @JvmOverloads constructor(
                 request.body?.contentLength() ?: 0,
                 contentLength,
                 response.code,
-                request.header(embrace.traceIdHeader),
+                request.header(CUSTOM_TRACE_ID_HEADER_NAME),
                 if (networkSpanForwardingEnabled) request.header(TRACEPARENT_HEADER_NAME) else null,
                 networkCaptureData
             )

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/NetworkCaptureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/NetworkCaptureConfig.kt
@@ -8,11 +8,6 @@ package io.embrace.android.embracesdk.internal.config.instrumented
 object NetworkCaptureConfig {
 
     /**
-     * Sets the default name of the HTTP request header to extract trace ID from.
-     */
-    const val CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE: String = "x-emb-trace-id"
-
-    /**
      * The network request capture limit per domain
      *
      * sdk_config.networking.default_capture_limit

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/NetworkCaptureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/NetworkCaptureConfig.kt
@@ -13,13 +13,6 @@ object NetworkCaptureConfig {
     const val CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE: String = "x-emb-trace-id"
 
     /**
-     * Declares a list of sensitive keys whose values should be redacted on capture.
-     *
-     * sdk_config.networking.trace_id_header
-     */
-    fun getTraceIdHeader(): String = CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
-
-    /**
      * The network request capture limit per domain
      *
      * sdk_config.networking.default_capture_limit

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -23,7 +23,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun getLastRunEndState ()Lio/embrace/android/embracesdk/LastRunEndState;
 	public fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
 	public fun getSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
-	public fun getTraceIdHeader ()Ljava/lang/String;
 	public fun isStarted ()Z
 	public fun logCustomStacktrace ([Ljava/lang/StackTraceElement;)V
 	public fun logCustomStacktrace ([Ljava/lang/StackTraceElement;Lio/embrace/android/embracesdk/Severity;)V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -109,9 +109,6 @@ public class Embrace private constructor(
         impl.clearUsername()
     }
 
-    override val traceIdHeader: String
-        get() = impl.traceIdHeader
-
     override fun generateW3cTraceparent(): String? {
         return impl.generateW3cTraceparent()
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import io.embrace.android.embracesdk.internal.IdGenerator
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi
-import io.embrace.android.embracesdk.internal.config.instrumented.NetworkCaptureConfig
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.embraceImplInject
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
@@ -25,15 +24,6 @@ internal class NetworkRequestApiDelegate(
             logNetworkRequest(networkRequest)
         }
     }
-
-    override val traceIdHeader: String
-        get() {
-            if (sdkCallChecker.check("get_trace_id_header")) {
-                return configService?.networkBehavior?.getTraceIdHeader()
-                    ?: NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
-            }
-            return NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
-        }
 
     override fun generateW3cTraceparent(): String? =
         if (configService?.networkSpanForwardingBehavior?.isNetworkSpanForwardingEnabled() == true) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
@@ -18,7 +18,7 @@ internal class SdkCallChecker(
      * Checks if the SDK is started and logs the public API usage.
      *
      * Every public API usage should go through this method, except the ones that are called too often and may cause a performance hit.
-     * For instance, get_current_session_id and get_trace_id_header go directly through checkSdkStarted.
+     * For instance, get_current_session_id go directly through checkSdkStarted.
      */
     fun check(action: String): Boolean {
         val isStarted = started.get()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegate.java
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
+import static io.embrace.android.embracesdk.internal.EmbraceInternalApi.CUSTOM_TRACE_ID_HEADER_NAME;
 import static io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl.TRACEPARENT_HEADER_NAME;
 
 import android.annotation.TargetApi;
@@ -659,8 +660,7 @@ class EmbraceUrlConnectionDelegate<T extends HttpURLConnection> implements Embra
     private void identifyTraceId() {
         if (isSDKStarted && traceId == null) {
             try {
-                String traceIdHeader = internalNetworkApi.getTraceIdHeader();
-                traceId = getRequestProperty(traceIdHeader);
+                traceId = getRequestProperty(CUSTOM_TRACE_ID_HEADER_NAME);
             } catch (Exception e) {
                 // don't do anything
             }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApi.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApi.kt
@@ -9,6 +9,5 @@ internal interface InternalNetworkApi {
     fun logInternalError(error: Throwable)
     fun getSdkCurrentTime(): Long
     fun isStarted(): Boolean
-    fun getTraceIdHeader(): String
     fun generateW3cTraceparent(): String?
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApiImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApiImpl.kt
@@ -17,8 +17,6 @@ internal class InternalNetworkApiImpl : InternalNetworkApi {
 
     override fun isStarted(): Boolean = embrace.isStarted
 
-    override fun getTraceIdHeader(): String = embrace.traceIdHeader
-
     override fun generateW3cTraceparent(): String? = embrace.generateW3cTraceparent()
 
     override fun isNetworkSpanForwardingEnabled(): Boolean = getInternalInterface().isNetworkSpanForwardingEnabled()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalNetworkApi.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeInternalNetworkApi.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.internal.config.instrumented.NetworkCaptureConfig
 import io.embrace.android.embracesdk.internal.network.http.InternalNetworkApi
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 
@@ -8,12 +7,10 @@ internal class FakeInternalNetworkApi(
     var internalInterface: FakeEmbraceInternalInterface = FakeEmbraceInternalInterface(),
     var time: Long = 0,
     var started: Boolean = true,
-    var traceHeader: String = NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE,
     var w3cTraceparent: String? = "00-3c72a77a7b51af6fb3778c06d4c165ce-4c1d710fffc88e35-01",
 ) : InternalNetworkApi {
     override fun getSdkCurrentTime(): Long = time
     override fun isStarted(): Boolean = started
-    override fun getTraceIdHeader(): String = traceHeader
     override fun generateW3cTraceparent(): String? = w3cTraceparent
     override fun isNetworkSpanForwardingEnabled(): Boolean = internalInterface.isNetworkSpanForwardingEnabled()
     override fun recordNetworkRequest(

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
@@ -57,11 +57,6 @@ internal class NetworkRequestApiDelegateTest {
     }
 
     @Test
-    fun `test trace id header`() {
-        assertEquals("x-emb-trace-id", delegate.traceIdHeader)
-    }
-
-    @Test
     fun testGenerateW3cTraceparentEnabled() {
         configService.networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior(true)
         assertNotNull(delegate.generateW3cTraceparent())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
@@ -412,8 +412,6 @@ internal class EmbraceUrlConnectionDelegateTest {
 
     @Test
     fun `check traceIds are logged if a custom header name is specified`() {
-        traceIdHeaderName = "my-trace-id-header"
-        internalApi.traceHeader = traceIdHeaderName
         executeRequest(
             connection = createMockGzipConnection(
                 extraRequestHeaders = mapOf(Pair(traceIdHeaderName, listOf(customTraceId)))

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlConnectionDelegateTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.network.http
 
 import io.embrace.android.embracesdk.fakes.FakeInternalNetworkApi
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl.Companion.TRACEPARENT_HEADER_NAME
-import io.embrace.android.embracesdk.internal.config.instrumented.NetworkCaptureConfig
 import io.embrace.android.embracesdk.internal.network.http.EmbraceHttpPathOverride.PATH_OVERRIDE
 import io.embrace.android.embracesdk.internal.network.http.EmbraceUrlConnectionDelegate.CONTENT_ENCODING
 import io.embrace.android.embracesdk.internal.network.http.EmbraceUrlConnectionDelegate.CONTENT_LENGTH
@@ -27,7 +26,7 @@ import javax.net.ssl.HttpsURLConnection
 
 internal class EmbraceUrlConnectionDelegateTest {
 
-    private var traceIdHeaderName = NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
+    private var traceIdHeaderName = "x-emb-trace-id"
 
     private lateinit var internalApi: FakeInternalNetworkApi
 
@@ -471,7 +470,7 @@ internal class EmbraceUrlConnectionDelegateTest {
 
         val requestHeaders = mutableMapOf(
             Pair(requestHeaderName, listOf(requestHeaderValue)),
-            Pair(NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE, listOf(defaultTraceId))
+            Pair(traceIdHeaderName, listOf(defaultTraceId))
         )
 
         if (extraRequestHeaders.isNotEmpty()) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/EmbraceUrlStreamHandlerTest.kt
@@ -27,7 +27,7 @@ internal class EmbraceUrlStreamHandlerTest {
     }
 
     @Test
-    fun `check traceheader is not injected into http request by default`() {
+    fun `check traceparent is not injected into http request by default`() {
         val url = URL(
             "http",
             "embrace.io",
@@ -43,7 +43,7 @@ internal class EmbraceUrlStreamHandlerTest {
     }
 
     @Test
-    fun `check traceheader is not injected into https request by default`() {
+    fun `check traceparent is not injected into https request by default`() {
         val url = URL(
             "https",
             "embrace.io",
@@ -59,7 +59,7 @@ internal class EmbraceUrlStreamHandlerTest {
     }
 
     @Test
-    fun `check traceheader is injected into http request if feature flag is on`() {
+    fun `check traceparent is injected into http request if feature flag is on`() {
         internalApi.internalInterface.networkSpanForwardingEnabled = true
         val url = URL(
             "http",
@@ -76,7 +76,7 @@ internal class EmbraceUrlStreamHandlerTest {
     }
 
     @Test
-    fun `check traceheader is injected into https request if feature flag is on`() {
+    fun `check traceparent is injected into https request if feature flag is on`() {
         internalApi.internalInterface.networkSpanForwardingEnabled = true
         val url = URL(
             "https",

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalApi.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalApi.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.api.delegate.NoopUnityInternalInte
 class EmbraceInternalApi private constructor() : InternalInterfaceApi {
 
     companion object {
+        const val CUSTOM_TRACE_ID_HEADER_NAME: String = "x-emb-trace-id"
         var internalTracingApi: InternalTracingApi? = null
         var internalInterfaceApi: InternalInterfaceApi? = null
         var isStarted: () -> Boolean = { false }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkBehavior.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.fakes.behavior
 
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
-import io.embrace.android.embracesdk.internal.config.instrumented.NetworkCaptureConfig
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 
 class FakeNetworkBehavior(
@@ -9,7 +8,6 @@ class FakeNetworkBehavior(
     private val domains: Map<String, Int> = emptyMap(),
     private val captureHttpUrlConnectionRequests: Boolean = true,
 ) : NetworkBehavior {
-    override fun getTraceIdHeader(): String = NetworkCaptureConfig.CONFIG_TRACE_ID_HEADER_DEFAULT_VALUE
     override fun isRequestContentLengthCaptureEnabled(): Boolean = false
     override fun isHttpUrlConnectionCaptureEnabled(): Boolean = captureHttpUrlConnectionRequests
     override fun getLimitsByDomain(): Map<String, Int> = domains


### PR DESCRIPTION
## Goal

Remove support for setting an custom name for the header where we expect to find a custom traceId that we will then log as part of the network request data. After this, we will only look for the custom traceId in the header `x-emb-trace-id` of the request.
