### PR TITLE
Define config for otel limits

### DIFF
--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/InstrumentedConfigImpl.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/InstrumentedConfigImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.config.instrumented.schema.BaseUrl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.EnabledFeatureConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.NetworkCaptureConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.ProjectConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.RedactionConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.SessionConfig
@@ -26,6 +27,7 @@ object InstrumentedConfigImpl : InstrumentedConfig {
     override val project: ProjectConfig = ProjectConfigImpl
     override val redaction: RedactionConfig = RedactionConfigImpl
     override val session: SessionConfig = SessionConfigImpl
+    override val spanLimits: OtelLimitsConfig = OtelLimitsConfigImpl
 }
 
 @Swazzled
@@ -45,3 +47,6 @@ object RedactionConfigImpl : RedactionConfig
 
 @Swazzled
 object SessionConfigImpl : SessionConfig
+
+@Swazzled
+object OtelLimitsConfigImpl : OtelLimitsConfig

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/InstrumentedConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/InstrumentedConfig.kt
@@ -11,4 +11,5 @@ interface InstrumentedConfig {
     val project: ProjectConfig
     val redaction: RedactionConfig
     val session: SessionConfig
+    val spanLimits: OtelLimitsConfig
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
@@ -1,0 +1,42 @@
+package io.embrace.android.embracesdk.internal.config.instrumented.schema
+
+/**
+ * Declares limits for span data.
+ */
+interface OtelLimitsConfig {
+
+    /**
+     * Max number of chars in a span name
+     *
+     * sdk_config.otel_limits.max_span_name_length
+     */
+    fun getSpanNameLimit(): Int = 50
+
+    /**
+     * Max number of events in a span
+     *
+     * sdk_config.otel_limits.max_events
+     */
+    fun getSpanEventLimit(): Int = 10
+
+    /**
+     * Max number of attributes
+     *
+     * sdk_config.otel_limits.max_attributes
+     */
+    fun getSpanAttributeLimit(): Int = 300
+
+    /**
+     * Max number of chars in an attribute key
+     *
+     * sdk_config.otel_limits.max_attribute_key_length
+     */
+    fun getSpanAttributeKeyLimit(): Int = 50
+
+    /**
+     * Max number of chars in an attribute value
+     *
+     * sdk_config.otel_limits.max_attribute_value_length
+     */
+    fun getSpanAttributeValueLimit(): Int = 500
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes.config
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.NetworkCaptureConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.ProjectConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.RedactionConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.SessionConfig
@@ -18,4 +19,5 @@ data class FakeInstrumentedConfig(
     override val project: ProjectConfig = FakeProjectConfig(base.project, appId = "abcde"),
     override val redaction: RedactionConfig = FakeRedactionConfig(base.redaction),
     override val session: SessionConfig = FakeSessionConfig(base.session),
+    override val spanLimits: OtelLimitsConfig = FakeOtelLimitsConfig(),
 ) : InstrumentedConfig

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeOtelLimitsConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeOtelLimitsConfig.kt
@@ -1,0 +1,5 @@
+package io.embrace.android.embracesdk.fakes.config
+
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
+
+class FakeOtelLimitsConfig : OtelLimitsConfig


### PR DESCRIPTION
## Goal

Defines the instrumented config that will be used to define user-specified OTel limits.

