### PR TITLE
strncpy out of bounds fix

### DIFF
--- a/embrace-android-sdk/src/main/cpp/utils/string_utils.c
+++ b/embrace-android-sdk/src/main/cpp/utils/string_utils.c
@@ -3,23 +3,22 @@
 
 /**
  * Copy a string from source to destination. If the source is larger than the destination, it will be truncated.
+ * The destination buffer will always be null-terminated.
  * @param destination The destination buffer.
  * @param source The source buffer.
  * @param destination_len The length of the destination buffer.
  */
 void emb_strncpy(char *destination, const char *source, size_t destination_len) {
-    if (destination == NULL || source == NULL) {
+    if (destination == NULL || source == NULL || destination_len == 0) {
         return;
     }
-    int i = 0;
-    while (i < destination_len && source[i] != '\0') {
-        char current = source[i];
-        destination[i] = current;
-        if (current == '\0') {
-            break;
-        }
-        i++;
+
+    size_t i;
+    for (i = 0; i < destination_len - 1 && source[i] != '\0'; i++) {
+        destination[i] = source[i];
     }
+
+    destination[i] = '\0'; // Null-terminate the destination buffer.
 }
 
 void emb_convert_to_hex_addr(uint64_t addr, char *buffer) {

--- a/embrace-android-sdk/src/main/cpp/utils/string_utils.c
+++ b/embrace-android-sdk/src/main/cpp/utils/string_utils.c
@@ -1,14 +1,20 @@
 #include "string_utils.h"
 #include "../schema/stack_frames.h"
 
-void emb_strncpy(char *dst, const char *src, size_t len) {
-    if (dst == NULL || src == NULL) {
+/**
+ * Copy a string from source to destination. If the source is larger than the destination, it will be truncated.
+ * @param destination The destination buffer.
+ * @param source The source buffer.
+ * @param destination_len The length of the destination buffer.
+ */
+void emb_strncpy(char *destination, const char *source, size_t destination_len) {
+    if (destination == NULL || source == NULL) {
         return;
     }
     int i = 0;
-    while (i <= len) {
-        char current = src[i];
-        dst[i] = current;
+    while (i < destination_len && source[i] != '\0') {
+        char current = source[i];
+        destination[i] = current;
         if (current == '\0') {
             break;
         }

--- a/embrace-android-sdk/src/main/cpp/utils/string_utils.h
+++ b/embrace-android-sdk/src/main/cpp/utils/string_utils.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void emb_strncpy(char *dst, const char *src, size_t len);
+void emb_strncpy(char *destination, const char *source, size_t destination_len);
 void emb_convert_to_hex_addr(uint64_t addr, char *buffer);
 
 #ifdef __cplusplus

--- a/embrace-android-sdk/src/test/cpp/testcases/utilities/test_string_utils.c
+++ b/embrace-android-sdk/src/test/cpp/testcases/utilities/test_string_utils.c
@@ -33,7 +33,7 @@ TEST test_string_copy_larger_source(void) {
     char dst[2];
     char src[] = "123456";
     emb_strncpy(dst, src, sizeof(dst));
-    ASSERT_STR_EQ("12", dst);
+    ASSERT_STR_EQ("1", dst);    // the rest of the source is truncated to size 2 (1 and a null terminator)
     PASS();
 }
 

--- a/embrace-android-sdk/src/test/cpp/testcases/utilities/test_string_utils.c
+++ b/embrace-android-sdk/src/test/cpp/testcases/utilities/test_string_utils.c
@@ -29,9 +29,27 @@ TEST convert_to_hex(void) {
     PASS();
 }
 
+TEST test_string_copy_larger_source(void) {
+    char dst[2];
+    char src[] = "123456";
+    emb_strncpy(dst, src, sizeof(dst));
+    ASSERT_STR_EQ("12", dst);
+    PASS();
+}
+
+TEST test_string_copy_larger_destination(void) {
+    char dst[6] = {0};
+    char src[] = "12";
+    emb_strncpy(dst, src, sizeof(dst));
+    ASSERT_STR_EQ("12", dst);
+    PASS();
+}
+
 SUITE(suite_utilities) {
     RUN_TEST(string_copy_success);
     RUN_TEST(string_null_src);
     RUN_TEST(string_null_dst);
     RUN_TEST(convert_to_hex);
+    RUN_TEST(test_string_copy_larger_source);
+    RUN_TEST(test_string_copy_larger_destination);
 }


### PR DESCRIPTION
We use strncpy in many places. In almost all places, we call it with the size of the destination array. That means something like this:

```
char destinationArray[3]
char sourceArray[5]
emb_strncpy(destinationArray, sourceArray, sizeof(destinationArray))
```

In that case, sizeof(destinationArray) will be 3. That means the while loop will execute until 4, and we will try to write `src[3]` to `dst[3]`, which is out of bounds.

While C might let you write out of bounds, it may cause memory corruption or failure. 

Changes: 
- Modified the while loop so `i` won't be equal to `destination_len`.
- Added a `source[i] != '\0'` verification in case the source is smaller than the destination. Strings passed in src should end in that termination char. If they don't, we might face another OOB. We could solve this by also passing source_len as a parameter.
- Added some test cases.
- Improved naming.