### PR TITLE
Change the order of the process state listen invocation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/EmbraceProcessStateService.kt
@@ -84,13 +84,14 @@ internal class EmbraceProcessStateService(
     override fun onBackground() {
         isInBackground = true
         val timestamp = clock.now()
-        invokeCallbackSafely { sessionOrchestrator?.onBackground(timestamp) }
 
         stream<ProcessStateListener>(listeners) { listener: ProcessStateListener ->
             invokeCallbackSafely {
                 listener.onBackground(timestamp)
             }
         }
+
+        invokeCallbackSafely { sessionOrchestrator?.onBackground(timestamp) }
     }
 
     private inline fun invokeCallbackSafely(action: () -> Unit) {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/EmbraceProcessStateServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/EmbraceProcessStateServiceTest.kt
@@ -179,8 +179,8 @@ internal class EmbraceProcessStateServiceTest {
         invocations.clear()
         stateService.onBackground()
         val backgroundExpected = listOf(
+            "DecoratedListener",
             "DecoratedSessionOrchestrator",
-            "DecoratedListener"
         )
         assertEquals(backgroundExpected, invocations)
     }


### PR DESCRIPTION
## Goal

Invoke the onBackground callback for the `SessionOrchestrator` last so that every other service has a chance to "do the wrap up before going into the background" thing.

Currently, this only affects the ANR service, which means it'll stop monitoring ANRs just before the session payload is taken. A side effect of this is our session payload creation time won't be counted in an on-going ANR, which seems to be correct to me as the app will soon not be on screen, so extending the blockage interval doesn't seem like it adds much value.