### PR TITLE
Disable daily run of publish-snapshot.yml

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,8 +6,6 @@ env:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 3 * * *'
 
 jobs:
   functional:


### PR DESCRIPTION
It's been failing for months so I'm guessing nobody really uses it

