### PR TITLE
Avoid inlining runTest function

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -104,7 +104,7 @@ internal class IntegrationTestRule(
      * assertions. This aims to enforce the better compartmentalisation & reuse of test code within
      * the integration test suite.
      */
-    inline fun runTest(
+    fun runTest(
         startSdk: Boolean = true,
         instrumentedConfig: FakeInstrumentedConfig = FakeInstrumentedConfig(),
         remoteConfig: RemoteConfig = RemoteConfig(),


### PR DESCRIPTION
## Goal

Removes `inline` from `runTest` which stops a failure in the integration tests, specifically `EmbraceInternalInterfaceTest`.

I assume this is because test code was moved in this commit, and inlining the function means some property was not always setup correctly: https://github.com/embrace-io/embrace-android-sdk/pull/1640/files#diff-3c7d753cda41b1a11be4b6fd644cc07b341483a78ea6c29980f0382211887704

