### PR TITLE
Add example app instrumented test workflow

### DIFF
--- a/.github/workflows/example-app-emulator-tests.yml
+++ b/.github/workflows/example-app-emulator-tests.yml
@@ -1,0 +1,79 @@
+name: Run example app on android emulator
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        api-level: [29]
+        target: [default]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Cache the emulator
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run tests on android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          working-directory: examples/ExampleApp
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: ./gradlew connectedCheck --stacktrace
+
+      - name: Archive Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-app-test-results
+          path: |
+            examples/ExampleApp/build/reports/androidTests/connected

--- a/examples/ExampleApp/app/src/androidTest/kotlin/io/embrace/android/example/SmokeTest.kt
+++ b/examples/ExampleApp/app/src/androidTest/kotlin/io/embrace/android/example/SmokeTest.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.example
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.exampleapp.MainActivity
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SmokeTest {
+
+    @Test
+    fun testActivityLaunches() {
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+
+        scenario.onActivity { activity ->
+            assertNotNull("Activity should not be null", activity)
+        }
+        scenario.close()
+    }
+}


### PR DESCRIPTION
## Goal

Adds a workflow that runs a smoke test to confirm the example app can launch its activity. This should allow us to merge dependabot PRs with more confidence.
