### PR TITLE
Hook up SDK to abandon app startup trace on background

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
@@ -38,7 +39,7 @@ internal class FlutterInternalInterfaceTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         val clock = FakeClock(SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
-        val fakeInitModule = FakeInitModule(clock = clock)
+        val fakeInitModule = FakeInitModule(clock = clock, logger = createForIntegrationTest())
         EmbraceSetupInterface(
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/LogRecordExporterTest.kt
@@ -2,11 +2,10 @@ package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,17 +33,9 @@ internal class LogRecordExporterTest {
                     embrace.logMessage("test message", Severity.INFO)
                 }
             },
-            assertAction = {
-                assertTrue(
-                    returnIfConditionMet(
-                        desiredValueSupplier = { true },
-                        dataProvider = { fakeLogRecordExporter.exportedLogs?.size },
-                        condition = { data ->
-                            data == 1
-                        },
-                    )
-                )
-                with(checkNotNull(fakeLogRecordExporter.exportedLogs?.first())) {
+            otelExportAssertion = {
+                val log = awaitLogs(1) { it.attributes.get(EmbType.System.Log.key.attributeKey) == EmbType.System.Log.value }
+                with(log.single()) {
                     assertEquals("test message", body.asString())
                     assertEquals(logTimestampNanos, timestampEpochNanos)
                     assertEquals(logTimestampNanos, observedTimestampEpochNanos)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -10,12 +10,15 @@ import android.os.Build
 import android.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.Log
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import io.embrace.android.embracesdk.testframework.assertions.getLastLog
+import io.embrace.android.embracesdk.testframework.assertions.getLogOfType
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -101,7 +104,7 @@ internal class AeiFeatureTest {
                 recordSession()
             },
             assertAction = {
-                val log = getSingleLogEnvelope().getLastLog()
+                val log = getSingleLogEnvelope().getLogOfType(EmbType.System.Exit)
                 log.assertContainsAeiData(jvmCrash)
             }
         )
@@ -117,7 +120,7 @@ internal class AeiFeatureTest {
                 recordSession()
             },
             assertAction = {
-                val log = getSingleLogEnvelope().getLastLog()
+                val log = getSingleLogEnvelope().getLogOfType(EmbType.System.Exit)
                 log.assertContainsAeiData(nativeCrash)
             }
         )
@@ -133,7 +136,9 @@ internal class AeiFeatureTest {
                 recordSession()
             },
             assertAction = {
-                val log = getSingleLogEnvelope().getLastLog()
+                val log = getLogEnvelopes(2)
+                    .flatMap { checkNotNull(it.data.logs) }
+                    .single { it.attributes?.findAttributeValue("emb.type") == "sys.exit" }
                 log.assertContainsAeiData(anr)
             }
         )
@@ -149,7 +154,7 @@ internal class AeiFeatureTest {
                 recordSession()
             },
             assertAction = {
-                val log = getSingleLogEnvelope().getLastLog()
+                val log = getSingleLogEnvelope().getLogOfType(EmbType.System.Exit)
                 log.assertContainsAeiData(anr)
             }
         )
@@ -172,6 +177,7 @@ internal class AeiFeatureTest {
                 val envelopes = getLogEnvelopes(expectedSize)
                 assertEquals(expectedSize, envelopes.size)
                 val logs = envelopes.mapNotNull { it.data.logs?.singleOrNull() }
+                    .filter { it.attributes?.findAttributeValue("emb.type") == "sys.exit" }
                 assertEquals(32, logs.size)
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.anr.detection.BlockedThreadDetector
@@ -18,11 +18,11 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
-import java.util.concurrent.atomic.AtomicReference
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicReference
 
 private const val START_TIME_MS = 10000000000L
 private const val INTERVAL_MS = 100L
@@ -41,7 +41,7 @@ internal class AnrFeatureTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         val clock = FakeClock(currentTime = START_TIME_MS)
-        val initModule = FakeInitModule(clock, FakeEmbLogger(throwOnInternalError = false))
+        val initModule = FakeInitModule(clock, createForIntegrationTest(throwOnInternalError = false))
         val workerThreadModule =
             FakeWorkerThreadModule(initModule, Worker.Background.AnrWatchdogWorker).apply {
                 anrMonitorThread = AtomicReference(Thread.currentThread())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
@@ -4,15 +4,15 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 internal class DisableSdkFeatureTest {
@@ -38,7 +38,7 @@ internal class DisableSdkFeatureTest {
     @Before
     fun setUp() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        embraceDirs = StorageLocation.values().map { it.asFile(ctx, FakeEmbLogger()).value }
+        embraceDirs = StorageLocation.values().map { it.asFile(ctx, createForIntegrationTest()).value }
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.embrace.android.embracesdk.testframework.assertions.getLastLog
+import io.embrace.android.embracesdk.testframework.assertions.getLogWithAttributeValue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -23,6 +23,7 @@ internal class InternalErrorLogTest {
         testRule.runTest(
             setupAction = {
                 (overriddenInitModule.logger as FakeEmbLogger).throwOnInternalError = false
+
             },
             testCaseAction = {
                 recordSession {
@@ -30,7 +31,7 @@ internal class InternalErrorLogTest {
                 }
             },
             assertAction = {
-                with(getSingleLogEnvelope().getLastLog()) {
+                with(getSingleLogEnvelope().getLogWithAttributeValue("exception.message", "Some error message")) {
                     assertEquals("ERROR", severityText)
                     assertEquals("", body)
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -30,7 +31,7 @@ internal class LogFeatureTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         val clock = FakeClock(SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
-        val fakeInitModule = FakeInitModule(clock = clock)
+        val fakeInitModule = FakeInitModule(clock = clock, logger = createForIntegrationTest())
         EmbraceSetupInterface(
             overriddenClock = clock,
             overriddenInitModule = fakeInitModule,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
@@ -2,9 +2,7 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionSpan
-import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
-import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
@@ -27,14 +25,9 @@ internal class PruningFeatureTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        val clock = FakeClock(0)
-        EmbraceSetupInterface(
-            overriddenClock = clock,
-            overriddenInitModule = FakeInitModule(
-                clock,
-                FakeEmbLogger(throwOnInternalError = false)
-            )
-        )
+        EmbraceSetupInterface().apply {
+            (overriddenInitModule.logger as FakeEmbLogger).throwOnInternalError = false
+        }
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.assertions.findEventsOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -48,7 +49,7 @@ internal class BackgroundActivityDisabledTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         val clock = FakeClock()
-        val initModule = FakeInitModule(clock)
+        val initModule = FakeInitModule(clock, createForIntegrationTest())
         val workerThreadModule =
             FakeWorkerThreadModule(initModule, Worker.Background.LogMessageWorker)
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.assertions.findSpanSnapshotOfType
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -40,7 +41,7 @@ internal class PeriodicSessionCacheTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         val clock = FakeClock(SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
-        val fakeInitModule = FakeInitModule(clock = clock)
+        val fakeInitModule = FakeInitModule(clock = clock, logger = createForIntegrationTest())
         executor = BlockingScheduledExecutorService(fakeClock = clock)
 
         workerThreadModule = FakeWorkerThreadModule(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeDeliveryService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeJniDelegate
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
@@ -12,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
 import io.embrace.android.embracesdk.fakes.FakeSymbolService
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -44,7 +44,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
     val processIdentifier: String = "integration-test-process",
     val overriddenInitModule: FakeInitModule = FakeInitModule(
         clock = overriddenClock,
-        logger = FakeEmbLogger(),
+        logger = createForIntegrationTest(),
         processIdentifierProvider = { processIdentifier }
     ),
     val overriddenOpenTelemetryModule: OpenTelemetryModule = overriddenInitModule.openTelemetryModule,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testframework.actions
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.createForIntegrationTest
 import io.embrace.android.embracesdk.fakes.fakeEmptyLogEnvelope
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeResource
@@ -32,7 +32,7 @@ internal data class StoredNativeCrashData(
 
     fun getCrashFile(): File {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        val outputDir = StorageLocation.NATIVE.asFile(ctx, FakeEmbLogger()).value.apply {
+        val outputDir = StorageLocation.NATIVE.asFile(ctx, createForIntegrationTest()).value.apply {
             mkdirs()
         }
         return File(outputDir, crashMetadata.filename)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/PayloadAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/PayloadAssertions.kt
@@ -1,8 +1,10 @@
 package io.embrace.android.embracesdk.testframework.assertions
 
+import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 
 /**
  * Returns the last log in a list of log payloads.
@@ -14,3 +16,19 @@ internal fun List<Envelope<LogPayload>>.getLastLog(): Log {
 internal fun Envelope<LogPayload>.getLastLog(): Log {
     return checkNotNull(data.logs).last()
 }
+
+internal fun Envelope<LogPayload>.getLogs(predicate: (Log) -> Boolean): List<Log> {
+    return checkNotNull(data.logs).filter { predicate(it) }
+}
+
+internal fun Envelope<LogPayload>.getLog(predicate: (Log) -> Boolean): Log = getLogs { predicate(it) }.single()
+
+internal fun Envelope<LogPayload>.getLogsWithAttributeValue(name: String, value: String): List<Log> =
+    getLogs { it.attributes?.findAttributeValue(name) == value }
+
+internal fun Envelope<LogPayload>.getLogWithAttributeValue(name: String, value: String): Log =
+    getLogsWithAttributeValue(name, value).single()
+
+internal fun Envelope<LogPayload>.getLogsOfType(type: TelemetryType): List<Log> = getLogsWithAttributeValue("emb.type", type.value)
+
+internal fun Envelope<LogPayload>.getLogOfType(type: TelemetryType): Log = getLogsOfType(type).single()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -267,6 +267,7 @@ internal class ModuleInitBootstrapper(
 
                     postInit(DataCaptureServiceModule::class) {
                         serviceRegistry.registerServices(
+                            lazy { dataCaptureServiceModule.appStartupDataCollector },
                             lazy { dataCaptureServiceModule.webviewService },
                             lazy { dataCaptureServiceModule.activityBreadcrumbTracker },
                             lazy { dataCaptureServiceModule.pushNotificationService },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.injection
 
 import android.content.Context
+import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -18,7 +19,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
+@Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
 internal class ModuleInitBootstrapperTest {
 


### PR DESCRIPTION
## Goal

Register `AppStartupTraceEmitter` as service so the `onBackground()` callback will be invoked when the app background while while app startup is still taking place

As a result, we had to make sure the integration tests that aren't faking app startup (which means the startup data it collects will be incomplete) ignore internal errors that are generated for when app startup trace cannot be generated. 

Similarly, startup traces will now be generated if the conditions are corrected, so those tests that assume that only the logs they create will be exported need to be modified to ignore the internal errors (which are also OTel logs).
