### PR TITLE
Alter integration tests to use config service

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
@@ -3,8 +3,10 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.EmbraceConfigService
+import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
 import io.embrace.android.embracesdk.internal.config.RemoteConfigSourceImpl
 import io.embrace.android.embracesdk.internal.payload.AppFramework
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class ConfigModuleImpl(
@@ -14,6 +16,7 @@ internal class ConfigModuleImpl(
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
     foregroundAction: () -> Unit,
+    remoteConfigSourceProvider: Provider<RemoteConfigSource?> = { null },
 ) : ConfigModule {
 
     override val configService: ConfigService by singleton {
@@ -28,9 +31,11 @@ internal class ConfigModuleImpl(
         }
     }
 
-    override val remoteConfigSource = RemoteConfigSourceImpl(
-        clock = initModule.clock,
-        backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
-        foregroundAction = foregroundAction,
-    )
+    override val remoteConfigSource by singleton {
+        remoteConfigSourceProvider() ?: RemoteConfigSourceImpl(
+            clock = initModule.clock,
+            backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
+            foregroundAction = foregroundAction,
+        )
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
 import io.embrace.android.embracesdk.internal.payload.AppFramework
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Function that returns an instance of [ConfigModule]. Matches the signature of the constructor for [ConfigModuleImpl]
@@ -12,6 +14,7 @@ typealias ConfigModuleSupplier = (
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
     foregroundAction: () -> Unit,
+    remoteConfigSourceProvider: Provider<RemoteConfigSource?>,
 ) -> ConfigModule
 
 fun createConfigModule(
@@ -21,11 +24,13 @@ fun createConfigModule(
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
     foregroundAction: () -> Unit,
+    remoteConfigSourceProvider: Provider<RemoteConfigSource?>,
 ): ConfigModule = ConfigModuleImpl(
     initModule,
     openTelemetryModule,
     workerThreadModule,
     androidServicesModule,
     framework,
-    foregroundAction
+    foregroundAction,
+    remoteConfigSourceProvider
 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -7,8 +7,6 @@ import io.embrace.android.embracesdk.LogType
 import io.embrace.android.embracesdk.assertions.findEventOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.findSpansByName
-import io.embrace.android.embracesdk.fakes.behavior.FakeSdkModeBehavior
-import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
@@ -205,23 +203,18 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `access check methods work as expected`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.networkBehavior =
-                    createNetworkBehavior(remoteCfg = {
-                        RemoteConfig(
-                            disabledUrlPatterns = setOf("dontlogmebro.pizza"),
-                            networkCaptureRules = setOf(
-                                NetworkCaptureRuleRemoteConfig(
-                                    id = "test",
-                                    duration = 10000,
-                                    method = "GET",
-                                    urlRegex = "capture.me",
-                                    expiresIn = 10000
-                                )
-                            )
-                        )
-                    })
-            },
+            remoteConfig = RemoteConfig(
+                disabledUrlPatterns = setOf("dontlogmebro.pizza"),
+                networkCaptureRules = setOf(
+                    NetworkCaptureRuleRemoteConfig(
+                        id = "test",
+                        duration = 10000,
+                        method = "GET",
+                        urlRegex = "capture.me",
+                        expiresIn = 10000
+                    )
+                )
+            ),
             testCaseAction = {
                 recordSession {
                     assertTrue(
@@ -237,7 +230,7 @@ internal class EmbraceInternalInterfaceTest {
                         )
                     )
                     assertFalse(EmbraceInternalApi.getInstance().internalInterface.shouldCaptureNetworkBody(URL, "GET"))
-                    assertTrue(EmbraceInternalApi.getInstance().internalInterface.isNetworkSpanForwardingEnabled())
+                    assertFalse(EmbraceInternalApi.getInstance().internalInterface.isNetworkSpanForwardingEnabled())
                 }
             }
         )
@@ -312,10 +305,8 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `SDK will not start if feature flag has it being disabled`() {
         testRule.runTest(
+            remoteConfig = RemoteConfig(threshold = 0),
             expectSdkToStart = false,
-            setupAction = {
-                overriddenConfigService.sdkModeBehavior = FakeSdkModeBehavior(sdkDisabled = true)
-            },
             testCaseAction = {
                 assertFalse(embrace.isStarted)
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -1,11 +1,10 @@
-@file:Suppress("DEPRECATION")
-
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.AppFramework.FLUTTER
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
@@ -30,13 +29,17 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class FlutterInternalInterfaceTest {
 
+    private val instrumentedConfig = FakeInstrumentedConfig(project = FakeProjectConfig(
+        appId = "abcde",
+        appFramework = "flutter"
+    ))
+
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule {
         val clock = FakeClock(IntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
         val fakeInitModule = FakeInitModule(clock = clock)
         EmbraceSetupInterface(
-            appFramework = FLUTTER,
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,
             overriddenWorkerThreadModule = FakeWorkerThreadModule(
@@ -49,6 +52,7 @@ internal class FlutterInternalInterfaceTest {
     @Test
     fun `flutter without values should return defaults`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession()
             },
@@ -65,6 +69,7 @@ internal class FlutterInternalInterfaceTest {
     @Test
     fun `flutter methods work in current session`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
@@ -84,6 +89,7 @@ internal class FlutterInternalInterfaceTest {
     @Test
     fun `flutter metadata already present from previous session`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
@@ -104,6 +110,7 @@ internal class FlutterInternalInterfaceTest {
     @Test
     fun `setting null is ignored`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
@@ -128,6 +135,7 @@ internal class FlutterInternalInterfaceTest {
     @Test
     fun `flutter values from current session override previous values`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
@@ -158,6 +166,7 @@ internal class FlutterInternalInterfaceTest {
         val expectedLibrary = "library"
 
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.logHandledDartException(
@@ -202,6 +211,7 @@ internal class FlutterInternalInterfaceTest {
         val expectedLibrary = "library"
 
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.logUnhandledDartException(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -180,23 +179,18 @@ internal class NetworkRequestApiTest {
     @Test
     fun `disabled URLs not recorded`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.networkBehavior =
-                    createNetworkBehavior(remoteCfg = {
-                        RemoteConfig(
-                            disabledUrlPatterns = setOf("dontlogmebro.pizza"),
-                            networkCaptureRules = setOf(
-                                NetworkCaptureRuleRemoteConfig(
-                                    id = "test",
-                                    duration = 10000,
-                                    method = "GET",
-                                    urlRegex = "capture.me",
-                                    expiresIn = 10000
-                                )
-                            )
-                        )
-                    })
-            },
+            remoteConfig = RemoteConfig(
+                disabledUrlPatterns = setOf("dontlogmebro.pizza"),
+                networkCaptureRules = setOf(
+                    NetworkCaptureRuleRemoteConfig(
+                        id = "test",
+                        duration = 10000,
+                        method = "GET",
+                        urlRegex = "capture.me",
+                        expiresIn = 10000
+                    )
+                )
+            ),
             testCaseAction = {
                 recordSession {
                     clock.tick(5)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
@@ -3,7 +3,8 @@ package io.embrace.android.embracesdk.testcases
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findEventOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
-import io.embrace.android.embracesdk.fakes.FakeBreadcrumbBehavior
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -84,11 +85,9 @@ internal class PushNotificationApiTest {
     @Test
     fun `log push notification with pii`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.breadcrumbBehavior = FakeBreadcrumbBehavior(
-                    captureFcmPiiDataEnabled = true
-                )
-            },
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(fcmPiiCapture = true),
+            ),
             testCaseAction = {
                 recordSession {
                     embrace.logPushNotification("title", "body", "from", "id", 1, 2, true, true)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
@@ -1,12 +1,11 @@
-@file:Suppress("DEPRECATION")
-
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.AppFramework.REACT_NATIVE
 import io.embrace.android.embracesdk.assertions.findSpanOfType
 import io.embrace.android.embracesdk.assertions.findSpanSnapshotOfType
 import io.embrace.android.embracesdk.assertions.findSpansByName
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -26,15 +25,19 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class ReactNativeInternalInterfaceTest {
 
+    private val instrumentedConfig = FakeInstrumentedConfig(project = FakeProjectConfig(
+        appId = "abcde",
+        appFramework = "react_native"
+    ))
+
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(appFramework = REACT_NATIVE)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `react native without values should return defaults`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession()
             },
@@ -51,6 +54,7 @@ internal class ReactNativeInternalInterfaceTest {
     @Test
     fun `react native methods work in current session`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
@@ -72,6 +76,7 @@ internal class ReactNativeInternalInterfaceTest {
     @Test
     fun `react native metadata already present from previous session`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
@@ -95,6 +100,7 @@ internal class ReactNativeInternalInterfaceTest {
     @Test
     fun `react native values from current session override previous values`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
@@ -123,6 +129,7 @@ internal class ReactNativeInternalInterfaceTest {
     @Test
     fun `react native action`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnAction(
@@ -163,6 +170,7 @@ internal class ReactNativeInternalInterfaceTest {
     @Test
     fun `react native log RN view`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnView("HomeScreen")
@@ -197,6 +205,7 @@ internal class ReactNativeInternalInterfaceTest {
     @Test
     fun `react native log RN view same name`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnView("HomeScreen")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.testcases
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.opentelemetry.embFreeDiskBytes
@@ -23,12 +25,7 @@ internal class SessionApiTest {
 
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface().apply {
-            overriddenConfigService.autoDataCaptureBehavior =
-                FakeAutoDataCaptureBehavior(diskUsageReportingEnabled = false)
-        }
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     /**
      * Verifies that a session end message is sent.
@@ -39,6 +36,7 @@ internal class SessionApiTest {
         var startTime: Long = -1
 
         testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(diskUsageCapture = false, bgActivityCapture = true)),
             testCaseAction = {
                 startTime = clock.now()
                 recordSession {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -5,6 +5,8 @@ import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
@@ -58,6 +60,7 @@ internal class TracingApiTest {
         val spanExporter = FakeSpanExporter()
 
         testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true)),
             preSdkStartAction = {
                 testStartTimeMs = clock.now()
                 clock.tick(100L)
@@ -322,9 +325,6 @@ internal class TracingApiTest {
     @Test
     fun `can only create span if there is a valid session`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.backgroundActivityBehavior = createBackgroundActivityBehavior { BackgroundActivityRemoteConfig(threshold = 0f) }
-            },
             preSdkStartAction = {
                 assertNull(embrace.startSpan("test"))
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
@@ -1,13 +1,11 @@
-@file:Suppress("DEPRECATION")
-
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.AppFramework.UNITY
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -20,15 +18,19 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class UnityInternalInterfaceTest {
 
+    private val instrumentedConfig = FakeInstrumentedConfig(project = FakeProjectConfig(
+        appId = "abcde",
+        appFramework = "unity"
+    ))
+
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(appFramework = UNITY)
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `unity without values should return defaults`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession()
             },
@@ -45,6 +47,7 @@ internal class UnityInternalInterfaceTest {
     @Test
     fun `unity methods work in current session`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().unityInternalInterface.setUnityMetaData(
@@ -68,6 +71,7 @@ internal class UnityInternalInterfaceTest {
     @Test
     fun `unity metadata already present from previous session`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().unityInternalInterface.setUnityMetaData(
@@ -92,6 +96,7 @@ internal class UnityInternalInterfaceTest {
     @Test
     fun `unity values from current session override previous values`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().unityInternalInterface.setUnityMetaData(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
@@ -4,6 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findEventOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -23,6 +25,7 @@ internal class BreadcrumbFeatureTest {
     @Test
     fun `custom breadcrumb feature`() {
         testRule.runTest(
+            remoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             testCaseAction = {
                 recordSession {
                     embrace.addBreadcrumb("Hello, world!")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/EmbraceLoggingFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/EmbraceLoggingFeatureTest.kt
@@ -4,6 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -20,6 +22,8 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class EmbraceLoggingFeatureTest {
+
+    private val instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true))
 
     @Rule
     @JvmField
@@ -39,6 +43,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log info message sent in foreground`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     embrace.logInfo("test message")
@@ -61,6 +66,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log warning message sent in background`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 embrace.logWarning("test message")
                 flushLogs()
@@ -80,6 +86,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log error message sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 embrace.logError("test message")
                 flushLogs()
@@ -99,6 +106,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log messages with different severities sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 Severity.values().forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
@@ -125,6 +133,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log messages with different severities and properties sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 Severity.values().forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
@@ -151,6 +160,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log exception message sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 embrace.logException(testException)
                 flushLogs()
@@ -175,6 +185,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log exception with different severities sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 embrace.logException(testException, Severity.INFO)
                 flushLogs()
@@ -199,6 +210,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log exception with different severities and properties sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 Severity.values().forEach { severity ->
                     embrace.logException(
@@ -232,6 +244,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log exception with different severities, properties, and custom message sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 Severity.values().forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
@@ -264,6 +277,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log custom stacktrace message sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 embrace.logCustomStacktrace(stacktrace)
                 flushLogs()
@@ -286,6 +300,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log custom stacktrace with different severities sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 Severity.values().forEach { severity ->
                     embrace.logCustomStacktrace(stacktrace, severity)
@@ -313,6 +328,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log custom stacktrace with different severities and properties sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 Severity.values().forEach { severity ->
                     embrace.logCustomStacktrace(stacktrace, severity, customProperties)
@@ -341,6 +357,7 @@ internal class EmbraceLoggingFeatureTest {
     @Test
     fun `log custom stacktrace with different severities, properties, and custom message sent`() {
         testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 Severity.values().forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -1,10 +1,13 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
 import io.embrace.android.embracesdk.internal.opentelemetry.embState
-import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
@@ -59,6 +62,7 @@ internal class JvmCrashFeatureTest {
     @Test
     fun `app crash in the background generates a crash log`() {
         testRule.runTest(
+            remoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             testCaseAction = {
                 simulateJvmUncaughtException(testException)
             },
@@ -72,13 +76,15 @@ internal class JvmCrashFeatureTest {
         )
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun `React Native crash generates an OTel Log and matches the crashId in the session`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.appFramework = AppFramework.REACT_NATIVE
-            },
+            instrumentedConfig = FakeInstrumentedConfig(
+                project = FakeProjectConfig(
+                    appId = "abcde",
+                    appFramework = "react_native"
+                )
+            ),
             testCaseAction = {
                 recordSession {
                     EmbraceInternalApi.getInstance().reactNativeInternalInterface.logUnhandledJsException(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
@@ -4,11 +4,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
-import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
-import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.worker.Worker.Priority.DataPersistenceWorker
@@ -42,9 +40,6 @@ internal class PruningFeatureTest {
     @Test
     fun `stored payloads are pruned appropriately`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.backgroundActivityBehavior = createBackgroundActivityBehavior { BackgroundActivityRemoteConfig(threshold = 0f) }
-            },
             testCaseAction = {
                 simulateNetworkChange(NetworkStatus.NOT_REACHABLE)
                 repeat(STORAGE_LIMIT + OVERAGE) { k ->

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -5,9 +5,12 @@ import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.FakeNativeCrashService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.fakeIncompleteSessionEnvelope
 import io.embrace.android.embracesdk.fixtures.fakeCachedSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -45,9 +48,6 @@ internal class ResurrectionFeatureTest {
         )
         testRule.runTest(
             setupAction = {
-                overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
-                    v2StorageEnabled = true
-                )
                 cacheStorageService.addPayload(sessionMetadata, deadSessionEnvelope)
                 cacheStorageServiceProvider = { cacheStorageService }
                 val nativeCrashService = fakeNativeFeatureModule.nativeCrashService as FakeNativeCrashService
@@ -84,11 +84,9 @@ internal class ResurrectionFeatureTest {
     @Test
     fun `resurrection attempt with v2 delivery layer off does not crash the SDK`() {
         testRule.runTest(
+            remoteConfig = RemoteConfig(killSwitchConfig = KillSwitchRemoteConfig(v2StoragePct = 0f)),
             setupAction = {
                 useMockWebServer = false
-                overriddenConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
-                    v2StorageEnabled = false
-                )
             },
             testCaseAction = {
                 recordSession()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SensitiveKeysRedactionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SensitiveKeysRedactionFeatureTest.kt
@@ -2,9 +2,9 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSpanByName
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeRedactionConfig
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
-import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Rule
@@ -13,21 +13,19 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class SensitiveKeysRedactionFeatureTest {
+
+    private val instrumentedConfig = FakeInstrumentedConfig(
+        redaction = FakeRedactionConfig(sensitiveKeys = listOf("password"))
+    )
+
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
-    private val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
-        listOf("password"),
- InstrumentedConfigImpl
-    )
-
     @Test
     fun `custom span properties are redacted if they are sensitive`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.sensitiveKeysBehavior = sensitiveKeysBehavior
-            },
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     embrace.startSpan("test span")?.apply {
@@ -51,9 +49,7 @@ internal class SensitiveKeysRedactionFeatureTest {
     @Test
     fun `custom span events are redacted if they are sensitive`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.sensitiveKeysBehavior = sensitiveKeysBehavior
-            },
+            instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
                     embrace.startSpan("test span")?.apply {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.testcases.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
@@ -27,6 +29,7 @@ internal class SessionPropertiesTest {
     @Test
     fun `session properties additions and removal works at all stages app state transition`() {
         testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true)),
             setupAction = {
                 setupPermanentProperties()
             },
@@ -69,7 +72,6 @@ internal class SessionPropertiesTest {
     fun `session properties work with background activity disabled`() {
         testRule.runTest(
             setupAction = {
-                overriddenConfigService.backgroundActivityBehavior = createBackgroundActivityBehavior { BackgroundActivityRemoteConfig(threshold = 0f) }
                 setupPermanentProperties()
             },
             testCaseAction = {
@@ -116,7 +118,6 @@ internal class SessionPropertiesTest {
     fun `session properties are persisted in cached payloads when bg activities are disabled`() {
         testRule.runTest(
             setupAction = {
-                overriddenConfigService.backgroundActivityBehavior = createBackgroundActivityBehavior { BackgroundActivityRemoteConfig(threshold = 0f) }
                 setupPermanentProperties()
             },
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ThermalStateTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ThermalStateTest.kt
@@ -5,7 +5,6 @@ import android.os.PowerManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSpanSnapshotOfType
 import io.embrace.android.embracesdk.assertions.findSpansOfType
-import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
@@ -26,16 +25,11 @@ internal class ThermalStateFeatureTest {
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
-    private val autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(thermalStatusCaptureEnabled = true)
-
     @Test
     fun `single thermal state change generates a snapshot`() {
         var startTimeMs = 0L
 
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.autoDataCaptureBehavior = autoDataCaptureBehavior
-            },
             testCaseAction = {
                 recordSession {
                     startTimeMs = clock.now()
@@ -64,9 +58,6 @@ internal class ThermalStateFeatureTest {
         var startTimeMs = 0L
 
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.autoDataCaptureBehavior = autoDataCaptureBehavior
-            },
             testCaseAction = {
                 recordSession {
                     startTimeMs = clock.now()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
@@ -7,7 +7,11 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
@@ -30,15 +34,17 @@ internal class V1DeliveryFeatureTest {
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
-    private val behavior = FakeAutoDataCaptureBehavior(v2StorageEnabled = false)
+    private val remoteConfig = RemoteConfig(
+        killSwitchConfig = KillSwitchRemoteConfig(v2StoragePct = 0f),
+        backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)
+    )
 
-    @Suppress("DEPRECATION")
     @Test
     fun `v1 session delivery`() {
         testRule.runTest(
+            remoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
-                overriddenConfigService.autoDataCaptureBehavior = behavior
             },
             testCaseAction = {
                 recordSession {
@@ -52,13 +58,12 @@ internal class V1DeliveryFeatureTest {
         )
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun `v1 background activity delivery`() {
         testRule.runTest(
+            remoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
-                overriddenConfigService.autoDataCaptureBehavior = behavior
             },
             testCaseAction = {
                 embrace.setUserIdentifier("foo")
@@ -74,9 +79,9 @@ internal class V1DeliveryFeatureTest {
     @Test
     fun `v1 crash delivery`() {
         testRule.runTest(
+            remoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
-                overriddenConfigService.autoDataCaptureBehavior = behavior
             },
             testCaseAction = {
                 recordSession {
@@ -93,9 +98,9 @@ internal class V1DeliveryFeatureTest {
     @Test
     fun `v1 log delivery`() {
         testRule.runTest(
+            remoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
-                overriddenConfigService.autoDataCaptureBehavior = behavior
                 setupFakeAeiData()
             },
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
@@ -5,7 +5,6 @@ import com.squareup.moshi.Types
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.assertions.findEventsOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
-import io.embrace.android.embracesdk.fakes.behavior.FakeWebViewVitalsBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.WebVital
 import io.embrace.android.embracesdk.internal.payload.WebVitalType
@@ -33,9 +32,6 @@ internal class WebviewFeatureTest {
     @Test
     fun `webview info feature`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.webViewVitalsBehavior = FakeWebViewVitalsBehavior(50, true)
-            },
             testCaseAction = {
                 recordSession {
                     embrace.trackWebViewPerformance("myWebView", expectedCompleteData)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -5,12 +5,10 @@ import io.embrace.android.embracesdk.assertions.findEventsOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embCleanExit
 import io.embrace.android.embracesdk.internal.opentelemetry.embColdStart
 import io.embrace.android.embracesdk.internal.opentelemetry.embProcessIdentifier
@@ -58,9 +56,7 @@ internal class BackgroundActivityDisabledTest {
             overriddenClock = clock,
             overriddenInitModule = initModule,
             overriddenWorkerThreadModule = workerThreadModule,
-        ).apply {
-            overriddenConfigService.backgroundActivityBehavior = createBackgroundActivityBehavior { BackgroundActivityRemoteConfig(threshold = 0f) }
-        }
+        )
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
@@ -5,6 +5,8 @@ import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.assertions.hasSpanSnapshotsOfType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
@@ -29,6 +31,7 @@ internal class BackgroundActivityTest {
     @Test
     fun `bg activity messages are recorded`() {
         testRule.runTest(
+            remoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             testCaseAction = {
                 recordSession()
                 clock.tick(30000)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualSessionTest.kt
@@ -2,7 +2,8 @@ package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionSpan
-import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.internal.opentelemetry.embSessionNumber
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
@@ -47,10 +48,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when session control enabled does not end sessions`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.sessionBehavior =
-                    FakeSessionBehavior(sessionControlEnabled = true)
-            },
+            remoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true)),
             testCaseAction = {
                 recordSession {
                     clock.tick(10000)
@@ -67,9 +65,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when state session is below 5s has no effect`() {
         testRule.runTest(
-            setupAction = {
-                overriddenConfigService.sessionBehavior = FakeSessionBehavior(sessionControlEnabled = true)
-            },
+            remoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true)),
             testCaseAction = {
                 recordSession {
                     clock.tick(1000) // not enough to trigger new session

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/OtelSessionGatingTest.kt
@@ -5,8 +5,6 @@ import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.hasEventOfType
 import io.embrace.android.embracesdk.assertions.hasSpanOfType
 import io.embrace.android.embracesdk.fakes.FakeAnrService
-import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.createSessionBehavior
 import io.embrace.android.embracesdk.fakes.fakeCompletedAnrInterval
 import io.embrace.android.embracesdk.fakes.fakeInProgressAnrInterval
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
@@ -17,7 +15,6 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -30,26 +27,14 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class OtelSessionGatingTest {
 
-    private var gatingConfig = SessionRemoteConfig(
-        fullSessionEvents = setOf(),
-        sessionComponents = setOf()
-    )
-
     @Rule
     @JvmField
-    val testRule: IntegrationTestRule = IntegrationTestRule {
-        EmbraceSetupInterface(
-            overriddenConfigService = FakeConfigService(
-                sessionBehavior = createSessionBehavior(remoteCfg = { RemoteConfig(sessionConfig = gatingConfig) })
-            )
-        )
-    }
+    val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
     fun `session sent in full without gating`() {
-        gatingConfig = SessionRemoteConfig()
-
         testRule.runTest(
+            remoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig()),
             testCaseAction = {
                 simulateSession()
             },
@@ -62,14 +47,16 @@ internal class OtelSessionGatingTest {
 
     @Test
     fun `session gated`() {
-        gatingConfig = SessionRemoteConfig(
-            sessionComponents = emptySet(),
-            fullSessionEvents = setOf(
-                "crashes",
-                "errors"
-            )
-        )
         testRule.runTest(
+            remoteConfig = RemoteConfig(
+                sessionConfig = SessionRemoteConfig(
+                    sessionComponents = emptySet(),
+                    fullSessionEvents = setOf(
+                        "crashes",
+                        "errors"
+                    )
+                )
+            ),
             testCaseAction = {
                 simulateSession()
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getSessionId
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
@@ -21,6 +23,7 @@ internal class SessionSpamTest {
     @Test
     fun `session messages are recorded`() {
         testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true)),
             testCaseAction = {
                 repeat(SESSION_COUNT) {
                     recordSession {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpanTest.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
@@ -21,6 +23,7 @@ internal class SessionSpanTest {
         val ids = mutableListOf<String?>()
 
         testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true)),
             testCaseAction = {
                 recordSession {
                     ids.add(embrace.currentSessionId)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -26,9 +26,6 @@ internal class EmbraceActionInterface(
     val clock: FakeClock
         get() = setup.overriddenClock
 
-    val configService: FakeConfigService
-        get() = setup.overriddenConfigService
-
     /**
      * Starts & ends a session for the purposes of testing. An action can be supplied as a lambda
      * parameter: any code inside the lambda will be executed, so can be used to add breadcrumbs,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -154,12 +154,14 @@ internal class ModuleInitBootstrapper(
                             openTelemetryModule,
                             workerThreadModule,
                             androidServicesModule,
-                            appFramework
-                        ) {
-                            if (configModule.configService.sdkModeBehavior.isSdkDisabled()) {
-                                EmbraceInternalApi.getInstance().internalInterface.stopSdk()
-                            }
-                        }
+                            appFramework,
+                            {
+                                if (configModule.configService.sdkModeBehavior.isSdkDisabled()) {
+                                    EmbraceInternalApi.getInstance().internalInterface.stopSdk()
+                                }
+                            },
+                            { null }
+                        )
                     }
                     postInit(ConfigModule::class) {
                         serviceRegistry.registerService(lazy { configModule.configService })
@@ -188,7 +190,8 @@ internal class ModuleInitBootstrapper(
                     postInit(EssentialServiceModule::class) {
                         // Allow config service to start making HTTP requests
                         with(essentialServiceModule) {
-                            (configModule.remoteConfigSource as? RemoteConfigSourceImpl)?.remoteConfigSource = apiService
+                            (configModule.remoteConfigSource as? RemoteConfigSourceImpl)?.remoteConfigSource =
+                                apiService
 
                             serviceRegistry.registerServices(
                                 lazy { essentialServiceModule.processStateService },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -43,7 +43,7 @@ internal fun fakeModuleInitBootstrapper(
     workerThreadModuleSupplier: WorkerThreadModuleSupplier = { FakeWorkerThreadModule() },
     storageModuleSupplier: StorageModuleSupplier = { _, _, _ -> FakeStorageModule() },
     essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
-    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule() },
+    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -32,7 +32,7 @@ internal class ModuleInitBootstrapperTest {
         logger = EmbLoggerImpl()
         coreModule = FakeCoreModule()
         moduleInitBootstrapper = ModuleInitBootstrapper(
-            configModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
+            configModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
             coreModuleSupplier = { _, _ -> coreModule },
             nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = logger

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.config.instrumented.schema.Session
 /**
  * A fake [InstrumentedConfig] implementation that defaults to the real implementation unless an override is supplied.
  */
-class FakeInstrumentedConfig(
+data class FakeInstrumentedConfig(
     private val base: InstrumentedConfig = InstrumentedConfigImpl,
     override val baseUrls: FakeBaseUrlConfig = FakeBaseUrlConfig(base.baseUrls),
     override val enabledFeatures: FakeEnabledFeatureConfig = FakeEnabledFeatureConfig(base.enabledFeatures),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -25,7 +25,7 @@ class FakeInitModule(
         logger = logger,
         systemInfo = systemInfo
     ),
-    override val instrumentedConfig: InstrumentedConfig = FakeInstrumentedConfig()
+    override var instrumentedConfig: InstrumentedConfig = FakeInstrumentedConfig()
 ) : InitModule by initModule {
 
     val openTelemetryModule: OpenTelemetryModule by lazy { createOpenTelemetryModule(initModule) }


### PR DESCRIPTION
## Goal

Alters the integration tests to use the real config service instead of a fake. This is achieved by passing in fake versions of the remote + instrumented config.

