### PR TITLE
Revert "Remove unused code from NDK"

### DIFF
--- a/embrace-android-sdk/src/main/cpp/safejni/jni_util.c
+++ b/embrace-android-sdk/src/main/cpp/safejni/jni_util.c
@@ -1,8 +1,29 @@
 #include "jni_util.h"
 #include <stdbool.h>
 
+JavaVM *emb_JVM;
+
+jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+    emb_JVM = vm;
+    return JNI_VERSION_1_6;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+bool emb_jniIsAttached() {
+    JNIEnv *env;
+    int status = (*emb_JVM)->GetEnv(emb_JVM, (void **)&env, JNI_VERSION_1_6);
+
+    return status == JNI_OK;
+}
+
 void emb_jni_release_string_utf_chars(JNIEnv *env, jstring string, const char *utf) {
     if (env != NULL && string != NULL && utf != NULL) {
         (*env)->ReleaseStringUTFChars(env, string, utf);
     }
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/embrace-android-sdk/src/main/cpp/serializer/file_writer.c
+++ b/embrace-android-sdk/src/main/cpp/serializer/file_writer.c
@@ -35,6 +35,7 @@ static const char *kFrameAddrKey = "fa";
 static const char *kOffsetAddrKey = "oa";
 static const char *kModuleAddrKey = "ma";
 static const char *kLineNumKey = "ln";
+static const char *kBuildIdKey = "build_id";
 static const char *kFullNameKey = "full_name";
 static const char *kFunctionNameKey = "function_name";
 static const char *kRelPcKey = "rel_pc";

--- a/embrace-android-sdk/src/main/cpp/utils/utilities.c
+++ b/embrace-android-sdk/src/main/cpp/utils/utilities.c
@@ -24,6 +24,43 @@ void emb_set_report_paths(emb_env *env, const char *session_id) {
     snprintf(env->map_src_path, MAP_SRC_PATH_SIZE, "/proc/%d/maps", getpid());
 }
 
+int emb_dump_map(emb_env *env) {
+    int fd_in = open(env->map_src_path, O_RDONLY | O_CLOEXEC);
+    if (fd_in == -1) {
+        return -1;
+    }
+
+    int fd_out = open(env->map_path, O_WRONLY | O_CREAT, 0644);
+    if (fd_out == -1) {
+        close(fd_in);
+        return -2;
+    }
+
+    char buf[1024];
+    int size;
+    int rv = 0;
+
+    while (true) {
+        size = read(fd_in, &buf, sizeof(buf));
+        if (size == 0) {
+            break;
+        }
+        if (size < 0) {
+            rv = -3;
+            goto cleanup;
+        }
+        write(fd_out, &buf, size);
+    }
+
+    cleanup:
+
+    close(fd_in);
+    close(fd_out);
+
+    return rv;
+}
+
+
 void emb_set_crash_time(emb_env *env) {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);

--- a/embrace-android-sdk/src/main/cpp/utils/utilities.h
+++ b/embrace-android-sdk/src/main/cpp/utils/utilities.h
@@ -39,6 +39,7 @@ extern "C" {
 
 #define EMB_MAX_ERRORS 10
 
+int emb_dump_map(emb_env *env);
 void emb_log_last_error(emb_env *env, int num, int context);
 void emb_set_crash_time(emb_env *env);
 void emb_set_report_paths(emb_env *env, const char *session_id);


### PR DESCRIPTION
Reverts embrace-io/embrace-android-sdk#1664. Turns out emb_jniIsAttached was used by unity 😬 
Will remove dump_map as part of the ndk rework, once we check if we can stop storing and parsing map files.