### PR TITLE
Set internal error logger correctly

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLoggerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLoggerImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.logging
 
 import android.util.Log
+import io.embrace.android.embracesdk.internal.utils.Provider
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal const val EMBRACE_TAG = "[Embrace]"
@@ -12,7 +13,7 @@ internal const val EMBRACE_TAG = "[Embrace]"
 class EmbLoggerImpl : EmbLogger {
 
     private val loggedSdkNotStarted = AtomicBoolean(false)
-    var errorHandler: InternalErrorHandler? = null
+    override var errorHandlerProvider: Provider<InternalErrorHandler?> = { null }
 
     override fun logInfo(msg: String, throwable: Throwable?) {
         log(msg, EmbLogger.Severity.INFO, throwable)
@@ -31,7 +32,7 @@ class EmbLoggerImpl : EmbLogger {
 
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {
         try {
-            errorHandler?.trackInternalError(type, throwable)
+            errorHandlerProvider()?.trackInternalError(type, throwable)
         } catch (exc: Throwable) {
             // don't cause a crash loop!
             Log.w(EMBRACE_TAG, "Failed to track internal error", exc)

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLogger.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/EmbLogger.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.logging
 
+import io.embrace.android.embracesdk.internal.utils.Provider
+
 /**
  * A simple interface that is used within the Embrace SDK for logging.
  */
@@ -8,6 +10,11 @@ interface EmbLogger : InternalErrorHandler {
     enum class Severity {
         DEBUG, INFO, WARNING, ERROR
     }
+
+    /**
+     * The implementation of the internal error handler. This is set after the logger is initialized.
+     */
+    var errorHandlerProvider: Provider<InternalErrorHandler?>
 
     /**
      * Logs an informational message.

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
@@ -1,0 +1,54 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.android.embracesdk.testframework.IntegrationTestRule
+import io.embrace.android.embracesdk.testframework.assertions.getLastLog
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class InternalErrorLogTest {
+
+    @Rule
+    @JvmField
+    val testRule: IntegrationTestRule = IntegrationTestRule()
+
+    @Test
+    fun `internal error log delivered`() {
+        testRule.runTest(
+            setupAction = {
+                (overriddenInitModule.logger as FakeEmbLogger).throwOnInternalError = false
+            },
+            testCaseAction = {
+                recordSession {
+                    embrace.impl.internalInterface.logInternalError("Some error message", null)
+                }
+            },
+            assertAction = {
+                with(getSingleLogEnvelope().getLastLog()) {
+                    assertEquals("ERROR", severityText)
+                    assertEquals("", body)
+
+                    val attrs = checkNotNull(attributes)
+                    assertEquals("sys.internal", attrs.findAttributeValue("emb.type"))
+                    assertEquals(
+                        "Some error message",
+                        attrs.findAttributeValue("exception.message")
+                    )
+                    assertEquals(
+                        "java.lang.RuntimeException",
+                        attrs.findAttributeValue("exception.type")
+                    )
+                    assertNotNull(attrs.findAttributeValue("log.record.uid"))
+                    assertNotNull(attrs.findAttributeValue("session.id"))
+                    checkNotNull(attrs.findAttributeValue("exception.stacktrace"))
+                }
+            }
+        )
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -246,9 +246,7 @@ internal class ModuleInitBootstrapper(
                     }
                     postInit(FeatureModule::class) {
                         featureModule.registerFeatures()
-                        (initModule.logger as? EmbLoggerImpl)?.let {
-                            it.errorHandler = featureModule.internalErrorDataSource.dataSource
-                        }
+                        initModule.logger.errorHandlerProvider = { featureModule.internalErrorDataSource.dataSource }
                     }
 
                     dataCaptureServiceModule = init(DataCaptureServiceModule::class) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -1,10 +1,13 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorHandler
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.utils.Provider
 
 class FakeEmbLogger(
     var throwOnInternalError: Boolean = true,
+    override var errorHandlerProvider: Provider<InternalErrorHandler?> = { null },
 ) : EmbLogger {
 
     data class LogMessage(
@@ -37,5 +40,6 @@ class FakeEmbLogger(
             throw IllegalStateException("Internal error: $type", throwable)
         }
         internalErrorMessages.add(LogMessage(type.toString(), throwable))
+        errorHandlerProvider()?.trackInternalError(type, throwable)
     }
 }


### PR DESCRIPTION
## Goal

The internal error logger was set in `ModuleInitBootstrapper` at a point where it would return false, meaning internal error logs were effectively not sent in 6.13.0. I've fixed this by setting the value via a lambda (as was the case in versions below 6.13.0). I also added the lambda as a property of the logging interface so that it's testable with the fake implementation.

## Testing

Added an integration test.

