### PR TITLE
Start render span when first frame callback is attached

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -144,14 +144,21 @@ private class LifecycleEventEmitter(
         if (activity.traceLoad()) {
             val instanceId = traceInstanceId(activity)
             if (drawEventEmitter != null) {
+                val renderStartCallback = {
+                    uiLoadEventListener.render(
+                        instanceId = instanceId,
+                        timestampMs = nowMs()
+                    )
+                }
+
                 // this callback will be cached, so it should not directly reference the Activity instance
-                val callback = {
+                val renderEndCallback = {
                     uiLoadEventListener.renderEnd(
                         instanceId = instanceId,
                         timestampMs = nowMs()
                     )
                 }
-                drawEventEmitter.registerFirstDrawCallback(activity, callback)
+                drawEventEmitter.registerFirstDrawCallback(activity, renderStartCallback, renderEndCallback)
             }
             instanceStartTime[instanceId] = nowMs()
         }
@@ -189,13 +196,6 @@ private class LifecycleEventEmitter(
                 instanceId = traceInstanceId(activity),
                 timestampMs = now
             )
-
-            if (drawEventEmitter != null) {
-                uiLoadEventListener.render(
-                    instanceId = traceInstanceId(activity),
-                    timestampMs = now
-                )
-            }
         }
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -52,7 +52,7 @@ class StartupTracker(
                     collectionCompleteCallback = { startupComplete(application) }
                 )
             }
-            drawEventEmitter?.registerFirstDrawCallback(activity, callback)
+            drawEventEmitter?.registerFirstDrawCallback(activity, {}, callback)
         }
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
@@ -10,7 +10,11 @@ interface DrawEventEmitter {
      * Register the given callback to the UI inside of the given activity instance to be invoked when the first frame
      * has drawn.
      */
-    fun registerFirstDrawCallback(activity: Activity, completionCallback: () -> Unit)
+    fun registerFirstDrawCallback(
+        activity: Activity,
+        drawBeginCallback: () -> Unit,
+        firstFrameDeliveredCallback: () -> Unit
+    )
 
     /**
      * Unregister any first draw callbacks registered for the given Activity instance

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/FirstDrawDetector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/FirstDrawDetector.kt
@@ -27,7 +27,11 @@ class FirstDrawDetector(
 
     private val loadingActivities: MutableMap<Int, () -> Unit> = ConcurrentHashMap()
 
-    override fun registerFirstDrawCallback(activity: Activity, completionCallback: () -> Unit) {
+    override fun registerFirstDrawCallback(
+        activity: Activity,
+        drawBeginCallback: () -> Unit,
+        firstFrameDeliveredCallback: () -> Unit
+    ) {
         val instanceId = traceInstanceId(activity)
         if (!trackingLoad(instanceId)) {
             val window = activity.window
@@ -36,8 +40,9 @@ class FirstDrawDetector(
                     val decorView = window.decorView
                     decorView.onNextDraw {
                         if (!trackingLoad(instanceId)) {
-                            loadingActivities[instanceId] = completionCallback
-                            decorView.viewTreeObserver.registerFrameCommitCallback(completionCallback)
+                            drawBeginCallback()
+                            loadingActivities[instanceId] = firstFrameDeliveredCallback
+                            decorView.viewTreeObserver.registerFrameCommitCallback(firstFrameDeliveredCallback)
                         }
                     }
                 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
@@ -166,18 +166,17 @@ internal class UiLoadExtTest {
         }
     }
 
-    private fun stepThroughActivityLifecycle(
-        isColdOpen: Boolean = true,
-    ) {
+    private fun stepThroughActivityLifecycle(isColdOpen: Boolean = true) {
         with(activityController) {
             if (isColdOpen) {
                 create()
             }
             start()
             resume()
-            if (uiLoadEventListener.events.any { it.stage == "render" }) {
-                clock.tick(RENDER_DURATION)
-                drawEventEmitter.draw(activityController.get())
+            if (BuildVersionChecker.isAtLeast(Build.VERSION_CODES.Q)) {
+                drawEventEmitter.draw(activityController.get()) {
+                    clock.tick(RENDER_DURATION)
+                }
             }
             pause()
             stop()
@@ -190,7 +189,7 @@ internal class UiLoadExtTest {
 
     private fun assertDrawEvents() {
         assertNotNull(drawEventEmitter.lastRegisteredActivity)
-        assertNotNull(drawEventEmitter.lastCallback)
+        assertNotNull(drawEventEmitter.lastFirstFrameDeliveredCallback)
         assertNotNull(drawEventEmitter.lastUnregisteredActivity)
         assertEquals(drawEventEmitter.lastRegisteredActivity, drawEventEmitter.lastRegisteredActivity)
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.export.SpanExporter
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * A [SpanExporter] used in the integration tests that allows retrieving exported spans
@@ -12,7 +13,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
  */
 internal class FilteredSpanExporter : SpanExporter {
 
-    private val spanData = mutableListOf<SpanData>()
+    private val spanData = CopyOnWriteArrayList<SpanData>()
 
     override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
         spanData.addAll(spans)


### PR DESCRIPTION
## Goal

Start the render span when the first frame starts to draw. This more accurately times the duration of the time it takes the frame to be delivered, rather than starting when resume ends.

