### PR TITLE
Simplify delivery loop logic

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
@@ -97,8 +97,8 @@ internal sealed class DeliveryTraceState {
     /**
      * The delivery loop was started
      */
-    internal class StartDeliveryLoop(private val loopAlreadyActive: Boolean) : DeliveryTraceState() {
-        override fun toString(): String = "StartDeliveryLoop loopAlreadyActive=$loopAlreadyActive"
+    internal object StartDeliveryLoop : DeliveryTraceState() {
+        override fun toString(): String = "StartDeliveryLoop"
     }
 
     /**

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
@@ -60,8 +60,8 @@ class DeliveryTracer {
             }.joinToString("\n")
     }
 
-    fun onStartDeliveryLoop(sendLoopActive: Boolean) {
-        events.add(DeliveryTraceState.StartDeliveryLoop(sendLoopActive))
+    fun onStartDeliveryLoop() {
+        events.add(DeliveryTraceState.StartDeliveryLoop)
     }
 
     fun onPayloadQueueCreated(

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -73,7 +73,7 @@ internal class SchedulingServiceImplTest {
         schedulingExecutor.blockingMode = true
         schedulingService.onPayloadIntake()
         schedulingService.onPayloadIntake()
-        assertEquals(1, schedulingExecutor.submitCount)
+        assertEquals(2, schedulingExecutor.submitCount)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Simplifies the delivery loop logic to avoid checking state as this was causing flakes in our integration tests. 

It's worth noting that (1) `deliveryLoop` can now be called multiple times and (2) `queueDelivery` is much more likely to fail as a consequence of this change, once old payloads are deleted from disk. FWIW, both of these conditions could occur with the old approach too via `scheduleDeliveryLoopForNextRetry`.

One alternative given that `deliveryWorker` is only ever used in this class would be to have `deliveryWorker` infinitely poll a `BlockingQueue`, and to have `schedulingWorker` add to that queue. This adds complications around checking for uniqueness on the elements in the queue & is a larger change, however.

Alternatively, given this is just an issue in testing & not really with deliverability we could just update our test harness to flush any payloads that are left hanging.

## Testing

I ran the integration tests ~15 times and they passed consistently with these changes, whereas without these changes one test case usually fails on every other run.

