### PR TITLE
Fix RN mapping file JSON bug

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/RnSourcemapTaskIntegrationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/RnSourcemapTaskIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.integration.testcases
 
+import com.squareup.moshi.JsonClass
 import io.embrace.android.gradle.integration.framework.IntegrationTestDefaults
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.buildFile
@@ -10,10 +11,14 @@ import io.embrace.android.gradle.network.validateBodyAppId
 import io.embrace.android.gradle.network.validateBodyBuildId
 import io.embrace.android.gradle.network.validateMappingFile
 import io.embrace.android.gradle.plugin.network.EmbraceEndpoint
+import io.embrace.android.gradle.plugin.util.serialization.MoshiSerializer
+import okio.buffer
+import okio.gzip
+import okio.source
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import java.io.File
 
 class RnSourcemapTaskIntegrationTest {
 
@@ -27,14 +32,12 @@ class RnSourcemapTaskIntegrationTest {
             fixture = "rn-upload-simple",
             assertions = { projectDir ->
                 // 1. assert that RN bundle ID was injected as a string resource
-                val symbols =
-                    projectDir.buildFile("generated-embrace-resources/values/rn_sourcemap.xml")
+                val symbols = projectDir.buildFile("generated-embrace-resources/values/rn_sourcemap.xml")
                 val expectedResXml = projectDir.file("expected/rn_sourcemap.xml").readText()
                 assertEquals(expectedResXml, symbols.readText())
 
                 // 2. assert that the task output was the bundle + sourcemap file zipped as JSON
-                val output = projectDir.buildFile("output")
-                assertTrue(output.exists() && output.length() > 0)
+                verifyOutputFile(projectDir.buildFile("output"))
 
                 // 3. assert that a request took place
                 val request = fetchRequest(EmbraceEndpoint.SOURCE_MAP)
@@ -50,4 +53,17 @@ class RnSourcemapTaskIntegrationTest {
             }
         )
     }
+
+    private fun verifyOutputFile(outputFile: File) {
+        // unzip the file - this will fail if the file is not gzipped
+        outputFile.source().gzip().buffer().use { source ->
+            // deserialize the JSON - this will fail if the JSON is not valid
+            val bundleAndSourceMap = MoshiSerializer().fromJson(source.readUtf8(), BundleAndSourceMap::class.java)
+            assertEquals("Fake bundle", bundleAndSourceMap.bundle)
+            assertEquals("Fake sourcemap", bundleAndSourceMap.sourcemap)
+        }
+    }
 }
+
+@JsonClass(generateAdapter = true)
+data class BundleAndSourceMap(val bundle: String, val sourcemap: String)


### PR DESCRIPTION
## Goal

We introduced a bug in the gradle plugin in 7.1.0 that caused the sourcemap file we send to the backend to be invalid. We were writing binary data to the JSON directly, without formatting it as a string.

## Testing

I corrected the integration test that verified this behavior, and asserted that now symbols are now parsed correctly in the backend.

