### PR TITLE
Prevent rare crash in compose click detection

### DIFF
--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/ComposeActivityListener.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/ComposeActivityListener.kt
@@ -6,20 +6,8 @@ import android.view.Window
 import io.embrace.android.embracesdk.compose.internal.ComposeInternalErrorLogger
 import io.embrace.android.embracesdk.compose.internal.EmbraceGestureListener
 import io.embrace.android.embracesdk.compose.internal.EmbraceWindowCallback
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ThreadFactory
 
 class ComposeActivityListener : ActivityLifeCycleCallbacks {
-
-    private val threadFactory: ThreadFactory = ThreadFactory { runnable: Runnable ->
-        Executors.defaultThreadFactory().newThread(runnable).apply {
-            this.name = "emb-compose-scheduled-reg"
-        }
-    }
-
-    private val service: ScheduledExecutorService =
-        Executors.newSingleThreadScheduledExecutor(threadFactory)
 
     private val composeInternalErrorLogger = ComposeInternalErrorLogger()
 
@@ -28,7 +16,7 @@ class ComposeActivityListener : ActivityLifeCycleCallbacks {
             // Set EmbraceWindowCallback to install Embrace Gesture Listener to capture onClick events
             val window: Window = activity.window
             if (window.callback == null || window.callback !is EmbraceWindowCallback) {
-                val gestureDetectorCompat = GestureDetector(activity, EmbraceGestureListener(activity, service))
+                val gestureDetectorCompat = GestureDetector(activity, EmbraceGestureListener(activity))
                 window.callback = EmbraceWindowCallback(
                     window.callback,
                     gestureDetectorCompat

--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeClickedTargetIterator.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeClickedTargetIterator.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import java.util.LinkedList
 import java.util.Queue
-import java.util.concurrent.ScheduledExecutorService
 
 internal class ComposeClickedTargetIterator : EmbraceClickedTargetIterator {
 
@@ -16,7 +15,6 @@ internal class ComposeClickedTargetIterator : EmbraceClickedTargetIterator {
         decorView: View,
         x: Float,
         y: Float,
-        onSingleTapUpBackgroundWorker: ScheduledExecutorService,
     ) {
         try {
             val queue: Queue<View> = LinkedList()
@@ -32,7 +30,7 @@ internal class ComposeClickedTargetIterator : EmbraceClickedTargetIterator {
                     }
 
                     if (it.parent is ComposeView) { // this validation is to reduce the locate method execution to the proper view
-                        nodeLocator.findClickedElement(it, x, y, onSingleTapUpBackgroundWorker)
+                        nodeLocator.findClickedElement(it, x, y)
                     }
                 }
             }

--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceClickedTargetIterator.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceClickedTargetIterator.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.compose.internal
 
 import android.view.View
-import java.util.concurrent.ScheduledExecutorService
 
 /**
  * Given a view and a position ( x, y),
@@ -13,6 +12,5 @@ internal interface EmbraceClickedTargetIterator {
         decorView: View,
         x: Float,
         y: Float,
-        onSingleTapUpBackgroundWorker: ScheduledExecutorService,
     )
 }

--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceGestureListener.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceGestureListener.kt
@@ -5,7 +5,6 @@ import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import java.lang.ref.WeakReference
-import java.util.concurrent.ScheduledExecutorService
 
 /**
  *  EmbraceGestureListener extends SimpleOnGestureListener to listen
@@ -13,17 +12,11 @@ import java.util.concurrent.ScheduledExecutorService
  */
 internal class EmbraceGestureListener(
     activity: Activity,
-    private val onSingleTapUpBackgroundWorker: ScheduledExecutorService,
 ) : GestureDetector.SimpleOnGestureListener() {
 
-    private var singleTapUpError: ComposeInternalErrorLogger = ComposeInternalErrorLogger()
-    private var activityRef: WeakReference<Activity>
-
+    private val singleTapUpError: ComposeInternalErrorLogger = ComposeInternalErrorLogger()
+    private val activityRef: WeakReference<Activity> = WeakReference(activity)
     private val composeClickedTargetIterator = ComposeClickedTargetIterator()
-
-    init {
-        activityRef = WeakReference(activity)
-    }
 
     override fun onSingleTapUp(event: MotionEvent): Boolean {
         try {
@@ -42,6 +35,6 @@ internal class EmbraceGestureListener(
     }
 
     private fun logTapUp(decorView: View, event: MotionEvent) {
-        composeClickedTargetIterator.findTarget(decorView, event.x, event.y, onSingleTapUpBackgroundWorker)
+        composeClickedTargetIterator.findTarget(decorView, event.x, event.y)
     }
 }

--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceNodeIterator.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceNodeIterator.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getAllSemanticsNodes
 import androidx.compose.ui.semantics.getOrNull
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
-import java.util.concurrent.ScheduledExecutorService
 
 private const val UNKNOWN_ELEMENT_NAME = "Unlabeled Compose element"
 
@@ -23,18 +22,16 @@ internal class EmbraceNodeIterator {
      *  we collect the compose tree and iterate over it to find the clicked view,
      *  by comparing with the received position (x,y)
      *  */
-    fun findClickedElement(root: View, x: Float, y: Float, backgroundWorker: ScheduledExecutorService) {
+    fun findClickedElement(root: View, x: Float, y: Float) {
         val semanticsOwner = if (root is AndroidComposeView) root.semanticsOwner else return
         val semanticsNodes = semanticsOwner.getAllSemanticsNodes(true)
 
-        backgroundWorker.submit {
-            findClickedElement(semanticsNodes, x, y)?.let {
-                val clickedView = ClickedView(it, x, y)
-                EmbraceInternalApi.getInstance().internalInterface.logComposeTap(
-                    Pair(clickedView.x, clickedView.y),
-                    clickedView.tag
-                )
-            }
+        findClickedElement(semanticsNodes, x, y)?.let {
+            val clickedView = ClickedView(it, x, y)
+            EmbraceInternalApi.getInstance().internalInterface.logComposeTap(
+                Pair(clickedView.x, clickedView.y),
+                clickedView.tag
+            )
         }
     }
 


### PR DESCRIPTION
## Goal

Prevents a rare crash in compose click detection. This was triggered by accessing elements of the compose tree on a background thread. It's possible the internals of compose may have changed to trigger this problem, as `SemanticNode` now has its properties implemented as customer getters.

## Testing

Manually verified clicking a compose button is shown in the dashboard when the functionality is enabled.

