### PR TITLE
Remove support of custom appIds in SDK internals

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/EmbraceConfigService.kt
@@ -48,7 +48,6 @@ import kotlin.math.min
  * Loads configuration for the app from the Embrace API.
  */
 internal class EmbraceConfigService(
-    customAppId: String?,
     openTelemetryCfg: OpenTelemetryConfiguration,
     private val preferencesService: PreferencesService,
     private val clock: Clock,
@@ -56,6 +55,7 @@ internal class EmbraceConfigService(
     private val backgroundWorker: BackgroundWorker,
     suppliedFramework: AppFramework,
     private val foregroundAction: ConfigService.() -> Unit,
+    appIdFromConfig: String?,
     val thresholdCheck: BehaviorThresholdCheck =
         BehaviorThresholdCheck { preferencesService.deviceIdentifier },
 ) : ConfigService, ProcessStateListener {
@@ -160,7 +160,7 @@ internal class EmbraceConfigService(
             remoteSupplier = remoteSupplier
         )
 
-    override val appId: String? = resolveAppId(customAppId, openTelemetryCfg)
+    override val appId: String? = resolveAppId(appIdFromConfig, openTelemetryCfg)
 
     override fun isOnlyUsingOtelExporters(): Boolean = appId.isNullOrEmpty()
 
@@ -170,18 +170,13 @@ internal class EmbraceConfigService(
      *
      * @return the local configuration
      */
-    fun resolveAppId(
-        customAppId: String?,
-        openTelemetryCfg: OpenTelemetryConfiguration,
-    ): String? {
-        val appId = customAppId ?: InstrumentedConfig.project.getAppId()
-
-        require(!appId.isNullOrEmpty() || openTelemetryCfg.hasConfiguredOtelExporters()) {
+    fun resolveAppId(id: String?, openTelemetryCfg: OpenTelemetryConfiguration): String? {
+        require(!id.isNullOrEmpty() || openTelemetryCfg.hasConfiguredOtelExporters()) {
             "No appId supplied in embrace-config.json. This is required if you want to " +
                 "send data to Embrace, unless you configure an OTel exporter and add" +
                 " embrace.disableMappingFileUpload=true to gradle.properties."
         }
-        return appId
+        return id
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
@@ -11,7 +11,6 @@ typealias ConfigModuleSupplier = (
     openTelemetryModule: OpenTelemetryModule,
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
-    customAppId: String?,
     framework: AppFramework,
     configServiceProvider: (framework: AppFramework) -> ConfigService?,
     foregroundAction: ConfigService.() -> Unit,
@@ -22,7 +21,6 @@ fun createConfigModule(
     openTelemetryModule: OpenTelemetryModule,
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
-    customAppId: String?,
     framework: AppFramework,
     configServiceProvider: (framework: AppFramework) -> ConfigService? = { null },
     foregroundAction: ConfigService.() -> Unit,
@@ -31,7 +29,6 @@ fun createConfigModule(
     openTelemetryModule,
     workerThreadModule,
     androidServicesModule,
-    customAppId,
     framework,
     configServiceProvider,
     foregroundAction

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -297,7 +297,7 @@ internal class EmbraceConfigServiceTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testEmptyAppId() {
-        createService(worker = worker, appId = "")
+        createService(worker = worker, appId = null)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -313,7 +313,7 @@ internal class EmbraceConfigServiceTest {
             SystemInfo()
         )
         cfg.addLogExporter(FakeLogRecordExporter())
-        val service = createService(worker = worker, appId = "", config = cfg)
+        val service = createService(worker = worker, config = cfg, appId = null)
         assertNotNull(service)
         assertTrue(service.isOnlyUsingOtelExporters())
     }
@@ -325,21 +325,21 @@ internal class EmbraceConfigServiceTest {
     private fun createService(
         worker: BackgroundWorker,
         action: ConfigService.() -> Unit = {},
-        appId: String? = "abcde",
         config: OpenTelemetryConfiguration = OpenTelemetryConfiguration(
             SpanSinkImpl(),
             LogSinkImpl(),
             SystemInfo()
         ),
+        appId: String? = "AbCdE",
     ): EmbraceConfigService = EmbraceConfigService(
-        appId,
-        config,
-        fakePreferenceService,
-        fakeClock,
-        logger,
-        worker,
-        AppFramework.NATIVE,
-        action
+        openTelemetryCfg = config,
+        preferencesService = fakePreferenceService,
+        clock = fakeClock,
+        logger = logger,
+        backgroundWorker = worker,
+        suppliedFramework = AppFramework.NATIVE,
+        foregroundAction = action,
+        appIdFromConfig = appId
     ).apply {
         remoteConfigSource = mockApiService
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/ConfigModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/ConfigModuleImplTest.kt
@@ -18,14 +18,14 @@ internal class ConfigModuleImplTest {
     @Test
     fun `test defaults`() {
         val module = ConfigModuleImpl(
-            FakeInitModule(),
-            FakeOpenTelemetryModule(),
-            FakeWorkerThreadModule(),
-            FakeAndroidServicesModule(),
-            "abcde",
-            AppFramework.NATIVE,
-            { null },
-            {}
+            initModule = FakeInitModule(),
+            openTelemetryModule = FakeOpenTelemetryModule(),
+            workerThreadModule = FakeWorkerThreadModule(),
+            androidServicesModule = FakeAndroidServicesModule(),
+            framework = AppFramework.NATIVE,
+            configServiceProvider = { null },
+            foregroundAction = {},
+            appIdFromConfig = "AbCeD",
         )
         assertNotNull(module.configService)
     }
@@ -34,15 +34,30 @@ internal class ConfigModuleImplTest {
     fun testConfigServiceProvider() {
         val fakeConfigService = FakeConfigService()
         val module = ConfigModuleImpl(
-            FakeInitModule(),
-            FakeOpenTelemetryModule(),
-            FakeWorkerThreadModule(),
-            FakeAndroidServicesModule(),
-            "abcde",
-            AppFramework.NATIVE,
-            { fakeConfigService },
-            {}
+            initModule = FakeInitModule(),
+            openTelemetryModule = FakeOpenTelemetryModule(),
+            workerThreadModule = FakeWorkerThreadModule(),
+            androidServicesModule = FakeAndroidServicesModule(),
+            framework = AppFramework.NATIVE,
+            configServiceProvider = { fakeConfigService },
+            foregroundAction = {},
+            appIdFromConfig = "AbCeD",
         )
         assertSame(fakeConfigService, module.configService)
+    }
+
+    @Test
+    fun `validate appId in appIdProvider is used`() {
+        val module = ConfigModuleImpl(
+            initModule = FakeInitModule(),
+            openTelemetryModule = FakeOpenTelemetryModule(),
+            workerThreadModule = FakeWorkerThreadModule(),
+            androidServicesModule = FakeAndroidServicesModule(),
+            framework = AppFramework.NATIVE,
+            configServiceProvider = { null },
+            foregroundAction = {},
+            appIdFromConfig = "AbCeD",
+        )
+        assertSame("AbCeD", module.configService.appId)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -95,8 +95,6 @@ internal class EmbraceImpl @JvmOverloads constructor(
 
     private val sdkClock by lazy { bootstrapper.initModule.clock }
     private val logger by lazy { bootstrapper.initModule.logger }
-    private val customAppId: String?
-        get() = sdkStateApiDelegate.customAppId
     private val sdkShuttingDown = AtomicBoolean(false)
 
     /**
@@ -169,7 +167,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
         val startTimeMs = sdkClock.now()
 
         val appFramework = fromFramework(framework)
-        bootstrapper.init(context, appFramework, startTimeMs, customAppId, configServiceProvider)
+        bootstrapper.init(context, appFramework, startTimeMs, configServiceProvider)
         startSynchronous("post-services-setup")
 
         val coreModule = bootstrapper.coreModule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
@@ -4,14 +4,12 @@ import io.embrace.android.embracesdk.LastRunEndState
 import io.embrace.android.embracesdk.internal.api.SdkStateApi
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.embraceImplInject
-import java.util.regex.Pattern
 
 internal class SdkStateApiDelegate(
     bootstrapper: ModuleInitBootstrapper,
     private val sdkCallChecker: SdkCallChecker,
 ) : SdkStateApi {
 
-    private val logger = bootstrapper.initModule.logger
     private val sessionIdTracker by embraceImplInject(sdkCallChecker) {
         bootstrapper.essentialServiceModule.sessionIdTracker
     }
@@ -20,17 +18,6 @@ internal class SdkStateApiDelegate(
     }
     private val crashVerifier by embraceImplInject(sdkCallChecker) { bootstrapper.crashModule.lastRunCrashVerifier }
 
-    /**
-     * Custom app ID that overrides the one specified at build time
-     */
-    @Volatile
-    var customAppId: String? = null
-
-    /**
-     * Whether or not the SDK has been started.
-     *
-     * @return true if the SDK is started, false otherwise
-     */
     override val isStarted: Boolean
         get() = sdkCallChecker.started.get()
 
@@ -67,8 +54,4 @@ internal class SdkStateApiDelegate(
                 LastRunEndState.INVALID
             }
         }
-
-    private companion object {
-        val appIdPattern: Pattern by lazy { Pattern.compile("^[A-Za-z0-9]{5}$") }
-    }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -117,7 +117,6 @@ internal class ModuleInitBootstrapper(
         context: Context,
         appFramework: AppFramework,
         sdkStartTimeMs: Long,
-        customAppId: String? = null,
         configServiceProvider: (framework: AppFramework) -> ConfigService? = { null },
         versionChecker: VersionChecker = BuildVersionChecker,
     ): Boolean {
@@ -156,7 +155,6 @@ internal class ModuleInitBootstrapper(
                             openTelemetryModule,
                             workerThreadModule,
                             androidServicesModule,
-                            customAppId,
                             appFramework,
                             configServiceProvider,
                         ) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -43,7 +43,7 @@ internal fun fakeModuleInitBootstrapper(
     workerThreadModuleSupplier: WorkerThreadModuleSupplier = { FakeWorkerThreadModule() },
     storageModuleSupplier: StorageModuleSupplier = { _, _, _ -> FakeStorageModule() },
     essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
-    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeConfigModule() },
+    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -32,7 +32,7 @@ internal class ModuleInitBootstrapperTest {
         logger = EmbLoggerImpl()
         coreModule = FakeCoreModule()
         moduleInitBootstrapper = ModuleInitBootstrapper(
-            configModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
+            configModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
             coreModuleSupplier = { _ -> coreModule },
             nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = logger


### PR DESCRIPTION
## Goal

Clean up SDK init to not assume the configured appId can be overridden at runtime
