### PR TITLE
Expose OpenTelemetry span and trace ID

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/InternalTracer.kt
@@ -97,6 +97,14 @@ class InternalTracer(
             value = value
         ) ?: false
 
+    override fun getSpanUnderlyingSpanId(spanId: String): String? {
+        return spanRepository.getSpan(spanId = spanId)?.spanId
+    }
+
+    override fun getSpanUnderlyingTraceId(spanId: String): String? {
+        return spanRepository.getSpan(spanId = spanId)?.traceId
+    }
+
     private fun mapToEvent(map: Map<String, Any>): EmbraceSpanEvent? {
         val name = map["name"]
         val timestampMs = map["timestampMs"] as? Long?

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/InternalTracingApi.kt
@@ -46,6 +46,16 @@ interface InternalTracingApi {
     ): Boolean
 
     /**
+     * Gets the OpenTelemetry span ID for the given [spanId].
+     */
+    fun getSpanUnderlyingSpanId(spanId: String): String?
+
+    /**
+     * Gets the OpenTelemetry trace ID  for the given [spanId].
+     */
+    fun getSpanUnderlyingTraceId(spanId: String): String?
+
+    /**
      * Record a span around the execution of the given lambda. If an uncaught exception occurs during the execution, the span will be
      * terminated as a failure.
      *

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopInternalTracingApi.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopInternalTracingApi.kt
@@ -25,6 +25,14 @@ internal class NoopInternalTracingApi : InternalTracingApi {
         return false
     }
 
+    override fun getSpanUnderlyingSpanId(spanId: String): String? {
+        return null
+    }
+
+    override fun getSpanUnderlyingTraceId(spanId: String): String? {
+        return null
+    }
+
     override fun <T> recordSpan(
         name: String,
         parentSpanId: String?,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
@@ -123,6 +123,14 @@ class FakeEmbraceInternalInterface(
         return true
     }
 
+    override fun getSpanUnderlyingSpanId(spanId: String): String? {
+        return null
+    }
+
+    override fun getSpanUnderlyingTraceId(spanId: String): String? {
+        return null
+    }
+
     override fun <T> recordSpan(
         name: String,
         parentSpanId: String?,


### PR DESCRIPTION
## Goal

Expose an API to access the OpenTelemetry trace and span IDs. This allows greater flexibility when integrating with custom observability components. For example, this allows us to create `traceparent` headers for distributed tracing.

## Testing

Not much to test.

