### PR TITLE
Add debug tracing to scheduling service

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -187,7 +187,8 @@ internal class DeliveryModuleImpl(
                 workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
                 workerThreadModule.backgroundWorker(Worker.Background.HttpRequestWorker),
                 initModule.clock,
-                initModule.logger
+                initModule.logger,
+                deliveryTracer
             )
         }
     }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
@@ -50,14 +50,16 @@ internal sealed class DeliveryTraceState {
      * The payload store returned a list of payloads by priority
      */
     internal class GetPayloadsByPriority(val payloads: List<StoredTelemetryMetadata>) : DeliveryTraceState() {
-        override fun toString(): String = "GetPayloadsByPriority, count=${payloads.size},\n${payloads.reportListString()}"
+        override fun toString(): String =
+            "GetPayloadsByPriority, count=${payloads.size},\n${payloads.reportListString()}"
     }
 
     /**
      * The payload store returned a list of undelivered payloads
      */
     internal class GetUndeliveredPayloads(val payloads: List<StoredTelemetryMetadata>) : DeliveryTraceState() {
-        override fun toString(): String = "GetUndeliveredPayloads, count=${payloads.size},\n${payloads.reportListString()}"
+        override fun toString(): String =
+            "GetUndeliveredPayloads, count=${payloads.size},\n${payloads.reportListString()}"
     }
 
     /**
@@ -90,6 +92,43 @@ internal sealed class DeliveryTraceState {
      */
     internal object SessionCacheAttempt : DeliveryTraceState() {
         override fun toString(): String = "SessionCacheAttempt"
+    }
+
+    /**
+     * The delivery loop was started
+     */
+    internal class StartDeliveryLoop(private val loopAlreadyActive: Boolean) : DeliveryTraceState() {
+        override fun toString(): String = "StartDeliveryLoop loopAlreadyActive=$loopAlreadyActive"
+    }
+
+    /**
+     * A payload was enqueued for delivery
+     */
+    class PayloadEnqueued(private val payload: StoredTelemetryMetadata) : DeliveryTraceState() {
+        override fun toString(): String = "PayloadEnqueued, ${payload.toReportString()}"
+    }
+
+    /**
+     * A payload result was obtained
+     */
+    class PayloadResult(
+        private val payload: StoredTelemetryMetadata,
+        private val result: ExecutionResult,
+    ) : DeliveryTraceState() {
+        override fun toString(): String = "PayloadResult, ${payload.toReportString()}, result=${result.javaClass.simpleName}"
+    }
+
+    /**
+     * A payload queue was created
+     */
+    class PayloadQueueCreated(
+        private val payloadsByPriority: List<StoredTelemetryMetadata>,
+        private val payloadsToSend: List<StoredTelemetryMetadata>,
+    ) : DeliveryTraceState() {
+        override fun toString(): String {
+            return "PayloadQueueCreated, payloadsByPriority=${payloadsByPriority.map { it.uuid }}, " +
+                "payloadsToSend=${payloadsToSend.map { it.uuid }}"
+        }
     }
 
     internal fun StoredTelemetryMetadata.toReportString(): String {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
@@ -59,4 +59,23 @@ class DeliveryTracer {
                 "#$k, $state"
             }.joinToString("\n")
     }
+
+    fun onStartDeliveryLoop(sendLoopActive: Boolean) {
+        events.add(DeliveryTraceState.StartDeliveryLoop(sendLoopActive))
+    }
+
+    fun onPayloadQueueCreated(
+        payloadsByPriority: List<StoredTelemetryMetadata>,
+        payloadsToSend: List<StoredTelemetryMetadata>,
+    ) {
+        events.add(DeliveryTraceState.PayloadQueueCreated(payloadsByPriority, payloadsToSend))
+    }
+
+    fun onPayloadEnqueued(payload: StoredTelemetryMetadata) {
+        events.add(DeliveryTraceState.PayloadEnqueued(payload))
+    }
+
+    fun onPayloadResult(payload: StoredTelemetryMetadata, result: ExecutionResult) {
+        events.add(DeliveryTraceState.PayloadResult(payload, result))
+    }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -60,8 +60,8 @@ class IntakeServiceImpl(
             val lastReference = cacheReferences[metadata.envelopeType]
 
             if (metadata.complete) {
-                schedulingService.onPayloadIntake()
                 deliveryTracer?.onPayloadIntake(metadata)
+                schedulingService.onPayloadIntake()
             } else {
                 cacheReferences[metadata.envelopeType] = metadata
                 if (!cacheableEnvelopeTypes.contains(metadata.envelopeType)) {


### PR DESCRIPTION
## Goal

Enhance the delivery tracing by adding some extra events in the `SchedulingService`. If an integration test fails now it should give us a decent idea of what's going wrong.
