### PR TITLE
Extract frame draw detection to its own component

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -2,18 +2,11 @@ package io.embrace.android.embracesdk.internal.capture.startup
 
 import android.app.Activity
 import android.app.Application
-import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.view.View
-import android.view.ViewTreeObserver
-import android.view.Window
 import io.embrace.android.embracesdk.annotation.StartupActivity
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.capture.activity.traceInstanceId
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
-import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.internal.ui.DrawEventEmitter
 
 /**
  * Component that captures various timestamps throughout the startup process and uses that information to log spans that approximates to
@@ -29,22 +22,16 @@ import io.embrace.android.embracesdk.internal.utils.VersionChecker
  *
  * For approximating the first frame being completely drawn:
  *
- * - Android 10 onwards, we use a [ViewTreeObserver.OnDrawListener] callback to detect that the first frame from the first activity load
- *   has been fully rendered and queued for display.
+ * - Android 10 onwards, [FirstDrawDetector] to detect that an activity's first frame was been rendered.
  *
  * - Older Android versions that are supported, we just use when the first Activity was resumed. We will iterate on this in the future.
- *
- * Note that this implementation has benefited from the work of Pierre-Yves Ricau and his blog post about Android application launch time
- * that can be found here: https://blog.p-y.wtf/tracking-android-app-launch-in-production. PY's code was adapted and tweaked for use here.
  */
 class StartupTracker(
     private val appStartupDataCollector: AppStartupDataCollector,
     private val activityLoadEventEmitter: ActivityLifecycleListener?,
-    private val logger: EmbLogger,
-    private val versionChecker: VersionChecker,
+    private val drawEventEmitter: DrawEventEmitter?,
 ) : Application.ActivityLifecycleCallbacks {
-    private var isFirstDraw = false
-    private var nullWindowCallbackErrorLogged = false
+
     private var startupActivityId: Int? = null
     private var startupDataCollectionComplete = false
 
@@ -56,39 +43,15 @@ class StartupTracker(
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (activity.useAsStartupActivity()) {
-            val activityName = activity.localClassName
-            val application = activity.application
             appStartupDataCollector.startupActivityInitStart()
-            if (versionChecker.isAtLeast(Build.VERSION_CODES.Q)) {
-                if (!isFirstDraw) {
-                    val window = activity.window
-                    if (window.callback != null) {
-                        window.onDecorViewReady {
-                            val decorView = window.decorView
-                            decorView.onNextDraw {
-                                if (!isFirstDraw) {
-                                    isFirstDraw = true
-                                    val callback = {
-                                        appStartupDataCollector.firstFrameRendered(
-                                            activityName = activityName,
-                                            collectionCompleteCallback = { startupComplete(application) }
-                                        )
-                                    }
-                                    decorView.viewTreeObserver.registerFrameCommitCallback(callback)
-                                }
-                            }
-                        }
-                    } else if (!nullWindowCallbackErrorLogged) {
-                        logger.trackInternalError(
-                            type = InternalErrorType.APP_LAUNCH_TRACE_FAIL,
-                            throwable = IllegalStateException(
-                                "Fail to attach frame rendering callback because the callback on Window was null"
-                            )
-                        )
-                        nullWindowCallbackErrorLogged = true
-                    }
-                }
+            val application = activity.application
+            val callback = {
+                appStartupDataCollector.firstFrameRendered(
+                    activityName = activity.localClassName,
+                    collectionCompleteCallback = { startupComplete(application) }
+                )
             }
+            drawEventEmitter?.registerFirstDrawCallback(activity, callback)
         }
     }
 
@@ -125,8 +88,8 @@ class StartupTracker(
     private fun startupComplete(application: Application) {
         if (!startupDataCollectionComplete) {
             application.unregisterActivityLifecycleCallbacks(this)
-            activityLoadEventEmitter?.apply {
-                application.registerActivityLifecycleCallbacks(this)
+            if (activityLoadEventEmitter != null) {
+                application.registerActivityLifecycleCallbacks(activityLoadEventEmitter)
             }
             startupDataCollectionComplete = true
         }
@@ -138,7 +101,7 @@ class StartupTracker(
      */
     private fun Activity.isStartupActivity(): Boolean {
         return if (observeForStartup()) {
-            startupActivityId == hashCode()
+            startupActivityId == traceInstanceId(this)
         } else {
             false
         }
@@ -154,78 +117,13 @@ class StartupTracker(
         }
 
         if (observeForStartup()) {
-            startupActivityId = hashCode()
+            startupActivityId = traceInstanceId(this)
         }
 
         return isStartupActivity()
     }
 
     private companion object {
-        private class PyNextDrawListener(
-            val view: View,
-            val onDrawCallback: () -> Unit,
-        ) : ViewTreeObserver.OnDrawListener {
-            val handler = Handler(Looper.getMainLooper())
-            var invoked = false
-
-            override fun onDraw() {
-                if (!invoked) {
-                    invoked = true
-                    onDrawCallback()
-                    handler.post {
-                        if (view.viewTreeObserver.isAlive) {
-                            view.viewTreeObserver.removeOnDrawListener(this)
-                        }
-                    }
-                }
-            }
-        }
-
-        private class PyWindowDelegateCallback(
-            private val delegate: Window.Callback,
-        ) : Window.Callback by delegate {
-
-            val onContentChangedCallbacks = mutableListOf<() -> Boolean>()
-
-            override fun onContentChanged() {
-                onContentChangedCallbacks.removeAll { callback ->
-                    !callback()
-                }
-                delegate.onContentChanged()
-            }
-        }
-
         fun Activity.observeForStartup(): Boolean = !javaClass.isAnnotationPresent(StartupActivity::class.java)
-
-        fun View.onNextDraw(onDrawCallback: () -> Unit) {
-            viewTreeObserver.addOnDrawListener(
-                PyNextDrawListener(this, onDrawCallback)
-            )
-        }
-
-        fun Window.onDecorViewReady(onDecorViewReady: () -> Unit) {
-            if (callback != null) {
-                if (peekDecorView() == null) {
-                    onContentChanged {
-                        onDecorViewReady()
-                        return@onContentChanged false
-                    }
-                } else {
-                    onDecorViewReady()
-                }
-            }
-        }
-
-        private fun Window.onContentChanged(onDrawCallbackInvocation: () -> Boolean) {
-            val currentCallback = callback
-            val callback = if (currentCallback is PyWindowDelegateCallback) {
-                currentCallback
-            } else {
-                val newCallback = PyWindowDelegateCallback(currentCallback)
-                callback = newCallback
-                newCallback
-            }
-            callback.onContentChangedCallbacks += onDrawCallbackInvocation
-        }
     }
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import android.os.Build
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.capture.activity.UiLoadEventListener
 import io.embrace.android.embracesdk.internal.capture.activity.UiLoadTraceEmitter
@@ -15,6 +16,7 @@ import io.embrace.android.embracesdk.internal.capture.webview.EmbraceWebViewServ
 import io.embrace.android.embracesdk.internal.capture.webview.WebViewService
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
+import io.embrace.android.embracesdk.internal.ui.FirstDrawDetector
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.worker.Worker
@@ -67,8 +69,11 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         StartupTracker(
             appStartupDataCollector = appStartupDataCollector,
             activityLoadEventEmitter = activityLoadEventEmitter,
-            logger = initModule.logger,
-            versionChecker = versionChecker,
+            drawEventEmitter = if (versionChecker.isAtLeast(Build.VERSION_CODES.Q)) {
+                FirstDrawDetector(initModule.logger)
+            } else {
+                null
+            }
         )
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.ui
+
+import android.app.Activity
+
+/**
+ * Interface that allows callbacks to be registered and invoked when UI draw events happen
+ */
+interface DrawEventEmitter {
+    fun registerFirstDrawCallback(activity: Activity, completionCallback: () -> Unit)
+}

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/FirstDrawDetector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/FirstDrawDetector.kt
@@ -1,0 +1,117 @@
+package io.embrace.android.embracesdk.internal.ui
+
+import android.app.Activity
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.Window
+import androidx.annotation.RequiresApi
+import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+
+/**
+ * Component that uses the [ViewTreeObserver.OnDrawListener] callback to detect that the first frame of a registered
+ * [Activity] has been fully rendered and queued for display.
+ *
+ * This implementation has benefited from the work of Pierre-Yves Ricau and his blog post about Android application launch time
+ * that can be found here: https://blog.p-y.wtf/tracking-android-app-launch-in-production. PY's code was adapted and tweaked for use here.
+ */
+@RequiresApi(Build.VERSION_CODES.Q)
+internal class FirstDrawDetector(
+    private val logger: EmbLogger,
+) : DrawEventEmitter {
+    private var isFirstDraw: Boolean = false
+    private var nullWindowCallbackErrorLogged = false
+
+    override fun registerFirstDrawCallback(activity: Activity, completionCallback: () -> Unit) {
+        if (!isFirstDraw) {
+            val window = activity.window
+            if (window.callback != null) {
+                window.onDecorViewReady {
+                    val decorView = window.decorView
+                    decorView.onNextDraw {
+                        if (!isFirstDraw) {
+                            isFirstDraw = true
+                            decorView.viewTreeObserver.registerFrameCommitCallback(completionCallback)
+                        }
+                    }
+                }
+            } else if (!nullWindowCallbackErrorLogged) {
+                logger.trackInternalError(
+                    type = InternalErrorType.UI_CALLBACK_FAIL,
+                    throwable = IllegalStateException(
+                        "Fail to attach frame rendering callback because the callback on Window was null"
+                    )
+                )
+                nullWindowCallbackErrorLogged = true
+            }
+        }
+    }
+
+    private fun View.onNextDraw(onDrawCallback: () -> Unit) {
+        viewTreeObserver.addOnDrawListener(
+            PyNextDrawListener(this, onDrawCallback)
+        )
+    }
+
+    private fun Window.onDecorViewReady(onDecorViewReady: () -> Unit) {
+        if (callback != null) {
+            if (peekDecorView() == null) {
+                onContentChanged {
+                    onDecorViewReady()
+                    return@onContentChanged false
+                }
+            } else {
+                onDecorViewReady()
+            }
+        }
+    }
+
+    private fun Window.onContentChanged(onDrawCallbackInvocation: () -> Boolean) {
+        val currentCallback = callback
+        val callback = if (currentCallback is PyWindowDelegateCallback) {
+            currentCallback
+        } else {
+            val newCallback = PyWindowDelegateCallback(currentCallback)
+            callback = newCallback
+            newCallback
+        }
+        callback.onContentChangedCallbacks += onDrawCallbackInvocation
+    }
+
+    private class PyNextDrawListener(
+        val view: View,
+        val onDrawCallback: () -> Unit,
+    ) : ViewTreeObserver.OnDrawListener {
+        val handler = Handler(Looper.getMainLooper())
+        var invoked = false
+
+        override fun onDraw() {
+            if (!invoked) {
+                invoked = true
+                onDrawCallback()
+                handler.post {
+                    if (view.viewTreeObserver.isAlive) {
+                        view.viewTreeObserver.removeOnDrawListener(this)
+                    }
+                }
+            }
+        }
+    }
+
+    private class PyWindowDelegateCallback(
+        private val delegate: Window.Callback,
+    ) : Window.Callback by delegate {
+
+        val onContentChangedCallbacks = mutableListOf<() -> Boolean>()
+
+        override fun onContentChanged() {
+            onContentChangedCallbacks.removeAll { callback ->
+                !callback()
+            }
+            delegate.onContentChanged()
+        }
+    }
+}

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
@@ -5,15 +5,18 @@ import android.app.Application
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeActivity
+import io.embrace.android.embracesdk.fakes.FakeActivityLifecycleListener
 import io.embrace.android.embracesdk.fakes.FakeAppStartupDataCollector
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeDrawEventEmitter
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeNotStartupActivity
 import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
-import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,6 +31,8 @@ internal class StartupTrackerTest {
     private lateinit var clock: FakeClock
     private lateinit var dataCollector: FakeAppStartupDataCollector
     private lateinit var logger: EmbLogger
+    private lateinit var activityLifecycleListener: FakeActivityLifecycleListener
+    private lateinit var drawEventEmitter: FakeDrawEventEmitter
     private lateinit var startupTracker: StartupTracker
     private lateinit var defaultActivityController: ActivityController<Activity>
 
@@ -37,11 +42,12 @@ internal class StartupTrackerTest {
         clock = FakeClock()
         logger = FakeEmbLogger()
         dataCollector = FakeAppStartupDataCollector(clock = clock)
+        activityLifecycleListener = FakeActivityLifecycleListener()
+        drawEventEmitter = FakeDrawEventEmitter()
         startupTracker = StartupTracker(
             appStartupDataCollector = dataCollector,
-            activityLoadEventEmitter = object : ActivityLifecycleListener { },
-            logger = logger,
-            versionChecker = BuildVersionChecker
+            activityLoadEventEmitter = activityLifecycleListener,
+            drawEventEmitter = drawEventEmitter,
         )
         application.registerActivityLifecycleCallbacks(startupTracker)
         defaultActivityController = Robolectric.buildActivity(Activity::class.java)
@@ -52,7 +58,7 @@ internal class StartupTrackerTest {
     fun `cold start in U`() {
         with(launchActivity()) {
             assertEquals("android.app.Activity", dataCollector.startupActivityName)
-            verifyTiming(
+            verifyLifecycle(
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -66,7 +72,7 @@ internal class StartupTrackerTest {
     @Test
     fun `cold start in Q`() {
         with(launchActivity()) {
-            verifyTiming(
+            verifyLifecycle(
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -80,7 +86,7 @@ internal class StartupTrackerTest {
     @Test
     fun `cold start in P`() {
         with(launchActivity()) {
-            verifyTiming(
+            verifyLifecycle(
                 createTime = createTime,
                 startTime = startTime,
                 resumeTime = resumeTime
@@ -92,7 +98,7 @@ internal class StartupTrackerTest {
     @Test
     fun `cold start in L`() {
         with(launchActivity()) {
-            verifyTiming(
+            verifyLifecycle(
                 createTime = createTime,
                 startTime = startTime,
                 resumeTime = resumeTime
@@ -107,7 +113,7 @@ internal class StartupTrackerTest {
         clock.tick()
         with(launchActivity(Robolectric.buildActivity(FakeActivity::class.java))) {
             assertEquals("io.embrace.android.embracesdk.fakes.FakeActivity", dataCollector.startupActivityName)
-            verifyTiming(
+            verifyLifecycle(
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -124,7 +130,7 @@ internal class StartupTrackerTest {
         clock.tick()
         with(launchActivity()) {
             assertEquals("android.app.Activity", dataCollector.startupActivityName)
-            verifyTiming(
+            verifyLifecycle(
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -144,6 +150,55 @@ internal class StartupTrackerTest {
         assertNotEquals(secondLaunchTimes.createTime, dataCollector.startupActivityInitStartMs)
     }
 
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `lifecycle event emitter attached after activity launch`() {
+        launchActivity()
+        assertEquals(0, activityLifecycleListener.onCreateInvokedCount)
+        defaultActivityController.create(null)
+        assertEquals(1, activityLifecycleListener.onCreateInvokedCount)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `data only collected if activity is used as startup activity`() {
+        launchActivity(Robolectric.buildActivity(FakeNotStartupActivity::class.java))
+        assertNull(dataCollector.applicationInitStartMs)
+        assertNull(dataCollector.applicationInitEndMs)
+        assertNull(dataCollector.startupActivityName)
+        assertNull(dataCollector.startupActivityPreCreatedMs)
+        assertNull(dataCollector.startupActivityInitStartMs)
+        assertNull(dataCollector.startupActivityPostCreatedMs)
+        assertNull(dataCollector.startupActivityInitEndMs)
+        assertNull(dataCollector.startupActivityResumedMs)
+        assertNull(dataCollector.firstFrameRenderedMs)
+        assertNull(drawEventEmitter.lastRegisteredActivity)
+        assertNull(drawEventEmitter.lastCallback)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `render time tracked if first draw event emitted`() {
+        launchActivity()
+        checkNotNull(drawEventEmitter.lastCallback)()
+        assertEquals(clock.now(), dataCollector.firstFrameRenderedMs)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `first draw event emitted detaches startup tracker and attaches lifecycle event emitter`() {
+        defaultActivityController.create(null)
+        assertEquals(clock.now(), dataCollector.startupActivityInitStartMs)
+        clock.tick()
+        defaultActivityController.create(null)
+        assertEquals(clock.now(), dataCollector.startupActivityInitStartMs)
+        clock.tick()
+        checkNotNull(drawEventEmitter.lastCallback)()
+        defaultActivityController.create(null)
+        assertNotEquals(clock.now(), dataCollector.startupActivityInitStartMs)
+        assertEquals(1, activityLifecycleListener.onCreateInvokedCount)
+    }
+
     private fun launchActivity(controller: ActivityController<*> = defaultActivityController): ActivityTiming {
         val createTime = clock.now()
         controller.create()
@@ -157,7 +212,7 @@ internal class StartupTrackerTest {
         return ActivityTiming(createTime, startTime, resumeTime)
     }
 
-    private fun verifyTiming(
+    private fun verifyLifecycle(
         preCreateTime: Long? = null,
         createTime: Long,
         postCreateTime: Long? = null,
@@ -169,11 +224,14 @@ internal class StartupTrackerTest {
         assertEquals(postCreateTime, dataCollector.startupActivityPostCreatedMs)
         assertEquals(startTime, dataCollector.startupActivityInitEndMs)
         assertEquals(resumeTime, dataCollector.startupActivityResumedMs)
+        assertNull(dataCollector.firstFrameRenderedMs)
+        assertNotNull(drawEventEmitter.lastRegisteredActivity)
+        assertNotNull(drawEventEmitter.lastCallback)
     }
 
     private data class ActivityTiming(
         val createTime: Long,
         val startTime: Long,
-        val resumeTime: Long,
+        val resumeTime: Long
     )
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -38,4 +38,5 @@ enum class InternalErrorType {
     INTERNAL_INTERFACE_FAIL,
     NATIVE_READ_FAIL,
     APP_LAUNCH_TRACE_FAIL,
+    UI_CALLBACK_FAIL,
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityLifecycleListener.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityLifecycleListener.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import android.os.Bundle
+import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
+
+class FakeActivityLifecycleListener : ActivityLifecycleListener {
+    var onCreateInvokedCount = 0
+
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+        onCreateInvokedCount++
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDrawEventEmitter.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDrawEventEmitter.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import io.embrace.android.embracesdk.internal.ui.DrawEventEmitter
+
+class FakeDrawEventEmitter : DrawEventEmitter {
+
+    var lastRegisteredActivity: Activity? = null
+    var lastCallback: (() -> Unit)? = null
+
+    override fun registerFirstDrawCallback(activity: Activity, completionCallback: () -> Unit) {
+        lastRegisteredActivity = activity
+        lastCallback = completionCallback
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import io.embrace.android.embracesdk.annotation.StartupActivity
+
+@StartupActivity
+class FakeNotStartupActivity : Activity()


### PR DESCRIPTION
## Goal

Extract the code to detect when a app startup is ended by the first activity drawing its first frame into its own class so it can be used for the UI Load trace as well.