### PR TITLE
Extract file storage to separate class

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import java.io.InputStream
 
 /**
@@ -9,7 +10,22 @@ import java.io.InputStream
 interface FileStorageService {
 
     /**
-     * Loads a stored payload as an [InputStream]
+     * Stores a payload
+     */
+    fun store(metadata: StoredTelemetryMetadata, action: SerializationAction)
+
+    /**
+     * Deletes a payload
+     */
+    fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit = {})
+
+    /**
+     * Loads a payload as an [InputStream]
      */
     fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream?
+
+    /**
+     * Return stored payloads as a list sorted in priority order
+     */
+    fun getStoredPayloads(): List<StoredTelemetryMetadata>
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -1,17 +1,91 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.InputStream
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.RejectedExecutionException
 
 internal class FileStorageServiceImpl(
     outputDir: Lazy<File>,
+    private val worker: PriorityWorker<StoredTelemetryMetadata>,
     private val logger: EmbLogger,
+    private val storageLimit: Int = 500,
 ) : FileStorageService {
 
     private val payloadDir by outputDir
+
+    // maintain an in-memory list of payloads to avoid calling listFiles() every time we need
+    // to check the storage limit. This will always remain in sync with the actual files on disk
+    // as the files are only manipulated from within this class.
+    private val storedFiles: CopyOnWriteArraySet<StoredTelemetryMetadata> by lazy {
+        val result = runCatching { payloadDir.listFiles() }.getOrNull()
+        val files = result?.toList() ?: emptyList()
+        val metadata = files.mapNotNull {
+            StoredTelemetryMetadata.fromFilename(it.name).getOrNull()
+        }
+        CopyOnWriteArraySet(metadata)
+    }
+
+    override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
+        try {
+            storeImpl(metadata, action)
+        } catch (exc: Throwable) {
+            logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+        }
+    }
+
+    private fun storeImpl(
+        metadata: StoredTelemetryMetadata,
+        action: SerializationAction,
+    ) {
+        if (pruneStorage(metadata)) {
+            return
+        }
+
+        // write to a temporary file then rename it, to avoid sending incomplete files
+        // to the backend (i.e. where the process terminates or there isn't any disk space).
+        val tmpFile = File.createTempFile(metadata.filename, ".tmp")
+        tmpFile.outputStream().buffered().use { stream ->
+            action(stream)
+        }
+
+        // move the complete file to its final location.
+        val dst = metadata.asFile()
+        dst.parentFile?.mkdirs()
+        if (tmpFile.renameTo(dst)) {
+            storedFiles.add(metadata)
+        }
+    }
+
+    override fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit) {
+        val action = {
+            processDelete(metadata)
+            callback()
+        }
+        try {
+            worker.submit(metadata, action)
+        } catch (exc: RejectedExecutionException) { // handle JVM crash case where worker is shutdown
+            action()
+        }
+    }
+
+    private fun processDelete(metadata: StoredTelemetryMetadata) {
+        try {
+            if (metadata.asFile().delete()) {
+                storedFiles.remove(metadata)
+            }
+        } catch (exc: Throwable) {
+            if (exc !is FileNotFoundException) {
+                logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+            }
+        }
+    }
 
     override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? {
         return try {
@@ -20,6 +94,33 @@ internal class FileStorageServiceImpl(
             logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
             null
         }
+    }
+
+    override fun getStoredPayloads(): List<StoredTelemetryMetadata> {
+        return storedFiles.toList()
+    }
+
+    private fun pruneStorage(metadata: StoredTelemetryMetadata): Boolean {
+        val count = storedFiles.size
+        if (count < storageLimit) {
+            return false
+        }
+        val input = storedFiles.plus(metadata)
+        val removalCount = input.size - storageLimit
+        if (removalCount < 0) {
+            return false
+        }
+        val removals = input.sortedWith(
+            compareByDescending(StoredTelemetryMetadata::envelopeType)
+                .thenBy(StoredTelemetryMetadata::timestamp)
+        )
+            .take(removalCount)
+        removals.forEach(::processDelete)
+        logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, RuntimeException("Pruned payload storage"))
+
+        // notify the caller whether the new payload should be dropped
+        val shouldNotPersist = removals.contains(metadata)
+        return shouldNotPersist
     }
 
     private fun StoredTelemetryMetadata.asFile(): File = File(payloadDir, filename)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -9,10 +9,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.InputStream
