### PR TITLE
Use crash handler installer

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.internal.ndk.NativeCrashHandlerInstallerImp
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.ndk.NativeInstallMessage
 import io.embrace.android.embracesdk.internal.ndk.NdkService
-import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegateImpl
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.worker.Worker
 
@@ -34,17 +33,13 @@ internal class NativeFeatureModuleImpl(
     override val ndkService: NdkService by singleton {
         Systrace.traceSynchronous("ndk-service-init") {
             EmbraceNdkService(
-                storageModule.storageService,
                 payloadSourceModule.metadataService,
                 essentialServiceModule.processStateService,
-                configModule.configService,
                 essentialServiceModule.userService,
                 essentialServiceModule.sessionPropertiesService,
                 nativeCoreModule.sharedObjectLoader,
-                initModule.logger,
                 nativeCoreModule.delegate,
                 workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
-                payloadSourceModule.deviceArchitecture,
                 initModule.jsonSerializer,
             )
         }
@@ -104,7 +99,7 @@ internal class NativeFeatureModuleImpl(
                 configService = configModule.configService,
                 sharedObjectLoader = nativeCoreModule.sharedObjectLoader,
                 logger = initModule.logger,
-                delegate = JniDelegateImpl(),
+                delegate = nativeCoreModule.delegate,
                 backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
                 nativeInstallMessage = nativeInstallMessage ?: return@singleton null,
                 mainThreadHandler = AndroidMainThreadHandler()

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/EmbraceNdkService.kt
@@ -1,52 +1,35 @@
 package io.embrace.android.embracesdk.internal.ndk
 
-import android.os.Build
-import android.os.Handler
-import android.os.Looper
-import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
-import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.crash.CrashFileMarkerImpl
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.ndk.jni.JniDelegate
 import io.embrace.android.embracesdk.internal.payload.NativeCrashMetadata
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
-import io.embrace.android.embracesdk.internal.storage.StorageService
-import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 internal class EmbraceNdkService(
-    private val storageService: StorageService,
     private val metadataService: MetadataService,
     private val processStateService: ProcessStateService,
-    private val configService: ConfigService,
     private val userService: UserService,
     private val sessionPropertiesService: SessionPropertiesService,
     private val sharedObjectLoader: SharedObjectLoader,
-    private val logger: EmbLogger,
     private val delegate: JniDelegate,
     private val backgroundWorker: BackgroundWorker,
-    private val deviceArchitecture: DeviceArchitecture,
     private val serializer: PlatformSerializer,
-    private val handler: Handler = Handler(checkNotNull(Looper.getMainLooper())),
 ) : NdkService, ProcessStateListener {
 
     override fun initializeService(sessionIdTracker: SessionIdTracker) {
         Systrace.traceSynchronous("init-ndk-service") {
-            if (startNativeCrashMonitoring { sessionIdTracker.getActiveSessionId() ?: "null" }) {
-                processStateService.addListener(this)
-                userService.addUserInfoListener(::onUserInfoUpdate)
-                sessionIdTracker.addListener { updateSessionId(it ?: "") }
-                sessionPropertiesService.addChangeListener(::onSessionPropertiesUpdate)
-            }
+            processStateService.addListener(this)
+            userService.addUserInfoListener(::onUserInfoUpdate)
+            sessionIdTracker.addListener { updateSessionId(it ?: "") }
+            sessionPropertiesService.addChangeListener(::onSessionPropertiesUpdate)
         }
     }
 
@@ -74,76 +57,6 @@ internal class EmbraceNdkService(
 
     override fun onForeground(coldStart: Boolean, timestamp: Long) {
         updateAppState(APPLICATION_STATE_FOREGROUND)
-    }
-
-    private fun startNativeCrashMonitoring(sessionIdProvider: () -> String): Boolean {
-        return try {
-            if (sharedObjectLoader.loadEmbraceNative()) {
-                handler.postAtFrontOfQueue { installSignals(sessionIdProvider) }
-                handler.postDelayed(
-                    Runnable(::checkSignalHandlersOverwritten),
-                    HANDLER_CHECK_DELAY_MS.toLong()
-                )
-                true
-            } else {
-                false
-            }
-        } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL, ex)
-            false
-        }
-    }
-
-    private fun checkSignalHandlersOverwritten() {
-        if (configService.autoDataCaptureBehavior.is3rdPartySigHandlerDetectionEnabled()) {
-            val culprit = delegate.checkForOverwrittenHandlers()
-            if (culprit != null) {
-                if (shouldIgnoreOverriddenHandler(culprit)) {
-                    return
-                }
-                delegate.reinstallSignalHandlers()
-            }
-        }
-    }
-
-    /**
-     * Contains a list of SO files which are known to install signal handlers that do not
-     * interfere with crash detection. This list will probably expand over time.
-     *
-     * @param culprit the culprit SO file as identified by dladdr
-     * @return true if we can safely ignore
-     */
-    private fun shouldIgnoreOverriddenHandler(culprit: String): Boolean {
-        val allowList = listOf("libwebviewchromium.so")
-        return allowList.any(culprit::contains)
-    }
-
-    private fun installSignals(sessionIdProvider: () -> String) {
-        val reportBasePath = try {
-            storageService.getOrCreateNativeCrashDir().absolutePath
-        } catch (e: Exception) {
-            logger.trackInternalError(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL, e)
-            return
-        }
-        val markerFilePath = storageService.getFileForWrite(
-            CrashFileMarkerImpl.CRASH_MARKER_FILE_NAME
-        ).absolutePath
-
-        val nativeCrashId: String = Uuid.getEmbUuid()
-        val is32bit = deviceArchitecture.is32BitDevice
-        Systrace.traceSynchronous("native-install-handlers") {
-            delegate.installSignalHandlers(
-                reportBasePath,
-                markerFilePath,
-                sessionIdProvider(),
-                processStateService.getAppState(),
-                nativeCrashId,
-                Build.VERSION.SDK_INT,
-                is32bit,
-                false
-            )
-        }
-        backgroundWorker.submit(runnable = ::updateDeviceMetaData)
     }
 
     private fun updateAppState(newAppState: String) {
@@ -194,6 +107,5 @@ internal class EmbraceNdkService(
          */
         private const val APPLICATION_STATE_BACKGROUND = "background"
         private const val EMB_DEVICE_META_DATA_SIZE = 2048
-        private const val HANDLER_CHECK_DELAY_MS = 5000
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -360,6 +360,7 @@ internal class ModuleInitBootstrapper(
                         if (configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
                             val worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker)
                             worker.submit {
+                                nativeFeatureModule.nativeCrashHandlerInstaller?.install()
                                 ndkService.initializeService(essentialServiceModule.sessionIdTracker)
                             }
                         }


### PR DESCRIPTION
## Goal

Uses the crash handler installer by hooking it up to the code, and removes old code from the `NdkService` implementation.
