### PR TITLE
Delete the setAppId method

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,6 +17,7 @@ Version 7 of the Embrace Android SDK contains the following breaking changes:
   `x-emb-trace-id` header will still be recorded and displayed on the dashboard.
 - Methods to add and remove the `payer` Persona has been removed. 
   - Use the generic Persona API methods with the name `payer` to get the equivalent functionality.
+- The `setAppId` API has been removed. Changing the `appId` at runtime is no longer supported.
 - Removed several obsolete remote config + local config properties. If you specify the below in your
   `embrace-config.json` they will be ignored:
     - `sdk_config.beta_features_enabled`
@@ -38,6 +39,7 @@ The following deprecated APIs have been removed:
 | `Embrace.getInstance().getSessionProperties()`                | N/A                                               |
 | `Embrace.getInstance().getTraceIdHeader()`                    | N/A                                               |
 | `Embrace.getInstance().isTracingAvailable()`                  | `Embrace.getInstance().isStarted()`               |
+| `Embrace.getInstance().setAppId()`                            | N/A                                               |
 | `Embrace.getInstance().setUserAsPayer()`                      | `Embrace.getInstance().addUserPersona("payer")`   |
 | `Embrace.getInstance().start(Context, boolean)`               | `Embrace.getInstance().start(Context)`            |
 | `Embrace.getInstance().start(Context, boolean, AppFramework)` | `Embrace.getInstance().isStarted(Context)`        |

--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -97,7 +97,6 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/SdkSt
 	public abstract fun getDeviceId ()Ljava/lang/String;
 	public abstract fun getLastRunEndState ()Lio/embrace/android/embracesdk/LastRunEndState;
 	public abstract fun isStarted ()Z
-	public abstract fun setAppId (Ljava/lang/String;)Z
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/SessionApi {

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/SdkStateApi.kt
@@ -13,15 +13,6 @@ public interface SdkStateApi {
      */
     public val isStarted: Boolean
 
-    /**
-     * Sets a custom app ID that overrides the one specified at build time. Must be called before
-     * the SDK is started.
-     *
-     * @param appId custom app ID
-     * @return true if the app ID could be set, false otherwise.
-     */
-    public fun setAppId(appId: String): Boolean
-
     public val deviceId: String
 
     public val currentSessionId: String?

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -50,7 +50,6 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun recordSpan (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun recordSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun removeSessionProperty (Ljava/lang/String;)Z
-	public fun setAppId (Ljava/lang/String;)Z
 	public fun setUserEmail (Ljava/lang/String;)V
 	public fun setUserIdentifier (Ljava/lang/String;)V
 	public fun setUsername (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -73,29 +73,6 @@ internal class PublicApiTest {
     }
 
     @Test
-    fun `custom appId must be valid`() {
-        testRule.runTest(
-            startSdk = false,
-            testCaseAction = {
-                assertFalse(embrace.setAppId(""))
-                assertFalse(embrace.setAppId("abcd"))
-                assertFalse(embrace.setAppId("abcdef"))
-                assertTrue(embrace.setAppId("abcde"))
-            }
-        )
-    }
-
-    @Test
-    fun `custom appId cannot be set after start`() {
-        testRule.runTest(
-            testCaseAction = {
-                assertTrue(embrace.isStarted)
-                assertFalse(embrace.setAppId("xyz12"))
-            }
-        )
-    }
-
-    @Test
     fun `getCurrentSessionId returns null when SDK is not started`() {
         testRule.runTest(
             startSdk = false,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -53,10 +53,6 @@ public class Embrace private constructor(
     override val isStarted: Boolean
         get() = impl.isStarted
 
-    override fun setAppId(appId: String): Boolean {
-        return impl.setAppId(appId)
-    }
-
     override fun setUserIdentifier(userId: String?) {
         impl.setUserIdentifier(userId)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
@@ -34,21 +34,6 @@ internal class SdkStateApiDelegate(
     override val isStarted: Boolean
         get() = sdkCallChecker.started.get()
 
-    /**
-     * Sets a custom app ID that overrides the one specified at build time. Must be called before
-     * the SDK is started.
-     *
-     * @param appId custom app ID
-     * @return true if the app ID could be set, false otherwise.
-     */
-    override fun setAppId(appId: String): Boolean {
-        if (isStarted || appId.isEmpty() || !appIdPattern.matcher(appId).find()) {
-            return false
-        }
-        customAppId = appId
-        return true
-    }
-
     override val deviceId: String
         get() {
             return if (sdkCallChecker.check("get_device_id")) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -47,13 +47,6 @@ internal class SdkStateApiDelegateTest {
     }
 
     @Test
-    fun getCustomAppId() {
-        sdkCallChecker.started.set(false)
-        delegate.setAppId("abcde")
-        assertEquals("abcde", delegate.customAppId)
-    }
-
-    @Test
     fun isStarted() {
         assertTrue(delegate.isStarted)
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -73,10 +73,6 @@ class FakeMetadataService(sessionId: String? = null) : MetadataService {
         appState = APP_STATE_FOREGROUND
     }
 
-    fun setAppId(id: String) {
-        fakeAppId = id
-    }
-
     fun setAppBackground() {
         appState = APP_STATE_BACKGROUND
     }


### PR DESCRIPTION
## Goal

Remove support for setting appId at runtime

