### PR TITLE
Disable SDK earlier in lifecycle

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -147,7 +147,7 @@ internal class IntegrationTestRule(
                 assertEquals(
                     "SDK did not start in integration test.",
                     expectSdkToStart,
-                    bootstrapper.essentialServiceModule.processStateService.isInitialized()
+                    embraceImpl.isStarted
                 )
             }
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -146,17 +146,18 @@ internal class EmbraceImpl @JvmOverloads constructor(
         val startTimeMs = sdkClock.now()
 
         val appFramework = fromFramework(framework)
-        bootstrapper.init(context, appFramework, startTimeMs)
+        if (!bootstrapper.init(context, appFramework, startTimeMs)) {
+            if (bootstrapper.configModule.configService.sdkModeBehavior.isSdkDisabled()) {
+                stop()
+            }
+            return
+        }
         startSynchronous("post-services-setup")
 
         val coreModule = bootstrapper.coreModule
         application = coreModule.application
 
         val configModule = bootstrapper.configModule
-        if (configModule.configService.sdkModeBehavior.isSdkDisabled()) {
-            stop()
-            return
-        }
 
         if (configModule.configService.autoDataCaptureBehavior.isComposeClickCaptureEnabled()) {
             registerComposeActivityListener(coreModule.application)


### PR DESCRIPTION
## Goal

Disables the SDK much earlier on in the bootstrapping process. Previously the disable call happened in an `onForeground()` callback which is non-deterministic. Due to the fact we now load config at startup it's possible to immediately check whether the SDK should be initialized & bail out of the initialization process much earlier.

## Testing

Relied on existing tests for now. A future changeset will add more extensive integration tests.

