### PR TITLE
Add OkHttp implementation of RemoteConfigSource interface

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.lifecycle.runtime)
     implementation(libs.lifecycle.process)
+    implementation(libs.okhttp)
 
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiUrlBuilder.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiUrlBuilder.kt
@@ -6,6 +6,16 @@ package io.embrace.android.embracesdk.internal.comms.api
 interface ApiUrlBuilder {
 
     /**
+     * The App ID that will be used in API requests.
+     */
+    val appId: String
+
+    /**
+     * The Device ID that will be used in API requests.
+     */
+    val deviceId: String
+
+    /**
      * Returns the url used to fetch the config.
      */
     fun getConfigUrl(): String

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilder.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilder.kt
@@ -5,13 +5,16 @@ import android.os.Build
 internal class EmbraceApiUrlBuilder(
     private val coreBaseUrl: String,
     private val configBaseUrl: String,
-    private val appId: String,
-    private val lazyDeviceId: Lazy<String>,
+    override val appId: String,
+    deviceIdImpl: Lazy<String>,
     private val lazyAppVersionName: Lazy<String>,
 ) : ApiUrlBuilder {
+
     companion object {
         private const val CONFIG_API_VERSION = 2
     }
+
+    override val deviceId: String by deviceIdImpl
 
     private fun getConfigBaseUrl() = "$configBaseUrl/v$CONFIG_API_VERSION/${"config"}"
 
@@ -19,7 +22,7 @@ internal class EmbraceApiUrlBuilder(
 
     override fun getConfigUrl(): String {
         return "${getConfigBaseUrl()}?appId=$appId&osVersion=${getOperatingSystemCode()}" +
-            "&appVersion=${lazyAppVersionName.value}&deviceId=${lazyDeviceId.value}"
+            "&appVersion=${lazyAppVersionName.value}&deviceId=$deviceId"
     }
 
     override fun getEmbraceUrlWithSuffix(apiVersion: String, suffix: String): String {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSource.kt
@@ -1,0 +1,57 @@
+package io.embrace.android.embracesdk.internal.config
+
+import io.embrace.android.embracesdk.core.BuildConfig
+import io.embrace.android.embracesdk.internal.comms.api.ApiRequest
+import io.embrace.android.embracesdk.internal.comms.api.ApiRequestUrl
+import io.embrace.android.embracesdk.internal.comms.api.ApiUrlBuilder
+import io.embrace.android.embracesdk.internal.comms.api.getHeaders
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+internal class OkHttpRemoteConfigSource(
+    private val okhttpClient: OkHttpClient,
+    private val apiUrlBuilder: ApiUrlBuilder,
+    private val serializer: PlatformSerializer,
+) : RemoteConfigSource {
+
+    override fun getConfig(): RemoteConfig? = try {
+        fetchConfigImpl()
+    } catch (exc: IOException) {
+        null
+    }
+
+    private fun fetchConfigImpl(): RemoteConfig? {
+        val url = apiUrlBuilder.getConfigUrl()
+        val headers = prepareConfigRequest(url).getHeaders()
+        val builder = Request.Builder().url(url)
+
+        headers.forEach { entry ->
+            builder.header(entry.key, entry.value)
+        }
+        val call = okhttpClient.newCall(
+            builder.build()
+        )
+
+        val response = call.execute()
+        if (!response.isSuccessful) {
+            return null
+        }
+        val config = response.body?.source()?.inputStream()?.buffered()?.use {
+            serializer.fromJson(it, RemoteConfig::class.java)
+        }
+        return config
+    }
+
+    private fun prepareConfigRequest(url: String) = ApiRequest(
+        userAgent = "Embrace/a/" + BuildConfig.VERSION_NAME,
+        url = ApiRequestUrl(url),
+        httpMethod = HttpMethod.GET,
+        acceptEncoding = "gzip",
+        appId = apiUrlBuilder.appId,
+        deviceId = apiUrlBuilder.deviceId,
+    )
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -69,7 +69,7 @@ class EssentialServiceModuleImpl(
                 coreBaseUrl = coreBaseUrl,
                 configBaseUrl = configBaseUrl,
                 appId = appId,
-                lazyDeviceId = lazyDeviceId,
+                deviceIdImpl = lazyDeviceId,
                 lazyAppVersionName = lazy { coreModule.packageVersionInfo.versionName }
             )
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -52,7 +52,7 @@ internal class EmbraceApiServiceTest {
             coreBaseUrl = "https://a-$fakeAppId.data.emb-api.com",
             configBaseUrl = "https://a-$fakeAppId.config.emb-api.com",
             appId = fakeAppId,
-            lazyDeviceId = lazy { fakeDeviceId },
+            deviceIdImpl = lazy { fakeDeviceId },
             lazyAppVersionName = lazy { fakeAppVersionName }
         )
         fakeApiClient = FakeApiClient()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
@@ -22,7 +22,7 @@ internal class EmbraceApiUrlBuilderTest {
             coreBaseUrl = baseUrlLocalConfig.getData(APP_ID),
             configBaseUrl = baseUrlLocalConfig.getConfig(APP_ID),
             appId = APP_ID,
-            lazyDeviceId = lazy { DEVICE_ID },
+            deviceIdImpl = lazy { DEVICE_ID },
             lazyAppVersionName = lazy { APP_VERSION_NAME },
         )
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
@@ -1,0 +1,156 @@
+package io.embrace.android.embracesdk.internal.config
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.internal.comms.api.EmbraceApiUrlBuilder
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class OkHttpRemoteConfigSourceTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+    private lateinit var urlBuilder: EmbraceApiUrlBuilder
+
+    private val remoteConfig = RemoteConfig(
+        backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)
+    )
+    private val configResponse = TestPlatformSerializer().toJson(remoteConfig)
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply {
+            protocols = listOf(Protocol.HTTP_1_1, Protocol.HTTP_2)
+            start()
+        }
+        val baseUrl = server.url("api").toString()
+        client = OkHttpClient.Builder().build()
+        urlBuilder = EmbraceApiUrlBuilder(
+            coreBaseUrl = baseUrl,
+            configBaseUrl = baseUrl,
+            appId = "abcde",
+            deviceIdImpl = lazy { "deviceId" },
+            lazyAppVersionName = lazy { "1.0.0" },
+        )
+    }
+
+    @Test
+    fun `test config 2xx`() {
+        val (cfg, request) = executeRequest(
+            MockResponse().setResponseCode(200).setBody(configResponse)
+        )
+        assertConfigRequestReceived(request)
+        assertConfigResponseDeserialized(cfg)
+    }
+
+    @Test
+    fun `test config 4xx`() {
+        val (cfg, request) = executeRequest(
+            MockResponse().setResponseCode(400)
+        )
+        assertConfigRequestReceived(request)
+        assertConfigResponseNotDeserialized(cfg)
+    }
+
+    @Test
+    fun `test config 5xx`() {
+        val (cfg, request) = executeRequest(
+            MockResponse().setResponseCode(500)
+        )
+        assertConfigRequestReceived(request)
+        assertConfigResponseNotDeserialized(cfg)
+    }
+
+    @Test
+    fun `test no response from server`() {
+        client = client.newBuilder().callTimeout(1, TimeUnit.MILLISECONDS).build()
+        val (cfg, request) = executeRequest(null)
+        assertConfigRequestNotReceived(request)
+        assertConfigResponseNotDeserialized(cfg)
+    }
+
+    @Test
+    fun `test call timeout in middle of server response`() {
+        client = client.newBuilder().callTimeout(5, TimeUnit.MILLISECONDS).build()
+        val (cfg, request) = executeRequest(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(configResponse)
+                .throttleBody(1, 1, TimeUnit.MILLISECONDS)
+        )
+        assertConfigRequestReceived(request)
+        assertConfigResponseNotDeserialized(cfg)
+    }
+
+    @Test
+    fun `test invalid response from server`() {
+        val (cfg, request) = executeRequest(
+            MockResponse().setResponseCode(200).setBody("{")
+        )
+        assertConfigRequestReceived(request)
+        assertConfigResponseNotDeserialized(cfg)
+    }
+
+    private fun executeRequest(response: MockResponse?): Pair<RemoteConfig?, RecordedRequest?> {
+        if (response == null) {
+            return Pair(null, null)
+        }
+        server.enqueue(response)
+        val source = OkHttpRemoteConfigSource(client, urlBuilder, TestPlatformSerializer())
+        val cfg = source.getConfig()
+        val request = pollRequest()
+        CallData(request, cfg)
+        return Pair(cfg, request)
+    }
+
+    private fun assertEmbraceHeadersAdded(request: RecordedRequest?) {
+        val headers = request?.headers?.toMap() ?: error("Request headers cannot be null")
+        assertEquals("application/json", headers["Accept"])
+        assertEquals("application/json", headers["Content-Type"])
+        assertEquals("gzip", headers["Accept-Encoding"])
+        assertEquals("abcde", headers["X-EM-AID"])
+        assertEquals("deviceId", headers["X-EM-DID"])
+    }
+
+    private fun assertConfigRequestNotReceived(request: RecordedRequest?) {
+        assertNull(request)
+    }
+
+    private fun assertConfigRequestReceived(request: RecordedRequest?) {
+        assertNotNull(request)
+        assertEmbraceHeadersAdded(request)
+        val requestUrl = request?.requestUrl?.toUrl() ?: error("Request URL cannot be null")
+        assertEquals("/api/v2/config", requestUrl.path)
+        assertEquals("appId=abcde&osVersion=21.0.0&appVersion=1.0.0&deviceId=deviceId", requestUrl.query)
+    }
+
+    private fun assertConfigResponseDeserialized(cfg: RemoteConfig?) {
+        checkNotNull(cfg)
+        assertEquals(remoteConfig.backgroundActivityConfig, cfg.backgroundActivityConfig)
+    }
+
+    private fun assertConfigResponseNotDeserialized(cfg: RemoteConfig?) {
+        assertNull(cfg)
+    }
+
+    private data class CallData(
+        val request: RecordedRequest?,
+        val deserializedConfig: RemoteConfig?,
+    )
+
+    private fun pollRequest(): RecordedRequest? = server.takeRequest(1, TimeUnit.SECONDS)
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeApiUrlBuilder.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeApiUrlBuilder.kt
@@ -2,12 +2,14 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.comms.api.ApiUrlBuilder
 
-class FakeApiUrlBuilder : ApiUrlBuilder {
-    override fun getConfigUrl(): String {
-        return ""
-    }
+class FakeApiUrlBuilder(
+    private val config: String = "",
+    private val other: String = "",
+    override val appId: String = "",
+    override val deviceId: String = "",
+) : ApiUrlBuilder {
 
-    override fun getEmbraceUrlWithSuffix(apiVersion: String, suffix: String): String {
-        return ""
-    }
+    override fun getConfigUrl(): String = config
+
+    override fun getEmbraceUrlWithSuffix(apiVersion: String, suffix: String): String = other
 }


### PR DESCRIPTION
## Goal

Adds an OkHttp implementation of the `RemoteConfigSource` interface. Ultimately this will be used to make requests to the config endpoint - for now it's not invoked in production code. The implementation does not deal with caching/scheduling the request, but the actual HTTP request & error handling should be considered complete for the purposes of review.

## Testing

Added unit tests
