### PR TITLE
Add interfaces for NDK implementation

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstaller.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstaller.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.internal.ndk
+
+/**
+ * Installs signal handlers that capture C/C++ crashes.
+ */
+interface NativeCrashHandlerInstaller {
+    fun install()
+}

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessor.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessor.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.internal.ndk
+
+/**
+ * Processes any native crashes that are stored on disk from previous processes & converts them
+ * into a format that can be ingested by the delivery layer.
+ */
+interface NativeCrashProcessor {
+    fun processNativeCrashes()
+}

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativePayloadCacher.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativePayloadCacher.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.internal.ndk
+
+/**
+ * Caches information that is needed by the native layer to construct a payload post-crash.
+ */
+interface NativePayloadCacher {
+
+    fun updateSessionId(newSessionId: String)
+
+    fun onSessionPropertiesUpdate(properties: Map<String, String>)
+
+    fun onUserInfoUpdate()
+}


### PR DESCRIPTION
## Goal

Adds the initial interfaces that will be used for splitting up the `NdkService` implementation. I've included 3 interfaces for installing, caching payloads, and processing crashes. The payload caching interface will need future change based on what we decide - I've biased towards just picking something that matches the existing function signatures for now so we can start splitting things up.

