### PR TITLE
Store remote config response uncompressed

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
@@ -4,8 +4,6 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import java.io.File
-import java.util.zip.GZIPInputStream
-import java.util.zip.GZIPOutputStream
 
 internal class RemoteConfigStoreImpl(
     private val serializer: PlatformSerializer,
@@ -26,7 +24,7 @@ internal class RemoteConfigStoreImpl(
 
     override fun loadResponse(): ConfigHttpResponse? {
         try {
-            val cfg = GZIPInputStream(configFile.inputStream().buffered()).use {
+            val cfg = configFile.inputStream().buffered().use {
                 serializer.fromJson(it, RemoteConfig::class.java)
             }
             return ConfigHttpResponse(
@@ -42,7 +40,7 @@ internal class RemoteConfigStoreImpl(
 
     override fun saveResponse(response: ConfigHttpResponse) {
         try {
-            GZIPOutputStream(configFile.outputStream().buffered()).use { stream ->
+            configFile.outputStream().buffered().use { stream ->
                 serializer.toJson(response.cfg, RemoteConfig::class.java, stream)
             }
             response.etag?.let(etagFile::writeText)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -28,7 +28,6 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import java.io.File
-import java.util.zip.GZIPOutputStream
 import okhttp3.Protocol
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
@@ -176,7 +175,7 @@ internal class IntegrationTestRule(
         File(storageDir, "etag").writeText("persisted_etag")
         val responseFile = File(storageDir, "most_recent_response")
 
-        GZIPOutputStream(responseFile.outputStream().buffered()).use { stream ->
+        responseFile.outputStream().buffered().use { stream ->
             TestPlatformSerializer().toJson(persistedRemoteConfig, RemoteConfig::class.java, stream)
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -24,7 +24,6 @@ import java.io.File
 import java.io.IOException
 import java.util.Locale
 import java.util.concurrent.TimeoutException
-import java.util.zip.GZIPInputStream
 import org.json.JSONObject
 import org.junit.Assert
 
@@ -222,7 +221,7 @@ internal class EmbracePayloadAssertionInterface(
 
     private fun readRemoteConfigFile(file: File): RemoteConfig {
         try {
-            return GZIPInputStream(file.inputStream().buffered()).use {
+            return file.inputStream().buffered().use {
                 serializer.fromJson(it, RemoteConfig::class.java)
             }
         } catch (exc: Throwable) {


### PR DESCRIPTION
## Goal

Stores the remote config response on disk uncompressed as it's relatively tiny & probably not worth the hit of gzipping.

