### PR TITLE
Remove splash screen time in warm/cold app startup heuristic

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
@@ -21,6 +21,11 @@ interface AppStartupDataCollector {
     fun applicationInitEnd(timestampMs: Long? = null)
 
     /**
+     * Set the time the first activity was detected to have started, irrespective of whether it should be used for startup
+     */
+    fun firstActivityInit(timestampMs: Long? = null)
+
+    /**
      * Set the time just prior to the creation of the Activity whose rendering will denote the end of the startup workflow
      */
     fun startupActivityPreCreated(timestampMs: Long? = null)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -113,6 +113,10 @@ internal class AppStartupTraceEmitter(
         applicationInitEndMs = timestampMs ?: nowMs()
     }
 
+    override fun firstActivityInit(timestampMs: Long?) {
+        firstActivityInitStartMs = timestampMs ?: nowMs()
+    }
+
     override fun startupActivityPreCreated(timestampMs: Long?) {
         startupActivityPreCreatedMs = timestampMs ?: nowMs()
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -35,14 +35,17 @@ class StartupTracker(
 
     private var startupActivityId: Int? = null
     private var startupDataCollectionComplete = false
+    private var firstActivitySeen = false
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+        firstActivityInit()
         if (activity.useAsStartupActivity()) {
             appStartupDataCollector.startupActivityPreCreated()
         }
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        firstActivityInit()
         if (activity.useAsStartupActivity()) {
             appStartupDataCollector.startupActivityInitStart()
             val application = activity.application
@@ -86,6 +89,13 @@ class StartupTracker(
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
 
     override fun onActivityDestroyed(activity: Activity) {}
+
+    private fun firstActivityInit() {
+        if (!firstActivitySeen) {
+            appStartupDataCollector.firstActivityInit()
+            firstActivitySeen = true
+        }
+    }
 
     private fun startupComplete(application: Application) {
         if (!startupDataCollectionComplete) {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.fakes.FakeAppStartupDataCollector
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeDrawEventEmitter
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
-import io.embrace.android.embracesdk.fakes.FakeNotStartupActivity
 import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmitter.Companion.startupHasRenderEvent
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
@@ -61,6 +60,7 @@ internal class StartupTrackerTest {
         with(launchActivity()) {
             assertEquals("android.app.Activity", dataCollector.startupActivityName)
             verifyLifecycle(
+                firstActivityInitTime = createTime,
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -76,6 +76,7 @@ internal class StartupTrackerTest {
     fun `cold start in Q`() {
         with(launchActivity()) {
             verifyLifecycle(
+                firstActivityInitTime = createTime,
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -91,6 +92,7 @@ internal class StartupTrackerTest {
     fun `cold start in P`() {
         with(launchActivity()) {
             verifyLifecycle(
+                firstActivityInitTime = createTime,
                 createTime = createTime,
                 startTime = startTime,
                 resumeTime = resumeTime,
@@ -103,6 +105,7 @@ internal class StartupTrackerTest {
     fun `cold start in L`() {
         with(launchActivity()) {
             verifyLifecycle(
+                firstActivityInitTime = createTime,
                 createTime = createTime,
                 startTime = startTime,
                 resumeTime = resumeTime
@@ -113,11 +116,13 @@ internal class StartupTrackerTest {
     @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `cold start with different activities being created and foregrounded first`() {
+        val firstActivityInitTime = clock.now()
         defaultActivityController.create()
         clock.tick()
         with(launchActivity(Robolectric.buildActivity(FakeActivity::class.java))) {
             assertEquals("io.embrace.android.embracesdk.fakes.FakeActivity", dataCollector.startupActivityName)
             verifyLifecycle(
+                firstActivityInitTime = firstActivityInitTime,
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -131,11 +136,12 @@ internal class StartupTrackerTest {
     @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `cold start initial activity not tracked will use the second for timing`() {
-        launchActivity(Robolectric.buildActivity(FakeSplashScreenActivity::class.java))
+        val firstActivityInitTime = launchActivity(Robolectric.buildActivity(FakeSplashScreenActivity::class.java)).createTime
         clock.tick()
         with(launchActivity()) {
             assertEquals("android.app.Activity", dataCollector.startupActivityName)
             verifyLifecycle(
+                firstActivityInitTime = firstActivityInitTime,
                 preCreateTime = createTime,
                 createTime = createTime,
                 postCreateTime = createTime,
@@ -168,7 +174,7 @@ internal class StartupTrackerTest {
     @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `data only collected if activity is used as startup activity`() {
-        launchActivity(Robolectric.buildActivity(FakeNotStartupActivity::class.java))
+        launchActivity(Robolectric.buildActivity(FakeSplashScreenActivity::class.java))
         assertNull(dataCollector.applicationInitStartMs)
         assertNull(dataCollector.applicationInitEndMs)
         assertNull(dataCollector.startupActivityName)
@@ -206,6 +212,7 @@ internal class StartupTrackerTest {
     }
 
     private fun launchActivity(controller: ActivityController<*> = defaultActivityController): ActivityTiming {
+        clock.tick()
         val createTime = clock.now()
         controller.create()
         clock.tick()
@@ -227,6 +234,7 @@ internal class StartupTrackerTest {
     }
 
     private fun verifyLifecycle(
+        firstActivityInitTime: Long,
         preCreateTime: Long? = null,
         createTime: Long,
         postCreateTime: Long? = null,
@@ -234,6 +242,7 @@ internal class StartupTrackerTest {
         resumeTime: Long,
         renderTime: Long? = null
     ) {
+        assertEquals(firstActivityInitTime, dataCollector.firstActivityInitMs)
         assertEquals(preCreateTime, dataCollector.startupActivityPreCreatedMs)
         assertEquals(createTime, dataCollector.startupActivityInitStartMs)
         assertEquals(postCreateTime, dataCollector.startupActivityPostCreatedMs)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeActivity
+import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -15,12 +17,16 @@ import io.embrace.android.embracesdk.internal.spans.toStatus
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.ACTIVITY_GAP
+import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
+import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.POST_ACTIVITY_ACTION_DWELL
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
 
 @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
@@ -90,6 +96,125 @@ internal class AppStartupTraceTest {
                     assertEquals(Span.Status.ERROR, status.statusCode.toStatus())
                 }
                 assertTrue(spans.containsKey("emb-activity-create"))
+                assertTrue(spans.containsKey("emb-activity-resume"))
+            }
+        )
+    }
+
+    @Test
+    fun `warm startup`() {
+        var startupActivityInitMs: Long? = null
+        testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(
+                    bgActivityCapture = true
+                )
+            ),
+            testCaseAction = {
+                val initGap = 10000L
+                clock.tick(initGap)
+                startupActivityInitMs = clock.now()
+                simulateOpeningActivities(
+                    addStartupActivity = false
+                )
+            },
+            otelExportAssertion = {
+                val spans = awaitSpansWithType(3, EmbType.Performance.Default).associateBy { it.name }
+                assertTrue(spans.isNotEmpty())
+                with(checkNotNull(spans["emb-app-startup-warm"])) {
+                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
+                }
+                with(checkNotNull(spans["emb-activity-create"])) {
+                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
+                }
+                assertTrue(spans.containsKey("emb-activity-resume"))
+            }
+        )
+    }
+
+    @Test
+    fun `cold startup with long splash screen`() {
+        var sdkStartTimeMs: Long? = null
+        var firstActivityInitMs: Long? = null
+        var startupActivityInitMs: Long? = null
+        testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(
+                    bgActivityCapture = true
+                )
+            ),
+            testCaseAction = {
+                val splashScreenDwellTime = 5000L
+                sdkStartTimeMs = clock.now()
+                firstActivityInitMs = clock.tick()
+                startupActivityInitMs = clock.now() + (3 * LIFECYCLE_EVENT_GAP) + POST_ACTIVITY_ACTION_DWELL +
+                    ACTIVITY_GAP + splashScreenDwellTime
+                simulateOpeningActivities(
+                    addStartupActivity = false,
+                    activitiesAndActions = listOf(
+                        Robolectric.buildActivity(FakeSplashScreenActivity::class.java) to {
+                            clock.tick(
+                                splashScreenDwellTime
+                            )
+                        },
+                        Robolectric.buildActivity(FakeActivity::class.java) to {},
+                    )
+                )
+            },
+            otelExportAssertion = {
+                val spans = awaitSpansWithType(5, EmbType.Performance.Default).associateBy { it.name }
+                assertTrue(spans.isNotEmpty())
+                assertTrue(spans.containsKey("emb-app-startup-cold"))
+                assertTrue(spans.containsKey("emb-embrace-init"))
+                with(checkNotNull(spans["emb-activity-init-gap"])) {
+                    assertEquals(sdkStartTimeMs, startEpochNanos.nanosToMillis())
+                    assertEquals(firstActivityInitMs, endEpochNanos.nanosToMillis())
+                }
+                with(checkNotNull(spans["emb-activity-create"])) {
+                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
+                }
+                assertTrue(spans.containsKey("emb-activity-resume"))
+            }
+        )
+    }
+
+    @Test
+    fun `warm startup with long splash screen`() {
+        var firstActivityInitMs: Long? = null
+        var startupActivityInitMs: Long? = null
+        testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(
+                    bgActivityCapture = true
+                )
+            ),
+            testCaseAction = {
+                val initGap = 10000L
+                val splashScreenDwellTime = 5000L
+                firstActivityInitMs = clock.tick(initGap)
+                startupActivityInitMs = clock.now() + (3 * LIFECYCLE_EVENT_GAP) + POST_ACTIVITY_ACTION_DWELL +
+                    ACTIVITY_GAP + splashScreenDwellTime
+                simulateOpeningActivities(
+                    addStartupActivity = false,
+                    activitiesAndActions = listOf(
+                        Robolectric.buildActivity(FakeSplashScreenActivity::class.java) to {
+                            clock.tick(
+                                splashScreenDwellTime
+                            )
+                        },
+                        Robolectric.buildActivity(FakeActivity::class.java) to {},
+                    )
+                )
+            },
+            otelExportAssertion = {
+                val spans = awaitSpansWithType(3, EmbType.Performance.Default).associateBy { it.name }
+                assertTrue(spans.isNotEmpty())
+                with(checkNotNull(spans["emb-app-startup-warm"])) {
+                    assertEquals(firstActivityInitMs, startEpochNanos.nanosToMillis())
+                }
+                with(checkNotNull(spans["emb-activity-create"])) {
+                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
+                }
                 assertTrue(spans.containsKey("emb-activity-resume"))
             }
         )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -19,6 +19,7 @@ class FakeAppStartupDataCollector(
     var applicationInitStartMs: Long? = null
     var applicationInitEndMs: Long? = null
     var startupActivityName: String? = null
+    var firstActivityInitMs: Long? = null
     var startupActivityPreCreatedMs: Long? = null
     var startupActivityInitStartMs: Long? = null
     var startupActivityPostCreatedMs: Long? = null
@@ -34,6 +35,10 @@ class FakeAppStartupDataCollector(
 
     override fun applicationInitEnd(timestampMs: Long?) {
         applicationInitEndMs = timestampMs ?: clock.now()
+    }
+
+    override fun firstActivityInit(timestampMs: Long?) {
+        firstActivityInitMs = timestampMs ?: clock.now()
     }
 
     override fun startupActivityPreCreated(timestampMs: Long?) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
@@ -1,7 +1,0 @@
-package io.embrace.android.embracesdk.fakes
-
-import android.app.Activity
-import io.embrace.android.embracesdk.annotation.IgnoreForStartup
-
-@IgnoreForStartup
-class FakeNotStartupActivity : Activity()


### PR DESCRIPTION
## Goal

Use the init of an ignored splashscreen activity to detect the first sign the app process is running because of a user initiated launch. This reduces the false positive for detecting a warm start when app startup is so slow, it takes more than 2s to transition of app object creation finishing to activity init. Previously, it was ignoring the signal from an activity we didn't use for startup calculation.

We could do a better job at detecting this even further by eliminating the heuristic of "time between app object activity object init" to separate warm and cold startups, but switching to that needs a bit more research and experimentation than we have time for. 

This, combined with the use of `applicatinInitEnd()`, should be good enough now for those who seek directional accuracy, with some small amount of false negatives for warm start if a user launch happens right within 2s of an app process finishing starting in the background.
