### PR TITLE
Delay starting of hot UI load traces until onStart completes

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -201,8 +201,10 @@ private class LifecycleEventEmitter(
 
     fun pause(activity: Activity) {
         if (activity.traceLoad()) {
+            val instanceId = traceInstanceId(activity)
+            instanceStartTime.remove(instanceId)
             uiLoadEventListener.discard(
-                instanceId = traceInstanceId(activity),
+                instanceId = instanceId,
                 timestampMs = nowMs()
             )
             drawEventEmitter?.unregisterFirstDrawCallback(activity)


### PR DESCRIPTION
## Goal

To make these traces work with our onForeground callbacks, which work off of different events, we delay the emission of the `start` event until `onStart` callbacks are all done. This will solve the synchronization issue as long as the onForeground callback is registered first, which should always been true for now.

## Testing

Covered by existing tests that verify the start times of child spans and hot UI load traces


