### PR TITLE
Log startup trace synchronously

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -45,7 +44,6 @@ internal class AppStartupTraceEmitter(
     private val clock: Clock,
     private val startupServiceProvider: Provider<StartupService?>,
     private val spanService: SpanService,
-    private val backgroundWorker: BackgroundWorker,
     private val versionChecker: VersionChecker,
     private val logger: EmbLogger,
     manualEnd: Boolean,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.capture.startup
 
 import android.os.Build.VERSION_CODES
 import android.os.Process
+import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -47,7 +48,7 @@ internal class AppStartupTraceEmitter(
     private val backgroundWorker: BackgroundWorker,
     private val versionChecker: VersionChecker,
     private val logger: EmbLogger,
-    manualEnd: Boolean
+    manualEnd: Boolean,
 ) : AppStartupDataCollector {
     private val processCreateRequestedMs: Long?
     private val processCreatedMs: Long?
@@ -216,7 +217,7 @@ internal class AppStartupTraceEmitter(
      */
     private fun dataCollectionComplete(traceEndTimeMs: Long) {
         if (!dataCollectionComplete.getAndSet(true)) {
-            backgroundWorker.submit {
+            Systrace.traceSynchronous("record-startup") {
                 recordStartup(traceEndTimeMs)
                 if (appStartupRootSpan.get()?.isRecording != false) {
                     logger.trackInternalError(

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -21,13 +21,11 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycl
 import io.embrace.android.embracesdk.internal.ui.FirstDrawDetector
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
     initModule: InitModule,
     openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
-    workerThreadModule: WorkerThreadModule,
     versionChecker: VersionChecker = BuildVersionChecker,
     featureModule: FeatureModule,
 ) : DataCaptureServiceModule {
@@ -61,7 +59,6 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
             clock = openTelemetryModule.openTelemetryClock,
             startupServiceProvider = { startupService },
             spanService = openTelemetryModule.spanService,
-            backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
             versionChecker = versionChecker,
             logger = initModule.logger,
             manualEnd = configService.autoDataCaptureBehavior.isEndStartupWithAppReadyEnabled()

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleSupplier.kt
@@ -11,7 +11,6 @@ typealias DataCaptureServiceModuleSupplier = (
     initModule: InitModule,
     openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
-    workerThreadModule: WorkerThreadModule,
     versionChecker: VersionChecker,
     featureModule: FeatureModule,
 ) -> DataCaptureServiceModule
@@ -20,14 +19,12 @@ fun createDataCaptureServiceModule(
     initModule: InitModule,
     openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
-    workerThreadModule: WorkerThreadModule,
     versionChecker: VersionChecker,
     featureModule: FeatureModule,
 ): DataCaptureServiceModule = DataCaptureServiceModuleImpl(
     initModule,
     openTelemetryModule,
     configService,
-    workerThreadModule,
     versionChecker,
     featureModule
 )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.arch.assertDoesNotHaveEmbraceAttribute
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
-import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmitter.Companion.ACTIVITY_INIT_DELAY_SPAN
@@ -26,7 +25,6 @@ import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.opentelemetry.sdk.common.Clock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -53,12 +51,10 @@ internal class AppStartupTraceEmitterTest {
     private lateinit var spanSink: SpanSink
     private lateinit var spanService: SpanService
     private lateinit var logger: FakeEmbLogger
-    private lateinit var backgroundWorker: BackgroundWorker
 
     @Before
     fun setUp() {
         clock = FakeClock(processInitTime)
-        backgroundWorker = fakeBackgroundWorker()
         FakeInitModule(clock = clock).run {
             otelClock = openTelemetryModule.openTelemetryClock
             spanSink = openTelemetryModule.spanSink
@@ -485,7 +481,6 @@ internal class AppStartupTraceEmitterTest {
             clock = otelClock,
             startupServiceProvider = { startupService },
             spanService = spanService,
-            backgroundWorker = backgroundWorker,
             versionChecker = BuildVersionChecker,
             logger = logger,
             manualEnd = manualEnd,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.fakes.FakeFeatureModule
 import io.embrace.android.embracesdk.fakes.FakeVersionChecker
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -21,7 +20,6 @@ internal class DataCaptureServiceModuleImplTest {
             initModule,
             openTelemetryModule,
             FakeConfigService(),
-            FakeWorkerThreadModule(),
             FakeVersionChecker(false),
             FakeFeatureModule()
         )
@@ -43,7 +41,6 @@ internal class DataCaptureServiceModuleImplTest {
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false)
             ),
-            FakeWorkerThreadModule(),
             FakeVersionChecker(false),
             FakeFeatureModule()
         )
@@ -60,7 +57,6 @@ internal class DataCaptureServiceModuleImplTest {
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false)
             ),
-            FakeWorkerThreadModule(),
             FakeVersionChecker(false),
             FakeFeatureModule()
         )

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -48,3 +48,6 @@
 -keep class io.embrace.android.embracesdk.WebViewChromeClientSwazzledHooks { *; }
 -keep class io.embrace.android.embracesdk.fcm.swazzle.callback.com.android.fcm.FirebaseSwazzledHooks { *; }
 -keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; }
+
+## Keep internal files for tracing
+-keep class io.embrace.android.embracesdk.internal.injection.** { *; }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -254,7 +254,6 @@ internal class ModuleInitBootstrapper(
                             initModule,
                             openTelemetryModule,
                             configModule.configService,
-                            workerThreadModule,
                             versionChecker,
                             featureModule
                         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -45,7 +45,7 @@ internal fun fakeModuleInitBootstrapper(
     essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
-    dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _, _ -> FakeDataCaptureServiceModule() },
+    dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },


### PR DESCRIPTION
## Goal

Eat the costs of logging the startup trace on the main thread so it will always be in the payload of the same session the trace ended in. This will take around 1ms on a mid-range device (Pixel 4) and about 4ms on a low end device (Samsung A14)