### PR TITLE
Extract storage dir logic from payload storage service

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServ
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServiceImpl
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageServiceImpl
+import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.internal.session.orchestrator.PayloadStore
 import io.embrace.android.embracesdk.internal.session.orchestrator.V1PayloadStore
@@ -119,11 +120,11 @@ internal class DeliveryModuleImpl(
         payloadStorageServiceProvider?.invoke() ?: if (configModule.configService.isOnlyUsingOtelExporters()) {
             null
         } else {
+            val location = StorageLocation.PAYLOAD.asFile(coreModule.context, initModule.logger)
             PayloadStorageServiceImpl(
-                coreModule.context,
+                location,
                 dataPersistenceWorker,
                 processIdProvider,
-                PayloadStorageServiceImpl.OutputType.PAYLOAD,
                 initModule.logger,
                 deliveryTracer
             )
@@ -134,11 +135,11 @@ internal class DeliveryModuleImpl(
         cacheStorageServiceProvider?.invoke() ?: if (configModule.configService.isOnlyUsingOtelExporters()) {
             null
         } else {
+            val location = StorageLocation.CACHE.asFile(coreModule.context, initModule.logger)
             PayloadStorageServiceImpl(
-                coreModule.context,
+                location,
                 dataPersistenceWorker,
                 processIdProvider,
-                PayloadStorageServiceImpl.OutputType.CACHE,
                 initModule.logger,
                 deliveryTracer
             )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImpl.kt
@@ -36,6 +36,6 @@ internal class NativeCoreModuleImpl(
         delegate,
         initModule.jsonSerializer,
         symbolService,
-        storageModule.storageService
+        storageModule.storageService,
     )
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -1,12 +1,10 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
-import android.content.Context
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 import java.io.InputStream
@@ -25,29 +23,6 @@ class PayloadStorageServiceImpl(
     private val deliveryTracer: DeliveryTracer? = null,
     storageLimit: Int = 500,
 ) : PayloadStorageService {
-
-    enum class OutputType(internal val dir: String) {
-
-        /**
-         * A complete payload that is ready to send
-         */
-        PAYLOAD("embrace_payloads"),
-
-        /**
-         * An incomplete cached payload that is not ready to send
-         */
-        CACHE("embrace_cache")
-    }
-
-    constructor(
-        ctx: Context,
-        worker: PriorityWorker<StoredTelemetryMetadata>,
-        processIdProvider: () -> String,
-        outputType: OutputType,
-        logger: EmbLogger,
-        deliveryTracer: DeliveryTracer? = null,
-        storageLimit: Int = 500,
-    ) : this(createOutputDir(ctx, outputType, logger), worker, processIdProvider, logger, deliveryTracer, storageLimit)
 
     private val fileStorageService: FileStorageService = FileStorageServiceImpl(
         outputDir,
@@ -94,20 +69,5 @@ class PayloadStorageServiceImpl(
             .toList().apply {
                 deliveryTracer?.onGetUndeliveredPayloads(this)
             }
-    }
-
-    private companion object {
-        fun createOutputDir(
-            ctx: Context,
-            outputType: OutputType,
-            logger: EmbLogger,
-        ) = lazy {
-            try {
-                File(ctx.filesDir, outputType.dir).apply(File::mkdirs)
-            } catch (exc: Throwable) {
-                logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
-                File(ctx.cacheDir, outputType.dir).apply(File::mkdirs)
-            }
-        }
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocation.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocation.kt
@@ -1,0 +1,36 @@
+package io.embrace.android.embracesdk.internal.delivery.storage
+
+import android.content.Context
+import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import java.io.File
+
+enum class StorageLocation(private val dir: String) {
+
+    /**
+     * A complete payload that is ready to send
+     */
+    PAYLOAD("embrace_payloads"),
+
+    /**
+     * An incomplete cached payload that is not ready to send
+     */
+    CACHE("embrace_cache"),
+
+    /**
+     * Native Embrace crash reports
+     */
+    NATIVE("embrace_native");
+
+    /**
+     * Get the directory as a [File] object
+     */
+    fun asFile(ctx: Context, logger: EmbLogger): Lazy<File> = lazy {
+        try {
+            File(ctx.filesDir, dir).apply(File::mkdirs)
+        } catch (exc: Throwable) {
+            logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+            File(ctx.cacheDir, dir).apply(File::mkdirs)
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Extracts the logic that declares where files are stored from `PayloadStorageService` as we will need to use this for the NDK crash reporting too.

