### PR TITLE
Move remote config tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -6,10 +6,8 @@ import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -35,36 +33,11 @@ internal class PublicApiTest {
     val testRule: IntegrationTestRule = IntegrationTestRule()
 
     @Test
-    fun `SDK can start`() {
-        testRule.runTest(
-            instrumentedConfig = instrumentedConfig,
-            preSdkStartAction = {
-                assertFalse(embrace.isStarted)
-            },
-            testCaseAction = {
-                assertTrue(embrace.isStarted)
-            }
-        )
-    }
-
-    @Test
     fun `SDK start defaults to native app framework`() {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 assertTrue(embrace.isStarted)
-            }
-        )
-    }
-
-    @Test
-    fun `SDK disabled via config cannot start`() {
-        testRule.runTest(
-            instrumentedConfig = instrumentedConfig,
-            remoteConfig = RemoteConfig(0),
-            expectSdkToStart = false,
-            testCaseAction = {
-                assertFalse(embrace.isStarted)
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests how the SDK behaves when controlling by 'remote config'. This is a HTTP response from the
+ * Embrace server that can enable or disable individual features or the entire SDK.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class RemoteConfigTest {
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule()
+
+    @Test
+    fun `SDK can start`() {
+        testRule.runTest(
+            remoteConfig = RemoteConfig(100),
+            preSdkStartAction = {
+                assertFalse(embrace.isStarted)
+            },
+            testCaseAction = {
+                assertTrue(embrace.isStarted)
+            }
+        )
+    }
+
+    @Test
+    fun `SDK disabled via config cannot start`() {
+        testRule.runTest(
+            remoteConfig = RemoteConfig(0),
+            expectSdkToStart = false,
+            testCaseAction = {
+                assertFalse(embrace.isStarted)
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Goal

Reorganises the integration tests so that remote config is stored in an individual source file.

