### PR TITLE
Improve debuggability of integration tests

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
@@ -131,6 +131,23 @@ internal sealed class DeliveryTraceState {
         }
     }
 
+    /**
+     * A HTTP request was started
+     */
+    class ServerReceivedRequest(private val endpoint: String) : DeliveryTraceState() {
+        override fun toString(): String = "ServerReceivedRequest, $endpoint"
+    }
+
+    /**
+     * A HTTP request was completed
+     */
+    class ServerCompletedRequest(
+        private val endpoint: String,
+        private val metadata: String
+    ) : DeliveryTraceState() {
+        override fun toString(): String = "ServerCompletedRequest, $endpoint $metadata"
+    }
+
     internal fun StoredTelemetryMetadata.toReportString(): String {
         return "$timestamp, $uuid, $payloadType, complete=$complete"
     }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
@@ -78,4 +78,12 @@ class DeliveryTracer {
     fun onPayloadResult(payload: StoredTelemetryMetadata, result: ExecutionResult) {
         events.add(DeliveryTraceState.PayloadResult(payload, result))
     }
+
+    fun onServerReceivedRequest(endpoint: String) {
+        events.add(DeliveryTraceState.ServerReceivedRequest(endpoint))
+    }
+
+    fun onServerCompletedRequest(endpoint: String, sessionId: String) {
+        events.add(DeliveryTraceState.ServerCompletedRequest(endpoint, sessionId))
+    }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -59,6 +59,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
 ) {
     fun createBootstrapper(
         instrumentedConfig: FakeInstrumentedConfig,
+        deliveryTracer: DeliveryTracer,
     ): ModuleInitBootstrapper = ModuleInitBootstrapper(
         initModule = overriddenInitModule.apply {
             this.instrumentedConfig = instrumentedConfig
@@ -102,7 +103,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                 cacheStorageServiceProvider = cacheStorageServiceProvider,
                 requestExecutionServiceProvider = requestExecutionServiceProvider,
                 deliveryServiceProvider = deliveryServiceProvider,
-                deliveryTracer = DeliveryTracer()
+                deliveryTracer = deliveryTracer
             )
         },
         anrModuleSupplier = { _, _, _ -> fakeAnrModule },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
@@ -1,13 +1,18 @@
 package io.embrace.android.embracesdk.testframework.server
 
+import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.internal.TypeUtils
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.threadLocal
-import java.util.concurrent.ConcurrentLinkedQueue
+import io.embrace.android.embracesdk.testframework.assertions.getLastLog
+import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.zip.GZIPInputStream
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -21,7 +26,10 @@ import org.junit.Assert.assertNotNull
 /**
  * Fake API server that is used to capture log/session requests made by the SDK in integration tests.
  */
-internal class FakeApiServer(private val remoteConfig: RemoteConfig) : Dispatcher() {
+internal class FakeApiServer(
+    private val remoteConfig: RemoteConfig,
+    private val deliveryTracer: DeliveryTracer
+) : Dispatcher() {
 
     private enum class Endpoint {
         LOGS,
@@ -30,9 +38,9 @@ internal class FakeApiServer(private val remoteConfig: RemoteConfig) : Dispatche
     }
 
     private val serializer by threadLocal { TestPlatformSerializer() }
-    private val sessionRequests = ConcurrentLinkedQueue<Envelope<SessionPayload>>()
-    private val logRequests = ConcurrentLinkedQueue<Envelope<LogPayload>>()
-    private val configRequests = ConcurrentLinkedQueue<String>()
+    private val sessionRequests = CopyOnWriteArrayList<Envelope<SessionPayload>>()
+    private val logRequests = CopyOnWriteArrayList<Envelope<LogPayload>>()
+    private val configRequests = CopyOnWriteArrayList<String>()
 
     /**
      * Returns a list of session envelopes in the order in which the server received them.
@@ -51,7 +59,9 @@ internal class FakeApiServer(private val remoteConfig: RemoteConfig) : Dispatche
     fun getConfigRequests(): List<String> = configRequests.toList()
 
     override fun dispatch(request: RecordedRequest): MockResponse {
-        return when (val endpoint = request.asEndpoint()) {
+        val endpoint = request.asEndpoint()
+        deliveryTracer.onServerReceivedRequest(endpoint.name)
+        return when (endpoint) {
             Endpoint.LOGS, Endpoint.SESSIONS -> handleEnvelopeRequest(request, endpoint)
 
             // IMPORTANT NOTE: this response is not used until the SDK next starts!
@@ -59,7 +69,6 @@ internal class FakeApiServer(private val remoteConfig: RemoteConfig) : Dispatche
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun handleEnvelopeRequest(
         request: RecordedRequest,
         endpoint: Endpoint,
@@ -68,11 +77,25 @@ internal class FakeApiServer(private val remoteConfig: RemoteConfig) : Dispatche
         validateHeaders(request.headers.toMultimap().mapValues { it.value.joinToString() })
 
         when (endpoint) {
-            Endpoint.SESSIONS -> sessionRequests.add(envelope as Envelope<SessionPayload>)
-            Endpoint.LOGS -> logRequests.add(envelope as Envelope<LogPayload>)
+            Endpoint.SESSIONS -> handleSessionRequest(endpoint, envelope)
+            Endpoint.LOGS -> handleLogRequest(endpoint, envelope)
             else -> error("Unsupported endpoint $endpoint")
         }
         return MockResponse().setResponseCode(200)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun handleSessionRequest(endpoint: Endpoint, envelope: Envelope<*>) {
+        val obj = envelope as Envelope<SessionPayload>
+        sessionRequests.add(obj)
+        deliveryTracer.onServerCompletedRequest(endpoint.name, obj.getSessionId())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun handleLogRequest(endpoint: Endpoint, envelope: Envelope<*>) {
+        val obj = envelope as Envelope<LogPayload>
+        logRequests.add(obj)
+        deliveryTracer.onServerCompletedRequest(endpoint.name, obj.getLastLog().attributes?.findAttributeValue(LogIncubatingAttributes.LOG_RECORD_UID.key) ?: "")
     }
 
     private fun handleConfigRequest(request: RecordedRequest): MockResponse {
@@ -86,10 +109,12 @@ internal class FakeApiServer(private val remoteConfig: RemoteConfig) : Dispatche
             RemoteConfig::class.java,
             gzipSink.outputStream()
         )
-        return MockResponse()
+        val response = MockResponse()
             .setBody(configResponseBuffer)
             .addHeader("etag", "server_etag_value")
             .setResponseCode(200)
+        deliveryTracer.onServerCompletedRequest("config", "")
+        return response
     }
 
     private fun validateHeaders(headers: Map<String, String>) {


### PR DESCRIPTION
## Goal

Improves the error message logged out when an integration test fails due to the envelopes not matching what is expected.