### PR TITLE
Use VariantConfigurationListProperty instead of EmbraceExtensionInternal

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -51,7 +51,7 @@ class EmbraceGradlePluginDelegate {
         )
 
         // bytecode instrumentation must be registered before project evaluation
-        registerAsmTasks(project, behavior)
+        registerAsmTasks(project, behavior, variantConfigurationsListProperty)
 
         val embraceVariantConfigurationBuilder =
             EmbraceVariantConfigurationBuilder(

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -41,9 +41,6 @@ class EmbraceGradlePluginDelegate {
             project.objects
         )
 
-        // we don't want anyone to update it once it's read
-        variantConfigurationsListProperty.finalizeValueOnRead()
-
         BuildTelemetryService.register(
             project,
             variantConfigurationsListProperty,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/VariantConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/VariantConfig.kt
@@ -11,7 +11,7 @@ import java.io.Serializable
  */
 @JsonClass(generateAdapter = true)
 data class VariantConfig(
-    val variantName: String? = null,
+    val variantName: String,
     val variantVersion: String? = null,
     val buildId: String? = null,
     val buildType: String? = null,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/EmbraceRnSourcemapGeneratorTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/EmbraceRnSourcemapGeneratorTaskRegistration.kt
@@ -79,19 +79,19 @@ class EmbraceRnSourcemapGeneratorTaskRegistration : EmbraceTaskRegistration {
     }
 
     private fun RegistrationParams.createRnSourcemapGeneratorTaskProvider(
-        generatorTask: TaskProvider<Task>
+        generatorTask: TaskProvider<Task>,
     ) = project.registerTask(
         SOURCEMAP_GENERATOR_NAME,
         EmbraceRnSourcemapGeneratorTask::class.java,
         data
     ) { rnTask ->
         try {
-            val variantExtension = extension.variants.getByName(variant.name)
+            val embraceConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }.embraceConfig
             rnTask.requestParams.set(
                 project.provider {
                     RequestParams(
-                        appId = variantExtension.config.orNull?.embraceConfig?.appId.orEmpty(),
-                        apiToken = variantExtension.config.orNull?.embraceConfig?.apiToken.orEmpty(),
+                        appId = embraceConfig?.appId.orEmpty(),
+                        apiToken = embraceConfig?.apiToken.orEmpty(),
                         endpoint = EmbraceEndpoint.SOURCE_MAP,
                         fileName = FILE_NAME_SOURCE_MAP_JSON,
                         baseUrl = baseUrl,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/RegistrationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/RegistrationParams.kt
@@ -1,16 +1,17 @@
 package io.embrace.android.gradle.plugin.tasks.registration
 
 import com.android.build.api.variant.Variant
-import io.embrace.android.gradle.plugin.extension.EmbraceExtensionInternal
+import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
 import io.embrace.android.gradle.plugin.network.NetworkService
 import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
 
 class RegistrationParams(
     val project: Project,
     val variant: Variant,
     val data: AndroidCompactedVariantData,
     val networkService: NetworkService,
-    val extension: EmbraceExtensionInternal,
+    val variantConfigurationsListProperty: ListProperty<VariantConfig>,
     val baseUrl: String,
 )

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/VariantConfigDeserializerTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/VariantConfigDeserializerTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.gradle.plugin.config
 
 import io.embrace.android.gradle.ResourceReader
-import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import io.embrace.android.gradle.plugin.instrumentation.config.model.EmbraceVariantConfig
 import io.embrace.android.gradle.plugin.util.serialization.MoshiSerializer
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -10,8 +10,9 @@ class VariantConfigDeserializerTest {
 
     @Test
     fun testSDKConfiguration() {
+        // TODO: this test doesn't make sense
         val configFile = ResourceReader.readResourceAsText("config_file_expected.json")
-        val obj = MoshiSerializer().fromJson(configFile, VariantConfig::class.java)
+        val obj = MoshiSerializer().fromJson(configFile, EmbraceVariantConfig::class.java)
         assertNotNull(obj)
     }
 }


### PR DESCRIPTION
Replace uses of EmbraceExtensionInternal.config with variantConfigurationListProperty.

We were using the config property of EmbraceExtensionInternal all across the task registration code. I replaced it with variantConfigurationListProperty, and I'll remove EmbraceExtensionInternal in a following PR.

Some considerations: 
- Before these changes, variantConfigurationListProperty was realized pretty late, as it was only used in a provider in the telemetry service. Now, it's resolved quite early, in the same fashion as the EmbraceExtensionInternal config was resolved. We should look into it and try to delay the access to the config, though it'll be quite hard because we need to consult it quite often to know if tasks should be registered.
- NdkUploadTaskRegistrationTest are quite bad, we should work on them in a separate PR.
- VariantConfigDeserializerTest isn't really testing anything. We should upgrade it or delete it.