### PR TITLE
Fix bug in test assertion code

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -191,11 +191,11 @@ internal class EmbraceInternalInterfaceTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 val tapBreadcrumb = session.findSessionSpan().findEventOfType(EmbType.Ux.Tap)
-                tapBreadcrumb.attributes?.assertMatches {
-                    "view.name" to "button"
-                    "tap.coords" to "10,99"
-                    "tap.type" to "tap"
-                }
+                tapBreadcrumb.attributes?.assertMatches(mapOf(
+                    "view.name" to "button",
+                    "tap.coords" to "0,0",
+                    "tap.type" to "tap",
+                ))
             }
         )
     }
@@ -282,15 +282,15 @@ internal class EmbraceInternalInterfaceTest {
                         .associateBy { it.name })
                 assertEquals(4, spans.size)
                 with(checkNotNull(spans["tz-parent-span"])) {
-                    attributes?.assertMatches {
-                        "testkey" to "testvalue"
-                    }
+                    attributes?.assertMatches(mapOf(
+                        "testkey" to "testvalue",
+                    ))
                 }
                 with(checkNotNull(spans["tz-child-span"])) {
                     val spanEvent = checkNotNull(events)[0]
-                    spanEvent.attributes?.assertMatches {
-                        "key" to "value"
-                    }
+                    spanEvent.attributes?.assertMatches(mapOf(
+                        "key" to "value",
+                    ))
                     assertEquals("cool event bro", spanEvent.name)
                     assertEquals(Span.Status.ERROR, status)
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -193,11 +193,11 @@ internal class FlutterInternalInterfaceTest {
                     expectedEmbType = "sys.flutter_exception",
                     expectedState = "foreground",
                 )
-                log.attributes?.assertMatches {
-                    ExceptionAttributes.EXCEPTION_STACKTRACE.key to expectedStacktrace
-                    "emb.exception.context" to expectedContext
-                    "emb.exception.library" to expectedLibrary
-                }
+                log.attributes?.assertMatches(mapOf(
+                    ExceptionAttributes.EXCEPTION_STACKTRACE.key to expectedStacktrace,
+                    "emb.exception.context" to expectedContext,
+                    "emb.exception.library" to expectedLibrary,
+                ))
             }
         )
     }
@@ -238,11 +238,11 @@ internal class FlutterInternalInterfaceTest {
                     expectedEmbType = "sys.flutter_exception",
                     expectedState = "foreground",
                 )
-                log.attributes?.assertMatches {
-                    ExceptionAttributes.EXCEPTION_STACKTRACE.key to expectedStacktrace
-                    "emb.exception.context" to expectedContext
-                    "emb.exception.library" to expectedLibrary
-                }
+                log.attributes?.assertMatches(mapOf(
+                    ExceptionAttributes.EXCEPTION_STACKTRACE.key to expectedStacktrace,
+                    "emb.exception.context" to expectedContext,
+                    "emb.exception.library" to expectedLibrary,
+                ))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -231,9 +231,9 @@ internal class NetworkRequestApiTest {
                 }
             },
             assertAction = {
-                validateAndReturnExpectedNetworkSpan().attributes?.assertMatches {
+                validateAndReturnExpectedNetworkSpan().attributes?.assertMatches(mapOf(
                     "url.full" to URL
-                }
+                ))
             }
         )
     }
@@ -307,32 +307,32 @@ internal class NetworkRequestApiTest {
                         assertEquals(Span.Status.ERROR, status)
                     }
 
