### PR TITLE
Add validation for bytecode instrumentation that looks at smali files

### DIFF
--- a/embrace-gradle-plugin-integration-tests/build.gradle.kts
+++ b/embrace-gradle-plugin-integration-tests/build.gradle.kts
@@ -30,10 +30,22 @@ dependencies {
     implementation(libs.apktool.lib)
 }
 
-// ensure that the plugin is published to maven local before running integration tests
+// ensure that the plugin + SDK is published to maven local before running integration tests
 tasks.withType(Test::class.java).configureEach {
-    dependsOn(":embrace-gradle-plugin-integration-tests:publishToMavenLocal")
-    dependsOn(":embrace-gradle-plugin:publishToMavenLocal")
+    val modules = listOf(
+        ":embrace-gradle-plugin-integration-tests",
+        ":embrace-gradle-plugin",
+        ":embrace-android-sdk",
+        ":embrace-android-core",
+        ":embrace-android-api",
+        ":embrace-android-okhttp3",
+        ":embrace-android-infra",
+        ":embrace-android-features",
+        ":embrace-android-payload",
+        ":embrace-android-delivery",
+        ":embrace-internal-api"
+    )
+    modules.forEach { dependsOn("$it:publishToMavenLocal") }
 }
 
 group = "io.embrace"

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id("com.android.application")
+    id("io.embrace.swazzler")
+    id("io.embrace.android.testplugin")
+}
+
+repositories {
+    google()
+    mavenCentral()
+    mavenLocal()
+}
+
+integrationTest.configureAndroidProject(project)
+
+swazzler {
+    disableDependencyInjection = false
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/proguard-rules.pro
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/proguard-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.example.app.Foo { *; }
+-keep class io.embrace.android.embracesdk.internal.config.instrumented.* { *; }

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/src/main/AndroidManifest.xml
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/src/main/java/com/example/app/Bar.java
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/src/main/java/com/example/app/Bar.java
@@ -1,0 +1,7 @@
+package com.example.app;
+
+public class Bar {
+    public static String getBar() {
+        return "bar";
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/src/main/java/com/example/app/Foo.java
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/src/main/java/com/example/app/Foo.java
@@ -1,0 +1,7 @@
+package com.example.app;
+
+public class Foo {
+    public static String getFoo() {
+        return "foo";
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/ArtifactFinder.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/ArtifactFinder.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.gradle.integration.framework
+
+import java.io.File
+
+fun findArtifact(projectDir: File, buildDir: String, suffix: String): File {
+    return File(projectDir, buildDir)
+        .listFiles { _, name -> name.endsWith(suffix) }
+        ?.single()
+        ?: error("File not found")
+}

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/DecodedApk.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/DecodedApk.kt
@@ -1,9 +1,16 @@
 package io.embrace.android.gradle.integration.framework
 
+import java.io.File
+
 internal class DecodedApk(
-    private val stringTable: Map<String, String>
+    private val stringTable: Map<String, String>,
+    private val smaliFiles: Map<String, File>,
 ) {
     fun getStringResource(name: String): String? {
         return stringTable[name]
+    }
+
+    fun getSmaliFiles(names: List<String>): List<File> = names.map { name ->
+        smaliFiles[name] ?: error("Smali file named '$name' not found")
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/smali/SmaliMethod.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/smali/SmaliMethod.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.gradle.integration.framework.smali
+
+/**
+ * Represents a method in a Smali file. This contains the method signature and the return value as a string.
+ */
+data class SmaliMethod(
+    val signature: String,
+    val returnValue: String,
+)

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/smali/SmaliParser.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/smali/SmaliParser.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.gradle.integration.framework.smali
+
+import java.io.File
+
+class SmaliParser {
+
+    private companion object {
+        private const val METHOD_START = ".method"
+        private const val METHOD_END = ".end method"
+        private const val STRING_CONSTANT = "const-string"
+    }
+
+    /**
+     * Parses a smali file and returns a list of method representations. This parser
+     * is fairly naive and makes various assumptions about smali, but this is sufficient for
+     * testing purposes right now given that our bytecode instrumentation is fairly simple.
+     */
+    fun parse(file: File): List<SmaliMethod> {
+        val methods = mutableMapOf<String, String>()
+        var methodSig: String? = null
+        var returnValue: String? = null
+
+        file.inputStream().bufferedReader().lines().forEach { line ->
+            val input = line.trim()
+            if (input.startsWith(METHOD_START)) {
+                if (methodSig != null || returnValue != null) {
+                    error("Expected null methodSig + returnValue: $input")
+                }
+                methodSig = input.split(" ").last()
+            }
+            if (input.startsWith(METHOD_END)) {
+                if (methodSig != null && returnValue != null) {
+                    methods[checkNotNull(methodSig)] = checkNotNull(returnValue)
+                }
+                methodSig = null
+                returnValue = null
+            }
+            if (input.startsWith(STRING_CONSTANT)) {
+                returnValue = input.split(" ").last().replace("\"", "")
+            }
+        }
+        return methods.map { SmaliMethod(it.key, it.value) }
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.gradle.integration.framework.ApkDisassembler
 import io.embrace.android.gradle.integration.framework.BundleToolApkBuilder
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.ProjectType
+import io.embrace.android.gradle.integration.framework.findArtifact
 import io.embrace.android.gradle.integration.utils.NdkSymbols
 import io.embrace.android.gradle.plugin.util.serialization.MoshiSerializer
 import okio.ByteString.Companion.decodeBase64
@@ -237,12 +238,5 @@ class AndroidNdkTest {
                 assertTrue(symbolsMap[arch]?.containsKey(lib) ?: false)
             }
         }
-    }
-
-    private fun findArtifact(projectDir: File, buildDir: String, suffix: String): File {
-        return File(projectDir, buildDir)
-            .listFiles { _, name -> name.endsWith(suffix) }
-            ?.single()
-            ?: error("File not found")
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ConfigInstrumentationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ConfigInstrumentationTest.kt
@@ -1,0 +1,60 @@
+package io.embrace.android.gradle.integration.testcases
+
+import io.embrace.android.gradle.integration.framework.ApkDisassembler
+import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
+import io.embrace.android.gradle.integration.framework.ProjectType
+import io.embrace.android.gradle.integration.framework.findArtifact
+import io.embrace.android.gradle.integration.framework.smali.SmaliMethod
+import io.embrace.android.gradle.integration.framework.smali.SmaliParser
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+
+class ConfigInstrumentationTest {
+
+    @Rule
+    @JvmField
+    val rule: PluginIntegrationTestRule = PluginIntegrationTestRule()
+
+    private val variants = listOf("debug", "release")
+
+    @Test
+    fun assembleRelease() {
+        rule.runTest(
+            fixture = "android-with-code",
+            task = "assembleRelease",
+            projectType = ProjectType.ANDROID,
+            assertions = { projectDir ->
+                verifyBuildTelemetryRequestSent(variants)
+                verifyJvmMappingRequestsSent(1)
+
+                val apk = findArtifact(projectDir, "build/outputs/apk/release/", ".apk")
+                val decodedApk = ApkDisassembler().disassembleApk(apk)
+
+                val smaliFiles = decodedApk.getSmaliFiles(
+                    listOf("/io/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl")
+                )
+                val parser = SmaliParser()
+                val methods = parser.parse(smaliFiles.single())
+                val observedMethods = methods.filterNot {
+                    it.signature.contains("getBuildId")
+                }
+
+                val expected = listOf(
+                    SmaliMethod("getAppId()Ljava/lang/String;", "abcde"),
+                    SmaliMethod("getBuildFlavor()Ljava/lang/String;", ""),
+                    SmaliMethod("getBuildType()Ljava/lang/String;", "release"),
+                )
+
+                observedMethods.zip(expected).forEach { (observed, expected) ->
+                    assert(observed == expected) {
+                        "Expected $expected but found $observed"
+                    }
+                }
+
+                // build ID is non-deterministic, test independently
+                assertNotNull(methods.single { it.signature.contains("getBuildId") }.returnValue)
+            }
+        )
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/smali_example.smali
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/smali_example.smali
@@ -1,0 +1,122 @@
+.class public final Lio/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl;
+.super Ljava/lang/Object;
+.source "SourceFile"
+
+# interfaces
+.implements Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig;
+
+
+# annotations
+.annotation runtime Lio/embrace/android/embracesdk/internal/config/instrumented/EmbraceInstrumented;
+.end annotation
+
+
+# static fields
+.field public static final INSTANCE:Lio/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl;
+
+
+# direct methods
+.method static constructor <clinit>()V
+    .locals 1
+
+    new-instance v0, Lio/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl;
+
+    invoke-direct {v0}, Lio/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl;-><init>()V
+
+    sput-object v0, Lio/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl;->INSTANCE:Lio/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl;
+
+    return-void
+.end method
+
+.method private constructor <init>()V
+    .locals 0
+
+    .line 1
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    .line 2
+    .line 3
+    .line 4
+    return-void
+.end method
+
+
+# virtual methods
+.method public getAppFramework()Ljava/lang/String;
+    .locals 1
+
+    .line 1
+    invoke-static {p0}, Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig$DefaultImpls;->getAppFramework(Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig;)Ljava/lang/String;
+
+    .line 2
+    .line 3
+    .line 4
+    move-result-object v0
+
+    .line 5
+    return-object v0
+.end method
+
+.method public getAppId()Ljava/lang/String;
+    .locals 1
+
+    .line 1
+    invoke-static {p0}, Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig$DefaultImpls;->getAppId(Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig;)Ljava/lang/String;
+
+    .line 2
+    .line 3
+    .line 4
+    const-string v0, "abcde"
+
+    .line 5
+    .line 6
+    return-object v0
+.end method
+
+.method public getBuildFlavor()Ljava/lang/String;
+    .locals 1
+
+    .line 1
+    invoke-static {p0}, Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig$DefaultImpls;->getBuildFlavor(Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig;)Ljava/lang/String;
+
+    .line 2
+    .line 3
+    .line 4
+    const-string v0, ""
+
+    .line 5
+    .line 6
+    return-object v0
+.end method
+
+.method public getBuildId()Ljava/lang/String;
+    .locals 1
+
+    .line 1
+    invoke-static {p0}, Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig$DefaultImpls;->getBuildId(Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig;)Ljava/lang/String;
+
+    .line 2
+    .line 3
+    .line 4
+    const-string v0, "68B76DEAB6B9476A9B76092EB9A3E884"
+
+    .line 5
+    .line 6
+    return-object v0
+.end method
+
+.method public getBuildType()Ljava/lang/String;
+    .locals 1
+
+    .line 1
+    invoke-static {p0}, Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig$DefaultImpls;->getBuildType(Lio/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig;)Ljava/lang/String;
+
+    .line 2
+    .line 3
+    .line 4
+    const-string v0, "release"
+
+    .line 5
+    .line 6
+    return-object v0
+.end method


### PR DESCRIPTION
## Goal

Adds a test that reads the smali files (generated from dex files) when disassembling the APK in a Gradle TestKit test case.

In short, this allows to verify our bytecode instrumentation at the integration test level. We can compare the expected return value against what is actually in the dex code.

Future changesets will increase the coverage of this test so that we check _all_ the config values that are instrumented, and also check the override behaviors.
