### PR TITLE
Add assertions for checking config request made

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -39,7 +39,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 /**
  * Loads configuration for the app from the Embrace API.
  */
-internal class EmbraceConfigService(
+internal class ConfigServiceImpl(
     openTelemetryCfg: OpenTelemetryConfiguration,
     preferencesService: PreferencesService,
     suppliedFramework: AppFramework,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.config.EmbraceConfigService
+import io.embrace.android.embracesdk.internal.config.ConfigServiceImpl
 import io.embrace.android.embracesdk.internal.config.RemoteConfigSource
 import io.embrace.android.embracesdk.internal.config.RemoteConfigSourceImpl
 import io.embrace.android.embracesdk.internal.payload.AppFramework
@@ -21,7 +21,7 @@ internal class ConfigModuleImpl(
 
     override val configService: ConfigService by singleton {
         Systrace.traceSynchronous("config-service-init") {
-            EmbraceConfigService(
+            ConfigServiceImpl(
                 openTelemetryCfg = openTelemetryModule.openTelemetryConfiguration,
                 preferencesService = androidServicesModule.preferencesService,
                 suppliedFramework = framework,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
@@ -34,10 +34,10 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 
-internal class EmbraceConfigServiceTest {
+internal class ConfigServiceImplTest {
 
     private lateinit var fakePreferenceService: PreferencesService
-    private lateinit var service: EmbraceConfigService
+    private lateinit var service: ConfigServiceImpl
     private lateinit var worker: BackgroundWorker
     private lateinit var executor: BlockingScheduledExecutorService
     private lateinit var thresholdCheck: BehaviorThresholdCheck
@@ -222,7 +222,7 @@ internal class EmbraceConfigServiceTest {
     }
 
     /**
-     * Create a new instance of the [EmbraceConfigService] using the passed in [worker] to run
+     * Create a new instance of the [ConfigServiceImpl] using the passed in [worker] to run
      * tasks for its internal [BackgroundWorker]
      */
     private fun createService(
@@ -234,14 +234,14 @@ internal class EmbraceConfigServiceTest {
             SystemInfo()
         ),
         appId: String? = "AbCdE",
-    ): EmbraceConfigService {
+    ): ConfigServiceImpl {
         thresholdCheck = BehaviorThresholdCheck { fakePreferenceService.deviceIdentifier }
         remoteConfigSource = RemoteConfigSourceImpl(
             clock = fakeClock,
             backgroundWorker = worker,
             foregroundAction = action,
         )
-        return EmbraceConfigService(
+        return ConfigServiceImpl(
             openTelemetryCfg = config,
             preferencesService = fakePreferenceService,
             suppliedFramework = AppFramework.NATIVE,


### PR DESCRIPTION
## Goal

Adds assertions to check that a config request was attempted. Additionally boosted the timeout to 10s as this may have been contributing to flakiness on CI.

It's not possible to use this right now because HttpUrlConnection doesn't play well with the tests - once OkHttp is used in the config request it should make this more testable.

