### PR TITLE
Bump max metaspace

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 description="Embrace Android SDK"
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g
 org.gradle.parallel=true
 version=7.2.0-SNAPSHOT
 android.useAndroidX=true


### PR DESCRIPTION
## Goal

Bumps the max metaspace to 2Gb in an attempt to workaround intermittent local build failures.
