### PR TITLE
Avoid running tests on RC workflow

### DIFF
--- a/.github/workflows/build-rc-workflow.yml
+++ b/.github/workflows/build-rc-workflow.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Generate Swazzler RC - Publish and Close repository
         run: |
-          ./gradlew clean check publishToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
+          ./gradlew clean publishToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
 
       - name: Set version tag in Swazzler
         run: |


### PR DESCRIPTION
## Goal

Avoids running tests on the RC workflow for consistency between the SDK + swazzler process.
