### PR TITLE
Synchronize access to complete spans

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 class SpanRepository {
     private val activeSpans: MutableMap<String, PersistableEmbraceSpan> = ConcurrentHashMap()
-    private val completedSpans: MutableMap<String, PersistableEmbraceSpan> = mutableMapOf()
+    private val completedSpans: MutableMap<String, PersistableEmbraceSpan> = ConcurrentHashMap()
     private val spanIdsInProcess: MutableMap<String, AtomicInteger> = ConcurrentHashMap()
     private var spanUpdateNotifier: (() -> Unit)? = null
 
@@ -127,8 +127,8 @@ class SpanRepository {
     }
 
     private fun buildSpanTree(): List<SpanNode> {
-        // first, create nodes individually
-        val spans = activeSpans.values.toList().plus(completedSpans.values)
+        // first, create nodes individually by getting all active spans, then adding them to all completed spans
+        val spans = getCompletedSpans().plus(getActiveSpans())
         val nodes = spans.map { SpanNode(it, mutableListOf()) }.associateBy(SpanNode::span)
         val roots = mutableListOf<SpanNode>()
 


### PR DESCRIPTION
## Goal

While building out the tree of spans to look for ones to auto terminate, make sure to access the completed spans is thread safe.

Changing the underlying map to a concurrent one should make it thread safe, and using the method to synchronize access will make consistent.

This runs only on background, so the extra bit of locking shouldn't affect perf things a great deal.

