### PR TITLE
Allow all activities to ge traced by default

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -27,10 +27,13 @@ public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/InternalApi : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class io/embrace/android/embracesdk/annotation/ObservedActivity : java/lang/annotation/Annotation {
+public abstract interface annotation class io/embrace/android/embracesdk/annotation/NotTracedActivity : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/StartupActivity : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class io/embrace/android/embracesdk/annotation/TracedActivity : java/lang/annotation/Annotation {
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/BreadcrumbApi {

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/NotTracedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/NotTracedActivity.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.annotation
+
+/**
+ * The loading of Activities annotated with this class will not generate traces if the feature is enabled, irrespective of
+ * the configured defaults.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class NotTracedActivity

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/ObservedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/ObservedActivity.kt
@@ -1,9 +1,0 @@
-package io.embrace.android.embracesdk.annotation
-
-import java.lang.annotation.Inherited
-
-@MustBeDocumented
-@Target(AnnotationTarget.CLASS)
-@Inherited
-@Retention(AnnotationRetention.RUNTIME)
-public annotation class ObservedActivity

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/TracedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/TracedActivity.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.annotation
+
+/**
+ * The loading of Activities annotated with this class will generate traces if the feature is enabled, irrespective of
+ * the configured defaults.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class TracedActivity

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
@@ -71,6 +71,11 @@ interface AutoDataCaptureBehavior : ConfigBehavior<EnabledFeatureConfig, RemoteC
     fun isUiLoadPerfCaptureEnabled(): Boolean
 
     /**
+     * Whether the SDK is configured to capture traces for the performance of the opening of all Activities by default.
+     */
+    fun isUiLoadPerfAutoCaptureEnabled(): Boolean
+
+    /**
      * Gates whether the SDK should use OkHttp or fallback to UrlConnection.
      */
     fun shouldUseOkHttp(): Boolean

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -44,6 +44,7 @@ class AutoDataCaptureBehaviorImpl(
     override fun isNativeCrashCaptureEnabled(): Boolean = local.isNativeCrashCaptureEnabled()
     override fun isDiskUsageCaptureEnabled(): Boolean = local.isDiskUsageCaptureEnabled()
     override fun isUiLoadPerfCaptureEnabled(): Boolean = local.isUiLoadPerfCaptureEnabled()
+    override fun isUiLoadPerfAutoCaptureEnabled(): Boolean = local.isUiLoadPerfAutoCaptureEnabled()
 
     private val v2StorageImpl by lazy {
         thresholdCheck.isBehaviorEnabled(remote?.killSwitchConfig?.v2StoragePct) ?: V2_STORAGE_ENABLED_DEFAULT

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -34,6 +34,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertTrue(isDiskUsageCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
             assertFalse(isUiLoadPerfCaptureEnabled())
+            assertFalse(isUiLoadPerfAutoCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
             assertTrue(isV2StorageEnabled())
         }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -83,6 +83,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         if (configService.autoDataCaptureBehavior.isUiLoadPerfCaptureEnabled()) {
             createActivityLoadEventEmitter(
                 uiLoadEventListener = uiLoadTraceEmitter,
+                autoTraceEnabled = configService.autoDataCaptureBehavior.isUiLoadPerfAutoCaptureEnabled(),
                 clock = openTelemetryModule.openTelemetryClock,
                 versionChecker = versionChecker
             )

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -152,4 +152,11 @@ interface EnabledFeatureConfig {
      * sdk_config.automatic_data_capture.ui_load_perf_info
      */
     fun isUiLoadPerfCaptureEnabled(): Boolean = false
+
+    /**
+     * Gates whether the SDK will default to automatically capture traces for the performance of the opening of all Activities.
+     *
+     * sdk_config.automatic_data_capture.ui_load_perf_info
+     */
+    fun isUiLoadPerfAutoCaptureEnabled(): Boolean = false
 }

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -1,4 +1,4 @@
--keepattributes LineNumberTable, SourceFile
+-keepattributes LineNumberTable, SourceFile, RuntimeVisibleAnnotations
 
 ## Keep public API including enums
 -keep class io.embrace.android.embracesdk.Embrace { *; }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotTracedActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotTracedActivity.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import io.embrace.android.embracesdk.annotation.NotTracedActivity
+
+@NotTracedActivity
+class FakeNotTracedActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeObservedActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeObservedActivity.kt
@@ -1,7 +1,0 @@
-package io.embrace.android.embracesdk.fakes
-
-import android.app.Activity
-import io.embrace.android.embracesdk.annotation.ObservedActivity
-
-@ObservedActivity
-class FakeObservedActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracedActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracedActivity.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import io.embrace.android.embracesdk.annotation.TracedActivity
+
+@TracedActivity
+class FakeTracedActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -16,6 +16,7 @@ class FakeAutoDataCaptureBehavior(
     private val ndkEnabled: Boolean = false,
     private val diskUsageReportingEnabled: Boolean = true,
     private val uiLoadPerfCaptureEnabled: Boolean = false,
+    private val uiLoadPerfAutoCaptureEnabled: Boolean = false,
     private val v2StorageEnabled: Boolean = true,
     private val useOkhttp: Boolean = true,
 ) : AutoDataCaptureBehavior {
@@ -36,6 +37,7 @@ class FakeAutoDataCaptureBehavior(
     override fun isNativeCrashCaptureEnabled(): Boolean = ndkEnabled
     override fun isDiskUsageCaptureEnabled(): Boolean = diskUsageReportingEnabled
     override fun isUiLoadPerfCaptureEnabled(): Boolean = uiLoadPerfCaptureEnabled
+    override fun isUiLoadPerfAutoCaptureEnabled(): Boolean = uiLoadPerfAutoCaptureEnabled
     override fun isV2StorageEnabled(): Boolean = v2StorageEnabled
     override fun shouldUseOkHttp(): Boolean = useOkhttp
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -26,7 +26,8 @@ class FakeEnabledFeatureConfig(
     private val requestContentLengthCapture: Boolean = base.isRequestContentLengthCaptureEnabled(),
     private val httpUrlConnectionCapture: Boolean = base.isHttpUrlConnectionCaptureEnabled(),
     private val networkSpanForwarding: Boolean = base.isNetworkSpanForwardingEnabled(),
-    private val uiLoadPerfCapture: Boolean = base.isUiLoadPerfCaptureEnabled()
+    private val uiLoadPerfCapture: Boolean = base.isUiLoadPerfCaptureEnabled(),
+    private val uiLoadPerfAutoCapture: Boolean = base.isUiLoadPerfAutoCaptureEnabled(),
 ) : EnabledFeatureConfig {
 
     override fun isUnityAnrCaptureEnabled(): Boolean = unityAnrCapture
@@ -52,4 +53,5 @@ class FakeEnabledFeatureConfig(
     override fun isHttpUrlConnectionCaptureEnabled(): Boolean = httpUrlConnectionCapture
     override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwarding
     override fun isUiLoadPerfCaptureEnabled(): Boolean = uiLoadPerfCapture
+    override fun isUiLoadPerfAutoCaptureEnabled(): Boolean = uiLoadPerfAutoCapture
 }


### PR DESCRIPTION
## Goal

Add in annotations that allow a local config to specify that all activities loads are traced, with an opt-out annotation for those that shouldn't be.

Note: a change to the swazzler is needed to properly wire this up, but the SDK changes are all contained and tested in this PR.