### PR TITLE
Change start time of UI Load traces

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
@@ -79,25 +79,25 @@ internal class UiLoadTest {
                 val rootSpanId = checkNotNull(trace.spanId)
                 assertEquals("emb-$ACTIVITY2_NAME-cold-time-to-initial-display", trace.name)
 
-                val expectedTraceStartTime = preLaunchTimeMs + 20301
+                val expectedTraceStartTime = preLaunchTimeMs + 20351
                 assertEmbraceSpanData(
                     span = trace,
                     expectedStartTimeMs = expectedTraceStartTime,
-                    expectedEndTimeMs = expectedTraceStartTime + 250,
+                    expectedEndTimeMs = expectedTraceStartTime + 200,
                     expectedParentId = SpanId.getInvalid(),
                 )
 
                 assertEmbraceSpanData(
                     span = payload.findSpansByName("emb-${LifecycleStage.CREATE.spanName(ACTIVITY2_NAME)}").single(),
-                    expectedStartTimeMs = expectedTraceStartTime + 50,
-                    expectedEndTimeMs = expectedTraceStartTime + 150,
+                    expectedStartTimeMs = expectedTraceStartTime,
+                    expectedEndTimeMs = expectedTraceStartTime + 100,
                     expectedParentId = rootSpanId,
                 )
 
                 assertEmbraceSpanData(
                     span = payload.findSpansByName("emb-${LifecycleStage.START.spanName(ACTIVITY2_NAME)}").single(),
-                    expectedStartTimeMs = expectedTraceStartTime + 150,
-                    expectedEndTimeMs = expectedTraceStartTime + 250,
+                    expectedStartTimeMs = expectedTraceStartTime + 100,
+                    expectedEndTimeMs = expectedTraceStartTime + 200,
                     expectedParentId = rootSpanId,
                 )
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import androidx.lifecycle.Lifecycle
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
@@ -30,8 +30,8 @@ fun assertEmbraceSpanData(
 ) {
     checkNotNull(span)
     with(span) {
-        assertEquals(expectedStartTimeMs, startTimeNanos?.nanosToMillis())
-        assertEquals(expectedEndTimeMs, endTimeNanos?.nanosToMillis())
+        assertEquals("Wrong start time", expectedStartTimeMs, startTimeNanos?.nanosToMillis())
+        assertEquals("Wrong end time", expectedEndTimeMs, endTimeNanos?.nanosToMillis())
         assertEquals(expectedParentId, parentSpanId)
         if (expectedTraceId != null) {
             assertEquals(expectedTraceId, traceId)


### PR DESCRIPTION
## Goal

Simplify the UI load trace by starting it on the first sign of the triggering lifecycle event. 

What we give up is including in a trace the time between when the previous activity was paused to when the new activity starts to be created. But this allows us to not worry about the state of the app prior to the start of the activity loading, which removes a lot of complexity when dealing with edge cases.

I think this simplification is overall beneficial, and if we want to add this back, we can do it later.

## Testing

Add appropriate unit and integration tests.