### PR TITLE
Add option to manually end UI load trace

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadEventListener.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadEventListener.kt
@@ -10,8 +10,10 @@ interface UiLoadEventListener {
      * When the given UI instance is starting to be created.
      *
      * For an Activity, it means it has entered the CREATED state of its lifecycle.
+     *
+     * Set [manualEnd] to true to signal that the load of this UI instance will be ended manually by calling [complete]
      */
-    fun create(instanceId: Int, activityName: String, timestampMs: Long)
+    fun create(instanceId: Int, activityName: String, timestampMs: Long, manualEnd: Boolean)
 
     /**
      * When the given UI instance has been fully created and is ready to be displayed on screen.
@@ -24,8 +26,10 @@ interface UiLoadEventListener {
      * When the given UI instance is starting to be displayed on screen
      *
      * For an Activity, it means it is about to enter the STARTED state of its lifecycle.
+     *
+     * Set [manualEnd] to true to signal that the load of this UI instance will be ended manually by calling [complete]
      */
-    fun start(instanceId: Int, activityName: String, timestampMs: Long)
+    fun start(instanceId: Int, activityName: String, timestampMs: Long, manualEnd: Boolean)
 
     /**
      * When the given UI instance is displayed on screen and its views are ready to be rendered
@@ -61,6 +65,12 @@ interface UiLoadEventListener {
      * For an Activity, it means when the first frame associated with its Window has delivered its first frame.
      */
     fun renderEnd(instanceId: Int, timestampMs: Long)
+
+    /**
+     * When the app manually signals that the load of the given UI instance is complete. This will only be respected
+     * if the load is expected to be ended manually.
+     */
+    fun complete(instanceId: Int, timestampMs: Long)
 
     /**
      * When we no longer wish to observe the loading of the given UI instance. This may be called during its load

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -148,7 +148,8 @@ private class UiLoadEventEmitter(
         uiLoadEventListener.create(
             instanceId = traceInstanceId(activity),
             activityName = activity.localClassName,
-            timestampMs = nowMs()
+            timestampMs = nowMs(),
+            manualEnd = false,
         )
     }
 
@@ -163,7 +164,8 @@ private class UiLoadEventEmitter(
         uiLoadEventListener.start(
             instanceId = traceInstanceId(activity),
             activityName = activity.localClassName,
-            timestampMs = nowMs()
+            timestampMs = nowMs(),
+            manualEnd = false,
         )
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadEventListener.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadEventListener.kt
@@ -25,7 +25,7 @@ class FakeUiLoadEventListener : UiLoadEventListener {
         )
     }
 
-    override fun create(instanceId: Int, activityName: String, timestampMs: Long) {
+    override fun create(instanceId: Int, activityName: String, timestampMs: Long, manualEnd: Boolean) {
         events.add(
             EventData(
                 stage = "create",
@@ -47,7 +47,7 @@ class FakeUiLoadEventListener : UiLoadEventListener {
         )
     }
 
-    override fun start(instanceId: Int, activityName: String, timestampMs: Long) {
+    override fun start(instanceId: Int, activityName: String, timestampMs: Long, manualEnd: Boolean) {
         events.add(
             EventData(
                 stage = "start",
@@ -104,6 +104,16 @@ class FakeUiLoadEventListener : UiLoadEventListener {
         events.add(
             EventData(
                 stage = "renderEnd",
+                instanceId = instanceId,
+                timestampMs = timestampMs
+            )
+        )
+    }
+
+    override fun complete(instanceId: Int, timestampMs: Long) {
+        events.add(
+            EventData(
+                stage = "complete",
                 instanceId = instanceId,
                 timestampMs = timestampMs
             )


### PR DESCRIPTION
## Goal

Add in the ability at the `UiLoadTraceEmitter` level to designate a UI Load trace to be ended manually. This has not been hooked up with the API yet so it cannot be triggered externally yet.