### PR TITLE
Support embrace hosted attachments

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -81,7 +81,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/LogsA
 	public abstract fun logInfo (Ljava/lang/String;)V
 	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;)V
 	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
-	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;J)V
+	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;[B)V
 	public abstract fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public abstract fun logWarning (Ljava/lang/String;)V

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/LogsApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/LogsApi.kt
@@ -61,7 +61,6 @@ public interface LogsApi {
      * @param properties the properties to attach to the log message
      * @param attachmentId a UUID that identifies the attachment
      * @param attachmentUrl a URL that gives the location of the attachment
-     * @param attachmentSize the size of the attachment in bytes
      */
     public fun logMessage(
         message: String,
@@ -69,7 +68,6 @@ public interface LogsApi {
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -62,7 +62,8 @@ internal class LogModuleImpl(
         EmbraceLogService(
             essentialServiceModule.logWriter,
             configModule.configService,
-            essentialServiceModule.sessionPropertiesService
+            essentialServiceModule.sessionPropertiesService,
+            deliveryModule.payloadStore,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.logs
 
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.internal.logs.attachments.Attachment
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
 import io.opentelemetry.api.common.AttributeKey
 
@@ -12,11 +13,6 @@ interface LogService : MemoryCleanerListener {
 
     /**
      * Creates a remote log.
-     *
-     * @param message            the message to log
-     * @param severity           the log severity
-     * @param logExceptionType   whether the log is a handled exception, unhandled, or non an exception
-     * @param properties         custom properties to send as part of the event
      */
     fun log(
         message: String,
@@ -24,6 +20,7 @@ interface LogService : MemoryCleanerListener {
         logExceptionType: LogExceptionType,
         properties: Map<String, Any>? = null,
         customLogAttrs: Map<AttributeKey<String>, String> = emptyMap(),
+        logAttachment: Attachment.EmbraceHosted? = null,
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentErrorCode.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentErrorCode.kt
@@ -5,7 +5,6 @@ package io.embrace.android.embracesdk.internal.logs.attachments
  */
 enum class AttachmentErrorCode {
     ATTACHMENT_TOO_LARGE,
-    UNSUCCESSFUL_UPLOAD,
     OVER_MAX_ATTACHMENTS,
     UNKNOWN
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentService.kt
@@ -16,9 +16,7 @@ class AttachmentService(private val limit: Int = 5) : MemoryCleanerListener {
     fun createAttachment(
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ): UserHosted = UserHosted(
-        attachmentSize,
         attachmentId,
         attachmentUrl,
         ::incrementAndCheckAttachmentLimit

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -97,7 +97,7 @@ internal class PayloadResurrectionServiceImpl(
                             inputStream = GZIPInputStream(
                                 cacheStorageService.loadPayloadAsStream(cachedCrashEnvelopeMetadata)
                             ),
-                            type = SupportedEnvelopeType.CRASH.serializedType
+                            type = checkNotNull(SupportedEnvelopeType.CRASH.serializedType)
                         ).also {
                             cacheStorageService.delete(cachedCrashEnvelopeMetadata)
                         }
@@ -157,7 +157,7 @@ internal class PayloadResurrectionServiceImpl(
             SupportedEnvelopeType.SESSION -> {
                 val deadSession = serializer.fromJson<Envelope<SessionPayload>>(
                     inputStream = GZIPInputStream(cacheStorageService.loadPayloadAsStream(this)),
-                    type = envelopeType.serializedType
+                    type = checkNotNull(envelopeType.serializedType)
                 )
 
                 val sessionId = deadSession.getSessionId()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStore.kt
@@ -31,7 +31,7 @@ interface PayloadStore : CrashTeardownHandler {
     /**
      * Stores a log attachment.
      */
-    fun storeAttachment(envelope: Envelope<ByteArray>)
+    fun storeAttachment(envelope: Envelope<Pair<String, ByteArray>>)
 
     /**
      * Stores an empty payload-type-less crash envelope for future use. One one cached version of this should

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V1PayloadStore.kt
@@ -31,7 +31,7 @@ class V1PayloadStore(
         }
     }
 
-    override fun storeAttachment(envelope: Envelope<ByteArray>) {
+    override fun storeAttachment(envelope: Envelope<Pair<String, ByteArray>>) {
         // ignored - v1 doesn't support attachments
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
@@ -41,7 +41,14 @@ internal class V2PayloadStore(
         intakeService.take(envelope, createMetadata(type, payloadType = payloadType))
     }
 
-    override fun storeAttachment(envelope: Envelope<ByteArray>) {
+    override fun storeAttachment(envelope: Envelope<Pair<String, ByteArray>>) {
+        intakeService.take(
+            envelope,
+            createMetadata(
+                type = SupportedEnvelopeType.ATTACHMENT,
+                payloadType = PayloadType.ATTACHMENT
+            )
+        )
     }
 
     override fun cacheEmptyCrashEnvelope(envelope: Envelope<LogPayload>) {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentTest.kt
@@ -73,57 +73,34 @@ internal class AttachmentTest {
 
     @Test
     fun `create user hosted attachment`() {
-        val attachment = UserHosted(SIZE, ID, URL, counter)
+        val attachment = UserHosted(ID, URL, counter)
         attachment.assertUserHostedAttributesMatch()
-    }
-
-    @Test
-    fun `user hosted attachment empty size`() {
-        val size: Long = 0
-        val attachment = UserHosted(size, ID, URL, counter)
-        attachment.assertUserHostedAttributesMatch(size = size)
-    }
-
-    @Test
-    fun `user hosted attachment invalid size`() {
-        val size: Long = -1
-        val attachment = UserHosted(size, ID, URL, counter)
-        attachment.assertUserHostedAttributesMatch(size = size, errorCode = UNKNOWN)
     }
 
     @Test
     fun `user hosted attachment invalid url`() {
         val url = ""
-        val attachment = UserHosted(SIZE, ID, url, counter)
+        val attachment = UserHosted(ID, url, counter)
         attachment.assertUserHostedAttributesMatch(url = url, errorCode = UNKNOWN)
     }
 
     @Test
     fun `user hosted attachment invalid ID`() {
         val id = "my-id"
-        val attachment = UserHosted(SIZE, id, URL, counter)
+        val attachment = UserHosted(id, URL, counter)
         attachment.assertUserHostedAttributesMatch(id = id, errorCode = UNKNOWN)
-    }
-
-    @Test
-    fun `user hosted attachment has no max size constraints`() {
-        val size = 5000000L // 50MiB
-        val attachment = UserHosted(size, ID, URL, counter)
-        attachment.assertUserHostedAttributesMatch(size = size)
     }
 
     @Test
     fun `user hosted attachment exceeds session limit`() {
         var limit = true
         val smallCounter: () -> Boolean = { limit }
-        val attachment = UserHosted(SIZE, ID, URL, smallCounter)
+        val attachment = UserHosted(ID, URL, smallCounter)
         attachment.assertUserHostedAttributesMatch()
 
-        val size = -1L
         limit = false
-        val limitedAttachment = UserHosted(size, ID, URL, smallCounter)
+        val limitedAttachment = UserHosted(ID, URL, smallCounter)
         limitedAttachment.assertUserHostedAttributesMatch(
-            size = size,
             errorCode = OVER_MAX_ATTACHMENTS
         )
     }
@@ -140,12 +117,10 @@ internal class AttachmentTest {
     }
 
     private fun UserHosted.assertUserHostedAttributesMatch(
-        size: Long = SIZE,
         url: String = URL,
         id: String = ID,
         errorCode: AttachmentErrorCode? = null,
     ) {
-        assertEquals(size, checkNotNull(attributes[embAttachmentSize]).toLong())
         assertEquals(id, checkNotNull(attributes[embAttachmentId]))
         assertEquals(errorCode?.toString(), attributes[embAttachmentErrorCode])
         assertEquals(url, checkNotNull(attributes[embAttachmentUrl]))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -110,6 +110,17 @@ class V2PayloadStoreTest {
         assertEquals(System.NetworkCapturedRequest.value, getLastLogMetadata().payloadType.value)
     }
 
+    @Test
+    fun `test log attachment`() {
+        val envelope = Envelope(data = Pair("test", ByteArray(5)))
+        store.storeAttachment(envelope)
+
+        val intake = intakeService.getIntakes<Pair<String, ByteArray>>().single()
+        assertSame(envelope, intake.envelope)
+        assertEquals("p4_1692201601000_fakeuuid_fakeProcessId_true_attachment_v1.json", intake.metadata.filename)
+        assertEquals(0, intakeService.shutdownCount)
+    }
+
     private fun storeLogWithType(type: TelemetryType) {
         val envelope = Envelope(
             data = LogPayload(

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
@@ -8,13 +8,14 @@ import java.lang.reflect.Type
  * Enumerates the different types of telemetry that are supported when persisting to disk.
  */
 enum class SupportedEnvelopeType(
-    val serializedType: Type,
+    val serializedType: Type?,
     val priority: String,
     val endpoint: Endpoint,
 ) {
 
     CRASH(Envelope.logEnvelopeType, "p1", Endpoint.LOGS),
     SESSION(Envelope.sessionEnvelopeType, "p3", Endpoint.SESSIONS),
+    ATTACHMENT(null, "p4", Endpoint.ATTACHMENT),
     LOG(Envelope.logEnvelopeType, "p5", Endpoint.LOGS),
     BLOB(Envelope.logEnvelopeType, "p7", Endpoint.LOGS);
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/AttachmentStorage.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/AttachmentStorage.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.internal.delivery.storage
+
+import java.io.InputStream
+import java.io.OutputStream
+
+fun storeAttachment(stream: OutputStream, attachment: ByteArray, id: String) {
+    stream.use {
+        it.write(id.toByteArray())
+        it.write("\n".toByteArray())
+        it.write(attachment)
+    }
+}
+
+fun loadAttachment(stream: InputStream): Pair<ByteArray, String>? {
+    stream.use {
+        val contents = it.readBytes()
+        val start = contents.indexOfFirst { byte -> byte == '\n'.code.toByte() }
+        val id = String(contents.sliceArray(0 until start))
+        val attachment = contents.sliceArray(start + 1 until contents.size)
+        return Pair(attachment, id)
+    }
+}

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
@@ -37,7 +37,7 @@ class CachedLogEnvelopeStoreImpl(
                     resource,
                     metadata
                 ),
-                storedTelemetryMetadata.envelopeType.serializedType,
+                checkNotNull(storedTelemetryMetadata.envelopeType.serializedType),
                 stream
             )
         }
@@ -48,7 +48,7 @@ class CachedLogEnvelopeStoreImpl(
             fileStorageService.loadPayloadAsStream(storedTelemetryMetadata)?.let { inputStream ->
                 serializer.fromJson<Envelope<LogPayload>>(
                     inputStream = inputStream,
-                    type = storedTelemetryMetadata.envelopeType.serializedType
+                    type = checkNotNull(storedTelemetryMetadata.envelopeType.serializedType)
                 )
             }
         }.getOrNull()

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -40,7 +40,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logInfo (Ljava/lang/String;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
-	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;J)V
+	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;[B)V
 	public fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public fun logWarning (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FileAttachmentFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FileAttachmentFeatureTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.testframework.assertions.getLastLog
 import io.embrace.android.embracesdk.testframework.assertions.getOtelSeverity
+import io.embrace.android.embracesdk.testframework.server.FormPart
 import java.util.UUID
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -37,18 +38,15 @@ internal class FileAttachmentFeatureTest {
         val size = 509L
         val url = "https://example.com/my-file.txt"
         val id = attachmentId.toString()
-        testRule.runTest(
-            testCaseAction = {
-                recordSession {
-                    logWithUserHostedAttachment(id, url, size)
-                }
-            },
-            assertAction = {
-                val log = getSingleLogEnvelope().getLastLog()
-                assertUserHostedLogSent(log, size, url, id)
-                assertNull(log.attributes?.findAttributeValue(ATTR_KEY_ERR_CODE))
+        testRule.runTest(testCaseAction = {
+            recordSession {
+                logWithUserHostedAttachment(id, url, size)
             }
-        )
+        }, assertAction = {
+            val log = getSingleLogEnvelope().getLastLog()
+            assertUserHostedLogSent(log, size, url, id)
+            assertNull(log.attributes?.findAttributeValue(ATTR_KEY_ERR_CODE))
+        })
     }
 
     @Test
@@ -56,64 +54,69 @@ internal class FileAttachmentFeatureTest {
         val size = 509L
         val url = "https://example.com/my-file.txt"
         val id = attachmentId.toString()
-        testRule.runTest(
-            testCaseAction = {
-                recordSession {
-                    repeat(6) {
-                        logWithUserHostedAttachment(id, url, size)
-                    }
-                }
-                recordSession {
-                    repeat(6) {
-                        logWithUserHostedAttachment(id, url, size)
-                    }
-                }
-            },
-            assertAction = {
-                val logs = getLogEnvelopes(2).flatMap { checkNotNull(it.data.logs) }
-                assertEquals(12, logs.size)
-
-                logs.forEachIndexed { k, log ->
-                    assertUserHostedLogSent(log, size, url, id)
-
-                    val errCode = log.attributes?.findAttributeValue(ATTR_KEY_ERR_CODE)
-                    val expectedCode = when (k) {
-                        5, 11 -> "OVER_MAX_ATTACHMENTS"
-                        else -> null
-                    }
-                    assertEquals(expectedCode, errCode)
+        val limit = 5
+        testRule.runTest(testCaseAction = {
+            recordSession {
+                repeat(limit + 1) {
+                    logWithUserHostedAttachment(id, url, size)
                 }
             }
-        )
+            recordSession {
+                repeat(limit + 1) {
+                    logWithUserHostedAttachment(id, url, size)
+                }
+            }
+        }, assertAction = {
+            val logs = getLogEnvelopes(2).flatMap { checkNotNull(it.data.logs) }
+            assertEquals((limit * 2) + 2, logs.size)
+
+            logs.forEachIndexed { k, log ->
+                assertUserHostedLogSent(log, size, url, id)
+
+                val errCode = log.attributes?.findAttributeValue(ATTR_KEY_ERR_CODE)
+                val expectedCode = when (k) {
+                    limit, limit + limit + 1 -> "OVER_MAX_ATTACHMENTS"
+                    else -> null
+                }
+                assertEquals(expectedCode, errCode)
+            }
+        })
     }
 
     @Test
     fun `log message with embrace hosted file attachment`() {
-        testRule.runTest(
-            testCaseAction = {
-                recordSession {
-                    embrace.logMessage(
-                        message = "test message",
-                        severity = Severity.INFO,
-                        properties = mapOf("key" to "value"),
-                        attachment = "Hello, world!".toByteArray()
-                    )
-                }
-            },
-            assertAction = {
-                val log = getSingleLogEnvelope().getLastLog()
-                assertOtelLogReceived(
-                    logReceived = log,
-                    expectedMessage = "test message",
-                    expectedSeverityNumber = getOtelSeverity(Severity.INFO).severityNumber,
-                    expectedSeverityText = Severity.INFO.name,
-                    expectedState = "foreground",
-                    expectedProperties = mapOf(
-                        "key" to "value",
-                    ),
+        val byteArray = "Hello, world!".toByteArray()
+        testRule.runTest(testCaseAction = {
+            recordSession {
+                embrace.logMessage(
+                    message = "test message",
+                    severity = Severity.INFO,
+                    properties = mapOf("key" to "value"),
+                    attachment = byteArray
                 )
             }
+        }, assertAction = {
+            val parts = getSingleAttachment()
+            verifyAttachment(parts, byteArray)
+
+            val log = getSingleLogEnvelope().getLastLog()
+            assertEmbraceHostedLogSent(log, byteArray.size.toLong())
+        })
+    }
+
+    private fun verifyAttachment(
+        parts: List<FormPart>,
+        byteArray: ByteArray,
+        appId: String = "abcde"
+    ) {
+        assertEquals("form-data; name=\"app_id\"", parts[0].contentDisposition)
+        assertEquals(appId, parts[0].data)
+        assertEquals("form-data; name=\"attachment_id\"", parts[1].contentDisposition)
+        checkNotNull(UUID.fromString(parts[1].data))
+        assertEquals(
+            "form-data; name=\"file\"; filename=\"file\"", parts[2].contentDisposition
         )
+        assertEquals(String(byteArray), parts[2].data)
     }
 
     private fun assertUserHostedLogSent(
@@ -136,6 +139,26 @@ internal class FileAttachmentFeatureTest {
                 ATTR_KEY_ID to id,
             ),
         )
+    }
+
+    private fun assertEmbraceHostedLogSent(
+        log: Log,
+        size: Long,
+    ) {
+        assertOtelLogReceived(
+            logReceived = log,
+            expectedMessage = "test message",
+            expectedSeverityNumber = getOtelSeverity(Severity.INFO).severityNumber,
+            expectedSeverityText = Severity.INFO.name,
+            expectedState = "foreground",
+            expectedTimeMs = null,
+            expectedProperties = mapOf(
+                "key" to "value",
+                ATTR_KEY_SIZE to size.toString(),
+            ),
+        )
+        val id = log.attributes?.findAttributeValue(ATTR_KEY_ID)
+        checkNotNull(UUID.fromString(id))
     }
 
     private fun EmbraceActionInterface.logWithUserHostedAttachment(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -103,7 +103,7 @@ internal class PeriodicSessionCacheTest {
         val inputStream = checkNotNull(cacheStorageService.loadPayloadAsStream(metadata))
         return TestPlatformSerializer().fromJson(
             inputStream,
-            SupportedEnvelopeType.SESSION.serializedType
+            checkNotNull(SupportedEnvelopeType.SESSION.serializedType)
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -154,9 +154,8 @@ public class Embrace private constructor(
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ) {
-        impl.logMessage(message, severity, properties, attachmentId, attachmentUrl, attachmentSize)
+        impl.logMessage(message, severity, properties, attachmentId, attachmentUrl)
     }
 
     override fun logException(throwable: Throwable) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -338,7 +338,6 @@ internal class EmbraceImpl @JvmOverloads constructor(
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ) {
         logsApiDelegate.logMessage(
             message,
@@ -346,7 +345,6 @@ internal class EmbraceImpl @JvmOverloads constructor(
             properties,
             attachmentId,
             attachmentUrl,
-            attachmentSize
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
@@ -105,9 +105,8 @@ internal class LogsApiDelegate(
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ) {
-        val obj = attachmentService?.createAttachment(attachmentId, attachmentUrl, attachmentSize) ?: return
+        val obj = attachmentService?.createAttachment(attachmentId, attachmentUrl) ?: return
         logMessageImpl(
             severity = severity,
             message = message,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeIntakeService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeIntakeService.kt
@@ -3,8 +3,6 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 import io.embrace.android.embracesdk.internal.payload.Envelope
-import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.payload.SessionPayload
 
 class FakeIntakeService : IntakeService {
 
@@ -14,9 +12,6 @@ class FakeIntakeService : IntakeService {
 
     @Suppress("UNCHECKED_CAST")
     inline fun <reified T : Any> getIntakes(complete: Boolean = true): List<FakePayloadIntake<T>> {
-        if (T::class != SessionPayload::class && T::class != LogPayload::class) {
-            error("Unsupported type: ${T::class}")
-        }
         val dst = when (complete) {
             true -> intakeList
             false -> cacheList

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.logs.LogService
+import io.embrace.android.embracesdk.internal.logs.attachments.Attachment
 import io.opentelemetry.api.common.AttributeKey
 
 class FakeLogService : LogService {
@@ -23,6 +24,7 @@ class FakeLogService : LogService {
         logExceptionType: LogExceptionType,
         properties: Map<String, Any>?,
         customLogAttrs: Map<AttributeKey<String>, String>,
+        logAttachment: Attachment.EmbraceHosted?,
     ) {
         loggedMessages.add(
             LogData(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.injection.SerializationAction
@@ -30,7 +31,11 @@ class FakePayloadStorageService(
         }
 
         val baos = ByteArrayOutputStream()
-        action(GZIPOutputStream(baos))
+        if (metadata.payloadType != PayloadType.ATTACHMENT) {
+            action(GZIPOutputStream(baos))
+        } else {
+            action(baos)
+        }
         cachedPayloads[metadata] = baos.toByteArray()
     }
 
@@ -58,7 +63,7 @@ class FakePayloadStorageService(
 
     fun <T> addPayload(metadata: StoredTelemetryMetadata, data: T) {
         store(metadata) { stream ->
-            serializer.toJson(data, metadata.envelopeType.serializedType, stream)
+            serializer.toJson(data, checkNotNull(metadata.envelopeType.serializedType), stream)
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStore.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStore.kt
@@ -13,7 +13,7 @@ class FakePayloadStore(
 
     val storedSessionPayloads = mutableListOf<Pair<Envelope<SessionPayload>, TransitionType>>()
     val storedLogPayloads = mutableListOf<Pair<Envelope<LogPayload>, Boolean>>()
-    val storedAttachments = mutableListOf<Envelope<ByteArray>>()
+    val storedAttachments = mutableListOf<Envelope<Pair<String, ByteArray>>>()
     val cachedSessionPayloads = mutableListOf<Envelope<SessionPayload>>()
     val cachedEmptyCrashPayloads = mutableListOf<Envelope<LogPayload>>()
     var crashCount: Int = 0
@@ -34,7 +34,7 @@ class FakePayloadStore(
         storedLogPayloads.add(Pair(envelope, attemptImmediateRequest))
     }
 
-    override fun storeAttachment(envelope: Envelope<ByteArray>) {
+    override fun storeAttachment(envelope: Envelope<Pair<String, ByteArray>>) {
         storedAttachments.add(envelope)
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
@@ -40,7 +40,7 @@ class FakeRequestExecutionService(
     ): ExecutionResult {
         exceptionOnExecution?.run { throw this }
         val bufferedStream = GZIPInputStream(payloadStream())
-        val envelope: Envelope<*> = serializer.fromJson(bufferedStream, envelopeType.serializedType)
+        val envelope: Envelope<*> = serializer.fromJson(bufferedStream, checkNotNull(envelopeType.serializedType))
         processEnvelope(envelope)
         return responseAction(envelope)
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureDataSource
 import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureService
 import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
+import io.embrace.android.embracesdk.fakes.FakePayloadStore
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.internal.injection.LogModule
 import io.embrace.android.embracesdk.internal.logs.EmbraceLogService
@@ -22,7 +23,8 @@ class FakeLogModule(
     override val logService: LogService = EmbraceLogService(
         FakeLogWriter(),
         FakeConfigService(),
-        FakeSessionPropertiesService()
+        FakeSessionPropertiesService(),
+        FakePayloadStore(),
     ),
 ) : LogModule {
 


### PR DESCRIPTION
## Goal

Adds support for log attachments that are hosted on Embrace's servers.

## Testing

Added basic integration tests. Further tests will follow in a future PR.
