### PR TITLE
Use correct endpoint for spans + logs

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilder.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilder.kt
@@ -15,7 +15,7 @@ internal class EmbraceApiUrlBuilder(
     }
 
     override val appId: String = checkNotNull(instrumentedConfig.project.getAppId())
-    private val coreBaseUrl = instrumentedConfig.baseUrls.getData() ?: "https://a-$appId.$DATA_DEFAULT/api"
+    private val coreBaseUrl = instrumentedConfig.baseUrls.getData() ?: "https://a-$appId.$DATA_DEFAULT"
     private val configBaseUrl = instrumentedConfig.baseUrls.getConfig() ?: "https://a-$appId.$CONFIG_DEFAULT"
     private val operatingSystemCode = Build.VERSION.SDK_INT.toString() + ".0.0"
     override val baseDataUrl: String = resolveUrl(Endpoint.SESSIONS).split(Endpoint.SESSIONS.path).first()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiServiceTest.kt
@@ -70,7 +70,7 @@ internal class EmbraceApiServiceTest {
         var finished = false
         apiService.sendSession({ it.write(payload) }) { finished = true }
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/spans",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/spans",
             expectedPayload = payload
         )
         assertTrue(finished)
@@ -100,7 +100,7 @@ internal class EmbraceApiServiceTest {
         val type: ParameterizedType = TypeUtils.parameterizedType(Envelope::class, LogPayload::class)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getGenericsExpectedPayloadSerialized(logsEnvelope, type)
         )
     }
@@ -130,7 +130,7 @@ internal class EmbraceApiServiceTest {
 
         val request = fakePendingApiCallsSender.retryQueue.single().first
         val payload = fakePendingApiCallsSender.retryQueue.single().second
-        assertEquals("https://a-$fakeAppId.data.emb-api.com/api/v2/logs", request.url.url)
+        assertEquals("https://a-$fakeAppId.data.emb-api.com/v2/logs", request.url.url)
         val type: ParameterizedType = TypeUtils.parameterizedType(Envelope::class, LogPayload::class)
         assertArrayEquals(getGenericsExpectedPayloadSerialized(logsEnvelope, type), payload)
     }
@@ -149,7 +149,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
         assertEquals(0, fakeApiClient.sentRequests.size)
         val request = fakePendingApiCallsSender.retryQueue.single().first
-        assertEquals("https://a-$fakeAppId.data.emb-api.com/api/v2/logs", request.url.url)
+        assertEquals("https://a-$fakeAppId.data.emb-api.com/v2/logs", request.url.url)
     }
 
     @Test
@@ -165,7 +165,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(1, fakePendingApiCallsSender.retryQueue.size)
@@ -183,7 +183,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(1, fakePendingApiCallsSender.retryQueue.size)
@@ -204,7 +204,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(0, fakePendingApiCallsSender.retryQueue.size)
@@ -222,7 +222,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(0, fakePendingApiCallsSender.retryQueue.size)
@@ -243,7 +243,7 @@ internal class EmbraceApiServiceTest {
         apiService.sendLogEnvelope(logPayload)
 
         verifyOnlyRequest(
-            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/api/v2/logs",
+            expectedUrl = "https://a-$fakeAppId.data.emb-api.com/v2/logs",
             expectedPayload = getExpectedPayloadSerialized(logPayload, logType)
         )
         assertEquals(0, fakePendingApiCallsSender.retryQueue.size)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/EmbraceApiUrlBuilderTest.kt
@@ -29,11 +29,11 @@ internal class EmbraceApiUrlBuilderTest {
             apiUrlBuilder.resolveUrl(Endpoint.CONFIG)
         )
         assertEquals(
-            "https://a-$APP_ID.data.emb-api.com/api/v2/logs",
+            "https://a-$APP_ID.data.emb-api.com/v2/logs",
             apiUrlBuilder.resolveUrl(Endpoint.LOGS)
         )
         assertEquals(
-            "https://a-$APP_ID.data.emb-api.com/api/v2/spans",
+            "https://a-$APP_ID.data.emb-api.com/v2/spans",
             apiUrlBuilder.resolveUrl(Endpoint.SESSIONS)
         )
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/delivery/EmbracePendingApiCallsSenderTest.kt
@@ -270,11 +270,11 @@ internal class EmbracePendingApiCallsSenderTest {
 
         // verify logs were added to the queue, and oldest added requests are dropped
         assertEquals(
-            "https://a-abcde.data.emb-api.com/api/v2/logs",
+            "https://a-abcde.data.emb-api.com/v2/logs",
             queue.pollNextPendingApiCall()?.apiRequest?.url?.url
         )
         assertEquals(
-            "https://a-abcde.data.emb-api.com/api/v2/logs",
+            "https://a-abcde.data.emb-api.com/v2/logs",
             queue.pollNextPendingApiCall()?.apiRequest?.url?.url
         )
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -67,9 +67,9 @@ internal class EmbraceNetworkCaptureServiceTest {
 
     @Test
     fun `test capture rule doesn't capture Embrace endpoints`() {
-        val rule = getDefaultRule(urlRegex = "https://a-abcde.data.emb-api.com/api/v2")
+        val rule = getDefaultRule(urlRegex = "https://a-abcde.data.emb-api.com/v2")
         cfg = RemoteConfig(networkCaptureRules = setOf(rule))
-        val result = getService().getNetworkCaptureRules("https://a-abcde.data.emb-api.com/api/v2/spans", "GET")
+        val result = getService().getNetworkCaptureRules("https://a-abcde.data.emb-api.com/v2/spans", "GET")
         assertEquals(0, result.size)
     }
 


### PR DESCRIPTION
## Goal

#1656 mistakenly added `/api` as a prefix of the span + log endpoints, whereas in reality this isn't used. I've updated the code to point at the correct endpoint. This likely crept in because the integration tests require _some_ path to be specified for the baseUrl of mockwebserver, and I picked 'api'.

## Testing

Updated unit tests to use correct assertions & confirmed that config, log, and session requests succeed.
