### PR TITLE
Add session properties to native crashes from the associated session

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbraceAttributeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbraceAttributeExt.kt
@@ -28,3 +28,5 @@ internal fun String.toEmbraceAttributeName(isPrivate: Boolean = false): String {
 }
 
 internal fun String.toSessionPropertyAttributeName(): String = EMBRACE_SESSION_PROPERTY_NAME_PREFIX + this
+
+internal fun String.isSessionPropertyAttributeName(): Boolean = startsWith(EMBRACE_SESSION_PROPERTY_NAME_PREFIX)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbraceAttributeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbraceAttributeExt.kt
@@ -27,6 +27,6 @@ internal fun String.toEmbraceAttributeName(isPrivate: Boolean = false): String {
     return prefix + this
 }
 
-internal fun String.toSessionPropertyAttributeName(): String = EMBRACE_SESSION_PROPERTY_NAME_PREFIX + this
+fun String.toSessionPropertyAttributeName(): String = EMBRACE_SESSION_PROPERTY_NAME_PREFIX + this
 
-internal fun String.isSessionPropertyAttributeName(): Boolean = startsWith(EMBRACE_SESSION_PROPERTY_NAME_PREFIX)
+fun String.isSessionPropertyAttributeName(): Boolean = startsWith(EMBRACE_SESSION_PROPERTY_NAME_PREFIX)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.ndk
 
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Service to retrieve and delivery native crash data
@@ -21,7 +22,11 @@ interface NativeCrashService {
     /**
      * Send the given native crash
      */
-    fun sendNativeCrash(nativeCrash: NativeCrashData)
+    fun sendNativeCrash(
+        nativeCrash: NativeCrashData,
+        sessionProperties: Map<String, String>,
+        metadata: Map<AttributeKey<String>, String> = emptyMap(),
+    )
 
     /**
      * Delete the data files associated with all the native crashes that have been recorded by the SDK

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
@@ -25,7 +25,7 @@ interface NativeCrashService {
     fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
-        metadata: Map<AttributeKey<String>, String> = emptyMap(),
+        metadata: Map<AttributeKey<String>, String>,
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.payload
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.internal.spans.getSessionProperties
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
@@ -12,4 +13,8 @@ fun Envelope<SessionPayload>.getSessionSpan(): Span? {
 
 fun Envelope<SessionPayload>.getSessionId(): String? {
     return getSessionSpan()?.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key)
+}
+
+fun Envelope<SessionPayload>.getSessionProperties(): Map<String, String> {
+    return getSessionSpan()?.getSessionProperties() ?: emptyMap()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -111,7 +111,7 @@ internal class PayloadResurrectionServiceImpl(
         }
         if (nativeCrashService != null) {
             nativeCrashes.values.filterNot { processedCrashes.contains(it) }.forEach { nativeCrash ->
-                nativeCrashService.sendNativeCrash(nativeCrash, emptyMap())
+                nativeCrashService.sendNativeCrash(nativeCrash = nativeCrash, sessionProperties = emptyMap())
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedCo
 import io.embrace.android.embracesdk.internal.config.instrumented.isAttributeValid
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
 import io.embrace.android.embracesdk.internal.payload.Attribute
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.utils.isBlankish
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -54,7 +55,7 @@ fun AttributesBuilder.fromMap(
     return this
 }
 
-fun io.embrace.android.embracesdk.internal.payload.Span.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean {
+fun Span.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean {
     return fixedAttribute.value == attributes?.singleOrNull { it.key == fixedAttribute.key.name }?.data
 }
 
@@ -70,9 +71,13 @@ fun SpanEvent.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
 
 fun List<Attribute>.findAttributeValue(key: String): String? = singleOrNull { it.key == key }?.data
 
-fun io.embrace.android.embracesdk.internal.payload.Span.getSessionProperty(key: String): String? {
+fun Span.getSessionProperty(key: String): String? {
     return attributes?.findAttributeValue(key.toSessionPropertyAttributeName())
 }
+
+@Suppress("UNCHECKED_CAST")
+fun Span.getSessionProperties(): Map<String, String> =
+    attributes?.filter { it.key != null && it.data != null }?.associate { it.key to it.data } as Map<String, String>
 
 fun Map<String, String>.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
     this[fixedAttribute.key.name] == fixedAttribute.value
@@ -92,7 +97,7 @@ private fun String.isValidLongValueAttribute(): Boolean = longValueAttributes.co
 
 private val longValueAttributes: Set<String> = setOf(ExceptionAttributes.EXCEPTION_STACKTRACE.key)
 
-fun StatusCode.toStatus(): io.embrace.android.embracesdk.internal.payload.Span.Status {
+fun StatusCode.toStatus(): Span.Status {
     return when (this) {
         StatusCode.UNSET -> io.embrace.android.embracesdk.internal.payload.Span.Status.UNSET
         StatusCode.OK -> io.embrace.android.embracesdk.internal.payload.Span.Status.OK

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeRedactionConfig
 import io.embrace.android.embracesdk.fakes.createSessionBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -83,7 +84,7 @@ internal class EmbraceLogServiceTest {
         // then the telemetry attributes are set correctly
         val log = fakeLogWriter.logEvents.single()
         val attributes = log.schemaType.attributes()
-        assertEquals("someValue", attributes["emb.properties.someProperty"])
+        assertEquals("someValue", attributes["someProperty".toSessionPropertyAttributeName()])
         assertTrue(attributes.containsKey(LogIncubatingAttributes.LOG_RECORD_UID.key))
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -249,8 +249,8 @@ class PayloadResurrectionServiceImplTest {
         }
 
         assertEquals(2, nativeCrashService.nativeCrashesSent.size)
-        assertEquals(deadSessionCrashData, nativeCrashService.nativeCrashesSent.first())
-        assertEquals(earlierSessionCrashData, nativeCrashService.nativeCrashesSent.last())
+        assertEquals(deadSessionCrashData, nativeCrashService.nativeCrashesSent.first().first)
+        assertEquals(earlierSessionCrashData, nativeCrashService.nativeCrashesSent.last().first)
     }
 
     private fun Envelope<SessionPayload>.resurrectPayload() {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -23,6 +23,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
+import io.embrace.android.embracesdk.internal.opentelemetry.embState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -240,6 +241,10 @@ class PayloadResurrectionServiceImplTest {
                 "native-crash-1",
                 envelope.getSessionSpan()?.attributes?.findAttributeValue(embCrashId.name)
             )
+            assertEquals(
+                "foreground",
+                envelope.getSessionSpan()?.attributes?.findAttributeValue(embState.name)
+            )
         }
 
         with(sessionPayloads.last()) {
@@ -248,6 +253,10 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(
                 "native-crash-2",
                 envelope.getSessionSpan()?.attributes?.findAttributeValue(embCrashId.name)
+            )
+            assertEquals(
+                "foreground",
+                envelope.getSessionSpan()?.attributes?.findAttributeValue(embState.name)
             )
         }
 
@@ -278,7 +287,7 @@ class PayloadResurrectionServiceImplTest {
         assertEquals(1, nativeCrashService.nativeCrashesSent.size)
         with(nativeCrashService.nativeCrashesSent.first()) {
             assertEquals(deadSessionCrashData, first)
-            assertTrue(second.keys.none { it.isSessionPropertyAttributeName() })
+            assertTrue(second.keys.none { it.isSessionPropertyAttributeName() || embState.name == it })
         }
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeFeatureModuleImpl.kt
@@ -57,7 +57,6 @@ internal class NativeFeatureModuleImpl(
             null
         } else {
             NativeCrashDataSourceImpl(
-                sessionPropertiesService = essentialServiceModule.sessionPropertiesService,
                 nativeCrashProcessor = nativeCoreModule.processor,
                 preferencesService = androidServicesModule.preferencesService,
                 logWriter = essentialServiceModule.logWriter,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
@@ -31,7 +31,7 @@ internal class NativeCrashDataSourceImpl(
 ) {
     override fun getAndSendNativeCrash(): NativeCrashData? {
         return nativeCrashProcessor.getLatestNativeCrash()?.apply {
-            sendNativeCrash(nativeCrash = this, sessionProperties = emptyMap())
+            sendNativeCrash(nativeCrash = this, sessionProperties = emptyMap(), metadata = emptyMap())
         }
     }
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
@@ -8,14 +8,12 @@ import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
-import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fixtures.testNativeCrashData
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriterImpl
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.NativeCrash.embNativeCrashException
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.NativeCrash.embNativeCrashSymbols
-import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
@@ -38,7 +36,6 @@ import org.junit.Test
 
 internal class NativeCrashDataSourceImplTest {
 
-    private lateinit var sessionPropertiesService: SessionPropertiesService
     private lateinit var crashProcessor: FakeNativeCrashProcessor
     private lateinit var preferencesService: FakePreferenceService
     private lateinit var configService: FakeConfigService
@@ -54,7 +51,6 @@ internal class NativeCrashDataSourceImplTest {
 
     @Before
     fun setUp() {
-        sessionPropertiesService = FakeSessionPropertiesService()
         crashProcessor = FakeNativeCrashProcessor()
         preferencesService = FakePreferenceService()
         logger = EmbLoggerImpl()
@@ -72,7 +68,6 @@ internal class NativeCrashDataSourceImplTest {
         configService = FakeConfigService()
         serializer = EmbraceSerializer()
         nativeCrashDataSource = NativeCrashDataSourceImpl(
-            sessionPropertiesService = sessionPropertiesService,
             nativeCrashProcessor = crashProcessor,
             preferencesService = preferencesService,
             logWriter = logWriter,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
@@ -122,7 +122,8 @@ internal class NativeCrashDataSourceImplTest {
                 crash = null,
                 symbols = null,
             ),
-            sessionProperties = emptyMap()
+            sessionProperties = emptyMap(),
+            metadata = emptyMap(),
         )
 
         with(otelLogger.builders.single()) {
@@ -146,7 +147,8 @@ internal class NativeCrashDataSourceImplTest {
                 crash = "",
                 symbols = emptyMap(),
             ),
-            sessionProperties = emptyMap()
+            sessionProperties = emptyMap(),
+            metadata = emptyMap(),
         )
 
         with(otelLogger.builders.single()) {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
@@ -87,8 +87,12 @@ internal class NativeCrashDataSourceImplTest {
     }
 
     @Test
-    fun `native crash sent with session properties`() {
-        nativeCrashDataSource.sendNativeCrash(testNativeCrashData, mapOf("prop" to "value"))
+    fun `native crash sent with session properties and metadata`() {
+        nativeCrashDataSource.sendNativeCrash(
+            nativeCrash = testNativeCrashData,
+            sessionProperties = mapOf("prop" to "value"),
+            metadata = mapOf(embState.attributeKey to "background")
+        )
 
         with(otelLogger.builders.single()) {
             assertEquals(1, emitCalled)
@@ -96,6 +100,7 @@ internal class NativeCrashDataSourceImplTest {
             assertEquals(0, observedTimestampEpochNanos.nanosToMillis())
             assertTrue(attributes.hasFixedAttribute(EmbType.System.NativeCrash))
             assertEquals("value", attributes.findAttributeValue("prop".toSessionPropertyAttributeName()))
+            assertEquals("background", attributes.getAttribute(embState))
             assertNotNull(attributes.getAttribute(LogIncubatingAttributes.LOG_RECORD_UID))
             assertEquals(testNativeCrashData.sessionId, attributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
             assertEquals("1", attributes.getAttribute(embCrashNumber))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
@@ -8,10 +8,10 @@ import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -157,7 +157,7 @@ internal class ReactNativeInternalInterfaceTest {
                     "name" to "MyAction",
                     "outcome" to "SUCCESS",
                     "payload_size" to "100",
-                    "emb.properties.key" to "value",
+                    "key".toSessionPropertyAttributeName() to "value",
                 ))
             }
         )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
@@ -2,30 +2,35 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class FakeNativeCrashService : NativeCrashService {
 
-    val nativeCrashesSent = ConcurrentLinkedQueue<NativeCrashData>()
-    private val nativeCrashDataBlobs = mutableListOf<NativeCrashData>()
+    val nativeCrashesSent = ConcurrentLinkedQueue<Pair<NativeCrashData, Map<String, String>>>()
+    private val nativeCrashDataBlobs = mutableListOf<Pair<NativeCrashData, Map<String, String>>>()
     var checkAndSendNativeCrashInvocation: Int = 0
 
     override fun getAndSendNativeCrash(): NativeCrashData? {
         checkAndSendNativeCrashInvocation++
-        return nativeCrashDataBlobs.lastOrNull()
+        return nativeCrashDataBlobs.lastOrNull()?.first
     }
 
-    override fun getNativeCrashes(): List<NativeCrashData> = nativeCrashDataBlobs
+    override fun getNativeCrashes(): List<NativeCrashData> = nativeCrashDataBlobs.map { it.first }
 
-    override fun sendNativeCrash(nativeCrash: NativeCrashData) {
-        nativeCrashesSent.add(nativeCrash)
+    override fun sendNativeCrash(
+        nativeCrash: NativeCrashData,
+        sessionProperties: Map<String, String>,
+        metadata: Map<AttributeKey<String>, String>,
+    ) {
+        nativeCrashesSent.add(Pair(nativeCrash, metadata.mapKeys { it.value } + sessionProperties))
     }
 
     override fun deleteAllNativeCrashes() {
         nativeCrashDataBlobs.clear()
     }
 
-    fun addNativeCrashData(nativeCrashData: NativeCrashData) {
-        nativeCrashDataBlobs.add(nativeCrashData)
+    fun addNativeCrashData(nativeCrashData: NativeCrashData, metadata: Map<String, String> = emptyMap()) {
+        nativeCrashDataBlobs.add(Pair(nativeCrashData, metadata))
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute.Failure.fromErrorCode
 import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.arch.schema.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
@@ -200,12 +201,20 @@ class FakePersistableEmbraceSpan(
             startTimeMs: Long,
             lastHeartbeatTimeMs: Long?,
             endTimeMs: Long? = null,
+            sessionProperties: Map<String, String>? = null,
         ): FakePersistableEmbraceSpan =
             FakePersistableEmbraceSpan(
                 name = "emb-session",
                 type = EmbType.Ux.Session
             ).apply {
                 start(startTimeMs)
+                sessionProperties?.forEach {
+                    addSystemAttribute(
+                        key = it.key.toSessionPropertyAttributeName(),
+                        value = it.value
+                    )
+                }
+
                 setSystemAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
                 setSystemAttribute(embState.attributeKey, "foreground")
                 setSystemAttribute(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -22,12 +22,14 @@ fun fakeSessionEnvelope(
     sessionId: String = "fakeSessionId",
     startMs: Long = 160000000000L,
     endMs: Long = 161000400000L,
+    sessionProperties: Map<String, String>? = null,
 ): Envelope<SessionPayload> {
     val sessionSpan = FakePersistableEmbraceSpan.sessionSpan(
         sessionId = sessionId,
         startTimeMs = startMs,
         lastHeartbeatTimeMs = endMs,
         endTimeMs = endMs,
+        sessionProperties = sessionProperties,
     )
     val spans = listOf(testSpan, checkNotNull(sessionSpan.snapshot()))
     val spanSnapshots = listOfNotNull(FakePersistableEmbraceSpan.started().snapshot())
@@ -48,12 +50,14 @@ fun fakeIncompleteSessionEnvelope(
     sessionId: String = "fakeIncompleteSessionId",
     startMs: Long = 1691000000000L,
     lastHeartbeatTimeMs: Long = 1691000300000L,
+    sessionProperties: Map<String, String>? = null,
 ): Envelope<SessionPayload> {
     val fakeClock = FakeClock(currentTime = startMs)
     val incompleteSessionSpan = FakePersistableEmbraceSpan.sessionSpan(
         sessionId = sessionId,
         startTimeMs = startMs,
-        lastHeartbeatTimeMs = lastHeartbeatTimeMs
+        lastHeartbeatTimeMs = lastHeartbeatTimeMs,
+        sessionProperties = sessionProperties,
     )
     return Envelope(
         resource = EnvelopeResource(),


### PR DESCRIPTION
## Goal

Use appState and session properties from associated session when sending native crashes. Prior to this, metadata from the current session was being used erroneously. Now, we will grab this from the session that is associated with the crash that will be resurrected.

In a later PR, the code will be modified to take from the cached payload envelope if a session doesn't exist.

