### PR TITLE
Prevent activity leak in startup tracking

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -46,9 +46,10 @@ class StartupTracker(
         if (activity.useAsStartupActivity()) {
             appStartupDataCollector.startupActivityInitStart()
             val application = activity.application
+            val activityName = activity.localClassName
             val callback = {
                 appStartupDataCollector.firstFrameRendered(
-                    activityName = activity.localClassName,
+                    activityName = activityName,
                     collectionCompleteCallback = { startupComplete(application) }
                 )
             }


### PR DESCRIPTION
## Goal

Prevents a leak in startup tracing where an activity reference was held in an anonymous inner class, leading to a potential leak reported via LeakCanary.

## Testing

Tested scenario via LeakCanary and confirmed that it happened before the changeset but not after.