### PR TITLE
Remove concept of key spans

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/KeySpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/KeySpan.kt
@@ -1,9 +1,0 @@
-package io.embrace.android.embracesdk.internal.arch.schema
-
-/**
- * Denotes an important span to be aggregated and displayed as such in the platform.
- */
-object KeySpan : FixedAttribute {
-    override val key: EmbraceAttributeKey = EmbraceAttributeKey(id = "key")
-    override val value: String = "true"
-}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanBuilder.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
-import io.embrace.android.embracesdk.internal.arch.schema.KeySpan
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -71,26 +69,14 @@ class EmbraceSpanBuilder(
     fun setParentContext(context: Context) {
         parentContext = context
         sdkSpanBuilder.setParent(parentContext)
-        updateKeySpan()
     }
 
     fun setNoParent() {
         parentContext = Context.root()
         sdkSpanBuilder.setNoParent()
-        updateKeySpan()
     }
 
     fun setSpanKind(spanKind: SpanKind) {
         sdkSpanBuilder.setSpanKind(spanKind)
-    }
-
-    private fun updateKeySpan() {
-        if (fixedAttributes.contains(EmbType.Performance.Default) || fixedAttributes.contains(EmbType.Performance.UiLoad)) {
-            if (getParentSpan() == null) {
-                fixedAttributes.add(KeySpan)
-            } else {
-                fixedAttributes.remove(KeySpan)
-            }
-        }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.payload
 
 import io.embrace.android.embracesdk.arch.assertError
-import io.embrace.android.embracesdk.arch.assertIsKeySpan
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.arch.assertSuccessful
@@ -35,7 +34,6 @@ internal class SpanMapperTest {
         // test attributes
         output.assertSuccessful()
         output.assertIsTypePerformance()
-        output.assertIsKeySpan()
         output.assertNotPrivateSpan()
         checkNotNull(output.attributes).forEach {
             assertEquals(input.attributes[it.key], it.data)
@@ -58,7 +56,6 @@ internal class SpanMapperTest {
         assertEquals(snapshot.events?.single(), failedSpan.events?.single())
         failedSpan.assertError(ErrorCode.FAILURE)
         failedSpan.assertIsTypePerformance()
-        failedSpan.assertIsKeySpan()
         failedSpan.assertNotPrivateSpan()
         val attributesOfFailedSpan = failedSpan.attributes?.associate { it.key to it.data } ?: emptyMap()
         checkNotNull(snapshot.attributes).forEach {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.spans
 import io.embrace.android.embracesdk.arch.assertError
 import io.embrace.android.embracesdk.arch.assertHasEmbraceAttribute
 import io.embrace.android.embracesdk.arch.assertIsType
-import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.assertions.findEventOfType
 import io.embrace.android.embracesdk.fakes.FakeClock
@@ -235,7 +234,6 @@ internal class CurrentSessionSpanImplTests {
                 assertEquals("emb-session", name)
                 assertIsType(EmbType.Ux.Session)
                 assertError(ErrorCode.FAILURE)
-                assertNotKeySpan()
                 assertHasEmbraceAttribute(cause)
             }
 
@@ -278,8 +276,7 @@ internal class CurrentSessionSpanImplTests {
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
                 EmbType.Performance.Default.toEmbraceKeyValuePair()
-            ),
-            key = true
+            )
         )
 
         assertEquals(0, spanSink.completedSpans().size)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -508,7 +508,7 @@ internal class EmbraceSpanImplTest {
         expectedType: EmbType = EmbType.Performance.Default,
         expectedStatus: Span.Status = Span.Status.UNSET,
         eventCount: Int = 0,
-        expectedEmbraceAttributes: Int = 2,
+        expectedEmbraceAttributes: Int = 1,
         expectedCustomAttributeCount: Int = 0,
         isPrivate: Boolean = false,
     ) {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.arch.assertError
-import io.embrace.android.embracesdk.arch.assertIsKeySpan
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
-import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.fakes.FakeClock
@@ -13,6 +11,7 @@ import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -356,9 +355,9 @@ internal class EmbraceTracerTest {
         assertEquals(name, currentSpan.name)
         currentSpan.assertIsTypePerformance()
         if (traceRoot) {
-            currentSpan.assertIsKeySpan()
+            assertEquals(SpanId.getInvalid(), currentSpan.parentSpanId)
         } else {
-            currentSpan.assertNotKeySpan()
+            assertNotNull(currentSpan.parentSpanId)
         }
         if (errorCode == null) {
             currentSpan.assertSuccessful()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.arch.assertError
-import io.embrace.android.embracesdk.arch.assertIsKeySpan
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
-import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.fakes.FakeClock
@@ -61,7 +59,7 @@ internal class InternalTracerTest {
         val childEndTimeMs = clock.now() - 1L
         assertTrue(internalTracer.stopSpan(spanId = spanId, endTimeMs = childEndTimeMs))
         assertFalse(internalTracer.addSpanAttribute(spanId = spanId, key = "fail", value = "value"))
-        with(verifyPublicSpan(name = "test-span", traceRoot = false)) {
+        with(verifyPublicSpan(name = "test-span")) {
             assertEquals("valuez", attributes["keyz"])
             assertEquals(childStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(childEndTimeMs, endTimeNanos.nanosToMillis())
@@ -211,7 +209,7 @@ internal class InternalTracerTest {
             )
         )
 
-        with(verifyPublicSpan(expectedName, true, ErrorCode.FAILURE)) {
+        with(verifyPublicSpan(expectedName, ErrorCode.FAILURE)) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
             assertEquals(StatusCode.ERROR, status)
@@ -234,7 +232,7 @@ internal class InternalTracerTest {
             )
         )
 
-        with(verifyPublicSpan(expectedName, false)) {
+        with(verifyPublicSpan(expectedName)) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
         }
@@ -269,7 +267,6 @@ internal class InternalTracerTest {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
             assertIsTypePerformance()
-            assertIsKeySpan()
             expectedAttributes.forEach {
                 assertEquals(it.value, attributes[it.key])
             }
@@ -305,7 +302,6 @@ internal class InternalTracerTest {
 
     private fun verifyPublicSpan(
         name: String,
-        traceRoot: Boolean = true,
         errorCode: ErrorCode? = null,
     ): EmbraceSpanData {
         val currentSpans = spanSink.completedSpans()
@@ -313,11 +309,6 @@ internal class InternalTracerTest {
         val currentSpan = currentSpans[0]
         assertEquals(name, currentSpan.name)
         currentSpan.assertIsTypePerformance()
-        if (traceRoot) {
-            currentSpan.assertIsKeySpan()
-        } else {
-            currentSpan.assertNotKeySpan()
-        }
         if (errorCode == null) {
             currentSpan.assertSuccessful()
         } else {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -2,11 +2,9 @@ package io.embrace.android.embracesdk.internal.spans
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.arch.assertError
-import io.embrace.android.embracesdk.arch.assertIsKeySpan
 import io.embrace.android.embracesdk.arch.assertIsPrivateSpan
 import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.arch.assertIsTypePerformance
-import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -69,7 +67,6 @@ internal class SpanServiceImplTest {
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
             assertEquals(SpanId.getInvalid(), parentSpanId)
             assertIsTypePerformance()
-            assertIsKeySpan()
             assertNotPrivateSpan()
         }
     }
@@ -118,7 +115,6 @@ internal class SpanServiceImplTest {
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
             assertEquals(SpanId.getInvalid(), parentSpanId)
             assertIsTypePerformance()
-            assertIsKeySpan()
         }
     }
 
@@ -141,7 +137,6 @@ internal class SpanServiceImplTest {
             assertEquals("emb-child-span", name)
             assertEquals(childSpan.spanId, spanId)
             assertEquals(childSpan.traceId, traceId)
-            assertNotKeySpan()
             assertNotPrivateSpan()
         }
 
@@ -150,7 +145,6 @@ internal class SpanServiceImplTest {
             assertEquals(SpanId.getInvalid(), parentSpanId)
             assertEquals(parentSpan.spanId, spanId)
             assertEquals(parentSpan.traceId, traceId)
-            assertIsKeySpan()
             assertNotPrivateSpan()
         }
     }
@@ -211,7 +205,6 @@ internal class SpanServiceImplTest {
             assertEquals(childStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(childSpanEndTimeMs, endTimeNanos.nanosToMillis())
             assertNotPrivateSpan()
-            assertNotKeySpan()
             assertIsType(EmbType.Ux.View)
         }
         clock.tick(10)
@@ -222,7 +215,6 @@ internal class SpanServiceImplTest {
             assertEquals(parentStartTime, startTimeNanos.nanosToMillis())
             assertEquals(parentEndTime, endTimeNanos.nanosToMillis())
             assertNotPrivateSpan()
-            assertIsKeySpan()
         }
     }
 
@@ -256,7 +248,6 @@ internal class SpanServiceImplTest {
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
             assertIsTypePerformance()
             assertEquals(SpanId.getInvalid(), parentSpanId)
-            assertIsKeySpan()
             assertNotPrivateSpan()
             expectedAttributes.forEach {
                 assertEquals(it.value, attributes[it.key])
@@ -284,7 +275,6 @@ internal class SpanServiceImplTest {
         with(verifyAndReturnSoleCompletedSpan("emb-$expectedName")) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
-            assertNotKeySpan()
             assertNotPrivateSpan()
         }
         assertTrue(parentSpan.stop())
@@ -383,7 +373,6 @@ internal class SpanServiceImplTest {
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
             assertEquals(SpanId.getInvalid(), parentSpanId)
             assertIsTypePerformance()
-            assertIsKeySpan()
             assertNotPrivateSpan()
         }
     }
@@ -405,7 +394,6 @@ internal class SpanServiceImplTest {
 
         with(currentSpans[0]) {
             assertEquals("emb-child-span", name)
-            assertNotKeySpan()
             assertNotPrivateSpan()
         }
     }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
@@ -145,7 +145,6 @@ internal class UiLoadTraceEmitterTest {
                 expectedStartTimeMs = timestamps.first,
                 expectedEndTimeMs = timestamps.second,
                 expectedParentId = SpanId.getInvalid(),
-                key = true,
             )
 
             val events = timestamps.third

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -3,13 +3,11 @@ package io.embrace.android.embracesdk.internal.capture.startup
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.arch.assertDoesNotHaveEmbraceAttribute
-import io.embrace.android.embracesdk.arch.assertIsKeySpan
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.internal.arch.schema.KeySpan
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
@@ -549,7 +547,6 @@ internal class AppStartupTraceEmitterTest {
         assertEquals(expectedStartTimeMs, trace.startTimeNanos?.nanosToMillis())
         assertEquals(expectedEndTimeMs, trace.endTimeNanos?.nanosToMillis())
         trace.assertDoesNotHaveEmbraceAttribute(PrivateSpan)
-        trace.assertIsKeySpan()
         val attrs = checkNotNull(trace.attributes)
         assertEquals(STARTUP_ACTIVITY_NAME, attrs.findAttributeValue("startup-activity-name"))
         assertEquals(expectedProcessCreateDelayMs?.toString(), attrs.findAttributeValue("process-create-delay-ms"))
@@ -574,7 +571,6 @@ internal class AppStartupTraceEmitterTest {
         assertEquals(expectedStartTimeNanos, span.startTimeNanos.nanosToMillis())
         assertEquals(expectedEndTimeNanos, span.endTimeNanos.nanosToMillis())
         span.assertDoesNotHaveEmbraceAttribute(PrivateSpan)
-        span.assertDoesNotHaveEmbraceAttribute(KeySpan)
     }
 
     private data class ActivityCreateEvents(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -144,8 +144,7 @@ internal class ExternalTracerTest {
                     expectedStartTimeMs = checkNotNull(startTimeMs),
                     expectedEndTimeMs = checkNotNull(endTimeMs),
                     expectedParentId = SpanId.getInvalid(),
-                    expectedCustomAttributes = mapOf("failures" to "1"),
-                    key = true
+                    expectedCustomAttributes = mapOf("failures" to "1")
                 )
                 assertEmbraceSpanData(
                     span = child,
@@ -168,8 +167,7 @@ internal class ExternalTracerTest {
                                 )
                             )
                         )
-                    ),
-                    key = false
+                    )
                 )
 
                 assertTrue("Timed out waiting for the span to be exported", spanExporter.awaitSpanExport(3))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -7,12 +7,10 @@ import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecut
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -185,8 +183,7 @@ internal class TracingApiTest {
                     expectedStartTimeMs = testStartTimeMs + 100,
                     expectedEndTimeMs = testStartTimeMs + 100,
                     expectedParentId = SpanId.getInvalid(),
-                    private = true,
-                    key = true
+                    private = true
                 )
                 assertEmbraceSpanData(
                     span = traceRootSpan,
@@ -210,8 +207,7 @@ internal class TracingApiTest {
                             timestampNanos = (testStartTimeMs + 350).millisToNanos(),
                             attributes = emptyList()
                         ),
-                    ),
-                    key = true
+                    )
                 )
                 val expectedParentId = traceRootSpan.spanId
                 assertEmbraceSpanData(
@@ -279,8 +275,7 @@ internal class TracingApiTest {
                             timestampNanos = (testStartTimeMs + 800).millisToNanos(),
                             attributes = emptyList()
                         )
-                    ),
-                    key = true
+                    )
                 )
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
@@ -85,7 +85,6 @@ internal class UiLoadTest {
                     expectedStartTimeMs = expectedTraceStartTime,
                     expectedEndTimeMs = expectedTraceStartTime + 250,
                     expectedParentId = SpanId.getInvalid(),
-                    key = true
                 )
 
                 assertEmbraceSpanData(
@@ -138,7 +137,6 @@ internal class UiLoadTest {
                     expectedStartTimeMs = expectedTraceStartTime,
                     expectedEndTimeMs = expectedTraceStartTime + 200,
                     expectedParentId = SpanId.getInvalid(),
-                    key = true
                 )
 
                 val lastBackgroundActivity = getSessionEnvelopes(2, ApplicationState.BACKGROUND)[1]
@@ -194,7 +192,6 @@ internal class UiLoadTest {
                     expectedStartTimeMs = expectedTraceStartTime,
                     expectedEndTimeMs = expectedTraceStartTime + 100,
                     expectedParentId = SpanId.getInvalid(),
-                    key = true
                 )
 
                 assertEmbraceSpanData(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute.Failure.fromErrorCode
 import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
-import io.embrace.android.embracesdk.internal.arch.schema.KeySpan
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.arch.schema.toPayload
@@ -30,10 +29,6 @@ fun EmbraceSpanData.assertIsTypePerformance(): Unit = assertIsType(EmbType.Perfo
  * Assert [EmbraceSpanData] is of type [telemetryType]
  */
 fun EmbraceSpanData.assertIsType(telemetryType: TelemetryType): Unit = assertHasEmbraceAttribute(telemetryType)
-
-fun EmbraceSpanData.assertIsKeySpan(): Unit = assertHasEmbraceAttribute(KeySpan)
-
-fun EmbraceSpanData.assertNotKeySpan(): Unit = assertDoesNotHaveEmbraceAttribute(KeySpan)
 
 fun EmbraceSpanData.assertIsPrivateSpan(): Unit = assertHasEmbraceAttribute(PrivateSpan)
 
@@ -69,10 +64,6 @@ fun EmbraceSpanData.assertSuccessful() {
 fun Span.assertIsTypePerformance(): Unit = assertIsType(EmbType.Performance.Default)
 
 fun Span.assertIsType(telemetryType: TelemetryType): Unit = assertHasEmbraceAttribute(telemetryType)
-
-fun Span.assertIsKeySpan(): Unit = assertHasEmbraceAttribute(KeySpan)
-
-fun Span.assertNotKeySpan(): Unit = assertDoesNotHaveEmbraceAttribute(KeySpan)
 
 fun Span.assertIsPrivateSpan(): Unit = assertHasEmbraceAttribute(PrivateSpan)
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.assertions
 
 import io.embrace.android.embracesdk.arch.assertError
-import io.embrace.android.embracesdk.arch.assertIsKeySpan
 import io.embrace.android.embracesdk.arch.assertIsPrivateSpan
-import io.embrace.android.embracesdk.arch.assertNotKeySpan
 import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -29,7 +27,6 @@ fun assertEmbraceSpanData(
     expectedCustomAttributes: Map<String, String> = emptyMap(),
     expectedEvents: List<SpanEvent> = emptyList(),
     private: Boolean = false,
-    key: Boolean = false,
 ) {
     checkNotNull(span)
     with(span) {
@@ -57,11 +54,6 @@ fun assertEmbraceSpanData(
             assertIsPrivateSpan()
         } else {
             assertNotPrivateSpan()
-        }
-        if (key) {
-            assertIsKeySpan()
-        } else {
-            assertNotKeySpan()
         }
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -3,7 +3,6 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.arch.schema.KeySpan
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.spans.fromMap
 import io.opentelemetry.api.common.Attributes
@@ -32,7 +31,6 @@ class FakeSpanData(
         Attributes.builder().fromMap(
             attributes = mapOf(
                 type.toEmbraceKeyValuePair(),
-                KeySpan.toEmbraceKeyValuePair(),
                 Pair("my-key", "my-value")
             ),
             internal = true,


### PR DESCRIPTION
## Goal

Removes the concept of key spans from the SDK. This attribute was used by the backend to aggregate spans but is no longer required given the backend checks for root spans instead.

## Testing

Updated existing test coverage.
