### PR TITLE
Use same kotlin version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,6 @@ nexus = "1.3.0"
 appcompat = "1.7.0"
 asmUtil = "9.7"
 gradleTestKit = "8.11.1"
-kotlin = "2.1.0"
 zstdJni = "1.5.6-10"
 detekt = "1.23.7"
 buildconfig = "5.5.1"
@@ -91,5 +90,5 @@ agp-library = { id = "com.android.library", version.ref = "agp" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinGradlePlugin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "koverGradlePlugin" }


### PR DESCRIPTION
## Goal

Use the same Kotlin version in the version catalog rather than defining versions in 2 places. This does not affect the Kotlin version exposed to consumers.

