### PR TITLE
Remove unused envelope fields

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -21,12 +21,10 @@ internal class EnvelopeResourceSourceImpl(
     private val rnBundleIdTracker: RnBundleIdTracker,
 ) : EnvelopeResourceSource {
 
-    @Suppress("DEPRECATION")
     override fun getEnvelopeResource(): EnvelopeResource {
         return EnvelopeResource(
             appVersion = packageVersionInfo.versionName,
             bundleVersion = packageVersionInfo.versionCode,
-            appEcosystemId = packageVersionInfo.packageName,
             appFramework = appFramework,
             buildId = buildInfo.buildId,
             buildType = buildInfo.buildType,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -75,7 +75,6 @@ internal class EnvelopeResourceSourceImplTest {
 
         assertEquals("1.0.0", envelope.appVersion)
         assertEquals(AppFramework.NATIVE, envelope.appFramework)
-        assertEquals("com.embrace.fake", envelope.appEcosystemId)
         assertEquals("100", envelope.buildId)
         assertEquals("release", envelope.buildType)
         assertEquals("oem", envelope.buildFlavor)

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -38,9 +38,6 @@ import com.squareup.moshi.JsonClass
  * @param appVersion The app's publicly displayed version name. Previous name: a.v
  * @param appFramework The frameworks in use by the app. 1=Native, 2=React Native, 3=Unity. Previous name: a.f
  * @param buildId A unique ID for the build that is generated at build time. Previous name: a.bi
- * @param appEcosystemId Unique identifier for the app in its ecosystem.
- * In Apple, this is the Bundle ID (e.g. com.io.embrace).
- * In Android, this is the app's package name (e.g. io.embrace.testapp). Previous name: a.bid
  * @param buildType (Android) - the buildType name. Previous name: a.bt
  * @param buildFlavor (Android) - the flavor name. If productFlavors are not used this will be null. Previous name: a.fl
  * @param environment The name of the environment, i.e. dev or prod. Previous name: a.e
@@ -84,11 +81,6 @@ data class EnvelopeResource(
     /* A unique ID for the build that is generated at build time. Previous name: a.bi */
     @Json(name = "build_id")
     val buildId: String? = null,
-
-    /* Unique identifier for the app in its ecosystem. In Apple, this is the Bundle ID (e.g. com.io.embrace).
-    In Android, this is the app's package name (e.g. io.embrace.testapp). Previous name: a.bid */
-    @Json(name = "app_ecosystem_id")
-    val appEcosystemId: String? = null,
 
     /* (Android) - the buildType name. Previous name: a.bt */
     @Json(name = "build_type")

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -45,7 +45,6 @@ import com.squareup.moshi.JsonClass
  * @param sdkVersion The version number of the Embrace SDK. Previous name: a.sdk
  * @param sdkSimpleVersion The simple version number of the Embrace SDK. Previous name: a.sdc
  * @param reactNativeBundleId (React Native) the MD5 hash of the React Native bundle file. Previous name: a.rn
- * @param reactNativeVersion (React Native) the React Native version number. Previous name: a.rnv
  * @param javascriptPatchNumber (React Native) the JavaScript patch number. Previous name: a.jsp
  * @param hostedPlatformVersion The version of the hosted platform engine, i.e.
  * Unity/React Native/Flutter. Previous name: a.unv
@@ -109,10 +108,6 @@ data class EnvelopeResource(
     /* (React Native) the MD5 hash of the React Native bundle file. Previous name: a.rn */
     @Json(name = "react_native_bundle_id")
     val reactNativeBundleId: String? = null,
-
-    /* (React Native) the React Native version number. Previous name: a.rnv */
-    @Json(name = "react_native_version")
-    val reactNativeVersion: String? = null,
 
     /* (React Native) the JavaScript patch number. Previous name: a.jsp */
     @Json(name = "javascript_patch_number")

--- a/embrace-android-sdk/src/test/resources/v2_session_expected.json
+++ b/embrace-android-sdk/src/test/resources/v2_session_expected.json
@@ -15,7 +15,6 @@
     "app_version": "2.5.1",
     "app_framework": 1,
     "build_id": "fakeBuildId",
-    "app_ecosystem_id": "com.fake.package",
     "build_type": "fakeBuildType",
     "build_flavor": "fakeBuildFlavor",
     "environment": "dev",


### PR DESCRIPTION
Removed fields:
- app_ecosystem_id
- react_native_version

Will remove additional fields in a separate PR, along with AppInfo and DeviceInfo:
- build_type
- build_flavor
- bundle_version
- os_code
- screen_resolution
- num_cores
