### PR TITLE
Restore public visibility of classes containing swazzled code

### DIFF
--- a/embrace-android-core/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
+++ b/embrace-android-core/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.annotation.InternalApi;
  * @hide
  */
 @InternalApi
-final class WebViewChromeClientSwazzledHooks {
+public final class WebViewChromeClientSwazzledHooks {
 
     private WebViewChromeClientSwazzledHooks() {
     }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -72,3 +72,18 @@ public final class io/embrace/android/embracesdk/Embrace$Companion {
 	public final fun getInstance ()Lio/embrace/android/embracesdk/Embrace;
 }
 
+public final class io/embrace/android/embracesdk/ViewSwazzledHooks {
+}
+
+public final class io/embrace/android/embracesdk/ViewSwazzledHooks$OnClickListener {
+	public static fun _preOnClick (Landroid/view/View$OnClickListener;Landroid/view/View;)V
+}
+
+public final class io/embrace/android/embracesdk/ViewSwazzledHooks$OnLongClickListener {
+	public static fun _preOnLongClick (Landroid/view/View$OnLongClickListener;Landroid/view/View;)V
+}
+
+public final class io/embrace/android/embracesdk/WebViewClientSwazzledHooks {
+	public static fun _preOnPageStarted (Landroid/webkit/WebView;Ljava/lang/String;Landroid/graphics/Bitmap;)V
+}
+

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
@@ -11,7 +11,7 @@ import kotlin.Pair;
  * @hide
  */
 @InternalApi
-final class ViewSwazzledHooks {
+public final class ViewSwazzledHooks {
 
     private static final String UNKNOWN_ELEMENT_NAME = "Unknown element";
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewClientSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewClientSwazzledHooks.java
@@ -1,20 +1,22 @@
 package io.embrace.android.embracesdk;
 
+import androidx.annotation.Nullable;
+
 import io.embrace.android.embracesdk.annotation.InternalApi;
 
 /**
  * @hide
  */
 @InternalApi
-final class WebViewClientSwazzledHooks {
+public final class WebViewClientSwazzledHooks {
 
     private WebViewClientSwazzledHooks() {
     }
 
     @SuppressWarnings("MethodNameCheck")
-    public static void _preOnPageStarted(android.webkit.WebView view,
-                                         java.lang.String url,
-                                         android.graphics.Bitmap favicon) {
+    public static void _preOnPageStarted(@Nullable android.webkit.WebView view,
+                                         @Nullable java.lang.String url,
+                                         @Nullable android.graphics.Bitmap favicon) {
         Embrace.getInstance().logWebView(url);
     }
 }


### PR DESCRIPTION
## Goal

Restore public-ness of classes whose methods are injected into the bytecode by the swazzler

Note: lint picked up some nullality annotation issues so I added them. I hope this won't break things?