### PR TITLE
Move gradle plugin check to a different step in build-rc-workflow.yml

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -82,9 +82,13 @@ jobs:
           ref: release/${{ github.event.inputs.version_of_rc }}
           token: ${{ secrets.GH_EMBRACE_SWAZZLER3_TOKEN }}
 
+      - name: Run gradle plugin tests
+        run: |
+          ./gradlew clean check -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
+
       - name: Generate Swazzler RC - Publish and Close repository
         run: |
-          ./gradlew clean check publishToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
+          ./gradlew clean publishToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
 
       - name: Set version tag in Swazzler
         run: |


### PR DESCRIPTION
If we run check along publishToSonatype, the gradle integration test plugin won't be installed, and the tests will fail