### PR TITLE
Split ndk service

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModule.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModule.kt
@@ -4,8 +4,10 @@ import io.embrace.android.embracesdk.internal.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerInstaller
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashHandlerInstaller
+import io.embrace.android.embracesdk.internal.ndk.NativeCrashProcessor
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.ndk.NdkService
+import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
 
 interface NativeFeatureModule {
     val ndkService: NdkService
@@ -13,5 +15,7 @@ interface NativeFeatureModule {
     val nativeThreadSamplerInstaller: NativeThreadSamplerInstaller?
     val nativeAnrOtelMapper: NativeAnrOtelMapper
     val nativeCrashService: NativeCrashService?
+    val symbolService: SymbolService
+    val processor: NativeCrashProcessor
     val nativeCrashHandlerInstaller: NativeCrashHandlerInstaller?
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.ndk
 
-import android.content.Context
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -15,8 +14,6 @@ import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
-import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
-import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolServiceImpl
 import io.embrace.android.embracesdk.internal.payload.NativeCrashMetadata
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
@@ -27,7 +24,6 @@ import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 internal class EmbraceNdkService(
-    context: Context,
     private val storageService: StorageService,
     private val metadataService: MetadataService,
     private val processStateService: ProcessStateService,
@@ -42,24 +38,7 @@ internal class EmbraceNdkService(
     private val deviceArchitecture: DeviceArchitecture,
     private val serializer: PlatformSerializer,
     private val handler: Handler = Handler(checkNotNull(Looper.getMainLooper())),
-    private val symbolService: SymbolService = SymbolServiceImpl(
-        context,
-        deviceArchitecture,
-        serializer,
-        logger
-    ),
-    private val processor: NativeCrashProcessor = NativeCrashProcessorImpl(
-        sharedObjectLoader,
-        logger,
-        repository,
-        delegate,
-        serializer,
-        symbolService
-    )
-) : NdkService,
-    ProcessStateListener,
-    SymbolService by symbolService,
-    NativeCrashProcessor by processor {
+) : NdkService, ProcessStateListener {
 
     override fun initializeService(sessionIdTracker: SessionIdTracker) {
         Systrace.traceSynchronous("init-ndk-service") {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
@@ -20,7 +20,7 @@ import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 internal class NativeCrashDataSourceImpl(
     private val sessionPropertiesService: SessionPropertiesService,
-    private val ndkService: NdkService,
+    private val nativeCrashProcessor: NativeCrashProcessor,
     private val preferencesService: PreferencesService,
     private val logWriter: LogWriter,
     private val configService: ConfigService,
@@ -32,12 +32,12 @@ internal class NativeCrashDataSourceImpl(
     limitStrategy = NoopLimitStrategy,
 ) {
     override fun getAndSendNativeCrash(): NativeCrashData? {
-        return ndkService.getLatestNativeCrash()?.apply {
+        return nativeCrashProcessor.getLatestNativeCrash()?.apply {
             sendNativeCrash(this)
         }
     }
 
-    override fun getNativeCrashes(): List<NativeCrashData> = ndkService.getNativeCrashes()
+    override fun getNativeCrashes(): List<NativeCrashData> = nativeCrashProcessor.getNativeCrashes()
 
     override fun sendNativeCrash(nativeCrash: NativeCrashData) {
         val nativeCrashNumber = preferencesService.incrementAndGetNativeCrashNumber()
@@ -95,6 +95,6 @@ internal class NativeCrashDataSourceImpl(
     }
 
     override fun deleteAllNativeCrashes() {
-        ndkService.deleteAllNativeCrashes()
+        nativeCrashProcessor.deleteAllNativeCrashes()
     }
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NdkService.kt
@@ -1,9 +1,8 @@
 package io.embrace.android.embracesdk.internal.ndk
 
-import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 
-interface NdkService : NativeCrashProcessor, SymbolService {
+interface NdkService {
     fun updateSessionId(newSessionId: String)
 
     fun onSessionPropertiesUpdate(properties: Map<String, String>)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImplTest.kt
@@ -43,6 +43,8 @@ internal class NativeFeatureModuleImplTest {
         assertNull(module.nativeThreadSamplerService)
         assertNull(module.nativeThreadSamplerInstaller)
         assertNotNull(module.nativeAnrOtelMapper)
+        assertNotNull(module.symbolService)
+        assertNotNull(module.processor)
         assertNull(module.nativeCrashService)
         assertNull(module.nativeCrashHandlerInstaller)
     }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.ndk
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.fakes.FakeNdkService
+import io.embrace.android.embracesdk.fakes.FakeNativeCrashProcessor
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
@@ -39,7 +39,7 @@ import org.junit.Test
 internal class NativeCrashDataSourceImplTest {
 
     private lateinit var sessionPropertiesService: SessionPropertiesService
-    private lateinit var fakeNdkService: FakeNdkService
+    private lateinit var crashProcessor: FakeNativeCrashProcessor
     private lateinit var preferencesService: FakePreferenceService
     private lateinit var configService: FakeConfigService
     private lateinit var serializer: EmbraceSerializer
@@ -55,7 +55,7 @@ internal class NativeCrashDataSourceImplTest {
     @Before
     fun setUp() {
         sessionPropertiesService = FakeSessionPropertiesService()
-        fakeNdkService = FakeNdkService()
+        crashProcessor = FakeNativeCrashProcessor()
         preferencesService = FakePreferenceService()
         logger = EmbLoggerImpl()
         sessionIdTracker = FakeSessionIdTracker().apply { setActiveSession("currentSessionId", true) }
@@ -73,7 +73,7 @@ internal class NativeCrashDataSourceImplTest {
         serializer = EmbraceSerializer()
         nativeCrashDataSource = NativeCrashDataSourceImpl(
             sessionPropertiesService = sessionPropertiesService,
-            ndkService = fakeNdkService,
+            nativeCrashProcessor = crashProcessor,
             preferencesService = preferencesService,
             logWriter = logWriter,
             configService = configService,
@@ -84,7 +84,7 @@ internal class NativeCrashDataSourceImplTest {
 
     @Test
     fun `native crash sent when there is one to be found`() {
-        fakeNdkService.addNativeCrashData(testNativeCrashData)
+        crashProcessor.addNativeCrashData(testNativeCrashData)
         assertNotNull(nativeCrashDataSource.getAndSendNativeCrash())
 
         with(otelLogger.builders.single()) {
@@ -106,7 +106,7 @@ internal class NativeCrashDataSourceImplTest {
 
     @Test
     fun `native crash sent without attributes that are null`() {
-        fakeNdkService.addNativeCrashData(
+        crashProcessor.addNativeCrashData(
             NativeCrashData(
                 nativeCrashId = "nativeCrashId",
                 sessionId = "null",
@@ -132,7 +132,7 @@ internal class NativeCrashDataSourceImplTest {
 
     @Test
     fun `native crash sent without attributes that are blankish`() {
-        fakeNdkService.addNativeCrashData(
+        crashProcessor.addNativeCrashData(
             NativeCrashData(
                 nativeCrashId = "nativeCrashId",
                 sessionId = "",

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImplTest.kt
@@ -1,0 +1,149 @@
+package io.embrace.android.embracesdk.internal.ndk
+
+import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeJniDelegate
+import io.embrace.android.embracesdk.fakes.FakeNdkServiceRepository
+import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
+import io.embrace.android.embracesdk.fakes.FakeStorageService
+import io.embrace.android.embracesdk.fakes.FakeSymbolService
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.payload.AppFramework
+import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+internal class NativeCrashProcessorImplTest {
+
+    private lateinit var service: NativeCrashProcessor
+    private lateinit var storageManager: FakeStorageService
+    private lateinit var configService: FakeConfigService
+    private lateinit var sharedObjectLoader: FakeSharedObjectLoader
+    private lateinit var logger: EmbLogger
+    private lateinit var delegate: FakeJniDelegate
+    private lateinit var repository: FakeNdkServiceRepository
+    private lateinit var blockableExecutorService: BlockableExecutorService
+    private val serializer = EmbraceSerializer()
+
+    @Before
+    fun setup() {
+        storageManager = FakeStorageService()
+        configService = FakeConfigService(autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(ndkEnabled = true))
+        sharedObjectLoader = FakeSharedObjectLoader().apply { loadEmbraceNative() }
+        logger = EmbLoggerImpl()
+        delegate = FakeJniDelegate()
+        repository = FakeNdkServiceRepository()
+        blockableExecutorService = BlockableExecutorService()
+    }
+
+    @After
+    fun after() {
+        val cacheDir = File("${storageManager.cacheDirectory}/ndk")
+        if (cacheDir.exists()) {
+            cacheDir.delete()
+        }
+        val filesDir = File("${storageManager.filesDirectory}/ndk")
+        if (filesDir.exists()) {
+            filesDir.delete()
+        }
+    }
+
+    private fun initializeService() {
+        service = NativeCrashProcessorImpl(
+            sharedObjectLoader,
+            logger,
+            repository,
+            delegate,
+            serializer,
+            FakeSymbolService(mapOf("symbol1" to "test"))
+        )
+    }
+
+    @Test
+    fun `test getLatestNativeCrash does nothing if there are no matchingFiles`() {
+        initializeService()
+        val result = service.getLatestNativeCrash()
+        assertNull(result)
+    }
+
+    @Test
+    fun `test getLatestNativeCrash catches an exception if _getCrashReport returns an empty string`() {
+        repository.addCrashFiles(File.createTempFile("test", "test"))
+        initializeService()
+        val crashData = service.getLatestNativeCrash()
+        assertNull(crashData)
+    }
+
+    @Test
+    fun `test getLatestNativeCrash catches an exception if _getCrashReport returns invalid json syntax`() {
+        repository.addCrashFiles(File.createTempFile("test", "test"))
+
+        val json = "{\n" +
+            "  \"sid\": [\n" +
+            "    {\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}"
+        delegate.crashRaw = json
+
+        initializeService()
+        val crashData = service.getLatestNativeCrash()
+        assertNull(crashData)
+    }
+
+    @Test
+    fun `test getLatestNativeCrash when a native crash was captured`() {
+        repository.addCrashFiles(
+            nativeCrashFile = File.createTempFile("test", "crash-test")
+        )
+        delegate.crashRaw = getNativeCrashRaw()
+
+        configService.appFramework = AppFramework.UNITY
+
+        initializeService()
+
+        val result = checkNotNull(service.getLatestNativeCrash())
+        with(result) {
+            assertNotNull(crash)
+        }
+    }
+
+    @Test
+    fun `test getLatestNativeCrash when there is no native crash does not execute crash files logic`() {
+        configService.appFramework = AppFramework.UNITY
+        initializeService()
+
+        val result = service.getLatestNativeCrash()
+        assertNull(result)
+    }
+
+    @Test
+    fun `getNativeCrashes returns all the crashes in the repository and doesn't invoke delete`() {
+        delegate.crashRaw = getNativeCrashRaw()
+        initializeService()
+        repository.addCrashFiles(File.createTempFile("file1", "tmp"))
+        repository.addCrashFiles(File.createTempFile("file2", "temp"))
+        assertEquals(2, service.getNativeCrashes().size)
+        assertEquals(2, service.getNativeCrashes().size)
+    }
+
+    @Test
+    fun `getLatestNativeCrash returns only one crash even if there are many and deletes them all`() {
+        delegate.crashRaw = getNativeCrashRaw()
+        initializeService()
+        repository.addCrashFiles(File.createTempFile("file1", "tmp"))
+        repository.addCrashFiles(File.createTempFile("file2", "temp"))
+        assertNotNull(service.getLatestNativeCrash())
+        assertEquals(0, service.getNativeCrashes().size)
+    }
+
+    private fun getNativeCrashRaw() = ResourceReader.readResourceAsText("native_crash_raw.txt")
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
 
 class FakeJniDelegate : JniDelegate {
 
+    var crashRaw: String? = null
     var culprit: String? = "testCulprit"
     var signalHandlerInstalled: Boolean = false
     var signalHandlerReinstalled = false
@@ -34,7 +35,7 @@ class FakeJniDelegate : JniDelegate {
     }
 
     override fun getCrashReport(path: String?): String? {
-        return null
+        return crashRaw
     }
 
     override fun checkForOverwrittenHandlers(): String? {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashProcessor.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashProcessor.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.ndk.NativeCrashProcessor
+import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+
+class FakeNativeCrashProcessor : NativeCrashProcessor {
+
+    private val nativeCrashDataBlobs = mutableListOf<NativeCrashData>()
+
+    override fun deleteAllNativeCrashes() {
+        nativeCrashDataBlobs.clear()
+    }
+
+    override fun getLatestNativeCrash(): NativeCrashData? = nativeCrashDataBlobs.lastOrNull()
+
+    override fun getNativeCrashes(): List<NativeCrashData> = nativeCrashDataBlobs
+
+    fun addNativeCrashData(data: NativeCrashData) {
+        nativeCrashDataBlobs.add(data)
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeFeatureModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeFeatureModule.kt
@@ -5,8 +5,10 @@ import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerInstall
 import io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerService
 import io.embrace.android.embracesdk.internal.injection.NativeFeatureModule
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashHandlerInstaller
+import io.embrace.android.embracesdk.internal.ndk.NativeCrashProcessor
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.ndk.NdkService
+import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 
 class FakeNativeFeatureModule(
@@ -15,5 +17,7 @@ class FakeNativeFeatureModule(
     override val ndkService: NdkService = FakeNdkService(),
     override val nativeAnrOtelMapper: NativeAnrOtelMapper = NativeAnrOtelMapper(null, EmbraceSerializer(), FakeClock()),
     override val nativeCrashService: NativeCrashService = FakeNativeCrashService(),
+    override val symbolService: SymbolService = FakeSymbolService(),
+    override val processor: NativeCrashProcessor = FakeNativeCrashProcessor(),
     override val nativeCrashHandlerInstaller: NativeCrashHandlerInstaller? = null
 ) : NativeFeatureModule

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNdkService.kt
@@ -1,20 +1,14 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.ndk.NdkService
-import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 
 class FakeNdkService : NdkService {
     val propUpdates: MutableList<Map<String, String>> = mutableListOf()
     var sessionId: String? = null
     var userUpdateCount: Int = 0
-    private val nativeCrashDataBlobs = mutableListOf<NativeCrashData>()
 
     override fun initializeService(sessionIdTracker: SessionIdTracker) {
-    }
-
-    override fun deleteAllNativeCrashes() {
-        nativeCrashDataBlobs.clear()
     }
 
     override fun updateSessionId(newSessionId: String) {
@@ -27,15 +21,5 @@ class FakeNdkService : NdkService {
 
     override fun onUserInfoUpdate() {
         userUpdateCount++
-    }
-
-    override fun getLatestNativeCrash(): NativeCrashData? = nativeCrashDataBlobs.lastOrNull()
-
-    override fun getNativeCrashes(): List<NativeCrashData> = nativeCrashDataBlobs
-
-    override val symbolsForCurrentArch: Map<String, String>? = null
-
-    fun addNativeCrashData(data: NativeCrashData) {
-        nativeCrashDataBlobs.add(data)
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSymbolService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSymbolService.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
+
+class FakeSymbolService(
+    override val symbolsForCurrentArch: Map<String, String> = emptyMap(),
+) : SymbolService


### PR DESCRIPTION
## Goal

Splits the `NativeCrashProcessor` and `SymbolService` out of the `NdkService` implementation. There are no functional changes with this PR.

## Testing

Updated existing unit tests where required.

