### PR TITLE
Add extra debugging for delivery layer failures

### DIFF
--- a/embrace-android-core/config/detekt/baseline.xml
+++ b/embrace-android-core/config/detekt/baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>LongParameterList:DeliveryModuleSupplier.kt$( configModule: ConfigModule, initModule: InitModule, otelModule: OpenTelemetryModule, workerThreadModule: WorkerThreadModule, coreModule: CoreModule, storageModule: StorageModule, essentialServiceModule: EssentialServiceModule, androidServicesModule: AndroidServicesModule, payloadStorageServiceProvider: Provider&lt;PayloadStorageService&gt;?, cacheStorageServiceProvider: Provider&lt;PayloadStorageService&gt;?, requestExecutionServiceProvider: Provider&lt;RequestExecutionService&gt;?, deliveryServiceProvider: Provider&lt;DeliveryService&gt;?, )</ID>
+    <ID>LongParameterList:DeliveryModuleSupplier.kt$( configModule: ConfigModule, initModule: InitModule, otelModule: OpenTelemetryModule, workerThreadModule: WorkerThreadModule, coreModule: CoreModule, storageModule: StorageModule, essentialServiceModule: EssentialServiceModule, androidServicesModule: AndroidServicesModule, payloadStorageServiceProvider: Provider&lt;PayloadStorageService&gt;?, cacheStorageServiceProvider: Provider&lt;PayloadStorageService&gt;?, requestExecutionServiceProvider: Provider&lt;RequestExecutionService&gt;?, deliveryServiceProvider: Provider&lt;DeliveryService&gt;?, deliveryTracer: DeliveryTracer?, )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
@@ -23,4 +24,5 @@ interface DeliveryModule {
     val cacheStorageService: PayloadStorageService?
     val requestExecutionService: RequestExecutionService?
     val schedulingService: SchedulingService?
+    val deliveryTracer: DeliveryTracer?
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.comms.delivery.EmbraceDeliveryServ
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingServiceImpl
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.HttpUrlConnectionRequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.execution.OkHttpRequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
@@ -35,7 +36,8 @@ internal class DeliveryModuleImpl(
     requestExecutionServiceProvider: Provider<RequestExecutionService>?,
     payloadStorageServiceProvider: Provider<PayloadStorageService>?,
     cacheStorageServiceProvider: Provider<PayloadStorageService>?,
-    deliveryServiceProvider: Provider<DeliveryService>?
+    deliveryServiceProvider: Provider<DeliveryService>?,
+    override val deliveryTracer: DeliveryTracer? = null,
 ) : DeliveryModule {
 
     private val processIdProvider = { otelModule.openTelemetryConfiguration.processIdentifier }
@@ -85,7 +87,8 @@ internal class DeliveryModuleImpl(
                 cacheStorageService,
                 initModule.logger,
                 initModule.jsonSerializer,
-                dataPersistenceWorker
+                dataPersistenceWorker,
+                deliveryTracer
             )
         }
     }
@@ -106,7 +109,8 @@ internal class DeliveryModuleImpl(
                 periodicSessionCacher,
                 initModule.clock,
                 essentialServiceModule.sessionIdTracker,
-                payloadStore
+                payloadStore,
+                deliveryTracer
             )
         }
     }
@@ -121,6 +125,7 @@ internal class DeliveryModuleImpl(
                 processIdProvider,
                 PayloadStorageServiceImpl.OutputType.PAYLOAD,
                 initModule.logger,
+                deliveryTracer
             )
         }
     }
@@ -135,6 +140,7 @@ internal class DeliveryModuleImpl(
                 processIdProvider,
                 PayloadStorageServiceImpl.OutputType.CACHE,
                 initModule.logger,
+                deliveryTracer
             )
         }
     }
