### PR TITLE
Add log message attachment example

### DIFF
--- a/examples/ExampleApp/app/build.gradle.kts
+++ b/examples/ExampleApp/app/build.gradle.kts
@@ -62,10 +62,12 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
 
     // uncomment to enable debugging through source contained in those modules
+//    implementation(libs.embrace.android.api)
 //    implementation(libs.embrace.android.sdk)
 //    implementation(libs.embrace.android.core)
 //    implementation(libs.embrace.android.features)
 //    implementation(libs.embrace.android.payload)
+//    implementation(libs.embrace.android.delivery)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/CodeExample.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/CodeExample.kt
@@ -9,6 +9,7 @@ enum class CodeExample(
     TRACING("Tracing API"),
     ADD_BREADCRUMB("Add Breadcrumb"),
     LOG_MESSAGE("Send Log Message"),
+    LOG_MESSAGE_ATTACHMENT("Log with Attachment"),
     RECORD_NETWORK_REQUEST("Network Requests"),
     SESSION_PROPERTIES("Session Properties"),
     END_SESSION("End Session"),

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/ExampleContent.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/ExampleContent.kt
@@ -5,6 +5,7 @@ import io.embrace.android.exampleapp.ui.examples.AddBreadcrumbExample
 import io.embrace.android.exampleapp.ui.examples.AnrDetectionExample
 import io.embrace.android.exampleapp.ui.examples.EndSessionExample
 import io.embrace.android.exampleapp.ui.examples.JvmCrashExample
+import io.embrace.android.exampleapp.ui.examples.LogMessageAttachmentsExample
 import io.embrace.android.exampleapp.ui.examples.NdkCrashExample
 import io.embrace.android.exampleapp.ui.examples.LogMessageExample
 import io.embrace.android.exampleapp.ui.examples.NetworkRequestExample
@@ -20,6 +21,7 @@ fun ExampleContent(example: CodeExample) {
         CodeExample.TRACING -> TracingApiExample()
         CodeExample.ADD_BREADCRUMB -> AddBreadcrumbExample()
         CodeExample.LOG_MESSAGE -> LogMessageExample()
+        CodeExample.LOG_MESSAGE_ATTACHMENT -> LogMessageAttachmentsExample()
         CodeExample.RECORD_NETWORK_REQUEST -> NetworkRequestExample()
         CodeExample.SESSION_PROPERTIES -> SessionPropertiesExample()
         CodeExample.END_SESSION -> EndSessionExample()

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/LogMessageAttachmentsExample.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/LogMessageAttachmentsExample.kt
@@ -1,0 +1,86 @@
+package io.embrace.android.exampleapp.ui.examples
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.exampleapp.ui.RadioButtonList
+import java.util.UUID
+
+@Composable
+fun LogMessageAttachmentsExample() {
+    var textValue by remember { mutableStateOf("My log message") }
+    var severityValue by remember { mutableStateOf(Severity.INFO) }
+    var includeProps by remember { mutableStateOf(true) }
+    var hostFileOn3rdPartyServer by remember { mutableStateOf(false) }
+
+    TextField(value = textValue, onValueChange = {
+        textValue = it
+    })
+    RadioButtonList(
+        items = Severity.entries,
+        selectedItem = severityValue
+    ) {
+        severityValue = it
+    }
+
+    Row {
+        Checkbox(
+            checked = includeProps,
+            onCheckedChange = {
+                includeProps = it
+            }
+        )
+        Text("Include properties", Modifier.padding(top = 8.dp))
+    }
+
+    Row {
+        Checkbox(
+            checked = hostFileOn3rdPartyServer,
+            onCheckedChange = {
+                hostFileOn3rdPartyServer = it
+            }
+        )
+        Text("Host files on a 3rd party server (not Embrace)", Modifier.padding(top = 8.dp))
+    }
+    Spacer(Modifier.padding(8.dp))
+    Button(onClick = {
+        val properties = when (includeProps) {
+            true -> mapOf(
+                "my_custom_key" to "my_custom_value"
+            )
+            else -> null
+        }
+
+        if (hostFileOn3rdPartyServer) {
+            Embrace.getInstance().logMessage(
+                message = textValue,
+                severity = severityValue,
+                properties = properties,
+                attachmentId = UUID.randomUUID().toString(),
+                attachmentUrl = "https://example.com/my-attachment",
+            )
+        } else {
+            Embrace.getInstance().logMessage(
+                message = textValue,
+                severity = severityValue,
+                properties = properties,
+                attachment = "Hello, world!".toByteArray(),
+            )
+        }
+    }) {
+        Text("Send Log")
+    }
+}

--- a/examples/ExampleApp/gradle/libs.versions.toml
+++ b/examples/ExampleApp/gradle/libs.versions.toml
@@ -29,14 +29,17 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-embrace-android-sdk = { group = "io.embrace", name = "embrace-android-sdk", version.ref = "embrace" }
-embrace-android-core = { group = "io.embrace", name = "embrace-android-core", version.ref = "embrace" }
-embrace-android-features = { group = "io.embrace", name = "embrace-android-features", version.ref = "embrace" }
-embrace-android-payload = { group = "io.embrace", name = "embrace-android-payload", version.ref = "embrace" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 opentelemetry-bom = { group = "io.opentelemetry", name = "opentelemetry-bom", version.ref = "otel" }
 opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api"}
 opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk"}
+
+embrace-android-api = { group = "io.embrace", name = "embrace-android-api", version.ref = "embrace" }
+embrace-android-sdk = { group = "io.embrace", name = "embrace-android-sdk", version.ref = "embrace" }
+embrace-android-core = { group = "io.embrace", name = "embrace-android-core", version.ref = "embrace" }
+embrace-android-features = { group = "io.embrace", name = "embrace-android-features", version.ref = "embrace" }
+embrace-android-payload = { group = "io.embrace", name = "embrace-android-payload", version.ref = "embrace" }
+embrace-android-delivery = { group = "io.embrace", name = "embrace-android-delivery", version.ref = "embrace" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Goal

Adds a log message attachment sample to the example app. As this relies on a new API it won't compile without a local artefact for now, so I'll avoid merging this until the feature has shipped.

