### PR TITLE
Increase timeout for checking remote config

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.testcases.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -60,9 +61,9 @@ internal class RemoteConfigTest {
             assertAction = {
                 assertConfigRequested(1)
                 returnIfConditionMet(
+                    waitTimeMs = 10000,
                     dataProvider = ::readPersistedConfigResponse,
-                    condition = {
-                        val response = readPersistedConfigResponse()
+                    condition = { response ->
                         response.cfg?.threshold == 100 && response.etag == "server_etag_value"
                     },
                     desiredValueSupplier = {}


### PR DESCRIPTION
## Goal

Increases the timeout for checking remote config. The default timeout in the test is 1s, which doesn't seem to be enough for serializing, writing config to disk, then reading it from within the test, leading to flakiness on CI.

