### PR TITLE
Publish local artefact without javadoc

### DIFF
--- a/.github/workflows/swazzler-tests.yml
+++ b/.github/workflows/swazzler-tests.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: 20.x
 
       - name: "Publish SDK locally"
-        run: ./gradlew publishToMavenLocal --no-daemon
+        run: ./gradlew publishDebugSdk --no-daemon
 
       - name: Checkout Swazzler
         uses: actions/checkout@v4


### PR DESCRIPTION
## Goal

Publishes the SDK artefact without generating Javadoc, which is a bottleneck in build time and doesn't affect things for test purposes.

`./gradlew publishDebugSdk` can be used to run this task.

