### PR TITLE
Pin runner version

### DIFF
--- a/.github/workflows/swazzler-tests.yml
+++ b/.github/workflows/swazzler-tests.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   runSwazzlerTests:
     name: "Run Gradle Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Goal

Ubuntu 22.04 has [Cmake 3.10 installed](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) but Ubuntu 24.04 does not, causing a build failure on the swazzler test workflow. Pinning this should resolve this specific problem until we decide to update.

