### PR TITLE
Remove size parameter from user hosted log messages

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -81,7 +81,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/LogsA
 	public abstract fun logInfo (Ljava/lang/String;)V
 	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;)V
 	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
-	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;J)V
+	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;[B)V
 	public abstract fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public abstract fun logWarning (Ljava/lang/String;)V

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/LogsApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/LogsApi.kt
@@ -61,7 +61,6 @@ public interface LogsApi {
      * @param properties the properties to attach to the log message
      * @param attachmentId a UUID that identifies the attachment
      * @param attachmentUrl a URL that gives the location of the attachment
-     * @param attachmentSize the size of the attachment in bytes
      */
     public fun logMessage(
         message: String,
@@ -69,7 +68,6 @@ public interface LogsApi {
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentErrorCode.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentErrorCode.kt
@@ -5,7 +5,6 @@ package io.embrace.android.embracesdk.internal.logs.attachments
  */
 enum class AttachmentErrorCode {
     ATTACHMENT_TOO_LARGE,
-    UNSUCCESSFUL_UPLOAD,
     OVER_MAX_ATTACHMENTS,
     UNKNOWN
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentService.kt
@@ -16,9 +16,7 @@ class AttachmentService(private val limit: Int = 5) : MemoryCleanerListener {
     fun createAttachment(
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ): UserHosted = UserHosted(
-        attachmentSize,
         attachmentId,
         attachmentUrl,
         ::incrementAndCheckAttachmentLimit

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentTest.kt
@@ -73,57 +73,34 @@ internal class AttachmentTest {
 
     @Test
     fun `create user hosted attachment`() {
-        val attachment = UserHosted(SIZE, ID, URL, counter)
+        val attachment = UserHosted(ID, URL, counter)
         attachment.assertUserHostedAttributesMatch()
-    }
-
-    @Test
-    fun `user hosted attachment empty size`() {
-        val size: Long = 0
-        val attachment = UserHosted(size, ID, URL, counter)
-        attachment.assertUserHostedAttributesMatch(size = size)
-    }
-
-    @Test
-    fun `user hosted attachment invalid size`() {
-        val size: Long = -1
-        val attachment = UserHosted(size, ID, URL, counter)
-        attachment.assertUserHostedAttributesMatch(size = size, errorCode = UNKNOWN)
     }
 
     @Test
     fun `user hosted attachment invalid url`() {
         val url = ""
-        val attachment = UserHosted(SIZE, ID, url, counter)
+        val attachment = UserHosted(ID, url, counter)
         attachment.assertUserHostedAttributesMatch(url = url, errorCode = UNKNOWN)
     }
 
     @Test
     fun `user hosted attachment invalid ID`() {
         val id = "my-id"
-        val attachment = UserHosted(SIZE, id, URL, counter)
+        val attachment = UserHosted(id, URL, counter)
         attachment.assertUserHostedAttributesMatch(id = id, errorCode = UNKNOWN)
-    }
-
-    @Test
-    fun `user hosted attachment has no max size constraints`() {
-        val size = 5000000L // 50MiB
-        val attachment = UserHosted(size, ID, URL, counter)
-        attachment.assertUserHostedAttributesMatch(size = size)
     }
 
     @Test
     fun `user hosted attachment exceeds session limit`() {
         var limit = true
         val smallCounter: () -> Boolean = { limit }
-        val attachment = UserHosted(SIZE, ID, URL, smallCounter)
+        val attachment = UserHosted(ID, URL, smallCounter)
         attachment.assertUserHostedAttributesMatch()
 
-        val size = -1L
         limit = false
-        val limitedAttachment = UserHosted(size, ID, URL, smallCounter)
+        val limitedAttachment = UserHosted(ID, URL, smallCounter)
         limitedAttachment.assertUserHostedAttributesMatch(
-            size = size,
             errorCode = OVER_MAX_ATTACHMENTS
         )
     }
@@ -140,12 +117,10 @@ internal class AttachmentTest {
     }
 
     private fun UserHosted.assertUserHostedAttributesMatch(
-        size: Long = SIZE,
         url: String = URL,
         id: String = ID,
         errorCode: AttachmentErrorCode? = null,
     ) {
-        assertEquals(size, checkNotNull(attributes[embAttachmentSize]).toLong())
         assertEquals(id, checkNotNull(attributes[embAttachmentId]))
         assertEquals(errorCode?.toString(), attributes[embAttachmentErrorCode])
         assertEquals(url, checkNotNull(attributes[embAttachmentUrl]))

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -40,7 +40,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logInfo (Ljava/lang/String;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;)V
-	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;J)V
+	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)V
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;[B)V
 	public fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public fun logWarning (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FileAttachmentFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FileAttachmentFeatureTest.kt
@@ -35,35 +35,33 @@ internal class FileAttachmentFeatureTest {
 
     @Test
     fun `log message with user hosted file attachment`() {
-        val size = 509L
         val url = "https://example.com/my-file.txt"
         val id = attachmentId.toString()
         testRule.runTest(testCaseAction = {
             recordSession {
-                logWithUserHostedAttachment(id, url, size)
+                logWithUserHostedAttachment(id, url)
             }
         }, assertAction = {
             val log = getSingleLogEnvelope().getLastLog()
-            assertUserHostedLogSent(log, size, url, id)
+            assertUserHostedLogSent(log, url, id)
             assertNull(log.attributes?.findAttributeValue(ATTR_KEY_ERR_CODE))
         })
     }
 
     @Test
     fun `user hosted file attachment exceeding limit`() {
-        val size = 509L
         val url = "https://example.com/my-file.txt"
         val id = attachmentId.toString()
         val limit = 5
         testRule.runTest(testCaseAction = {
             recordSession {
                 repeat(limit + 1) {
-                    logWithUserHostedAttachment(id, url, size)
+                    logWithUserHostedAttachment(id, url)
                 }
             }
             recordSession {
                 repeat(limit + 1) {
-                    logWithUserHostedAttachment(id, url, size)
+                    logWithUserHostedAttachment(id, url)
                 }
             }
         }, assertAction = {
@@ -71,7 +69,7 @@ internal class FileAttachmentFeatureTest {
             assertEquals((limit * 2) + 2, logs.size)
 
             logs.forEachIndexed { k, log ->
-                assertUserHostedLogSent(log, size, url, id)
+                assertUserHostedLogSent(log, url, id)
 
                 val errCode = log.attributes?.findAttributeValue(ATTR_KEY_ERR_CODE)
                 val expectedCode = when (k) {
@@ -107,7 +105,7 @@ internal class FileAttachmentFeatureTest {
     private fun verifyAttachment(
         parts: List<FormPart>,
         byteArray: ByteArray,
-        appId: String = "abcde"
+        appId: String = "abcde",
     ) {
         assertEquals("form-data; name=\"app_id\"", parts[0].contentDisposition)
         assertEquals(appId, parts[0].data)
@@ -121,7 +119,6 @@ internal class FileAttachmentFeatureTest {
 
     private fun assertUserHostedLogSent(
         log: Log,
-        size: Long,
         url: String,
         id: String,
     ) {
@@ -134,7 +131,6 @@ internal class FileAttachmentFeatureTest {
             expectedTimeMs = null,
             expectedProperties = mapOf(
                 "key" to "value",
-                ATTR_KEY_SIZE to size.toString(),
                 ATTR_KEY_URL to url,
                 ATTR_KEY_ID to id,
             ),
@@ -164,7 +160,6 @@ internal class FileAttachmentFeatureTest {
     private fun EmbraceActionInterface.logWithUserHostedAttachment(
         id: String,
         url: String,
-        size: Long,
     ) {
         embrace.logMessage(
             message = "test message",
@@ -172,7 +167,6 @@ internal class FileAttachmentFeatureTest {
             properties = mapOf("key" to "value"),
             attachmentId = id,
             attachmentUrl = url,
-            attachmentSize = size,
         )
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -154,9 +154,8 @@ public class Embrace private constructor(
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ) {
-        impl.logMessage(message, severity, properties, attachmentId, attachmentUrl, attachmentSize)
+        impl.logMessage(message, severity, properties, attachmentId, attachmentUrl)
     }
 
     override fun logException(throwable: Throwable) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -338,7 +338,6 @@ internal class EmbraceImpl @JvmOverloads constructor(
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ) {
         logsApiDelegate.logMessage(
             message,
@@ -346,7 +345,6 @@ internal class EmbraceImpl @JvmOverloads constructor(
             properties,
             attachmentId,
             attachmentUrl,
-            attachmentSize
         )
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
@@ -105,9 +105,8 @@ internal class LogsApiDelegate(
         properties: Map<String, Any>?,
         attachmentId: String,
         attachmentUrl: String,
-        attachmentSize: Long,
     ) {
-        val obj = attachmentService?.createAttachment(attachmentId, attachmentUrl, attachmentSize) ?: return
+        val obj = attachmentService?.createAttachment(attachmentId, attachmentUrl) ?: return
         logMessageImpl(
             severity = severity,
             message = message,


### PR DESCRIPTION
## Goal

Removes the size parameter from user hosted log messages as we will calculate this on the backend & the attribute was unnecessary

## Testing

Updated existing tests.

