### PR TITLE
Revert in-flight app startup changes

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -27,9 +27,6 @@ public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/CustomLoadTracedActivity : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class io/embrace/android/embracesdk/annotation/IgnoreForStartup : java/lang/annotation/Annotation {
-}
-
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/InternalApi : java/lang/annotation/Annotation {
 }
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/IgnoreForStartup.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/IgnoreForStartup.kt
@@ -1,8 +1,0 @@
-package io.embrace.android.embracesdk.annotation
-
-/**
- * Ignore for the purposes of tracking App startup
- */
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-public annotation class IgnoreForStartup

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/StartupActivity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/annotation/StartupActivity.kt
@@ -1,6 +1,23 @@
 package io.embrace.android.embracesdk.annotation
 
-@Deprecated("Does nothing")
+import java.lang.annotation.Inherited
+
+/**
+ * `@Documented` means that the annotation indicates that elements using this annotation should be documented by JavaDoc.
+ *
+ *
+ * `@Target` specifies where we can use the annotation.
+ * If you do not define any Target type that means annotation can be applied to any element.
+ *
+ *
+ * `@Inherited` signals that a custom annotation used in a class should be inherited by all of its sub classes.
+ *
+ *
+ * `@Retention` indicates how long annotations with the annotated type are to be retained.
+ * RetentionPolicy.RUNTIME means the annotation should be available at runtime, for inspection via java reflection.
+ */
+@MustBeDocumented
 @Target(AnnotationTarget.CLASS)
