### PR TITLE
Fix auto termination propagation

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -83,11 +83,11 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/SdkAp
 
 public final class io/embrace/android/embracesdk/internal/api/SdkApi$DefaultImpls {
 	public static fun createSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJ)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;)Z
 	public static fun recordSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun recordSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun recordSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
@@ -289,12 +289,12 @@ public abstract interface class io/embrace/android/embracesdk/spans/TracingApi {
 	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public abstract fun createSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public abstract fun getSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
-	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
+	public abstract fun recordCompletedSpan (Ljava/lang/String;JJ)Z
+	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;)Z
+	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;)Z
+	public abstract fun recordCompletedSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;)Z
 	public abstract fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public abstract fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public abstract fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
@@ -308,17 +308,11 @@ public final class io/embrace/android/embracesdk/spans/TracingApi$DefaultImpls {
 	public static fun createSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public static synthetic fun createSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public static synthetic fun createSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public static synthetic fun recordCompletedSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Z
-	public static synthetic fun recordCompletedSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Z
-	public static synthetic fun recordCompletedSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Z
-	public static synthetic fun recordCompletedSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Z
-	public static synthetic fun recordCompletedSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Z
-	public static synthetic fun recordCompletedSpan$default (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;ILjava/lang/Object;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJ)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public static fun recordCompletedSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;)Z
 	public static fun recordSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun recordSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun recordSpan (Lio/embrace/android/embracesdk/spans/TracingApi;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -15,7 +15,7 @@ public interface TracingApi {
     public fun createSpan(
         name: String,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-    ): EmbraceSpan? = createSpan(name = name, parent = null)
+    ): EmbraceSpan? = createSpan(name = name, parent = null, autoTerminationMode = autoTerminationMode)
 
     /**
      * Create an [EmbraceSpan] with the given name and parent. Passing in a parent that is null result in a new trace with this
@@ -37,7 +37,7 @@ public interface TracingApi {
     public fun startSpan(
         name: String,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-    ): EmbraceSpan? = startSpan(name = name, parent = null)
+    ): EmbraceSpan? = startSpan(name = name, parent = null, autoTerminationMode = autoTerminationMode)
 
     /**
      * Create, start, and return a new [EmbraceSpan] with the given name and parent. Returns null if the [EmbraceSpan] cannot be created
@@ -50,7 +50,8 @@ public interface TracingApi {
     ): EmbraceSpan? = startSpan(
         name = name,
         parent = parent,
-        startTimeMs = null
+        startTimeMs = null,
+        autoTerminationMode = autoTerminationMode,
     )
 
     /**
@@ -73,7 +74,14 @@ public interface TracingApi {
         name: String,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         code: () -> T,
-    ): T = recordSpan(name = name, parent = null, attributes = null, events = null, code = code)
+    ): T = recordSpan(
+        name = name,
+        parent = null,
+        attributes = null,
+        events = null,
+        code = code,
+        autoTerminationMode = autoTerminationMode,
+    )
 
     /**
      * Execute the given block of code and record a new span around it with the given parent. Passing in a parent that is null will result
@@ -86,7 +94,14 @@ public interface TracingApi {
         parent: EmbraceSpan?,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         code: () -> T,
-    ): T = recordSpan(name = name, parent = parent, attributes = null, events = null, code = code)
+    ): T = recordSpan(
+        name = name,
+        parent = parent,
+        attributes = null,
+        events = null,
+        code = code,
+        autoTerminationMode = autoTerminationMode,
+    )
 
     /**
      * Execute the given block of code and record a new trace around it with optional attributes and list of [EmbraceSpanEvent]. If the span
@@ -99,7 +114,14 @@ public interface TracingApi {
         events: List<EmbraceSpanEvent>?,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         code: () -> T,
-    ): T = recordSpan(name = name, parent = null, attributes = attributes, events = events, code = code)
+    ): T = recordSpan(
+        name = name,
+        parent = null,
+        attributes = attributes,
+        events = events,
+        code = code,
+        autoTerminationMode = autoTerminationMode,
+    )
 
     /**
      * Execute the given block of code and record a new span around it with the given parent with optional attributes and list
@@ -125,7 +147,6 @@ public interface TracingApi {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): Boolean =
         recordCompletedSpan(
             name = name,
@@ -147,7 +168,6 @@ public interface TracingApi {
         startTimeMs: Long,
         endTimeMs: Long,
         errorCode: ErrorCode?,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): Boolean =
         recordCompletedSpan(
             name = name,
@@ -168,7 +188,6 @@ public interface TracingApi {
         startTimeMs: Long,
         endTimeMs: Long,
         parent: EmbraceSpan?,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): Boolean =
         recordCompletedSpan(
             name = name,
@@ -191,7 +210,6 @@ public interface TracingApi {
         endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): Boolean = recordCompletedSpan(
         name = name,
         startTimeMs = startTimeMs,
@@ -213,7 +231,6 @@ public interface TracingApi {
         endTimeMs: Long,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): Boolean = recordCompletedSpan(
         name = name,
         startTimeMs = startTimeMs,
@@ -239,7 +256,6 @@ public interface TracingApi {
         parent: EmbraceSpan?,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): Boolean
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -67,7 +67,6 @@ class EmbraceTracer(
         parent: EmbraceSpan?,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?,
-        autoTerminationMode: AutoTerminationMode,
     ): Boolean = spanService.recordCompletedSpan(
         name = name,
         startTimeMs = startTimeMs.normalizeTimestampAsMillis(),
@@ -77,7 +76,6 @@ class EmbraceTracer(
         private = false,
         attributes = attributes ?: emptyMap(),
         events = events ?: emptyList(),
-        autoTerminationMode = autoTerminationMode,
         errorCode = errorCode
     )
 

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -38,12 +38,12 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public fun logWarning (Ljava/lang/String;)V
 	public fun logWebView (Ljava/lang/String;)V
-	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
-	public fun recordCompletedSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Z
+	public fun recordCompletedSpan (Ljava/lang/String;JJ)Z
+	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;)Z
+	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;)Z
+	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;)Z
+	public fun recordCompletedSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;)Z
 	public fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -214,7 +214,7 @@ public class Embrace private constructor(
         name: String,
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSpan? {
-        return impl.createSpan(name)
+        return impl.createSpan(name, autoTerminationMode)
     }
 
     override fun createSpan(
@@ -222,14 +222,14 @@ public class Embrace private constructor(
         parent: EmbraceSpan?,
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSpan? {
-        return impl.createSpan(name, parent)
+        return impl.createSpan(name, parent, autoTerminationMode)
     }
 
     override fun startSpan(
         name: String,
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSpan? {
-        return impl.startSpan(name)
+        return impl.startSpan(name, autoTerminationMode)
     }
 
     override fun startSpan(
@@ -237,7 +237,7 @@ public class Embrace private constructor(
         parent: EmbraceSpan?,
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSpan? {
-        return impl.startSpan(name, parent)
+        return impl.startSpan(name, parent, autoTerminationMode)
     }
 
     override fun startSpan(
@@ -246,7 +246,7 @@ public class Embrace private constructor(
         startTimeMs: Long?,
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSpan? {
-        return impl.startSpan(name, parent, startTimeMs)
+        return impl.startSpan(name, parent, startTimeMs, autoTerminationMode)
     }
 
     override fun <T> recordSpan(
@@ -295,7 +295,6 @@ public class Embrace private constructor(
         parent: EmbraceSpan?,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?,
-        autoTerminationMode: AutoTerminationMode,
     ): Boolean {
         return impl.recordCompletedSpan(
             name,
@@ -312,7 +311,6 @@ public class Embrace private constructor(
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        autoTerminationMode: AutoTerminationMode,
     ): Boolean {
         return impl.recordCompletedSpan(name, startTimeMs, endTimeMs)
     }
@@ -322,7 +320,6 @@ public class Embrace private constructor(
         startTimeMs: Long,
         endTimeMs: Long,
         errorCode: ErrorCode?,
-        autoTerminationMode: AutoTerminationMode,
     ): Boolean {
         return impl.recordCompletedSpan(name, startTimeMs, endTimeMs, errorCode)
     }
@@ -332,7 +329,6 @@ public class Embrace private constructor(
         startTimeMs: Long,
         endTimeMs: Long,
         parent: EmbraceSpan?,
-        autoTerminationMode: AutoTerminationMode,
     ): Boolean {
         return impl.recordCompletedSpan(name, startTimeMs, endTimeMs, parent)
     }
@@ -343,7 +339,6 @@ public class Embrace private constructor(
         endTimeMs: Long,
         errorCode: ErrorCode?,
         parent: EmbraceSpan?,
-        autoTerminationMode: AutoTerminationMode,
     ): Boolean {
         return impl.recordCompletedSpan(name, startTimeMs, endTimeMs, errorCode, parent)
     }
@@ -354,7 +349,6 @@ public class Embrace private constructor(
         endTimeMs: Long,
         attributes: Map<String, String>?,
         events: List<EmbraceSpanEvent>?,
-        autoTerminationMode: AutoTerminationMode,
     ): Boolean {
         return impl.recordCompletedSpan(name, startTimeMs, endTimeMs, attributes, events)
     }


### PR DESCRIPTION
## Goal

Fixes a few places where the `AutoTermination` enum wasn't getting passed through. I also removed it as a parameter from `recordCompletedSpan` as it doesn't make sense in the context of that function. I debated removing it from `recordSpan` but believe it makes sense to keep it there given that the code block could potentially run for a long time.

## Testing

Relied on existing test coverage. An upcoming PR will include the integration test that originally caught these problems.

