### PR TITLE
Custom attributes and child spans for UI Load traces

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceModifier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceModifier.kt
@@ -1,0 +1,28 @@
+package io.embrace.android.embracesdk.internal.capture.activity
+
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.android.embracesdk.spans.ErrorCode
+
+/**
+ * Interface containing methods that will add more data to any on-going UI Load trace
+ */
+interface UiLoadTraceModifier {
+
+    /**
+     * Add attribute to the root span of the in-process UI Load trace being recorded for the given instanceId.
+     */
+    fun addAttribute(instanceId: Int, key: String, value: String)
+
+    /**
+     * Add a child span with the given parameters to the in-process UI Load trace being recorded for the given instanceId
+     */
+    fun addChildSpan(
+        instanceId: Int,
+        name: String,
+        startTimeMs: Long,
+        endTimeMs: Long,
+        attributes: Map<String, String> = emptyMap(),
+        events: List<EmbraceSpanEvent> = emptyList(),
+        errorCode: ErrorCode? = null,
+    )
+}


### PR DESCRIPTION
## Goal

Add the ability to customize an on-going UI Load trace with custom attribute and child spans. API to expose this to customers will come in the subsequent PR.

## Testing
Unit tests