-                    attributes?.assertMatches {
-                        "url.full" to expectedRequest.url
-                        HttpAttributes.HTTP_REQUEST_METHOD.key to expectedRequest.httpMethod
-                        "emb.trace_id" to expectedRequest.traceId
-                        "emb.w3c_traceparent" to expectedRequest.w3cTraceparent
+                    attributes?.assertMatches(mapOf(
+                        "url.full" to expectedRequest.url,
+                        HttpAttributes.HTTP_REQUEST_METHOD.key to expectedRequest.httpMethod,
+                        "emb.trace_id" to expectedRequest.traceId,
+                        "emb.w3c_traceparent" to expectedRequest.w3cTraceparent,
                         HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key to when {
                             completed -> expectedRequest.responseCode
                             else -> null
-                        }
+                        },
                         HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key to when {
                             completed -> expectedRequest.bytesSent
                             else -> null
-                        }
+                        },
                         HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key to when {
                             completed -> expectedRequest.bytesReceived
                             else -> null
-                        }
+                        },
                         "error.type" to when {
                             completed -> null
                             else -> expectedRequest.errorType
-                        }
+                        },
                         ExceptionAttributes.EXCEPTION_MESSAGE.key to when {
                             completed -> null
                             else -> expectedRequest.errorMessage
-                        }
-                    }
+                        },
+                    ))
                 }
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
@@ -98,15 +98,15 @@ internal class PushNotificationApiTest {
                 val sessionSpan = payload.findSessionSpan()
                 val event = sessionSpan.findEventOfType(EmbType.System.PushNotification)
                 assertTrue(checkNotNull(event.timestampNanos) > 0)
-                event.attributes?.assertMatches {
-                    EmbType.System.PushNotification.toEmbraceKeyValuePair()
-                    "notification.title" to "title"
-                    "notification.type" to "notif-data"
-                    "notification.body" to "body"
-                    "notification.id" to "id"
-                    "notification.from" to "from"
-                    "notification.priority" to 1
-                }
+                event.attributes?.assertMatches(mapOf(
+                    EmbType.System.PushNotification.toEmbraceKeyValuePair(),
+                    "notification.title" to "title",
+                    "notification.type" to "notif-data",
+                    "notification.body" to "body",
+                    "notification.id" to "id",
+                    "notification.from" to "from",
+                    "notification.priority" to 1,
+                ))
             }
         )
     }
@@ -115,11 +115,11 @@ internal class PushNotificationApiTest {
         val sessionSpan = findSessionSpan()
         val event = sessionSpan.findEventOfType(EmbType.System.PushNotification)
         assertTrue(checkNotNull(event.timestampNanos) > 0)
-        event.attributes?.assertMatches {
-            EmbType.System.PushNotification.toEmbraceKeyValuePair()
-            "notification.type" to type
-            "notification.id" to "id"
-            "notification.priority" to 1
-        }
+        event.attributes?.assertMatches(mapOf(
+            EmbType.System.PushNotification.toEmbraceKeyValuePair(),
+            "notification.type" to type,
+            "notification.id" to "id",
+            "notification.priority" to 1,
+        ))
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
@@ -152,13 +152,13 @@ internal class ReactNativeInternalInterfaceTest {
                 assertEquals(1000L, span.startTimeNanos?.nanosToMillis())
                 assertEquals(5000L, span.endTimeNanos?.nanosToMillis())
 
-                span.attributes?.assertMatches {
-                    "emb.type" to "sys.rn_action"
-                    "name" to "MyAction"
-                    "outcome" to "SUCCESS"
-                    "payload_size" to "100"
-                    "emb.properties.key" to "value"
-                }
+                span.attributes?.assertMatches(mapOf(
+                    "emb.type" to "sys.rn_action",
+                    "name" to "MyAction",
+                    "outcome" to "SUCCESS",
+                    "payload_size" to "100",
+                    "emb.properties.key" to "value",
+                ))
             }
         )
     }
@@ -184,16 +184,16 @@ internal class ReactNativeInternalInterfaceTest {
                 val secondSpan = message.findSpanSnapshotOfType(EmbType.Ux.View)
 
                 assertEquals("emb-screen-view", firstSpan.name)
-                firstSpan.attributes?.assertMatches {
-                    "emb.type" to "ux.view"
-                    "view.name" to "HomeScreen"
-                }
+                firstSpan.attributes?.assertMatches(mapOf(
+                    "emb.type" to "ux.view",
+                    "view.name" to "HomeScreen",
+                ))
 
                 assertEquals("emb-screen-view", secondSpan.name)
-                secondSpan.attributes?.assertMatches {
-                    "emb.type" to "ux.view"
-                    "view.name" to "DetailsScreen"
-                }
+                secondSpan.attributes?.assertMatches(mapOf(
+                    "emb.type" to "ux.view",
+                    "view.name" to "DetailsScreen",
+                ))
             }
         )
     }
