### PR TITLE
Start app start up root span early to detect terminations

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -45,10 +45,17 @@ internal class EmbraceSpanImpl(
 ) : PersistableEmbraceSpan {
 
     private val startedSpan: AtomicReference<io.opentelemetry.api.trace.Span?> = AtomicReference(null)
+
+    @Volatile
     private var spanStartTimeMs: Long? = null
+
+    @Volatile
     private var spanEndTimeMs: Long? = null
+
+    @Volatile
     private var status = Span.Status.UNSET
     private var updatedName: String? = null
+
     private val systemEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     private val customEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     private val systemAttributes = ConcurrentHashMap<String, String>().apply {
@@ -229,6 +236,8 @@ internal class EmbraceSpanImpl(
             }
         }
     }
+
+    override fun getStartTimeMs(): Long? = spanStartTimeMs
 
     override fun addAttribute(key: String, value: String): Boolean {
         if (customAttributes.size < limits.getMaxCustomAttributeCount() && limits.isAttributeValid(key, value, spanBuilder.internal)) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
@@ -70,6 +70,8 @@ interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
      */
     fun setStatus(statusCode: StatusCode, description: String = "")
 
+    fun getStartTimeMs(): Long?
+
     override fun storeInContext(context: Context): Context = context.with(embraceSpanContextKey, this)
 }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -126,6 +126,8 @@ class FakePersistableEmbraceSpan(
         statusDescription = description
     }
 
+    override fun getStartTimeMs(): Long? = spanStartTimeMs
+
     override fun addAttribute(key: String, value: String): Boolean {
         attributes[key] = value
         return true


### PR DESCRIPTION
## Goal

Start the startup span as soon as it's reasonable that any terminations during it can result in it being captured as having failed.

## Testing
Rely on existing tests for now to ensure there are no regressions. Additional tests will be added later to check for in-process termination when we're able to allow the finish to be triggered manaually
