### PR TITLE
Remove the payer person API methods

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,32 +7,40 @@ Version 7 of the Embrace Android SDK contains the following breaking changes:
 - The `startMoment/endMoment` API has been removed. Use `startSpan/recordSpan` instead.
 - `Embrace.AppFramework` is now its own top level class, `AppFramework`
 - `Embrace.LastRunEndState` is now its own top level class, `LastRunEndState`
-- Several public APIs are now implemented in Kotlin rather than Java. Generally this will not affect backwards compatibility but the following may have slight changes to their signatures:
-  - `EmbraceNetworkRequest` Java overloads replaced with default parameters
-- View taps do not capture coordinates by default. Set `sdk_config.taps.capture_coordinates` to `true` in your `embrace-config.json` to enable this feature
+- Several public APIs are now implemented in Kotlin rather than Java. Generally this will not affect backwards
+  compatibility but the following may have slight changes to their signatures:
+    - `EmbraceNetworkRequest` Java overloads replaced with default parameters
+- View taps do not capture coordinates by default. Set `sdk_config.taps.capture_coordinates` to `true` in your
+  `embrace-config.json` to enable this feature
 - Several internally used classes and symbols have been hidden from the public API
-- Recording a custom trace ID for an HTTP request from a custom request header is no longer supported. IDs in the `x-emb-trace-id` header will still be recorded and displayed on the dashboard.
-- Removed several obsolete remote config + local config properties. If you specify the below in your `embrace-config.json` they will be ignored:
-  - `sdk_config.beta_features_enabled`
-  - `sdk_config.anr.capture_google`
-  - `sdk_config.background_activity.manual_background_activity_limit`
-  - `sdk_config.background_activity.min_background_activity_duration`
-  - `sdk_config.background_activity.max_cached_activities`
-  - `sdk_config.base_urls.images`
-  - `sdk_config.networking.trace_id_header`
-  - `sdk_config.startup_moment.automatically_end`
+- Recording a custom trace ID for an HTTP request from a custom request header is no longer supported. IDs in the
+  `x-emb-trace-id` header will still be recorded and displayed on the dashboard.
+- Methods to add and remove the `payer` Persona has been removed. 
+  - Use the generic Persona API methods with the name `payer` to get the equivalent functionality.
+- Removed several obsolete remote config + local config properties. If you specify the below in your
+  `embrace-config.json` they will be ignored:
+    - `sdk_config.beta_features_enabled`
+    - `sdk_config.anr.capture_google`
+    - `sdk_config.background_activity.manual_background_activity_limit`
+    - `sdk_config.background_activity.min_background_activity_duration`
+    - `sdk_config.background_activity.max_cached_activities`
+    - `sdk_config.base_urls.images`
+    - `sdk_config.networking.trace_id_header`
+    - `sdk_config.startup_moment.automatically_end`
 
 ### Removed APIs
 
 The following deprecated APIs have been removed:
 
-| Old API                                                       | New API                                    |
-|---------------------------------------------------------------|--------------------------------------------|
-| `Embrace.getInstance().getSessionProperties()`                | N/A                                        |
-| `Embrace.getInstance().getTraceIdHeader()`                    | N/A                                        |
-| `Embrace.getInstance().isTracingAvailable()`                  | `Embrace.getInstance().isStarted()`        |
-| `Embrace.getInstance().start(Context, boolean)`               | `Embrace.getInstance().start(Context)`     |
-| `Embrace.getInstance().start(Context, boolean, AppFramework)` | `Embrace.getInstance().isStarted(Context)` |
+| Old API                                                       | New API                                           |
+|---------------------------------------------------------------|---------------------------------------------------|
+| `Embrace.getInstance().clearUserAsPayer()`                    | `Embrace.getInstance().clearUserPersona("payer")` |
+| `Embrace.getInstance().getSessionProperties()`                | N/A                                               |
+| `Embrace.getInstance().getTraceIdHeader()`                    | N/A                                               |
+| `Embrace.getInstance().isTracingAvailable()`                  | `Embrace.getInstance().isStarted()`               |
+| `Embrace.getInstance().setUserAsPayer()`                      | `Embrace.getInstance().addUserPersona("payer")`   |
+| `Embrace.getInstance().start(Context, boolean)`               | `Embrace.getInstance().start(Context)`            |
+| `Embrace.getInstance().start(Context, boolean, AppFramework)` | `Embrace.getInstance().isStarted(Context)`        |
 
 # Upgrading from 5.x to 6.x
 

