### PR TITLE
Hook up API to allow manual app start trace ending

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -62,6 +62,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Instr
 	public abstract fun addStartupTraceAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun addStartupTraceChildSpan (Ljava/lang/String;JJ)V
 	public abstract fun addStartupTraceChildSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
+	public abstract fun appReady ()V
 	public abstract fun applicationInitEnd ()V
 	public abstract fun getSdkCurrentTimeMs ()J
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
@@ -19,6 +19,11 @@ public interface InstrumentationApi {
     public fun applicationInitEnd()
 
     /**
+     * Notify the Embrace SDK that app startup has completed and the UI is ready to be used.
+     */
+    public fun appReady()
+
+    /**
      * Notify the Embrace UI Load instrumentation that the given [Activity] instance has fully loaded, so its associated
      * trace can be stopped
      */

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
@@ -79,4 +79,9 @@ interface AutoDataCaptureBehavior : ConfigBehavior<EnabledFeatureConfig, RemoteC
      * Gates whether the SDK should use OkHttp or fallback to UrlConnection.
      */
     fun shouldUseOkHttp(): Boolean
+
+    /**
+     * Whether the app startup trace will be waiting for a call to Embrace.appReady() to signal completion
+     */
+    fun isManualAppStartupCompletionEnabled(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -61,4 +61,5 @@ class AutoDataCaptureBehaviorImpl(
     }
 
     override fun shouldUseOkHttp(): Boolean = shouldUseOkHttpImpl
+    override fun isManualAppStartupCompletionEnabled(): Boolean = local.isManualAppStartupCompletionEnabled()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
@@ -23,7 +23,7 @@ interface AppStartupDataCollector {
     /**
      * Set the time the first activity was detected to have started, irrespective of whether it should be used for startup
      */
-    fun firstActivityInit(timestampMs: Long? = null)
+    fun firstActivityInit(timestampMs: Long? = null, startupCompleteCallback: () -> Unit)
 
     /**
      * Set the time just prior to the creation of the Activity whose rendering will denote the end of the startup workflow
@@ -50,7 +50,6 @@ interface AppStartupDataCollector {
      */
     fun startupActivityResumed(
         activityName: String,
-        collectionCompleteCallback: (() -> Unit)? = null,
         timestampMs: Long? = null,
     )
 
@@ -59,17 +58,13 @@ interface AppStartupDataCollector {
      */
     fun firstFrameRendered(
         activityName: String,
-        collectionCompleteCallback: (() -> Unit)? = null,
         timestampMs: Long? = null,
     )
 
     /**
      * Notify the SDK app startup is complete. The startup trace will end if it's configured to wait for this to complete.
      */
-    fun appReady(
-        timestampMs: Long? = null,
-        collectionCompleteCallback: (() -> Unit)? = null
-    )
+    fun appReady(timestampMs: Long? = null)
 
     /**
      * Set an arbitrary time interval during startup that is of note

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -63,7 +63,8 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
             spanService = openTelemetryModule.spanService,
             backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
             versionChecker = versionChecker,
-            logger = initModule.logger
+            logger = initModule.logger,
+            manualEnd = configService.autoDataCaptureBehavior.isManualAppStartupCompletionEnabled()
         )
     }
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -76,59 +76,60 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `no crashes if startup service not available in T`() {
         startupService = null
-        createTraceEmitter().firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
-        assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
+        createTraceEmitter().simulateAppStartup(verifyTrace = false)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace with every event triggered in T`() {
-        createTraceEmitter().verifyAppStartupTrace()
+        createTraceEmitter().simulateAppStartup()
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace without application init start and end triggered in T`() {
-        createTraceEmitter().verifyAppStartupTrace(hasAppInitEvents = false)
+        createTraceEmitter().simulateAppStartup(hasAppInitEvents = false)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace aborted activity creation in T`() {
-        createTraceEmitter().verifyAppStartupTrace(abortFirstActivityLoad = true)
+        createTraceEmitter().simulateAppStartup(abortFirstActivityLoad = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace with splash screen in T`() {
-        createTraceEmitter().verifyAppStartupTrace(loadSplashScreen = true)
+        createTraceEmitter().simulateAppStartup(loadSplashScreen = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace with manual end in T`() {
-        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(manualEnd = true)
+        createTraceEmitter(manualEnd = true).simulateAppStartup(manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify warm start trace without application init start and end triggered in T`() {
-        createTraceEmitter().verifyAppStartupTrace(isColdStart = false, hasAppInitEvents = false)
+        createTraceEmitter().simulateAppStartup(isColdStart = false, hasAppInitEvents = false)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify warm start trace with manual end in T`() {
-        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(isColdStart = false, manualEnd = true)
+        createTraceEmitter(manualEnd = true).simulateAppStartup(isColdStart = false, manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `trace end callback will not be invoked twice`() {
         startupService = null
-        val appStartupTraceEmitter = createTraceEmitter()
-        appStartupTraceEmitter.firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
-        appStartupTraceEmitter.firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+        createTraceEmitter().run {
+            firstActivityInit(startupCompleteCallback = { dataCollectionCompletedCallbackInvokedCount++ })
+            firstFrameRendered(STARTUP_ACTIVITY_NAME)
+            firstFrameRendered(STARTUP_ACTIVITY_NAME)
+        }
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
     }
 
@@ -136,45 +137,44 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `no crashes if startup service not available in S`() {
         startupService = null
-        createTraceEmitter().firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
-        assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
+        createTraceEmitter().simulateAppStartup(verifyTrace = false)
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify cold start trace with every event triggered in S`() {
-        createTraceEmitter().verifyAppStartupTrace()
+        createTraceEmitter().simulateAppStartup()
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify cold start trace without application init start and end triggered in S`() {
-        createTraceEmitter().verifyAppStartupTrace(hasAppInitEvents = false)
+        createTraceEmitter().simulateAppStartup(hasAppInitEvents = false)
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify cold start trace aborted activity creation in S`() {
-        createTraceEmitter().verifyAppStartupTrace(abortFirstActivityLoad = true)
+        createTraceEmitter().simulateAppStartup(abortFirstActivityLoad = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify cold start trace with splash screen in S`() {
-        createTraceEmitter().verifyAppStartupTrace(loadSplashScreen = true)
+        createTraceEmitter().simulateAppStartup(loadSplashScreen = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify cold start trace with manual end in S`() {
-        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(manualEnd = true)
+        createTraceEmitter(manualEnd = true).simulateAppStartup(manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify warm start trace without application init start and end triggered in S`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 hasAppInitEvents = false
             )
@@ -184,7 +184,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace aborted activity creation S`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 hasAppInitEvents = false,
                 abortFirstActivityLoad = true
@@ -194,22 +194,25 @@ internal class AppStartupTraceEmitterTest {
     @Config(sdk = [Build.VERSION_CODES.S])
     @Test
     fun `verify warm start trace with manual end in S`() {
-        createTraceEmitter(manualEnd = true).verifyAppStartupTrace(isColdStart = false, manualEnd = true)
+        createTraceEmitter(manualEnd = true).simulateAppStartup(isColdStart = false, manualEnd = true)
     }
 
     @Config(sdk = [Build.VERSION_CODES.P])
     @Test
     fun `no crashes if startup service not available in P`() {
         startupService = null
-        createTraceEmitter().startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
-        assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
+        createTraceEmitter().simulateAppStartup(
+            verifyTrace = false,
+            firePreAndPostCreate = false,
+            hasRenderEvent = false
+        )
     }
 
     @Config(sdk = [Build.VERSION_CODES.P])
     @Test
     fun `verify cold start trace with every event triggered in P`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 hasRenderEvent = false
             )
@@ -219,7 +222,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace without application init start and end triggered in P`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 hasAppInitEvents = false,
                 hasRenderEvent = false
@@ -230,7 +233,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace aborted activity creation in P`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 hasRenderEvent = false,
                 abortFirstActivityLoad = true
@@ -241,7 +244,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace with splash screen in P`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 hasRenderEvent = false,
                 loadSplashScreen = true
@@ -252,7 +255,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace with manual end in P`() {
         createTraceEmitter(manualEnd = true)
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 hasRenderEvent = false,
                 manualEnd = true
@@ -263,7 +266,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace without application init start and end triggered in P`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 firePreAndPostCreate = false,
                 hasAppInitEvents = false,
@@ -275,7 +278,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace with manual end in P`() {
         createTraceEmitter(manualEnd = true)
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 firePreAndPostCreate = false,
                 hasRenderEvent = false,
@@ -287,15 +290,19 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `no crashes if startup service not available in M`() {
         startupService = null
-        createTraceEmitter().startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
-        assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
+        createTraceEmitter().simulateAppStartup(
+            verifyTrace = false,
+            firePreAndPostCreate = false,
+            trackProcessStart = false,
+            hasRenderEvent = false
+        )
     }
 
     @Config(sdk = [Build.VERSION_CODES.M])
     @Test
     fun `verify cold start trace with every event triggered in M`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false
@@ -306,7 +313,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace without application init start and end triggered in M`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasAppInitEvents = false,
@@ -318,7 +325,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace aborted activity creation in M`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false,
@@ -330,7 +337,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace with splash screen in M`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false,
@@ -342,7 +349,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace with manual end in M`() {
         createTraceEmitter(manualEnd = true)
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false,
@@ -354,7 +361,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace without application init start and end triggered in M`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
@@ -367,7 +374,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace with manual end in M`() {
         createTraceEmitter(manualEnd = true)
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
@@ -380,15 +387,19 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `no crashes if startup service not available in L`() {
         startupService = null
-        createTraceEmitter().startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
-        assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
+        createTraceEmitter().simulateAppStartup(
+            verifyTrace = false,
+            firePreAndPostCreate = false,
+            trackProcessStart = false,
+            hasRenderEvent = false
+        )
     }
 
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `verify cold start trace with every event triggered in L`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false
@@ -399,7 +410,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace without application init start and end triggered in L`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasAppInitEvents = false,
@@ -411,7 +422,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace aborted activity creation in L`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false,
@@ -423,7 +434,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace with splash screen in L`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false,
@@ -435,7 +446,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify cold start trace with manual end in L`() {
         createTraceEmitter(manualEnd = true)
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
                 hasRenderEvent = false,
@@ -447,7 +458,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace without application init start and end triggered in L`() {
         createTraceEmitter()
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
@@ -460,7 +471,7 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace with manual end in L`() {
         createTraceEmitter(manualEnd = true)
-            .verifyAppStartupTrace(
+            .simulateAppStartup(
                 isColdStart = false,
                 firePreAndPostCreate = false,
                 trackProcessStart = false,
@@ -481,7 +492,8 @@ internal class AppStartupTraceEmitterTest {
         )
 
     @Suppress("CyclomaticComplexMethod", "ComplexMethod")
-    private fun AppStartupTraceEmitter.verifyAppStartupTrace(
+    private fun AppStartupTraceEmitter.simulateAppStartup(
+        verifyTrace: Boolean = true,
         isColdStart: Boolean = true,
         firePreAndPostCreate: Boolean = true,
         trackProcessStart: Boolean = true,
@@ -559,24 +571,26 @@ internal class AppStartupTraceEmitterTest {
             uiLoadEnd
         }
 
-        StartupTimestamps(
-            traceStart = traceStart,
-            sdkInitStart = sdkInitStart,
-            sdkInitEnd = sdkInitEnd,
-            applicationInitEnd = applicationInitEnd,
-            customSpanStart = customSpanStartMs,
-            customSpanEnd = customSpanEndMs,
-            firstActivityInit = firstActivityInit,
-            startupActivityStart = startupActivityStart,
-            startupActivityEnd = startupActivityEnd,
-            uiLoadEnd = uiLoadEnd,
-            traceEnd = traceEnd
-        ).verifyTrace(
-            isColdStart = isColdStart,
-            hasAppInitEvents = hasAppInitEvents,
-            hasRenderEvent = hasRenderEvent,
-            manualEnd = manualEnd
-        )
+        if (verifyTrace) {
+            StartupTimestamps(
+                traceStart = traceStart,
+                sdkInitStart = sdkInitStart,
+                sdkInitEnd = sdkInitEnd,
+                applicationInitEnd = applicationInitEnd,
+                customSpanStart = customSpanStartMs,
+                customSpanEnd = customSpanEndMs,
+                firstActivityInit = firstActivityInit,
+                startupActivityStart = startupActivityStart,
+                startupActivityEnd = startupActivityEnd,
+                uiLoadEnd = uiLoadEnd,
+                traceEnd = traceEnd
+            ).verifyTrace(
+                isColdStart = isColdStart,
+                hasAppInitEvents = hasAppInitEvents,
+                hasRenderEvent = hasRenderEvent,
+                manualEnd = manualEnd
+            )
+        }
     }
 
     private fun StartupTimestamps.verifyTrace(
@@ -633,17 +647,13 @@ internal class AppStartupTraceEmitterTest {
         assertEquals(0, logger.internalErrorMessages.size)
     }
 
-    private fun dataCollectionCompletedCallback() {
-        dataCollectionCompletedCallbackInvokedCount++
-    }
-
     private fun startSdk(): Pair<Long, Long> {
         clock.tick(100L)
         val sdkInitStart = clock.now()
         clock.tick(30L)
         val sdkInitEnd = clock.now()
         clock.tick(400L)
-        checkNotNull(startupService).setSdkStartupInfo(
+        startupService?.setSdkStartupInfo(
             startTimeMs = sdkInitStart,
             endTimeMs = sdkInitEnd,
             endedInForeground = false,
@@ -658,7 +668,7 @@ internal class AppStartupTraceEmitterTest {
         abortFirstLoad: Boolean,
     ): ActivityCreateEvents {
         val activityCreateEvents = ActivityCreateEvents()
-        firstActivityInit()
+        firstActivityInit(startupCompleteCallback = { dataCollectionCompletedCallbackInvokedCount++ })
         activityCreateEvents.firstEvent = clock.now()
 
         if (loadSplashScreen) {
@@ -695,18 +705,18 @@ internal class AppStartupTraceEmitterTest {
     }
 
     private fun AppStartupTraceEmitter.startupActivityRender(renderFrame: Boolean): Pair<Long, Long> {
-        startupActivityResumed(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+        startupActivityResumed(STARTUP_ACTIVITY_NAME)
         val resumed = clock.now()
         if (renderFrame) {
             clock.tick(199L)
-            firstFrameRendered(STARTUP_ACTIVITY_NAME, ::dataCollectionCompletedCallback)
+            firstFrameRendered(STARTUP_ACTIVITY_NAME)
         }
         return Pair(resumed, clock.now())
     }
 
     private fun AppStartupTraceEmitter.invokeAppReady(): Long {
         clock.tick(1000L)
-        appReady(collectionCompleteCallback = ::dataCollectionCompletedCallback)
+        appReady()
         return clock.now()
     }
 

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -161,4 +161,6 @@ interface EnabledFeatureConfig {
      * - sdk_config.automatic_data_capture.ui_load_tracing_selected_only
      */
     fun isUiLoadTracingTraceAll(): Boolean = true
+
+    fun isManualAppStartupCompletionEnabled(): Boolean = false
 }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -12,6 +12,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun addStartupTraceChildSpan (Ljava/lang/String;JJ)V
 	public fun addStartupTraceChildSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
 	public fun addUserPersona (Ljava/lang/String;)V
+	public fun appReady ()V
 	public fun applicationInitEnd ()V
 	public fun clearAllUserPersonas ()V
 	public fun clearUserEmail ()V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -47,7 +47,7 @@ public class Embrace private constructor(
         impl.start(context)
     }
 
-    @Deprecated("Use {@link #start(Context)} instead.")
+    @Deprecated("Use {@link #start(Context)} instead.", ReplaceWith("start(Context)"))
     override fun start(context: Context, appFramework: AppFramework) {
         impl.start(context, appFramework)
     }
@@ -431,6 +431,10 @@ public class Embrace private constructor(
 
     override fun applicationInitEnd() {
         impl.applicationInitEnd()
+    }
+
+    override fun appReady() {
+        impl.appReady()
     }
 
     override fun logWebView(url: String?) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
@@ -28,6 +28,12 @@ internal class InstrumentationApiDelegate(
         }
     }
 
+    override fun appReady() {
+        if (sdkCallChecker.check("app_ready")) {
+            appStartupDataCollector?.appReady(timestampMs = clock.now())
+        }
+    }
+
     override fun activityLoaded(activity: Activity) {
         if (sdkCallChecker.check("activity_fully_loaded")) {
             uiLoadTraceEmitter?.complete(traceInstanceId(activity), clock.now())

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -27,6 +27,7 @@ class FakeAppStartupDataCollector(
     var startupActivityResumedMs: Long? = null
     var firstFrameRenderedMs: Long? = null
     var appReadyMs: Long? = null
+    var appStartupCompleteCallback: (() -> Unit)? = null
     var customChildSpans = ConcurrentLinkedQueue<SpanData>()
     var customAttributes: MutableMap<String, String> = ConcurrentHashMap()
 
@@ -38,8 +39,9 @@ class FakeAppStartupDataCollector(
         applicationInitEndMs = timestampMs ?: clock.now()
     }
 
-    override fun firstActivityInit(timestampMs: Long?) {
+    override fun firstActivityInit(timestampMs: Long?, startupCompleteCallback: () -> Unit) {
         firstActivityInitMs = timestampMs ?: clock.now()
+        appStartupCompleteCallback = startupCompleteCallback
     }
 
     override fun startupActivityPreCreated(timestampMs: Long?) {
@@ -60,27 +62,25 @@ class FakeAppStartupDataCollector(
 
     override fun startupActivityResumed(
         activityName: String,
-        collectionCompleteCallback: (() -> Unit)?,
         timestampMs: Long?,
     ) {
         startupActivityName = activityName
         startupActivityResumedMs = timestampMs ?: clock.now()
-        collectionCompleteCallback?.invoke()
+        appStartupCompleteCallback?.invoke()
     }
 
     override fun firstFrameRendered(
         activityName: String,
-        collectionCompleteCallback: (() -> Unit)?,
         timestampMs: Long?,
     ) {
         startupActivityName = activityName
         firstFrameRenderedMs = timestampMs ?: clock.now()
-        collectionCompleteCallback?.invoke()
+        appStartupCompleteCallback?.invoke()
     }
 
-    override fun appReady(timestampMs: Long?, collectionCompleteCallback: (() -> Unit)?) {
+    override fun appReady(timestampMs: Long?) {
         appReadyMs = timestampMs ?: clock.now()
-        collectionCompleteCallback?.invoke()
+        appStartupCompleteCallback?.invoke()
     }
 
     override fun addTrackedInterval(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -19,6 +19,7 @@ class FakeAutoDataCaptureBehavior(
     private val uiLoadTracingTraceAll: Boolean = true,
     private val v2StorageEnabled: Boolean = true,
     private val useOkhttp: Boolean = true,
+    private val manualAppStartupCompletion: Boolean = false,
 ) : AutoDataCaptureBehavior {
 
     override val local: EnabledFeatureConfig
@@ -40,4 +41,5 @@ class FakeAutoDataCaptureBehavior(
     override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
     override fun isV2StorageEnabled(): Boolean = v2StorageEnabled
     override fun shouldUseOkHttp(): Boolean = useOkhttp
+    override fun isManualAppStartupCompletionEnabled(): Boolean = manualAppStartupCompletion
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -28,6 +28,7 @@ class FakeEnabledFeatureConfig(
     private val networkSpanForwarding: Boolean = base.isNetworkSpanForwardingEnabled(),
     private val uiLoadTracingEnabled: Boolean = base.isUiLoadTracingEnabled(),
     private val uiLoadTracingTraceAll: Boolean = base.isUiLoadTracingTraceAll(),
+    private val manualAppStartupCompletion: Boolean = base.isManualAppStartupCompletionEnabled(),
 ) : EnabledFeatureConfig {
 
     override fun isUnityAnrCaptureEnabled(): Boolean = unityAnrCapture
@@ -54,4 +55,5 @@ class FakeEnabledFeatureConfig(
     override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwarding
     override fun isUiLoadTracingEnabled(): Boolean = uiLoadTracingEnabled
     override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
+    override fun isManualAppStartupCompletionEnabled(): Boolean = manualAppStartupCompletion
 }


### PR DESCRIPTION
## Goal

Add `appReady()` to the public API that ends the startup trace if a local feature flag set on the AutoDataCaptureBehavior indicates that it should do so.

The code to derive the value for the flag will come in a later PR.

## Testing
Add integration test
