### PR TITLE
Disable the use of render events to construct UI load traces for now

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -47,8 +47,11 @@ fun traceInstanceId(activity: Activity): Int = activity.hashCode()
 
 /**
  * Determine if the current instance of the app will fire render events
+ *
+ * Disabled temporarily as we figure out how it interacts with Compose navigation
  */
-fun hasRenderEvent(versionChecker: VersionChecker) = versionChecker.isAtLeast(VERSION_CODES.Q)
+@Suppress("FunctionOnlyReturningConstant", "UNUSED_PARAMETER")
+fun hasRenderEvent(versionChecker: VersionChecker): Boolean = false
 
 /**
  * Determine if the current instance of the app will pre and post lifecycle events

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
@@ -223,17 +223,21 @@ internal class UiLoadExtTest {
                 stage = "resumeEnd",
                 timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
             ),
-            createEvent(
-                stage = "render",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
-            ),
-            createEvent(
-                stage = "renderEnd",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION
-            ),
+//            createEvent(
+//                stage = "render",
+//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
+//            ),
+//            createEvent(
+//                stage = "renderEnd",
+//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION
+//            ),
+//            createEvent(
+//                stage = "discard",
+//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION + PRE_DURATION
+//            ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION + PRE_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + PRE_DURATION
             ),
         )
 
@@ -254,17 +258,21 @@ internal class UiLoadExtTest {
                 stage = "resumeEnd",
                 timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
             ),
-            createEvent(
-                stage = "render",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
-            ),
-            createEvent(
-                stage = "renderEnd",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION
-            ),
+//            createEvent(
+//                stage = "render",
+//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
+//            ),
+//            createEvent(
+//                stage = "renderEnd",
+//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION
+//            ),
+//            createEvent(
+//                stage = "discard",
+//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION + PRE_DURATION
+//            ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION + PRE_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + PRE_DURATION
             ),
         )
 


### PR DESCRIPTION
## Goal

Disable rendering event usage in UI load traces for now, as the way it detects the first frame draw is on the Window's root view, which isn't compatible with Compose navigation. 

This means that for now, all versions of Android will end with the onResume event. 

## Testing

Existing tests pass after adjustments