-import java.util.concurrent.CopyOnWriteArraySet
-import java.util.concurrent.RejectedExecutionException
 import java.util.zip.GZIPOutputStream
 
 /**
@@ -22,15 +19,11 @@ import java.util.zip.GZIPOutputStream
  */
 class PayloadStorageServiceImpl(
     outputDir: Lazy<File>,
-    private val worker: PriorityWorker<StoredTelemetryMetadata>,
+    worker: PriorityWorker<StoredTelemetryMetadata>,
     private val processIdProvider: () -> String,
-    private val logger: EmbLogger,
+    logger: EmbLogger,
     private val deliveryTracer: DeliveryTracer? = null,
-    private val storageLimit: Int = 500,
-    private val fileStorageService: FileStorageService = FileStorageServiceImpl(
-        outputDir,
-        logger
-    ),
+    storageLimit: Int = 500,
 ) : PayloadStorageService {
 
     enum class OutputType(internal val dir: String) {
@@ -56,79 +49,27 @@ class PayloadStorageServiceImpl(
         storageLimit: Int = 500,
     ) : this(createOutputDir(ctx, outputType, logger), worker, processIdProvider, logger, deliveryTracer, storageLimit)
 
-    private val payloadDir by outputDir
-
-    // maintain an in-memory list of payloads to avoid calling listFiles() every time we need
-    // to check the storage limit. This will always remain in sync with the actual files on disk
-    // as the files are only manipulated from within this class.
-    private val storedFiles: CopyOnWriteArraySet<StoredTelemetryMetadata> by lazy {
-        val result = runCatching { payloadDir.listFiles() }.getOrNull()
-        val files = result?.toList() ?: emptyList()
-        val metadata = files.mapNotNull {
-            StoredTelemetryMetadata.fromFilename(it.name).getOrNull()
-        }
-        CopyOnWriteArraySet(metadata)
-    }
+    private val fileStorageService: FileStorageService = FileStorageServiceImpl(
+        outputDir,
+        worker,
+        logger,
+        storageLimit
+    )
 
     /**
      * [SerializationAction] is expected to return bytes that are not compressed, and they will be gzipped before
      * being persisted.
      */
     override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
-        try {
-            storeImpl(metadata, action)
-        } catch (exc: Throwable) {
-            logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
-        }
-    }
-
-    private fun storeImpl(
-        metadata: StoredTelemetryMetadata,
-        action: SerializationAction,
-    ) {
-        if (pruneStorage(metadata)) {
-            return
-        }
-
-        // write to a temporary file then rename it, to avoid sending incomplete files
-        // to the backend (i.e. where the process terminates or there isn't any disk space).
-        val tmpFile = File.createTempFile(metadata.filename, ".tmp")
-        GZIPOutputStream(tmpFile.outputStream().buffered()).use { stream ->
-            action(stream)
-        }
-
-        // move the complete file to its final location.
-        val dst = metadata.asFile()
-        dst.parentFile?.mkdirs()
-        if (tmpFile.renameTo(dst)) {
-            storedFiles.add(metadata)
+        fileStorageService.store(metadata) { stream ->
+            GZIPOutputStream(stream).use(action)
         }
         deliveryTracer?.onStore(metadata)
     }
 
     override fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit) {
-        val action = {
-            processDelete(metadata)
-            callback()
-        }
-        try {
-            worker.submit(metadata, action)
-        } catch (exc: RejectedExecutionException) { // handle JVM crash case where worker is shutdown
-            action()
-        }
-    }
-
-    private fun processDelete(metadata: StoredTelemetryMetadata) {
-        try {
-            if (metadata.asFile().delete()) {
-                storedFiles.remove(metadata)
-            }
-            deliveryTracer?.onDelete(metadata)
-        } catch (exc: Throwable) {
-            if (exc !is FileNotFoundException) {
-                logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
-            }
-        }
+        fileStorageService.delete(metadata, callback)
+        deliveryTracer?.onDelete(metadata)
     }
 
     /**
@@ -142,43 +83,18 @@ class PayloadStorageServiceImpl(
     }
 
     override fun getPayloadsByPriority(): List<StoredTelemetryMetadata> {
-        return storedFiles.toList().sortedWith(storedTelemetryComparator).apply {
+        return fileStorageService.getStoredPayloads().sortedWith(storedTelemetryComparator).apply {
             deliveryTracer?.onGetPayloadsByPriority(this)
         }
     }
 
     override fun getUndeliveredPayloads(): List<StoredTelemetryMetadata> {
-        return storedFiles.sortedWith(storedTelemetryComparator)
+        return fileStorageService.getStoredPayloads().sortedWith(storedTelemetryComparator)
             .filter { !it.complete && it.processId != processIdProvider() }
             .toList().apply {
                 deliveryTracer?.onGetUndeliveredPayloads(this)
             }
     }
-
-    private fun pruneStorage(metadata: StoredTelemetryMetadata): Boolean {
-        val count = storedFiles.size
-        if (count < storageLimit) {
-            return false
-        }
-        val input = storedFiles.plus(metadata)
-        val removalCount = input.size - storageLimit
-        if (removalCount < 0) {
-            return false
-        }
-        val removals = input.sortedWith(
-            compareByDescending(StoredTelemetryMetadata::envelopeType)
-                .thenBy(StoredTelemetryMetadata::timestamp)
-        )
-            .take(removalCount)
-        removals.forEach(::processDelete)
-        logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, RuntimeException("Pruned payload storage"))
-
-        // notify the caller whether the new payload should be dropped
-        val shouldNotPersist = removals.contains(metadata)
-        return shouldNotPersist
-    }
-
-    private fun StoredTelemetryMetadata.asFile(): File = File(payloadDir, filename)
 
     private companion object {
         fun createOutputDir(


### PR DESCRIPTION
## Goal

Extracts file storage to a separate class so that it can be used for storing NDK payloads too.

## Testing

Mostly relied on existing test coverage as `PayloadStorageService` is well tested.
