### PR TITLE
Avoid out of bound access to emb_exception->stacktrace

### DIFF
--- a/embrace-android-sdk/src/main/cpp/serializer/file_writer.c
+++ b/embrace-android-sdk/src/main/cpp/serializer/file_writer.c
@@ -211,7 +211,7 @@ bool emb_add_exc_info_to_json(const emb_crash *crash, JSON_Object *crash_object,
 bool emb_add_exc_to_json(const emb_exception *exception, JSON_Array *frames_object) {
     EMB_LOGDEV("About to serialize %d stack frames.", (int) exception->num_sframes);
 
-    for (int i = 0; i < exception->num_sframes; ++i) {
+    for (int i = 0; i < exception->num_sframes && i < kEMBMaxSFrames; ++i) {
         JSON_Value *frame_value = json_value_init_object();
         if (frame_value == NULL) {
             return false;

--- a/embrace-android-sdk/src/main/cpp/unwinders/stack_unwinder.cpp
+++ b/embrace-android-sdk/src/main/cpp/unwinders/stack_unwinder.cpp
@@ -17,6 +17,9 @@ static inline void emb_copy_frame_data(unwindstack::AndroidUnwinderData &android
     int k = 0;
 
     for (const auto &frame: android_unwinder_data.frames) {
+        if (k >= kEMBMaxSFrames) {
+            break;
+        }
         emb_sframe *data = &stacktrace[k++];
 
         // populate the link register for the first value only

--- a/embrace-android-sdk/src/main/cpp/unwinders/unwinder.c
+++ b/embrace-android-sdk/src/main/cpp/unwinders/unwinder.c
@@ -12,12 +12,12 @@
 void emb_fix_fileinfo(ssize_t frame_count,
                          emb_sframe stacktrace[kEMBMaxSFrames]) {
     static Dl_info info;
-    for (int i = 0; i < frame_count; ++i) {
+
+    for (int i = 0; i < frame_count && i < kEMBMaxSFrames; ++i) {
         if (dladdr((void *)stacktrace[i].frame_addr, &info) != 0) {
             stacktrace[i].module_addr = (uintptr_t)info.dli_fbase;
             stacktrace[i].offset_addr = (uintptr_t)info.dli_saddr;
-            stacktrace[i].line_num =
-                    stacktrace[i].frame_addr - stacktrace[i].module_addr;
+            stacktrace[i].line_num = stacktrace[i].frame_addr - stacktrace[i].module_addr;
             if (info.dli_fname != NULL) {
                 emb_strncpy(stacktrace[i].filename, (char *)info.dli_fname, sizeof(stacktrace[i].filename));
             }


### PR DESCRIPTION
Tested by reducing kEMBMaxSFrames to 3, and forcing a native crash. Before this fix, either the native crash is lost due to an exception, or the native crash is sent but with trash data (things like sessionId containing a stack frame or other weirdness).

Now, the native crash is sent correctly, but capped to 3.

In the future, we might want to: 
- Increase the kEMBMaxSFrames limit.
- Add some kind of warning to let the user know that the stacktrace was limited.