### PR TITLE
Create OkHttp on background thread during initialization

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilder.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilder.kt
@@ -15,7 +15,7 @@ internal class EmbraceApiUrlBuilder(
     }
 
     override val appId: String = checkNotNull(instrumentedConfig.project.getAppId())
-    private val coreBaseUrl = instrumentedConfig.baseUrls.getData() ?: "https://a-$appId.$DATA_DEFAULT/api"
+    private val coreBaseUrl = instrumentedConfig.baseUrls.getData() ?: "https://a-$appId.$DATA_DEFAULT"
     private val configBaseUrl = instrumentedConfig.baseUrls.getConfig() ?: "https://a-$appId.$CONFIG_DEFAULT"
     private val operatingSystemCode = Build.VERSION.SDK_INT.toString() + ".0.0"
     override val baseDataUrl: String = resolveUrl(Endpoint.SESSIONS).split(Endpoint.SESSIONS.path).first()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
@@ -8,10 +8,12 @@ import java.util.concurrent.TimeUnit
 
 class CombinedRemoteConfigSource(
     private val store: RemoteConfigStore,
-    private val httpSource: RemoteConfigSource,
+    httpSource: Lazy<RemoteConfigSource>,
     private val worker: BackgroundWorker,
     private val intervalMs: Long = 60 * 60 * 1000
 ) {
+
+    private val httpSource: RemoteConfigSource by httpSource
 
     // the remote config that is used for the lifetime of the process.
     private val response by lazy {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -70,7 +70,7 @@ internal class EmbraceApiServiceTest {
         var finished = false
         apiService.sendSession({ it.write(payload) }) { finished = true }
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/spans",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/spans",
             expectedPayload = payload
         )
         assertTrue(finished)
@@ -100,7 +100,7 @@ internal class EmbraceApiServiceTest {
         val type: ParameterizedType = TypeUtils.parameterizedType(Envelope::class, LogPayload::class)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getGenericsExpectedPayloadSerialized(logsEnvelope, type)
         )
     }
@@ -130,7 +130,7 @@ internal class EmbraceApiServiceTest {
 
         val request = fakePendingApiCallsSender.retryQueue.single().first
         val payload = fakePendingApiCallsSender.retryQueue.single().second
-        assertEquals("https://a-$fakeAppId.data.emb-api.com/api/v2/logs", request.url.url)
+        assertEquals("https://a-$fakeAppId.data.emb-api.com/v2/logs", request.url.url)
         val type: ParameterizedType = TypeUtils.parameterizedType(Envelope::class, LogPayload::class)
         assertArrayEquals(getGenericsExpectedPayloadSerialized(logsEnvelope, type), payload)
     }
@@ -149,7 +149,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
         assertEquals(0, fakeApiClient.sentRequests.size)
         val request = fakePendingApiCallsSender.retryQueue.single().first
-        assertEquals("https://a-$fakeAppId.data.emb-api.com/api/v2/logs", request.url.url)
+        assertEquals("https://a-$fakeAppId.data.emb-api.com/v2/logs", request.url.url)
     }
 
     @Test
@@ -165,7 +165,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(1, fakePendingApiCallsSender.retryQueue.size)
@@ -183,7 +183,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(1, fakePendingApiCallsSender.retryQueue.size)
@@ -204,7 +204,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(0, fakePendingApiCallsSender.retryQueue.size)
@@ -222,7 +222,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(0, fakePendingApiCallsSender.retryQueue.size)
@@ -243,7 +243,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(0, fakePendingApiCallsSender.retryQueue.size)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
@@ -29,11 +29,11 @@ internal class EmbraceApiUrlBuilderTest {
             apiUrlBuilder.resolveUrl(Endpoint.CONFIG)
         )
         assertEquals(
-            "https://a-$APP_ID.data.emb-api.com/api/v2/logs",
+            "https://a-$APP_ID.data.emb-api.com/v2/logs",
             apiUrlBuilder.resolveUrl(Endpoint.LOGS)
         )
         assertEquals(
-            "https://a-$APP_ID.data.emb-api.com/api/v2/spans",
+            "https://a-$APP_ID.data.emb-api.com/v2/spans",
             apiUrlBuilder.resolveUrl(Endpoint.SESSIONS)
         )
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -270,11 +270,11 @@ internal class EmbracePendingApiCallsSenderTest {
 
         // verify logs were added to the queue, and oldest added requests are dropped
         assertEquals(
-            "https://a-abcde.data.emb-api.com/api/v2/logs",
+            "https://a-abcde.data.emb-api.com/v2/logs",
             queue.pollNextPendingApiCall()?.apiRequest?.url?.url
         )
         assertEquals(
-            "https://a-abcde.data.emb-api.com/api/v2/logs",
+            "https://a-abcde.data.emb-api.com/v2/logs",
             queue.pollNextPendingApiCall()?.apiRequest?.url?.url
         )
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
@@ -26,7 +26,7 @@ class CombinedRemoteConfigSourceTest {
         remoteConfigStore = FakeRemoteConfigStore()
         source = CombinedRemoteConfigSource(
             remoteConfigStore,
-            remoteConfigSource,
+            lazy { remoteConfigSource },
             BackgroundWorker(executorService)
         )
     }
@@ -41,7 +41,7 @@ class CombinedRemoteConfigSourceTest {
         val cfg = RemoteConfig(100)
         source = CombinedRemoteConfigSource(
             FakeRemoteConfigStore(ConfigHttpResponse(cfg, null)),
-            remoteConfigSource,
+            lazy { remoteConfigSource },
             BackgroundWorker(executorService)
         )
         assertEquals(cfg, source.getConfig())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -67,9 +67,9 @@ internal class EmbraceNetworkCaptureServiceTest {
 
     @Test
     fun `test capture rule doesn't capture Embrace endpoints`() {
-        val rule = getDefaultRule(urlRegex = "https://a-abcde.data.emb-api.com/api/v2")
+        val rule = getDefaultRule(urlRegex = "https://a-abcde.data.emb-api.com/v2")
         cfg = RemoteConfig(networkCaptureRules = setOf(rule))
-        val result = getService().getNetworkCaptureRules("https://a-abcde.data.emb-api.com/api/v2/spans", "GET")
+        val result = getService().getNetworkCaptureRules("https://a-abcde.data.emb-api.com/v2/spans", "GET")
         assertEquals(0, result.size)
     }
 


### PR DESCRIPTION
## Goal

The SDK instantiates OkHttp on the main thread which hit perf. We should load it on a background thread instead.

<img width="1138" alt="baseline" src="https://github.com/user-attachments/assets/5b0a41c7-29a6-4165-8083-8ff2f6d97bdb">
<img width="1092" alt="Screenshot 2024-11-14 at 13 06 26" src="https://github.com/user-attachments/assets/393754a7-243c-44b4-a611-551b1380d73a">
