### PR TITLE
Align event emitter names with lifecycle methods

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadEventListener.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadEventListener.kt
@@ -76,7 +76,7 @@ interface UiLoadEventListener {
      * When we no longer wish to observe the loading of the given UI instance. This may be called during its load
      * or after it has loaded. Calls to this for a given instance should be idempotent.
      */
-    fun abandon(instanceId: Int, activityName: String, timestampMs: Long)
+    fun exit(instanceId: Int, activityName: String, timestampMs: Long)
 
     /**
      * When the app is no longer in a state where it is trying to open up UI. All traces should be abandoned and

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
@@ -156,7 +156,7 @@ class UiLoadTraceEmitter(
         }
     }
 
-    override fun abandon(instanceId: Int, activityName: String, timestampMs: Long) {
+    override fun exit(instanceId: Int, activityName: String, timestampMs: Long) {
         currentTracedInstanceId?.let { currentlyTracedInstanceId ->
             if (instanceId != currentlyTracedInstanceId) {
                 endTrace(

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
@@ -322,7 +322,7 @@ internal class UiLoadTraceEmitterTest {
         clock.tick(100L)
 
         // set state of tracker to simulate that at least one activity has been opened
-        traceEmitter.abandon(lastInstanceId, lastActivityName, lastActivityExitMs)
+        traceEmitter.exit(lastInstanceId, lastActivityName, lastActivityExitMs)
         when (previousState) {
             PreviousState.FROM_ACTIVITY -> {
                 // do nothing extra

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadEventListener.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadEventListener.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.capture.activity.UiLoadEventListen
 class FakeUiLoadEventListener : UiLoadEventListener {
     val events = mutableListOf<EventData>()
 
-    override fun abandon(instanceId: Int, activityName: String, timestampMs: Long) {
+    override fun exit(instanceId: Int, activityName: String, timestampMs: Long) {
         events.add(
             EventData(
                 stage = "abandon",


### PR DESCRIPTION
## Goal

A renaming of interface and objects to make them align better with their purpose. Note there are additional naming changes down the line, i.e. `exit` becomes `discard`.

