### PR TITLE
Extract functions to new hierarchy

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceRepository.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkServiceRepository.kt
@@ -1,9 +1,5 @@
 package io.embrace.android.embracesdk.internal.ndk
 
-import io.embrace.android.embracesdk.internal.ndk.EmbraceNdkService.Companion.NATIVE_CRASH_ERROR_FILE_SUFFIX
-import io.embrace.android.embracesdk.internal.ndk.EmbraceNdkService.Companion.NATIVE_CRASH_FILE_PREFIX
-import io.embrace.android.embracesdk.internal.ndk.EmbraceNdkService.Companion.NATIVE_CRASH_FILE_SUFFIX
-import io.embrace.android.embracesdk.internal.ndk.EmbraceNdkService.Companion.NATIVE_CRASH_MAP_FILE_SUFFIX
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.storage.NATIVE_CRASH_FILE_FOLDER
 import io.embrace.android.embracesdk.internal.storage.StorageService
@@ -124,6 +120,13 @@ internal class EmbraceNdkServiceRepository(
     private fun hasNativeCrashFile(file: File): Boolean {
         val crashFilename = file.absolutePath.substringBeforeLast('.') + NATIVE_CRASH_FILE_SUFFIX
         return File(crashFilename).exists()
+    }
+
+    private companion object {
+        const val NATIVE_CRASH_FILE_PREFIX = "emb_ndk"
+        const val NATIVE_CRASH_FILE_SUFFIX = ".crash"
+        const val NATIVE_CRASH_ERROR_FILE_SUFFIX = ".error"
+        const val NATIVE_CRASH_MAP_FILE_SUFFIX = ".map"
     }
 }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessor.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessor.kt
@@ -1,9 +1,25 @@
 package io.embrace.android.embracesdk.internal.ndk
 
+import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+
 /**
  * Processes any native crashes that are stored on disk from previous processes & converts them
  * into a format that can be ingested by the delivery layer.
  */
 interface NativeCrashProcessor {
-    fun processNativeCrashes()
+
+    /**
+     * Get the latest stored [NativeCrashData] instance and purge all existing native crash data files.
+     */
+    fun getLatestNativeCrash(): NativeCrashData?
+
+    /**
+     * Get all the native crash instances that have been persisted without deleting anything
+     */
+    fun getNativeCrashes(): List<NativeCrashData>
+
+    /**
+     * Purge all existing native crash data files.
+     */
+    fun deleteAllNativeCrashes()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImpl.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.TypeUtils
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
-import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolServiceImpl
+import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.NativeCrashDataError
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
@@ -22,14 +22,14 @@ internal class NativeCrashProcessorImpl(
     private val repository: NdkServiceRepository,
     private val delegate: JniDelegate,
     private val serializer: PlatformSerializer,
-    private val symbolService: SymbolServiceImpl,
-) {
+    private val symbolService: SymbolService,
+) : NativeCrashProcessor {
 
-    fun getLatestNativeCrash(): NativeCrashData? = getAllNativeCrashes(repository::deleteFiles).lastOrNull()
+    override fun getLatestNativeCrash(): NativeCrashData? = getAllNativeCrashes(repository::deleteFiles).lastOrNull()
 
-    fun getNativeCrashes(): List<NativeCrashData> = getAllNativeCrashes()
+    override fun getNativeCrashes(): List<NativeCrashData> = getAllNativeCrashes()
 
-    fun deleteAllNativeCrashes() {
+    override fun deleteAllNativeCrashes() {
         getAllNativeCrashes(repository::deleteFiles)
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
@@ -1,34 +1,14 @@
 package io.embrace.android.embracesdk.internal.ndk
 
-import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 
-interface NdkService {
+interface NdkService : NativeCrashProcessor, SymbolService {
     fun updateSessionId(newSessionId: String)
 
     fun onSessionPropertiesUpdate(properties: Map<String, String>)
 
     fun onUserInfoUpdate()
 
-    /**
-     * Get the latest stored [NativeCrashData] instance and purge all existing native crash data files.
-     */
-    fun getLatestNativeCrash(): NativeCrashData?
-
-    /**
-     * Get all the native crash instances that have been persisted without deleting anything
-     */
-    fun getNativeCrashes(): List<NativeCrashData>
-
-    /**
-     * Retrieves symbol information for the current architecture.
-     */
-    val symbolsForCurrentArch: Map<String, String>?
-
     fun initializeService(sessionIdTracker: SessionIdTracker)
-
-    /**
-     * Purge all existing native crash data files.
-     */
-    fun deleteAllNativeCrashes()
 }


### PR DESCRIPTION
## Goal

Adds functions to the `NativeCrashProcessor` interface and uses delegation to avoid unnecessary function declarations in `EmbraceNdkService`

## Testing

Relied on existing test coverage.