### PR TITLE
Fix an incorrect path in a workflow

### DIFF
--- a/.github/workflows/swazzler-tests.yml
+++ b/.github/workflows/swazzler-tests.yml
@@ -68,5 +68,5 @@ jobs:
         with:
           name: swazzler-test-results
           path: |
-            ./embrace-swazzler3/embrace-gradle-plugin-functional-tests/reports/tests/test/
+            ./embrace-swazzler3/embrace-gradle-plugin-functional-tests/build/reports/tests/test
             ./embrace-swazzler3/embrace-gradle-plugin-functional-tests/test_debug_output


### PR DESCRIPTION
## Goal

Fixes an incorrect path in a GH workflow that means test results aren't uploaded as an artefact.

