### PR TITLE
Prevent null session ID crashing ndk processing

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegate.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegate.kt
@@ -10,7 +10,7 @@ interface JniDelegate {
         devLogging: Boolean,
     )
     fun updateMetaData(metadata: String?)
-    fun onSessionChange(sessionId: String?, reportPath: String)
+    fun onSessionChange(sessionId: String, reportPath: String)
     fun updateAppState(appState: String?)
     fun getCrashReport(path: String): String?
     fun checkForOverwrittenHandlers(): String?

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegateImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/jni/JniDelegateImpl.kt
@@ -11,7 +11,7 @@ class JniDelegateImpl : JniDelegate {
     )
 
     external override fun updateMetaData(metadata: String?)
-    external override fun onSessionChange(sessionId: String?, reportPath: String)
+    external override fun onSessionChange(sessionId: String, reportPath: String)
     external override fun updateAppState(appState: String?)
     external override fun getCrashReport(path: String): String?
     external override fun checkForOverwrittenHandlers(): String?

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
@@ -25,7 +25,7 @@ class FakeJniDelegate : JniDelegate {
         // do nothing
     }
 
-    override fun onSessionChange(sessionId: String?, reportPath: String) {
+    override fun onSessionChange(sessionId: String, reportPath: String) {
         this.reportPath = reportPath
     }
 


### PR DESCRIPTION
## Goal

Prevents a null session ID from crashing in the JNI due to not checking for null. I fixed this by serializing `null` instead, which is the previous behavior before our NDK refactors.

