### PR TITLE
Deprecate explicit storing of PII in telemetry

### DIFF
--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserApi.kt
@@ -10,16 +10,18 @@ public interface UserApi {
 
     /**
      * Sets the user ID. This would typically be some form of unique identifier such as a UUID or database key for the user.
-     * This ID will persist across app launches until it is explicitly removed using [.clearUserIdentifier]
+     * This ID will persist across app launches until it is explicitly removed using [clearUserIdentifier]
      * or otherwise cleared.
      *
      * @param userId the unique identifier for the user
      */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun setUserIdentifier(userId: String?)
 
     /**
      * Clears the currently set user ID. For example, if the user logs out.
      */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun clearUserIdentifier()
 
     /**
@@ -27,11 +29,13 @@ public interface UserApi {
      *
      * @param email the email address of the current user
      */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun setUserEmail(email: String?)
 
     /**
      * Clears the currently set user's email address.
      */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun clearUserEmail()
 
     /**
@@ -59,10 +63,12 @@ public interface UserApi {
      *
      * @param username the username to set
      */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun setUsername(username: String?)
 
     /**
      * Clears the username of the currently logged in user, for example if the user has logged out.
      */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun clearUsername()
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserApi.kt
@@ -11,17 +11,15 @@ public interface UserApi {
     /**
      * Sets the user ID. This would typically be some form of unique identifier such as a UUID or database key for the user.
      * This ID will persist across app launches until it is explicitly removed using [clearUserIdentifier]
-     * or otherwise cleared.
+     * or otherwise cleared. Do not put personal identifying information such as email addresses in this field.
      *
      * @param userId the unique identifier for the user
      */
-    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun setUserIdentifier(userId: String?)
 
     /**
      * Clears the currently set user ID. For example, if the user logs out.
      */
-    @Deprecated("Discourage storing personal identifying information in telemetry")
     public fun clearUserIdentifier()
 
     /**
@@ -29,13 +27,13 @@ public interface UserApi {
      *
      * @param email the email address of the current user
      */
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     public fun setUserEmail(email: String?)
 
     /**
      * Clears the currently set user's email address.
      */
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     public fun clearUserEmail()
 
     /**
@@ -63,12 +61,12 @@ public interface UserApi {
      *
      * @param username the username to set
      */
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     public fun setUsername(username: String?)
 
     /**
      * Clears the username of the currently logged in user, for example if the user has logged out.
      */
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     public fun clearUsername()
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -33,6 +33,7 @@ internal class SessionApiTest {
     /**
      * Verifies that a session end message is sent.
      */
+    @Suppress("DEPRECATION")
     @Test
     fun sessionEndMessageTest() {
         var startTime: Long = -1

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
@@ -16,6 +16,7 @@ internal class UserFeaturesTest {
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
+    @Suppress("DEPRECATION")
     @Test
     fun `user info setting and clearing`() {
         testRule.runTest(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
@@ -32,6 +32,7 @@ internal class V1DeliveryFeatureTest {
 
     private val behavior = FakeAutoDataCaptureBehavior(v2StorageEnabled = false)
 
+    @Suppress("DEPRECATION")
     @Test
     fun `v1 session delivery`() {
         testRule.runTest(
@@ -51,6 +52,7 @@ internal class V1DeliveryFeatureTest {
         )
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `v1 background activity delivery`() {
         testRule.runTest(

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -57,22 +57,20 @@ public class Embrace private constructor(
         return impl.setAppId(appId)
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun setUserIdentifier(userId: String?) {
         impl.setUserIdentifier(userId)
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun clearUserIdentifier() {
         impl.clearUserIdentifier()
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.", ReplaceWith(""))
     override fun setUserEmail(email: String?) {
         impl.setUserEmail(email)
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.", ReplaceWith(""))
     override fun clearUserEmail() {
         impl.clearUserEmail()
     }
@@ -97,12 +95,12 @@ public class Embrace private constructor(
         return impl.removeSessionProperty(key)
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.", ReplaceWith(""))
     override fun setUsername(username: String?) {
         impl.setUsername(username)
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.", ReplaceWith(""))
     override fun clearUsername() {
         impl.clearUsername()
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -57,18 +57,22 @@ public class Embrace private constructor(
         return impl.setAppId(appId)
     }
 
+    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun setUserIdentifier(userId: String?) {
         impl.setUserIdentifier(userId)
     }
 
+    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun clearUserIdentifier() {
         impl.clearUserIdentifier()
     }
 
+    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun setUserEmail(email: String?) {
         impl.setUserEmail(email)
     }
 
+    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun clearUserEmail() {
         impl.clearUserEmail()
     }
@@ -93,10 +97,12 @@ public class Embrace private constructor(
         return impl.removeSessionProperty(key)
     }
 
+    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun setUsername(username: String?) {
         impl.setUsername(username)
     }
 
+    @Deprecated("Discourage storing personal identifying information in telemetry", ReplaceWith(""))
     override fun clearUsername() {
         impl.clearUsername()
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegate.kt
@@ -11,52 +11,34 @@ internal class UserApiDelegate(
 
     private val userService by embraceImplInject(sdkCallChecker) { bootstrapper.essentialServiceModule.userService }
 
-    /**
-     * Sets the user ID. This would typically be some form of unique identifier such as a UUID or
-     * database key for the user.
-     *
-     * @param userId the unique identifier for the user
-     */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun setUserIdentifier(userId: String?) {
         if (sdkCallChecker.check("set_user_identifier")) {
             userService?.setUserIdentifier(userId)
         }
     }
 
-    /**
-     * Clears the currently set user ID. For example, if the user logs out.
-     */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun clearUserIdentifier() {
         if (sdkCallChecker.check("clear_user_identifier")) {
             userService?.clearUserIdentifier()
         }
     }
 
-    /**
-     * Sets the current user's email address.
-     *
-     * @param email the email address of the current user
-     */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun setUserEmail(email: String?) {
         if (sdkCallChecker.check("set_user_email")) {
             userService?.setUserEmail(email)
         }
     }
 
-    /**
-     * Clears the currently set user's email address.
-     */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun clearUserEmail() {
         if (sdkCallChecker.check("clear_user_email")) {
             userService?.clearUserEmail()
         }
     }
 
-    /**
-     * Sets a custom user persona. A persona is a trait associated with a given user.
-     *
-     * @param persona the persona to set
-     */
     override fun addUserPersona(persona: String) {
         if (sdkCallChecker.check("add_user_persona")) {
             userService?.addUserPersona(persona)
@@ -83,20 +65,14 @@ internal class UserApiDelegate(
         }
     }
 
-    /**
-     * Sets the username of the currently logged in user.
-     *
-     * @param username the username to set
-     */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun setUsername(username: String?) {
         if (sdkCallChecker.check("set_username")) {
             userService?.setUsername(username)
         }
     }
 
-    /**
-     * Clears the username of the currently logged in user, for example if the user has logged out.
-     */
+    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun clearUsername() {
         if (sdkCallChecker.check("clear_username")) {
             userService?.clearUsername()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegate.kt
@@ -11,28 +11,26 @@ internal class UserApiDelegate(
 
     private val userService by embraceImplInject(sdkCallChecker) { bootstrapper.essentialServiceModule.userService }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun setUserIdentifier(userId: String?) {
         if (sdkCallChecker.check("set_user_identifier")) {
             userService?.setUserIdentifier(userId)
         }
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry")
     override fun clearUserIdentifier() {
         if (sdkCallChecker.check("clear_user_identifier")) {
             userService?.clearUserIdentifier()
         }
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     override fun setUserEmail(email: String?) {
         if (sdkCallChecker.check("set_user_email")) {
             userService?.setUserEmail(email)
         }
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     override fun clearUserEmail() {
         if (sdkCallChecker.check("clear_user_email")) {
             userService?.clearUserEmail()
@@ -65,14 +63,14 @@ internal class UserApiDelegate(
         }
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     override fun setUsername(username: String?) {
         if (sdkCallChecker.check("set_username")) {
             userService?.setUsername(username)
         }
     }
 
-    @Deprecated("Discourage storing personal identifying information in telemetry")
+    @Deprecated("Use discouraged. Personal identifying information shouldn't be stored in telemetry.")
     override fun clearUsername() {
         if (sdkCallChecker.check("clear_username")) {
             userService?.clearUsername()

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@Suppress("DEPRECATION")
 @RunWith(AndroidJUnit4::class)
 internal class UserApiDelegateTest {
 


### PR DESCRIPTION
## Goal

Deprecate these methods - they will still work, but we don't want to support these going forward, as we should allow customers to set key-value pairs attached to the specific user rather than have methods that explicitly call out PII, which we don't want to handle.