--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -110,12 +110,10 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Sessi
 public abstract interface class io/embrace/android/embracesdk/internal/api/UserApi {
 	public abstract fun addUserPersona (Ljava/lang/String;)V
 	public abstract fun clearAllUserPersonas ()V
-	public abstract fun clearUserAsPayer ()V
 	public abstract fun clearUserEmail ()V
 	public abstract fun clearUserIdentifier ()V
 	public abstract fun clearUserPersona (Ljava/lang/String;)V
 	public abstract fun clearUsername ()V
-	public abstract fun setUserAsPayer ()V
 	public abstract fun setUserEmail (Ljava/lang/String;)V
 	public abstract fun setUserIdentifier (Ljava/lang/String;)V
 	public abstract fun setUsername (Ljava/lang/String;)V

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserApi.kt
@@ -35,17 +35,6 @@ public interface UserApi {
     public fun clearUserEmail()
 
     /**
-     * Sets this user as a paying user. This adds a persona to the user's identity.
-     */
-    public fun setUserAsPayer()
-
-    /**
-     * Clears this user as a paying user. This would typically be called if a user is no longer
-     * paying for the service and has reverted back to a basic user.
-     */
-    public fun clearUserAsPayer()
-
-    /**
      * Adds a custom user persona. A persona is a trait associated with a given user. A maximum
      * of 10 personas can be set.
      *

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
@@ -70,14 +70,6 @@ internal class EmbraceUserService(
         setUserEmail(null)
     }
 
-    override fun setUserAsPayer() {
-        addUserPersona(PERSONA_PAYER)
-    }
-
-    override fun clearUserAsPayer() {
-        clearUserPersona(PERSONA_PAYER)
-    }
-
     override fun addUserPersona(persona: String?) {
         if (persona == null) {
             return

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/UserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/UserService.kt
@@ -51,16 +51,6 @@ interface UserService {
     fun clearUserEmail()
 
     /**
-     * Sets the user as a paying user, attaching the paying persona to the user.
-     */
-    fun setUserAsPayer()
-
-    /**
-     * Unsets the user as a paying user, removing the paying persona from the user.
-     */
-    fun clearUserAsPayer()
-
-    /**
      * Attaches the specified persona to the user. This can be used for user segmentation.
      *
      * @param persona the persona to attach to the user

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
@@ -102,9 +102,9 @@ internal class EmbraceUserServiceTest {
 
         with(service) {
             assertTrue(checkNotNull(getUserInfo().personas).contains("payer"))
-            clearUserAsPayer()
+            clearUserPersona("payer")
             assertFalse(checkNotNull(getUserInfo().personas).contains("payer"))
-            setUserAsPayer()
+            addUserPersona("payer")
             assertTrue(checkNotNull(getUserInfo().personas).contains("payer"))
         }
     }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -6,7 +6,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun addSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
 	public fun addUserPersona (Ljava/lang/String;)V
 	public fun clearAllUserPersonas ()V
-	public fun clearUserAsPayer ()V
 	public fun clearUserEmail ()V
 	public fun clearUserIdentifier ()V
 	public fun clearUserPersona (Ljava/lang/String;)V
@@ -52,7 +51,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun recordSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun removeSessionProperty (Ljava/lang/String;)Z
 	public fun setAppId (Ljava/lang/String;)Z
-	public fun setUserAsPayer ()V
 	public fun setUserEmail (Ljava/lang/String;)V
 	public fun setUserIdentifier (Ljava/lang/String;)V
 	public fun setUsername (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
@@ -22,7 +22,7 @@ internal class PersonaFeaturesTest {
                 overriddenAndroidServicesModule.preferencesService.userPersonas = setOf("preloaded")
             },
             testCaseAction = {
-                embrace.setUserAsPayer()
+                embrace.addUserPersona("payer")
                 recordSession {
                     embrace.addUserPersona("test")
                 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -73,14 +73,6 @@ public class Embrace private constructor(
         impl.clearUserEmail()
     }
 
-    override fun setUserAsPayer() {
-        impl.setUserAsPayer()
-    }
-
-    override fun clearUserAsPayer() {
-        impl.clearUserAsPayer()
-    }
-
     override fun addUserPersona(persona: String) {
         impl.addUserPersona(persona)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegate.kt
@@ -53,25 +53,6 @@ internal class UserApiDelegate(
     }
 
     /**
-     * Sets this user as a paying user. This adds a persona to the user's identity.
-     */
-    override fun setUserAsPayer() {
-        if (sdkCallChecker.check("set_user_as_payer")) {
-            userService?.setUserAsPayer()
-        }
-    }
-
-    /**
-     * Clears this user as a paying user. This would typically be called if a user is no longer
-     * paying for the service and has reverted back to a basic user.
-     */
-    override fun clearUserAsPayer() {
-        if (sdkCallChecker.check("clear_user_as_payer")) {
-            userService?.clearUserAsPayer()
-        }
-    }
-
-    /**
      * Sets a custom user persona. A persona is a trait associated with a given user.
      *
      * @param persona the persona to set

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
@@ -9,7 +9,9 @@ import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,10 +67,10 @@ internal class UserApiDelegateTest {
 
     @Test
     fun `user payer`() {
-        delegate.setUserAsPayer()
-        assertEquals(true, fakeUserService.payer)
-        delegate.clearUserAsPayer()
-        assertNull(fakeUserService.payer)
+        delegate.addUserPersona("payer")
+        assertTrue(fakeUserService.personas.contains("payer"))
+        delegate.clearUserPersona("payer")
+        assertFalse(fakeUserService.personas.contains("test"))
     }
 
     @Test

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUserService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUserService.kt
@@ -9,7 +9,6 @@ class FakeUserService : UserService {
     var id: String? = null
     var email: String? = null
     var name: String? = null
-    var payer: Boolean? = null
     var personas: MutableList<String> = mutableListOf()
     var clearedCount: Int = 0
     var listeners: MutableList<() -> Unit> = mutableListOf()
@@ -38,14 +37,6 @@ class FakeUserService : UserService {
 
     override fun clearUserEmail() {
         email = null
-    }
-
-    override fun setUserAsPayer() {
-        payer = true
-    }
-
-    override fun clearUserAsPayer() {
-        payer = null
     }
 
     override fun addUserPersona(persona: String?) {


### PR DESCRIPTION
## Goal

Delete the methods to explicit add and remove the "payer" persona. Customers that use that can add a custom persona called "payer" to achieve the same effect.

