### PR TITLE
Add failBuildOnUploadErrors gradle plugin property

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
@@ -30,6 +30,11 @@ interface PluginBehavior {
     val isUploadMappingFilesDisabled: Boolean
 
     /**
+     * Whether the plugin should fail the build on upload errors, set via `embrace.failBuildOnUploadErrors`
+     */
+    val failBuildOnUploadErrors: Boolean
+
+    /**
      * The base URL for the Embrace API, set via `embrace.baseUrl`
      */
     val baseUrl: String
@@ -78,5 +83,6 @@ const val EMBRACE_INSTRUMENTATION_SCOPE = "embrace.instrumentationScope"
 const val EMBRACE_DISABLE_COLLECT_BUILD_DATA = "embrace.disableCollectBuildData"
 const val EMBRACE_UPLOAD_IL2CPP_MAPPING_FILES = "embrace.uploadIl2CppMappingFiles"
 const val EMBRACE_DISABLE_MAPPING_FILE_UPLOAD = "embrace.disableMappingFileUpload"
+const val EMBRACE_FAIL_BUILD_ON_UPLOAD_ERRORS = "embrace.failBuildOnUploadErrors"
 const val EMBRACE_UNITY_EXTERNAL_DEPENDENCY_MANAGER = "embrace.externalDependencyManager"
 const val DEFAULT_SYMBOL_STORE_HOST_URL = "https://dsym-store.emb-api.com"

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
@@ -35,6 +35,10 @@ class PluginBehaviorImpl(
         project.getBoolProperty(EMBRACE_DISABLE_MAPPING_FILE_UPLOAD)
     }
 
+    override val failBuildOnUploadErrors: Boolean by lazy {
+        project.getBoolProperty(EMBRACE_FAIL_BUILD_ON_UPLOAD_ERRORS)
+    }
+
     override val baseUrl: String by lazy {
         val prop = project.getProperty(EMBRACE_BASE_URL)
             ?: return@lazy DEFAULT_SYMBOL_STORE_HOST_URL


### PR DESCRIPTION
## Goal

If failBuildOnUploadErrors is enabled, any error during an upload task in the gradle plugin will fail the build. If it's not, build should continue as usual.

## Testing

Will add tests on specific tasks that use this property