@@ -217,17 +217,17 @@ internal class ReactNativeInternalInterfaceTest {
                 val message = getSingleSessionEnvelope()
                 val firstSpan = message.findSpanOfType(EmbType.Ux.View)
                 assertEquals("emb-screen-view", firstSpan.name)
-                firstSpan.attributes?.assertMatches {
-                    "emb.type" to "ux.view"
-                    "view.name" to "HomeScreen"
-                }
+                firstSpan.attributes?.assertMatches(mapOf(
+                    "emb.type" to "ux.view",
+                    "view.name" to "HomeScreen",
+                ))
 
                 val secondSpan = message.findSpanSnapshotOfType(EmbType.Ux.View)
                 assertEquals("emb-screen-view", secondSpan.name)
-                secondSpan.attributes?.assertMatches {
-                    "emb.type" to "ux.view"
-                    "view.name" to "HomeScreen"
-                }
+                secondSpan.attributes?.assertMatches(mapOf(
+                    "emb.type" to "ux.view",
+                    "view.name" to "HomeScreen",
+                ))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -60,9 +60,9 @@ internal class SessionApiTest {
                 // validate network status span
                 val networkStatusSpan = snapshots.single { it.name == "emb-network-status" }
                 assertEquals(startTime, networkStatusSpan.startTimeNanos?.nanosToMillis())
-                networkStatusSpan.attributes?.assertMatches {
-                    "emb.type" to "sys.network_status"
-                }
+                networkStatusSpan.attributes?.assertMatches(mapOf(
+                    "emb.type" to "sys.network_status",
+                ))
 
                 // validate session span
                 val spans = checkNotNull(message.data.spans)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
@@ -36,9 +36,9 @@ internal class ActivityFeatureTest {
                 val message = getSingleSessionEnvelope()
                 val viewSpan = message.findSpanOfType(EmbType.Ux.View)
 
-                viewSpan.attributes?.assertMatches {
+                viewSpan.attributes?.assertMatches(mapOf(
                     "view.name" to "android.app.Activity"
-                }
+                ))
 
                 with(viewSpan) {
                     assertEquals(startTimeMs, startTimeNanos?.nanosToMillis())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -41,17 +41,17 @@ internal class AeiFeatureTest {
                 val log = getSingleLogEnvelope().getLastLog()
 
                 // assert AEI fields populated
-                log.attributes?.assertMatches {
-                    "timestamp" to 15000000000L
-                    "aei_session_id" to "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
-                    "process_importance" to 125
-                    "pss" to 1509123409L
-                    "rss" to 1123409L
-                    "exit_status" to 1
-                    "description" to "testDescription"
-                    "reason" to 4
-                    "emb.type" to "sys.exit"
-                }
+                log.attributes?.assertMatches(mapOf(
+                    "timestamp" to 15000000000L,
+                    "aei_session_id" to "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d",
+                    "process_importance" to 125,
+                    "pss" to 1509123409L,
+                    "rss" to 1123409L,
+                    "exit_status" to 1,
+                    "description" to "testDescription",
+                    "reason" to 4,
+                    "emb.type" to "sys.exit",
+                ))
                 assertEquals("testInputStream", log.body)
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -183,10 +183,10 @@ internal class AnrFeatureTest {
         assertEquals(endTime, span.endTimeNanos?.nanosToMillis())
 
         // assert span attributes
-        span.attributes?.assertMatches {
-            "emb.type" to "perf.thread_blockage"
+        span.attributes?.assertMatches(mapOf(
+            "emb.type" to "perf.thread_blockage",
             "interval_code" to expectedIntervalCode
-        }
+        ))
 
         val events = checkNotNull(span.events)
 
@@ -194,14 +194,14 @@ internal class AnrFeatureTest {
             assertEquals("perf.thread_blockage_sample", event.name)
 
             // assert attributes
-            event.attributes?.assertMatches {
-                "emb.type" to "perf.thread_blockage_sample"
-                "sample_overhead" to 0
+            event.attributes?.assertMatches(mapOf(
+                "emb.type" to "perf.thread_blockage_sample",
+                "sample_overhead" to 0,
                 "sample_code" to when {
                     index < MAX_SAMPLE_COUNT -> "0"
                     else -> "1"
                 }
-            }
+            ))
 
             // assert interval time
             val expectedTime = startTime + ANR_THRESHOLD_MS + ((index + 1) * INTERVAL_MS)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
@@ -44,8 +44,8 @@ internal class BreadcrumbFeatureTest {
     }
 
     private fun Envelope<SessionPayload>.assertBreadcrumbWithMessage(message: String) {
-        findSessionSpan().findEventOfType(EmbType.System.Breadcrumb).attributes?.assertMatches {
+        findSessionSpan().findEventOfType(EmbType.System.Breadcrumb).attributes?.assertMatches(mapOf(
             "message" to message
-        }
+        ))
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -118,12 +118,12 @@ internal class JvmCrashFeatureTest {
                 val message = getSingleSessionEnvelope()
                 val crashId = message.getSessionSpan()?.attributes?.findAttributeValue(embCrashId.name)
                 assertNotNull(crashId)
-                log.attributes?.assertMatches {
-                    "emb.android.react_native_crash.js_exception" to expectedJsException
-                    "emb.android.crash_number" to 1
-                    "emb.android.crash.exception_cause" to expectedExceptionCause
+                log.attributes?.assertMatches(mapOf(
+                    "emb.android.react_native_crash.js_exception" to expectedJsException,
+                    "emb.android.crash_number" to 1,
+                    "emb.android.crash.exception_cause" to expectedExceptionCause,
                     LogIncubatingAttributes.LOG_RECORD_UID.key to crashId
-                }
+                ))
                 assertNotNull(log.attributes?.findAttributeValue("emb.android.threads"))
             }
         )
@@ -155,12 +155,12 @@ internal class JvmCrashFeatureTest {
         val exceptionInfo = LegacyExceptionInfo.ofThrowable(testException)
         val expectedExceptionCause = serializer.toJson(listOf(exceptionInfo), List::class.java)
 
-        attributes?.assertMatches {
-            embState.attributeKey.key to state
-            "emb.android.crash_number" to 1
-            "emb.android.crash.exception_cause" to expectedExceptionCause
+        attributes?.assertMatches(mapOf(
+            embState.attributeKey.key to state,
+            "emb.android.crash_number" to 1,
+            "emb.android.crash.exception_cause" to expectedExceptionCause,
             LogIncubatingAttributes.LOG_RECORD_UID.key to crashId
-        }
+        ))
         assertNotNull(attributes?.findAttributeValue("emb.android.threads"))
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
@@ -37,9 +37,9 @@ internal class LowPowerFeatureTest {
             assertAction = {
                 val message = getSingleSessionEnvelope()
                 val span = message.findSpanOfType(EmbType.System.LowPower)
-                span.attributes?.assertMatches {
+                span.attributes?.assertMatches(mapOf(
                     "emb.type" to "sys.low_power"
-                }
+                ))
                 assertEquals("emb-device-low-power", span.name)
                 assertEquals(startTimeMs, span.startTimeNanos?.nanosToMillis())
                 assertEquals(startTimeMs + tickTimeMs, span.endTimeNanos?.nanosToMillis())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NetworkStatusFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NetworkStatusFeatureTest.kt
@@ -40,18 +40,18 @@ internal class NetworkStatusFeatureTest {
                 assertEquals(startTimeMs, span.startTimeNanos?.nanosToMillis())
                 assertEquals(startTimeMs + tickTimeMs, span.endTimeNanos?.nanosToMillis())
 
-                span.attributes?.assertMatches {
-                    "emb.type" to "sys.network_status"
+                span.attributes?.assertMatches(mapOf(
+                    "emb.type" to "sys.network_status",
                     "network" to "unknown"
-                }
+                ))
 
                 val snapshot = message.findSpanSnapshotOfType(EmbType.System.NetworkStatus)
                 assertEquals("emb-network-status", snapshot.name)
                 assertEquals(startTimeMs + tickTimeMs, snapshot.startTimeNanos?.nanosToMillis())
-                snapshot.attributes?.assertMatches {
-                    "emb.type" to "sys.network_status"
+                snapshot.attributes?.assertMatches(mapOf(
+                    "emb.type" to "sys.network_status",
                     "network" to "wifi"
-                }
+                ))
             }
         )
     }
@@ -70,10 +70,10 @@ internal class NetworkStatusFeatureTest {
                 val snapshot = message.findSpanSnapshotOfType(EmbType.System.NetworkStatus)
                 assertEquals("emb-network-status", snapshot.name)
                 assertEquals(startTimeMs, snapshot.startTimeNanos?.nanosToMillis())
-                snapshot.attributes?.assertMatches {
-                    "emb.type" to "sys.network_status"
+                snapshot.attributes?.assertMatches(mapOf(
+                    "emb.type" to "sys.network_status",
                     "network" to "unknown"
-                }
+                ))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SensitiveKeysRedactionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SensitiveKeysRedactionFeatureTest.kt
@@ -38,10 +38,10 @@ internal class SensitiveKeysRedactionFeatureTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 val recordedSpan = session.findSpanByName("test span")
-                recordedSpan.attributes?.assertMatches {
-                    "password" to REDACTED_LABEL
+                recordedSpan.attributes?.assertMatches(mapOf(
+                    "password" to REDACTED_LABEL,
                     "not a password" to "1234"
-                }
+                ))
             }
         )
     }
@@ -65,14 +65,14 @@ internal class SensitiveKeysRedactionFeatureTest {
 
                 val event = recordedSpan.events?.first { it.name == "event" }
                 val anotherEvent = recordedSpan.events?.first { it.name == "anotherEvent" }
-                event?.attributes?.assertMatches {
-                    "password" to REDACTED_LABEL
+                event?.attributes?.assertMatches(mapOf(
+                    "password" to REDACTED_LABEL,
                     "status" to "ok"
-                }
-                anotherEvent?.attributes?.assertMatches {
-                    "password" to REDACTED_LABEL
+                ))
+                anotherEvent?.attributes?.assertMatches(mapOf(
+                    "password" to REDACTED_LABEL,
                     "someKey" to "someValue"
-                }
+                ))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ThermalStateTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ThermalStateTest.kt
@@ -79,24 +79,24 @@ internal class ThermalStateFeatureTest {
                     assertEquals("perf.thermal_state", it.attributes?.findAttributeValue("emb.type"))
                 }
                 val firstSpan = spans.first()
-                firstSpan.attributes?.assertMatches {
+                firstSpan.attributes?.assertMatches(mapOf(
                     "status" to PowerManager.THERMAL_STATUS_CRITICAL.toString()
-                }
+                ))
                 assertEquals(startTimeMs, firstSpan.startTimeNanos?.nanosToMillis())
                 assertEquals(startTimeMs + tickTimeMs, firstSpan.endTimeNanos?.nanosToMillis())
                 val secondSpan = spans.last()
-                secondSpan.attributes?.assertMatches {
+                secondSpan.attributes?.assertMatches(mapOf(
                     "status" to PowerManager.THERMAL_STATUS_MODERATE.toString()
-                }
+                ))
                 assertEquals(startTimeMs + tickTimeMs, secondSpan.startTimeNanos?.nanosToMillis())
                 assertEquals(startTimeMs + tickTimeMs * 2, secondSpan.endTimeNanos?.nanosToMillis())
 
                 val snapshot = message.findSpanSnapshotOfType(EmbType.Performance.ThermalState)
                 assertEquals("emb-thermal-state", snapshot.name)
                 assertEquals("perf.thermal_state", snapshot.attributes?.findAttributeValue("emb.type"))
-                snapshot.attributes?.assertMatches {
+                snapshot.attributes?.assertMatches(mapOf(
                     "status" to PowerManager.THERMAL_STATUS_NONE.toString()
-                }
+                ))
                 assertEquals(startTimeMs + tickTimeMs * 2, snapshot.startTimeNanos?.nanosToMillis())
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/V1DeliveryFeatureTest.kt
@@ -108,17 +108,17 @@ internal class V1DeliveryFeatureTest {
                 val log = getLogEnvelopesV1(1).getLastLog()
 
                 // assert AEI fields populated
-                log.attributes?.assertMatches {
-                    "timestamp" to 15000000000L
-                    "aei_session_id" to "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
-                    "process_importance" to 125
-                    "pss" to 1509123409L
-                    "rss" to 1123409L
-                    "exit_status" to 1
-                    "description" to "testDescription"
-                    "reason" to 4
-                    "emb.type" to "sys.exit"
-                }
+                log.attributes?.assertMatches(mapOf(
+                    "timestamp" to 15000000000L,
+                    "aei_session_id" to "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d",
+                    "process_importance" to 125,
+                    "pss" to 1509123409L,
+                    "rss" to 1123409L,
+                    "exit_status" to 1,
+                    "description" to "testDescription",
+                    "reason" to 4,
+                    "emb.type" to "sys.exit",
+                ))
                 assertEquals("testInputStream", log.body)
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ViewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ViewFeatureTest.kt
@@ -40,17 +40,17 @@ internal class ViewFeatureTest {
                 assertEquals(2, viewSpans.size)
 
                 with(viewSpans[0]) {
-                    attributes?.assertMatches {
+                    attributes?.assertMatches(mapOf(
                         "view.name" to "MyView"
-                    }
+                    ))
                     assertEquals(startTimeMs, startTimeNanos?.nanosToMillis())
                     assertEquals(startTimeMs + 3000L, endTimeNanos?.nanosToMillis())
                 }
 
                 with(viewSpans[1]) {
-                    attributes?.assertMatches {
+                    attributes?.assertMatches(mapOf(
                         "view.name" to "AnotherView"
-                    }
+                    ))
                     assertEquals(startTimeMs + 1000L, startTimeNanos?.nanosToMillis())
                     assertEquals(startTimeMs + 3000L, endTimeNanos?.nanosToMillis())
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
@@ -44,10 +44,10 @@ internal class WebviewFeatureTest {
 
                 val event = events[0]
                 assertEquals("emb-webview-info", event.name)
-                event.attributes?.assertMatches {
-                    "emb.webview_info.tag" to "myWebView"
+                event.attributes?.assertMatches(mapOf(
+                    "emb.webview_info.tag" to "myWebView",
                     URL_FULL.key to "https://embrace.io/"
-                }
+                ))
 
 
                 val webVitalsAttr = checkNotNull(event.attributes?.findAttributeValue("emb.webview_info.web_vitals"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -104,24 +104,24 @@ internal class BackgroundActivityDisabledTest {
 
                 with(logs[0]) {
                     assertEquals("error", body)
-                    attributes?.assertMatches {
+                    attributes?.assertMatches(mapOf(
                         embState.attributeKey.key to "background"
-                    }
+                    ))
                     assertNull(attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
                 }
                 with(logs[1]) {
                     assertEquals("info", body)
-                    attributes?.assertMatches {
+                    attributes?.assertMatches(mapOf(
                         embState.attributeKey.key to "background"
-                    }
+                    ))
                     assertNull(attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
                 }
                 with(logs[2]) {
                     assertEquals("warning", body)
-                    attributes?.assertMatches {
-                        embState.attributeKey.key to "foreground"
-                        SessionIncubatingAttributes.SESSION_ID.key to sessions[0].getSessionId()
-                    }
+                    attributes?.assertMatches(mapOf(
+                        embState.attributeKey.key to "foreground",
+                        SessionIncubatingAttributes.SESSION_ID.key to sessions[1].getSessionId()
+                    ))
                 }
                 val secondSession = sessions[1]
                 assertEquals(
@@ -131,19 +131,19 @@ internal class BackgroundActivityDisabledTest {
 
                 with(logs[3]) {
                     assertEquals("sent-after-session", body)
-                    attributes?.assertMatches {
-                        embState.attributeKey.key to "foreground"
+                    attributes?.assertMatches(mapOf(
+                        embState.attributeKey.key to "foreground",
                         SessionIncubatingAttributes.SESSION_ID.key to secondSession.getSessionId()
-                    }
+                    ))
                 }
 
                 with(secondSession) {
                     with(findSessionSpan()) {
                         with(findEventsOfType(EmbType.System.Breadcrumb)) {
                             assertEquals(1, size)
-                            single().attributes?.assertMatches {
+                            single().attributes?.assertMatches(mapOf(
                                 "message" to "logged"
-                            }
+                            ))
                         }
                     }
 
@@ -240,16 +240,16 @@ internal class BackgroundActivityDisabledTest {
     ) {
         assertEquals(startMs, startTimeNanos?.nanosToMillis())
         assertEquals(endMs, endTimeNanos?.nanosToMillis())
-        attributes?.assertMatches {
-            embSessionNumber.attributeKey.key to sessionNumber
-            embSequenceId.attributeKey.key to sequenceId
-            embColdStart.attributeKey.key to coldStart
-            embState.attributeKey.key to "foreground"
-            embCleanExit.attributeKey.key to "true"
-            embTerminated.attributeKey.key to "false"
-            embSessionStartType.attributeKey.key to "state"
-            embSessionEndType.attributeKey.key to "state"
-        }
+        attributes?.assertMatches(mapOf(
+            embSessionNumber.attributeKey.key to sessionNumber,
+            embSequenceId.attributeKey.key to sequenceId,
+            embColdStart.attributeKey.key to coldStart,
+            embState.attributeKey.key to "foreground",
+            embCleanExit.attributeKey.key to "true",
+            embTerminated.attributeKey.key to "false",
+            embSessionStartType.attributeKey.key to "state",
+            embSessionEndType.attributeKey.key to "state",
+        ))
         with(checkNotNull(attributes)) {
             assertFalse(findAttributeValue(embProcessIdentifier.attributeKey.key).isNullOrBlank())
             assertFalse(findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key).isNullOrBlank())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
@@ -44,16 +44,16 @@ internal class BackgroundActivityTest {
 
                 // verify first bg activity
                 val first = bgActivities[0]
-                first.findSessionSpan().attributes?.assertMatches {
+                first.findSessionSpan().attributes?.assertMatches(mapOf(
                     embSessionNumber.name to 1
-                }
+                ))
                 assertFalse(first.hasSpanSnapshotsOfType(EmbType.Ux.Session))
 
                 // verify second bg activity
                 val second = bgActivities[1]
-                second.findSessionSpan().attributes?.assertMatches {
+                second.findSessionSpan().attributes?.assertMatches(mapOf(
                     embSessionNumber.name to 2
-                }
+                ))
 
                 // ID should be different for each
                 assertNotEquals(first.getSessionId(), second.getSessionId())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualSessionTest.kt
@@ -35,12 +35,12 @@ internal class ManualSessionTest {
                 val stateSession = messages[0] // started via state, ended manually
                 val manualSession = messages[1] // started manually, ended via state
 
-                stateSession.findSessionSpan().attributes?.assertMatches {
+                stateSession.findSessionSpan().attributes?.assertMatches(mapOf(
                     embSessionNumber.name to 1
-                }
-                manualSession.findSessionSpan().attributes?.assertMatches {
+                ))
+                manualSession.findSessionSpan().attributes?.assertMatches(mapOf(
                     embSessionNumber.name to 2
-                }
+                ))
             }
         )
     }
@@ -74,9 +74,9 @@ internal class ManualSessionTest {
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
-                message.findSessionSpan().attributes?.assertMatches {
+                message.findSessionSpan().attributes?.assertMatches(mapOf(
                     embSessionNumber.name to 1
-                }
+                ))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -83,17 +83,17 @@ internal class PeriodicSessionCacheTest {
                 val endMessage = checkNotNull(snapshot)
                 val span = endMessage.findSpanSnapshotOfType(EmbType.Ux.Session)
                 assertNotNull(span.getSessionProperty("Test"))
-                span.attributes?.assertMatches {
-                    "emb.clean_exit" to false
+                span.attributes?.assertMatches(mapOf(
+                    "emb.clean_exit" to false,
                     "emb.terminated" to true
-                }
+                ))
                 val completedMessage = getSingleSessionEnvelope()
                 val completedSpan = completedMessage.findSessionSpan()
                 assertEquals("Test", completedSpan.getSessionProperty("Test"))
-                completedSpan.attributes?.assertMatches {
-                    "emb.clean_exit" to true
+                completedSpan.attributes?.assertMatches(mapOf(
+                    "emb.clean_exit" to true,
                     "emb.terminated" to false
-                }
+                ))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SequentialSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SequentialSessionTest.kt
@@ -38,22 +38,22 @@ internal class SequentialSessionTest {
                 val third = sessions[2]
 
                 assertFalse(first.hasSpanSnapshotsOfType(EmbType.Ux.Session))
-                first.findSessionSpan().attributes?.assertMatches {
-                    embSessionNumber.name to 1
+                first.findSessionSpan().attributes?.assertMatches(mapOf(
+                    embSessionNumber.name to 1,
                     embColdStart.name to true
-                }
+                ))
 
                 assertFalse(second.hasSpanSnapshotsOfType(EmbType.Ux.Session))
-                second.findSessionSpan().attributes?.assertMatches {
-                    embSessionNumber.name to 2
+                second.findSessionSpan().attributes?.assertMatches(mapOf(
+                    embSessionNumber.name to 2,
                     embColdStart.name to false
-                }
+                ))
 
                 assertFalse(third.hasSpanSnapshotsOfType(EmbType.Ux.Session))
-                third.findSessionSpan().attributes?.assertMatches {
-                    embSessionNumber.name to 3
+                third.findSessionSpan().attributes?.assertMatches(mapOf(
+                    embSessionNumber.name to 3,
                     embColdStart.name to false
-                }
+                ))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/StatefulSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/StatefulSessionTest.kt
@@ -43,11 +43,11 @@ internal class StatefulSessionTest {
                 // verify first session
                 val messages = getSessionEnvelopesFromMockServer(2)
                 val first = messages[0]
-                first.findSessionSpan().attributes?.assertMatches {
-                    embSessionStartType.name to LifeEventType.STATE.name.lowercase(Locale.ENGLISH)
-                    embSessionEndType.name to LifeEventType.STATE.name.lowercase(Locale.ENGLISH)
+                first.findSessionSpan().attributes?.assertMatches(mapOf(
+                    embSessionStartType.name to LifeEventType.STATE.name.lowercase(Locale.ENGLISH),
+                    embSessionEndType.name to LifeEventType.STATE.name.lowercase(Locale.ENGLISH),
                     embErrorLogCount.name to 0
-                }
+                ))
 
                 assertFalse(first.hasSpanSnapshotsOfType(EmbType.Ux.Session))
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/AttributeExtensions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/AttributeExtensions.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.testframework.assertions
 
 import io.embrace.android.embracesdk.internal.payload.Attribute
+import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import org.junit.Assert.assertEquals
 
 internal fun List<Attribute>.toMap(): Map<String, String> {
@@ -12,8 +13,8 @@ internal fun List<Attribute>.toMap(): Map<String, String> {
  *
  * This does _not_ check for the presence of any other attributes.
  */
-internal fun List<Attribute>.assertMatches(expected: MutableMap<String, Any>.() -> Unit) {
-    val expectedMap = mutableMapOf<String, Any>().apply(expected).mapValues { it.toString() }
-    val observed = toMap().filterKeys(expectedMap::containsKey)
-    assertEquals(expectedMap.toSortedMap(), observed.toSortedMap())
+internal fun List<Attribute>.assertMatches(expected: Map<String, Any?>) {
+    val expectedMap = expected.toNonNullMap().mapValues { it.value.toString() }.toSortedMap()
+    val observedMap = toMap().toNonNullMap().filterKeys(expected::containsKey).toSortedMap()
+    assertEquals(expectedMap, observedMap)
 }


### PR DESCRIPTION
## Goal

`assertMatches` was not adding values to the `expected` parameter which meant assertions did not fail in tests. I've fixed this by refactoring how the function works & altered a couple of assertions that were silently failing.

