### PR TITLE
Rollback naming logic for JvmMappingUpload tasks

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -58,8 +58,10 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
         baseUrl: String,
         variantConfigurationsListProperty: ListProperty<VariantConfig>,
     ): TaskProvider<MultipartUploadTask> {
+        val anchorTaskWithoutVariant = anchorTask.name.replace(variant.name, "", true)
+        val compressionTaskName = "${COMPRESS_TASK_NAME}For${anchorTaskWithoutVariant}OnVariant"
         val compressionTask = project.registerTask(
-            "$COMPRESS_TASK_NAME${variant.name}",
+            compressionTaskName,
             FileCompressionTask::class.java,
             variant
         ) { task: FileCompressionTask ->
@@ -72,8 +74,9 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
             )
         }
 
+        val uploadTaskName = "${UPLOAD_TASK_NAME}For${anchorTaskWithoutVariant}OnVariant"
         val uploadTask = project.registerTask(
-            "$UPLOAD_TASK_NAME${variant.name}",
+            uploadTaskName,
             MultipartUploadTask::class.java,
             variant
         ) { task ->


### PR DESCRIPTION
## Goal

An error was reported in 7.1.0 where multiple jvmMapping tasks are registered with the same name. This change rolls back the naming logic to the one we used in 7.0.0, though keeping the new task name.

## Testing

Relied on existing tests. Will add tests for dexguard next week.
