### PR TITLE
Remove low-value attributes added to startup spans

### DIFF
--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -76,13 +76,13 @@ internal class AppStartupTraceEmitterTest {
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace with every event triggered in T`() {
-        verifyColdStartWithRender(processCreateDelayMs = 0L)
+        verifyColdStartWithRender()
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace without application init start and end triggered in T`() {
-        verifyColdStartWithRenderWithoutAppInitEvents(processCreateDelayMs = 0L)
+        verifyColdStartWithRenderWithoutAppInitEvents()
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
@@ -94,7 +94,7 @@ internal class AppStartupTraceEmitterTest {
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify warm start trace without application init start and end triggered in T`() {
-        verifyWarmStartWithRenderWithoutAppInitEvents(processCreateDelayMs = 0L)
+        verifyWarmStartWithRenderWithoutAppInitEvents()
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
@@ -220,7 +220,7 @@ internal class AppStartupTraceEmitterTest {
         dataCollectionCompletedCallbackInvokedCount++
     }
 
-    private fun verifyColdStartWithRender(processCreateDelayMs: Long? = null) {
+    private fun verifyColdStartWithRender() {
         clock.tick(100L)
         appStartupTraceEmitter.applicationInitStart()
         val customSpanStartMs = clock.now()
@@ -252,10 +252,6 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = DEFAULT_FAKE_CURRENT_TIME,
             expectedEndTimeMs = traceEnd,
-            expectedProcessCreateDelayMs = processCreateDelayMs,
-            expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
-            expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
-            expectedFirstActivityLifecycleEventMs = activityCreateEvents.firstEvent,
             expectedCustomAttributes = mapOf("custom-attribute" to "true")
         )
         assertChildSpan(processInit, DEFAULT_FAKE_CURRENT_TIME, applicationInitEnd)
@@ -267,7 +263,7 @@ internal class AppStartupTraceEmitterTest {
         assertEquals(0, logger.internalErrorMessages.size)
     }
 
-    private fun verifyColdStartWithRenderWithoutAppInitEvents(processCreateDelayMs: Long? = null) {
+    private fun verifyColdStartWithRenderWithoutAppInitEvents() {
         val (sdkInitStart, sdkInitEnd) = startSdk()
         val activityCreateEvents = createStartupActivity()
         val traceEnd = startupActivityRender().second
@@ -287,10 +283,6 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = DEFAULT_FAKE_CURRENT_TIME,
             expectedEndTimeMs = traceEnd,
-            expectedProcessCreateDelayMs = processCreateDelayMs,
-            expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
-            expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
-            expectedFirstActivityLifecycleEventMs = activityCreateEvents.firstEvent,
         )
 
         assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
@@ -333,7 +325,6 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = traceStartMs,
             expectedEndTimeMs = traceEnd,
-            expectedFirstActivityLifecycleEventMs = startupActivityStart,
         )
         assertChildSpan(processInit, traceStartMs, applicationInitEnd)
         assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
@@ -368,7 +359,6 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = traceStartMs,
             expectedEndTimeMs = traceEnd,
-            expectedFirstActivityLifecycleEventMs = startupActivityStart,
         )
         assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
         assertChildSpan(activityInitDelay, sdkInitEnd, startupActivityStart)
@@ -377,8 +367,8 @@ internal class AppStartupTraceEmitterTest {
         assertEquals(0, logger.internalErrorMessages.size)
     }
 
-    private fun verifyWarmStartWithRenderWithoutAppInitEvents(processCreateDelayMs: Long? = null) {
-        val sdkInitEnd = startSdk().second
+    private fun verifyWarmStartWithRenderWithoutAppInitEvents() {
+        startSdk()
         clock.tick(1601L)
         val activityCreateEvents = createStartupActivity()
         val traceEnd = startupActivityRender().second
@@ -392,19 +382,12 @@ internal class AppStartupTraceEmitterTest {
         val startupActivityStart = checkNotNull(activityCreateEvents.create)
         val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
 
-        with(trace) {
-            assertTraceRoot(
-                input = this,
-                expectedStartTimeMs = startupActivityStart,
-                expectedEndTimeMs = traceEnd,
-                expectedProcessCreateDelayMs = processCreateDelayMs,
-                expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
-                expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
-                expectedFirstActivityLifecycleEventMs = startupActivityStart,
-            )
-            assertEquals((startupActivityStart - sdkInitEnd).toString(), attributes["activity-init-gap-ms"])
-            assertEquals("30", attributes["embrace-init-duration-ms"])
-        }
+        assertTraceRoot(
+            input = trace,
+            expectedStartTimeMs = startupActivityStart,
+            expectedEndTimeMs = traceEnd,
+        )
+
         assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
         assertChildSpan(firstRender, startupActivityEnd, traceEnd)
         assertEquals(0, logger.internalErrorMessages.size)
@@ -425,16 +408,12 @@ internal class AppStartupTraceEmitterTest {
         val startupActivityStart = checkNotNull(activityCreateEvents.create)
         val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
 
-        with(trace) {
-            assertTraceRoot(
-                input = this,
-                expectedStartTimeMs = startupActivityStart,
-                expectedEndTimeMs = traceEnd,
-                expectedFirstActivityLifecycleEventMs = startupActivityStart,
-            )
-            assertEquals("2401", attributes["activity-init-gap-ms"])
-            assertEquals("30", attributes["embrace-init-duration-ms"])
-        }
+        assertTraceRoot(
+            input = trace,
+            expectedStartTimeMs = startupActivityStart,
+            expectedEndTimeMs = traceEnd,
+        )
+
         assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
         assertChildSpan(activityResume, startupActivityEnd, traceEnd)
         assertEquals(0, logger.internalErrorMessages.size)
@@ -472,11 +451,7 @@ internal class AppStartupTraceEmitterTest {
         assertTraceRoot(
             input = trace,
             expectedStartTimeMs = traceStart,
-            expectedEndTimeMs = traceEnd,
-            expectedProcessCreateDelayMs = if (isWarm) null else 0,
-            expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
-            expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
-            expectedFirstActivityLifecycleEventMs = firstActivityInit
+            expectedEndTimeMs = traceEnd
         )
 
         assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
@@ -544,10 +519,6 @@ internal class AppStartupTraceEmitterTest {
         input: EmbraceSpanData,
         expectedStartTimeMs: Long,
         expectedEndTimeMs: Long,
-        expectedProcessCreateDelayMs: Long? = null,
-        expectedActivityPreCreatedMs: Long? = null,
-        expectedActivityPostCreatedMs: Long? = null,
-        expectedFirstActivityLifecycleEventMs: Long? = null,
         expectedCustomAttributes: Map<String, String> = emptyMap(),
     ) {
         val trace = input.toNewPayload()
@@ -556,21 +527,6 @@ internal class AppStartupTraceEmitterTest {
         trace.assertDoesNotHaveEmbraceAttribute(PrivateSpan)
         val attrs = checkNotNull(trace.attributes)
         assertEquals(STARTUP_ACTIVITY_NAME, attrs.findAttributeValue("startup-activity-name"))
-        assertEquals(expectedProcessCreateDelayMs?.toString(), attrs.findAttributeValue("process-create-delay-ms"))
-        assertEquals(
-            expectedActivityPreCreatedMs?.toString(),
-            attrs.findAttributeValue("startup-activity-pre-created-ms")
-        )
-        assertEquals(
-            expectedActivityPostCreatedMs?.toString(),
-            attrs.findAttributeValue("startup-activity-post-created-ms")
-        )
-        assertEquals(
-            expectedFirstActivityLifecycleEventMs?.toString(),
-            attrs.findAttributeValue("first-activity-init-ms")
-        )
-        assertEquals("false", attrs.findAttributeValue("embrace-init-in-foreground"))
-        assertEquals("main", attrs.findAttributeValue("embrace-init-thread-name"))
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
 
         expectedCustomAttributes.forEach { entry ->


### PR DESCRIPTION
## Goal

Remove attributes useful for debugging the startup spans but ultimately little value for customers. If folks request these, we can add them back. The correctness of these spans are verified in tests with respect to the start and end times of child spans, so these are more information in production more than anything.

