### PR TITLE
Throw error if gradle plugin fails HTTP request

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/ndk-upload-simple/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/ndk-upload-simple/build.gradle
@@ -11,7 +11,7 @@ plugins {
 project.tasks.register("testTask", NdkUploadTask) { task ->
     integrationTest.configureGradleUploadTask(project, task, EmbraceEndpoint.NDK, null)
     task.ndkEnabled.set(true)
-
+    task.failBuildOnUploadErrors.set(true)
     task.projectType.set(ProjectType.NATIVE)
 
     task.architecturesDirectoryForNative.from(

--- a/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
@@ -49,6 +49,7 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
                 buildId = buildId.orNull,
                 endpoint = endpoint,
                 fileName = filename,
+                failBuildOnUploadErrors = true,
                 baseUrl = checkNotNull(project.findProperty("embrace.baseUrl")?.toString())
             )
         )

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/NdkUploadTaskIntegrationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/NdkUploadTaskIntegrationTest.kt
@@ -19,6 +19,9 @@ class NdkUploadTaskIntegrationTest {
     fun `ndk upload`() {
         rule.runTest(
             fixture = "ndk-upload-simple",
+            setup = {
+                setupMockResponses(emptyList(), emptyList(), listOf("release"))
+            },
             assertions = { projectDir ->
                 // 1. assert that the symbols were injected as a string resource
                 val symbols =

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/UnityTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/UnityTest.kt
@@ -35,6 +35,9 @@ class UnityTest {
             fixture = "unity-fake-project",
             task = "assembleRelease",
             projectType = ProjectType.ANDROID,
+            setup = {
+                setupMockResponses(emptyList(), emptyList(), listOf("release"))
+            },
             assertions = {
                 verifyLineMapRequestSent()
                 verifyMethodMapRequestSent()

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/UnsuccessfulHttpCallTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/UnsuccessfulHttpCallTest.kt
@@ -1,0 +1,51 @@
+package io.embrace.android.gradle.integration.testcases
+
+import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
+import io.embrace.android.gradle.integration.framework.ProjectType
+import io.embrace.android.gradle.plugin.network.EmbraceEndpoint
+import okhttp3.mockwebserver.MockResponse
+import org.junit.Rule
+import org.junit.Test
+
+class UnsuccessfulHttpCallTest {
+
+    @Rule
+    @JvmField
+    val rule: PluginIntegrationTestRule = PluginIntegrationTestRule()
+
+    private val variants = listOf("debug", "release")
+
+    @Test
+    fun `proguard 4xx status code`() {
+        rule.runTest(
+            fixture = "android-simple",
+            task = "assembleRelease",
+            projectType = ProjectType.ANDROID,
+            setup = {
+                enqueueResponse(EmbraceEndpoint.PROGUARD, MockResponse().setResponseCode(400))
+            },
+            assertions = {
+                verifyBuildTelemetryRequestSent(variants)
+                verifyJvmMappingRequestsSent(1)
+            },
+            expectedExceptionMessage = "Embrace HTTP request failed: ${EmbraceEndpoint.PROGUARD.url}, status=400"
+        )
+    }
+
+    @Test
+    fun `proguard 5xx status code`() {
+        rule.runTest(
+            fixture = "android-simple",
+            task = "assembleRelease",
+            projectType = ProjectType.ANDROID,
+            setup = {
+                enqueueResponse(EmbraceEndpoint.PROGUARD, MockResponse().setResponseCode(500))
+            },
+            assertions = {
+                verifyBuildTelemetryRequestSent(variants)
+                verifyJvmMappingRequestsSent(1)
+            },
+            expectedExceptionMessage = "Embrace HTTP request failed: ${EmbraceEndpoint.PROGUARD.url}"
+        )
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -10,7 +10,6 @@ import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurati
 import io.embrace.android.gradle.plugin.gradle.getProperty
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.instrumentation.registerAsmTasks
-import io.embrace.android.gradle.plugin.network.OkHttpNetworkService
 import io.embrace.android.gradle.plugin.tasks.registration.TaskRegistrar
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import org.gradle.api.Project
@@ -33,7 +32,6 @@ class EmbraceGradlePluginDelegate {
 
         val behavior = PluginBehaviorImpl(project, extension)
         Logger.setPluginLogLevel(behavior.logLevel)
-        val networkService = OkHttpNetworkService(behavior.baseUrl)
 
         BuildTelemetryService.register(
             project,
@@ -56,7 +54,6 @@ class EmbraceGradlePluginDelegate {
             behavior,
             embraceVariantConfigurationBuilder,
             variantConfigurationsListProperty,
-            networkService,
             agpWrapper
         )
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
@@ -36,7 +36,7 @@ class PluginBehaviorImpl(
     }
 
     override val failBuildOnUploadErrors: Boolean by lazy {
-        project.getBoolProperty(EMBRACE_FAIL_BUILD_ON_UPLOAD_ERRORS)
+        project.getProperty(EMBRACE_FAIL_BUILD_ON_UPLOAD_ERRORS) != "false"
     }
 
     override val baseUrl: String by lazy {
@@ -70,7 +70,7 @@ class PluginBehaviorImpl(
 
     @Suppress("DEPRECATION")
     override val customSymbolsDirectory: String? by lazy {
-        extension.customSymbolsDirectory.get()
+        extension.customSymbolsDirectory.orNull
     }
 
     override fun isInstrumentationDisabledForVariant(variantName: String): Boolean {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/HttpCallResultHandler.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/HttpCallResultHandler.kt
@@ -1,0 +1,31 @@
+package io.embrace.android.gradle.plugin.tasks
+
+import io.embrace.android.gradle.plugin.network.EmbraceEndpoint
+import io.embrace.android.gradle.plugin.network.HttpCallResult
+import io.embrace.android.gradle.plugin.network.HttpCallResult.Error
+import io.embrace.android.gradle.plugin.network.HttpCallResult.Failure
+import io.embrace.android.gradle.plugin.network.HttpCallResult.Success
+import io.embrace.android.gradle.plugin.tasks.common.RequestParams
+
+/**
+ * Handles a HTTP call result by throwing an error that stops the build (if configured) _or_ logging the error.
+ */
+fun handleHttpCallResult(
+    result: HttpCallResult,
+    params: RequestParams,
+) = handleHttpCallResult(result, params.endpoint, params.failBuildOnUploadErrors)
+
+fun handleHttpCallResult(
+    result: HttpCallResult,
+    endpoint: EmbraceEndpoint,
+    failBuildOnUploadErrors: Boolean,
+) {
+    val msg = when (result) {
+        is Failure -> "failed: ${endpoint.url}, status=${result.code}"
+        is Error -> "errored: ${endpoint.url}, stacktrace=${result.exception.stackTrace.joinToString("\n")}"
+        is Success<*> -> null
+    }
+    if (msg != null && failBuildOnUploadErrors) {
+        error("Embrace HTTP request $msg")
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/common/MultipartUploadTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/common/MultipartUploadTask.kt
@@ -3,6 +3,7 @@ package io.embrace.android.gradle.plugin.tasks.common
 import io.embrace.android.gradle.plugin.network.OkHttpNetworkService
 import io.embrace.android.gradle.plugin.tasks.EmbraceUploadTask
 import io.embrace.android.gradle.plugin.tasks.EmbraceUploadTaskImpl
+import io.embrace.android.gradle.plugin.tasks.handleHttpCallResult
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.InputFiles
@@ -14,7 +15,7 @@ import javax.inject.Inject
  * Task in charge of uploading a compressed file as a multipart request.
  */
 abstract class MultipartUploadTask @Inject constructor(
-    objectFactory: ObjectFactory
+    objectFactory: ObjectFactory,
 ) : EmbraceUploadTask, EmbraceUploadTaskImpl(objectFactory) {
 
     @get:InputFiles
@@ -23,6 +24,9 @@ abstract class MultipartUploadTask @Inject constructor(
 
     @TaskAction
     fun onRun() {
-        OkHttpNetworkService(requestParams.get().baseUrl).uploadFile(requestParams.get(), uploadFile.asFile.get())
+        val params = requestParams.get()
+        val networkService = OkHttpNetworkService(params.baseUrl)
+        val result = networkService.uploadFile(params, uploadFile.asFile.get())
+        handleHttpCallResult(result, params)
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/common/RequestParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/common/RequestParams.kt
@@ -8,6 +8,7 @@ data class RequestParams(
     val apiToken: String,
     val endpoint: EmbraceEndpoint,
     val baseUrl: String,
+    val failBuildOnUploadErrors: Boolean,
     val fileName: String? = null,
     val buildId: String? = null,
 ) : Serializable {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppUploadTaskRegistration.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin.tasks.il2cpp
 
+import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.gradle.registerTask
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
@@ -38,7 +39,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
                     task,
                     data,
                     variantConfigurationsListProperty,
-                    baseUrl
+                    behavior
                 )
             }
         }
@@ -49,7 +50,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
         ndkTaskProvider: TaskProvider<Task>,
         variant: AndroidCompactedVariantData,
         variantConfigurationsListProperty: ListProperty<VariantConfig>,
-        baseUrl: String,
+        behavior: PluginBehavior,
     ) {
         val il2cppSymbolsDir = File(project.rootDir, IL2CPP_SYMBOLS_DIR)
         val variantConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }
@@ -67,7 +68,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
             ndkTaskProvider,
             lineNumberCompressionTaskProvider,
             variantConfig,
-            baseUrl,
+            behavior,
         )
 
         val methodMapCompressionTaskProvider = configureFileCompressionTask(
@@ -84,7 +85,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
             ndkTaskProvider,
             methodMapCompressionTaskProvider,
             variantConfig,
-            baseUrl,
+            behavior,
         )
     }
 
@@ -121,7 +122,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
         ndkTaskProvider: TaskProvider<Task>,
         fileCompressionTask: TaskProvider<FileCompressionTask>,
         variantInfo: VariantConfig,
-        baseUrl: String,
+        behavior: PluginBehavior,
     ) {
         val uploadTask = project.registerTask(
             info.uploadTaskName,
@@ -136,7 +137,8 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
                         endpoint = info.endpoint,
                         fileName = info.filename,
                         buildId = variantInfo.buildId,
-                        baseUrl = baseUrl,
+                        failBuildOnUploadErrors = behavior.failBuildOnUploadErrors,
+                        baseUrl = behavior.baseUrl,
                     )
                 }
             )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTaskRegistration.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.gradle.plugin.tasks.ndk
 
-import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.config.ProjectType
 import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
 import io.embrace.android.gradle.plugin.gradle.nullSafeMap
@@ -25,7 +24,6 @@ private const val GENERATED_RESOURCE_PATH = "generated/embrace/res"
  * In charge of registering tasks for ndk mapping file upload.
  */
 class NdkUploadTaskRegistration(
-    private val behavior: PluginBehavior,
     private val unitySymbolsDir: Provider<UnitySymbolsDir>,
     private val projectType: Provider<ProjectType>,
 ) : EmbraceTaskRegistration {
@@ -55,13 +53,15 @@ class NdkUploadTaskRegistration(
             NdkUploadTask::class.java,
             data
         ) { task ->
+            task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
             task.requestParams.set(
                 project.provider {
                     RequestParams(
                         appId = embraceConfig?.appId.orEmpty(),
                         apiToken = embraceConfig?.apiToken.orEmpty(),
                         endpoint = EmbraceEndpoint.NDK,
-                        baseUrl = baseUrl,
+                        failBuildOnUploadErrors = behavior.failBuildOnUploadErrors,
+                        baseUrl = behavior.baseUrl,
                     )
                 }
             )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -3,6 +3,7 @@ package io.embrace.android.gradle.plugin.tasks.r8
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.Variant
 import io.embrace.android.gradle.plugin.agp.AgpUtils.isDexguard
+import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.gradle.isTaskRegistered
 import io.embrace.android.gradle.plugin.gradle.nullSafeMap
 import io.embrace.android.gradle.plugin.gradle.registerTask
@@ -42,7 +43,7 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
                         data,
                         task,
                         fetchJvmMappingFile(task, variant),
-                        baseUrl,
+                        behavior,
                         variantConfigurationsListProperty
                     )
                 }
@@ -55,7 +56,7 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
         variant: AndroidCompactedVariantData,
         anchorTask: TaskProvider<Task>,
         mappingFile: Provider<File?>,
-        baseUrl: String,
+        behavior: PluginBehavior,
         variantConfigurationsListProperty: ListProperty<VariantConfig>,
     ): TaskProvider<MultipartUploadTask> {
         val anchorTaskWithoutVariant = anchorTask.name.replace(variant.name, "", true)
@@ -89,7 +90,8 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
                         endpoint = EmbraceEndpoint.PROGUARD,
                         fileName = FILE_NAME_MAPPING_TXT,
                         buildId = variantConfig.buildId,
-                        baseUrl = baseUrl,
+                        baseUrl = behavior.baseUrl,
+                        failBuildOnUploadErrors = behavior.failBuildOnUploadErrors,
                     )
                 }
             )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/EmbraceRnSourcemapGeneratorTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/EmbraceRnSourcemapGeneratorTaskRegistration.kt
@@ -94,7 +94,8 @@ class EmbraceRnSourcemapGeneratorTaskRegistration : EmbraceTaskRegistration {
                         apiToken = embraceConfig?.apiToken.orEmpty(),
                         endpoint = EmbraceEndpoint.SOURCE_MAP,
                         fileName = FILE_NAME_SOURCE_MAP_JSON,
-                        baseUrl = baseUrl,
+                        baseUrl = behavior.baseUrl,
+                        failBuildOnUploadErrors = behavior.failBuildOnUploadErrors,
                     )
                 }
             )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/RegistrationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/RegistrationParams.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.gradle.plugin.tasks.registration
 
 import com.android.build.api.variant.Variant
+import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
-import io.embrace.android.gradle.plugin.network.NetworkService
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 
@@ -11,7 +11,6 @@ class RegistrationParams(
     val project: Project,
     val variant: Variant,
     val data: AndroidCompactedVariantData,
-    val networkService: NetworkService,
     val variantConfigurationsListProperty: ListProperty<VariantConfig>,
-    val baseUrl: String,
+    val behavior: PluginBehavior,
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -11,7 +11,6 @@ import io.embrace.android.gradle.plugin.dependency.installDependenciesForVariant
 import io.embrace.android.gradle.plugin.gradle.GradleCompatibilityHelper
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
-import io.embrace.android.gradle.plugin.network.NetworkService
 import io.embrace.android.gradle.plugin.tasks.il2cpp.Il2CppUploadTaskRegistration
 import io.embrace.android.gradle.plugin.tasks.il2cpp.UnitySymbolFilesManager
 import io.embrace.android.gradle.plugin.tasks.ndk.NdkUploadTaskRegistration
@@ -29,7 +28,6 @@ class TaskRegistrar(
     private val behavior: PluginBehavior,
     private val embraceVariantConfigurationBuilder: EmbraceVariantConfigurationBuilder,
     private val variantConfigurationsListProperty: ListProperty<VariantConfig>,
-    private val networkService: NetworkService,
     private val agpWrapper: AgpWrapper,
 ) {
 
@@ -56,9 +54,8 @@ class TaskRegistrar(
                 project,
                 ref,
                 variant,
-                networkService,
                 variantConfigurationsListProperty,
-                behavior.baseUrl,
+                behavior,
             )
             registerTasks(params, variant)
         }
@@ -73,7 +70,7 @@ class TaskRegistrar(
         val variantConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }
         val symbolsDir = getSymbolsDir(variantConfig)
         val projectType = getProjectType(symbolsDir, agpWrapper, variantConfig.variantName, project)
-        NdkUploadTaskRegistration(behavior, symbolsDir, projectType).register(params)
+        NdkUploadTaskRegistration(symbolsDir, projectType).register(params)
         if (behavior.isIl2CppMappingFilesUploadEnabled) {
             Il2CppUploadTaskRegistration().register(params)
         }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.gradle.plugin.ndk
 
 import com.android.build.api.variant.Variant
+import io.embrace.android.gradle.plugin.config.PluginBehaviorImpl
 import io.embrace.android.gradle.plugin.config.ProjectType
 import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
 import io.embrace.android.gradle.plugin.gradle.GradleCompatibilityHelper
@@ -14,6 +15,7 @@ import io.embrace.android.gradle.plugin.tasks.ndk.NdkUploadTask
 import io.embrace.android.gradle.plugin.tasks.ndk.NdkUploadTaskRegistration
 import io.embrace.android.gradle.plugin.tasks.registration.RegistrationParams
 import io.embrace.android.gradle.plugin.util.capitalizedString
+import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -32,8 +34,10 @@ import org.junit.Test
 
 class NdkUploadTaskRegistrationTest {
 
-    private val baseUrl = "https://example.com/api"
+    private val baseUrl = "https://dsym-store.emb-api.com"
     private val project = ProjectBuilder.builder().build()
+    private val behavior =
+        PluginBehaviorImpl(project, project.extensions.create("swazzler", SwazzlerExtension::class.java))
     private lateinit var variantConfigurationsListProperty: ListProperty<VariantConfig>
 
     private val mockVariant = mockk<Variant>(relaxed = true)
@@ -80,14 +84,13 @@ class NdkUploadTaskRegistrationTest {
         val projectTypeProvider = project.provider { ProjectType.UNITY }
 
         val registration =
-            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
+            NdkUploadTaskRegistration(unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project = project,
             variant = mockVariant,
             data = testAndroidCompactedVariantData,
-            networkService = mockk(relaxed = true),
             variantConfigurationsListProperty = variantConfigurationsListProperty,
-            baseUrl = baseUrl,
+            behavior = behavior,
         )
         assertFalse(
             project.isTaskRegistered(
@@ -113,14 +116,13 @@ class NdkUploadTaskRegistrationTest {
         val projectTypeProvider = project.provider { ProjectType.NATIVE }
 
         val registration =
-            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
+            NdkUploadTaskRegistration(unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             variant = mockVariant,
             testAndroidCompactedVariantData,
-            mockk(relaxed = true),
             variantConfigurationsListProperty,
-            baseUrl,
+            behavior = behavior,
         )
         assertFalse(
             project.isTaskRegistered(
@@ -159,14 +161,13 @@ class NdkUploadTaskRegistrationTest {
         val projectTypeProvider = project.provider { ProjectType.UNITY }
 
         val registration =
-            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
+            NdkUploadTaskRegistration(unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             variant = mockVariant,
             testAndroidCompactedVariantData,
-            mockk(relaxed = true),
             variantConfigurationsListProperty,
-            baseUrl,
+            behavior = behavior,
         )
         assertFalse(
             project.isTaskRegistered(
@@ -210,14 +211,13 @@ class NdkUploadTaskRegistrationTest {
         val projectTypeProvider = project.provider { ProjectType.UNITY }
 
         val registration =
-            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
+            NdkUploadTaskRegistration(unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             variant = mockVariant,
             testAndroidCompactedVariantData,
-            mockk(relaxed = true),
             variantConfigurationsListProperty,
-            baseUrl,
+            behavior = behavior,
         )
 
         assertFalse(
@@ -252,14 +252,13 @@ class NdkUploadTaskRegistrationTest {
         val projectTypeProvider = project.provider { ProjectType.NATIVE }
 
         val registration =
-            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
+            NdkUploadTaskRegistration(unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             variant = mockVariant,
             testAndroidCompactedVariantData,
-            mockk(relaxed = true),
             variantConfigurationsListProperty,
-            baseUrl,
+            behavior = behavior,
         )
         try {
             registration.register(params)
@@ -278,27 +277,27 @@ class NdkUploadTaskRegistrationTest {
         val projectTypeProvider = project.provider { ProjectType.NATIVE }
 
         val registration =
-            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
+            NdkUploadTaskRegistration(unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             variant = mockVariant,
             testAndroidCompactedVariantData,
-            mockk(relaxed = true),
             variantConfigurationsListProperty,
-            baseUrl,
+            behavior = behavior,
         )
         registration.register(params)
         val ndkUploadTask: NdkUploadTask =
             project.tasks.findByName("$taskName${testAndroidCompactedVariantData.name.capitalizedString()}") as NdkUploadTask
 
         assertEquals(
-            ndkUploadTask.requestParams.get(),
             RequestParams(
                 appId = "appId",
                 apiToken = "apiToken",
                 endpoint = EmbraceEndpoint.NDK,
-                baseUrl,
-            )
+                failBuildOnUploadErrors = true,
+                baseUrl = baseUrl,
+            ),
+            ndkUploadTask.requestParams.get(),
         )
         assertEquals(ndkUploadTask.unitySymbolsDir.orNull, null)
     }
@@ -313,27 +312,27 @@ class NdkUploadTaskRegistrationTest {
         val projectTypeProvider = project.provider { ProjectType.UNITY }
 
         val registration =
-            NdkUploadTaskRegistration(mockk(relaxed = true), unitySymbolsDirProvider, projectTypeProvider)
+            NdkUploadTaskRegistration(unitySymbolsDirProvider, projectTypeProvider)
         val params = RegistrationParams(
             project,
             variant = mockVariant,
             testAndroidCompactedVariantData,
-            mockk(relaxed = true),
             variantConfigurationsListProperty,
-            baseUrl,
+            behavior = behavior,
         )
         registration.register(params)
         val ndkUploadTask: NdkUploadTask =
             project.tasks.findByName("$taskName${testAndroidCompactedVariantData.name.capitalizedString()}") as NdkUploadTask
 
         assertEquals(
-            ndkUploadTask.requestParams.get(),
             RequestParams(
                 appId = "appId",
                 apiToken = "apiToken",
                 endpoint = EmbraceEndpoint.NDK,
-                baseUrl,
-            )
+                failBuildOnUploadErrors = true,
+                baseUrl = baseUrl,
+            ),
+            ndkUploadTask.requestParams.get(),
         )
         assertEquals(ndkUploadTask.unitySymbolsDir.orNull, unitySymbolsDir)
     }


### PR DESCRIPTION
## Goal

If the gradle plugin fails during a HTTP request then it now throws an error. This can be disabled by setting `embrace.failBuildOnUploadErrors` to `false` in `gradle.properties`. This did necessitate removing try-catch blocks from a few places in the tasks but I think we would rather know if there are any hidden problems in these tasks than silently swallowing bugs.

## Testing

I've added a test for 4xx + 5xx status codes for the proguard endpoint. I thought it was overkill to add test cases for every endpoint given that each test case takes at least a couple of seconds to execute & the code runs through the same path anyway.

