### PR TITLE
Add support in the config file to enable manual ending of startup traces

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
@@ -83,5 +83,5 @@ interface AutoDataCaptureBehavior : ConfigBehavior<EnabledFeatureConfig, RemoteC
     /**
      * Whether the app startup trace will be waiting for a call to Embrace.appReady() to signal completion
      */
-    fun isManualAppStartupCompletionEnabled(): Boolean
+    fun isEndStartupWithAppReadyEnabled(): Boolean
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -61,5 +61,5 @@ class AutoDataCaptureBehaviorImpl(
     }
 
     override fun shouldUseOkHttp(): Boolean = shouldUseOkHttpImpl
-    override fun isManualAppStartupCompletionEnabled(): Boolean = local.isManualAppStartupCompletionEnabled()
+    override fun isEndStartupWithAppReadyEnabled(): Boolean = local.isEndStartupWithAppReadyEnabled()
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -41,6 +41,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertFalse(isUiLoadTracingTraceAll())
             assertTrue(isThermalStatusCaptureEnabled())
             assertTrue(isV2StorageEnabled())
+            assertFalse(isEndStartupWithAppReadyEnabled())
         }
     }
 
@@ -108,6 +109,18 @@ internal class AutoDataCaptureBehaviorImplTest {
 
     @Test
     fun `disable ui load trace all locally`() {
+        val behavior = createBehavior(
+            localUiLoadTracingEnabled = true,
+            localUiLoadTracingTraceAllEnabled = false,
+            remote = remote.copy(uiLoadInstrumentationEnabled = true)
+        )
+
+        assertTrue(behavior.isUiLoadTracingEnabled())
+        assertFalse(behavior.isUiLoadTracingTraceAll())
+    }
+
+    @Test
+    fun `enable ui load trace all locally`() {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = false,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -47,7 +47,7 @@ internal class AppStartupTraceEmitter(
     private val backgroundWorker: BackgroundWorker,
     private val versionChecker: VersionChecker,
     private val logger: EmbLogger,
-    manualEnd: Boolean = false,
+    manualEnd: Boolean
 ) : AppStartupDataCollector {
     private val processCreateRequestedMs: Long?
     private val processCreatedMs: Long?

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -64,7 +64,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
             backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
             versionChecker = versionChecker,
             logger = initModule.logger,
-            manualEnd = configService.autoDataCaptureBehavior.isManualAppStartupCompletionEnabled()
+            manualEnd = configService.autoDataCaptureBehavior.isEndStartupWithAppReadyEnabled()
         )
     }
 

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -162,5 +162,11 @@ interface EnabledFeatureConfig {
      */
     fun isUiLoadTracingTraceAll(): Boolean = true
 
-    fun isManualAppStartupCompletionEnabled(): Boolean = false
+    /**
+     * Requires appReady() to be invoked manually to end appStartup. If that is not called before the app backgrounds, it is considered
+     * to have been abandoned.
+     *
+     * Will be true only if sdk_config.automatic_data_capture.end_startup_with_app_ready is true
+     */
+    fun isEndStartupWithAppReadyEnabled(): Boolean = false
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -107,7 +107,7 @@ internal class AppStartupTraceTest {
             instrumentedConfig = FakeInstrumentedConfig(
                 enabledFeatures = FakeEnabledFeatureConfig(
                     bgActivityCapture = true,
-                    manualAppStartupCompletion = true
+                    endStartupWithAppReady = true
                 )
             ),
             testCaseAction = {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
@@ -37,5 +37,6 @@ fun createEnabledFeatureConfigInstrumentation(cfg: VariantConfig) = modelSdkConf
                 true
             }
         }
+        boolMethod("isEndStartupWithAppReadyEnabled") { automaticDataCaptureConfig?.endStartupWithAppReadyEnabled }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/AutomaticDataCaptureLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/AutomaticDataCaptureLocalConfig.kt
@@ -23,6 +23,9 @@ data class AutomaticDataCaptureLocalConfig(
 
     @Json(name = "ui_load_tracing_selected_only")
     val uiLoadPerfTracingSelectedOnly: Boolean? = null,
+
+    @Json(name = "end_startup_with_app_ready")
+    val endStartupWithAppReadyEnabled: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigInstrumentationAssertions.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigInstrumentationAssertions.kt
@@ -16,7 +16,7 @@ private val nextVisitor: MethodVisitor = mockk(relaxed = true)
 
 fun verifyConfigMethodVisitor(
     instrumentation: InstrumentedConfigClass,
-    method: ConfigMethod
+    method: ConfigMethod,
 ) {
     val visitor = instrumentation.getMethodVisitor(
         method.name,
@@ -32,7 +32,7 @@ fun verifyConfigMethodVisitor(
             is IntReturnValueMethodVisitor -> visitor.replacedValue
             is LongReturnValueMethodVisitor -> visitor.replacedValue
             is StringReturnValueMethodVisitor -> visitor.replacedValue
-            is io.embrace.android.gradle.plugin.instrumentation.config.StringListReturnValueMethodVisitor -> visitor.replacedValue
+            is StringListReturnValueMethodVisitor -> visitor.replacedValue
             is MapReturnValueMethodVisitor -> visitor.replacedValue
             else -> null
         }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
@@ -49,6 +49,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
         ConfigMethod("isNetworkSpanForwardingEnabled", "()Z", true),
         ConfigMethod("isUiLoadTracingEnabled", "()Z", true),
         ConfigMethod("isUiLoadTracingTraceAll", "()Z", true),
+        ConfigMethod("isEndStartupWithAppReadyEnabled", "()Z", true),
     )
 
     @Test
@@ -85,6 +86,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
                             anrServiceEnabled = true,
                             uiLoadPerfTracingDisabled = false,
                             uiLoadPerfTracingSelectedOnly = false,
+                            endStartupWithAppReadyEnabled = true,
                         ),
                         backgroundActivityConfig = BackgroundActivityLocalConfig(
                             backgroundActivityCaptureEnabled = true

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -19,7 +19,7 @@ class FakeAutoDataCaptureBehavior(
     private val uiLoadTracingTraceAll: Boolean = true,
     private val v2StorageEnabled: Boolean = true,
     private val useOkhttp: Boolean = true,
-    private val manualAppStartupCompletion: Boolean = false,
+    private val endStartupWithAppReady: Boolean = false,
 ) : AutoDataCaptureBehavior {
 
     override val local: EnabledFeatureConfig
@@ -41,5 +41,5 @@ class FakeAutoDataCaptureBehavior(
     override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
     override fun isV2StorageEnabled(): Boolean = v2StorageEnabled
     override fun shouldUseOkHttp(): Boolean = useOkhttp
-    override fun isManualAppStartupCompletionEnabled(): Boolean = manualAppStartupCompletion
+    override fun isEndStartupWithAppReadyEnabled(): Boolean = endStartupWithAppReady
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -28,7 +28,7 @@ class FakeEnabledFeatureConfig(
     private val networkSpanForwarding: Boolean = base.isNetworkSpanForwardingEnabled(),
     private val uiLoadTracingEnabled: Boolean = base.isUiLoadTracingEnabled(),
     private val uiLoadTracingTraceAll: Boolean = base.isUiLoadTracingTraceAll(),
-    private val manualAppStartupCompletion: Boolean = base.isManualAppStartupCompletionEnabled(),
+    private val endStartupWithAppReady: Boolean = base.isEndStartupWithAppReadyEnabled(),
 ) : EnabledFeatureConfig {
 
     override fun isUnityAnrCaptureEnabled(): Boolean = unityAnrCapture
@@ -55,5 +55,5 @@ class FakeEnabledFeatureConfig(
     override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwarding
     override fun isUiLoadTracingEnabled(): Boolean = uiLoadTracingEnabled
     override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
-    override fun isManualAppStartupCompletionEnabled(): Boolean = manualAppStartupCompletion
+    override fun isEndStartupWithAppReadyEnabled(): Boolean = endStartupWithAppReady
 }


### PR DESCRIPTION
## Goal

Add support in the plugin to pickup the appropriate attribute in the config file to enable/disable this.

## Testing
Added unit tests in the gradle plugin an sdk behavior,. The integration tests have already been written as we were faking that  layer in the test.
