### PR TITLE
Add native crash handler installer

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/storage/EmbraceStorageService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/storage/EmbraceStorageService.kt
@@ -45,8 +45,10 @@ internal class EmbraceStorageService(
         return File(cacheDirectory, EMBRACE_CONFIG_CACHE_DIRECTORY)
     }
 
-    override fun getNativeCrashDir(): File {
-        return File(filesDirectory, NATIVE_CRASH_FILE_FOLDER)
+    override fun getOrCreateNativeCrashDir(): File {
+        val nativeCrashDirectory = File(filesDirectory, NATIVE_CRASH_FILE_FOLDER)
+        nativeCrashDirectory.mkdirs()
+        return nativeCrashDirectory
     }
 
     override fun listFiles(filter: FilenameFilter): List<File> {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/storage/StorageService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/storage/StorageService.kt
@@ -28,7 +28,7 @@ interface StorageService {
     /**
      * Returns a [File] instance referencing the directory where the native crash files are stored.
      */
-    fun getNativeCrashDir(): File
+    fun getOrCreateNativeCrashDir(): File
 
     /**
      * Returns a list of files from the files and cache directories that match the [filter].

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceStorageServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/storage/EmbraceStorageServiceTest.kt
@@ -97,7 +97,7 @@ internal class EmbraceStorageServiceTest {
 
     @Test
     fun `test getNativeCrashDir returns files dir`() {
-        val storageDirForNativeCrash = storageManager.getNativeCrashDir()
+        val storageDirForNativeCrash = storageManager.getOrCreateNativeCrashDir()
         assertNotNull(storageDirForNativeCrash)
         assertEquals("$embraceFilesDir/ndk", storageDirForNativeCrash.absolutePath)
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModule.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerInstaller
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerService
+import io.embrace.android.embracesdk.internal.ndk.NativeCrashHandlerInstaller
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.ndk.NdkService
 
@@ -12,4 +13,5 @@ interface NativeFeatureModule {
     val nativeThreadSamplerInstaller: NativeThreadSamplerInstaller?
     val nativeAnrOtelMapper: NativeAnrOtelMapper
     val nativeCrashService: NativeCrashService?
+    val nativeCrashHandlerInstaller: NativeCrashHandlerInstaller?
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerInstall
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
+import io.embrace.android.embracesdk.internal.handler.AndroidMainThreadHandler
 import io.embrace.android.embracesdk.internal.ndk.EmbraceNdkService
 import io.embrace.android.embracesdk.internal.ndk.EmbraceNdkServiceRepository
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashDataSourceImpl
@@ -119,6 +120,7 @@ internal class NativeFeatureModuleImpl(
                         payloadSourceModule.deviceArchitecture.is32BitDevice
                     )
                 },
+                mainThreadHandler = AndroidMainThreadHandler()
             )
         } else {
             null

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNativeCrashHandlerInstaller.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNativeCrashHandlerInstaller.kt
@@ -1,0 +1,108 @@
+package io.embrace.android.embracesdk.internal.ndk
+
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import io.embrace.android.embracesdk.internal.SharedObjectLoader
+import io.embrace.android.embracesdk.internal.Systrace
+import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
+import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.storage.StorageService
+import io.embrace.android.embracesdk.internal.utils.Uuid
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+
+private const val HANDLER_CHECK_DELAY_MS = 5000
+
+internal class EmbraceNativeCrashHandlerInstaller(
+    private val storageService: StorageService,
+    private val appState: String,
+    private val configService: ConfigService,
+    private val sharedObjectLoader: SharedObjectLoader,
+    private val logger: EmbLogger,
+    private val repository: NdkServiceRepository,
+    private val delegate: NdkServiceDelegate.NdkDelegate,
+    private val backgroundWorker: BackgroundWorker,
+    private val handler: Handler = Handler(checkNotNull(Looper.getMainLooper())),
+    private val is32BitDevice: Boolean,
+    private val activeSessionId: String?,
+) : NativeCrashHandlerInstaller {
+
+    override fun install() {
+        backgroundWorker.submit {
+            Systrace.traceSynchronous("install-native-crash-signal-handlers") {
+                if (startNativeCrashMonitoring()) {
+                    repository.cleanOldCrashFiles()
+                }
+            }
+        }
+    }
+
+    private fun startNativeCrashMonitoring(): Boolean {
+        return try {
+            if (sharedObjectLoader.loadEmbraceNative()) {
+                handler.postAtFrontOfQueue { installSignals() }
+                handler.postDelayed(
+                    Runnable(::checkSignalHandlersOverwritten),
+                    HANDLER_CHECK_DELAY_MS.toLong()
+                )
+                true
+            } else {
+                false
+            }
+        } catch (ex: Exception) {
+            logger.trackInternalError(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL, ex)
+            false
+        }
+    }
+
+    private fun checkSignalHandlersOverwritten() {
+        if (configService.autoDataCaptureBehavior.is3rdPartySigHandlerDetectionEnabled()) {
+            val culprit = delegate._checkForOverwrittenHandlers()
+            if (culprit != null) {
+                if (shouldIgnoreOverriddenHandler(culprit)) {
+                    return
+                }
+                delegate._reinstallSignalHandlers()
+            }
+        }
+    }
+
+    /**
+     * Contains a list of SO files which are known to install signal handlers that do not
+     * interfere with crash detection. This list will probably expand over time.
+     *
+     * @param culprit the culprit SO file as identified by dladdr
+     * @return true if we can safely ignore
+     */
+    private fun shouldIgnoreOverriddenHandler(culprit: String): Boolean {
+        val allowList = listOf("libwebviewchromium.so")
+        return allowList.any(culprit::contains)
+    }
+
+    private fun installSignals() {
+        val reportBasePath = try {
+            storageService.getOrCreateNativeCrashDir().absolutePath
+        } catch (e: Exception) {
+            logger.trackInternalError(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL, e)
+            return
+        }
+        val markerFilePath = storageService.getFileForWrite(
+            CrashFileMarkerImpl.CRASH_MARKER_FILE_NAME
+        ).absolutePath
+
+        Systrace.traceSynchronous("native-install-handlers") {
+            delegate._installSignalHandlers(
+                reportBasePath,
+                markerFilePath,
+                activeSessionId ?: "null",
+                appState,
+                Uuid.getEmbUuid(),
+                Build.VERSION.SDK_INT,
+                is32BitDevice,
+                false
+            )
+        }
+    }
+}

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -1,32 +1,27 @@
 package io.embrace.android.embracesdk.internal.ndk
 
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
-import io.embrace.android.embracesdk.internal.storage.StorageService
-import io.embrace.android.embracesdk.internal.utils.Uuid
+import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 private const val HANDLER_CHECK_DELAY_MS = 5000
 
-internal class EmbraceNativeCrashHandlerInstaller(
-    private val storageService: StorageService,
-    private val appState: String,
+internal class NativeCrashHandlerInstallerImpl(
     private val configService: ConfigService,
     private val sharedObjectLoader: SharedObjectLoader,
     private val logger: EmbLogger,
     private val repository: NdkServiceRepository,
-    private val delegate: NdkServiceDelegate.NdkDelegate,
+    private val delegate: JniDelegate,
     private val backgroundWorker: BackgroundWorker,
+    private val nativeInstallMessageProvider: Provider<NativeInstallMessage?>,
     private val handler: Handler = Handler(checkNotNull(Looper.getMainLooper())),
-    private val is32BitDevice: Boolean,
-    private val activeSessionId: String?,
 ) : NativeCrashHandlerInstaller {
 
     override fun install() {
@@ -59,12 +54,12 @@ internal class EmbraceNativeCrashHandlerInstaller(
 
     private fun checkSignalHandlersOverwritten() {
         if (configService.autoDataCaptureBehavior.is3rdPartySigHandlerDetectionEnabled()) {
-            val culprit = delegate._checkForOverwrittenHandlers()
+            val culprit = delegate.checkForOverwrittenHandlers()
             if (culprit != null) {
                 if (shouldIgnoreOverriddenHandler(culprit)) {
                     return
                 }
-                delegate._reinstallSignalHandlers()
+                delegate.reinstallSignalHandlers()
             }
         }
     }
@@ -82,26 +77,23 @@ internal class EmbraceNativeCrashHandlerInstaller(
     }
 
     private fun installSignals() {
-        val reportBasePath = try {
-            storageService.getOrCreateNativeCrashDir().absolutePath
-        } catch (e: Exception) {
-            logger.trackInternalError(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL, e)
-            return
-        }
-        val markerFilePath = storageService.getFileForWrite(
-            CrashFileMarkerImpl.CRASH_MARKER_FILE_NAME
-        ).absolutePath
-
         Systrace.traceSynchronous("native-install-handlers") {
-            delegate._installSignalHandlers(
-                reportBasePath,
-                markerFilePath,
-                activeSessionId ?: "null",
-                appState,
-                Uuid.getEmbUuid(),
-                Build.VERSION.SDK_INT,
-                is32BitDevice,
-                false
+            val nativeInstallMessage = nativeInstallMessageProvider() ?: run {
+                logger.trackInternalError(
+                    InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL,
+                    IllegalStateException("Native install message is null")
+                )
+                return
+            }
+            delegate.installSignalHandlers(
+                nativeInstallMessage.reportPath,
+                nativeInstallMessage.markerFilePath,
+                nativeInstallMessage.sessionId,
+                nativeInstallMessage.appState,
+                nativeInstallMessage.reportId,
+                nativeInstallMessage.apiLevel,
+                nativeInstallMessage.is32bit,
+                nativeInstallMessage.devLogging
             )
         }
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeInstallMessage.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeInstallMessage.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.internal.ndk
+
+data class NativeInstallMessage(
+    val reportPath: String,
+    val markerFilePath: String,
+    val sessionId: String,
+    val appState: String,
+    val reportId: String,
+    val apiLevel: Int,
+    val is32bit: Boolean,
+    val devLogging: Boolean,
+)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkServiceRepository.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkServiceRepository.kt
@@ -33,5 +33,8 @@ interface NdkServiceRepository {
         nativeCrash: NativeCrashData?,
     )
 
+    /**
+     * Delete old native crash files when the number of files exceeds the maximum allowed
+     */
     fun cleanOldCrashFiles()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegate.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegate.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.ndk.jni
 
-internal interface JniDelegate {
+interface JniDelegate {
     fun installSignalHandlers(
         reportPath: String?,
         markerFilePath: String?,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImplTest.kt
@@ -2,6 +2,10 @@ package io.embrace.android.embracesdk.internal.injection
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
+import io.embrace.android.embracesdk.fakes.FakeStorageService
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -11,6 +15,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
@@ -18,24 +23,112 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(AndroidJUnit4::class)
 internal class NativeFeatureModuleImplTest {
 
+    private lateinit var fakeConfigModule: FakeConfigModule
+    private lateinit var fakeStorageService: FakeStorageService
+    private lateinit var fakeEssentialServiceModule: FakeEssentialServiceModule
+
+    private lateinit var module: NativeFeatureModuleImpl
+
+    @Before
+    fun setUp() {
+        fakeConfigModule = FakeConfigModule()
+        fakeStorageService = FakeStorageService()
+        fakeEssentialServiceModule = FakeEssentialServiceModule()
+        module = createNativeFeatureModule(fakeConfigModule)
+    }
+
     @Test
     fun testDefaultImplementations() {
-        val initModule = FakeInitModule()
-        val module = NativeFeatureModuleImpl(
-            initModule,
-            CoreModuleImpl(RuntimeEnvironment.getApplication(), initModule),
-            FakeStorageModule(),
-            FakeEssentialServiceModule(),
-            FakeConfigModule(),
-            FakePayloadSourceModule(),
-            FakeAndroidServicesModule(),
-            FakeWorkerThreadModule(),
-            FakeNativeCoreModule()
-        )
         assertNotNull(module.ndkService)
         assertNull(module.nativeThreadSamplerService)
         assertNull(module.nativeThreadSamplerInstaller)
         assertNotNull(module.nativeAnrOtelMapper)
         assertNull(module.nativeCrashService)
+        assertNull(module.nativeCrashHandlerInstaller)
+    }
+
+    @Test
+    fun `do not create native crash handler installer when create native crash id throws`() {
+        fakeStorageService.shouldThrow = true
+        fakeConfigModule = FakeConfigModule(
+            configService = FakeConfigService(
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
+                    ndkEnabled = true
+                )
+            )
+        )
+
+        module = createNativeFeatureModule(fakeConfigModule)
+
+        assertNull(module.nativeCrashHandlerInstaller)
+    }
+
+    @Test
+    fun `do not create native crash handler installer when active session id is null`() {
+        // given active session id is null
+        fakeConfigModule = FakeConfigModule(
+            configService = FakeConfigService(
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
+                    ndkEnabled = true
+                )
+            )
+        )
+        fakeEssentialServiceModule = FakeEssentialServiceModule(sessionIdTracker = FakeSessionIdTracker())
+
+        module = createNativeFeatureModule(fakeConfigModule)
+
+        assertNull(module.nativeCrashHandlerInstaller)
+    }
+
+    @Test
+    fun `create native crash handler installer when everything is fine`() {
+        fakeConfigModule = FakeConfigModule(
+            configService = FakeConfigService(
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
+                    ndkEnabled = true
+                )
+            )
+        )
+        fakeEssentialServiceModule = FakeEssentialServiceModule(
+            sessionIdTracker = FakeSessionIdTracker().apply {
+                setActiveSession("sessionId", true)
+            }
+        )
+
+        module = createNativeFeatureModule(fakeConfigModule)
+
+        assertNotNull(module.nativeCrashHandlerInstaller)
+    }
+
+    @Test
+    fun `create services when native crash capture is enabled`() {
+        fakeConfigModule = FakeConfigModule(
+            configService = FakeConfigService(
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
+                    ndkEnabled = true
+                )
+            )
+        )
+
+        module = createNativeFeatureModule(fakeConfigModule)
+
+        assertNotNull(module.nativeCrashService)
+        assertNotNull(module.nativeThreadSamplerService)
+        assertNotNull(module.nativeThreadSamplerInstaller)
+    }
+
+    private fun createNativeFeatureModule(fakeConfigModule: FakeConfigModule): NativeFeatureModuleImpl {
+        val initModule = FakeInitModule()
+        return NativeFeatureModuleImpl(
+            initModule,
+            CoreModuleImpl(RuntimeEnvironment.getApplication(), initModule),
+            FakeStorageModule(storageService = fakeStorageService),
+            fakeEssentialServiceModule,
+            fakeConfigModule,
+            FakePayloadSourceModule(),
+            FakeAndroidServicesModule(),
+            FakeWorkerThreadModule(),
+            FakeNativeCoreModule()
+        )
     }
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceTest.kt
@@ -365,7 +365,6 @@ internal class EmbraceNdkServiceTest {
         sharedObjectLoader.failLoad = true
         initializeService()
         verify(exactly = 0) { embraceNdkService["installSignals"]({ "null" }) }
-        verify(exactly = 0) { embraceNdkService["createCrashReportDirectory"]() }
     }
 
     @Test

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -53,7 +53,7 @@ class NativeCrashHandlerInstallerImplTest {
             fakeRepository,
             fakeDelegate,
             fakeBackgroundWorker(),
-            { testNativeInstallMessage },
+            testNativeInstallMessage,
             fakeMainThreadHandler,
         )
     }
@@ -63,26 +63,6 @@ class NativeCrashHandlerInstallerImplTest {
         nativeCrashHandlerInstaller.install()
 
         assertTrue(fakeDelegate.signalHandlerInstalled)
-    }
-
-    @Test
-    fun `do not install signals when the native install message is null`() {
-        nativeCrashHandlerInstaller = NativeCrashHandlerInstallerImpl(
-            fakeConfigService,
-            fakeSharedObjectLoader,
-            fakeLogger,
-            fakeRepository,
-            fakeDelegate,
-            fakeBackgroundWorker(),
-            { null },
-            fakeMainThreadHandler,
-        )
-
-        nativeCrashHandlerInstaller.install()
-
-        assertFalse(fakeDelegate.signalHandlerInstalled)
-        assertEquals(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL.toString(), fakeLogger.internalErrorMessages.last().msg)
-        assertEquals("Native install message is null", fakeLogger.internalErrorMessages.last().throwable?.message)
     }
 
     @Test

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -1,0 +1,147 @@
+package io.embrace.android.embracesdk.internal.ndk
+
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeJniDelegate
+import io.embrace.android.embracesdk.fakes.FakeMainThreadHandler
+import io.embrace.android.embracesdk.fakes.FakeNdkServiceRepository
+import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NativeCrashHandlerInstallerImplTest {
+
+    private val testNativeInstallMessage = NativeInstallMessage(
+        reportPath = "testReportPath",
+        markerFilePath = "testMarkerFilePath",
+        sessionId = "testSessionId",
+        appState = "testAppState",
+        reportId = "testReportId",
+        apiLevel = 28,
+        is32bit = false,
+        devLogging = false,
+    )
+
+    private lateinit var fakeConfigService: FakeConfigService
+    private lateinit var fakeSharedObjectLoader: FakeSharedObjectLoader
+    private lateinit var fakeLogger: FakeEmbLogger
+    private lateinit var fakeRepository: FakeNdkServiceRepository
+    private lateinit var fakeDelegate: FakeJniDelegate
+    private lateinit var fakeMainThreadHandler: FakeMainThreadHandler
+
+    private lateinit var nativeCrashHandlerInstaller: NativeCrashHandlerInstallerImpl
+
+    @Before
+    fun setUp() {
+        fakeConfigService = FakeConfigService()
+        fakeSharedObjectLoader = FakeSharedObjectLoader()
+        fakeLogger = FakeEmbLogger(false)
+        fakeRepository = FakeNdkServiceRepository()
+        fakeDelegate = FakeJniDelegate()
+        fakeMainThreadHandler = FakeMainThreadHandler()
+
+        nativeCrashHandlerInstaller = NativeCrashHandlerInstallerImpl(
+            fakeConfigService,
+            fakeSharedObjectLoader,
+            fakeLogger,
+            fakeRepository,
+            fakeDelegate,
+            fakeBackgroundWorker(),
+            { testNativeInstallMessage },
+            fakeMainThreadHandler,
+        )
+    }
+
+    @Test
+    fun `install should start native crash monitoring`() {
+        nativeCrashHandlerInstaller.install()
+
+        assertTrue(fakeDelegate.signalHandlerInstalled)
+    }
+
+    @Test
+    fun `do not install signals when the native install message is null`() {
+        nativeCrashHandlerInstaller = NativeCrashHandlerInstallerImpl(
+            fakeConfigService,
+            fakeSharedObjectLoader,
+            fakeLogger,
+            fakeRepository,
+            fakeDelegate,
+            fakeBackgroundWorker(),
+            { null },
+            fakeMainThreadHandler,
+        )
+
+        nativeCrashHandlerInstaller.install()
+
+        assertFalse(fakeDelegate.signalHandlerInstalled)
+        assertEquals(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL.toString(), fakeLogger.internalErrorMessages.last().msg)
+        assertEquals("Native install message is null", fakeLogger.internalErrorMessages.last().throwable?.message)
+    }
+
+    @Test
+    fun `signal handlers are not reinstalled when the 3rd party signal handler detection is disabled`() {
+        fakeConfigService.autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(sigHandlerDetectionEnabled = false)
+
+        nativeCrashHandlerInstaller.install()
+
+        assertTrue(fakeDelegate.signalHandlerInstalled)
+        assertFalse(fakeDelegate.signalHandlerReinstalled)
+    }
+
+    @Test
+    fun `signal handlers are not reinstalled when the culprit is in the allow list`() {
+        fakeDelegate.culprit = "libwebviewchromium.so"
+
+        nativeCrashHandlerInstaller.install()
+
+        assertTrue(fakeDelegate.signalHandlerInstalled)
+        assertFalse(fakeDelegate.signalHandlerReinstalled)
+    }
+
+    @Test
+    fun `signal handlers are not reinstalled when the culprit is null`() {
+        fakeDelegate.culprit = null
+
+        nativeCrashHandlerInstaller.install()
+
+        assertTrue(fakeDelegate.signalHandlerInstalled)
+        assertFalse(fakeDelegate.signalHandlerReinstalled)
+    }
+
+    @Test
+    fun `signal handlers are reinstalled when the culprit is not in the allow list`() {
+        fakeDelegate.culprit = "libtest.so"
+
+        nativeCrashHandlerInstaller.install()
+
+        assertTrue(fakeDelegate.signalHandlerInstalled)
+        assertTrue(fakeDelegate.signalHandlerReinstalled)
+    }
+
+    @Test
+    fun `an internal error is tracked when an exception occurs`() {
+        fakeSharedObjectLoader.throwWhenLoading = true
+
+        nativeCrashHandlerInstaller.install()
+
+        assertEquals(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL.toString(), fakeLogger.internalErrorMessages.last().msg)
+        assertEquals(SecurityException::class.java, fakeLogger.internalErrorMessages.last().throwable?.javaClass)
+    }
+
+    @Test
+    fun `do not track internal error when loading embrace native fails`() {
+        fakeSharedObjectLoader.failLoad = true
+
+        nativeCrashHandlerInstaller.install()
+
+        assertEquals(0, fakeLogger.internalErrorMessages.size)
+        assertFalse(fakeDelegate.signalHandlerInstalled)
+    }
+}

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/AndroidMainThreadHandler.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/AndroidMainThreadHandler.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.internal.handler
+
+import android.os.Handler
+import android.os.Looper
+
+class AndroidMainThreadHandler : MainThreadHandler {
+    val handler = Handler(checkNotNull(Looper.getMainLooper()))
+
+    override fun postAtFrontOfQueue(function: () -> Unit) {
+        handler.postAtFrontOfQueue(function)
+    }
+
+    override fun postDelayed(runnable: Runnable, delayMillis: Long) {
+        handler.postDelayed(runnable, delayMillis)
+    }
+}

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/MainThreadHandler.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/MainThreadHandler.kt
@@ -1,0 +1,6 @@
+package io.embrace.android.embracesdk.internal.handler
+
+interface MainThreadHandler {
+    fun postAtFrontOfQueue(function: () -> Unit)
+    fun postDelayed(runnable: Runnable, delayMillis: Long)
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
+
+class FakeJniDelegate : JniDelegate {
+    override fun installSignalHandlers(
+        reportPath: String?,
+        markerFilePath: String?,
+        sessionId: String?,
+        appState: String?,
+        reportId: String?,
+        apiLevel: Int,
+        is32bit: Boolean,
+        devLogging: Boolean,
+    ) {
+        // do nothing
+    }
+
+    override fun updateMetaData(metadata: String?) {
+        // do nothing
+    }
+
+    override fun updateSessionId(sessionId: String?) {
+        // do nothing
+    }
+
+    override fun updateAppState(appState: String?) {
+        // do nothing
+    }
+
+    override fun getCrashReport(path: String?): String? {
+        return null
+    }
+
+    override fun getErrors(path: String?): String? {
+        return null
+    }
+
+    override fun checkForOverwrittenHandlers(): String? {
+        return null
+    }
+
+    override fun reinstallSignalHandlers(): Boolean {
+        return false
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
@@ -3,6 +3,11 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
 
 class FakeJniDelegate : JniDelegate {
+
+    var culprit: String? = "testCulprit"
+    var signalHandlerInstalled: Boolean = false
+    var signalHandlerReinstalled = false
+
     override fun installSignalHandlers(
         reportPath: String?,
         markerFilePath: String?,
@@ -13,7 +18,7 @@ class FakeJniDelegate : JniDelegate {
         is32bit: Boolean,
         devLogging: Boolean,
     ) {
-        // do nothing
+        signalHandlerInstalled = true
     }
 
     override fun updateMetaData(metadata: String?) {
@@ -37,10 +42,11 @@ class FakeJniDelegate : JniDelegate {
     }
 
     override fun checkForOverwrittenHandlers(): String? {
-        return null
+        return culprit
     }
 
     override fun reinstallSignalHandlers(): Boolean {
+        signalHandlerReinstalled = true
         return false
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
@@ -8,7 +8,7 @@ class FakeMainThreadHandler : MainThreadHandler {
     }
 
     override fun postDelayed(runnable: Runnable, delayMillis: Long) {
-        Thread.sleep(1000L)
+        Thread.sleep(20L)
         runnable.run()
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.handler.MainThreadHandler
+
+class FakeMainThreadHandler : MainThreadHandler {
+    override fun postAtFrontOfQueue(function: () -> Unit) {
+        function()
+    }
+
+    override fun postDelayed(runnable: Runnable, delayMillis: Long) {
+        runnable.run()
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
@@ -8,6 +8,7 @@ class FakeMainThreadHandler : MainThreadHandler {
     }
 
     override fun postDelayed(runnable: Runnable, delayMillis: Long) {
+        Thread.sleep(1000L)
         runnable.run()
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeFeatureModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeFeatureModule.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerInstaller
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.internal.injection.NativeFeatureModule
+import io.embrace.android.embracesdk.internal.ndk.NativeCrashHandlerInstaller
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.ndk.NdkService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
@@ -14,4 +15,5 @@ class FakeNativeFeatureModule(
     override val ndkService: NdkService = FakeNdkService(),
     override val nativeAnrOtelMapper: NativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer(), FakeClock()),
     override val nativeCrashService: NativeCrashService = FakeNativeCrashService(),
+    override val nativeCrashHandlerInstaller: NativeCrashHandlerInstaller? = null
 ) : NativeFeatureModule

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSharedObjectLoader.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSharedObjectLoader.kt
@@ -7,9 +7,14 @@ class FakeSharedObjectLoader(
     var failLoad: Boolean = false
 ) : SharedObjectLoader {
 
+    var throwWhenLoading = false
+
     override val loaded: AtomicBoolean = AtomicBoolean(false)
 
     override fun loadEmbraceNative(): Boolean {
+        if (throwWhenLoading) {
+            throw SecurityException()
+        }
         loaded.set(!failLoad)
         return loaded.get()
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
@@ -7,6 +7,8 @@ import java.nio.file.Files
 
 class FakeStorageService : StorageService {
 
+    var shouldThrow = false
+
     val cacheDirectory: File by lazy {
         Files.createTempDirectory("cache_temp").toFile()
     }
@@ -23,8 +25,12 @@ class FakeStorageService : StorageService {
     override fun getConfigCacheDir(): File =
         File(cacheDirectory, "emb_config_cache")
 
-    override fun getOrCreateNativeCrashDir(): File =
-        File(filesDirectory, "ndk")
+    override fun getOrCreateNativeCrashDir(): File {
+        if (shouldThrow) {
+            throw SecurityException("getOrCreateNativeCrashDir failed")
+        }
+        return File(filesDirectory, "ndk")
+    }
 
     override fun listFiles(filter: FilenameFilter): List<File> {
         val filesDir = filesDirectory.listFiles(filter) ?: emptyArray()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeStorageService.kt
@@ -23,7 +23,7 @@ class FakeStorageService : StorageService {
     override fun getConfigCacheDir(): File =
         File(cacheDirectory, "emb_config_cache")
 
-    override fun getNativeCrashDir(): File =
+    override fun getOrCreateNativeCrashDir(): File =
         File(filesDirectory, "ndk")
 
     override fun listFiles(filter: FilenameFilter): List<File> {


### PR DESCRIPTION
- Moved the native crash directory creation to EmbraceStorageService. Also handled a possible exception while this is created.
- Created EmbraceNativeCrashHandlerInstaller, with the logic related to installed the signal handlers copied from EmbraceNdkService.

Some considerations when comparing EmbraceNdkService and this new EmbraceNativeCrashHandlerInstaller:
- symbolsForCurrentArch should be moved to the native thread sampler.
- unityCrashId was removed.
- I'm passing the activeSessionId as a class dependency in form of a string, instead of a provider from SessionIdTracker. If we needed the provider to avoid resolving this too quickly, this could be rolled back.
- Listeners that handle updates to session properties, ids, or other metadata should be added in another class. We should check what happens when they receive updates and the signals are not installed, though this shouldn't happen.
- We should review the logic of cleanOldCrashFiles. Why do we only want to clean old crash files when the signal handler is installed? If installSignals fail in the main thread, this won't return false. Should we clean old files too in that case?
- initializeService was always called in a background worker from the ModuleInitBootstraper. That's why I called the background worker in install()
- Added is32bit as a boolean dependency, to not pass the whole deviceArchitecture object.
- getNativeCrashErrors and the logic associated to it should be moved to another class.