### PR TITLE
Remove unityCrashId, as we don't use it anymore

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
@@ -19,7 +19,7 @@ import io.embrace.android.embracesdk.internal.payload.ThreadInfo
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.spans.toOtelSeverity
-import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
+import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
 import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
@@ -30,7 +30,6 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 internal class CrashDataSourceImpl(
     private val sessionPropertiesService: SessionPropertiesService,
-    private val unityCrashIdProvider: () -> String?,
     private val preferencesService: PreferencesService,
     private val logWriter: LogWriter,
     private val configService: ConfigService,
@@ -64,10 +63,7 @@ internal class CrashDataSourceImpl(
         if (!mainCrashHandled) {
             mainCrashHandled = true
 
-            // Check if the unity crash id exists. If so, means that the native crash capture
-            // is enabled for an Unity build. When a native crash occurs and the NDK sends an
-            // uncaught exception the SDK assign the unity crash id as the java crash id.
-            val crashId = unityCrashIdProvider() ?: getEmbUuid()
+            val crashId = Uuid.getEmbUuid()
             val crashNumber = preferencesService.incrementAndGetCrashNumber()
             val crashAttributes = TelemetryAttributes(
                 configService = configService,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CrashModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CrashModuleImpl.kt
@@ -11,8 +11,7 @@ internal class CrashModuleImpl(
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
-    androidServicesModule: AndroidServicesModule,
-    private val unityCrashIdProvider: () -> String?,
+    androidServicesModule: AndroidServicesModule
 ) : CrashModule {
 
     private val crashMarker: CrashFileMarker by singleton {
@@ -25,7 +24,6 @@ internal class CrashModuleImpl(
     override val crashDataSource: CrashDataSource by singleton {
         CrashDataSourceImpl(
             essentialServiceModule.sessionPropertiesService,
-            unityCrashIdProvider,
             androidServicesModule.preferencesService,
             essentialServiceModule.logWriter,
             configModule.configService,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CrashModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CrashModuleSupplier.kt
@@ -9,7 +9,6 @@ typealias CrashModuleSupplier = (
     essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
     androidServicesModule: AndroidServicesModule,
-    unityCrashIdProvider: () -> String?,
 ) -> CrashModule
 
 fun createCrashModule(
@@ -18,7 +17,6 @@ fun createCrashModule(
     essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
     androidServicesModule: AndroidServicesModule,
-    unityCrashIdProvider: () -> String?,
 ): CrashModule {
     return CrashModuleImpl(
         initModule,
@@ -26,6 +24,5 @@ fun createCrashModule(
         essentialServiceModule,
         configModule,
         androidServicesModule,
-        unityCrashIdProvider,
     )
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
-import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.NativeCrashDataError
 import io.embrace.android.embracesdk.internal.payload.NativeCrashMetadata
@@ -55,7 +54,6 @@ internal class EmbraceNdkService(
     private val handler: Handler = Handler(checkNotNull(Looper.getMainLooper())),
 ) : NdkService, ProcessStateListener {
 
-    override var unityCrashId: String? = null
     override val symbolsForCurrentArch by lazy {
         val nativeSymbols = getNativeSymbols()
         if (nativeSymbols != null) {
@@ -72,9 +70,6 @@ internal class EmbraceNdkService(
                 userService.addUserInfoListener(::onUserInfoUpdate)
                 sessionIdTracker.addListener { updateSessionId(it ?: "") }
                 sessionPropertiesService.addChangeListener(::onSessionPropertiesUpdate)
-                if (configService.appFramework == AppFramework.UNITY) {
-                    unityCrashId = Uuid.getEmbUuid()
-                }
                 repository.cleanOldCrashFiles()
             }
         }
@@ -163,9 +158,7 @@ internal class EmbraceNdkService(
             CrashFileMarkerImpl.CRASH_MARKER_FILE_NAME
         ).absolutePath
 
-        // Assign the native crash id to the unity crash id. Then when a unity crash occurs, the
-        // Embrace crash service will set the unity crash id to the java crash.
-        val nativeCrashId: String = unityCrashId ?: Uuid.getEmbUuid()
+        val nativeCrashId: String = Uuid.getEmbUuid()
         val is32bit = deviceArchitecture.is32BitDevice
         Systrace.traceSynchronous("native-install-handlers") {
             delegate.installSignalHandlers(

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
@@ -10,8 +10,6 @@ interface NdkService {
 
     fun onUserInfoUpdate()
 
-    val unityCrashId: String?
-
     /**
      * Get the latest stored [NativeCrashData] instance and purge all existing native crash data files.
      */

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
@@ -69,7 +69,6 @@ internal class CrashDataSourceImplTest {
         )
         crashDataSource = CrashDataSourceImpl(
             sessionPropertiesService,
-            ndkService::unityCrashId,
             preferencesService,
             logWriter,
             configService,
@@ -127,22 +126,6 @@ internal class CrashDataSourceImplTest {
         assertEquals(1, anrService.crashCount)
         assertEquals(1, logWriter.logEvents.size)
         assertSame(lastSentCrash, logWriter.logEvents.single())
-    }
-
-    @Test
-    fun `test LogWriter and SessionOrchestrator are called when handleCrash is called with unityId`() {
-        setupForHandleCrash()
-        ndkService.lastUnityCrashId = "Unity123"
-
-        crashDataSource.handleCrash(testException)
-
-        assertEquals(1, anrService.crashCount)
-        assertEquals(1, logWriter.logEvents.size)
-        assertEquals(
-            logWriter.logEvents.single().schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key],
-            sessionOrchestrator.crashId
-        )
-        assertEquals(ndkService.lastUnityCrashId, sessionOrchestrator.crashId)
     }
 
     @Test

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/CrashModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/CrashModuleImplTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -17,14 +16,12 @@ internal class CrashModuleImplTest {
 
     @Test
     fun testDefaultImplementations() {
-        val nativeFeatureModule = FakeNativeFeatureModule()
         val module = createCrashModule(
             FakeInitModule(),
             FakeStorageModule(),
             FakeEssentialServiceModule(),
             FakeConfigModule(),
             FakeAndroidServicesModule(),
-            nativeFeatureModule.ndkService::unityCrashId,
         )
         assertNotNull(module.lastRunCrashVerifier)
         assertNotNull(module.crashDataSource)
@@ -32,7 +29,6 @@ internal class CrashModuleImplTest {
 
     @Test
     fun `default config turns on v2 native crash service`() {
-        val nativeFeatureModule = FakeNativeFeatureModule()
         val module = createCrashModule(
             FakeInitModule(),
             FakeStorageModule(),
@@ -43,7 +39,6 @@ internal class CrashModuleImplTest {
                 )
             ),
             FakeAndroidServicesModule(),
-            nativeFeatureModule.ndkService::unityCrashId,
         )
         assertNotNull(module.lastRunCrashVerifier)
         assertNotNull(module.crashDataSource)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
@@ -205,10 +205,7 @@ internal class EmbraceNdkServiceTest {
     }
 
     @Test
-    fun `test initialization with unity id and ndk enabled runs installSignals and updateDeviceMetaData`() {
-        val unityId = "unityId"
-        every { Uuid.getEmbUuid() } returns unityId
-
+    fun `test initialization with ndk enabled runs installSignals and updateDeviceMetaData`() {
         configService.appFramework = AppFramework.UNITY
         initializeService()
         assertEquals(1, processStateService.listeners.size)
@@ -222,7 +219,7 @@ internal class EmbraceNdkServiceTest {
                 markerFilePath,
                 "null",
                 "foreground",
-                unityId,
+                any(),
                 Build.VERSION.SDK_INT,
                 deviceArchitecture.is32BitDevice,
                 false
@@ -239,7 +236,6 @@ internal class EmbraceNdkServiceTest {
         )
 
         verify(exactly = 1) { delegate.updateMetaData(newDeviceMetaData) }
-        assertEquals(embraceNdkService.unityCrashId, Uuid.getEmbUuid())
     }
 
     @Test
@@ -266,15 +262,6 @@ internal class EmbraceNdkServiceTest {
             )
             delegate.updateMetaData(any())
         }
-    }
-
-    @Test
-    fun `test getUnityCrashId`() {
-        configService.appFramework = AppFramework.UNITY
-        every { Uuid.getEmbUuid() } returns "unityId"
-        initializeService()
-        val uuid = embraceNdkService.unityCrashId
-        assertEquals(uuid, "unityId")
     }
 
     @Test
@@ -330,7 +317,6 @@ internal class EmbraceNdkServiceTest {
     @Test
     fun `test getLatestNativeCrash catches an exception if _getCrashReport returns invalid json syntax`() {
         repository.addCrashFiles(File.createTempFile("test", "test"))
-        every { Uuid.getEmbUuid() } returns "unityId"
 
         val json = "{\n" +
             "  \"sid\": [\n" +

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -410,7 +410,6 @@ internal class ModuleInitBootstrapper(
                             essentialServiceModule,
                             configModule,
                             androidServicesModule,
-                            nativeFeatureModule.ndkService::unityCrashId
                         )
                     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -52,7 +52,7 @@ internal fun fakeModuleInitBootstrapper(
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _ -> FakeNativeCoreModule() },
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier =
         { _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
-    crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _, _ -> FakeCrashModule() },
+    crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _ -> FakeCrashModule() },
     payloadSourceModuleSupplier: PayloadSourceModuleSupplier =
         { _, _, _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() },
 ) = ModuleInitBootstrapper(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
@@ -8,7 +8,6 @@ class FakeNdkService : NdkService {
     val propUpdates: MutableList<Map<String, String>> = mutableListOf()
     var sessionId: String? = null
     var userUpdateCount: Int = 0
-    var lastUnityCrashId: String? = null
     private val nativeCrashDataBlobs = mutableListOf<NativeCrashData>()
 
     override fun initializeService(sessionIdTracker: SessionIdTracker) {
@@ -29,11 +28,6 @@ class FakeNdkService : NdkService {
     override fun onUserInfoUpdate() {
         userUpdateCount++
     }
-
-    override val unityCrashId: String?
-        get() {
-            return lastUnityCrashId
-        }
 
     override fun getLatestNativeCrash(): NativeCrashData? = nativeCrashDataBlobs.lastOrNull()
 


### PR DESCRIPTION
- The backend isn't considering any case where NDK and JVM crashes have the same ID. It might even bring issues.
- We weren't setting the ID correctly. If installSignalHandlers gets posted to the main thread handler before we set the ID, we will always use different IDs.
- I tested crashes on an armeabi-v7a device, and we only get native crashes. The CrashDataSource handler never gets called.