### PR TITLE
Remove incorrect token setting in baseline profile workflow

### DIFF
--- a/.github/workflows/generate-baseline-profile.yml
+++ b/.github/workflows/generate-baseline-profile.yml
@@ -51,7 +51,7 @@ jobs:
           repository: embrace-io/android-sdk-benchmark
           ref: main
           path: ./android-sdk-benchmark
-          token: ${{ secrets.GH_ANDROID_SDK_TOKEN || secrets.token }} # NOTE: read android-sdk-benchmark
+          token: ${{ secrets.GH_ANDROID_SDK_TOKEN }} # NOTE: read android-sdk-benchmark
 
       - name: Clean Managed Devices
         working-directory: android-sdk-benchmark


### PR DESCRIPTION
## Goal

Removes incorrect syntax for setting a token in the baseline profile workflow

