### PR TITLE
Throw an exception when building with a Gradle version lower than the minimum supported

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
@@ -34,13 +34,14 @@ class AgpSupportTest {
     fun `maximum supported version`() = runTest(MaxVersion)
 
     @Test
-    fun `unsupported old version`() {
+    fun `unsupported old gradle version`() {
         rule.runTest(
             fixture = "android-version-support",
             task = "assembleRelease",
             testMatrix = TestMatrix.UnsupportedOldGradleVersion,
             projectType = ProjectType.ANDROID,
-            expectedExceptionMessage = "Embrace Gradle Plugin requires Gradle version ${GradleVersion.MIN_VERSION} or newer",
+            expectedExceptionMessage =
+            "Embrace requires Gradle version ${GradleVersion.MIN_VERSION} or higher. Please update your Gradle version.",
             assertions = {
                 verifyNoUploads()
             }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
@@ -46,7 +46,7 @@ class EmbraceGradlePlugin : Plugin<Project> {
 
     private fun validateMinGradleVersion() {
         if (!isAtLeast(GradleVersion.MIN_VERSION)) {
-            error("Embrace Gradle Plugin requires Gradle version ${GradleVersion.MIN_VERSION} or newer")
+            error("Embrace requires Gradle version ${GradleVersion.MIN_VERSION} or higher. Please update your Gradle version.")
         }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -28,9 +28,11 @@ class EmbraceGradlePluginDelegate {
         variantConfigurationsListProperty: ListProperty<VariantConfig>,
         extension: SwazzlerExtension,
     ) {
+        val agpWrapper = AgpWrapperImpl(project)
+        validateMinAgpVersion(agpWrapper)
+
         val behavior = PluginBehaviorImpl(project, extension)
         Logger.setPluginLogLevel(behavior.logLevel)
-        val agpWrapper = AgpWrapperImpl(project)
         val networkService = OkHttpNetworkService(behavior.baseUrl)
 
         BuildTelemetryService.register(
@@ -125,6 +127,12 @@ class EmbraceGradlePluginDelegate {
                         " https://issuetracker.google.com/issues/230454566#comment18"
                 )
             }
+        }
+    }
+
+    private fun validateMinAgpVersion(agpWrapper: AgpWrapper) {
+        if (agpWrapper.version < AgpVersion.MIN_VERSION) {
+            error("Embrace requires AGP version ${AgpVersion.MIN_VERSION} or higher. Please update your AGP version.")
         }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpVersion.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpVersion.kt
@@ -5,6 +5,7 @@ import com.android.build.api.AndroidPluginVersion
 sealed class AgpVersion(private val version: AndroidPluginVersion) : Comparable<AgpVersion> {
 
     class CURRENT(version: AndroidPluginVersion) : AgpVersion(version)
+    object MIN_VERSION : AgpVersion(AndroidPluginVersion(7, 4, 2))
     object AGP_8_3_0 : AgpVersion(AndroidPluginVersion(8, 3, 0))
     object AGP_8_0_0 : AgpVersion(AndroidPluginVersion(8, 0, 0))
 


### PR DESCRIPTION
## Goal

Validate that the AGP version used to build an app that uses Embrace is higher or equal to the minimum supported.

## Testing

Validated that an exception is thrown using a custom test app. Could not add an integration test.

