### PR TITLE
Extract config loading to separate class

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiService.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.internal.comms.api
 
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityListener
-import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
+import io.embrace.android.embracesdk.internal.config.CachedRemoteConfigSource
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import java.util.concurrent.Future
 
-interface ApiService : RemoteConfigSource, NetworkConnectivityListener {
+interface ApiService : CachedRemoteConfigSource, NetworkConnectivityListener {
 
     /**
      * Sends a list of OTel Logs to the API.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/CachedRemoteConfigSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/CachedRemoteConfigSource.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.internal.config
+
+import io.embrace.android.embracesdk.internal.comms.api.CachedConfig
+
+interface CachedRemoteConfigSource : RemoteConfigSource {
+
+    fun getCachedConfig(): CachedConfig
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -23,8 +23,6 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
  */
 interface ConfigService {
 
-    var remoteConfigSource: RemoteConfigSource?
-
     /**
      * How background activity functionality should behave.
      */

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/RemoteConfigSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/RemoteConfigSource.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.config
 
-import io.embrace.android.embracesdk.internal.comms.api.CachedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 
 interface RemoteConfigSource {
@@ -14,6 +13,4 @@ interface RemoteConfigSource {
      * @return a future containing the configuration.
      */
     fun getConfig(): RemoteConfig?
-
-    fun getCachedConfig(): CachedConfig
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/RemoteConfigSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/RemoteConfigSourceImpl.kt
@@ -1,0 +1,142 @@
+package io.embrace.android.embracesdk.internal.config
+
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import kotlin.math.min
+
+/**
+ * Loads configuration for the app from the Embrace API.
+ */
+class RemoteConfigSourceImpl(
+    private val clock: Clock,
+    private val backgroundWorker: BackgroundWorker,
+    private val foregroundAction: () -> Unit,
+) : RemoteConfigSource, ProcessStateListener {
+
+    private val lock = Any()
+
+    var remoteConfigSource: CachedRemoteConfigSource? = null
+        set(value) {
+            field = value
+            loadConfigFromCache()
+            attemptConfigRefresh()
+        }
+
+    @Volatile
+    private var configProp = RemoteConfig()
+
+    @Volatile
+    var lastUpdated: Long = 0
+
+    @Volatile
+    private var lastRefreshConfigAttempt: Long = 0
+
+    @Volatile
+    private var configRetrySafeWindow = DEFAULT_RETRY_WAIT_TIME.toDouble()
+
+    override fun getConfig(): RemoteConfig {
+        attemptConfigRefresh()
+        return configProp
+    }
+
+    /**
+     * Load Config from cache if present.
+     */
+    internal fun loadConfigFromCache() {
+        val cachedConfig = remoteConfigSource?.getCachedConfig()
+        val obj = cachedConfig?.remoteConfig
+
+        if (obj != null) {
+            val oldConfig = configProp
+            updateConfig(oldConfig, obj)
+        }
+    }
+
+    private fun attemptConfigRefresh() {
+        if (configRequiresRefresh() && configRetryIsSafe()) {
+            synchronized(lock) {
+                if (configRequiresRefresh() && configRetryIsSafe()) {
+                    lastRefreshConfigAttempt = clock.now()
+                    // Attempt to asynchronously update the config if it is out of date
+                    refreshConfig()
+                }
+            }
+        }
+    }
+
+    private fun refreshConfig() {
+        val previousConfig = configProp
+        backgroundWorker.submit {
+            // Ensure that another thread didn't refresh it already in the meantime
+            if (configRequiresRefresh()) {
+                try {
+                    lastRefreshConfigAttempt = clock.now()
+                    val newConfig = remoteConfigSource?.getConfig()
+                    if (newConfig != null) {
+                        updateConfig(previousConfig, newConfig)
+                        lastUpdated = clock.now()
+                    }
+                    configRetrySafeWindow = DEFAULT_RETRY_WAIT_TIME.toDouble()
+                } catch (ex: Exception) {
+                    configRetrySafeWindow =
+                        min(
+                            MAX_ALLOWED_RETRY_WAIT_TIME.toDouble(),
+                            configRetrySafeWindow * 2
+                        )
+                }
+            }
+        }
+    }
+
+    private fun updateConfig(previousConfig: RemoteConfig, newConfig: RemoteConfig) {
+        val b = newConfig != previousConfig
+        if (b) {
+            configProp = newConfig
+        }
+    }
+
+    override fun onForeground(coldStart: Boolean, timestamp: Long) {
+        // Refresh the config on resume if it has expired
+        getConfig()
+        foregroundAction()
+    }
+
+    /**
+     * Checks if the time diff since the last fetch exceeds the
+     * [RemoteConfigSourceImpl.CONFIG_TTL] millis.
+     *
+     * @return if the config requires to be fetched from the remote server again or not.
+     */
+    private fun configRequiresRefresh(): Boolean {
+        return clock.now() - lastUpdated > CONFIG_TTL
+    }
+
+    /**
+     * Checks if the time diff since the last attempt is enough to try again.
+     *
+     * @return if the config can be fetched from the remote server again or not.
+     */
+    private fun configRetryIsSafe(): Boolean {
+        return clock.now() > lastRefreshConfigAttempt + configRetrySafeWindow * 1000
+    }
+
+    private companion object {
+
+        /**
+         * Config lives for 1 hour before attempting to retrieve again.
+         */
+        private const val CONFIG_TTL = 60 * 60 * 1000L
+
+        /**
+         * Config refresh default retry period.
+         */
+        private const val DEFAULT_RETRY_WAIT_TIME: Long = 20 // 20 seconds
+
+        /**
+         * Config max allowed refresh retry period.
+         */
+        private const val MAX_ALLOWED_RETRY_WAIT_TIME: Long = 300 // 5 minutes
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModule.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
 
 interface ConfigModule {
     val configService: ConfigService
+    val remoteConfigSource: RemoteConfigSource
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.EmbraceConfigService
+import io.embrace.android.embracesdk.internal.config.RemoteConfigSourceImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.worker.Worker
@@ -13,23 +14,25 @@ internal class ConfigModuleImpl(
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
-    private val configServiceProvider: (framework: AppFramework) -> ConfigService? = { null },
-    private val foregroundAction: ConfigService.() -> Unit,
+    foregroundAction: () -> Unit,
     private val appIdFromConfig: String? = InstrumentedConfig.project.getAppId(),
 ) : ConfigModule {
 
     override val configService: ConfigService by singleton {
         Systrace.traceSynchronous("config-service-init") {
-            configServiceProvider(framework)
-                ?: EmbraceConfigService(
-                    openTelemetryCfg = openTelemetryModule.openTelemetryConfiguration,
-                    preferencesService = androidServicesModule.preferencesService,
-                    clock = initModule.clock,
-                    backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
-                    suppliedFramework = framework,
-                    foregroundAction = foregroundAction,
-                    appIdFromConfig = appIdFromConfig,
-                )
+            EmbraceConfigService(
+                openTelemetryCfg = openTelemetryModule.openTelemetryConfiguration,
+                preferencesService = androidServicesModule.preferencesService,
+                suppliedFramework = framework,
+                appIdFromConfig = appIdFromConfig,
+                configProvider = remoteConfigSource::getConfig
+            )
         }
     }
+
+    override val remoteConfigSource = RemoteConfigSourceImpl(
+        clock = initModule.clock,
+        backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
+        foregroundAction = foregroundAction,
+    )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 
 /**
@@ -12,8 +11,7 @@ typealias ConfigModuleSupplier = (
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
-    configServiceProvider: (framework: AppFramework) -> ConfigService?,
-    foregroundAction: ConfigService.() -> Unit,
+    foregroundAction: () -> Unit,
 ) -> ConfigModule
 
 fun createConfigModule(
@@ -22,14 +20,12 @@ fun createConfigModule(
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
-    configServiceProvider: (framework: AppFramework) -> ConfigService? = { null },
-    foregroundAction: ConfigService.() -> Unit,
+    foregroundAction: () -> Unit,
 ): ConfigModule = ConfigModuleImpl(
     initModule,
     openTelemetryModule,
     workerThreadModule,
     androidServicesModule,
     framework,
-    configServiceProvider,
     foregroundAction
 )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/EmbraceConfigServiceTest.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.internal.config
 
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
-import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.internal.comms.api.ApiService
 import io.embrace.android.embracesdk.internal.comms.api.CachedConfig
-import io.embrace.android.embracesdk.internal.comms.delivery.CacheService
+import io.embrace.android.embracesdk.internal.config.behavior.BehaviorThresholdCheck
 import io.embrace.android.embracesdk.internal.config.remote.AnrRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
@@ -21,11 +20,8 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateServ
 import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.clearAllMocks
-import io.mockk.every
-import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import io.mockk.verify
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
@@ -41,17 +37,16 @@ internal class EmbraceConfigServiceTest {
     private lateinit var fakePreferenceService: PreferencesService
     private lateinit var service: EmbraceConfigService
     private lateinit var worker: BackgroundWorker
+    private lateinit var executor: BlockingScheduledExecutorService
+    private lateinit var thresholdCheck: BehaviorThresholdCheck
+    private lateinit var remoteConfigSource: RemoteConfigSourceImpl
 
     companion object {
         private lateinit var remoteConfig: RemoteConfig
-        private lateinit var mockApiService: ApiService
         private lateinit var processStateService: ProcessStateService
-        private lateinit var mockCacheService: CacheService
         private lateinit var logger: EmbLogger
         private lateinit var fakeClock: FakeClock
-        private lateinit var mockConfigListener: () -> Unit
         private lateinit var fakeCachedConfig: RemoteConfig
-        private var configListenerTriggered = false
 
         /**
          * Setup before all tests get executed. Create mocks here.
@@ -61,13 +56,9 @@ internal class EmbraceConfigServiceTest {
         fun setupBeforeAll() {
             mockkStatic(RemoteConfig::class)
             remoteConfig = RemoteConfig()
-            mockApiService = mockk()
             processStateService = FakeProcessStateService()
-            mockCacheService = mockk(relaxed = true)
             fakeClock = FakeClock()
             logger = EmbLoggerImpl()
-            configListenerTriggered = false
-            mockConfigListener = { configListenerTriggered = true }
             fakeCachedConfig = RemoteConfig( // alter config to trigger listener
                 anrConfig = AnrRemoteConfig()
             )
@@ -89,13 +80,9 @@ internal class EmbraceConfigServiceTest {
     @Before
     fun setup() {
         fakeClock.setCurrentTime(1000000000000)
-        every { mockApiService.getConfig() } returns remoteConfig
         fakePreferenceService = FakePreferenceService(deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D07FF")
-        every {
-            mockCacheService.loadObject<RemoteConfig>("config.json", RemoteConfig::class.java)
-        } returns fakeCachedConfig
-        every { mockApiService.getCachedConfig() } returns CachedConfig(fakeCachedConfig, null)
-        worker = fakeBackgroundWorker()
+        executor = BlockingScheduledExecutorService(blockingMode = false)
+        worker = BackgroundWorker(executor)
         service = createService(worker = worker, action = {})
         assertFalse(service.isOnlyUsingOtelExporters())
     }
@@ -112,94 +99,70 @@ internal class EmbraceConfigServiceTest {
     @Test
     fun `test legacy normalized DeviceId`() {
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D0700"
-        assertEquals(0.0, service.thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
+        assertEquals(0.0, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D07FF"
-        assertEquals(100.0, service.thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
+        assertEquals(100.0, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D0739"
-        assertEquals(22.35, service.thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
+        assertEquals(22.35, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D07D9"
-        assertEquals(85.09, service.thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
+        assertEquals(85.09, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
     }
 
     @Test
     fun `test new normalized DeviceId`() {
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC000000"
-        assertEquals(0.0, service.thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(0.0, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFCFFFFFF"
-        assertEquals(100.0, service.thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(100.0, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D0739"
-        assertEquals(5.08, service.thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(5.08, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFCED0739"
-        assertEquals(92.58, service.thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(92.58, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
     }
 
     @Test
     fun `test isBehaviourEnabled`() {
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC000000"
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(0.0f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(0.1f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(100.0f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(99.9f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(34.9f))
+        assertFalse(thresholdCheck.isBehaviorEnabled(0.0f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(0.1f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(100.0f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(99.9f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(34.9f))
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFCFFFFFF"
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(99.9f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(100.0f))
+        assertFalse(thresholdCheck.isBehaviorEnabled(99.9f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(100.0f))
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D0739"
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(0.0f))
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(2.0f))
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(5.0f))
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(5.07f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(5.09f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(47.92f))
-        assertTrue(service.thresholdCheck.isBehaviorEnabled(100.0f))
+        assertFalse(thresholdCheck.isBehaviorEnabled(0.0f))
+        assertFalse(thresholdCheck.isBehaviorEnabled(2.0f))
+        assertFalse(thresholdCheck.isBehaviorEnabled(5.0f))
+        assertFalse(thresholdCheck.isBehaviorEnabled(5.07f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(5.09f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(47.92f))
+        assertTrue(thresholdCheck.isBehaviorEnabled(100.0f))
     }
 
     @Test
     fun `test isBehaviourEnabled with bad input`() {
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFCFFFFFF"
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(1000f))
-        assertFalse(service.thresholdCheck.isBehaviorEnabled(-1000f))
-    }
-
-    @Test
-    fun `test config exists in cache and is loaded correctly`() {
-        assertTrue(service.anrBehavior.isAnrCaptureEnabled())
-
-        val obj = RemoteConfig(anrConfig = AnrRemoteConfig(pctEnabled = 0))
-        every { mockApiService.getCachedConfig() } returns CachedConfig(obj, null)
-        service.loadConfigFromCache()
-
-        // config was updated
-        assertFalse(service.anrBehavior.isAnrCaptureEnabled())
+        assertFalse(thresholdCheck.isBehaviorEnabled(1000f))
+        assertFalse(thresholdCheck.isBehaviorEnabled(-1000f))
     }
 
     @Test
     fun `test config does not exist in cache, so it's not loaded`() {
         assertTrue(service.anrBehavior.isAnrCaptureEnabled())
-        every { mockApiService.getCachedConfig() } returns CachedConfig(null, null)
-        service.loadConfigFromCache()
+        remoteConfigSource.loadConfigFromCache()
 
         // config was not updated
         assertTrue(service.anrBehavior.isAnrCaptureEnabled())
-    }
-
-    @Test
-    fun `test service constructor reads cached config`() {
-        val obj = RemoteConfig(anrConfig = AnrRemoteConfig(pctEnabled = 0))
-        every { mockApiService.getConfig() } returns null
-        every { mockApiService.getCachedConfig() } returns CachedConfig(obj, null)
-        service = createService(worker)
-
-        // config was updated
-        assertFalse(service.anrBehavior.isAnrCaptureEnabled())
     }
 
     /**
@@ -213,10 +176,19 @@ internal class EmbraceConfigServiceTest {
         // advance the clock so it's safe to retry config refresh
         fakeClock.tick(1000000000000)
         val newConfig = RemoteConfig(anrConfig = AnrRemoteConfig())
-        every { mockApiService.getConfig() } returns newConfig
+        var count = 0
 
-        service.onForeground(true, 1100L)
-        verify(exactly = 2) { mockApiService.getConfig() }
+        remoteConfigSource.remoteConfigSource = object : CachedRemoteConfigSource {
+            override fun getCachedConfig(): CachedConfig {
+                return CachedConfig(null, null)
+            }
+            override fun getConfig(): RemoteConfig {
+                count++
+                return newConfig
+            }
+        }
+        remoteConfigSource.onForeground(true, 1100L)
+        assertEquals(1, count)
     }
 
     @Test
@@ -253,22 +225,27 @@ internal class EmbraceConfigServiceTest {
      */
     private fun createService(
         worker: BackgroundWorker,
-        action: ConfigService.() -> Unit = {},
+        action: () -> Unit = {},
         config: OpenTelemetryConfiguration = OpenTelemetryConfiguration(
             SpanSinkImpl(),
             LogSinkImpl(),
             SystemInfo()
         ),
         appId: String? = "AbCdE",
-    ): EmbraceConfigService = EmbraceConfigService(
-        openTelemetryCfg = config,
-        preferencesService = fakePreferenceService,
-        clock = fakeClock,
-        backgroundWorker = worker,
-        suppliedFramework = AppFramework.NATIVE,
-        foregroundAction = action,
-        appIdFromConfig = appId
-    ).apply {
-        remoteConfigSource = mockApiService
+    ): EmbraceConfigService {
+        thresholdCheck = BehaviorThresholdCheck { fakePreferenceService.deviceIdentifier }
+        remoteConfigSource = RemoteConfigSourceImpl(
+            clock = fakeClock,
+            backgroundWorker = worker,
+            foregroundAction = action,
+        )
+        return EmbraceConfigService(
+            openTelemetryCfg = config,
+            preferencesService = fakePreferenceService,
+            suppliedFramework = AppFramework.NATIVE,
+            appIdFromConfig = appId,
+            thresholdCheck = thresholdCheck,
+            configProvider = remoteConfigSource::getConfig,
+        )
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/ConfigModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/ConfigModuleImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -23,27 +22,10 @@ internal class ConfigModuleImplTest {
             workerThreadModule = FakeWorkerThreadModule(),
             androidServicesModule = FakeAndroidServicesModule(),
             framework = AppFramework.NATIVE,
-            configServiceProvider = { null },
             foregroundAction = {},
             appIdFromConfig = "AbCeD",
         )
         assertNotNull(module.configService)
-    }
-
-    @Test
-    fun testConfigServiceProvider() {
-        val fakeConfigService = FakeConfigService()
-        val module = ConfigModuleImpl(
-            initModule = FakeInitModule(),
-            openTelemetryModule = FakeOpenTelemetryModule(),
-            workerThreadModule = FakeWorkerThreadModule(),
-            androidServicesModule = FakeAndroidServicesModule(),
-            framework = AppFramework.NATIVE,
-            configServiceProvider = { fakeConfigService },
-            foregroundAction = {},
-            appIdFromConfig = "AbCeD",
-        )
-        assertSame(fakeConfigService, module.configService)
     }
 
     @Test
@@ -54,7 +36,6 @@ internal class ConfigModuleImplTest {
             workerThreadModule = FakeWorkerThreadModule(),
             androidServicesModule = FakeAndroidServicesModule(),
             framework = AppFramework.NATIVE,
-            configServiceProvider = { null },
             foregroundAction = {},
             appIdFromConfig = "AbCeD",
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceOtelExportAssertionInterface
@@ -118,9 +119,8 @@ internal class IntegrationTestRule(
             embraceImpl.addSpanExporter(spanExporter)
 
             if (startSdk) {
-                embraceImpl.start(overriddenCoreModule.context, appFramework) {
-                    overriddenConfigService.apply { appFramework = it }
-                }
+                overriddenConfigService.appFramework = findAppFramework()
+                embraceImpl.start(overriddenCoreModule.context)
                 assertEquals(expectSdkToStart, bootstrapper.essentialServiceModule.processStateService.isInitialized())
             }
         }
@@ -129,6 +129,15 @@ internal class IntegrationTestRule(
         spanExporter.failOnDuplicate()
         otelExportAssertion(otelAssertion)
     }
+
+    @Suppress("DEPRECATION")
+    fun EmbraceSetupInterface.findAppFramework() =
+        when (appFramework) {
+            io.embrace.android.embracesdk.AppFramework.NATIVE -> AppFramework.NATIVE
+            io.embrace.android.embracesdk.AppFramework.REACT_NATIVE -> AppFramework.REACT_NATIVE
+            io.embrace.android.embracesdk.AppFramework.UNITY -> AppFramework.UNITY
+            io.embrace.android.embracesdk.AppFramework.FLUTTER -> AppFramework.FLUTTER
+        }
 
     /**
      * Setup the Embrace SDK so it's ready for testing.

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.AppFramework
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
@@ -28,6 +29,7 @@ import io.embrace.android.embracesdk.internal.injection.NativeCoreModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.createAndroidServicesModule
+import io.embrace.android.embracesdk.internal.injection.createConfigModule
 import io.embrace.android.embracesdk.internal.injection.createDeliveryModule
 import io.embrace.android.embracesdk.internal.injection.createEssentialServiceModule
 import io.embrace.android.embracesdk.internal.injection.createWorkerThreadModule
@@ -106,6 +108,11 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                         else -> FakeDeliveryService()
                     }
                 })
+        },
+        configModuleSupplier = { _, _, _, _, _, _ ->
+            FakeConfigModule(
+                configService = overriddenConfigService
+            )
         },
         anrModuleSupplier = { _, _, _ -> fakeAnrModule },
         nativeCoreModuleSupplier = { fakeNativeCoreModule },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -118,34 +118,14 @@ internal class EmbraceImpl @JvmOverloads constructor(
     }
 
     @Suppress("DEPRECATION")
-    override fun start(context: Context) = start(context, io.embrace.android.embracesdk.AppFramework.NATIVE) { null }
+    override fun start(context: Context) = start(context, io.embrace.android.embracesdk.AppFramework.NATIVE)
 
     @Suppress("DEPRECATION")
     @Deprecated("Use {@link #start(Context)} instead.", ReplaceWith("start(context)"))
-    override fun start(context: Context, appFramework: io.embrace.android.embracesdk.AppFramework) =
-        start(context, appFramework) { null }
-
-    /**
-     * Starts instrumentation of the Android application using the Embrace SDK. This should be
-     * called during creation of the application, as early as possible.
-     *
-     * See [Embrace Docs](https://embrace.io/docs/android/) for
-     * integration instructions. For compatibility with other networking SDKs such as Akamai,
-     * the Embrace SDK must be initialized after any other SDK.
-     *
-     * @param context                  an instance of context
-     * @param appFramework             the AppFramework of the application
-     * @param configServiceProvider    provider for the config service
-     */
-    @Suppress("DEPRECATION")
-    fun start(
-        context: Context,
-        appFramework: io.embrace.android.embracesdk.AppFramework,
-        configServiceProvider: (framework: AppFramework) -> ConfigService? = { null },
-    ) {
+    override fun start(context: Context, appFramework: io.embrace.android.embracesdk.AppFramework) {
         try {
             startSynchronous("sdk-start")
-            startImpl(context, appFramework, configServiceProvider)
+            startImpl(context, appFramework)
             endSynchronous()
         } catch (t: Throwable) {
             runCatching {
@@ -157,8 +137,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
     @Suppress("DEPRECATION", "CyclomaticComplexMethod", "ComplexMethod")
     private fun startImpl(
         context: Context,
-        framework: io.embrace.android.embracesdk.AppFramework,
-        configServiceProvider: (framework: AppFramework) -> ConfigService?,
+        framework: io.embrace.android.embracesdk.AppFramework
     ) {
         if (application != null) {
             return
@@ -167,7 +146,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
         val startTimeMs = sdkClock.now()
 
         val appFramework = fromFramework(framework)
-        bootstrapper.init(context, appFramework, startTimeMs, configServiceProvider)
+        bootstrapper.init(context, appFramework, startTimeMs)
         startSynchronous("post-services-setup")
 
         val coreModule = bootstrapper.coreModule

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -43,7 +43,7 @@ internal fun fakeModuleInitBootstrapper(
     workerThreadModuleSupplier: WorkerThreadModuleSupplier = { FakeWorkerThreadModule() },
     storageModuleSupplier: StorageModuleSupplier = { _, _, _ -> FakeStorageModule() },
     essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
-    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule() },
+    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -32,7 +32,7 @@ internal class ModuleInitBootstrapperTest {
         logger = EmbLoggerImpl()
         coreModule = FakeCoreModule()
         moduleInitBootstrapper = ModuleInitBootstrapper(
-            configModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
+            configModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
             coreModuleSupplier = { _ -> coreModule },
             nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = logger

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigModule.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkBehavior
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
 import io.embrace.android.embracesdk.internal.injection.ConfigModule
 
 class FakeConfigModule(
@@ -10,4 +11,5 @@ class FakeConfigModule(
             captureHttpUrlConnectionRequests = false
         )
     ),
+    override val remoteConfigSource: RemoteConfigSource = FakeRemoteConfigSource()
 ) : ConfigModule

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
 import io.embrace.android.embracesdk.internal.config.behavior.AnrBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.AppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.AutoDataCaptureBehavior
@@ -42,6 +41,5 @@ class FakeConfigService(
     override var networkSpanForwardingBehavior: NetworkSpanForwardingBehavior = createNetworkSpanForwardingBehavior(),
     override var sensitiveKeysBehavior: SensitiveKeysBehavior = createSensitiveKeysBehavior(),
 ) : ConfigService {
-    override var remoteConfigSource: RemoteConfigSource? = null
     override fun isOnlyUsingOtelExporters(): Boolean = onlyUsingOtelExporters
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigSource.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+
+class FakeRemoteConfigSource(
+    var cfg: RemoteConfig? = null
+) : RemoteConfigSource {
+    override fun getConfig(): RemoteConfig? = cfg
+}


### PR DESCRIPTION
## Goal

Extracts the logic for loading remote config from HTTP requests/cache out of `EmbraceConfigService` and into its own class. I've lifted this pretty much as-is and put it behind the `RemoteConfigSource` interface. My intention is to refactor the behavior in a subsequent PR.

## Testing

Relied on existing test coverage.
