### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/upload-artifacts-to-sonatype.yml
+++ b/.github/workflows/upload-artifacts-to-sonatype.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Publish and close Sonatype repository
         run: |
-          ./gradlew clean :embrace-gradle-plugin:publishToSonatype publishReleasePublicationToSonatype closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
+          ./gradlew publishAllPublicationsToSonatypeRepository -x embrace-gradle-plugin-integration-tests:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository -Dorg.gradle.parallel=false --no-build-cache --no-configuration-cache --stacktrace
 
       - name: Publish git tag
         run: |

--- a/embrace-gradle-plugin/build.gradle.kts
+++ b/embrace-gradle-plugin/build.gradle.kts
@@ -43,10 +43,15 @@ allprojects {
     extra["signing.password"] = System.getenv("mavenSigningKeyPassword")
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 // marker artifact publication
 gradlePlugin {
     plugins {
-        create("swazzlerPlugin") {
+        create("embraceGradle") {
             id = "io.embrace.swazzler"
             group = "io.embrace"
             implementationClass = "io.embrace.android.gradle.plugin.EmbraceGradlePlugin"
@@ -64,7 +69,7 @@ publishing {
                 artifactId = "embrace-swazzler"
                 name = "embrace-swazzler"
                 group = "io.embrace"
-                description = "Embrace Swazzler Gradle Plugin"
+                description = "Embrace Gradle Plugin"
                 url = "https://github.com/embrace-io/embrace-android-sdk"
                 licenses {
                     license {
@@ -87,10 +92,10 @@ publishing {
             }
         }
     }
-    // I need afterEvaluate otherwise it does not find swazzlerPluginPluginMarkerMaven
+
     afterEvaluate {
         publications {
-            named<MavenPublication>("swazzlerPluginPluginMarkerMaven") {
+            named<MavenPublication>("embraceGradlePluginMarkerMaven") {
                 pom {
                     name = "embrace-swazzler"
                     artifactId = "io.embrace.swazzler.gradle.plugin"
@@ -119,8 +124,8 @@ publishing {
             }
         }
         signing {
-            setRequired { gradle.taskGraph.hasTask("publishSwazzlerPluginPluginMarkerMavenPublicationToSonatypeRepository") }
-            sign(publishing.publications["swazzlerPluginPluginMarkerMaven"])
+            setRequired { gradle.taskGraph.hasTask("publishEmbraceGradlePluginMarkerMavenPublicationToSonatypeRepository") }
+            sign(publishing.publications["embraceGradlePluginMarkerMaven"])
         }
     }
 


### PR DESCRIPTION
## Goal

Fixes the publishing workflow on CI by ensuring javadoc + source JARs are added to the publication for the gradle plugin. Additionally prevent the integration test plugin from getting uploaded by removing the task from execution in the CI workflow.

## Testing

Ran the workflow and confirmed artifacts were uploaded in a closed state & an example app could compile with them: https://github.com/embrace-io/embrace-android-sdk/actions/runs/13369659964

