### PR TITLE
Support manual ending of an app startup trace

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
@@ -64,6 +64,14 @@ interface AppStartupDataCollector {
     )
 
     /**
+     * Notify the SDK app startup is complete. The startup trace will end if it's configured to wait for this to complete.
+     */
+    fun appReady(
+        timestampMs: Long? = null,
+        collectionCompleteCallback: (() -> Unit)? = null
+    )
+
+    /**
      * Set an arbitrary time interval during startup that is of note
      */
     fun addTrackedInterval(

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -17,7 +17,9 @@ import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.opentelemetry.sdk.common.Clock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,74 +35,88 @@ import org.robolectric.annotation.Config
  */
 @RunWith(AndroidJUnit4::class)
 internal class AppStartupTraceEmitterTest {
+    private val processInitTime: Long = DEFAULT_FAKE_CURRENT_TIME
     private var startupService: StartupService? = null
     private var dataCollectionCompletedCallbackInvokedCount = 0
     private lateinit var clock: FakeClock
+    private lateinit var otelClock: Clock
     private lateinit var spanSink: SpanSink
     private lateinit var spanService: SpanService
     private lateinit var logger: FakeEmbLogger
     private lateinit var backgroundWorker: BackgroundWorker
-    private lateinit var appStartupTraceEmitter: AppStartupTraceEmitter
 
     @Before
     fun setUp() {
-        clock = FakeClock()
-        val initModule = FakeInitModule(clock = clock)
+        clock = FakeClock(processInitTime)
         backgroundWorker = fakeBackgroundWorker()
-        spanSink = initModule.openTelemetryModule.spanSink
-        spanService = initModule.openTelemetryModule.spanService
+        FakeInitModule(clock = clock).run {
+            otelClock = openTelemetryModule.openTelemetryClock
+            spanSink = openTelemetryModule.spanSink
+            spanService = openTelemetryModule.spanService
+        }
         spanService.initializeService(clock.now())
         startupService = StartupServiceImpl(
             spanService
         )
         clock.tick(100L)
         logger = FakeEmbLogger(false)
-        appStartupTraceEmitter = AppStartupTraceEmitter(
-            clock = initModule.openTelemetryModule.openTelemetryClock,
-            startupServiceProvider = { startupService },
-            spanService = spanService,
-            backgroundWorker = backgroundWorker,
-            versionChecker = BuildVersionChecker,
-            logger = logger
-        )
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `no crashes if startup service not available in T`() {
         startupService = null
-        appStartupTraceEmitter.firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+        createTraceEmitter().firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace with every event triggered in T`() {
-        verifyColdStartWithRender()
+        createTraceEmitter().verifyAppStartupTrace()
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace without application init start and end triggered in T`() {
-        verifyColdStartWithRenderWithoutAppInitEvents()
+        createTraceEmitter().verifyAppStartupTrace(hasAppInitEvents = false)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
-    fun `verify cold start trace aborted activity creation T`() {
-        verifyStartMultipleActivityCreated()
+    fun `verify cold start trace aborted activity creation in T`() {
+        createTraceEmitter().verifyAppStartupTrace(abortFirstActivityLoad = true)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify cold start trace with splash screen in T`() {
+        createTraceEmitter().verifyAppStartupTrace(loadSplashScreen = true)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify cold start trace with manual end in T`() {
+        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify warm start trace without application init start and end triggered in T`() {
-        verifyWarmStartWithRenderWithoutAppInitEvents()
+        createTraceEmitter().verifyAppStartupTrace(isColdStart = false, hasAppInitEvents = false)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify warm start trace with manual end in T`() {
+        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(isColdStart = false, manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `trace end callback will not be invoked twice`() {
         startupService = null
+        val appStartupTraceEmitter = createTraceEmitter()
         appStartupTraceEmitter.firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         appStartupTraceEmitter.firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
@@ -110,352 +126,505 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `no crashes if startup service not available in S`() {
         startupService = null
-        appStartupTraceEmitter.firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+        createTraceEmitter().firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify cold start trace with every event triggered in S`() {
-        verifyColdStartWithRender()
+        createTraceEmitter().verifyAppStartupTrace()
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify cold start trace without application init start and end triggered in S`() {
-        verifyColdStartWithRenderWithoutAppInitEvents()
+        createTraceEmitter().verifyAppStartupTrace(hasAppInitEvents = false)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S])
+    @Test
+    fun `verify cold start trace aborted activity creation in S`() {
+        createTraceEmitter().verifyAppStartupTrace(abortFirstActivityLoad = true)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S])
+    @Test
+    fun `verify cold start trace with splash screen in S`() {
+        createTraceEmitter().verifyAppStartupTrace(loadSplashScreen = true)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S])
+    @Test
+    fun `verify cold start trace with manual end in S`() {
+        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify warm start trace without application init start and end triggered in S`() {
-        verifyWarmStartWithRenderWithoutAppInitEvents()
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                hasAppInitEvents = false
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify warm start trace aborted activity creation S`() {
-        verifyStartMultipleActivityCreated(isWarm = true)
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                hasAppInitEvents = false,
+                abortFirstActivityLoad = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S])
+    @Test
+    fun `verify warm start trace with manual end in S`() {
+        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(isColdStart = false, manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.P])
     @Test
     fun `no crashes if startup service not available in P`() {
         startupService = null
-        appStartupTraceEmitter.startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+        createTraceEmitter().startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
     }
 
     @Config(sdk = [Build.VERSION_CODES.P])
     @Test
     fun `verify cold start trace with every event triggered in P`() {
-        verifyColdStartWithResume(firePreAndPostCreate = false)
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                hasRenderEvent = false
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.P])
     @Test
     fun `verify cold start trace without application init start and end triggered in P`() {
-        verifyColdStartWithResumeWithoutAppInitEvents()
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                hasAppInitEvents = false,
+                hasRenderEvent = false
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.P])
     @Test
-    fun `verify warm start trace without application init start and end triggered in O`() {
-        verifyWarmStartWithResumeWithoutAppInitEvents()
+    fun `verify cold start trace aborted activity creation in P`() {
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                hasRenderEvent = false,
+                abortFirstActivityLoad = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `verify cold start trace with splash screen in P`() {
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                hasRenderEvent = false,
+                loadSplashScreen = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `verify cold start trace with manual end in P`() {
+        createTraceEmitter(manualEnd = true)
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                hasRenderEvent = false,
+                manualEnd = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `verify warm start trace without application init start and end triggered in P`() {
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                firePreAndPostCreate = false,
+                hasAppInitEvents = false,
+                hasRenderEvent = false
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `verify warm start trace with manual end in P`() {
+        createTraceEmitter(manualEnd = true)
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                firePreAndPostCreate = false,
+                hasRenderEvent = false,
+                manualEnd = true
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.M])
     @Test
     fun `no crashes if startup service not available in M`() {
         startupService = null
-        appStartupTraceEmitter.startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+        createTraceEmitter().startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
     }
 
     @Config(sdk = [Build.VERSION_CODES.M])
     @Test
     fun `verify cold start trace with every event triggered in M`() {
-        verifyColdStartWithResume(trackProcessStart = false, firePreAndPostCreate = false)
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.M])
     @Test
     fun `verify cold start trace without application init start and end triggered in M`() {
-        verifyColdStartWithResumeWithoutAppInitEvents(trackProcessStart = false)
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasAppInitEvents = false,
+                hasRenderEvent = false
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.M])
+    @Test
+    fun `verify cold start trace aborted activity creation in M`() {
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                abortFirstActivityLoad = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.M])
+    @Test
+    fun `verify cold start trace with splash screen in M`() {
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                loadSplashScreen = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.M])
+    @Test
+    fun `verify cold start trace with manual end in M`() {
+        createTraceEmitter(manualEnd = true)
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                manualEnd = true
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.M])
     @Test
     fun `verify warm start trace without application init start and end triggered in M`() {
-        verifyWarmStartWithResumeWithoutAppInitEvents()
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasAppInitEvents = false,
+                hasRenderEvent = false
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.M])
+    @Test
+    fun `verify warm start trace with manual end in M`() {
+        createTraceEmitter(manualEnd = true)
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                manualEnd = true
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `no crashes if startup service not available in L`() {
         startupService = null
-        appStartupTraceEmitter.startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+        createTraceEmitter().startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
     }
 
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `verify cold start trace with every event triggered in L`() {
-        verifyColdStartWithResume(trackProcessStart = false, firePreAndPostCreate = false)
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `verify cold start trace without application init start and end triggered in L`() {
-        verifyColdStartWithResumeWithoutAppInitEvents(trackProcessStart = false)
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasAppInitEvents = false,
+                hasRenderEvent = false
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify cold start trace aborted activity creation in L`() {
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                abortFirstActivityLoad = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify cold start trace with splash screen in L`() {
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                loadSplashScreen = true
+            )
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify cold start trace with manual end in L`() {
+        createTraceEmitter(manualEnd = true)
+            .verifyAppStartupTrace(
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                manualEnd = true
+            )
     }
 
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `verify warm start trace without application init start and end triggered in L`() {
-        verifyWarmStartWithResumeWithoutAppInitEvents()
+        createTraceEmitter()
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasAppInitEvents = false,
+                hasRenderEvent = false
+            )
     }
 
-    private fun dataCollectionCompletedCallback() {
-        dataCollectionCompletedCallbackInvokedCount++
+    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify warm start trace with manual end in L`() {
+        createTraceEmitter(manualEnd = true)
+            .verifyAppStartupTrace(
+                isColdStart = false,
+                firePreAndPostCreate = false,
+                trackProcessStart = false,
+                hasRenderEvent = false,
+                manualEnd = true
+            )
     }
 
-    private fun verifyColdStartWithRender() {
-        clock.tick(100L)
-        appStartupTraceEmitter.applicationInitStart()
+    private fun createTraceEmitter(manualEnd: Boolean = false) =
+        AppStartupTraceEmitter(
+            clock = otelClock,
+            startupServiceProvider = { startupService },
+            spanService = spanService,
+            backgroundWorker = backgroundWorker,
+            versionChecker = BuildVersionChecker,
+            logger = logger,
+            manualEnd = manualEnd,
+        )
+
+    @Suppress("CyclomaticComplexMethod", "ComplexMethod")
+    private fun AppStartupTraceEmitter.verifyAppStartupTrace(
+        isColdStart: Boolean = true,
+        firePreAndPostCreate: Boolean = true,
+        trackProcessStart: Boolean = true,
+        hasAppInitEvents: Boolean = true,
+        hasRenderEvent: Boolean = true,
+        manualEnd: Boolean = false,
+        abortFirstActivityLoad: Boolean = false,
+        loadSplashScreen: Boolean = false,
+    ) {
+        val applicationInitStart = if (hasAppInitEvents) {
+            clock.tick(100L)
+            applicationInitStart()
+            clock.now()
+        } else {
+            null
+        }
+
+        val (sdkInitStart, sdkInitEnd) = startSdk().run {
+            if (isColdStart) {
+                this
+            } else {
+                null to null
+            }
+        }
+
         val customSpanStartMs = clock.now()
-        clock.tick(15L)
-        val (sdkInitStart, sdkInitEnd) = startSdk()
-        appStartupTraceEmitter.addAttribute("custom-attribute", "true")
-        appStartupTraceEmitter.applicationInitEnd()
-        val applicationInitEnd = clock.now()
-        clock.tick(50L)
-        appStartupTraceEmitter.addTrackedInterval("custom-span", customSpanStartMs, applicationInitEnd)
+        addAttribute("custom-attribute", "true")
+        val customSpanEndMs = clock.tick(15L)
+        addTrackedInterval("custom-span", customSpanStartMs, customSpanEndMs)
 
-        val activityCreateEvents = createStartupActivity()
-        val traceEnd = startupActivityRender().second
-
-        assertEquals(8, spanSink.completedSpans().size)
-        val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
-        val processInit = checkNotNull(spanMap["emb-process-init"])
-        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
-        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
-        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
-        val firstRender = checkNotNull(spanMap["emb-first-frame-render"])
-        val customSpan = checkNotNull(spanMap["custom-span"])
-
-        val startupActivityStart = checkNotNull(activityCreateEvents.create)
-        val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
-
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = DEFAULT_FAKE_CURRENT_TIME,
-            expectedEndTimeMs = traceEnd,
-            expectedCustomAttributes = mapOf("custom-attribute" to "true")
-        )
-        assertChildSpan(processInit, DEFAULT_FAKE_CURRENT_TIME, applicationInitEnd)
-        assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
-        assertChildSpan(activityInitDelay, applicationInitEnd, startupActivityStart)
-        assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
-        assertChildSpan(firstRender, startupActivityEnd, traceEnd)
-        assertChildSpan(customSpan, customSpanStartMs, applicationInitEnd)
-        assertEquals(0, logger.internalErrorMessages.size)
-    }
-
-    private fun verifyColdStartWithRenderWithoutAppInitEvents() {
-        val (sdkInitStart, sdkInitEnd) = startSdk()
-        val activityCreateEvents = createStartupActivity()
-        val traceEnd = startupActivityRender().second
-
-        assertEquals(6, spanSink.completedSpans().size)
-        val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
-        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
-        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
-        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
-        val firstRender = checkNotNull(spanMap["emb-first-frame-render"])
-
-        val startupActivityStart = checkNotNull(activityCreateEvents.create)
-        val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
-
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = DEFAULT_FAKE_CURRENT_TIME,
-            expectedEndTimeMs = traceEnd,
-        )
-
-        assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
-        assertChildSpan(activityInitDelay, sdkInitEnd, startupActivityStart)
-        assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
-        assertChildSpan(firstRender, startupActivityEnd, traceEnd)
-        assertEquals(0, logger.internalErrorMessages.size)
-    }
-
-    private fun verifyColdStartWithResume(trackProcessStart: Boolean = true, firePreAndPostCreate: Boolean = true) {
-        clock.tick(100L)
-        appStartupTraceEmitter.applicationInitStart()
-        val applicationInitStart = clock.now()
-        clock.tick(10L)
-        val (sdkInitStart, sdkInitEnd) = startSdk()
-        appStartupTraceEmitter.applicationInitEnd()
-        val applicationInitEnd = clock.now()
-        clock.tick(50L)
-        val activityCreateEvents = createStartupActivity(firePreAndPostCreate = firePreAndPostCreate)
-        val traceEnd = startupActivityRender(renderFrame = false).first
-
-        assertEquals(7, spanSink.completedSpans().size)
-        val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
-        val processInit = checkNotNull(spanMap["emb-process-init"])
-        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
-        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
-        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
-        val activityResume = checkNotNull(spanMap["emb-activity-resume"])
-
-        val traceStartMs = if (trackProcessStart) {
-            DEFAULT_FAKE_CURRENT_TIME
+        val applicationInitEnd = if (hasAppInitEvents) {
+            clock.tick(44L)
+            applicationInitEnd()
+            clock.now()
         } else {
-            applicationInitStart
+            null
         }
-        val startupActivityStart = checkNotNull(activityCreateEvents.create)
-        val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
 
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = traceStartMs,
-            expectedEndTimeMs = traceEnd,
-        )
-        assertChildSpan(processInit, traceStartMs, applicationInitEnd)
-        assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
-        assertChildSpan(activityInitDelay, applicationInitEnd, startupActivityStart)
-        assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
-        assertChildSpan(activityResume, startupActivityEnd, traceEnd)
-        assertEquals(0, logger.internalErrorMessages.size)
-    }
-
-    private fun verifyColdStartWithResumeWithoutAppInitEvents(trackProcessStart: Boolean = true) {
-        val (sdkInitStart, sdkInitEnd) = startSdk()
-        val activityCreateEvents = createStartupActivity(firePreAndPostCreate = false)
-        val traceEnd = startupActivityRender(renderFrame = false).first
-
-        assertEquals(6, spanSink.completedSpans().size)
-        val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
-        val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
-        val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
-        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
-        val activityResume = checkNotNull(spanMap["emb-activity-resume"])
-
-        val traceStartMs = if (trackProcessStart) {
-            DEFAULT_FAKE_CURRENT_TIME
+        if (isColdStart) {
+            clock.tick(50L)
         } else {
-            sdkInitStart
+            clock.tick(AppStartupTraceEmitter.SDK_AND_ACTIVITY_INIT_GAP + 1)
         }
-        val startupActivityStart = checkNotNull(activityCreateEvents.create)
-        val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
 
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = traceStartMs,
-            expectedEndTimeMs = traceEnd,
+        val activityCreateEvents = launchActivity(
+            firePreAndPostCreate = firePreAndPostCreate,
+            loadSplashScreen = loadSplashScreen,
+            abortFirstLoad = abortFirstActivityLoad
         )
-        assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
-        assertChildSpan(activityInitDelay, sdkInitEnd, startupActivityStart)
-        assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
-        assertChildSpan(activityResume, startupActivityEnd, traceEnd)
-        assertEquals(0, logger.internalErrorMessages.size)
-    }
-
-    private fun verifyWarmStartWithRenderWithoutAppInitEvents() {
-        startSdk()
-        clock.tick(1601L)
-        val activityCreateEvents = createStartupActivity()
-        val traceEnd = startupActivityRender().second
-
-        assertEquals(4, spanSink.completedSpans().size)
-        val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-warm"])
-        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
-        val firstRender = checkNotNull(spanMap["emb-first-frame-render"])
-
-        val startupActivityStart = checkNotNull(activityCreateEvents.create)
-        val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
-
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = startupActivityStart,
-            expectedEndTimeMs = traceEnd,
-        )
-
-        assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
-        assertChildSpan(firstRender, startupActivityEnd, traceEnd)
-        assertEquals(0, logger.internalErrorMessages.size)
-    }
-
-    private fun verifyWarmStartWithResumeWithoutAppInitEvents() {
-        startSdk()
-        clock.tick(2001)
-        val activityCreateEvents = createStartupActivity(firePreAndPostCreate = false)
-        val traceEnd = startupActivityRender(renderFrame = false).first
-
-        assertEquals(4, spanSink.completedSpans().size)
-        val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-warm"])
-        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
-        val activityResume = checkNotNull(spanMap["emb-activity-resume"])
-
-        val startupActivityStart = checkNotNull(activityCreateEvents.create)
-        val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
-
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = startupActivityStart,
-            expectedEndTimeMs = traceEnd,
-        )
-
-        assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
-        assertChildSpan(activityResume, startupActivityEnd, traceEnd)
-        assertEquals(0, logger.internalErrorMessages.size)
-    }
-
-    private fun verifyStartMultipleActivityCreated(isWarm: Boolean = false) {
-        val sdkInitEnd = startSdk().second
-        if (isWarm) {
-            clock.tick(1601L)
+        val uiLoadEnd = startupActivityRender(hasRenderEvent).run {
+            if (hasRenderEvent) {
+                second
+            } else {
+                first
+            }
         }
-        val firstActivityCreateEvents = abortedActivityCreation()
-        val activityCreateEvents = createStartupActivity()
-        val traceEnd = startupActivityRender().second
 
-        val firstActivityInit = checkNotNull(firstActivityCreateEvents.firstEvent)
-        val startupActivityStart = checkNotNull(activityCreateEvents.create)
+        val firstActivityInit = activityCreateEvents.firstEvent ?: error("No first Activity init time")
+        val startupActivityStart = activityCreateEvents.preCreate ?: activityCreateEvents.create ?: error("No activity create time")
         val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
 
-        val traceStart = if (isWarm) {
+        val traceStart = if (isColdStart) {
+            if (trackProcessStart) {
+                processInitTime
+            } else {
+                applicationInitStart ?: sdkInitStart ?: firstActivityInit
+            }
+        } else {
             firstActivityInit
-        } else {
-            DEFAULT_FAKE_CURRENT_TIME
         }
 
-        val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val traceName = if (isWarm) {
-            "emb-app-startup-warm"
+        val traceEnd = if (manualEnd) {
+            invokeAppReady()
         } else {
-            assertChildSpan(checkNotNull(spanMap["emb-activity-init-gap"]), sdkInitEnd, firstActivityInit)
-            "emb-app-startup-cold"
+            uiLoadEnd
         }
-        val trace = checkNotNull(spanMap[traceName])
-        val activityCreate = checkNotNull(spanMap["emb-activity-create"])
+
+        StartupTimestamps(
+            traceStart = traceStart,
+            sdkInitStart = sdkInitStart,
+            sdkInitEnd = sdkInitEnd,
+            applicationInitEnd = applicationInitEnd,
+            customSpanStart = customSpanStartMs,
+            customSpanEnd = customSpanEndMs,
+            firstActivityInit = firstActivityInit,
+            startupActivityStart = startupActivityStart,
+            startupActivityEnd = startupActivityEnd,
+            uiLoadEnd = uiLoadEnd,
+            traceEnd = traceEnd
+        ).verifyTrace(
+            isColdStart = isColdStart,
+            hasAppInitEvents = hasAppInitEvents,
+            hasRenderEvent = hasRenderEvent,
+            manualEnd = manualEnd
+        )
+    }
+
+    private fun StartupTimestamps.verifyTrace(
+        isColdStart: Boolean = true,
+        hasAppInitEvents: Boolean = true,
+        hasRenderEvent: Boolean = true,
+        manualEnd: Boolean = false,
+    ) {
+        val spanMap = spanSink.completedSpans().associateBy { it.name }
+        val trace = if (isColdStart) {
+            assertChildSpan(spanMap.embraceInitSpan(), sdkInitStart, sdkInitEnd)
+            val gapStart = if (hasAppInitEvents) {
+                applicationInitEnd
+            } else {
+                sdkInitEnd
+            }
+            assertChildSpan(spanMap.initGapSpan(), gapStart, firstActivityInit)
+            spanMap.coldAppStartupRootSpan()
+        } else {
+            assertNull(spanMap.embraceInitSpan())
+            assertNull(spanMap.initGapSpan())
+            spanMap.warmAppStartupRootSpan()
+        }
 
         assertTraceRoot(
             input = trace,
             expectedStartTimeMs = traceStart,
-            expectedEndTimeMs = traceEnd
+            expectedEndTimeMs = traceEnd,
+            expectedCustomAttributes = mapOf("custom-attribute" to "true")
         )
 
-        assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
+        if (isColdStart && hasAppInitEvents) {
+            assertChildSpan(spanMap.processInitSpan(), traceStart, applicationInitEnd)
+        } else {
+            assertNull(spanMap.processInitSpan())
+        }
+        assertChildSpan(spanMap.customSpan(), customSpanStart, customSpanEnd)
+        assertChildSpan(spanMap.activityInitSpan(), startupActivityStart, startupActivityEnd)
+
+        if (hasRenderEvent) {
+            assertChildSpan(spanMap.firstFrameRenderSpan(), startupActivityEnd, uiLoadEnd)
+            assertNull(spanMap.activityResumeSpan())
+        } else {
+            assertChildSpan(spanMap.activityResumeSpan(), startupActivityEnd, uiLoadEnd)
+            assertNull(spanMap.firstFrameRenderSpan())
+        }
+
+        if (manualEnd) {
+            assertChildSpan(spanMap.appReadySpan(), uiLoadEnd, traceEnd)
+        } else {
+            assertNull(spanMap.appReadySpan())
+        }
+
         assertEquals(0, logger.internalErrorMessages.size)
+    }
+
+    private fun dataCollectionCompletedCallback() {
+        dataCollectionCompletedCallbackInvokedCount++
     }
 
     private fun startSdk(): Pair<Long, Long> {
@@ -473,54 +642,71 @@ internal class AppStartupTraceEmitterTest {
         return Pair(sdkInitStart, sdkInitEnd)
     }
 
-    private fun abortedActivityCreation(): ActivityCreateEvents {
-        appStartupTraceEmitter.startupActivityPreCreated()
-        val preCreate = clock.now()
-        clock.tick()
-        appStartupTraceEmitter.startupActivityInitStart()
-        val create = clock.now()
-        clock.tick(500)
-        return ActivityCreateEvents(preCreate = preCreate, create = create, firstEvent = create)
-    }
-
-    private fun createStartupActivity(firePreAndPostCreate: Boolean = true): ActivityCreateEvents {
+    private fun AppStartupTraceEmitter.launchActivity(
+        firePreAndPostCreate: Boolean,
+        loadSplashScreen: Boolean,
+        abortFirstLoad: Boolean,
+    ): ActivityCreateEvents {
         val activityCreateEvents = ActivityCreateEvents()
+        firstActivityInit()
+        activityCreateEvents.firstEvent = clock.now()
+
+        if (loadSplashScreen) {
+            clock.tick(400L)
+        }
+
         if (firePreAndPostCreate) {
-            appStartupTraceEmitter.startupActivityPreCreated()
+            startupActivityPreCreated()
             activityCreateEvents.preCreate = clock.now()
             clock.tick()
         }
-        appStartupTraceEmitter.startupActivityInitStart()
+        startupActivityInitStart()
         activityCreateEvents.create = clock.now()
-        activityCreateEvents.firstEvent = activityCreateEvents.create
         clock.tick(180)
+
+        if (abortFirstLoad) {
+            startupActivityPreCreated()
+            activityCreateEvents.preCreate = clock.now()
+            clock.tick()
+            startupActivityInitStart()
+            activityCreateEvents.create = clock.now()
+            clock.tick(230)
+        }
+
         if (firePreAndPostCreate) {
-            appStartupTraceEmitter.startupActivityPostCreated()
+            startupActivityPostCreated()
             activityCreateEvents.postCreate = clock.now()
             clock.tick()
         }
-        appStartupTraceEmitter.startupActivityInitEnd()
+        startupActivityInitEnd()
         activityCreateEvents.finished = clock.now()
         clock.tick(15L)
         return activityCreateEvents
     }
 
-    private fun startupActivityRender(renderFrame: Boolean = true): Pair<Long, Long> {
-        appStartupTraceEmitter.startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+    private fun AppStartupTraceEmitter.startupActivityRender(renderFrame: Boolean): Pair<Long, Long> {
+        startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         val resumed = clock.now()
         if (renderFrame) {
             clock.tick(199L)
-            appStartupTraceEmitter.firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+            firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
         }
         return Pair(resumed, clock.now())
     }
 
+    private fun AppStartupTraceEmitter.invokeAppReady(): Long {
+        clock.tick(1000L)
+        appReady(collectionCompleteCallback = ::dataCollectionCompletedCallback)
+        return clock.now()
+    }
+
     private fun assertTraceRoot(
-        input: EmbraceSpanData,
+        input: EmbraceSpanData?,
         expectedStartTimeMs: Long,
         expectedEndTimeMs: Long,
         expectedCustomAttributes: Map<String, String> = emptyMap(),
     ) {
+        checkNotNull(input)
         val trace = input.toNewPayload()
         assertEquals(expectedStartTimeMs, trace.startTimeNanos?.nanosToMillis())
         assertEquals(expectedEndTimeMs, trace.endTimeNanos?.nanosToMillis())
@@ -534,11 +720,37 @@ internal class AppStartupTraceEmitterTest {
         }
     }
 
-    private fun assertChildSpan(span: EmbraceSpanData, expectedStartTimeNanos: Long, expectedEndTimeNanos: Long) {
+    private fun assertChildSpan(span: EmbraceSpanData?, expectedStartTimeNanos: Long?, expectedEndTimeNanos: Long?) {
+        checkNotNull(span)
         assertEquals(expectedStartTimeNanos, span.startTimeNanos.nanosToMillis())
         assertEquals(expectedEndTimeNanos, span.endTimeNanos.nanosToMillis())
         span.assertDoesNotHaveEmbraceAttribute(PrivateSpan)
     }
+
+    private fun Map<String, EmbraceSpanData?>.coldAppStartupRootSpan() = this["emb-app-startup-cold"]
+    private fun Map<String, EmbraceSpanData?>.warmAppStartupRootSpan() = this["emb-app-startup-warm"]
+    private fun Map<String, EmbraceSpanData?>.processInitSpan() = this["emb-process-init"]
+    private fun Map<String, EmbraceSpanData?>.embraceInitSpan() = this["emb-embrace-init"]
+    private fun Map<String, EmbraceSpanData?>.initGapSpan() = this["emb-activity-init-gap"]
+    private fun Map<String, EmbraceSpanData?>.customSpan() = this["custom-span"]
+    private fun Map<String, EmbraceSpanData?>.activityInitSpan() = this["emb-activity-create"]
+    private fun Map<String, EmbraceSpanData?>.firstFrameRenderSpan() = this["emb-first-frame-render"]
+    private fun Map<String, EmbraceSpanData?>.activityResumeSpan() = this["emb-activity-resume"]
+    private fun Map<String, EmbraceSpanData?>.appReadySpan() = this["emb-app-ready"]
+
+    private data class StartupTimestamps(
+        val traceStart: Long,
+        val sdkInitStart: Long? = null,
+        val sdkInitEnd: Long? = null,
+        val applicationInitEnd: Long? = null,
+        val customSpanStart: Long? = null,
+        val customSpanEnd: Long? = null,
+        val firstActivityInit: Long,
+        val startupActivityStart: Long,
+        val startupActivityEnd: Long,
+        val uiLoadEnd: Long,
+        val traceEnd: Long,
+    )
 
     private data class ActivityCreateEvents(
         var firstEvent: Long? = null,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -26,6 +26,7 @@ class FakeAppStartupDataCollector(
     var startupActivityInitEndMs: Long? = null
     var startupActivityResumedMs: Long? = null
     var firstFrameRenderedMs: Long? = null
+    var appReadyMs: Long? = null
     var customChildSpans = ConcurrentLinkedQueue<SpanData>()
     var customAttributes: MutableMap<String, String> = ConcurrentHashMap()
 
@@ -74,6 +75,11 @@ class FakeAppStartupDataCollector(
     ) {
         startupActivityName = activityName
         firstFrameRenderedMs = timestampMs ?: clock.now()
+        collectionCompleteCallback?.invoke()
+    }
+
+    override fun appReady(timestampMs: Long?, collectionCompleteCallback: (() -> Unit)?) {
+        appReadyMs = timestampMs ?: clock.now()
         collectionCompleteCallback?.invoke()
     }
 


### PR DESCRIPTION
## Goal

Add the ability to defer ending of a startup trace until manually notified. Note that this has not been hooked up to the SDK yet, which will come in a subsequent PR. This just adds the ability to do so in the trace emitting and data collection components.

I also significantly refactored the tests so that I can test this more easily. Doing so reveal a small bug where the pre-create time was not used when available (the activity create time was always used), which this PR also addressed.
