### PR TITLE
Add proguard rules for FCM capture

### DIFF
--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -33,10 +33,13 @@
 -keep class okhttp3.OkHttp { *; }
 -keep class okhttp3.OkHttpClient { *; }
 
-## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) at compile time. No need to keep them for runtime.
+## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) and features (FCM capture) at compile time.
+## No need to keep them for runtime.
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.errorprone.annotations.MustBeClosed
+-dontwarn com.google.firebase.messaging.RemoteMessage$Notification
+-dontwarn com.google.firebase.messaging.RemoteMessage
 
 ## Keep swazzler hooks
 -keep class io.embrace.android.embracesdk.okhttp3.** { *; }


### PR DESCRIPTION
Without those rules, enabling FCM capture with a proguard build resulted in a compilation error