### PR TITLE
Use resume end for UI load end for now if possible

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
@@ -46,11 +46,13 @@ import java.util.concurrent.atomic.AtomicReference
  */
 class UiLoadTraceEmitter(
     private val spanService: SpanService,
-    private val versionChecker: VersionChecker,
+    versionChecker: VersionChecker,
 ) : UiLoadDataListener {
 
     private val activeTraces: MutableMap<Int, UiLoadTrace> = ConcurrentHashMap()
     private var currentInstance: AtomicReference<UiInstance?> = AtomicReference()
+    private val hasRenderEvent = hasRenderEvent(versionChecker)
+    private val hasPrePostEvents = hasPrePostEvents(versionChecker)
 
     override fun create(instanceId: Int, activityName: String, timestampMs: Long, manualEnd: Boolean) {
         startTrace(
@@ -99,16 +101,16 @@ class UiLoadTraceEmitter(
     }
 
     override fun resume(instanceId: Int, timestampMs: Long) {
-        if (traceCompleteTrigger(instanceId) == TraceCompleteTrigger.RESUME) {
-            endTrace(
-                instanceId = instanceId,
-                timestampMs = timestampMs,
-            )
-        } else if (hasRenderEvent(versionChecker)) {
+        if (hasPrePostEvents) {
             startChildSpan(
                 instanceId = instanceId,
                 timestampMs = timestampMs,
                 lifecycleStage = LifecycleStage.RESUME
+            )
+        } else if (traceCompleteTrigger(instanceId) == TraceCompleteTrigger.RESUME) {
+            endTrace(
+                instanceId = instanceId,
+                timestampMs = timestampMs,
             )
         }
     }
@@ -119,28 +121,39 @@ class UiLoadTraceEmitter(
             timestampMs = timestampMs,
             lifecycleStage = LifecycleStage.RESUME
         )
-    }
 
-    override fun render(instanceId: Int, timestampMs: Long) {
-        startChildSpan(
-            instanceId = instanceId,
-            timestampMs = timestampMs,
-            lifecycleStage = LifecycleStage.RENDER
-        )
-    }
-
-    override fun renderEnd(instanceId: Int, timestampMs: Long) {
-        endChildSpan(
-            instanceId = instanceId,
-            timestampMs = timestampMs,
-            lifecycleStage = LifecycleStage.RENDER
-        )
-
-        if (traceCompleteTrigger(instanceId) == TraceCompleteTrigger.RENDER) {
+        if (traceCompleteTrigger(instanceId) == TraceCompleteTrigger.RESUME) {
             endTrace(
                 instanceId = instanceId,
                 timestampMs = timestampMs,
             )
+        }
+    }
+
+    override fun render(instanceId: Int, timestampMs: Long) {
+        if (hasRenderEvent) {
+            startChildSpan(
+                instanceId = instanceId,
+                timestampMs = timestampMs,
+                lifecycleStage = LifecycleStage.RENDER
+            )
+        }
+    }
+
+    override fun renderEnd(instanceId: Int, timestampMs: Long) {
+        if (hasRenderEvent) {
+            endChildSpan(
+                instanceId = instanceId,
+                timestampMs = timestampMs,
+                lifecycleStage = LifecycleStage.RENDER
+            )
+
+            if (traceCompleteTrigger(instanceId) == TraceCompleteTrigger.RENDER) {
+                endTrace(
+                    instanceId = instanceId,
+                    timestampMs = timestampMs,
+                )
+            }
         }
     }
 
@@ -221,7 +234,7 @@ class UiLoadTraceEmitter(
     private fun determineEndEvent(manualEnd: Boolean): TraceCompleteTrigger {
         return if (manualEnd) {
             TraceCompleteTrigger.MANUAL
-        } else if (hasRenderEvent(versionChecker)) {
+        } else if (hasRenderEvent) {
             TraceCompleteTrigger.RENDER
         } else {
             TraceCompleteTrigger.RESUME


### PR DESCRIPTION
## Goal

End UI load traces on `postResume` for API versions that support it. This will allow us to track the duration for all onResume callbacks.

## Testing
Existing tests passed after adjustment