### PR TITLE
Remove symbolsDir and projectType from EmbraceExtensionInternal and pass them directly to NdkTaskRegistration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
 [*]
 insert_final_newline = true
-max_line_length = 120
+max_line_length = 140
 ij_continuation_indent_size = 4
-ij_visual_guides = 120
+ij_visual_guides = 140
 
 [*.java]
 ij_java_class_count_to_use_import_on_demand = 99

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
 [*]
 insert_final_newline = true
-max_line_length = 140
+max_line_length = 120
 ij_continuation_indent_size = 4
-ij_visual_guides = 140
+ij_visual_guides = 120
 
 [*.java]
 ij_java_class_count_to_use_import_on_demand = 99

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/extension/EmbraceExtensionInternal.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/extension/EmbraceExtensionInternal.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.gradle.plugin.extension
 
-import io.embrace.android.gradle.plugin.config.ProjectType
-import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectContainer
@@ -33,14 +31,9 @@ abstract class EmbraceExtensionInternal(
         // convention(EmbraceExtensionInternal.getAppId())
         val config: Property<VariantConfig> = objectFactory.property(VariantConfig::class.java)
 
-        val projectType: Property<ProjectType> = objectFactory.property(ProjectType::class.java)
-        val unitySymbolsDir: Property<UnitySymbolsDir?> = objectFactory.property(UnitySymbolsDir::class.java)
-
         // we need this because older gradle can not inject ObjectFactory
         fun initialize() {
             config.finalizeValueOnRead()
-            projectType.finalizeValueOnRead()
-            unitySymbolsDir.finalizeValueOnRead()
         }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/extension/EmbraceExtensionInternalSource.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/extension/EmbraceExtensionInternalSource.kt
@@ -1,8 +1,5 @@
 package io.embrace.android.gradle.plugin.extension
 
-import io.embrace.android.gradle.plugin.agp.AgpWrapper
-import io.embrace.android.gradle.plugin.agp.AgpWrapperImpl
-import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurationBuilder
 import io.embrace.android.gradle.plugin.extension.utils.VariantConfigurationToEmbraceExtensionInternal
 import io.embrace.android.gradle.plugin.gradle.GradleCompatibilityHelper
@@ -16,7 +13,6 @@ class EmbraceExtensionInternalSource {
 
     fun setupExtension(
         project: Project,
-        behavior: PluginBehavior,
         variant: AndroidCompactedVariantData,
         embraceVariantConfigurationBuilder: EmbraceVariantConfigurationBuilder,
         variantConfigurationsListProperty: ListProperty<VariantConfig>,
@@ -39,9 +35,7 @@ class EmbraceExtensionInternalSource {
         configureEmbraceExtensionInternalForVariant(
             variant,
             fullVariantConfiguration,
-            AgpWrapperImpl(project),
             project,
-            behavior,
         )
 
         // let's add configuration for current variant to our property
@@ -54,19 +48,14 @@ class EmbraceExtensionInternalSource {
     private fun configureEmbraceExtensionInternalForVariant(
         variantInfo: AndroidCompactedVariantData,
         variantConfigProvider: Provider<VariantConfig>,
-        agpWrapper: AgpWrapper,
         project: Project,
-        behavior: PluginBehavior,
     ) {
         with(project.extensions) {
             configure(
                 EmbraceExtensionInternal::class.java,
                 VariantConfigurationToEmbraceExtensionInternal(
                     variantInfo,
-                    variantConfigProvider,
-                    agpWrapper,
-                    behavior,
-                    project
+                    variantConfigProvider
                 )
             )
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/extension/utils/VariantConfigurationToEmbraceExtensionInternal.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/extension/utils/VariantConfigurationToEmbraceExtensionInternal.kt
@@ -1,14 +1,8 @@
 package io.embrace.android.gradle.plugin.extension.utils
 
-import io.embrace.android.gradle.plugin.agp.AgpWrapper
-import io.embrace.android.gradle.plugin.config.PluginBehavior
-import io.embrace.android.gradle.plugin.config.ProjectTypeVerifier
-import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
 import io.embrace.android.gradle.plugin.extension.EmbraceExtensionInternal
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
-import io.embrace.android.gradle.plugin.tasks.il2cpp.UnitySymbolFilesManager
-import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 
 /**
@@ -17,47 +11,12 @@ import org.gradle.api.provider.Provider
 class VariantConfigurationToEmbraceExtensionInternal(
     private val variantInfo: AndroidCompactedVariantData,
     private val variantConfigProvider: Provider<VariantConfig>,
-    private val agpWrapper: AgpWrapper,
-    private val behavior: PluginBehavior,
-    private val project: Project
 ) : BaseVariantToEmbraceExtensionInternal(variantInfo.name) {
 
     override fun setupVariant(extension: EmbraceExtensionInternal) {
         extension.variants.named(variantInfo.name).configure {
             // properties from variant configuration
             it.config.set(variantConfigProvider)
-
-            val symbolsDir = getSymbolsDir()
-            val projectType = getProjectType(symbolsDir)
-
-            it.unitySymbolsDir.set(symbolsDir)
-            it.projectType.set(projectType)
         }
-    }
-
-    // there is no need to let Gradle know about the knowledge of how to get unitySymbolsDir, because
-    // all properties that getSymbolsDir depends on are already config-cache aware. Meaning that if any
-    // of the properties that this function uses changes, Gradle will invalidate config cache.
-    private fun getSymbolsDir(): Provider<UnitySymbolsDir> = project.provider {
-        val unityConfig = if (variantConfigProvider.isPresent) {
-            variantConfigProvider.get().embraceConfig?.unityConfig
-        } else {
-            null
-        }
-
-        val realProject = project.parent ?: project
-        UnitySymbolFilesManager.of().getSymbolsDir(
-            realProject.layout.projectDirectory,
-            project.layout.projectDirectory,
-            unityConfig
-        )
-    }
-
-    private fun getProjectType(symbolsDir: Provider<UnitySymbolsDir>) = project.provider {
-        ProjectTypeVerifier.getProjectType(
-            symbolsDir,
-            agpWrapper,
-            behavior,
-        )
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTaskRegistration.kt
@@ -2,6 +2,7 @@ package io.embrace.android.gradle.plugin.tasks.ndk
 
 import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.config.ProjectType
+import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
 import io.embrace.android.gradle.plugin.gradle.isTaskRegistered
 import io.embrace.android.gradle.plugin.gradle.nullSafeMap
 import io.embrace.android.gradle.plugin.gradle.registerTask
@@ -24,6 +25,8 @@ private const val GENERATED_RESOURCE_PATH = "generated/embrace/res"
  */
 class NdkUploadTaskRegistration(
     private val behavior: PluginBehavior,
+    private val unitySymbolsDir: Provider<UnitySymbolsDir>,
+    private val projectType: Provider<ProjectType>
 ) : EmbraceTaskRegistration {
 
     override fun register(params: RegistrationParams) {
@@ -67,9 +70,9 @@ class NdkUploadTaskRegistration(
             )
 
             task.unitySymbolsDir.set(
-                variantExtension.projectType.nullSafeMap {
+                projectType.nullSafeMap {
                     when (it) {
-                        ProjectType.UNITY -> variantExtension.unitySymbolsDir.orNull
+                        ProjectType.UNITY -> unitySymbolsDir.orNull
                         else -> null
                     }
                 }
@@ -125,7 +128,7 @@ class NdkUploadTaskRegistration(
         ndkUploadTaskProvider.configure { ndkUploadTask: NdkUploadTask ->
             ndkUploadTask.onlyIf { variantExtension.config.orNull?.embraceConfig?.ndkEnabled ?: true }
             ndkUploadTask.ndkType.set(
-                variantExtension.projectType.map {
+                projectType.map {
                     when (it) {
                         ProjectType.UNITY -> NdkType.UNITY
                         ProjectType.NATIVE -> {

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
@@ -44,7 +44,10 @@ class NdkUploadTaskRegistrationTest {
         }
     }
 
-    private fun createExtension(project: Project, ndkEnabled: Boolean, projectType: ProjectType): EmbraceExtensionInternal {
+    private fun createExtension(
+        project: Project,
+        ndkEnabled: Boolean
+    ): EmbraceExtensionInternal {
         val extension = project.extensions.create(
             EXTENSION_EMBRACE_INTERNAL,
             EmbraceExtensionInternal::class.java,
@@ -69,8 +72,6 @@ class NdkUploadTaskRegistrationTest {
                     )
                 )
             )
-            newVariant.projectType.set(projectType)
-            newVariant.unitySymbolsDir.set(unitySymbolsDir)
         }
 
         return extension
@@ -90,9 +91,12 @@ class NdkUploadTaskRegistrationTest {
         }
         val project = ProjectBuilder.builder().build()
 
-        val extension = createExtension(project, false, ProjectType.UNITY)
+        val extension = createExtension(project, false)
+        val unitySymbolsDirProvider = project.provider { unitySymbolsDir }
+        val projectTypeProvider = project.provider { ProjectType.UNITY }
 
-        val registration = NdkUploadTaskRegistration(mockk(relaxed = true))
+        val registration =
+            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             mockk(relaxed = true),
@@ -121,9 +125,12 @@ class NdkUploadTaskRegistrationTest {
             every { name } returns "variantName"
         }
 
-        val extension = createExtension(project, true, ProjectType.NATIVE)
+        val extension = createExtension(project, true)
+        val unitySymbolsDirProvider = project.provider { unitySymbolsDir }
+        val projectTypeProvider = project.provider { ProjectType.NATIVE }
 
-        val registration = NdkUploadTaskRegistration(mockk(relaxed = true))
+        val registration =
+            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             mockk(relaxed = true),
@@ -163,11 +170,15 @@ class NdkUploadTaskRegistrationTest {
         val transformNativeLibsTaskName =
             "transformNativeLibsWithMergeJniLibsFor${variant.name.capitalizedString()}"
 
-        val extension = createExtension(project, true, ProjectType.UNITY)
+        val extension = createExtension(project, true)
 
         registerTestTask(project, transformNativeLibsTaskName)
 
-        val registration = NdkUploadTaskRegistration(mockk(relaxed = true))
+        val unitySymbolsDirProvider = project.provider { unitySymbolsDir }
+        val projectTypeProvider = project.provider { ProjectType.UNITY }
+
+        val registration =
+            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             mockk(relaxed = true),
@@ -216,9 +227,13 @@ class NdkUploadTaskRegistrationTest {
             "merge${variant.name.capitalizedString()}NativeLibs"
 
         registerTestTask(project, mergeNativeLibs)
-        val extension = createExtension(project, true, ProjectType.UNITY)
+        val extension = createExtension(project, true)
 
-        val registration = NdkUploadTaskRegistration(mockk(relaxed = true))
+        val unitySymbolsDirProvider = project.provider { unitySymbolsDir }
+        val projectTypeProvider = project.provider { ProjectType.UNITY }
+
+        val registration =
+            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             mockk(relaxed = true),
@@ -257,9 +272,13 @@ class NdkUploadTaskRegistrationTest {
         val variant = mockk<AndroidCompactedVariantData>(relaxed = true) {
             every { name } returns "variantName"
         }
-        val extension = createExtension(project, true, ProjectType.NATIVE)
+        val extension = createExtension(project, true)
 
-        val registration = NdkUploadTaskRegistration(mockk(relaxed = true))
+        val unitySymbolsDirProvider = project.provider { unitySymbolsDir }
+        val projectTypeProvider = project.provider { ProjectType.NATIVE }
+
+        val registration =
+            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             mockk(relaxed = true),
@@ -283,9 +302,13 @@ class NdkUploadTaskRegistrationTest {
             every { name } returns "variantName"
         }
 
-        val extension = createExtension(project, true, ProjectType.NATIVE)
+        val extension = createExtension(project, true)
 
-        val registration = NdkUploadTaskRegistration(mockk(relaxed = true))
+        val unitySymbolsDirProvider = project.provider { unitySymbolsDir }
+        val projectTypeProvider = project.provider { ProjectType.NATIVE }
+
+        val registration =
+            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             mockk(relaxed = true),
@@ -318,9 +341,13 @@ class NdkUploadTaskRegistrationTest {
             every { name } returns "variantName"
         }
 
-        val extension = createExtension(project, true, ProjectType.UNITY)
+        val extension = createExtension(project, true)
 
-        val registration = NdkUploadTaskRegistration(mockk(relaxed = true))
+        val unitySymbolsDirProvider = project.provider { unitySymbolsDir }
+        val projectTypeProvider = project.provider { ProjectType.UNITY }
+
+        val registration =
+            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             mockk(relaxed = true),


### PR DESCRIPTION
## Goal

symbolsDir and projectType are only used in NdkUploadTaskRegistration so I added them as parameters wrapped in providers to not realize them too soon.

## Testing

Relied in existing testing
