### PR TITLE
Update swazzler test workflow

### DIFF
--- a/.github/workflows/swazzler-tests.yml
+++ b/.github/workflows/swazzler-tests.yml
@@ -44,32 +44,23 @@ jobs:
         with:
           node-version: 20.x
 
-      # make sure version in gradle.properties matches the version of embrace-swazzler3 version
       - name: "Publish SDK locally"
         run: ./gradlew publishToMavenLocal --no-daemon
-
-      - name: Checkout Swazzler-Test
-        uses: actions/checkout@v4
-        with:
-          repository: embrace-io/swazzler-test
-          path: ./swazzler-test
-          submodules: recursive
-          token: ${{ secrets.GH_ANDROID_SDK_TOKEN || secrets.token }}
 
       - name: Checkout Swazzler
         uses: actions/checkout@v4
         with:
           repository: embrace-io/embrace-swazzler3
-          path: ./swazzler-test/embrace-swazzler3
+          path: ./embrace-swazzler3
           token: ${{ secrets.GH_ANDROID_SDK_TOKEN }}
 
       - name: "Publish Swazzler locally"
-        working-directory: ./swazzler-test/embrace-swazzler3
+        working-directory: ./embrace-swazzler3
         run: ./gradlew publishToMavenLocal --no-daemon
 
       - name: "Run Gradle Tests"
-        working-directory: ./swazzler-test
-        run: ./gradlew :functional-tests:swazzlerTests --tests "io.embrace.android.gradle.swazzler.tests.*" --stacktrace
+        working-directory: ./embrace-swazzler3
+        run: ./gradlew :embrace-gradle-plugin-functional-tests:test --tests "io.embrace.android.gradle.swazzler.tests.*" --stacktrace
 
       - name: "Test Results"
         if: ${{ always() }}
@@ -77,5 +68,5 @@ jobs:
         with:
           name: swazzler-test-results
           path: |
-            ./swazzler-test/functional-tests/build/reports/tests/swazzlerTests/
-            ./swazzler-test/functional-tests/swazzler_test_debug_output
+            ./embrace-swazzler3/embrace-gradle-plugin-functional-tests/reports/tests/swazzlerTests/
+            ./embrace-swazzler3/embrace-gradle-plugin-functional-tests/test_debug_output


### PR DESCRIPTION
## Goal

Updates the swazzler-test workflow due to repo reorganisation.

The ref in the workflow needs to be updated before merging to main, but this allows us to test the workflow now.