@@ -154,6 +160,7 @@ internal class DeliveryModuleImpl(
                     appId,
                     BuildConfig.VERSION_NAME,
                     initModule.logger,
+                    deliveryTracer
                 )
             } else {
                 HttpUrlConnectionRequestExecutionService(
@@ -179,7 +186,8 @@ internal class DeliveryModuleImpl(
                 workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
                 workerThreadModule.backgroundWorker(Worker.Background.HttpRequestWorker),
                 initModule.clock,
-                initModule.logger
+                initModule.logger,
+                deliveryTracer
             )
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleSupplier.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.utils.Provider
@@ -21,6 +22,7 @@ typealias DeliveryModuleSupplier = (
     cacheStorageServiceProvider: Provider<PayloadStorageService>?,
     requestExecutionServiceProvider: Provider<RequestExecutionService>?,
     deliveryServiceProvider: Provider<DeliveryService>?,
+    deliveryTracer: DeliveryTracer?,
 ) -> DeliveryModule
 
 fun createDeliveryModule(
@@ -36,6 +38,7 @@ fun createDeliveryModule(
     cacheStorageServiceProvider: Provider<PayloadStorageService>?,
     requestExecutionServiceProvider: Provider<RequestExecutionService>?,
     deliveryServiceProvider: Provider<DeliveryService>?,
+    deliveryTracer: DeliveryTracer?,
 ): DeliveryModule = DeliveryModuleImpl(
     configModule,
     initModule,
@@ -48,5 +51,6 @@ fun createDeliveryModule(
     requestExecutionServiceProvider,
     payloadStorageServiceProvider,
     cacheStorageServiceProvider,
-    deliveryServiceProvider
+    deliveryServiceProvider,
+    deliveryTracer
 )

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
@@ -1,0 +1,103 @@
+package io.embrace.android.embracesdk.internal.delivery.debug
+
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult
+
+/**
+ * Models states in the delivery layer that can be useful as a starting point for debugging
+ * problems with payload delivery. This is not an exhaustive model of states and it may be helpful to add
+ * more in future to aid debugging.
+ */
+internal sealed class DeliveryTraceState {
+
+    /**
+     * The schedule service was informed of a new payload
+     */
+    internal class IntakeServiceAcceptedEnvelope(val metadata: StoredTelemetryMetadata) : DeliveryTraceState() {
+        override fun toString(): String = "IntakeServiceAccepted, ${metadata.toReportString()}"
+    }
+
+    /**
+     * An envelope was accepted by the intake service
+     */
+    internal object ScheduleServiceInformed : DeliveryTraceState() {
+        override fun toString(): String = "ScheduleServiceInformed"
+    }
+
+    /**
+     * The payload store service persisted a payload
+     */
+    internal class PayloadStored(val metadata: StoredTelemetryMetadata) : DeliveryTraceState() {
+        override fun toString(): String = "PayloadStored, ${metadata.toReportString()}"
+    }
+
+    /**
+     * The payload store service deleted a payload
+     */
+    internal class PayloadDeleted(val metadata: StoredTelemetryMetadata) : DeliveryTraceState() {
+        override fun toString(): String = "PayloadDeleted, ${metadata.toReportString()}"
+    }
+
+    /**
+     * The payload store service loaded a payload
+     */
+    internal class PayloadLoaded(val success: Boolean) : DeliveryTraceState() {
+        override fun toString(): String = "PayloadLoaded, success=$success"
+    }
+
+    /**
+     * The payload store returned a list of payloads by priority
+     */
+    internal class GetPayloadsByPriority(val payloads: List<StoredTelemetryMetadata>) : DeliveryTraceState() {
+        override fun toString(): String = "GetPayloadsByPriority, count=${payloads.size},\n${payloads.reportListString()}"
+    }
+
+    /**
+     * The payload store returned a list of undelivered payloads
+     */
+    internal class GetUndeliveredPayloads(val payloads: List<StoredTelemetryMetadata>) : DeliveryTraceState() {
+        override fun toString(): String = "GetUndeliveredPayloads, count=${payloads.size},\n${payloads.reportListString()}"
+    }
+
+    /**
+     * A HTTP call ended with the attached results
+     */
+    internal class HttpCallEnded(
+        val result: ExecutionResult,
+        val envelopeType: SupportedEnvelopeType,
+        val payloadType: String,
+    ) : DeliveryTraceState() {
+        override fun toString(): String = "HttpCallEnded, ${result.javaClass.simpleName}, $envelopeType, $payloadType"
+    }
+
+    /**
+     * Session caching was started for the current session
+     */
+    internal object SessionCachingStarted : DeliveryTraceState() {
+        override fun toString(): String = "SessionCachingStarted"
+    }
+
+    /**
+     * Session caching was stopped for the current session
+     */
+    internal object SessionCachingStopped : DeliveryTraceState() {
+        override fun toString(): String = "SessionCachingStopped"
+    }
+
+    /**
+     * A session was written to the cache.
+     */
+    internal object SessionCacheAttempt : DeliveryTraceState() {
+        override fun toString(): String = "SessionCacheAttempt"
+    }
+
+    internal fun StoredTelemetryMetadata.toReportString(): String {
+        return "$timestamp, $uuid, $payloadType, complete=$complete"
+    }
+
+    internal fun List<StoredTelemetryMetadata>.reportListString() = joinToString(
+        "\n",
+        transform = { it.toReportString() }
+    )
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
@@ -1,0 +1,62 @@
+package io.embrace.android.embracesdk.internal.delivery.debug
+
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult
+import java.util.concurrent.CopyOnWriteArrayList
+
+class DeliveryTracer {
+
+    private val events: MutableList<DeliveryTraceState> = CopyOnWriteArrayList()
+
+    fun onHttpCallEnded(result: ExecutionResult, envelopeType: SupportedEnvelopeType, payloadType: String) {
+        events.add(DeliveryTraceState.HttpCallEnded(result, envelopeType, payloadType))
+    }
+
+    fun onPayloadIntake() {
+        events.add(DeliveryTraceState.ScheduleServiceInformed)
+    }
+
+    fun onTake(metadata: StoredTelemetryMetadata) {
+        events.add(DeliveryTraceState.IntakeServiceAcceptedEnvelope(metadata))
+    }
+
+    fun onStore(metadata: StoredTelemetryMetadata) {
+        events.add(DeliveryTraceState.PayloadStored(metadata))
+    }
+
+    fun onDelete(metadata: StoredTelemetryMetadata) {
+        events.add(DeliveryTraceState.PayloadDeleted(metadata))
+    }
+
+    fun onLoadPayloadAsStream(success: Boolean) {
+        events.add(DeliveryTraceState.PayloadLoaded(success))
+    }
+
+    fun onGetPayloadsByPriority(payloads: List<StoredTelemetryMetadata>) {
+        events.add(DeliveryTraceState.GetPayloadsByPriority(payloads))
+    }
+
+    fun onGetUndeliveredPayloads(payloads: List<StoredTelemetryMetadata>) {
+        events.add(DeliveryTraceState.GetUndeliveredPayloads(payloads))
+    }
+
+    fun onCachingStopped() {
+        events.add(DeliveryTraceState.SessionCachingStopped)
+    }
+
+    fun onCachingStarted() {
+        events.add(DeliveryTraceState.SessionCachingStarted)
+    }
+
+    fun onSessionCache() {
+        events.add(DeliveryTraceState.SessionCacheAttempt)
+    }
+
+    fun generateReport(): String {
+        return "Delivery layer Trace Report\n" +
+            events.toList().mapIndexed { k, state ->
+                "#$k, $state"
+            }.joinToString("\n")
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.delivery.execution
 import io.embrace.android.embracesdk.internal.comms.api.ApiRequestV2
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult.Companion.getResult
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -24,6 +25,7 @@ class OkHttpRequestExecutionService(
     private val appId: String,
     private val embraceVersionName: String,
     private val logger: EmbLogger,
+    private val deliveryTracer: DeliveryTracer? = null,
 ) : RequestExecutionService {
 
     override fun attemptHttpRequest(
@@ -65,7 +67,9 @@ class OkHttpRequestExecutionService(
             responseCode = httpCallResponse?.code,
             headersProvider = { httpCallResponse?.headers?.toMap() ?: emptyMap() },
             executionError = executionError,
-        )
+        ).apply {
+            deliveryTracer?.onHttpCallEnded(this, envelopeType, payloadType)
+        }
     }
 
     private fun Endpoint.getApiRequestFromEndpoint(): ApiRequestV2 = ApiRequestV2(

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.delivery.intake
 
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
@@ -18,6 +19,7 @@ class IntakeServiceImpl(
     private val logger: EmbLogger,
     private val serializer: PlatformSerializer,
     private val worker: PriorityWorker<StoredTelemetryMetadata>,
+    private val deliveryTracer: DeliveryTracer? = null,
     private val shutdownTimeoutMs: Long = 3000,
 ) : IntakeService {
 
@@ -29,6 +31,7 @@ class IntakeServiceImpl(
     }
 
     override fun take(intake: Envelope<*>, metadata: StoredTelemetryMetadata) {
+        deliveryTracer?.onTake(metadata)
         val future = worker.submit(metadata) {
             processIntake(intake, metadata)
         }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
@@ -26,6 +27,7 @@ class SchedulingServiceImpl(
     private val deliveryWorker: BackgroundWorker,
     private val clock: Clock,
     private val logger: EmbLogger,
+    private val deliveryTracer: DeliveryTracer? = null
 ) : SchedulingService {
 
     private val blockedEndpoints: MutableMap<Endpoint, Long> = ConcurrentHashMap()
@@ -37,6 +39,7 @@ class SchedulingServiceImpl(
     private val payloadsToRetry: MutableMap<StoredTelemetryMetadata, RetryInstance> = ConcurrentHashMap()
 
     override fun onPayloadIntake() {
+        deliveryTracer?.onPayloadIntake()
         queryForPayloads.set(true)
         startDeliveryLoop()
     }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -90,7 +90,7 @@ class PayloadStorageServiceImplTest {
     @Test
     fun `test objects pruned past limit`() {
         assertNull(outputDir.listFiles())
-        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger, 4)
+        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger, null, 4)
 
         // exceed storage limit
         listOf(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeCoreModule
 import io.embrace.android.embracesdk.internal.comms.delivery.DeliveryService
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
@@ -73,7 +74,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                 { lifecycleOwner }
             ) { networkConnectivityService }
         },
-        deliveryModuleSupplier = { configModule, otelModule, initModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, androidServicesModule, _, _, _, _ ->
+        deliveryModuleSupplier = { configModule, initModule, otelModule, workerThreadModule, coreModule, storageModule, essentialServiceModule, androidServicesModule, _, _, _, _, _ ->
             val requestExecutionServiceProvider: Provider<RequestExecutionService>? = when {
                 useMockWebServer -> null
                 else -> ::FakeRequestExecutionService
@@ -84,8 +85,8 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
             }
             createDeliveryModule(
                 configModule,
-                otelModule,
                 initModule,
+                otelModule,
                 workerThreadModule,
                 coreModule,
                 storageModule,
@@ -94,7 +95,8 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                 payloadStorageServiceProvider = payloadStorageServiceProvider,
                 cacheStorageServiceProvider = cacheStorageServiceProvider,
                 requestExecutionServiceProvider = requestExecutionServiceProvider,
-                deliveryServiceProvider = deliveryServiceProvider
+                deliveryServiceProvider = deliveryServiceProvider,
+                deliveryTracer = DeliveryTracer()
             )
         },
         anrModuleSupplier = { _, _, _ -> fakeAnrModule },

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -289,6 +289,7 @@ internal class ModuleInitBootstrapper(
                             null,
                             null,
                             null,
+                            null,
                             null
                         )
                     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -46,7 +46,7 @@ internal fun fakeModuleInitBootstrapper(
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
-    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
+    deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _ -> FakeNativeCoreModule() },

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeDeliveryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeDeliveryModule.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakePayloadStore
 import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.fakes.FakeSchedulingService
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
@@ -24,4 +25,5 @@ class FakeDeliveryModule(
     override val cacheStorageService: PayloadStorageService = FakePayloadStorageService(),
     override val requestExecutionService: RequestExecutionService = FakeRequestExecutionService(),
     override val schedulingService: SchedulingService = FakeSchedulingService(),
+    override val deliveryTracer: DeliveryTracer? = null
 ) : DeliveryModule


### PR DESCRIPTION
## Goal

Adds extra debugging for failures in the delivery layer. When a log/session envelope doesn't match the expected number of payloads in an integration test, the error message will now print a trace of important state changes & milestones that happened in the delivery layer.

This does not track all important events (e.g. resurrection) but IMO is good enough to include for now, and we can expand it later if needed.

An example of what an error message looks like can be found below, which was generated by tweaking an assertion in `BreadcrumbFeatureTest` to fail.


```
Expected 3 envelopes, but got 2. Envelopes: [{sessionId=E9BDFEFCA7E64D79AE94AEBBA8C05435, cleanExit=true, state=foreground}, {sessionId=C946E4B93A5947709786DCC10A60589F, cleanExit=true, state=foreground}].
Delivery layer Trace Report
#0, SessionCachingStopped
#1, SessionCachingStarted
#2, SessionCacheAttempt
#3, IntakeServiceAccepted, 169220160000, FE202B1E218541EE830D8FC2A7EAFA38, SESSION, complete=false
#4, PayloadStored, 169220160000, FE202B1E218541EE830D8FC2A7EAFA38, SESSION, complete=false
#5, GetUndeliveredPayloads, count=0,

#6, ScheduleServiceInformed
#7, GetPayloadsByPriority, count=0,

#8, SessionCachingStopped
#9, IntakeServiceAccepted, 169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
#10, SessionCachingStarted
#11, SessionCacheAttempt
#12, IntakeServiceAccepted, 169220160000, 4AAFE498C61748FBB668E7785EC4A7C8, SESSION, complete=false
#13, PayloadStored, 169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
#14, ScheduleServiceInformed
#15, GetPayloadsByPriority, count=1,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
#16, GetPayloadsByPriority, count=1,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
#17, PayloadLoaded, success=true
#18, PayloadStored, 169220160000, 4AAFE498C61748FBB668E7785EC4A7C8, SESSION, complete=false
#19, PayloadDeleted, 169220160000, FE202B1E218541EE830D8FC2A7EAFA38, SESSION, complete=false
#20, PayloadDeleted, 169220160000, FE202B1E218541EE830D8FC2A7EAFA38, SESSION, complete=false
#21, SessionCachingStopped
#22, IntakeServiceAccepted, 169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
#23, SessionCachingStarted
#24, SessionCacheAttempt
#25, IntakeServiceAccepted, 169220190000, 6D47880F45A74254A8CF572718C8F325, SESSION, complete=false
#26, PayloadStored, 169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
#27, ScheduleServiceInformed
#28, GetPayloadsByPriority, count=2,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
#29, GetPayloadsByPriority, count=2,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
#30, PayloadDeleted, 169220160000, 4AAFE498C61748FBB668E7785EC4A7C8, SESSION, complete=false
#31, SessionCachingStopped
#32, PayloadStored, 169220190000, 6D47880F45A74254A8CF572718C8F325, SESSION, complete=false
#33, PayloadDeleted, 169220160000, 4AAFE498C61748FBB668E7785EC4A7C8, SESSION, complete=false
#34, IntakeServiceAccepted, 169220210000, 55847F6D875C4D418A33186C63214BDA, SESSION, complete=true
#35, SessionCachingStarted
#36, SessionCacheAttempt
#37, SessionCachingStopped
#38, IntakeServiceAccepted, 169220240000, 2F771B59CE9C4AA5A6C591E0F846BAF6, SESSION, complete=false
#39, IntakeServiceAccepted, 169220240000, 13CF40CE469E48D494417C79B03FDEFA, SESSION, complete=true
#40, PayloadStored, 169220210000, 55847F6D875C4D418A33186C63214BDA, SESSION, complete=true
#41, ScheduleServiceInformed
#42, GetPayloadsByPriority, count=3,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
169220210000, 55847F6D875C4D418A33186C63214BDA, SESSION, complete=true
#43, GetPayloadsByPriority, count=3,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
169220210000, 55847F6D875C4D418A33186C63214BDA, SESSION, complete=true
#44, SessionCachingStarted
#45, PayloadDeleted, 169220190000, 6D47880F45A74254A8CF572718C8F325, SESSION, complete=false
#46, SessionCacheAttempt
#47, IntakeServiceAccepted, 169220240000, 94695DAF55C940EEA778829EE98C6807, SESSION, complete=false
#48, PayloadStored, 169220240000, 13CF40CE469E48D494417C79B03FDEFA, SESSION, complete=true
#49, ScheduleServiceInformed
#50, GetPayloadsByPriority, count=4,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
169220210000, 55847F6D875C4D418A33186C63214BDA, SESSION, complete=true
169220240000, 13CF40CE469E48D494417C79B03FDEFA, SESSION, complete=true
#51, PayloadDeleted, 169220190000, 6D47880F45A74254A8CF572718C8F325, SESSION, complete=false
#52, GetPayloadsByPriority, count=4,
169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
169220210000, 55847F6D875C4D418A33186C63214BDA, SESSION, complete=true
169220240000, 13CF40CE469E48D494417C79B03FDEFA, SESSION, complete=true
#53, PayloadStored, 169220240000, 94695DAF55C940EEA778829EE98C6807, SESSION, complete=false
#54, PayloadDeleted, 169220190000, 6D47880F45A74254A8CF572718C8F325, SESSION, complete=false
#55, HttpCallEnded, Success, SESSION, ux.session
#56, PayloadLoaded, success=true
#57, PayloadDeleted, 169220160000, 10C7FC4CB3C147B8AC342297B90B42EF, SESSION, complete=true
#58, HttpCallEnded, Success, SESSION, ux.session
#59, PayloadLoaded, success=true
#60, PayloadDeleted, 169220190000, 13B6F3BD82D44A088DC5DE6D19D1E35B, SESSION, complete=true
#61, HttpCallEnded, Success, SESSION, ux.session
#62, PayloadDeleted, 169220210000, 55847F6D875C4D418A33186C63214BDA, SESSION, complete=true
#63, PayloadLoaded, success=true
#64, HttpCallEnded, Success, SESSION, ux.session
#65, PayloadDeleted, 169220240000, 13CF40CE469E48D494417C79B03FDEFA, SESSION, complete=true
#66, SessionCacheAttempt
#67, IntakeServiceAccepted, 169220240000, 6189D9B6B1504AAAB31E39ECCC5CBB54, SESSION, complete=false
#68, PayloadStored, 169220240000, 6189D9B6B1504AAAB31E39ECCC5CBB54, SESSION, complete=false
#69, PayloadDeleted, 169220240000, 94695DAF55C940EEA778829EE98C6807, SESSION, complete=false
#70, SessionCacheAttempt
#71, IntakeServiceAccepted, 169220240000, 2FB6BD51B25542B7AE2EC6797B538EB7, SESSION, complete=false
#72, PayloadStored, 169220240000, 2FB6BD51B25542B7AE2EC6797B538EB7, SESSION, complete=false
#73, PayloadDeleted, 169220240000, 6189D9B6B1504AAAB31E39ECCC5CBB54, SESSION, complete=false
#74, SessionCacheAttempt
#75, IntakeServiceAccepted, 169220240000, B1DEF684092C4681B8C07746A52AD623, SESSION, complete=false
#76, PayloadStored, 169220240000, B1DEF684092C4681B8C07746A52AD623, SESSION, complete=false
#77, PayloadDeleted, 169220240000, 2FB6BD51B25542B7AE2EC6797B538EB7, SESSION, complete=false
#78, SessionCacheAttempt
#79, IntakeServiceAccepted, 169220240000, 0386576D8C2140439C7D0A1DCA08E2C3, SESSION, complete=false
#80, PayloadStored, 169220240000, 0386576D8C2140439C7D0A1DCA08E2C3, SESSION, complete=false
#81, PayloadDeleted, 169220240000, B1DEF684092C4681B8C07746A52AD623, SESSION, complete=false
#82, SessionCacheAttempt
#83, IntakeServiceAccepted, 169220240000, 5662946105E34943ABBCD16AC55209A2, SESSION, complete=false
#84, PayloadStored, 169220240000, 5662946105E34943ABBCD16AC55209A2, SESSION, complete=false
#85, PayloadDeleted, 169220240000, 0386576D8C2140439C7D0A1DCA08E2C3, SESSION, complete=false
#86, SessionCacheAttempt
#87, IntakeServiceAccepted, 169220240000, B41F51112EC648A78DB516E5CCC3A35E, SESSION, complete=false
#88, PayloadStored, 169220240000, B41F51112EC648A78DB516E5CCC3A35E, SESSION, complete=false
#89, PayloadDeleted, 169220240000, 5662946105E34943ABBCD16AC55209A2, SESSION, complete=false
java.lang.IllegalStateException: Expected 3 envelopes, but got 2. Envelopes: [{sessionId=E9BDFEFCA7E64D79AE94AEBBA8C05435, cleanExit=true, state=foreground}, {sessionId=C946E4B93A5947709786DCC10A60589F, cleanExit=true, state=foreground}].
```



