### PR TITLE
Defer the initialization of the OkHttp client until it's needed

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
@@ -25,9 +25,6 @@ class CombinedRemoteConfigSource(
     fun getConfig(): RemoteConfig? = response?.cfg
 
     fun scheduleConfigRequests() {
-        Systrace.traceSynchronous("set-initial-etag") {
-            response?.etag?.let(httpSource::setInitialEtag)
-        }
         Systrace.traceSynchronous("schedule-http-request") {
             worker.scheduleWithFixedDelay(
                 ::attemptConfigRequest,
@@ -39,6 +36,9 @@ class CombinedRemoteConfigSource(
     }
 
     private fun attemptConfigRequest() {
+        response?.etag?.let {
+            httpSource.setInitialEtag(it)
+        }
         httpSource.getConfig()?.let {
             store.saveResponse(it)
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
@@ -61,8 +61,8 @@ class CombinedRemoteConfigSourceTest {
         remoteConfigStore.impl = ConfigHttpResponse(RemoteConfig(), "etag")
         assertEquals(0, remoteConfigSource.callCount)
         source.scheduleConfigRequests()
-        assertEquals("etag", remoteConfigSource.etag)
         executorService.runCurrentlyBlocked()
+        assertEquals("etag", remoteConfigSource.etag)
         assertEquals(1, remoteConfigSource.callCount)
         assertEquals(1, remoteConfigStore.saveCount)
     }


### PR DESCRIPTION
## Goal

Defer the reading of the etag until the request runs, which allows `HttpSource` (and its copy of the OkHttpClient) to be initialized in the background. The `response` object and the deserialization thereof will still need to happen on the main thread but will do so when it's really needed, when the config service is initialized, but it still allows us to eliminate the OkHttpClient creation.