### PR TITLE
Simplify otel limits

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
@@ -22,10 +22,10 @@ interface SessionSpanWriter {
     /**
      * Add the given key-value pair as an Attribute to the session span
      */
-    fun addSystemAttribute(attribute: SpanAttributeData)
+    fun addAttribute(attribute: SpanAttributeData)
 
     /**
      * Remove the attribute with the given key
      */
-    fun removeSystemAttribute(key: String)
+    fun removeAttribute(key: String)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionProperties.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionProperties.kt
@@ -56,7 +56,7 @@ internal class EmbraceSessionProperties(
                 }
                 temporary[sanitizedKey] = sanitizedValue
             }
-            writer.addSystemAttribute(
+            writer.addAttribute(
                 SpanAttributeData(
                     sanitizedKey.toSessionPropertyAttributeName(),
                     sanitizedValue
@@ -79,7 +79,7 @@ internal class EmbraceSessionProperties(
                 preferencesService.permanentSessionProperties = permanentProperties()
                 existed = true
             }
-            writer.removeSystemAttribute(sanitizedKey.toSessionPropertyAttributeName())
+            writer.removeAttribute(sanitizedKey.toSessionPropertyAttributeName())
             return existed
         }
     }
@@ -98,7 +98,7 @@ internal class EmbraceSessionProperties(
 
     fun addPermPropsToSessionSpan() {
         permanentProperties().entries.forEach {
-            writer.addSystemAttribute(
+            writer.addAttribute(
                 SpanAttributeData(
                     it.key.toSessionPropertyAttributeName(),
                     it.value

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/OtelLimitsConfigExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/OtelLimitsConfigExt.kt
@@ -2,9 +2,8 @@ package io.embrace.android.embracesdk.internal.config.instrumented
 
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
 
-internal fun OtelLimitsConfig.isNameValid(str: String, internal: Boolean): Boolean =
-    str.isNotBlank() && ((internal && str.length <= getMaxInternalNameLength()) || str.length <= getMaxNameLength())
+internal fun OtelLimitsConfig.isNameValid(str: String): Boolean =
+    str.isNotBlank() && str.length <= getMaxNameLength()
 
-internal fun OtelLimitsConfig.isAttributeValid(key: String, value: String, internal: Boolean) =
-    ((internal && key.length <= getMaxInternalAttributeKeyLength()) || key.length <= getMaxCustomAttributeKeyLength()) &&
-        ((internal && value.length <= getMaxInternalAttributeValueLength()) || value.length <= getMaxCustomAttributeValueLength())
+internal fun OtelLimitsConfig.isAttributeValid(key: String, value: String) =
+    key.length <= getMaxAttributeKeyLength() && value.length <= getMaxAttributeValueLength()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
@@ -36,8 +36,8 @@ internal class OpenTelemetrySdk(
                     SpanLimits
                         .getDefault()
                         .toBuilder()
-                        .setMaxNumberOfEvents(limits.getMaxTotalEventCount())
-                        .setMaxNumberOfAttributes(limits.getMaxTotalAttributeCount())
+                        .setMaxNumberOfEvents(limits.getMaxEventCount())
+                        .setMaxNumberOfAttributes(limits.getMaxAttributeCount())
                         .build()
                 )
                 .setClock(openTelemetryClock)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -247,7 +247,7 @@ internal class SessionOrchestratorImpl(
     private fun updatePeriodicCacheAttrs() {
         val now = clock.now().millisToNanos()
         val attr = SpanAttributeData(embHeartbeatTimeUnixNano.name, now.toString())
-        sessionSpanWriter.addSystemAttribute(attr)
-        sessionSpanWriter.addSystemAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+        sessionSpanWriter.addAttribute(attr)
+        sessionSpanWriter.addAttribute(SpanAttributeData(embTerminated.name, true.toString()))
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
@@ -29,39 +29,39 @@ internal class SessionSpanAttrPopulatorImpl(
 
     override fun populateSessionSpanStartAttrs(session: SessionZygote) {
         with(sessionSpanWriter) {
-            addSystemAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
-            addSystemAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
-            addSystemAttribute(SpanAttributeData(embState.name, session.appState.name.lowercase(Locale.US)))
-            addSystemAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
-            addSystemAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+            addAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
+            addAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
+            addAttribute(SpanAttributeData(embState.name, session.appState.name.lowercase(Locale.US)))
+            addAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
+            addAttribute(SpanAttributeData(embTerminated.name, true.toString()))
 
             session.startType.toString().lowercase(Locale.US).let {
-                addSystemAttribute(SpanAttributeData(embSessionStartType.name, it))
+                addAttribute(SpanAttributeData(embSessionStartType.name, it))
             }
         }
     }
 
     override fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean) {
         with(sessionSpanWriter) {
-            addSystemAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
-            addSystemAttribute(SpanAttributeData(embTerminated.name, false.toString()))
+            addAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
+            addAttribute(SpanAttributeData(embTerminated.name, false.toString()))
             crashId?.let {
-                addSystemAttribute(SpanAttributeData(embCrashId.name, crashId))
+                addAttribute(SpanAttributeData(embCrashId.name, crashId))
             }
             endType?.toString()?.lowercase(Locale.US)?.let {
-                addSystemAttribute(SpanAttributeData(embSessionEndType.name, it))
+                addAttribute(SpanAttributeData(embSessionEndType.name, it))
             }
             if (coldStart) {
                 startupService.getSdkStartupDuration()?.let { duration ->
-                    addSystemAttribute(SpanAttributeData(embSessionStartupDuration.name, duration.toString()))
+                    addAttribute(SpanAttributeData(embSessionStartupDuration.name, duration.toString()))
                 }
             }
 
             val logCount = logService.getErrorLogsCount()
-            addSystemAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
+            addAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
 
             metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
-                addSystemAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
+                addAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -82,7 +82,7 @@ internal class CurrentSessionSpanImpl(
     }
 
     override fun getSessionId(): String {
-        return sessionSpan.get()?.getSystemAttribute(SessionIncubatingAttributes.SESSION_ID) ?: ""
+        return sessionSpan.get()?.getAttribute(SessionIncubatingAttributes.SESSION_ID) ?: ""
     }
 
     override fun readySession(): Boolean {
@@ -124,8 +124,8 @@ internal class CurrentSessionSpanImpl(
                 } else {
                     val crashTime = openTelemetryClock.now().nanosToMillis()
                     spanRepository.failActiveSpans(crashTime)
-                    endingSessionSpan.setSystemAttribute(
-                        appTerminationCause.key.attributeKey,
+                    endingSessionSpan.addAttribute(
+                        appTerminationCause.key.attributeKey.key,
                         appTerminationCause.value
                     )
                     endingSessionSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
@@ -139,7 +139,7 @@ internal class CurrentSessionSpanImpl(
 
     override fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean {
         val currentSession = sessionSpan.get() ?: return false
-        return currentSession.addSystemEvent(
+        return currentSession.addEvent(
             schemaType.fixedObjectName.toEmbraceObjectName(),
             startTimeMs,
             schemaType.attributes() + schemaType.telemetryType.toEmbraceKeyValuePair()
@@ -148,17 +148,17 @@ internal class CurrentSessionSpanImpl(
 
     override fun removeEvents(type: EmbType) {
         val currentSession = sessionSpan.get() ?: return
-        currentSession.removeSystemEvents(type)
+        currentSession.removeEvents(type)
     }
 
-    override fun addSystemAttribute(attribute: SpanAttributeData) {
+    override fun addAttribute(attribute: SpanAttributeData) {
         val currentSession = sessionSpan.get() ?: return
-        currentSession.addSystemAttribute(attribute.key, attribute.value)
+        currentSession.addAttribute(attribute.key, attribute.value)
     }
 
-    override fun removeSystemAttribute(key: String) {
+    override fun removeAttribute(key: String) {
         val currentSession = sessionSpan.get() ?: return
-        currentSession.removeSystemAttribute(key)
+        currentSession.removeAttribute(key)
     }
 
     /**
@@ -175,7 +175,7 @@ internal class CurrentSessionSpanImpl(
             private = false,
         ).apply {
             start(startTimeMs = startTimeMs)
-            setSystemAttribute(SessionIncubatingAttributes.SESSION_ID, Uuid.getEmbUuid())
+            addAttribute(SessionIncubatingAttributes.SESSION_ID.key, Uuid.getEmbUuid())
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -43,11 +43,10 @@ internal fun LogRecordBuilder.setAttribute(
  */
 fun AttributesBuilder.fromMap(
     attributes: Map<String, String>,
-    internal: Boolean,
     limits: OtelLimitsConfig = InstrumentedConfigImpl.otelLimits,
 ): AttributesBuilder {
     attributes.filter {
-        limits.isAttributeValid(it.key, it.value, internal) || it.key.isValidLongValueAttribute()
+        limits.isAttributeValid(it.key, it.value) || it.key.isValidLongValueAttribute()
     }.forEach {
         put(it.key, it.value)
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
@@ -34,36 +34,17 @@ interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
     /**
      * Get the value of the attribute with the given key. Returns null if the attribute does not exist.
      */
-    fun getSystemAttribute(key: AttributeKey<String>): String?
-
-    /**
-     * Set the value of the attribute with the given key, overwriting the original value if it's already set
-     */
-    fun setSystemAttribute(key: AttributeKey<String>, value: String)
-
-    /**
-     * Add the given key value pair as a system attribute to ths span
-     */
-    fun addSystemAttribute(key: String, value: String)
+    fun getAttribute(key: AttributeKey<String>): String?
 
     /**
      * Remove the system attribute with the given key name
      */
-    fun removeSystemAttribute(key: String)
-
-    /**
-     * Add a system event to the span that will subjected to a different maximum than typical span events.
-     */
-    fun addSystemEvent(
-        name: String,
-        timestampMs: Long?,
-        attributes: Map<String, String>?,
-    ): Boolean
+    fun removeAttribute(key: String)
 
     /**
      * Removes all system events with the given [EmbType]
      */
-    fun removeSystemEvents(type: EmbType): Boolean
+    fun removeEvents(type: EmbType): Boolean
 
     /**
      * Set the [StatusCode] and status description of the wrapped Span

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -39,7 +39,7 @@ internal class SpanServiceImpl(
         internal: Boolean,
         private: Boolean,
     ): PersistableEmbraceSpan? {
-        return if (inputsValid(name, internal) && currentSessionSpan.canStartNewSpan(parent, internal)) {
+        return if (inputsValid(name) && currentSessionSpan.canStartNewSpan(parent, internal)) {
             embraceSpanFactory.create(
                 name = name,
                 type = type,
@@ -55,7 +55,7 @@ internal class SpanServiceImpl(
 
     override fun createSpan(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan? {
         return if (
-            inputsValid(embraceSpanBuilder.spanName, embraceSpanBuilder.internal) &&
+            inputsValid(embraceSpanBuilder.spanName) &&
             currentSessionSpan.canStartNewSpan(embraceSpanBuilder.getParentSpan(), embraceSpanBuilder.internal)
         ) {
             embraceSpanFactory.create(embraceSpanBuilder)
@@ -125,7 +125,7 @@ internal class SpanServiceImpl(
             return false
         }
 
-        if (inputsValid(name, internal, events, attributes) && currentSessionSpan.canStartNewSpan(parent, internal)) {
+        if (inputsValid(name, events, attributes) && currentSessionSpan.canStartNewSpan(parent, internal)) {
             val newSpan = embraceSpanFactory.create(
                 name = name,
                 type = type,
@@ -152,13 +152,12 @@ internal class SpanServiceImpl(
 
     private fun inputsValid(
         name: String,
-        internal: Boolean,
         events: List<EmbraceSpanEvent>? = null,
         attributes: Map<String, String>? = null,
     ): Boolean {
-        return (limits.isNameValid(name, internal)) &&
-            ((events == null) || (events.size <= limits.getMaxCustomEventCount())) &&
-            ((attributes == null) || (attributes.size <= limits.getMaxCustomAttributeCount()))
+        return (limits.isNameValid(name)) &&
+            ((events == null) || (events.size <= limits.getMaxEventCount())) &&
+            ((attributes == null) || (attributes.size <= limits.getMaxAttributeCount()))
     }
 
     companion object {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanTest.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
-import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.opentelemetry.api.common.AttributeKey
@@ -143,7 +142,7 @@ internal class EmbSpanTest {
 
         with(checkNotNull(fakeEmbraceSpan.events)) {
             assertEquals(2, size)
-            val expectedName = InstrumentedConfigImpl.otelLimits.getExceptionEventName()
+            val expectedName = "exception"
             with(first()) {
                 assertEquals(expectedName, name)
                 assertEquals(firstExceptionTime, timestampNanos)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -495,7 +495,7 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `validate maximum events on session span`() {
-        val limit = InstrumentedConfigImpl.otelLimits.getMaxTotalEventCount()
+        val limit = InstrumentedConfigImpl.otelLimits.getMaxEventCount()
         repeat(limit + 1) {
             currentSessionSpan.addEvent(SchemaType.Breadcrumb("test-event"), 1000L + it)
         }
@@ -509,9 +509,9 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add and remove attribute forwarded to span`() {
-        currentSessionSpan.addSystemAttribute(SpanAttributeData("my_key", "my_value"))
-        currentSessionSpan.addSystemAttribute(SpanAttributeData("missing", "my_value"))
-        currentSessionSpan.removeSystemAttribute("missing")
+        currentSessionSpan.addAttribute(SpanAttributeData("my_key", "my_value"))
+        currentSessionSpan.addAttribute(SpanAttributeData("missing", "my_value"))
+        currentSessionSpan.removeAttribute("missing")
         val span = currentSessionSpan.endSession(true).single()
         assertEquals("emb-session", span.name)
 
@@ -522,9 +522,9 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `validate maximum attributes on session span`() {
-        val limit = InstrumentedConfigImpl.otelLimits.getMaxTotalAttributeCount()
+        val limit = InstrumentedConfigImpl.otelLimits.getMaxAttributeCount()
         repeat(limit + 1) {
-            currentSessionSpan.addSystemAttribute(SpanAttributeData("attribute-$it", "value"))
+            currentSessionSpan.addAttribute(SpanAttributeData("attribute-$it", "value"))
         }
 
         val span = currentSessionSpan.endSession(true).single()
@@ -540,8 +540,8 @@ internal class CurrentSessionSpanImplTests {
         assertTrue(endSession(true).isEmpty())
         assertFalse(addEvent(SchemaType.Breadcrumb("test"), clock.now()))
         // check doesn't throw exception
-        addSystemAttribute(attribute = SpanAttributeData("test", "test"))
-        removeSystemAttribute("test")
+        addAttribute(attribute = SpanAttributeData("test", "test"))
+        removeAttribute("test")
         removeEvents(EmbType.System.Breadcrumb)
     }
 
@@ -550,8 +550,8 @@ internal class CurrentSessionSpanImplTests {
         assertTrue(canStartNewSpan(parent = null, internal = true))
         assertTrue(addEvent(SchemaType.Breadcrumb("test"), clock.now()))
         // check doesn't throw exception
-        addSystemAttribute(attribute = SpanAttributeData("test", "test"))
-        removeSystemAttribute("test")
+        addAttribute(attribute = SpanAttributeData("test", "test"))
+        removeAttribute("test")
         removeEvents(EmbType.System.Breadcrumb)
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
@@ -187,7 +187,7 @@ class UiLoadTraceEmitter(
                 startTimeMs = startTimeMs,
             )?.let { root ->
                 if (zygote.lastActivityInstanceId != -1) {
-                    root.addSystemAttribute("last_activity", zygote.lastActivityName)
+                    root.addAttribute("last_activity", zygote.lastActivityName)
                 }
                 activeTraces[instanceId] = UiLoadTrace(root = root, activityName = activityName)
             }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
@@ -7,15 +7,39 @@ package io.embrace.android.embracesdk.internal.config.instrumented.schema
  * be implemented in a future PR.
  */
 interface OtelLimitsConfig {
-    fun getMaxInternalNameLength(): Int = 2000
-    fun getMaxNameLength(): Int = 50
-    fun getMaxCustomEventCount(): Int = 10
-    fun getMaxTotalEventCount(): Int = 11000
-    fun getMaxCustomAttributeCount(): Int = 50
-    fun getMaxTotalAttributeCount(): Int = 300
-    fun getMaxInternalAttributeKeyLength(): Int = 1000
-    fun getMaxInternalAttributeValueLength(): Int = 2000
-    fun getMaxCustomAttributeKeyLength(): Int = 50
-    fun getMaxCustomAttributeValueLength(): Int = 500
-    fun getExceptionEventName(): String = "exception"
+
+    /**
+     * The maximum length of a span name.
+     *
+     * sdk_config.otel_limits.max_span_name_length
+     */
+    fun getMaxNameLength(): Int = 2000
+
+    /**
+     * The maximum number of events in a span.
+     *
+     * sdk_config.otel_limits.max_events
+     */
+    fun getMaxEventCount(): Int = 11000
+
+    /**
+     * The maximum number of attributes in a span.
+     *
+     * sdk_config.otel_limits.max_attributes
+     */
+    fun getMaxAttributeCount(): Int = 300
+
+    /**
+     * The maximum number of characters in an attribute key.
+     *
+     * sdk_config.otel_limits.max_attribute_key_length
+     */
+    fun getMaxAttributeKeyLength(): Int = 1000
+
+    /**
+     * The maximum number of characters in an attribute value.
+     *
+     * sdk_config.otel_limits.max_attribute_value_length
+     */
+    fun getMaxAttributeValueLength(): Int = 2000
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -34,11 +34,11 @@ class FakeCurrentSessionSpan(
         addedEvents.removeAll { it.schemaType.telemetryType.key == type.key }
     }
 
-    override fun addSystemAttribute(attribute: SpanAttributeData) {
+    override fun addAttribute(attribute: SpanAttributeData) {
         attributes[attribute.key] = attribute.value
     }
 
-    override fun removeSystemAttribute(key: String) {
+    override fun removeAttribute(key: String) {
         attributes.remove(key)
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -36,7 +36,7 @@ class FakeDataSource(
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         captureData(inputValidation = { true }) {
-            addSystemAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
+            addAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -33,7 +33,6 @@ class FakeSpanData(
                 type.toEmbraceKeyValuePair(),
                 Pair("my-key", "my-value")
             ),
-            internal = true,
         ).build(),
     private var events: MutableList<EventData> = mutableListOf(
         EventData.create(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.fixtures
 
-import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.opentelemetry.embSequenceId
@@ -42,18 +41,6 @@ val testSpan: Span = EmbraceSpanData(
     )
 ).toNewPayload()
 
-val testSpanSnapshot: Span = Span(
-    traceId = "snapshot-trace-id",
-    spanId = "snapshot-span-id",
-    parentSpanId = null,
-    name = "snapshot",
-    startTimeNanos = DEFAULT_FAKE_CURRENT_TIME,
-    endTimeNanos = null,
-    status = Span.Status.UNSET,
-    events = emptyList(),
-    attributes = emptyList()
-)
-
 val fakeContextKey: ContextKey<String> = ContextKey.named<String>("fake-context-key")
 
 private fun createMapOfSize(size: Int): Map<String, String> {
@@ -79,24 +66,16 @@ private val limits = InstrumentedConfigImpl.otelLimits
 
 val MAX_LENGTH_SPAN_NAME: String = "s".repeat(limits.getMaxNameLength())
 val TOO_LONG_SPAN_NAME: String = "s".repeat(limits.getMaxNameLength() + 1)
-val MAX_LENGTH_INTERNAL_SPAN_NAME: String = "s".repeat(limits.getMaxInternalNameLength())
-val TOO_LONG_INTERNAL_SPAN_NAME: String = "s".repeat(limits.getMaxInternalNameLength() + 1)
 val MAX_LENGTH_EVENT_NAME: String = "s".repeat(MAX_EVENT_NAME_LENGTH)
 val TOO_LONG_EVENT_NAME: String = "s".repeat(MAX_EVENT_NAME_LENGTH + 1)
-val MAX_LENGTH_ATTRIBUTE_KEY: String = "s".repeat(limits.getMaxCustomAttributeKeyLength())
-val TOO_LONG_ATTRIBUTE_KEY: String = "s".repeat(limits.getMaxCustomAttributeKeyLength() + 1)
-val MAX_LENGTH_ATTRIBUTE_VALUE: String = "s".repeat(limits.getMaxCustomAttributeValueLength())
-val TOO_LONG_ATTRIBUTE_VALUE: String = "s".repeat(limits.getMaxCustomAttributeValueLength() + 1)
-val MAX_LENGTH_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN: String = "s".repeat(limits.getMaxInternalAttributeKeyLength())
-val TOO_LONG_ATTRIBUTE_KEY_FOR_INTERNAL_SPAN: String = "s".repeat(limits.getMaxInternalAttributeKeyLength() + 1)
-val MAX_LENGTH_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN: String =
-    "s".repeat(limits.getMaxInternalAttributeValueLength())
-val TOO_LONG_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN: String =
-    "s".repeat(limits.getMaxInternalAttributeValueLength() + 1)
+val MAX_LENGTH_ATTRIBUTE_KEY: String = "s".repeat(limits.getMaxAttributeKeyLength())
+val TOO_LONG_ATTRIBUTE_KEY: String = "s".repeat(limits.getMaxAttributeKeyLength() + 1)
+val MAX_LENGTH_ATTRIBUTE_VALUE: String = "s".repeat(limits.getMaxAttributeValueLength())
+val TOO_LONG_ATTRIBUTE_VALUE: String = "s".repeat(limits.getMaxAttributeValueLength() + 1)
 
-val maxSizeAttributes: Map<String, String> = createMapOfSize(limits.getMaxCustomAttributeCount())
-val tooBigAttributes: Map<String, String> = createMapOfSize(limits.getMaxCustomAttributeCount() + 1)
+val maxSizeAttributes: Map<String, String> = createMapOfSize(limits.getMaxAttributeCount())
+val tooBigAttributes: Map<String, String> = createMapOfSize(limits.getMaxAttributeCount() + 1)
 val maxSizeEventAttributes: Map<String, String> = createMapOfSize(MAX_EVENT_ATTRIBUTE_COUNT)
 val tooBigEventAttributes: Map<String, String> = createMapOfSize(MAX_EVENT_ATTRIBUTE_COUNT + 1)
-val maxSizeEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxCustomEventCount())
-val tooBigEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxCustomEventCount() + 1)
+val maxSizeEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxEventCount())
+val tooBigEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxEventCount() + 1)


### PR DESCRIPTION
## Goal

Simplifies the limits enforced on OTel data capture by rolling custom and system attributes + events into one. This should make it simpler for pure OTel folks to send as much data as they want by configuring the SDK appropriately.

## Testing

Relied on existing test coverage.