+@Inherited
 @Retention(AnnotationRetention.RUNTIME)
 public annotation class StartupActivity

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/registry/ServiceRegistry.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/registry/ServiceRegistry.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
+import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -32,6 +33,7 @@ class ServiceRegistry : Closeable {
     val activityLifecycleListeners: List<ActivityLifecycleListener> by lazy {
         finalRegistry.filterIsInstance<ActivityLifecycleListener>()
     }
+    val startupListener: List<StartupListener> by lazy { finalRegistry.filterIsInstance<StartupListener>() }
 
     fun registerServices(vararg services: Lazy<Any?>) {
         Systrace.trace("register-services") {
@@ -63,6 +65,11 @@ class ServiceRegistry : Closeable {
     fun registerMemoryCleanerListeners(memoryCleanerService: MemoryCleanerService): Unit =
         memoryCleanerListeners.forEachSafe(
             memoryCleanerService::addListener
+        )
+
+    fun registerStartupListener(activityLifecycleTracker: ActivityTracker): Unit =
+        startupListener.forEachSafe(
+            activityLifecycleTracker::addStartupListener
         )
 
     // close all of the services in one go. this prevents someone creating a Closeable service

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityTracker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/ActivityTracker.kt
@@ -17,4 +17,6 @@ interface ActivityTracker : Application.ActivityLifecycleCallbacks, Closeable {
     val foregroundActivity: Activity?
 
     fun addListener(listener: ActivityLifecycleListener)
+
+    fun addStartupListener(listener: StartupListener)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/StartupListener.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/StartupListener.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.internal.session.lifecycle
+
+interface StartupListener {
+    /**
+     * Triggered when the application has completed startup;
+     */
+    fun applicationStartupComplete() {}
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
+import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -26,6 +27,7 @@ internal class ServiceRegistryTest {
         assertEquals(expected, registry.processStateListeners)
         assertEquals(expected, registry.activityLifecycleListeners)
         assertEquals(expected, registry.memoryCleanerListeners)
+        assertEquals(expected, registry.startupListener)
     }
 
     @Test
@@ -41,7 +43,9 @@ internal class ServiceRegistryTest {
 
         val activityLifecycleTracker = FakeActivityTracker()
         registry.registerActivityLifecycleListeners(activityLifecycleTracker)
+        registry.registerStartupListener(activityLifecycleTracker)
         assertEquals(expected, activityLifecycleTracker.listeners)
+        assertEquals(expected, activityLifecycleTracker.startupListeners)
 
         val memoryCleanerService = FakeMemoryCleanerService()
         registry.registerMemoryCleanerListeners(memoryCleanerService)
@@ -63,7 +67,8 @@ internal class ServiceRegistryTest {
         Closeable,
         MemoryCleanerListener,
         ProcessStateListener,
-        ActivityLifecycleListener {
+        ActivityLifecycleListener,
+        StartupListener {
 
         var closed = false
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/ActivityLifecycleTrackerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/ActivityLifecycleTrackerTest.kt
@@ -6,10 +6,13 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Bundle
 import android.os.Looper
+import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleTracker
+import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
+import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -121,6 +124,25 @@ internal class ActivityLifecycleTrackerTest {
     }
 
     @Test
+    fun `verify on activity resumed for a StartupActivity does not trigger listeners`() {
+        val mockActivityLifecycleListener = mockk<ActivityLifecycleListener>()
+        activityLifecycleTracker.addListener(mockActivityLifecycleListener)
+
+        activityLifecycleTracker.onActivityResumed(TestStartupActivity())
+
+        verify { mockActivityLifecycleListener wasNot Called }
+    }
+
+    @Test
+    fun `verify on activity resumed for a non StartupActivity does trigger listeners`() {
+        val mockStartupListener = mockk<StartupListener>()
+        activityLifecycleTracker.addStartupListener(mockStartupListener)
+        activityLifecycleTracker.onActivityResumed(TestNonStartupActivity())
+
+        verify { mockStartupListener.applicationStartupComplete() }
+    }
+
+    @Test
     fun `verify on activity stopped triggers listeners`() {
         val mockActivity = mockk<Activity>()
         every { mockActivity.localClassName } returns "localClassName"
@@ -170,6 +192,17 @@ internal class ActivityLifecycleTrackerTest {
     }
 
     @Test
+    fun `verify startup listener is added`() {
+        // assert empty list first
+        assertEquals(0, activityLifecycleTracker.startupListeners.size)
+
+        val mockStartupListeners = mockk<StartupListener>()
+        activityLifecycleTracker.addStartupListener(mockStartupListeners)
+
+        assertEquals(1, activityLifecycleTracker.startupListeners.size)
+    }
+
+    @Test
     fun `verify if listener is already present, then it does not add anything`() {
         val mockActivityLifecycleListener = mockk<ActivityLifecycleListener>()
         activityLifecycleTracker.addListener(mockActivityLifecycleListener)
@@ -195,7 +228,9 @@ internal class ActivityLifecycleTrackerTest {
     fun `verify close cleans everything`() {
         // add a listener first, so we then check that listener have been cleared
         val mockActivityLifecycleListener = mockk<ActivityLifecycleListener>()
+        val mockStartupListeners = mockk<StartupListener>()
         activityLifecycleTracker.addListener(mockActivityLifecycleListener)
+        activityLifecycleTracker.addStartupListener(mockStartupListeners)
 
         every { application.unregisterActivityLifecycleCallbacks(activityLifecycleTracker) } returns Unit
 
@@ -203,5 +238,11 @@ internal class ActivityLifecycleTrackerTest {
 
         verify { application.unregisterActivityLifecycleCallbacks(activityLifecycleTracker) }
         assertTrue(activityLifecycleTracker.activityListeners.isEmpty())
+        assertTrue(activityLifecycleTracker.startupListeners.isEmpty())
     }
+
+    @StartupActivity
+    private class TestStartupActivity : Activity()
+
+    private class TestNonStartupActivity : Activity()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupDataCollector.kt
@@ -21,11 +21,6 @@ interface AppStartupDataCollector {
     fun applicationInitEnd(timestampMs: Long? = null)
 
     /**
-     * Set the time the first activity was detected to have started, irrespective of whether it should be used for startup
-     */
-    fun firstActivityInit(timestampMs: Long? = null)
-
-    /**
      * Set the time just prior to the creation of the Activity whose rendering will denote the end of the startup workflow
      */
     fun startupActivityPreCreated(timestampMs: Long? = null)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -291,7 +291,7 @@ internal class AppStartupTraceEmitter(
     ): EmbraceSpan? {
         return if (!startupRecorded.get()) {
             spanService.startSpan(
-                name = "app-startup-cold",
+                name = "cold-time-to-initial-display",
                 startTimeMs = traceStartTimeMs,
             )?.apply {
                 addTraceMetadata()
@@ -361,7 +361,7 @@ internal class AppStartupTraceEmitter(
     ): EmbraceSpan? {
         return if (!startupRecorded.get()) {
             spanService.startSpan(
-                name = "app-startup-warm",
+                name = "warm-time-to-initial-display",
                 startTimeMs = traceStartTimeMs,
             )?.apply {
                 addTraceMetadata()

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -113,10 +113,6 @@ internal class AppStartupTraceEmitter(
         applicationInitEndMs = timestampMs ?: nowMs()
     }
 
-    override fun firstActivityInit(timestampMs: Long?) {
-        firstActivityInitStartMs = timestampMs ?: nowMs()
-    }
-
     override fun startupActivityPreCreated(timestampMs: Long?) {
         startupActivityPreCreatedMs = timestampMs ?: nowMs()
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -209,6 +209,7 @@ internal class AppStartupTraceEmitter(
         val startupService = startupServiceProvider() ?: return
         val sdkInitStartMs = startupService.getSdkInitStartMs()
         val sdkInitEndMs = startupService.getSdkInitEndMs()
+        val sdkStartupDuration = duration(sdkInitStartMs, sdkInitEndMs)
         val processStartTimeMs: Long? =
             if (versionChecker.isAtLeast(VERSION_CODES.N)) {
                 processCreatedMs
@@ -250,6 +251,8 @@ internal class AppStartupTraceEmitter(
                             activityInitStartMs = startupActivityInitStartMs,
                             activityInitEndMs = startupActivityInitEndMs,
                             traceEndTimeMs = traceEndTimeMs,
+                            processToActivityCreateGap = gap,
+                            sdkStartupDuration = sdkStartupDuration,
                         )
                     }
                 }
@@ -358,12 +361,21 @@ internal class AppStartupTraceEmitter(
         activityInitStartMs: Long?,
         activityInitEndMs: Long?,
         traceEndTimeMs: Long,
+        processToActivityCreateGap: Long?,
+        sdkStartupDuration: Long?,
     ): EmbraceSpan? {
         return if (!startupRecorded.get()) {
             spanService.startSpan(
                 name = "warm-time-to-initial-display",
                 startTimeMs = traceStartTimeMs,
             )?.apply {
+                processToActivityCreateGap?.let { gap ->
+                    addAttribute("activity-init-gap-ms", gap.toString())
+                }
+                sdkStartupDuration?.let { duration ->
+                    addAttribute("embrace-init-duration-ms", duration.toString())
+                }
+
                 addTraceMetadata()
 
                 if (stop(endTimeMs = traceEndTimeMs)) {
@@ -394,6 +406,8 @@ internal class AppStartupTraceEmitter(
         }
     }
 
+    private fun processCreateDelay(): Long? = duration(processCreateRequestedMs, processCreatedMs)
+
     private fun applicationActivityCreationGap(sdkInitEndMs: Long): Long? =
         duration(applicationInitEndMs ?: sdkInitEndMs, firstActivityInitStartMs)
 
@@ -401,9 +415,32 @@ internal class AppStartupTraceEmitter(
 
     private fun PersistableEmbraceSpan.addTraceMetadata() {
         addCustomAttributes()
+        processCreateDelay()?.let { delay ->
+            addAttribute("process-create-delay-ms", delay.toString())
+        }
 
         startupActivityName?.let { name ->
             addAttribute("startup-activity-name", name)
+        }
+
+        startupActivityPreCreatedMs?.let { timeMs ->
+            addAttribute("startup-activity-pre-created-ms", timeMs.toString())
+        }
+
+        startupActivityPostCreatedMs?.let { timeMs ->
+            addAttribute("startup-activity-post-created-ms", timeMs.toString())
+        }
+
+        sdkInitEndedInForeground?.let { inForeground ->
+            addAttribute("embrace-init-in-foreground", inForeground.toString())
+        }
+
+        firstActivityInitStartMs?.let { timeMs ->
+            addAttribute("first-activity-init-ms", timeMs.toString())
+        }
+
+        sdkInitThreadName?.let { threadName ->
+            addAttribute("embrace-init-thread-name", threadName)
         }
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.capture.startup
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import io.embrace.android.embracesdk.annotation.IgnoreForStartup
+import io.embrace.android.embracesdk.annotation.StartupActivity
 import io.embrace.android.embracesdk.internal.capture.activity.traceInstanceId
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.ui.DrawEventEmitter
@@ -126,6 +126,6 @@ class StartupTracker(
     }
 
     private companion object {
-        fun Activity.observeForStartup(): Boolean = !javaClass.isAnnotationPresent(IgnoreForStartup::class.java)
+        fun Activity.observeForStartup(): Boolean = !javaClass.isAnnotationPresent(StartupActivity::class.java)
     }
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupTracker.kt
@@ -35,17 +35,14 @@ class StartupTracker(
 
     private var startupActivityId: Int? = null
     private var startupDataCollectionComplete = false
-    private var firstActivitySeen = false
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
-        firstActivityInit()
         if (activity.useAsStartupActivity()) {
             appStartupDataCollector.startupActivityPreCreated()
         }
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        firstActivityInit()
         if (activity.useAsStartupActivity()) {
             appStartupDataCollector.startupActivityInitStart()
             val application = activity.application
@@ -89,13 +86,6 @@ class StartupTracker(
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
 
     override fun onActivityDestroyed(activity: Activity) {}
-
-    private fun firstActivityInit() {
-        if (!firstActivitySeen) {
-            appStartupDataCollector.firstActivityInit()
-            firstActivitySeen = true
-        }
-    }
 
     private fun startupComplete(application: Application) {
         if (!startupDataCollectionComplete) {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -237,7 +237,7 @@ internal class AppStartupTraceEmitterTest {
 
         assertEquals(8, spanSink.completedSpans().size)
         val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
         val processInit = checkNotNull(spanMap["emb-process-init"])
         val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
         val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
@@ -270,7 +270,7 @@ internal class AppStartupTraceEmitterTest {
 
         assertEquals(6, spanSink.completedSpans().size)
         val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
         val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
         val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
         val activityCreate = checkNotNull(spanMap["emb-activity-create"])
@@ -306,7 +306,7 @@ internal class AppStartupTraceEmitterTest {
 
         assertEquals(7, spanSink.completedSpans().size)
         val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
         val processInit = checkNotNull(spanMap["emb-process-init"])
         val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
         val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
@@ -341,7 +341,7 @@ internal class AppStartupTraceEmitterTest {
 
         assertEquals(6, spanSink.completedSpans().size)
         val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-cold"])
+        val trace = checkNotNull(spanMap["emb-cold-time-to-initial-display"])
         val embraceInit = checkNotNull(spanMap["emb-embrace-init"])
         val activityInitDelay = checkNotNull(spanMap["emb-activity-init-gap"])
         val activityCreate = checkNotNull(spanMap["emb-activity-create"])
@@ -375,7 +375,7 @@ internal class AppStartupTraceEmitterTest {
 
         assertEquals(4, spanSink.completedSpans().size)
         val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-warm"])
+        val trace = checkNotNull(spanMap["emb-warm-time-to-initial-display"])
         val activityCreate = checkNotNull(spanMap["emb-activity-create"])
         val firstRender = checkNotNull(spanMap["emb-first-frame-render"])
 
@@ -401,7 +401,7 @@ internal class AppStartupTraceEmitterTest {
 
         assertEquals(4, spanSink.completedSpans().size)
         val spanMap = spanSink.completedSpans().associateBy { it.name }
-        val trace = checkNotNull(spanMap["emb-app-startup-warm"])
+        val trace = checkNotNull(spanMap["emb-warm-time-to-initial-display"])
         val activityCreate = checkNotNull(spanMap["emb-activity-create"])
         val activityResume = checkNotNull(spanMap["emb-activity-resume"])
 
@@ -440,10 +440,10 @@ internal class AppStartupTraceEmitterTest {
 
         val spanMap = spanSink.completedSpans().associateBy { it.name }
         val traceName = if (isWarm) {
-            "emb-app-startup-warm"
+            "emb-warm-time-to-initial-display"
         } else {
             assertChildSpan(checkNotNull(spanMap["emb-activity-init-gap"]), sdkInitEnd, firstActivityInit)
-            "emb-app-startup-cold"
+            "emb-cold-time-to-initial-display"
         }
         val trace = checkNotNull(spanMap[traceName])
         val activityCreate = checkNotNull(spanMap["emb-activity-create"])

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -76,13 +76,13 @@ internal class AppStartupTraceEmitterTest {
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace with every event triggered in T`() {
-        verifyColdStartWithRender()
+        verifyColdStartWithRender(processCreateDelayMs = 0L)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace without application init start and end triggered in T`() {
-        verifyColdStartWithRenderWithoutAppInitEvents()
+        verifyColdStartWithRenderWithoutAppInitEvents(processCreateDelayMs = 0L)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
@@ -94,7 +94,7 @@ internal class AppStartupTraceEmitterTest {
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `verify warm start trace without application init start and end triggered in T`() {
-        verifyWarmStartWithRenderWithoutAppInitEvents()
+        verifyWarmStartWithRenderWithoutAppInitEvents(processCreateDelayMs = 0L)
     }
 
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
@@ -220,7 +220,7 @@ internal class AppStartupTraceEmitterTest {
         dataCollectionCompletedCallbackInvokedCount++
     }
 
-    private fun verifyColdStartWithRender() {
+    private fun verifyColdStartWithRender(processCreateDelayMs: Long? = null) {
         clock.tick(100L)
         appStartupTraceEmitter.applicationInitStart()
         val customSpanStartMs = clock.now()
@@ -252,6 +252,10 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = DEFAULT_FAKE_CURRENT_TIME,
             expectedEndTimeMs = traceEnd,
+            expectedProcessCreateDelayMs = processCreateDelayMs,
+            expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
+            expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
+            expectedFirstActivityLifecycleEventMs = activityCreateEvents.firstEvent,
             expectedCustomAttributes = mapOf("custom-attribute" to "true")
         )
         assertChildSpan(processInit, DEFAULT_FAKE_CURRENT_TIME, applicationInitEnd)
@@ -263,7 +267,7 @@ internal class AppStartupTraceEmitterTest {
         assertEquals(0, logger.internalErrorMessages.size)
     }
 
-    private fun verifyColdStartWithRenderWithoutAppInitEvents() {
+    private fun verifyColdStartWithRenderWithoutAppInitEvents(processCreateDelayMs: Long? = null) {
         val (sdkInitStart, sdkInitEnd) = startSdk()
         val activityCreateEvents = createStartupActivity()
         val traceEnd = startupActivityRender().second
@@ -283,6 +287,10 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = DEFAULT_FAKE_CURRENT_TIME,
             expectedEndTimeMs = traceEnd,
+            expectedProcessCreateDelayMs = processCreateDelayMs,
+            expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
+            expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
+            expectedFirstActivityLifecycleEventMs = activityCreateEvents.firstEvent,
         )
 
         assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
@@ -325,6 +333,7 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = traceStartMs,
             expectedEndTimeMs = traceEnd,
+            expectedFirstActivityLifecycleEventMs = startupActivityStart,
         )
         assertChildSpan(processInit, traceStartMs, applicationInitEnd)
         assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
@@ -359,6 +368,7 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = traceStartMs,
             expectedEndTimeMs = traceEnd,
+            expectedFirstActivityLifecycleEventMs = startupActivityStart,
         )
         assertChildSpan(embraceInit, sdkInitStart, sdkInitEnd)
         assertChildSpan(activityInitDelay, sdkInitEnd, startupActivityStart)
@@ -367,8 +377,8 @@ internal class AppStartupTraceEmitterTest {
         assertEquals(0, logger.internalErrorMessages.size)
     }
 
-    private fun verifyWarmStartWithRenderWithoutAppInitEvents() {
-        startSdk()
+    private fun verifyWarmStartWithRenderWithoutAppInitEvents(processCreateDelayMs: Long? = null) {
+        val sdkInitEnd = startSdk().second
         clock.tick(1601L)
         val activityCreateEvents = createStartupActivity()
         val traceEnd = startupActivityRender().second
@@ -382,12 +392,19 @@ internal class AppStartupTraceEmitterTest {
         val startupActivityStart = checkNotNull(activityCreateEvents.create)
         val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
 
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = startupActivityStart,
-            expectedEndTimeMs = traceEnd,
-        )
-
+        with(trace) {
+            assertTraceRoot(
+                input = this,
+                expectedStartTimeMs = startupActivityStart,
+                expectedEndTimeMs = traceEnd,
+                expectedProcessCreateDelayMs = processCreateDelayMs,
+                expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
+                expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
+                expectedFirstActivityLifecycleEventMs = startupActivityStart,
+            )
+            assertEquals((startupActivityStart - sdkInitEnd).toString(), attributes["activity-init-gap-ms"])
+            assertEquals("30", attributes["embrace-init-duration-ms"])
+        }
         assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
         assertChildSpan(firstRender, startupActivityEnd, traceEnd)
         assertEquals(0, logger.internalErrorMessages.size)
@@ -408,12 +425,16 @@ internal class AppStartupTraceEmitterTest {
         val startupActivityStart = checkNotNull(activityCreateEvents.create)
         val startupActivityEnd = checkNotNull((activityCreateEvents.finished))
 
-        assertTraceRoot(
-            input = trace,
-            expectedStartTimeMs = startupActivityStart,
-            expectedEndTimeMs = traceEnd,
-        )
-
+        with(trace) {
+            assertTraceRoot(
+                input = this,
+                expectedStartTimeMs = startupActivityStart,
+                expectedEndTimeMs = traceEnd,
+                expectedFirstActivityLifecycleEventMs = startupActivityStart,
+            )
+            assertEquals("2401", attributes["activity-init-gap-ms"])
+            assertEquals("30", attributes["embrace-init-duration-ms"])
+        }
         assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
         assertChildSpan(activityResume, startupActivityEnd, traceEnd)
         assertEquals(0, logger.internalErrorMessages.size)
@@ -451,7 +472,11 @@ internal class AppStartupTraceEmitterTest {
         assertTraceRoot(
             input = trace,
             expectedStartTimeMs = traceStart,
-            expectedEndTimeMs = traceEnd
+            expectedEndTimeMs = traceEnd,
+            expectedProcessCreateDelayMs = if (isWarm) null else 0,
+            expectedActivityPreCreatedMs = activityCreateEvents.preCreate,
+            expectedActivityPostCreatedMs = activityCreateEvents.postCreate,
+            expectedFirstActivityLifecycleEventMs = firstActivityInit
         )
 
         assertChildSpan(activityCreate, startupActivityStart, startupActivityEnd)
@@ -519,6 +544,10 @@ internal class AppStartupTraceEmitterTest {
         input: EmbraceSpanData,
         expectedStartTimeMs: Long,
         expectedEndTimeMs: Long,
+        expectedProcessCreateDelayMs: Long? = null,
+        expectedActivityPreCreatedMs: Long? = null,
+        expectedActivityPostCreatedMs: Long? = null,
+        expectedFirstActivityLifecycleEventMs: Long? = null,
         expectedCustomAttributes: Map<String, String> = emptyMap(),
     ) {
         val trace = input.toNewPayload()
@@ -527,6 +556,21 @@ internal class AppStartupTraceEmitterTest {
         trace.assertDoesNotHaveEmbraceAttribute(PrivateSpan)
         val attrs = checkNotNull(trace.attributes)
         assertEquals(STARTUP_ACTIVITY_NAME, attrs.findAttributeValue("startup-activity-name"))
+        assertEquals(expectedProcessCreateDelayMs?.toString(), attrs.findAttributeValue("process-create-delay-ms"))
+        assertEquals(
+            expectedActivityPreCreatedMs?.toString(),
+            attrs.findAttributeValue("startup-activity-pre-created-ms")
+        )
+        assertEquals(
+            expectedActivityPostCreatedMs?.toString(),
+            attrs.findAttributeValue("startup-activity-post-created-ms")
+        )
+        assertEquals(
+            expectedFirstActivityLifecycleEventMs?.toString(),
+            attrs.findAttributeValue("first-activity-init-ms")
+        )
+        assertEquals("false", attrs.findAttributeValue("embrace-init-in-foreground"))
+        assertEquals("main", attrs.findAttributeValue("embrace-init-thread-name"))
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
 
         expectedCustomAttributes.forEach { entry ->

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -73,7 +73,7 @@ internal class AppStartupTraceTest {
             otelExportAssertion = {
                 val spans = awaitSpansWithType(7, EmbType.Performance.Default).associateBy { it.name }
                 assertTrue(spans.isNotEmpty())
-                with(checkNotNull(spans["emb-app-startup-cold"])) {
+                with(checkNotNull(spans["emb-cold-time-to-initial-display"])) {
                     assertEquals("yes", attributes.toNewPayload().findAttributeValue("custom-attribute"))
                 }
                 assertTrue(spans.containsKey("emb-embrace-init"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.testcases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeActivity
-import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -17,16 +15,12 @@ import io.embrace.android.embracesdk.internal.spans.toStatus
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.ACTIVITY_GAP
-import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
-import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.POST_ACTIVITY_ACTION_DWELL
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
 
 @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
@@ -96,125 +90,6 @@ internal class AppStartupTraceTest {
                     assertEquals(Span.Status.ERROR, status.statusCode.toStatus())
                 }
                 assertTrue(spans.containsKey("emb-activity-create"))
-                assertTrue(spans.containsKey("emb-activity-resume"))
-            }
-        )
-    }
-
-    @Test
-    fun `warm startup`() {
-        var startupActivityInitMs: Long? = null
-        testRule.runTest(
-            instrumentedConfig = FakeInstrumentedConfig(
-                enabledFeatures = FakeEnabledFeatureConfig(
-                    bgActivityCapture = true
-                )
-            ),
-            testCaseAction = {
-                val initGap = 10000L
-                clock.tick(initGap)
-                startupActivityInitMs = clock.now()
-                simulateOpeningActivities(
-                    addStartupActivity = false
-                )
-            },
-            otelExportAssertion = {
-                val spans = awaitSpansWithType(3, EmbType.Performance.Default).associateBy { it.name }
-                assertTrue(spans.isNotEmpty())
-                with(checkNotNull(spans["emb-app-startup-warm"])) {
-                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
-                }
-                with(checkNotNull(spans["emb-activity-create"])) {
-                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
-                }
-                assertTrue(spans.containsKey("emb-activity-resume"))
-            }
-        )
-    }
-
-    @Test
-    fun `cold startup with long splash screen`() {
-        var sdkStartTimeMs: Long? = null
-        var firstActivityInitMs: Long? = null
-        var startupActivityInitMs: Long? = null
-        testRule.runTest(
-            instrumentedConfig = FakeInstrumentedConfig(
-                enabledFeatures = FakeEnabledFeatureConfig(
-                    bgActivityCapture = true
-                )
-            ),
-            testCaseAction = {
-                val splashScreenDwellTime = 5000L
-                sdkStartTimeMs = clock.now()
-                firstActivityInitMs = clock.tick()
-                startupActivityInitMs = clock.now() + (3 * LIFECYCLE_EVENT_GAP) + POST_ACTIVITY_ACTION_DWELL +
-                    ACTIVITY_GAP + splashScreenDwellTime
-                simulateOpeningActivities(
-                    addStartupActivity = false,
-                    activitiesAndActions = listOf(
-                        Robolectric.buildActivity(FakeSplashScreenActivity::class.java) to {
-                            clock.tick(
-                                splashScreenDwellTime
-                            )
-                        },
-                        Robolectric.buildActivity(FakeActivity::class.java) to {},
-                    )
-                )
-            },
-            otelExportAssertion = {
-                val spans = awaitSpansWithType(5, EmbType.Performance.Default).associateBy { it.name }
-                assertTrue(spans.isNotEmpty())
-                assertTrue(spans.containsKey("emb-app-startup-cold"))
-                assertTrue(spans.containsKey("emb-embrace-init"))
-                with(checkNotNull(spans["emb-activity-init-gap"])) {
-                    assertEquals(sdkStartTimeMs, startEpochNanos.nanosToMillis())
-                    assertEquals(firstActivityInitMs, endEpochNanos.nanosToMillis())
-                }
-                with(checkNotNull(spans["emb-activity-create"])) {
-                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
-                }
-                assertTrue(spans.containsKey("emb-activity-resume"))
-            }
-        )
-    }
-
-    @Test
-    fun `warm startup with long splash screen`() {
-        var firstActivityInitMs: Long? = null
-        var startupActivityInitMs: Long? = null
-        testRule.runTest(
-            instrumentedConfig = FakeInstrumentedConfig(
-                enabledFeatures = FakeEnabledFeatureConfig(
-                    bgActivityCapture = true
-                )
-            ),
-            testCaseAction = {
-                val initGap = 10000L
-                val splashScreenDwellTime = 5000L
-                firstActivityInitMs = clock.tick(initGap)
-                startupActivityInitMs = clock.now() + (3 * LIFECYCLE_EVENT_GAP) + POST_ACTIVITY_ACTION_DWELL +
-                    ACTIVITY_GAP + splashScreenDwellTime
-                simulateOpeningActivities(
-                    addStartupActivity = false,
-                    activitiesAndActions = listOf(
-                        Robolectric.buildActivity(FakeSplashScreenActivity::class.java) to {
-                            clock.tick(
-                                splashScreenDwellTime
-                            )
-                        },
-                        Robolectric.buildActivity(FakeActivity::class.java) to {},
-                    )
-                )
-            },
-            otelExportAssertion = {
-                val spans = awaitSpansWithType(3, EmbType.Performance.Default).associateBy { it.name }
-                assertTrue(spans.isNotEmpty())
-                with(checkNotNull(spans["emb-app-startup-warm"])) {
-                    assertEquals(firstActivityInitMs, startEpochNanos.nanosToMillis())
-                }
-                with(checkNotNull(spans["emb-activity-create"])) {
-                    assertEquals(startupActivityInitMs, startEpochNanos.nanosToMillis())
-                }
                 assertTrue(spans.containsKey("emb-activity-resume"))
             }
         )

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -432,6 +432,7 @@ internal class ModuleInitBootstrapper(
                         serviceRegistry.registerActivityListeners(essentialServiceModule.processStateService)
                         serviceRegistry.registerMemoryCleanerListeners(sessionOrchestrationModule.memoryCleanerService)
                         serviceRegistry.registerActivityLifecycleListeners(essentialServiceModule.activityLifecycleTracker)
+                        serviceRegistry.registerStartupListener(essentialServiceModule.activityLifecycleTracker)
                     }
 
                     // Verify that the ProcessStateService is fully initialized at this point, and log otherwise.

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt
@@ -4,15 +4,21 @@ import android.app.Activity
 import android.os.Bundle
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityTracker
+import io.embrace.android.embracesdk.internal.session.lifecycle.StartupListener
 
 class FakeActivityTracker(
     override var foregroundActivity: Activity? = null,
 ) : ActivityTracker {
 
     val listeners: MutableList<ActivityLifecycleListener> = mutableListOf()
+    val startupListeners: MutableList<StartupListener> = mutableListOf()
 
     override fun addListener(listener: ActivityLifecycleListener) {
         listeners.add(listener)
+    }
+
+    override fun addStartupListener(listener: StartupListener) {
+        startupListeners.add(listener)
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -19,7 +19,6 @@ class FakeAppStartupDataCollector(
     var applicationInitStartMs: Long? = null
     var applicationInitEndMs: Long? = null
     var startupActivityName: String? = null
-    var firstActivityInitMs: Long? = null
     var startupActivityPreCreatedMs: Long? = null
     var startupActivityInitStartMs: Long? = null
     var startupActivityPostCreatedMs: Long? = null
@@ -35,10 +34,6 @@ class FakeAppStartupDataCollector(
 
     override fun applicationInitEnd(timestampMs: Long?) {
         applicationInitEndMs = timestampMs ?: clock.now()
-    }
-
-    override fun firstActivityInit(timestampMs: Long?) {
-        firstActivityInitMs = timestampMs ?: clock.now()
     }
 
     override fun startupActivityPreCreated(timestampMs: Long?) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import io.embrace.android.embracesdk.annotation.IgnoreForStartup
+
+@IgnoreForStartup
+class FakeNotStartupActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNotStartupActivity.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.app.Activity
-import io.embrace.android.embracesdk.annotation.IgnoreForStartup
+import io.embrace.android.embracesdk.annotation.StartupActivity
 
-@IgnoreForStartup
+@StartupActivity
 class FakeNotStartupActivity : Activity()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSplashScreenActivity.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSplashScreenActivity.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.app.Activity
-import io.embrace.android.embracesdk.annotation.IgnoreForStartup
+import io.embrace.android.embracesdk.annotation.StartupActivity
 
 /**
  * Activity that will not be used in recording the startup trace
  */
-@IgnoreForStartup
+@StartupActivity
 class FakeSplashScreenActivity : Activity()


### PR DESCRIPTION
## Goal

Revert app startup changes so we can release without leaving the feature in a partially changed state.