### PR TITLE
Throw an exception when building with a Gradle version lower than the minimum supported

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.gradle.config.TestMatrix.NewerVersion
 import io.embrace.android.gradle.config.TestMatrix.OlderVersion
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.ProjectType
+import io.embrace.android.gradle.plugin.gradle.GradleVersion
 import org.junit.Rule
 import org.junit.Test
 
@@ -31,6 +32,20 @@ class AgpSupportTest {
 
     @Test
     fun `maximum supported version`() = runTest(MaxVersion)
+
+    @Test
+    fun `unsupported old version`() {
+        rule.runTest(
+            fixture = "android-version-support",
+            task = "assembleRelease",
+            testMatrix = TestMatrix.UnsupportedOldGradleVersion,
+            projectType = ProjectType.ANDROID,
+            expectedExceptionMessage = "Embrace Gradle Plugin requires Gradle version ${GradleVersion.MIN_VERSION} or newer",
+            assertions = {
+                verifyNoUploads()
+            }
+        )
+    }
 
     private fun runTest(testMatrix: TestMatrix) {
         rule.runTest(

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.gradle.plugin
 
+import io.embrace.android.gradle.plugin.gradle.GradleVersion
+import io.embrace.android.gradle.plugin.gradle.GradleVersion.Companion.isAtLeast
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import org.gradle.api.Plugin
@@ -18,6 +20,8 @@ class EmbraceGradlePlugin : Plugin<Project> {
     }
 
     override fun apply(project: Project) {
+        validateMinGradleVersion()
+
         val extension = project.extensions.create(
             EXTENSION_NAME,
             SwazzlerExtension::class.java,
@@ -37,6 +41,12 @@ class EmbraceGradlePlugin : Plugin<Project> {
                 variantConfigurationsListProperty,
                 extension
             )
+        }
+    }
+
+    private fun validateMinGradleVersion() {
+        if (!isAtLeast(GradleVersion.MIN_VERSION)) {
+            error("Embrace Gradle Plugin requires Gradle version ${GradleVersion.MIN_VERSION} or newer")
         }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/GradleVersion.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/GradleVersion.kt
@@ -5,6 +5,7 @@ import org.gradle.util.GradleVersion.version
 sealed class GradleVersion(private val version: org.gradle.util.GradleVersion) :
     Comparable<GradleVersion> {
 
+    object MIN_VERSION : GradleVersion(version("7.5.1"))
     object CURRENT : GradleVersion(org.gradle.util.GradleVersion.current())
     object GRADLE_7_6 : GradleVersion(version("7.6"))
     object GRADLE_8_0 : GradleVersion(version("8.0"))

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
@@ -19,6 +19,8 @@ sealed class TestMatrix(
     val jdk: JdkEnv,
 ) {
 
+    object UnsupportedOldGradleVersion : TestMatrix("7.4.2", "7.5", "1.8.22", JdkEnv.JAVA_11)
+
     /**
      * The minimum version we support & run tests against.
      */


### PR DESCRIPTION
## Goal

Validate that the version used to build an app that uses Embrace is higher or equal than the minimum

## Testing

Added an integration test that validates this behavior