### PR TITLE
Support otel export only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Currently, only Spans and Logs are supported, but other signals will be added in
      - Doing bytecode instrumentation to enable the capture of certain telemetry.
 2. For multi-module projects, in the Gradle files of modules you want to invoke Embrace SDK API methods, add a dependency to the main Embrace SDK module: `'io.embrace:embrace-android-sdk:<version>`.
 3. In the `main` directory of your app's root source folder (i.e. `app/src/main/`), add in a file called `embrace-config.json` that contains `{}` as its only line.
+   - Add `sdk_config.otel_export_only: true` to the JSON object
    - To further configure the SDK, additional attributes can be added to this configuration file. 
    - See our [configuration documentation page](https://embrace.io/docs/android/features/configuration-file/) for further details.
 4. In your app's Gradle properties file, add in the entry `embrace.disableMappingFileUpload=true`

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -96,11 +96,4 @@ interface ConfigService {
      * The Embrace app ID. This is used to identify the app within the database.
      */
     val appId: String?
-
-    /**
-     * Whether only OTel exporters should be used. If this returns true,
-     * the SDK should avoid enabling unnecessary systems (such as anything that creates requests
-     * to Embrace).
-     */
-    fun isOnlyUsingOtelExporters(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -41,11 +41,12 @@ internal class DeliveryModuleImpl(
     override val deliveryTracer: DeliveryTracer? = null,
 ) : DeliveryModule {
 
+    private val enabledFeatures = initModule.instrumentedConfig.enabledFeatures
     private val processIdProvider = { otelModule.openTelemetryConfiguration.processIdentifier }
 
     override val payloadStore: PayloadStore? by singleton {
         val configService = configModule.configService
-        if (configService.isOnlyUsingOtelExporters()) {
+        if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             val deliveryService = deliveryService ?: return@singleton null
@@ -60,7 +61,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val deliveryService: DeliveryService? by singleton {
-        deliveryServiceProvider?.invoke() ?: if (configModule.configService.isOnlyUsingOtelExporters()) {
+        deliveryServiceProvider?.invoke() ?: if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             EmbraceDeliveryService(
@@ -76,7 +77,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val intakeService: IntakeService? by singleton {
-        if (configModule.configService.isOnlyUsingOtelExporters()) {
+        if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             val payloadStorageService = payloadStorageService ?: return@singleton null
@@ -102,7 +103,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val payloadCachingService: PayloadCachingService? by singleton {
-        if (configModule.configService.isOnlyUsingOtelExporters()) {
+        if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             val payloadStore = payloadStore ?: return@singleton null
@@ -117,7 +118,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val payloadStorageService: PayloadStorageService? by singleton {
-        payloadStorageServiceProvider?.invoke() ?: if (configModule.configService.isOnlyUsingOtelExporters()) {
+        payloadStorageServiceProvider?.invoke() ?: if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             val location = StorageLocation.PAYLOAD.asFile(coreModule.context, initModule.logger)
@@ -132,7 +133,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val cacheStorageService: PayloadStorageService? by singleton {
-        cacheStorageServiceProvider?.invoke() ?: if (configModule.configService.isOnlyUsingOtelExporters()) {
+        cacheStorageServiceProvider?.invoke() ?: if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             val location = StorageLocation.CACHE.asFile(coreModule.context, initModule.logger)
@@ -147,7 +148,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val requestExecutionService: RequestExecutionService? by singleton {
-        requestExecutionServiceProvider?.invoke() ?: if (configModule.configService.isOnlyUsingOtelExporters()) {
+        requestExecutionServiceProvider?.invoke() ?: if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             val appId = configModule.configService.appId ?: return@singleton null
@@ -176,7 +177,7 @@ internal class DeliveryModuleImpl(
     }
 
     override val schedulingService: SchedulingService? by singleton {
-        if (configModule.configService.isOnlyUsingOtelExporters()) {
+        if (enabledFeatures.isOtelExportOnly()) {
             null
         } else {
             val payloadStorageService = payloadStorageService ?: return@singleton null

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
@@ -79,7 +79,6 @@ internal class ConfigServiceImplTest {
         executor = BlockingScheduledExecutorService(blockingMode = false)
         worker = BackgroundWorker(executor)
         service = createService()
-        assertFalse(service.isOnlyUsingOtelExporters())
     }
 
     /**
@@ -160,7 +159,6 @@ internal class ConfigServiceImplTest {
         cfg.addLogExporter(FakeLogRecordExporter())
         val service = createService(config = cfg, appId = null)
         assertNotNull(service)
-        assertTrue(service.isOnlyUsingOtelExporters())
     }
 
     /**

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImplTest.kt
@@ -8,11 +8,14 @@ import io.embrace.android.embracesdk.fakes.FakeDeliveryService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeStorageModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.session.orchestrator.V2PayloadStore
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -30,7 +33,11 @@ class DeliveryModuleImplTest {
     @Before
     fun setUp() {
         configService = FakeConfigService()
-        val initModule = FakeInitModule()
+        createModule()
+    }
+
+    private fun createModule(cfg: InstrumentedConfig = FakeInstrumentedConfig()) {
+        val initModule = FakeInitModule(instrumentedConfig = cfg)
         module = DeliveryModuleImpl(
             FakeConfigModule(configService),
             initModule,
@@ -62,7 +69,7 @@ class DeliveryModuleImplTest {
 
     @Test
     fun `test otel export only`() {
-        configService.onlyUsingOtelExporters = true
+        createModule(FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(otelExportOnly = true)))
         assertNotNull(module)
         assertTrue(module.deliveryService is FakeDeliveryService)
         assertNull(module.intakeService)

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -6,6 +6,13 @@ package io.embrace.android.embracesdk.internal.config.instrumented.schema
 interface EnabledFeatureConfig {
 
     /**
+     * Whether the SDK is configured to send data to Embrace or should be used purely for OTel export.
+     *
+     * sdk_config.otel_export_only
+     */
+    fun isOtelExportOnly(): Boolean = false
+
+    /**
      * Gates Unity ANR capture.
      *
      * sdk_config.anr.capture_unity_thread

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
@@ -5,6 +5,8 @@ package io.embrace.android.embracesdk.internal.config.instrumented.schema
  *
  * Currently this is not instrumented by the gradle plugin so the values won't change - that will
  * be implemented in a future PR.
+ *
+ * IMPORTANT NOTE: these functions are only swazzled when the sdk_config.send_data_to_embrace is set to `true`.
  */
 interface OtelLimitsConfig {
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/OtelExportOnlyTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/OtelExportOnlyTest.kt
@@ -1,0 +1,57 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the SDK can export OpenTelemetry spans without sending any data to Embrace.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class OtelExportOnlyTest {
+
+    private val otelOnlyConfig = FakeInstrumentedConfig(
+        project = FakeProjectConfig(appId = null),
+        enabledFeatures = FakeEnabledFeatureConfig(otelExportOnly = true)
+    )
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule()
+
+    @Test
+    fun `only export OTel`() {
+        testRule.runTest(
+            instrumentedConfig = otelOnlyConfig,
+            testCaseAction = {
+                recordSession {
+                    embrace.startSpan("test-span")?.stop()
+                    embrace.logInfo("test-log")
+                }
+            },
+            assertAction = {
+                assertEquals(0, getSessionEnvelopes(0).size)
+                assertEquals(0, getLogEnvelopes(0).size)
+            },
+            otelExportAssertion = {
+                // span exported
+                val span = awaitSpanExport(1) {
+                    it.name == "test-span"
+                }.single()
+                assertEquals("test-span", span.name)
+
+                // log exported
+                val log = awaitLogExport(1) {
+                    true
+                }.single()
+                assertEquals("test-log", log.bodyValue?.value)
+            }
+        )
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/IntegrationTestRule.kt
@@ -26,6 +26,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceOtelExportAsse
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
+import io.embrace.android.embracesdk.testframework.export.FilteredLogExporter
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import java.io.File
@@ -98,6 +99,7 @@ internal class IntegrationTestRule(
     lateinit var preSdkStart: EmbracePreSdkStartInterface
     private lateinit var otelAssertion: EmbraceOtelExportAssertionInterface
     private lateinit var spanExporter: FilteredSpanExporter
+    private lateinit var logExporter: FilteredLogExporter
     private lateinit var embraceImpl: EmbraceImpl
     private lateinit var baseUrl: String
 
@@ -139,7 +141,8 @@ internal class IntegrationTestRule(
         action = EmbraceActionInterface(setup, bootstrapper)
         payloadAssertion = EmbracePayloadAssertionInterface(bootstrapper, apiServer)
         spanExporter = FilteredSpanExporter()
-        otelAssertion = EmbraceOtelExportAssertionInterface(spanExporter)
+        logExporter = FilteredLogExporter()
+        otelAssertion = EmbraceOtelExportAssertionInterface(spanExporter, logExporter)
 
         setupAction(setup)
         with(setup) {
@@ -147,6 +150,7 @@ internal class IntegrationTestRule(
             EmbraceHooks.setImpl(embraceImpl)
             preSdkStartAction(preSdkStart)
             embraceImpl.addSpanExporter(spanExporter)
+            embraceImpl.addLogRecordExporter(logExporter)
 
             // persist config here before the SDK starts up
             persistConfig(persistedRemoteConfig)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceOtelExportAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceOtelExportAssertionInterface.kt
@@ -2,7 +2,9 @@ package io.embrace.android.embracesdk.testframework.actions
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.testframework.export.ExportedSpanValidator
+import io.embrace.android.embracesdk.testframework.export.FilteredLogExporter
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
+import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.trace.data.SpanData
 
 /**
@@ -11,6 +13,7 @@ import io.opentelemetry.sdk.trace.data.SpanData
  */
 internal class EmbraceOtelExportAssertionInterface(
     private val spanExporter: FilteredSpanExporter,
+    private val logExporter: FilteredLogExporter,
     private val validator: ExportedSpanValidator = ExportedSpanValidator(),
 ) {
 
@@ -20,6 +23,26 @@ internal class EmbraceOtelExportAssertionInterface(
      */
     fun awaitSpansWithType(type: EmbType, expectedCount: Int): List<SpanData> {
         return spanExporter.awaitSpansWithType(type, expectedCount)
+    }
+
+    /**
+     * Retrieves spans that match the provided filter and waits until they are exported or a timeout is reached
+     */
+    fun awaitSpanExport(
+        expectedCount: Int,
+        filter: (SpanData) -> Boolean = { true },
+    ): List<SpanData> {
+        return spanExporter.awaitSpanExport(expectedCount, filter)
+    }
+
+    /**
+     * Retrieves logs that match the provided filter and waits until they are exported or a timeout is reached
+     */
+    fun awaitLogExport(
+        expectedCount: Int,
+        filter: (LogRecordData) -> Boolean = { true },
+    ): List<LogRecordData> {
+        return logExporter.awaitLogExport(expectedCount, filter)
     }
 
     /**

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredLogExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredLogExporter.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.embracesdk.testframework.export
+
+import io.embrace.android.embracesdk.assertions.returnIfConditionMet
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.opentelemetry.sdk.logs.export.LogRecordExporter
+
+/**
+ * A [LogRecordExporter] used in the integration tests that allows retrieving exported logs
+ * to perform assertions against.
+ */
+internal class FilteredLogExporter : LogRecordExporter {
+
+    private val logData = mutableListOf<LogRecordData>()
+
+    override fun export(logs: MutableCollection<LogRecordData>): CompletableResultCode {
+        logData.addAll(logs)
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun flush(): CompletableResultCode {
+        return CompletableResultCode.ofSuccess()
+    }
+
+    override fun shutdown(): CompletableResultCode {
+        return CompletableResultCode.ofSuccess()
+    }
+
+    fun awaitLogExport(expectedCount: Int, filter: (LogRecordData) -> Boolean): List<LogRecordData> {
+        val supplier = { logData.filter(filter) }
+        return returnIfConditionMet(
+            desiredValueSupplier = supplier,
+            dataProvider = supplier,
+            condition = { data ->
+                data.size == expectedCount
+            },
+            errorMessageSupplier = {
+                "Timeout. Expected $expectedCount logs, but got ${supplier().size}."
+            }
+        )
+    }
+
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
@@ -28,11 +28,11 @@ internal class FilteredSpanExporter : SpanExporter {
     }
 
     fun awaitSpansWithType(type: EmbType, expectedCount: Int): List<SpanData> {
-        return awaitSpanExport({
+        return awaitSpanExport(expectedCount) {
             it.attributes.asMap().any { entry ->
                 entry.key.key == "emb.type" && entry.value == type.value
             }
-        }, expectedCount)
+        }
     }
 
     fun failOnDuplicate() {
@@ -52,11 +52,11 @@ internal class FilteredSpanExporter : SpanExporter {
         }
     }
 
-    private fun awaitSpanExport(
-        spanFilter: (SpanData) -> Boolean,
+    fun awaitSpanExport(
         expectedCount: Int,
+        filter: (SpanData) -> Boolean,
     ): List<SpanData> {
-        val supplier = { spanData.filter(spanFilter) }
+        val supplier = { spanData.filter(filter) }
         return returnIfConditionMet(
             desiredValueSupplier = supplier,
             dataProvider = supplier,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -25,7 +25,6 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
 class FakeConfigService(
     override var appFramework: AppFramework = AppFramework.NATIVE,
     override var appId: String = "abcde",
-    var onlyUsingOtelExporters: Boolean = false,
     override var backgroundActivityBehavior: BackgroundActivityBehavior = createBackgroundActivityBehavior(),
     override var autoDataCaptureBehavior: AutoDataCaptureBehavior = createAutoDataCaptureBehavior(),
     override var breadcrumbBehavior: BreadcrumbBehavior = FakeBreadcrumbBehavior(),
@@ -39,6 +38,4 @@ class FakeConfigService(
     override var appExitInfoBehavior: AppExitInfoBehavior = createAppExitInfoBehavior(),
     override var networkSpanForwardingBehavior: NetworkSpanForwardingBehavior = createNetworkSpanForwardingBehavior(),
     override var sensitiveKeysBehavior: SensitiveKeysBehavior = createSensitiveKeysBehavior(),
-) : ConfigService {
-    override fun isOnlyUsingOtelExporters(): Boolean = onlyUsingOtelExporters
-}
+) : ConfigService

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.config.instrumented.schema.Enabled
 @Suppress("DEPRECATION")
 class FakeEnabledFeatureConfig(
     base: EnabledFeatureConfig = InstrumentedConfigImpl.enabledFeatures,
+    private val otelExportOnly: Boolean = base.isOtelExportOnly(),
     private val unityAnrCapture: Boolean = base.isUnityAnrCaptureEnabled(),
     private val activityBreadcrumbCapture: Boolean = base.isActivityBreadcrumbCaptureEnabled(),
     private val composeClickCapture: Boolean = base.isComposeClickCaptureEnabled(),
@@ -29,6 +30,7 @@ class FakeEnabledFeatureConfig(
     private val uiLoadPerfCapture: Boolean = base.isUiLoadPerfCaptureEnabled()
 ) : EnabledFeatureConfig {
 
+    override fun isOtelExportOnly(): Boolean = otelExportOnly
     override fun isUnityAnrCaptureEnabled(): Boolean = unityAnrCapture
     override fun isActivityBreadcrumbCaptureEnabled(): Boolean = activityBreadcrumbCapture
     override fun isComposeClickCaptureEnabled(): Boolean = composeClickCapture


### PR DESCRIPTION
## Goal

Adds a new flag to the config with the key `sdk_config.otel_export_only`. The intention is that customers who don't want to send data to Embrace can set this flag to `true`, and the SDK will avoid sending any data to Embrace. This also alters what bytecode we instrument (i.e. data limits).

## Testing

Added an integration test that confirms this workflow isn't broken.
