### PR TITLE
API and integration tests for manually ending UI load traces

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -24,19 +24,19 @@ public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 	public static fun values ()[Lio/embrace/android/embracesdk/Severity;
 }
 
-public abstract interface annotation class io/embrace/android/embracesdk/annotation/CustomTracedActivity : java/lang/annotation/Annotation {
+public abstract interface annotation class io/embrace/android/embracesdk/annotation/CustomLoadTracedActivity : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/InternalApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class io/embrace/android/embracesdk/annotation/LoadTracedActivity : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/NotTracedActivity : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/StartupActivity : java/lang/annotation/Annotation {
-}
-
-public abstract interface annotation class io/embrace/android/embracesdk/annotation/TracedActivity : java/lang/annotation/Annotation {
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/BreadcrumbApi {

--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -24,6 +24,9 @@ public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 	public static fun values ()[Lio/embrace/android/embracesdk/Severity;
 }
 
+public abstract interface annotation class io/embrace/android/embracesdk/annotation/CustomTracedActivity : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/InternalApi : java/lang/annotation/Annotation {
 }
 
@@ -46,6 +49,10 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Embra
 	public abstract fun start (Landroid/content/Context;)V
 	public abstract fun start (Landroid/content/Context;Lio/embrace/android/embracesdk/AppFramework;)V
 	public abstract fun startView (Ljava/lang/String;)Z
+}
+
+public abstract interface class io/embrace/android/embracesdk/internal/api/InstrumentationApi {
+	public abstract fun activityLoaded (Landroid/app/Activity;)V
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/InternalWebViewApi {
@@ -82,7 +89,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/OTelA
 	public abstract fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
 }
 
-public abstract interface class io/embrace/android/embracesdk/internal/api/SdkApi : io/embrace/android/embracesdk/internal/api/BreadcrumbApi, io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi, io/embrace/android/embracesdk/internal/api/InternalWebViewApi, io/embrace/android/embracesdk/internal/api/LogsApi, io/embrace/android/embracesdk/internal/api/NetworkRequestApi, io/embrace/android/embracesdk/internal/api/OTelApi, io/embrace/android/embracesdk/internal/api/SdkStateApi, io/embrace/android/embracesdk/internal/api/SessionApi, io/embrace/android/embracesdk/internal/api/UserApi, io/embrace/android/embracesdk/spans/TracingApi {
+public abstract interface class io/embrace/android/embracesdk/internal/api/SdkApi : io/embrace/android/embracesdk/internal/api/BreadcrumbApi, io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi, io/embrace/android/embracesdk/internal/api/InstrumentationApi, io/embrace/android/embracesdk/internal/api/InternalWebViewApi, io/embrace/android/embracesdk/internal/api/LogsApi, io/embrace/android/embracesdk/internal/api/NetworkRequestApi, io/embrace/android/embracesdk/internal/api/OTelApi, io/embrace/android/embracesdk/internal/api/SdkStateApi, io/embrace/android/embracesdk/internal/api/SessionApi, io/embrace/android/embracesdk/internal/api/UserApi, io/embrace/android/embracesdk/spans/TracingApi {
 }
 
 public final class io/embrace/android/embracesdk/internal/api/SdkApi$DefaultImpls {

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/CustomLoadTracedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/CustomLoadTracedActivity.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.annotation
+
+/**
+ * The loading of Activities annotated with this will generate UI Load traces when the SDK is manually notified
+ * that their loading has finished unless the feature is disabled.
+ *
+ * This works similarly to [LoadTracedActivity] except the trace will only be recorded if the appropriate API method
+ * is called to signal the end of the load.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class CustomLoadTracedActivity

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/CustomTracedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/CustomTracedActivity.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.annotation
+
+/**
+ * The loading of Activities annotated with this class will generate traces if the feature is enabled, irrespective of
+ * the configured defaults.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class CustomTracedActivity

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/CustomTracedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/CustomTracedActivity.kt
@@ -1,9 +1,0 @@
-package io.embrace.android.embracesdk.annotation
-
-/**
- * The loading of Activities annotated with this class will generate traces if the feature is enabled, irrespective of
- * the configured defaults.
- */
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-public annotation class CustomTracedActivity

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/LoadTracedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/LoadTracedActivity.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.annotation
+
+/**
+ * The loading of Activities annotated with this will generate UI Load traces unless the feature is disabled.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class LoadTracedActivity

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/TracedActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/TracedActivity.kt
@@ -1,9 +1,0 @@
-package io.embrace.android.embracesdk.annotation
-
-/**
- * The loading of Activities annotated with this class will generate traces if the feature is enabled, irrespective of
- * the configured defaults.
- */
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-public annotation class TracedActivity

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.internal.api
+
+import android.app.Activity
+import io.embrace.android.embracesdk.annotation.InternalApi
+
+/**
+ * API to control and customize Embrace instrumentation
+ */
+@InternalApi
+public interface InstrumentationApi {
+
+    /**
+     * Notify the Embrace UI Load instrumentation that the given [Activity] instance has fully loaded, so its associated
+     * trace can be stopped
+     */
+    public fun activityLoaded(activity: Activity)
+}

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/SdkApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/SdkApi.kt
@@ -17,4 +17,5 @@ public interface SdkApi :
     SdkStateApi,
     OTelApi,
     BreadcrumbApi,
-    InternalWebViewApi
+    InternalWebViewApi,
+    InstrumentationApi

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
@@ -68,12 +68,12 @@ interface AutoDataCaptureBehavior : ConfigBehavior<EnabledFeatureConfig, RemoteC
     /**
      * Whether the SDK is configured to capture traces for the performance of the opening of Activities.
      */
-    fun isUiLoadPerfCaptureEnabled(): Boolean
+    fun isUiLoadTracingEnabled(): Boolean
 
     /**
      * Whether the SDK is configured to capture traces for the performance of the opening of all Activities by default.
      */
-    fun isUiLoadPerfAutoCaptureEnabled(): Boolean
+    fun isUiLoadTracingTraceAll(): Boolean
 
     /**
      * Gates whether the SDK should use OkHttp or fallback to UrlConnection.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -43,8 +43,8 @@ class AutoDataCaptureBehaviorImpl(
 
     override fun isNativeCrashCaptureEnabled(): Boolean = local.isNativeCrashCaptureEnabled()
     override fun isDiskUsageCaptureEnabled(): Boolean = local.isDiskUsageCaptureEnabled()
-    override fun isUiLoadPerfCaptureEnabled(): Boolean = local.isUiLoadPerfCaptureEnabled()
-    override fun isUiLoadPerfAutoCaptureEnabled(): Boolean = local.isUiLoadPerfAutoCaptureEnabled()
+    override fun isUiLoadTracingEnabled(): Boolean = local.isUiLoadPerfCaptureEnabled()
+    override fun isUiLoadTracingTraceAll(): Boolean = local.isUiLoadPerfAutoCaptureEnabled()
 
     private val v2StorageImpl by lazy {
         thresholdCheck.isBehaviorEnabled(remote?.killSwitchConfig?.v2StoragePct) ?: V2_STORAGE_ENABLED_DEFAULT

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -43,8 +43,8 @@ class AutoDataCaptureBehaviorImpl(
 
     override fun isNativeCrashCaptureEnabled(): Boolean = local.isNativeCrashCaptureEnabled()
     override fun isDiskUsageCaptureEnabled(): Boolean = local.isDiskUsageCaptureEnabled()
-    override fun isUiLoadTracingEnabled(): Boolean = local.isUiLoadPerfCaptureEnabled()
-    override fun isUiLoadTracingTraceAll(): Boolean = local.isUiLoadPerfAutoCaptureEnabled()
+    override fun isUiLoadTracingEnabled(): Boolean = local.isUiLoadTracingEnabled()
+    override fun isUiLoadTracingTraceAll(): Boolean = local.isUiLoadTracingTraceAll()
 
     private val v2StorageImpl by lazy {
         thresholdCheck.isBehaviorEnabled(remote?.killSwitchConfig?.v2StoragePct) ?: V2_STORAGE_ENABLED_DEFAULT

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -34,7 +34,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertTrue(isDiskUsageCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
             assertTrue(isUiLoadTracingEnabled())
-            assertFalse(isUiLoadTracingTraceAll())
+            assertTrue(isUiLoadTracingTraceAll())
             assertTrue(isThermalStatusCaptureEnabled())
             assertTrue(isV2StorageEnabled())
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -33,7 +33,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertFalse(isNativeCrashCaptureEnabled())
             assertTrue(isDiskUsageCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
-            assertFalse(isUiLoadPerfCaptureEnabled())
+            assertTrue(isUiLoadPerfCaptureEnabled())
             assertFalse(isUiLoadPerfAutoCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
             assertTrue(isV2StorageEnabled())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -33,8 +33,8 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertFalse(isNativeCrashCaptureEnabled())
             assertTrue(isDiskUsageCaptureEnabled())
             assertTrue(isThermalStatusCaptureEnabled())
-            assertTrue(isUiLoadPerfCaptureEnabled())
-            assertFalse(isUiLoadPerfAutoCaptureEnabled())
+            assertTrue(isUiLoadTracingEnabled())
+            assertFalse(isUiLoadTracingTraceAll())
             assertTrue(isThermalStatusCaptureEnabled())
             assertTrue(isV2StorageEnabled())
         }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -4,9 +4,9 @@ import android.app.Activity
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import androidx.annotation.RequiresApi
-import io.embrace.android.embracesdk.annotation.CustomTracedActivity
+import io.embrace.android.embracesdk.annotation.CustomLoadTracedActivity
+import io.embrace.android.embracesdk.annotation.LoadTracedActivity
 import io.embrace.android.embracesdk.annotation.NotTracedActivity
-import io.embrace.android.embracesdk.annotation.TracedActivity
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
@@ -183,10 +183,10 @@ private class LifecycleEventEmitter(
     private fun Activity.traceLoad(): Boolean {
         return (autoTraceEnabled && !javaClass.isAnnotationPresent(NotTracedActivity::class.java)) ||
             isManualEnd() ||
-            javaClass.isAnnotationPresent(TracedActivity::class.java)
+            javaClass.isAnnotationPresent(LoadTracedActivity::class.java)
     }
 
-    private fun Activity.isManualEnd(): Boolean = javaClass.isAnnotationPresent(CustomTracedActivity::class.java)
+    private fun Activity.isManualEnd(): Boolean = javaClass.isAnnotationPresent(CustomLoadTracedActivity::class.java)
 
     private fun nowMs(): Long = clock.now().nanosToMillis()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import androidx.annotation.RequiresApi
+import io.embrace.android.embracesdk.annotation.CustomTracedActivity
 import io.embrace.android.embracesdk.annotation.NotTracedActivity
 import io.embrace.android.embracesdk.annotation.TracedActivity
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -34,6 +35,11 @@ fun createActivityLoadEventEmitter(
         LegacyActivityLoadEventEmitter(lifecycleEventEmitter)
     }
 }
+
+/**
+ * Return an ID to identify the trace for the given [Activity] instance
+ */
+fun traceInstanceId(activity: Activity): Int = activity.hashCode()
 
 /**
  * Implementation that works with Android 10+ APIs
@@ -108,18 +114,18 @@ private class LifecycleEventEmitter(
 ) {
 
     fun create(activity: Activity) {
-        if (activity.observe()) {
+        if (activity.traceLoad()) {
             uiLoadEventListener.create(
                 instanceId = traceInstanceId(activity),
                 activityName = activity.localClassName,
                 timestampMs = nowMs(),
-                manualEnd = false,
+                manualEnd = activity.isManualEnd(),
             )
         }
     }
 
     fun createEnd(activity: Activity) {
-        if (activity.observe()) {
+        if (activity.traceLoad()) {
             uiLoadEventListener.createEnd(
                 instanceId = traceInstanceId(activity),
                 timestampMs = nowMs()
@@ -128,18 +134,18 @@ private class LifecycleEventEmitter(
     }
 
     fun start(activity: Activity) {
-        if (activity.observe()) {
+        if (activity.traceLoad()) {
             uiLoadEventListener.start(
                 instanceId = traceInstanceId(activity),
                 activityName = activity.localClassName,
                 timestampMs = nowMs(),
-                manualEnd = false,
+                manualEnd = activity.isManualEnd(),
             )
         }
     }
 
     fun startEnd(activity: Activity) {
-        if (activity.observe()) {
+        if (activity.traceLoad()) {
             uiLoadEventListener.startEnd(
                 instanceId = traceInstanceId(activity),
                 timestampMs = nowMs()
@@ -148,7 +154,7 @@ private class LifecycleEventEmitter(
     }
 
     fun resume(activity: Activity) {
-        if (activity.observe()) {
+        if (activity.traceLoad()) {
             uiLoadEventListener.resume(
                 instanceId = traceInstanceId(activity),
                 timestampMs = nowMs()
@@ -157,7 +163,7 @@ private class LifecycleEventEmitter(
     }
 
     fun resumeEnd(activity: Activity) {
-        if (activity.observe()) {
+        if (activity.traceLoad()) {
             uiLoadEventListener.resumeEnd(
                 instanceId = traceInstanceId(activity),
                 timestampMs = nowMs()
@@ -166,7 +172,7 @@ private class LifecycleEventEmitter(
     }
 
     fun pause(activity: Activity) {
-        if (activity.observe()) {
+        if (activity.traceLoad()) {
             uiLoadEventListener.discard(
                 instanceId = traceInstanceId(activity),
                 timestampMs = nowMs()
@@ -174,12 +180,13 @@ private class LifecycleEventEmitter(
         }
     }
 
-    private fun Activity.observe(): Boolean {
-        return javaClass.isAnnotationPresent(TracedActivity::class.java) ||
-            autoTraceEnabled && !javaClass.isAnnotationPresent(NotTracedActivity::class.java)
+    private fun Activity.traceLoad(): Boolean {
+        return (autoTraceEnabled && !javaClass.isAnnotationPresent(NotTracedActivity::class.java)) ||
+            isManualEnd() ||
+            javaClass.isAnnotationPresent(TracedActivity::class.java)
     }
 
-    private fun traceInstanceId(activity: Activity): Int = activity.hashCode()
+    private fun Activity.isManualEnd(): Boolean = javaClass.isAnnotationPresent(CustomTracedActivity::class.java)
 
     private fun nowMs(): Long = clock.now().nanosToMillis()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModule.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModule.kt
@@ -37,11 +37,23 @@ interface DataCaptureServiceModule {
      */
     val startupService: StartupService
 
+    /**
+     * Collects data happening during app startup so that startup traces can be created from it
+     */
     val appStartupDataCollector: AppStartupDataCollector
 
+    /**
+     * Listens for events in the app to pass along to [appStartupDataCollector]
+     */
     val startupTracker: StartupTracker
 
-    val uiLoadTraceEmitter: UiLoadEventListener
+    /**
+     * Creates UI Load traces based data it collects
+     */
+    val uiLoadTraceEmitter: UiLoadEventListener?
 
+    /**
+     * Listens for lifecycle events during the loading of Activities proxies them to [uiLoadTraceEmitter]
+     */
     val activityLoadEventEmitter: ActivityLifecycleListener?
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -72,18 +72,23 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         )
     }
 
-    override val uiLoadTraceEmitter: UiLoadEventListener by singleton {
-        UiLoadTraceEmitter(
-            spanService = openTelemetryModule.spanService,
-            versionChecker = versionChecker,
-        )
+    override val uiLoadTraceEmitter: UiLoadEventListener? by singleton {
+        if (configService.autoDataCaptureBehavior.isUiLoadTracingEnabled()) {
+            UiLoadTraceEmitter(
+                spanService = openTelemetryModule.spanService,
+                versionChecker = versionChecker,
+            )
+        } else {
+            null
+        }
     }
 
     override val activityLoadEventEmitter: ActivityLifecycleListener? by singleton {
-        if (configService.autoDataCaptureBehavior.isUiLoadPerfCaptureEnabled()) {
+        val traceEmitter = uiLoadTraceEmitter
+        if (traceEmitter != null) {
             createActivityLoadEventEmitter(
-                uiLoadEventListener = uiLoadTraceEmitter,
-                autoTraceEnabled = configService.autoDataCaptureBehavior.isUiLoadPerfAutoCaptureEnabled(),
+                uiLoadEventListener = traceEmitter,
+                autoTraceEnabled = configService.autoDataCaptureBehavior.isUiLoadTracingTraceAll(),
                 clock = openTelemetryModule.openTelemetryClock,
                 versionChecker = versionChecker
             )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
+import io.embrace.android.embracesdk.fakes.FakeCustomTracedActivity
 import io.embrace.android.embracesdk.fakes.FakeNotTracedActivity
 import io.embrace.android.embracesdk.fakes.FakeTracedActivity
 import io.embrace.android.embracesdk.fakes.FakeUiLoadEventListener
@@ -84,6 +85,14 @@ internal class UiLoadExtTest {
         assertTrue(uiLoadEventListener.events.isEmpty())
     }
 
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `activities with manual ended trace will emit ui load events in U`() {
+        createEventEmitter(autoTraceEnabled = false, activityClass = FakeCustomTracedActivity::class)
+        stepThroughActivityLifecycle()
+        uiLoadEventListener.events.assertEventData(expectedColdOpenEvents)
+    }
+
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `check cold ui load event stages in L`() {
@@ -122,6 +131,14 @@ internal class UiLoadExtTest {
         createEventEmitter(autoTraceEnabled = true, activityClass = FakeNotTracedActivity::class)
         stepThroughActivityLifecycle()
         assertTrue(uiLoadEventListener.events.isEmpty())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `activities with manual ended trace will emit ui load events in L`() {
+        createEventEmitter(autoTraceEnabled = false, activityClass = FakeCustomTracedActivity::class)
+        stepThroughActivityLifecycle()
+        uiLoadEventListener.events.assertEventData(legacyColdOpenEvents)
     }
 
     private fun <T : Activity> createEventEmitter(autoTraceEnabled: Boolean, activityClass: KClass<T>) {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
@@ -31,16 +31,34 @@ internal class DataCaptureServiceModuleImplTest {
         assertNotNull(module.appStartupDataCollector)
         assertNotNull(module.pushNotificationService)
         assertNotNull(module.startupService)
-        assertNull(module.activityLoadEventEmitter)
+        assertNotNull(module.activityLoadEventEmitter)
+        assertNotNull(module.uiLoadTraceEmitter)
     }
 
     @Test
-    fun `enable ui load performance capture`() {
+    fun `disable ui load performance capture`() {
         val module = DataCaptureServiceModuleImpl(
             initModule,
             openTelemetryModule,
             FakeConfigService(
-                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadPerfCaptureEnabled = true)
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false)
+            ),
+            FakeWorkerThreadModule(),
+            FakeVersionChecker(false),
+            FakeFeatureModule()
+        )
+
+        assertNull(module.uiLoadTraceEmitter)
+        assertNull(module.activityLoadEventEmitter)
+    }
+
+    @Test
+    fun `enable only selected ui load performance capture`() {
+        val module = DataCaptureServiceModuleImpl(
+            initModule,
+            openTelemetryModule,
+            FakeConfigService(
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false)
             ),
             FakeWorkerThreadModule(),
             FakeVersionChecker(false),

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -149,14 +149,14 @@ interface EnabledFeatureConfig {
     /**
      * Gates whether the SDK will capture traces for the performance of the opening of Activities.
      *
-     * sdk_config.automatic_data_capture.ui_load_perf_info
+     * Will be true if sdk_config.automatic_data_capture.ui_load_perf_info is not "DISABLE"
      */
-    fun isUiLoadPerfCaptureEnabled(): Boolean = false
+    fun isUiLoadPerfCaptureEnabled(): Boolean = true
 
     /**
      * Gates whether the SDK will default to automatically capture traces for the performance of the opening of all Activities.
      *
-     * sdk_config.automatic_data_capture.ui_load_perf_info
+     * Will be true sdk_config.automatic_data_capture.ui_load_perf_info equals "ENABLE_ALL"
      */
     fun isUiLoadPerfAutoCaptureEnabled(): Boolean = false
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -149,14 +149,16 @@ interface EnabledFeatureConfig {
     /**
      * Gates whether the SDK will capture traces for the performance of the opening of Activities.
      *
-     * Will be true if sdk_config.automatic_data_capture.ui_load_perf_info is not "DISABLE"
+     * Will be true if sdk_config.automatic_data_capture.ui_load_tracing_disabled is not true
      */
-    fun isUiLoadPerfCaptureEnabled(): Boolean = true
+    fun isUiLoadTracingEnabled(): Boolean = true
 
     /**
      * Gates whether the SDK will default to automatically capture traces for the performance of the opening of all Activities.
      *
-     * Will be true sdk_config.automatic_data_capture.ui_load_perf_info equals "ENABLE_ALL"
+     * Will be true NEITHER of the following is true:
+     * - sdk_config.automatic_data_capture.ui_load_tracing_disabled
+     * - sdk_config.automatic_data_capture.ui_load_tracing_selected_only
      */
-    fun isUiLoadPerfAutoCaptureEnabled(): Boolean = false
+    fun isUiLoadTracingTraceAll(): Boolean = true
 }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -1,5 +1,6 @@
 public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/embracesdk/internal/api/SdkApi {
 	public static final field Companion Lio/embrace/android/embracesdk/Embrace$Companion;
+	public fun activityLoaded (Landroid/app/Activity;)V
 	public fun addBreadcrumb (Ljava/lang/String;)V
 	public fun addLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
 	public fun addSessionProperty (Ljava/lang/String;Ljava/lang/String;Z)Z

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -65,7 +65,9 @@ internal class EmbraceActionInterface(
         startInBackground: Boolean = false,
         createFirstActivity: Boolean = true,
         invokeManualEnd: Boolean = false,
-        activitiesAndActions: List<Pair<ActivityController<*>, () -> Unit>> = listOf(),
+        activitiesAndActions: List<Pair<ActivityController<*>, () -> Unit>> = listOf(
+            Robolectric.buildActivity(Activity::class.java) to {},
+        ),
         lifecycleEventGap: Long = 100L,
         postActionDwell: Long = 20000L,
         activityGap: Long = 50L,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -64,6 +64,7 @@ internal class EmbraceActionInterface(
         addStartupActivity: Boolean = true,
         startInBackground: Boolean = false,
         createFirstActivity: Boolean = true,
+        invokeManualEnd: Boolean = false,
         activitiesAndActions: List<Pair<ActivityController<*>, () -> Unit>> = listOf(),
         lifecycleEventGap: Long = 100L,
         postActionDwell: Long = 20000L,
@@ -99,6 +100,10 @@ internal class EmbraceActionInterface(
             }
             activityController.resume()
             setup.overriddenClock.tick(lifecycleEventGap)
+            if (invokeManualEnd) {
+                setup.overriddenClock.tick(lifecycleEventGap)
+                embrace.activityLoaded(activityController.get())
+            }
             lastActivity?.stop()
             setup.overriddenClock.tick()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -3,6 +3,7 @@
 package io.embrace.android.embracesdk
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.webkit.ConsoleMessage
 import io.embrace.android.embracesdk.internal.Systrace
@@ -421,5 +422,9 @@ public class Embrace private constructor(
 
     override fun disable() {
         impl.disable()
+    }
+
+    override fun activityLoaded(activity: Activity) {
+        impl.activityLoaded(activity)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.Systrace.startSynchronous
 import io.embrace.android.embracesdk.internal.UnityInternalInterface
 import io.embrace.android.embracesdk.internal.anr.ndk.isUnityMainThread
 import io.embrace.android.embracesdk.internal.api.BreadcrumbApi
+import io.embrace.android.embracesdk.internal.api.InstrumentationApi
 import io.embrace.android.embracesdk.internal.api.InternalWebViewApi
 import io.embrace.android.embracesdk.internal.api.LogsApi
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi
@@ -25,6 +26,7 @@ import io.embrace.android.embracesdk.internal.api.SessionApi
 import io.embrace.android.embracesdk.internal.api.UserApi
 import io.embrace.android.embracesdk.internal.api.ViewTrackingApi
 import io.embrace.android.embracesdk.internal.api.delegate.BreadcrumbApiDelegate
+import io.embrace.android.embracesdk.internal.api.delegate.InstrumentationApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.InternalWebViewApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.LogsApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.NetworkRequestApiDelegate
@@ -76,6 +78,8 @@ internal class EmbraceImpl @JvmOverloads constructor(
     private val breadcrumbApiDelegate: BreadcrumbApiDelegate = BreadcrumbApiDelegate(bootstrapper, sdkCallChecker),
     private val webviewApiDelegate: InternalWebViewApiDelegate =
         InternalWebViewApiDelegate(bootstrapper, sdkCallChecker),
+    private val instrumentationApiDelegate: InstrumentationApiDelegate =
+        InstrumentationApiDelegate(bootstrapper, sdkCallChecker)
 ) : SdkApi,
     LogsApi by logsApiDelegate,
     NetworkRequestApi by networkRequestApiDelegate,
@@ -87,6 +91,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
     ViewTrackingApi by viewTrackingApiDelegate,
     BreadcrumbApi by breadcrumbApiDelegate,
     InternalWebViewApi by webviewApiDelegate,
+    InstrumentationApi by instrumentationApiDelegate,
     InternalInterfaceApi {
 
     init {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import android.app.Activity
+import io.embrace.android.embracesdk.internal.api.InstrumentationApi
+import io.embrace.android.embracesdk.internal.capture.activity.traceInstanceId
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.internal.injection.embraceImplInject
+
+internal class InstrumentationApiDelegate(
+    bootstrapper: ModuleInitBootstrapper,
+    private val sdkCallChecker: SdkCallChecker,
+) : InstrumentationApi {
+
+    private val clock: Clock = bootstrapper.initModule.clock
+    private val uiLoadTraceEmitter by embraceImplInject(sdkCallChecker) {
+        bootstrapper.dataCaptureServiceModule.uiLoadTraceEmitter
+    }
+
+    override fun activityLoaded(activity: Activity) {
+        if (sdkCallChecker.check("activity_fully_loaded")) {
+            uiLoadTraceEmitter?.complete(traceInstanceId(activity), clock.now())
+        }
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCustomTracedActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCustomTracedActivity.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import io.embrace.android.embracesdk.annotation.CustomTracedActivity
+
+@CustomTracedActivity
+class FakeCustomTracedActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCustomTracedActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCustomTracedActivity.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.app.Activity
-import io.embrace.android.embracesdk.annotation.CustomTracedActivity
+import io.embrace.android.embracesdk.annotation.CustomLoadTracedActivity
 
-@CustomTracedActivity
+@CustomLoadTracedActivity
 class FakeCustomTracedActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracedActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracedActivity.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.app.Activity
-import io.embrace.android.embracesdk.annotation.TracedActivity
+import io.embrace.android.embracesdk.annotation.LoadTracedActivity
 
-@TracedActivity
+@LoadTracedActivity
 class FakeTracedActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -15,8 +15,8 @@ class FakeAutoDataCaptureBehavior(
     private val sigHandlerDetectionEnabled: Boolean = true,
     private val ndkEnabled: Boolean = false,
     private val diskUsageReportingEnabled: Boolean = true,
-    private val uiLoadPerfCaptureEnabled: Boolean = false,
-    private val uiLoadPerfAutoCaptureEnabled: Boolean = false,
+    private val uiLoadTracingEnabled: Boolean = true,
+    private val uiLoadTracingTraceAll: Boolean = true,
     private val v2StorageEnabled: Boolean = true,
     private val useOkhttp: Boolean = true,
 ) : AutoDataCaptureBehavior {
@@ -36,8 +36,8 @@ class FakeAutoDataCaptureBehavior(
     override fun is3rdPartySigHandlerDetectionEnabled(): Boolean = sigHandlerDetectionEnabled
     override fun isNativeCrashCaptureEnabled(): Boolean = ndkEnabled
     override fun isDiskUsageCaptureEnabled(): Boolean = diskUsageReportingEnabled
-    override fun isUiLoadPerfCaptureEnabled(): Boolean = uiLoadPerfCaptureEnabled
-    override fun isUiLoadPerfAutoCaptureEnabled(): Boolean = uiLoadPerfAutoCaptureEnabled
+    override fun isUiLoadTracingEnabled(): Boolean = uiLoadTracingEnabled
+    override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
     override fun isV2StorageEnabled(): Boolean = v2StorageEnabled
     override fun shouldUseOkHttp(): Boolean = useOkhttp
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -26,8 +26,8 @@ class FakeEnabledFeatureConfig(
     private val requestContentLengthCapture: Boolean = base.isRequestContentLengthCaptureEnabled(),
     private val httpUrlConnectionCapture: Boolean = base.isHttpUrlConnectionCaptureEnabled(),
     private val networkSpanForwarding: Boolean = base.isNetworkSpanForwardingEnabled(),
-    private val uiLoadPerfCapture: Boolean = base.isUiLoadPerfCaptureEnabled(),
-    private val uiLoadPerfAutoCapture: Boolean = base.isUiLoadPerfAutoCaptureEnabled(),
+    private val uiLoadTracingEnabled: Boolean = base.isUiLoadTracingEnabled(),
+    private val uiLoadTracingTraceAll: Boolean = base.isUiLoadTracingTraceAll(),
 ) : EnabledFeatureConfig {
 
     override fun isUnityAnrCaptureEnabled(): Boolean = unityAnrCapture
@@ -52,6 +52,6 @@ class FakeEnabledFeatureConfig(
     override fun isRequestContentLengthCaptureEnabled(): Boolean = requestContentLengthCapture
     override fun isHttpUrlConnectionCaptureEnabled(): Boolean = httpUrlConnectionCapture
     override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwarding
-    override fun isUiLoadPerfCaptureEnabled(): Boolean = uiLoadPerfCapture
-    override fun isUiLoadPerfAutoCaptureEnabled(): Boolean = uiLoadPerfAutoCapture
+    override fun isUiLoadTracingEnabled(): Boolean = uiLoadTracingEnabled
+    override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
 }


### PR DESCRIPTION
## Goal

Add in the ability to specify that a a UI Load trace should wait for a manual end as well as a public API to do that.
