### PR TITLE
Add a new annotation for splash screen activities

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -27,6 +27,9 @@ public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/CustomLoadTracedActivity : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class io/embrace/android/embracesdk/annotation/IgnoreForStartup : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/InternalApi : java/lang/annotation/Annotation {
 }
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/IgnoreForStartup.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/IgnoreForStartup.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.annotation
 
-@Deprecated("Does nothing")
+/**
+ * Ignore for the purposes of tracking App startup
+ */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-public annotation class StartupActivity
+public annotation class IgnoreForStartup

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/registry/ServiceRegistry.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/registry/ServiceRegistry.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
-import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -33,7 +32,6 @@ class ServiceRegistry : Closeable {
     val activityLifecycleListeners: List<ActivityLifecycleListener> by lazy {
         finalRegistry.filterIsInstance<ActivityLifecycleListener>()
     }
-    val startupListener: List<StartupListener> by lazy { finalRegistry.filterIsInstance<StartupListener>() }
 
     fun registerServices(vararg services: Lazy<Any?>) {
         Systrace.trace("register-services") {
@@ -65,11 +63,6 @@ class ServiceRegistry : Closeable {
     fun registerMemoryCleanerListeners(memoryCleanerService: MemoryCleanerService): Unit =
         memoryCleanerListeners.forEachSafe(
             memoryCleanerService::addListener
-        )
-
-    fun registerStartupListener(activityLifecycleTracker: ActivityTracker): Unit =
-        startupListener.forEachSafe(
-            activityLifecycleTracker::addStartupListener
         )
 
     // close all of the services in one go. this prevents someone creating a Closeable service

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleTracker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityLifecycleTracker.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.session.lifecycle
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.stream
@@ -27,11 +26,6 @@ class ActivityLifecycleTracker(
      */
     val activityListeners: CopyOnWriteArrayList<ActivityLifecycleListener> =
         CopyOnWriteArrayList<ActivityLifecycleListener>()
-
-    /**
-     * List of listeners notified when application startup is complete
-     */
-    val startupListeners: CopyOnWriteArrayList<StartupListener> = CopyOnWriteArrayList<StartupListener>()
 
     /**
      * The currently active activity.
@@ -84,21 +78,9 @@ class ActivityLifecycleTracker(
         }
     }
 
-    override fun onActivityResumed(activity: Activity) {
-        if (!activity.javaClass.isAnnotationPresent(StartupActivity::class.java)) {
-            // If the activity coming to foreground doesn't have the StartupActivity annotation
-            // the the SDK will finalize any pending startup moment.
-            stream(startupListeners) { listener: StartupListener ->
-                try {
-                    listener.applicationStartupComplete()
-                } catch (ex: Exception) {
-                    logger.trackInternalError(InternalErrorType.ACTIVITY_LISTENER_FAIL, ex)
-                }
-            }
-        }
-    }
-
+    override fun onActivityResumed(activity: Activity) {}
     override fun onActivityPaused(activity: Activity) {}
+
     override fun onActivityStopped(activity: Activity) {
         stream(activityListeners) { listener: ActivityLifecycleListener ->
             try {
@@ -119,17 +101,10 @@ class ActivityLifecycleTracker(
         }
     }
 
-    override fun addStartupListener(listener: StartupListener) {
-        if (!startupListeners.contains(listener)) {
-            startupListeners.addIfAbsent(listener)
-        }
-    }
-
     override fun close() {
         runCatching {
             application.unregisterActivityLifecycleCallbacks(this)
             activityListeners.clear()
-            startupListeners.clear()
         }
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityTracker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityTracker.kt
@@ -17,6 +17,4 @@ interface ActivityTracker : Application.ActivityLifecycleCallbacks, Closeable {
     val foregroundActivity: Activity?
 
     fun addListener(listener: ActivityLifecycleListener)
-
-    fun addStartupListener(listener: StartupListener)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/StartupListener.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/StartupListener.kt
@@ -1,8 +1,0 @@
-package io.embrace.android.embracesdk.internal.session.lifecycle
-
-interface StartupListener {
-    /**
-     * Triggered when the application has completed startup;
-     */
-    fun applicationStartupComplete() {}
-}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
-import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -27,7 +26,6 @@ internal class ServiceRegistryTest {
         assertEquals(expected, registry.processStateListeners)
         assertEquals(expected, registry.activityLifecycleListeners)
         assertEquals(expected, registry.memoryCleanerListeners)
-        assertEquals(expected, registry.startupListener)
     }
 
     @Test
@@ -43,9 +41,7 @@ internal class ServiceRegistryTest {
 
         val activityLifecycleTracker = FakeActivityTracker()
         registry.registerActivityLifecycleListeners(activityLifecycleTracker)
-        registry.registerStartupListener(activityLifecycleTracker)
         assertEquals(expected, activityLifecycleTracker.listeners)
-        assertEquals(expected, activityLifecycleTracker.startupListeners)
 
         val memoryCleanerService = FakeMemoryCleanerService()
         registry.registerMemoryCleanerListeners(memoryCleanerService)
@@ -67,8 +63,7 @@ internal class ServiceRegistryTest {
         Closeable,
         MemoryCleanerListener,
         ProcessStateListener,
-        ActivityLifecycleListener,
-        StartupListener {
+        ActivityLifecycleListener {
 
         var closed = false
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/ActivityLifecycleTrackerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/ActivityLifecycleTrackerTest.kt
@@ -6,13 +6,10 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Bundle
 import android.os.Looper
-import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
-import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -124,25 +121,6 @@ internal class ActivityLifecycleTrackerTest {
     }
 
     @Test
-    fun `verify on activity resumed for a StartupActivity does not trigger listeners`() {
-        val mockActivityLifecycleListener = mockk<ActivityLifecycleListener>()
-        activityLifecycleTracker.addListener(mockActivityLifecycleListener)
-
-        activityLifecycleTracker.onActivityResumed(TestStartupActivity())
-
-        verify { mockActivityLifecycleListener wasNot Called }
-    }
-
-    @Test
-    fun `verify on activity resumed for a non StartupActivity does trigger listeners`() {
-        val mockStartupListener = mockk<StartupListener>()
-        activityLifecycleTracker.addStartupListener(mockStartupListener)
-        activityLifecycleTracker.onActivityResumed(TestNonStartupActivity())
-
-        verify { mockStartupListener.applicationStartupComplete() }
-    }
-
-    @Test
     fun `verify on activity stopped triggers listeners`() {
         val mockActivity = mockk<Activity>()
         every { mockActivity.localClassName } returns "localClassName"
@@ -192,17 +170,6 @@ internal class ActivityLifecycleTrackerTest {
     }
 
     @Test
-    fun `verify startup listener is added`() {
-        // assert empty list first
-        assertEquals(0, activityLifecycleTracker.startupListeners.size)
-
-        val mockStartupListeners = mockk<StartupListener>()
-        activityLifecycleTracker.addStartupListener(mockStartupListeners)
-
-        assertEquals(1, activityLifecycleTracker.startupListeners.size)
-    }
-
-    @Test
     fun `verify if listener is already present, then it does not add anything`() {
         val mockActivityLifecycleListener = mockk<ActivityLifecycleListener>()
         activityLifecycleTracker.addListener(mockActivityLifecycleListener)
@@ -228,9 +195,7 @@ internal class ActivityLifecycleTrackerTest {
     fun `verify close cleans everything`() {
         // add a listener first, so we then check that listener have been cleared
         val mockActivityLifecycleListener = mockk<ActivityLifecycleListener>()
-        val mockStartupListeners = mockk<StartupListener>()
         activityLifecycleTracker.addListener(mockActivityLifecycleListener)
-        activityLifecycleTracker.addStartupListener(mockStartupListeners)
 
         every { application.unregisterActivityLifecycleCallbacks(activityLifecycleTracker) } returns Unit
 
@@ -238,11 +203,5 @@ internal class ActivityLifecycleTrackerTest {
 
         verify { application.unregisterActivityLifecycleCallbacks(activityLifecycleTracker) }
         assertTrue(activityLifecycleTracker.activityListeners.isEmpty())
-        assertTrue(activityLifecycleTracker.startupListeners.isEmpty())
     }
-
-    @StartupActivity
-    private class TestStartupActivity : Activity()
-
-    private class TestNonStartupActivity : Activity()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.capture.startup
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import io.embrace.android.embracesdk.annotation.StartupActivity
+import io.embrace.android.embracesdk.annotation.IgnoreForStartup
 import io.embrace.android.embracesdk.internal.capture.activity.traceInstanceId
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.ui.DrawEventEmitter
@@ -126,6 +126,6 @@ class StartupTracker(
     }
 
     private companion object {
-        fun Activity.observeForStartup(): Boolean = !javaClass.isAnnotationPresent(StartupActivity::class.java)
+        fun Activity.observeForStartup(): Boolean = !javaClass.isAnnotationPresent(IgnoreForStartup::class.java)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -432,7 +432,6 @@ internal class ModuleInitBootstrapper(
                         serviceRegistry.registerActivityListeners(essentialServiceModule.processStateService)
                         serviceRegistry.registerMemoryCleanerListeners(sessionOrchestrationModule.memoryCleanerService)
                         serviceRegistry.registerActivityLifecycleListeners(essentialServiceModule.activityLifecycleTracker)
-                        serviceRegistry.registerStartupListener(essentialServiceModule.activityLifecycleTracker)
                     }
 
                     // Verify that the ProcessStateService is fully initialized at this point, and log otherwise.

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt
@@ -4,21 +4,15 @@ import android.app.Activity
 import android.os.Bundle
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 
 class FakeActivityTracker(
     override var foregroundActivity: Activity? = null,
 ) : ActivityTracker {
 
     val listeners: MutableList<ActivityLifecycleListener> = mutableListOf()
-    val startupListeners: MutableList<StartupListener> = mutableListOf()
 
     override fun addListener(listener: ActivityLifecycleListener) {
         listeners.add(listener)
-    }
-
-    override fun addStartupListener(listener: StartupListener) {
-        startupListeners.add(listener)
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.app.Activity
-import io.embrace.android.embracesdk.annotation.StartupActivity
+import io.embrace.android.embracesdk.annotation.IgnoreForStartup
 
-@StartupActivity
+@IgnoreForStartup
 class FakeNotStartupActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSplashScreenActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSplashScreenActivity.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.app.Activity
-import io.embrace.android.embracesdk.annotation.StartupActivity
+import io.embrace.android.embracesdk.annotation.IgnoreForStartup
 
 /**
  * Activity that will not be used in recording the startup trace
  */
-@StartupActivity
+@IgnoreForStartup
 class FakeSplashScreenActivity : Activity()


### PR DESCRIPTION
## Goal

Add new, appropriately named annotation for activities to be ignored during app startup (i.e. splash screens whose loading does not represent the completion of app startup).

We used to use the old `@StartupActivity` annotation for Moments but that is terribly named, as it is literally not the activity you want to track for start up.

As well, I removed the listener infra that you can add to listen to app startup - it was only used for moments, so it's actually not ever used now.