### PR TITLE
Alter how threshold works for disabling the SDK

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BehaviorThresholdCheck.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BehaviorThresholdCheck.kt
@@ -10,6 +10,10 @@ class BehaviorThresholdCheck(
     private val deviceIdProvider: Provider<String>,
 ) {
 
+    private companion object {
+        private const val DIGITS = 6
+    }
+
     /**
      * An implementation of [isBehaviorEnabled] that returns null if the pctEnabled parameter
      * is null.
@@ -40,26 +44,16 @@ class BehaviorThresholdCheck(
         if (pctEnabled <= 0 || pctEnabled > 100) {
             return false
         }
-        val deviceId = getNormalizedLargeDeviceId()
+        val deviceId = getNormalizedDeviceId()
         return pctEnabled >= deviceId
     }
 
-    fun getNormalizedLargeDeviceId(): Float = getNormalizedDeviceId(6)
-
-    /**
-     * Use [.isBehaviorEnabled] instead as it allows rollouts to be controlled
-     * at greater granularity.
-     */
-    @Deprecated("")
-    fun getNormalizedDeviceId(): Float = getNormalizedDeviceId(2)
-
-    private fun getNormalizedDeviceId(digits: Int): Float {
+    fun getNormalizedDeviceId(): Float {
         val deviceId = deviceIdProvider()
-        val finalChars = deviceId.substring(deviceId.length - digits)
-
+        val finalChars = deviceId.substring(deviceId.length - DIGITS)
         // Normalize the device ID to a value between 0.0 - 100.0
         val radix = 16
-        val space = (radix.toDouble().pow(digits.toDouble()) - 1).toInt()
+        val space = (radix.toDouble().pow(DIGITS.toDouble()) - 1).toInt()
         val value = Integer.valueOf(finalChars, radix)
         return value.toFloat() / space * 100
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImpl.kt
@@ -39,7 +39,6 @@ class SdkModeBehaviorImpl(
     private fun getOffset(): Int = remote?.offset ?: DEFAULT_OFFSET
 
     override fun isSdkDisabled(): Boolean {
-        @Suppress("DEPRECATION")
         val result = thresholdCheck.getNormalizedDeviceId()
         // Check if this is lower than the threshold, to determine whether
         // we should enable/disable the SDK.

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
@@ -90,35 +90,19 @@ internal class ConfigServiceImplTest {
         clearAllMocks()
     }
 
-    @Suppress("DEPRECATION")
-    @Test
-    fun `test legacy normalized DeviceId`() {
-        fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D0700"
-        assertEquals(0.0, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
-
-        fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D07FF"
-        assertEquals(100.0, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
-
-        fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D0739"
-        assertEquals(22.35, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
-
-        fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D07D9"
-        assertEquals(85.09, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
-    }
-
     @Test
     fun `test new normalized DeviceId`() {
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC000000"
-        assertEquals(0.0, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(0.0, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFCFFFFFF"
-        assertEquals(100.0, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(100.0, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFC0D0739"
-        assertEquals(5.08, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(5.08, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
 
         fakePreferenceService.deviceIdentifier = "07D85B44E4E245F4A30E559BFCED0739"
-        assertEquals(92.58, thresholdCheck.getNormalizedLargeDeviceId().toDouble(), 0.01)
+        assertEquals(92.58, thresholdCheck.getNormalizedDeviceId().toDouble(), 0.01)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Alters how the SDK calculates whether it should be disabled by checking the last 6 digits of the device ID. This matches the behavior with iOS & allows for more granular control of behavior.

## Testing

Relied on existing test coverage.
