### PR TITLE
Create child span for time waiting for manual UI load ending

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/LifecycleStage.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/LifecycleStage.kt
@@ -7,7 +7,8 @@ enum class LifecycleStage(private val typeName: String) {
     CREATE("create"),
     START("start"),
     RESUME("resume"),
-    RENDER("render");
+    RENDER("render"),
+    READY("ready");
 
     fun spanName(componentName: String): String = "$componentName-$typeName"
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
@@ -298,10 +298,17 @@ internal class UiLoadTraceEmitterTest {
                 }
             }
 
+            val traceEndTime = trace.endTimeNanos.nanosToMillis()
             if (manualEnd) {
-                assertNotEquals(trace.endTimeNanos.nanosToMillis(), lastEventEndTimeMs)
+                assertEmbraceSpanData(
+                    span = checkNotNull(spanMap["emb-$activityName-ready"]).toNewPayload(),
+                    expectedStartTimeMs = lastEventEndTimeMs,
+                    expectedEndTimeMs = traceEndTime,
+                    expectedParentId = trace.spanId
+                )
+                assertNotEquals(traceEndTime, lastEventEndTimeMs)
             } else {
-                assertEquals(trace.endTimeNanos.nanosToMillis(), lastEventEndTimeMs)
+                assertEquals(traceEndTime, lastEventEndTimeMs)
             }
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
@@ -24,6 +24,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.STARTUP_BACKGROUND_TIME
 import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -148,6 +149,10 @@ internal class UiLoadTest {
                         expectedParentId = SpanId.getInvalid(),
                         expectedCustomAttributes = mapOf("manual-end" to "true")
                     )
+
+                    assertNotNull(findSpansByName("emb-$MANUAL_STOP_ACTIVITY_NAME-create").single())
+                    assertNotNull(findSpansByName("emb-$MANUAL_STOP_ACTIVITY_NAME-start").single())
+                    assertNotNull(findSpansByName("emb-$MANUAL_STOP_ACTIVITY_NAME-ready").single())
 
                     assertEmbraceSpanData(
                         span = findSpansByName("loading-time").single(),


### PR DESCRIPTION
## Goal

Add extra child span modelling the time after activity resumes to when the trace is manually terminated for completeness.