### PR TITLE
API to notify SDK when application object created

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -59,6 +59,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Instr
 	public abstract fun addStartupTraceAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun addStartupTraceChildSpan (Ljava/lang/String;JJ)V
 	public abstract fun addStartupTraceChildSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
+	public abstract fun applicationInitEnd ()V
 	public abstract fun getSdkCurrentTimeMs ()J
 }
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
@@ -12,6 +12,13 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 public interface InstrumentationApi {
 
     /**
+     * Notify the Embrace SDK that the application has been fully created. This is typically called at the end of the
+     * Application.onCreate() function. Calling this will allow the SDK to more accurately gather the details of the
+     * trace recorded for app startup.
+     */
+    public fun applicationInitEnd()
+
+    /**
      * Notify the Embrace UI Load instrumentation that the given [Activity] instance has fully loaded, so its associated
      * trace can be stopped
      */

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -12,6 +12,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun addStartupTraceChildSpan (Ljava/lang/String;JJ)V
 	public fun addStartupTraceChildSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
 	public fun addUserPersona (Ljava/lang/String;)V
+	public fun applicationInitEnd ()V
 	public fun clearAllUserPersonas ()V
 	public fun clearUserEmail ()V
 	public fun clearUserIdentifier ()V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -2,14 +2,16 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
+import io.embrace.android.embracesdk.internal.spans.toStatus
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.IntegrationTestRule
@@ -30,6 +32,8 @@ internal class AppStartupTraceTest {
 
     @Test
     fun `startup spans recorded in foreground session when background activity is enabled`() {
+        var sdkStartTimeMs: Long? = null
+        var activityInitStartMs: Long? = null
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(
                 enabledFeatures = FakeEnabledFeatureConfig(
@@ -37,8 +41,9 @@ internal class AppStartupTraceTest {
                 )
             ),
             testCaseAction = {
-                val customStartTimeMs = clock.now()
-                val customEndTimeMs = clock.tick(100L)
+                sdkStartTimeMs = clock.now()
+                val customStartTimeMs = clock.tick()
+                val customEndTimeMs = clock.tick(95L)
                 embrace.addStartupTraceChildSpan("custom-span", customStartTimeMs, customEndTimeMs)
                 embrace.addStartupTraceChildSpan(
                     name = "custom-span-with-stuff",
@@ -57,28 +62,69 @@ internal class AppStartupTraceTest {
                     errorCode = ErrorCode.FAILURE
                 )
                 embrace.addStartupTraceAttribute("custom-attribute", "yes")
+                clock.tick(55)
+                activityInitStartMs = clock.now()
                 simulateOpeningActivities(
                     addStartupActivity = false,
-                    startInBackground = true
+                    startInBackground = true,
+                    endInBackground = false,
                 )
             },
-            assertAction = {
-                with(getSingleSessionEnvelope()) {
-                    val spans = findSpansOfType(EmbType.Performance.Default).associateBy { it.name }
-                    assertTrue(spans.isNotEmpty())
-                    with(checkNotNull(spans["emb-cold-time-to-initial-display"])) {
-                        assertEquals("yes", attributes?.findAttributeValue("custom-attribute"))
-                    }
-                    assertTrue(spans.containsKey("emb-embrace-init"))
-                    assertTrue(spans.containsKey("custom-span"))
-                    with(checkNotNull(spans["custom-span-with-stuff"])) {
-                        assertEquals("attribute", attributes?.findAttributeValue("custom"))
-                        assertEquals(true, attributes?.hasFixedAttribute(ErrorCodeAttribute.Failure))
-                        assertNotNull(events?.single())
-                        assertEquals(Span.Status.ERROR, status)
-                    }
-                    assertTrue(spans.containsKey("emb-activity-create"))
-                    assertTrue(spans.containsKey("emb-activity-resume"))
+            otelExportAssertion = {
+                val spans = awaitSpansWithType(7, EmbType.Performance.Default).associateBy { it.name }
+                assertTrue(spans.isNotEmpty())
+                with(checkNotNull(spans["emb-cold-time-to-initial-display"])) {
+                    assertEquals("yes", attributes.toNewPayload().findAttributeValue("custom-attribute"))
+                }
+                assertTrue(spans.containsKey("emb-embrace-init"))
+                with(checkNotNull(spans["emb-activity-init-gap"])) {
+                    assertEquals(sdkStartTimeMs, startEpochNanos.nanosToMillis())
+                    assertEquals(activityInitStartMs, endEpochNanos.nanosToMillis())
+                }
+                assertTrue(spans.containsKey("custom-span"))
+                with(checkNotNull(spans["custom-span-with-stuff"])) {
+                    val attributesList = attributes.toNewPayload()
+                    assertEquals("attribute", attributesList.findAttributeValue("custom"))
+                    assertEquals(true, attributesList.hasFixedAttribute(ErrorCodeAttribute.Failure))
+                    assertNotNull(events?.single())
+                    assertEquals(Span.Status.ERROR, status.statusCode.toStatus())
+                }
+                assertTrue(spans.containsKey("emb-activity-create"))
+                assertTrue(spans.containsKey("emb-activity-resume"))
+            }
+        )
+    }
+
+    @Test
+    fun `applicationInitEnd call adds extra information`() {
+        var applicationEndTimeMs: Long? = null
+        var activityInitStartMs: Long? = null
+        testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(
+                    bgActivityCapture = true
+                )
+            ),
+            testCaseAction = {
+                clock.tick(44)
+                applicationEndTimeMs = clock.now()
+                embrace.applicationInitEnd()
+                clock.tick(33)
+                activityInitStartMs = clock.now()
+                simulateOpeningActivities(
+                    addStartupActivity = false,
+                    startInBackground = true,
+                    endInBackground = false,
+                )
+            },
+            otelExportAssertion = {
+                val spans = awaitSpansWithType(6, EmbType.Performance.Default).associateBy { it.name }
+                with(checkNotNull(spans["emb-process-init"])) {
+                    assertEquals(applicationEndTimeMs, endEpochNanos.nanosToMillis())
+                }
+                with(checkNotNull(spans["emb-activity-init-gap"])) {
+                    assertEquals(applicationEndTimeMs, startEpochNanos.nanosToMillis())
+                    assertEquals(activityInitStartMs, endEpochNanos.nanosToMillis())
                 }
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -63,6 +63,7 @@ internal class EmbraceActionInterface(
     internal fun simulateOpeningActivities(
         addStartupActivity: Boolean = true,
         startInBackground: Boolean = false,
+        endInBackground: Boolean = true,
         createFirstActivity: Boolean = true,
         invokeManualEnd: Boolean = false,
         activitiesAndActions: List<Pair<ActivityController<*>, () -> Unit>> = listOf(
@@ -123,9 +124,13 @@ internal class EmbraceActionInterface(
             setup.overriddenClock.tick(ACTIVITY_GAP)
             lastActivity = activityController
         }
+
         lastActivity?.stop()
         setup.overriddenClock.tick()
-        onBackground()
+
+        if (endInBackground) {
+            onBackground()
+        }
     }
 
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
@@ -36,7 +36,9 @@ internal class FilteredSpanExporter : SpanExporter {
                 data.size == expectedCount
             },
             errorMessageSupplier = {
-                "Timeout. Expected $expectedCount spans, but got ${supplier().size}."
+                val spans = supplier()
+                "Timeout. Expected $expectedCount spans, but got ${spans.size}. " +
+                    "Found spans: ${spans.joinToString { it.name }}"
             }
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -410,6 +410,10 @@ public class Embrace private constructor(
         impl.trackWebViewPerformance(tag, message)
     }
 
+    override fun applicationInitEnd() {
+        impl.applicationInitEnd()
+    }
+
     override fun logWebView(url: String?) {
         impl.logWebView(url)
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
@@ -22,6 +22,12 @@ internal class InstrumentationApiDelegate(
         bootstrapper.dataCaptureServiceModule.appStartupDataCollector
     }
 
+    override fun applicationInitEnd() {
+        if (sdkCallChecker.check("application_init_end")) {
+            appStartupDataCollector?.applicationInitEnd()
+        }
+    }
+
     override fun activityLoaded(activity: Activity) {
         if (sdkCallChecker.check("activity_fully_loaded")) {
             uiLoadTraceEmitter?.complete(traceInstanceId(activity), clock.now())


### PR DESCRIPTION
## Goal

Add API to notify the SDK when the application object init has ended so we can better estimate the time it takes between the launching of the first activity from when the app object was created.

This makes the heuristic of identifying warm vs cold starts better.
