### PR TITLE
Use FileStore for NDK crash reports

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleSupplier.kt
@@ -11,6 +11,7 @@ typealias NativeCoreModuleSupplier = (
     configModule: ConfigModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    otelModule: OpenTelemetryModule,
 ) -> NativeCoreModule
 
 fun createNativeCoreModule(
@@ -21,6 +22,7 @@ fun createNativeCoreModule(
     configModule: ConfigModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    otelModule: OpenTelemetryModule,
 ): NativeCoreModule = NativeCoreModuleImpl(
     initModule,
     coreModule,
@@ -28,5 +30,6 @@ fun createNativeCoreModule(
     workerThreadModule,
     configModule,
     storageModule,
-    essentialServiceModule
+    essentialServiceModule,
+    otelModule
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImpl.kt
@@ -1,13 +1,16 @@
 package io.embrace.android.embracesdk.internal.ndk
 
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
+import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
+import io.embrace.android.embracesdk.internal.delivery.storage.FileStorageService
+import io.embrace.android.embracesdk.internal.delivery.storage.FileStorageServiceImpl
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
 import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.storage.StorageService
+import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -17,8 +20,15 @@ class NativeCrashProcessorImpl(
     private val delegate: JniDelegate,
     private val serializer: PlatformSerializer,
     private val symbolService: SymbolService,
-    private val storageService: StorageService,
+    private val outputDir: Lazy<File>,
+    worker: PriorityWorker<StoredTelemetryMetadata>,
 ) : NativeCrashProcessor {
+
+    private val fileStorageService: FileStorageService = FileStorageServiceImpl(
+        outputDir,
+        worker,
+        logger,
+    )
 
     override fun getLatestNativeCrash(): NativeCrashData? {
         return getAllNativeCrashes().lastOrNull().also {
@@ -29,14 +39,15 @@ class NativeCrashProcessorImpl(
     override fun getNativeCrashes(): List<NativeCrashData> = getAllNativeCrashes()
 
     override fun deleteAllNativeCrashes() {
-        getNativeCrashFiles().forEach(File::delete)
+        fileStorageService.getStoredPayloads().forEach(fileStorageService::delete)
     }
 
     private fun getAllNativeCrashes(): List<NativeCrashData> {
         if (!sharedObjectLoader.loaded.get()) {
             return emptyList()
         }
-        val nativeCrashes = getNativeCrashFiles().mapNotNull { crashFile ->
+        val files = fileStorageService.getStoredPayloads().map { File(outputDir.value, it.filename) }
+        val nativeCrashes = files.mapNotNull { crashFile ->
             try {
                 val crashReport = delegate.getCrashReport(crashFile.path)
                 if (crashReport != null) {
@@ -63,11 +74,5 @@ class NativeCrashProcessorImpl(
             }
         }
         return nativeCrashes
-    }
-
-    private fun getNativeCrashFiles(): List<File> {
-        val nativeCrashDir: File = storageService.getOrCreateNativeCrashDir()
-        val files = nativeCrashDir.listFiles() ?: emptyArray()
-        return files.filter { it.extension == "crash" }.sortedBy(File::lastModified)
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeInstallMessage.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeInstallMessage.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.internal.ndk
 
 data class NativeInstallMessage(
-    val reportPath: String,
     val markerFilePath: String,
-    val sessionId: String,
     val appState: String,
     val reportId: String,
     val apiLevel: Int,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegate.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegate.kt
@@ -2,9 +2,7 @@ package io.embrace.android.embracesdk.internal.ndk.jni
 
 interface JniDelegate {
     fun installSignalHandlers(
-        reportPath: String,
         markerFilePath: String?,
-        sessionId: String?,
         appState: String?,
         reportId: String?,
         apiLevel: Int,
@@ -12,7 +10,7 @@ interface JniDelegate {
         devLogging: Boolean,
     )
     fun updateMetaData(metadata: String?)
-    fun onSessionChange(sessionId: String?)
+    fun onSessionChange(sessionId: String?, reportPath: String)
     fun updateAppState(appState: String?)
     fun getCrashReport(path: String?): String?
     fun checkForOverwrittenHandlers(): String?

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegateImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegateImpl.kt
@@ -2,9 +2,7 @@ package io.embrace.android.embracesdk.internal.ndk.jni
 
 class JniDelegateImpl : JniDelegate {
     external override fun installSignalHandlers(
-        reportPath: String,
         markerFilePath: String?,
-        sessionId: String?,
         appState: String?,
         reportId: String?,
         apiLevel: Int,
@@ -13,7 +11,7 @@ class JniDelegateImpl : JniDelegate {
     )
 
     external override fun updateMetaData(metadata: String?)
-    external override fun onSessionChange(sessionId: String?)
+    external override fun onSessionChange(sessionId: String?, reportPath: String)
     external override fun updateAppState(appState: String?)
     external override fun getCrashReport(path: String?): String?
     external override fun checkForOverwrittenHandlers(): String?

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImplTest.kt
@@ -1,6 +1,10 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
@@ -8,9 +12,10 @@ import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.mockk.mockk
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 internal class NativeCoreModuleImplTest {
 
     @Test
@@ -21,14 +26,21 @@ internal class NativeCoreModuleImplTest {
             createCoreModule(mockk(relaxed = true), initModule),
             FakePayloadSourceModule(),
             FakeWorkerThreadModule(),
-            FakeConfigModule(),
+            FakeConfigModule(
+                configService = FakeConfigService(
+                    autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
+                        ndkEnabled = true
+                    )
+                )
+            ),
             FakeStorageModule(),
             FakeEssentialServiceModule(),
+            FakeOpenTelemetryModule()
         )
         assertNotNull(module.sharedObjectLoader)
         assertNotNull(module.symbolService)
         assertNotNull(module.processor)
         assertNotNull(module.delegate)
-        assertNull(module.nativeCrashHandlerInstaller)
+        assertNotNull(module.nativeCrashHandlerInstaller)
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -18,7 +18,9 @@ class FileStorageServiceImpl(
     private val storageLimit: Int = 500,
 ) : FileStorageService {
 
-    private val payloadDir by outputDir
+    private val payloadDir by lazy {
+        outputDir.value.apply { mkdirs() }
+    }
 
     // maintain an in-memory list of payloads to avoid calling listFiles() every time we need
     // to check the storage limit. This will always remain in sync with the actual files on disk

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -70,7 +71,7 @@ class PayloadStorageServiceImplTest {
     @Test
     fun `delete non existent file`() {
         service.delete(metadata) // no exception thrown
-        assertNull(outputDir.listFiles())
+        assertTrue(checkNotNull(outputDir.listFiles()).isEmpty())
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -100,7 +100,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
             )
         },
         anrModuleSupplier = { _, _, _ -> fakeAnrModule },
-        nativeCoreModuleSupplier = { _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
+        nativeCoreModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
         nativeFeatureModuleSupplier = { _, _, _, _, _, _, _ -> fakeNativeFeatureModule }
     )
 }

--- a/embrace-android-sdk/src/main/cpp/jnibridge/emb_ndk_manager.c
+++ b/embrace-android-sdk/src/main/cpp/jnibridge/emb_ndk_manager.c
@@ -33,9 +33,7 @@ static emb_env *__emb_env = &__impl_emb_env;
 JNIEXPORT void JNICALL
 Java_io_embrace_android_embracesdk_internal_ndk_jni_JniDelegateImpl_installSignalHandlers(JNIEnv *env,
                                                                                       jobject thiz,
-                                                                                      jstring _base_path,
                                                                                       jstring _crash_marker_path,
-                                                                                      jstring _session_id,
                                                                                       jstring _app_state,
                                                                                       jstring _report_id,
                                                                                       jint api_level,
@@ -54,15 +52,8 @@ Java_io_embrace_android_embracesdk_internal_ndk_jni_JniDelegateImpl_installSigna
     EMB_LOGDEV("unwinder args: apiLevel=%d, 32bit=%d", api_level, is_32bit);
 
     EMB_LOGDEV("Setting up initial state.");
-    const char *session_id = (*env)->GetStringUTFChars(env, _session_id, 0);
-    snprintf(__emb_env->crash.session_id, EMB_SESSION_ID_SIZE, "%s", session_id);
     const char *report_id = (*env)->GetStringUTFChars(env, _report_id, 0);
     snprintf(__emb_env->crash.report_id, EMB_REPORT_ID_SIZE, "%s", report_id);
-
-    EMB_LOGDEV("Setting up base path.");
-    const char *base_path = (*env)->GetStringUTFChars(env, _base_path, 0);
-    snprintf(__emb_env->base_path, EMB_PATH_SIZE, "%s", base_path);
-    EMB_LOGINFO("base path: %s", base_path);
 
     EMB_LOGDEV("Setting up crash marker path.");
     const char *crash_marker_path = (*env)->GetStringUTFChars(env, _crash_marker_path, 0);
@@ -74,9 +65,6 @@ Java_io_embrace_android_embracesdk_internal_ndk_jni_JniDelegateImpl_installSigna
     clock_gettime(CLOCK_REALTIME, &ts);
     // get timestamp in millis
     __emb_env->crash.start_ts = ((int64_t) ts.tv_sec * 1000) + ((int64_t) ts.tv_nsec / 1000000);
-
-    // must set start_ts before calling this
-    emb_set_report_paths(__emb_env, session_id);
 
     // install signal handlers
     if (!emb_setup_c_signal_handlers(__emb_env)) {
@@ -101,9 +89,13 @@ Java_io_embrace_android_embracesdk_internal_ndk_jni_JniDelegateImpl_updateMetaDa
 
 JNIEXPORT void JNICALL
 Java_io_embrace_android_embracesdk_internal_ndk_jni_JniDelegateImpl_onSessionChange(JNIEnv *env,
-                                                                                jobject thiz,
-                                                                                jstring _session_id) {
-    // do nothing
+                                                                                   jobject thiz,
+                                                                                   jstring _session_id,
+                                                                                   jstring _report_path) {
+    const char *session_id = (*env)->GetStringUTFChars(env, _session_id, 0);
+    snprintf(__emb_env->crash.session_id, EMB_SESSION_ID_SIZE, "%s", session_id);
+    const char *report_path = (*env)->GetStringUTFChars(env, _report_path, 0);
+    snprintf(__emb_env->report_path, EMB_PATH_SIZE, "%s", report_path);
 }
 
 JNIEXPORT void JNICALL

--- a/embrace-android-sdk/src/main/cpp/jnibridge/emb_ndk_manager.h
+++ b/embrace-android-sdk/src/main/cpp/jnibridge/emb_ndk_manager.h
@@ -18,9 +18,8 @@
 #define CRASH_REPORT_CURRENT_VERSION CRASH_REPORT_VERSION1
 
 typedef struct {
-    char base_path[EMB_PATH_SIZE];
-    char crash_marker_path[EMB_PATH_SIZE];
     char report_path[EMB_PATH_SIZE];
+    char crash_marker_path[EMB_PATH_SIZE];
     bool currently_handling;
     bool already_handled_crash;
     emb_crash crash;

--- a/embrace-android-sdk/src/main/cpp/utils/utilities.c
+++ b/embrace-android-sdk/src/main/cpp/utils/utilities.c
@@ -11,12 +11,6 @@
 #include "utilities.h"
 #include "emb_log.h"
 
-void emb_set_report_paths(emb_env *env, const char *session_id) {
-    snprintf(env->report_path, EMB_PATH_SIZE, "%s/emb_ndk.%s.%s.%" PRId64 ".crash", env->base_path,
-            CRASH_REPORT_CURRENT_VERSION, session_id, env->crash.start_ts);
-    EMB_LOGINFO("report path: %s", env->report_path);
-}
-
 void emb_set_crash_time(emb_env *env) {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);

--- a/embrace-android-sdk/src/main/cpp/utils/utilities.h
+++ b/embrace-android-sdk/src/main/cpp/utils/utilities.h
@@ -27,10 +27,7 @@ extern "C" {
 
 // the backend can handle error codes between 0-255.
 
-#define EMB_MAX_ERRORS 10
-
 void emb_set_crash_time(emb_env *env);
-void emb_set_report_paths(emb_env *env, const char *session_id);
 
 #ifdef __cplusplus
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -336,6 +336,7 @@ internal class ModuleInitBootstrapper(
                             configModule,
                             storageModule,
                             essentialServiceModule,
+                            openTelemetryModule,
                         )
                     }
 
@@ -352,6 +353,7 @@ internal class ModuleInitBootstrapper(
                     }
 
                     postInit(NativeFeatureModule::class) {
+                        nativeCoreModule.sharedObjectLoader.loadEmbraceNative()
                         serviceRegistry.registerServices(
                             lazy { nativeFeatureModule.nativeThreadSamplerService }
                         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -49,7 +49,7 @@ internal fun fakeModuleInitBootstrapper(
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },
-    nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
+    nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier =
         { _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
     crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _ -> FakeCrashModule() },

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
@@ -6,13 +6,12 @@ class FakeJniDelegate : JniDelegate {
 
     var crashRaw: String? = null
     var culprit: String? = "testCulprit"
+    var reportPath: String? = null
     var signalHandlerInstalled: Boolean = false
     var signalHandlerReinstalled = false
 
     override fun installSignalHandlers(
-        reportPath: String,
         markerFilePath: String?,
-        sessionId: String?,
         appState: String?,
         reportId: String?,
         apiLevel: Int,
@@ -26,8 +25,8 @@ class FakeJniDelegate : JniDelegate {
         // do nothing
     }
 
-    override fun onSessionChange(sessionId: String?) {
-        // do nothing
+    override fun onSessionChange(sessionId: String?, reportPath: String) {
+        this.reportPath = reportPath
     }
 
     override fun updateAppState(appState: String?) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
@@ -15,5 +15,8 @@ class FakeSessionIdTracker : SessionIdTracker {
 
     override fun setActiveSession(sessionId: String?, isSession: Boolean) {
         sessionData = sessionId?.run { SessionData(sessionId, isSession) }
+        listeners.forEach {
+            it(sessionId)
+        }
     }
 }


### PR DESCRIPTION
## Goal

Updates the native crash processor to use `FileStore` to read crash reports.

## Testing

Relied on existing test coverage & added extra test cases where appropriate.
