### PR TITLE
Alter units for retry-after header

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
@@ -21,7 +21,7 @@ sealed class ExecutionResult(
     /**
      * A completed HTTP request that returned a 429 (Too Many Requests) status code.
      */
-    data class TooManyRequests(val endpoint: Endpoint, val retryAfter: Long?) : ExecutionResult(true)
+    data class TooManyRequests(val endpoint: Endpoint, val retryAfterMs: Long?) : ExecutionResult(true)
 
     /**
      * A completed HTTP request that with a status code that indicates it did not succeed (4xx and 5xx)
@@ -78,7 +78,7 @@ sealed class ExecutionResult(
                 HTTP_ENTITY_TOO_LARGE -> PayloadTooLarge
                 HTTP_TOO_MANY_REQUESTS -> TooManyRequests(
                     endpoint,
-                    headersProvider()["Retry-After"]?.toLongOrNull()
+                    headersProvider()["Retry-After"]?.toLongOrNull()?.times(1000)
                 )
 
                 in HTTP_FAILURES -> Failure(responseCode)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -162,8 +162,8 @@ class SchedulingServiceImpl(
                     // If delivery of this payload should be retried, add or replace the entry in the retry map
                     // with the new values for how many times it has failed, and when the next retry should happen
                     val retryAttempts = payloadsToRetry[payload]?.failedAttempts ?: 0
-                    val nextRetryTimeMs = if (this is ExecutionResult.TooManyRequests && retryAfter != null) {
-                        val unblockedTimestampMs = clock.now() + retryAfter
+                    val nextRetryTimeMs = if (this is ExecutionResult.TooManyRequests && retryAfterMs != null) {
+                        val unblockedTimestampMs = clock.now() + retryAfterMs
                         blockedEndpoints[endpoint] = unblockedTimestampMs
                         unblockedTimestampMs + 1L
                     } else {

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/HttpUrlConnectionRequestExecutionServiceTest.kt
@@ -150,7 +150,7 @@ class HttpUrlConnectionRequestExecutionServiceTest {
 
         // then the response should be too many requests
         check(response is ExecutionResult.TooManyRequests)
-        assertEquals(10L, response.retryAfter)
+        assertEquals(10000L, response.retryAfterMs)
     }
 
     @Test

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -154,7 +154,7 @@ class OkHttpRequestExecutionServiceTest {
 
         // then the result should be too many requests
         check(result is ExecutionResult.TooManyRequests)
-        assertEquals(10L, result.retryAfter)
+        assertEquals(10000L, result.retryAfterMs)
     }
 
     @Test

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -161,7 +161,7 @@ internal class SchedulingServiceImplTest {
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
         executionService.constantResponse = ExecutionResult.TooManyRequests(
             endpoint = Endpoint.SESSIONS,
-            retryAfter = longBlockedDuration
+            retryAfterMs = longBlockedDuration
         )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
@@ -182,7 +182,7 @@ internal class SchedulingServiceImplTest {
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
         executionService.constantResponse = ExecutionResult.TooManyRequests(
             endpoint = Endpoint.SESSIONS,
-            retryAfter = SHORT_BLOCKED_DURATION
+            retryAfterMs = SHORT_BLOCKED_DURATION
         )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
@@ -199,7 +199,7 @@ internal class SchedulingServiceImplTest {
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
         executionService.constantResponse = ExecutionResult.TooManyRequests(
             endpoint = Endpoint.SESSIONS,
-            retryAfter = SHORT_BLOCKED_DURATION
+            retryAfterMs = SHORT_BLOCKED_DURATION
         )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
@@ -219,7 +219,7 @@ internal class SchedulingServiceImplTest {
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata2)
         executionService.constantResponse = ExecutionResult.TooManyRequests(
             endpoint = Endpoint.SESSIONS,
-            retryAfter = SHORT_BLOCKED_DURATION
+            retryAfterMs = SHORT_BLOCKED_DURATION
         )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()
@@ -235,7 +235,7 @@ internal class SchedulingServiceImplTest {
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
         executionService.constantResponse = ExecutionResult.TooManyRequests(
             endpoint = Endpoint.SESSIONS,
-            retryAfter = SHORT_BLOCKED_DURATION
+            retryAfterMs = SHORT_BLOCKED_DURATION
         )
         waitForOnPayloadIntakeTaskCompletion()
         deliveryExecutor.awaitExecutionCompletion()


### PR DESCRIPTION
## Goal

`Retry-After` was assumed to be in milliseconds in `ExecutionResult` whereas it's actually in seconds according to MDN. `ApiResponse` in the old delivery layer assumes seconds. The server doesn't actually send the header yet but when it does we should assume the incoming unit is in seconds.

