### PR TITLE
Added CollectSharedObjectFilesTask

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/CollectSharedObjectFilesTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/CollectSharedObjectFilesTask.kt
@@ -1,0 +1,96 @@
+package io.embrace.android.gradle.plugin.tasks.ndk
+
+import io.embrace.android.gradle.plugin.config.ProjectType
+import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
+import io.embrace.android.gradle.plugin.tasks.EmbraceTask
+import io.embrace.android.gradle.plugin.tasks.EmbraceTaskImpl
+import io.embrace.android.gradle.plugin.tasks.il2cpp.UnitySymbolFilesManager
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Collects .so files from the project, depending on the project type.
+ */
+abstract class CollectSharedObjectFilesTask @Inject constructor(
+    objectFactory: ObjectFactory,
+) : EmbraceTask, EmbraceTaskImpl(objectFactory) {
+
+    @get:Input
+    val projectType: Property<ProjectType> = objectFactory.property(ProjectType::class.java)
+
+    @get:Input
+    val shouldFailBuildOnUploadErrors: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    @get:Input
+    @get:Optional
+    val unitySharedObjectsDir: Property<UnitySymbolsDir?> = objectFactory.property(UnitySymbolsDir::class.java)
+
+    @get:InputDirectory
+    @get:Optional
+    val decompressedUnitySharedObjectDirectory: DirectoryProperty = objectFactory.directoryProperty()
+
+    @get:InputFiles
+    @get:SkipWhenEmpty
+    val architecturesDirectoryForNative: ConfigurableFileCollection = objectFactory.fileCollection()
+
+    @get:OutputFiles
+    val sharedObjectFiles: ConfigurableFileCollection = objectFactory.fileCollection()
+
+    @TaskAction
+    fun onRun() {
+        try {
+            collectSharedObjectFiles()
+        } catch (e: Exception) {
+            if (shouldFailBuildOnUploadErrors.get()) {
+                throw e
+            } else {
+                logger.error("Failed to collect shared object files", e)
+            }
+        }
+    }
+
+    private fun collectSharedObjectFiles() {
+        val files = when (projectType.get()) {
+            ProjectType.UNITY -> getUnitySharedObjectFiles()
+            ProjectType.NATIVE -> getNativeSharedObjectFiles()
+            else -> error("Shared object file collection failed: unsupported project type")
+        }
+        sharedObjectFiles.from(files)
+    }
+
+    private fun getUnitySharedObjectFiles(): Array<File> {
+        val sharedObjectsDir = unitySharedObjectsDir.orNull ?: error("Unity shared objects directory not found")
+        val decompressedUnitySharedObjectDir = decompressedUnitySharedObjectDirectory.orNull
+            ?: error("Decompressed Unity shared object directory not found")
+        val unitySharedObjectFiles = UnitySymbolFilesManager.of().getSymbolFiles(
+            sharedObjectsDir,
+            decompressedUnitySharedObjectDir
+        )
+
+        // TODO: is this an error? does every unity project have .so files?
+        if (unitySharedObjectFiles.isEmpty()) {
+            error("Unity shared object files not found")
+        }
+
+        return unitySharedObjectFiles
+    }
+
+    private fun getNativeSharedObjectFiles(): Array<File> {
+        return architecturesDirectoryForNative.single().listFiles() ?: emptyArray() // should not be empty due to SkipWhenEmpty annotation.
+    }
+
+    companion object {
+        const val NAME: String = "collectSharedObjectFilesTask"
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/CollectSharedObjectFilesTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/CollectSharedObjectFilesTaskRegistration.kt
@@ -1,0 +1,107 @@
+package io.embrace.android.gradle.plugin.tasks.ndk
+
+import com.android.build.api.variant.Variant
+import io.embrace.android.gradle.plugin.config.PluginBehavior
+import io.embrace.android.gradle.plugin.config.ProjectType
+import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
+import io.embrace.android.gradle.plugin.gradle.nullSafeMap
+import io.embrace.android.gradle.plugin.gradle.registerTask
+import io.embrace.android.gradle.plugin.gradle.safeFlatMap
+import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
+import io.embrace.android.gradle.plugin.instrumentation.config.model.EmbraceVariantConfig
+import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
+import io.embrace.android.gradle.plugin.tasks.registration.EmbraceTaskRegistration
+import io.embrace.android.gradle.plugin.tasks.registration.RegistrationParams
+import io.embrace.android.gradle.plugin.util.capitalizedString
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+
+class CollectSharedObjectFilesTaskRegistration(
+    private val behavior: PluginBehavior,
+    private val unitySymbolsDir: Provider<UnitySymbolsDir>,
+    private val projectType: Provider<ProjectType>,
+) : EmbraceTaskRegistration {
+    override fun register(params: RegistrationParams) {
+        params.execute()
+    }
+
+    fun RegistrationParams.execute(): TaskProvider<CollectSharedObjectFilesTask>? {
+        val variantConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }
+        val embraceConfig = variantConfig.embraceConfig
+
+        if (embraceConfig?.ndkEnabled == false) return null
+
+        val collectSharedObjectFilesTaskProvider = project.registerTask(
+            CollectSharedObjectFilesTask.NAME,
+            CollectSharedObjectFilesTask::class.java,
+            data
+        ) { task ->
+            // TODO: is the ndkEnabled check needed? We are already checking that in the execute method above
+            task.onlyIf { shouldExecuteTask(embraceConfig) }
+            task.projectType.set(projectType)
+            task.shouldFailBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
+            task.unitySharedObjectsDir.set(
+                projectType.nullSafeMap {
+                    when (it) {
+                        ProjectType.UNITY -> unitySymbolsDir.orNull
+                        else -> null
+                    }
+                }
+            )
+            task.decompressedUnitySharedObjectDirectory.set(
+                project.layout.buildDirectory.dir(
+                    "/intermediates/embrace/unity/${getMappingFileFolder(data)}"
+                )
+            )
+
+            task.architecturesDirectoryForNative.from(
+                getSymbolsDir(project, variant)
+            )
+        }
+
+        return collectSharedObjectFilesTaskProvider
+    }
+
+    private fun getSymbolsDir(project: Project, variant: Variant) =
+        behavior.customSymbolsDirectory?.takeIf { it.isNotEmpty() }?.let { customSymbolsDir ->
+            project.rootProject.file(customSymbolsDir).takeIf { it.exists() }
+                ?: error("Custom symbols directory does not exist. Specified path: $customSymbolsDir")
+        } ?: getNativeArchitecturesDirectoryProvider(project, variant)
+
+    private fun getNativeArchitecturesDirectoryProvider(project: Project, variant: Variant): Provider<Set<File>> {
+        val mergeNativeLibsProvider = project.provider {
+            project.tryGetTaskProvider(
+                "merge${variant.name.capitalizedString()}NativeLibs"
+            )
+        }.flatMap { it as Provider<Task> }
+        return mergeNativeLibsProvider.safeFlatMap { libTask ->
+            // we want the directory where all architectures live. So to make it generic and
+            // work with any native build tool, we will go to any .so file, and then go up from
+            // there to the architectures directory. This way we don't have to hardcode any path
+            // For example:
+            // /Users/.../build/intermediates/embrace/NdkTest/_tmp_/app/build/
+            // intermediates/merged_native_libs/release/out/lib/armeabi-v7a/libembrace-native.so
+            // the .so file will always be inside its corresponding architecture folder.
+            // By going 2 levels up, we will get all available architecture folders
+            return@safeFlatMap libTask.outputs.files.asFileTree.elements.nullSafeMap {
+                setOfNotNull(
+                    it.firstOrNull { possibleSoFile ->
+                        possibleSoFile.asFile.absolutePath.endsWith(".so")
+                    }?.asFile?.parentFile?.parentFile
+                )
+            }
+        }
+    }
+
+    private fun shouldExecuteTask(embraceConfig: EmbraceVariantConfig?): Boolean = embraceConfig?.ndkEnabled ?: true &&
+        (projectType.orNull == ProjectType.NATIVE || projectType.orNull == ProjectType.UNITY)
+
+    private fun getMappingFileFolder(variantData: AndroidCompactedVariantData) = if (variantData.flavorName.isBlank()) {
+        variantData.buildTypeName
+    } else {
+        "${variantData.flavorName}/${variantData.buildTypeName}"
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTask.kt
@@ -131,7 +131,6 @@ abstract class NdkUploadTask @Inject constructor(
             unitySymbolFilesManager.getSymbolFiles(
                 symbolsDir,
                 getProjectLayout().buildDirectory.get(),
-                variantData.get()
             )
         } else {
             emptyArray()


### PR DESCRIPTION
## Goal

This is one of the 4 tasks NdkUploadTask will get separated into. The idea for this task is to find .so files and output them so the next task can grab them.

Some questions which I also added as TODOs in the code to resolve:
- Is it possible for a native project to not have .so files?
- Is it possible for a Unity project to not have .so files?
- Is checking `embraceConfig.ndkEnabled` at the start of the registration enough, or should we also pass it to `task.onlyIf { }`

## Testing

Will add tests in a following commit.


