### PR TITLE
Add integration tests for remote config disabling sdk

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleImpl.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.internal.config.source.OkHttpRemoteConfigSo
 import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStore
 import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStoreImpl
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.Worker
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
@@ -24,7 +23,6 @@ internal class ConfigModuleImpl(
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
-    remoteConfigStoreProvider: Provider<RemoteConfigStore?> = { null },
 ) : ConfigModule {
 
     companion object {
@@ -72,7 +70,7 @@ internal class ConfigModuleImpl(
     }
 
     override val remoteConfigStore: RemoteConfigStore by singleton {
-        remoteConfigStoreProvider() ?: RemoteConfigStoreImpl(
+        RemoteConfigStoreImpl(
             serializer = initModule.jsonSerializer,
             storageDir = File(coreModule.context.filesDir, "embrace_remote_config"),
         )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ConfigModuleSupplier.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStore
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
  * Function that returns an instance of [ConfigModule]. Matches the signature of the constructor for [ConfigModuleImpl]
@@ -14,7 +12,6 @@ typealias ConfigModuleSupplier = (
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
-    remoteConfigStoreProvider: Provider<RemoteConfigStore?>,
 ) -> ConfigModule
 
 fun createConfigModule(
@@ -24,7 +21,6 @@ fun createConfigModule(
     workerThreadModule: WorkerThreadModule,
     androidServicesModule: AndroidServicesModule,
     framework: AppFramework,
-    remoteConfigStoreProvider: Provider<RemoteConfigStore?>,
 ): ConfigModule = ConfigModuleImpl(
     initModule,
     coreModule,
@@ -32,5 +28,4 @@ fun createConfigModule(
     workerThreadModule,
     androidServicesModule,
     framework,
-    remoteConfigStoreProvider
 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -203,7 +203,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `access check methods work as expected`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(
+            persistedRemoteConfig = RemoteConfig(
                 disabledUrlPatterns = setOf("dontlogmebro.pizza"),
                 networkCaptureRules = setOf(
                     NetworkCaptureRuleRemoteConfig(
@@ -305,7 +305,7 @@ internal class EmbraceInternalInterfaceTest {
     @Test
     fun `SDK will not start if feature flag has it being disabled`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(threshold = 0),
+            persistedRemoteConfig = RemoteConfig(threshold = 0),
             expectSdkToStart = false,
             testCaseAction = {
                 assertFalse(embrace.isStarted)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -179,7 +179,7 @@ internal class NetworkRequestApiTest {
     @Test
     fun `disabled URLs not recorded`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(
+            persistedRemoteConfig = RemoteConfig(
                 disabledUrlPatterns = setOf("dontlogmebro.pizza"),
                 networkCaptureRules = setOf(
                     NetworkCaptureRuleRemoteConfig(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -74,7 +74,7 @@ internal class PublicApiTest {
         var foregroundSessionId: String? = null
         var backgroundSessionId: String? = null
         testRule.runTest(
-            remoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
@@ -25,7 +25,7 @@ internal class BreadcrumbFeatureTest {
     @Test
     fun `custom breadcrumb feature`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             testCaseAction = {
                 recordSession {
                     embrace.addBreadcrumb("Hello, world!")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -62,7 +62,7 @@ internal class JvmCrashFeatureTest {
     @Test
     fun `app crash in the background generates a crash log`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             testCaseAction = {
                 simulateJvmUncaughtException(testException)
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
@@ -1,8 +1,10 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -16,6 +18,9 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class RemoteConfigTest {
 
+    private val sdkDisabledConfig = RemoteConfig(0)
+    private val sdkEnabledConfig = RemoteConfig(100)
+
     @Rule
     @JvmField
     val testRule: IntegrationTestRule = IntegrationTestRule()
@@ -23,12 +28,19 @@ internal class RemoteConfigTest {
     @Test
     fun `SDK can start`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(100),
+            persistedRemoteConfig = sdkEnabledConfig,
             preSdkStartAction = {
+                assertNoConfigPersisted()
                 assertFalse(embrace.isStarted)
             },
             testCaseAction = {
                 assertTrue(embrace.isStarted)
+            },
+            assertAction = {
+                assertConfigRequested(1)
+                val response = readPersistedConfigResponse()
+                assertEquals(100, response.cfg?.threshold)
+                assertEquals("server_etag_value", response.etag)
             }
         )
     }
@@ -36,10 +48,25 @@ internal class RemoteConfigTest {
     @Test
     fun `SDK disabled via config cannot start`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(0),
+            persistedRemoteConfig = sdkDisabledConfig,
+            serverResponseConfig = sdkEnabledConfig,
             expectSdkToStart = false,
+            preSdkStartAction = {
+                assertNoConfigPersisted()
+            },
             testCaseAction = {
                 assertFalse(embrace.isStarted)
+            },
+            assertAction = {
+                assertConfigRequested(1)
+                returnIfConditionMet(
+                    dataProvider = ::readPersistedConfigResponse,
+                    condition = {
+                        val response = readPersistedConfigResponse()
+                        response.cfg?.threshold == 100 && response.etag == "server_etag_value"
+                    },
+                    desiredValueSupplier = {}
+                )
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -4,8 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.FakeNativeCrashService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
-import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.fakeIncompleteSessionEnvelope
 import io.embrace.android.embracesdk.fixtures.fakeCachedSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -84,7 +82,7 @@ internal class ResurrectionFeatureTest {
     @Test
     fun `resurrection attempt with v2 delivery layer off does not crash the SDK`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(killSwitchConfig = KillSwitchRemoteConfig(v2StoragePct = 0f)),
+            persistedRemoteConfig = RemoteConfig(killSwitchConfig = KillSwitchRemoteConfig(v2StoragePct = 0f)),
             setupAction = {
                 useMockWebServer = false
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
@@ -7,8 +7,6 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
-import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -42,7 +40,7 @@ internal class V1DeliveryFeatureTest {
     @Test
     fun `v1 session delivery`() {
         testRule.runTest(
-            remoteConfig = remoteConfig,
+            persistedRemoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
             },
@@ -61,7 +59,7 @@ internal class V1DeliveryFeatureTest {
     @Test
     fun `v1 background activity delivery`() {
         testRule.runTest(
-            remoteConfig = remoteConfig,
+            persistedRemoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
             },
@@ -79,7 +77,7 @@ internal class V1DeliveryFeatureTest {
     @Test
     fun `v1 crash delivery`() {
         testRule.runTest(
-            remoteConfig = remoteConfig,
+            persistedRemoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
             },
@@ -98,7 +96,7 @@ internal class V1DeliveryFeatureTest {
     @Test
     fun `v1 log delivery`() {
         testRule.runTest(
-            remoteConfig = remoteConfig,
+            persistedRemoteConfig = remoteConfig,
             setupAction = {
                 useMockWebServer = false
                 setupFakeAeiData()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
@@ -31,7 +31,7 @@ internal class BackgroundActivityTest {
     @Test
     fun `bg activity messages are recorded`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             testCaseAction = {
                 recordSession()
                 clock.tick(30000)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualSessionTest.kt
@@ -48,7 +48,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when session control enabled does not end sessions`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true)),
+            persistedRemoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true)),
             testCaseAction = {
                 recordSession {
                     clock.tick(10000)
@@ -65,7 +65,7 @@ internal class ManualSessionTest {
     @Test
     fun `calling endSession when state session is below 5s has no effect`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true)),
+            persistedRemoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig(isEnabled = true)),
             testCaseAction = {
                 recordSession {
                     clock.tick(1000) // not enough to trigger new session

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/OtelSessionGatingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/OtelSessionGatingTest.kt
@@ -34,7 +34,7 @@ internal class OtelSessionGatingTest {
     @Test
     fun `session sent in full without gating`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig()),
+            persistedRemoteConfig = RemoteConfig(sessionConfig = SessionRemoteConfig()),
             testCaseAction = {
                 simulateSession()
             },
@@ -48,7 +48,7 @@ internal class OtelSessionGatingTest {
     @Test
     fun `session gated`() {
         testRule.runTest(
-            remoteConfig = RemoteConfig(
+            persistedRemoteConfig = RemoteConfig(
                 sessionConfig = SessionRemoteConfig(
                     sessionComponents = emptySet(),
                     fullSessionEvents = setOf(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePreSdkStartInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePreSdkStartInterface.kt
@@ -1,7 +1,10 @@
 package io.embrace.android.embracesdk.testframework.actions
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.fakes.FakeClock
+import java.io.File
 
 internal class EmbracePreSdkStartInterface(
     private val setup: EmbraceSetupInterface,
@@ -10,4 +13,15 @@ internal class EmbracePreSdkStartInterface(
 
     val clock: FakeClock
         get() = setup.overriddenClock
+
+    /**
+     * Asserts that no config has been persisted on disk yet.
+     */
+    internal fun assertNoConfigPersisted() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val storageDir = File(ctx.filesDir, "embrace_remote_config")
+        if (storageDir.exists()) {
+            throw IllegalStateException("Did not expect config storage directory to exist.")
+        }
+    }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -7,8 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
-import io.embrace.android.embracesdk.fakes.FakeRemoteConfigSource
-import io.embrace.android.embracesdk.fakes.FakeRemoteConfigStore
 import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
@@ -16,8 +14,6 @@ import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeCoreModule
 import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
@@ -26,7 +22,6 @@ import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.createAndroidServicesModule
-import io.embrace.android.embracesdk.internal.injection.createConfigModule
 import io.embrace.android.embracesdk.internal.injection.createDeliveryModule
 import io.embrace.android.embracesdk.internal.injection.createEssentialServiceModule
 import io.embrace.android.embracesdk.internal.injection.createWorkerThreadModule
@@ -57,7 +52,6 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
 ) {
     fun createBootstrapper(
         instrumentedConfig: FakeInstrumentedConfig,
-        remoteConfig: RemoteConfig,
     ): ModuleInitBootstrapper = ModuleInitBootstrapper(
         initModule = overriddenInitModule.apply {
             this.instrumentedConfig = instrumentedConfig
@@ -102,18 +96,6 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                 requestExecutionServiceProvider = requestExecutionServiceProvider,
                 deliveryServiceProvider = deliveryServiceProvider
             )
-        },
-        configModuleSupplier = { initModule, coreModule, openTelemetryModule, workerThreadModule, androidServicesModule, appFramework, _ ->
-            createConfigModule(
-                initModule,
-                coreModule,
-                openTelemetryModule,
-                workerThreadModule,
-                androidServicesModule,
-                appFramework,
-            ) {
-                FakeRemoteConfigStore(ConfigHttpResponse(remoteConfig, null))
-            }
         },
         anrModuleSupplier = { _, _, _ -> fakeAnrModule },
         nativeCoreModuleSupplier = { FakeNativeCoreModule() },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -145,7 +145,7 @@ internal class ModuleInitBootstrapper(
                             workerThreadModule,
                             androidServicesModule,
                             appFramework
-                        ) { null }
+                        )
                     }
 
                     Systrace.traceSynchronous("sdk-disable-check") {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -43,7 +43,7 @@ internal fun fakeModuleInitBootstrapper(
     workerThreadModuleSupplier: WorkerThreadModuleSupplier = { FakeWorkerThreadModule() },
     storageModuleSupplier: StorageModuleSupplier = { _, _, _ -> FakeStorageModule() },
     essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
-    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule() },
+    configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -32,7 +32,7 @@ internal class ModuleInitBootstrapperTest {
         logger = EmbLoggerImpl()
         coreModule = FakeCoreModule()
         moduleInitBootstrapper = ModuleInitBootstrapper(
-            configModuleSupplier = { _, _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
+            configModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
             coreModuleSupplier = { _, _ -> coreModule },
             nativeFeatureModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeFeatureModule() },
             logger = logger


### PR DESCRIPTION
## Goal

Adds integration tests that assert the remote config response controls whether the SDK is initialized or not. There are 2 scenarios tested here:

1. If the persisted config disables the SDK, a HTTP request will always be made whose response is persisted on disk
2. If the SDK starts normally, it will always attempt a HTTP request

