### PR TITLE
Configure codecov plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.android.library") apply false
     alias(libs.plugins.nexus.publish)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kover)
 }
 
 group = "io.embrace"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     implementation(libs.agp)
     implementation(libs.detekt.gradle.plugin)
     implementation(libs.binary.compatibility.validator)
-    implementation(libs.kover.gradle.plugin)
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/kotlin/io/embrace/internal/ProductionModuleConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/internal/ProductionModuleConfig.kt
@@ -72,8 +72,6 @@ fun Project.configureProductionModule(
         add("androidTestImplementation", findLibrary("androidx.test.core"))
         add("androidTestImplementation", findLibrary("androidx.test.runner"))
         add("androidTestUtil", findLibrary("androidx.test.orchestrator"))
-
-        add("kover", project)
     }
 
     project.afterEvaluate {

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -1,3 +1,5 @@
+import io.embrace.internal.EmbraceBuildLogicExtension
+
 plugins {
     id("com.android.library")
     id("kotlin-android")
@@ -41,6 +43,23 @@ kover {
             xml {}
         }
     }
+}
+
+val codeCoverageModules = listOf( // FIXME: future: add gradle plugin to code coverage
+    ":embrace-android-api",
+    ":embrace-internal-api",
+    ":embrace-android-sdk",
+    ":embrace-android-core",
+    ":embrace-android-infra",
+    ":embrace-android-features",
+    ":embrace-android-payload",
+    ":embrace-android-delivery",
+    ":embrace-android-okhttp3",
+    ":embrace-android-fcm",
+    ":embrace-android-compose",
+)
+codeCoverageModules.forEach { projectName ->
+    dependencies.add("kover", project(projectName))
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,6 @@ binary-compatibility-validator = { module = "org.jetbrains.kotlinx:binary-compat
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektGradlePlugin" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
-kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "koverGradlePlugin" }
 lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 lifecycle-compiler = { group = "androidx.lifecycle", name = "lifecycle-compiler", version.ref = "lifecycle" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
@@ -93,3 +92,4 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "koverGradlePlugin" }


### PR DESCRIPTION
## Goal

Configures the codecov plugin so that coverage is aggregated into one report rather than just using coverage from one module.

I wasn't able to get this working instantly with the gradle plugin module, [possibly due to this issue](https://github.com/Kotlin/kotlinx-kover/issues/728), so I'd suggest we just stick with our previous behavior & fix this when I have a bit more time to investigate what's going wrong.
