### PR TITLE
Reduce the overridding surface area for integration test setup

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DataSourceModuleImplTest.kt
@@ -16,7 +16,7 @@ internal class DataSourceModuleImplTest {
             fakeInitModule,
             FakeWorkerThreadModule(
                 fakeInitModule = fakeInitModule,
-                testWorkerName = Worker.Background.NonIoRegWorker
+                testWorker = Worker.Background.NonIoRegWorker
             ),
         )
         assertSame(module.dataCaptureOrchestrator, module.embraceFeatureRegistry)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionOrchestrationModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionOrchestrationModuleImplTest.kt
@@ -25,7 +25,7 @@ internal class SessionOrchestrationModuleImplTest {
     private val configService = FakeConfigService()
     private val workerThreadModule = FakeWorkerThreadModule(
         fakeInitModule = initModule,
-        testWorkerName = Worker.Background.NonIoRegWorker
+        testWorker = Worker.Background.NonIoRegWorker
     )
 
     @Test

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/crash/LastRunCrashVerifierTest.kt
@@ -25,7 +25,7 @@ internal class LastRunCrashVerifierTest {
         mockCrashFileMarker = mockk()
         lastRunCrashVerifier = LastRunCrashVerifier(mockCrashFileMarker)
         fakeWorkerThreadModule =
-            FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), testWorkerName = Worker.Background.NonIoRegWorker)
+            FakeWorkerThreadModule(fakeInitModule = FakeInitModule(), testWorker = Worker.Background.NonIoRegWorker)
         worker = fakeWorkerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -37,8 +37,8 @@ internal class FlutterInternalInterfaceTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).apply {
-            executor = getFakedWorkerExecutor()
+        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).also {
+            executor = it.getFakedWorkerExecutor()
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -2,12 +2,9 @@ package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.LogExceptionType
-import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
-import io.embrace.android.embracesdk.fakes.createForIntegrationTest
-import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.worker.Worker
@@ -35,19 +32,14 @@ internal class FlutterInternalInterfaceTest {
         appFramework = "flutter"
     ))
 
+    private lateinit var executor: BlockingScheduledExecutorService
+
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        val clock = FakeClock(SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
-        val fakeInitModule = FakeInitModule(clock = clock, logger = createForIntegrationTest())
-        EmbraceSetupInterface(
-            overriddenClock = clock,
-            overriddenInitModule = fakeInitModule,
-            overriddenWorkerThreadModule = FakeWorkerThreadModule(
-                fakeInitModule = fakeInitModule,
-                testWorkerName = Worker.Background.LogMessageWorker
-            )
-        )
+        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).apply {
+            executor = getFakedWorkerExecutor()
+        }
     }
 
     @Test
@@ -249,9 +241,7 @@ internal class FlutterInternalInterfaceTest {
     }
 
     private fun flushLogs() {
-        val executor = (testRule.setup.overriddenWorkerThreadModule as FakeWorkerThreadModule).executor
         executor.runCurrentlyBlocked()
-        val logOrchestrator = testRule.bootstrapper.logModule.logOrchestrator
-        logOrchestrator.flush(false)
+        testRule.bootstrapper.logModule.logOrchestrator.flush(false)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -65,7 +65,7 @@ internal class AeiFeatureTest {
 
     @Rule
     @JvmField
-    val testRule = SdkIntegrationTestRule()
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
 
     private val jvmCrash = TestAeiData(
         ApplicationExitInfo.REASON_CRASH,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -37,10 +37,12 @@ internal class AnrFeatureTest {
             currentTimeMs = START_TIME_MS,
             workerToFake = Worker.Background.AnrWatchdogWorker,
             anrMonitoringThread = Thread.currentThread()
-        ).apply {
-            anrMonitorExecutor = getFakedWorkerExecutor()
-            anrMonitorExecutor.blockingMode = false
-            blockedThreadDetector = getBlockedThreadDetector()
+        ).also {
+            with(it) {
+                anrMonitorExecutor = getFakedWorkerExecutor()
+                anrMonitorExecutor.blockingMode = false
+                blockedThreadDetector = getBlockedThreadDetector()
+            }
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -2,14 +2,8 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
-import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.createForIntegrationTest
-import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.anr.detection.BlockedThreadDetector
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.injection.createAnrModule
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -22,7 +16,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.atomic.AtomicReference
 
 private const val START_TIME_MS = 10000000000L
 private const val INTERVAL_MS = 100L
@@ -40,27 +33,15 @@ internal class AnrFeatureTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        val clock = FakeClock(currentTime = START_TIME_MS)
-        val initModule = FakeInitModule(clock, createForIntegrationTest(throwOnInternalError = false))
-        val workerThreadModule =
-            FakeWorkerThreadModule(initModule, Worker.Background.AnrWatchdogWorker).apply {
-                anrMonitorThread = AtomicReference(Thread.currentThread())
-            }
-        anrMonitorExecutor = workerThreadModule.executor.apply { blockingMode = false }
-        val anrModule = createAnrModule(
-            initModule,
-            FakeConfigService(),
-            workerThreadModule
-        )
-        blockedThreadDetector = anrModule.blockedThreadDetector
-
         EmbraceSetupInterface(
             currentTimeMs = START_TIME_MS,
-            overriddenClock = clock,
-            overriddenInitModule = initModule,
-            overriddenWorkerThreadModule = workerThreadModule,
-            fakeAnrModule = anrModule
-        )
+            workerToFake = Worker.Background.AnrWatchdogWorker,
+            anrMonitoringThread = Thread.currentThread()
+        ).apply {
+            anrMonitorExecutor = getFakedWorkerExecutor()
+            anrMonitorExecutor.blockingMode = false
+            blockedThreadDetector = getBlockedThreadDetector()
+        }
     }
 
     @Test
@@ -183,10 +164,12 @@ internal class AnrFeatureTest {
         assertEquals(endTime, span.endTimeNanos?.nanosToMillis())
 
         // assert span attributes
-        span.attributes?.assertMatches(mapOf(
-            "emb.type" to "perf.thread_blockage",
-            "interval_code" to expectedIntervalCode
-        ))
+        span.attributes?.assertMatches(
+            mapOf(
+                "emb.type" to "perf.thread_blockage",
+                "interval_code" to expectedIntervalCode
+            )
+        )
 
         val events = checkNotNull(span.events)
 
@@ -194,14 +177,16 @@ internal class AnrFeatureTest {
             assertEquals("perf.thread_blockage_sample", event.name)
 
             // assert attributes
-            event.attributes?.assertMatches(mapOf(
-                "emb.type" to "perf.thread_blockage_sample",
-                "sample_overhead" to 0,
-                "sample_code" to when {
-                    index < MAX_SAMPLE_COUNT -> "0"
-                    else -> "1"
-                }
-            ))
+            event.attributes?.assertMatches(
+                mapOf(
+                    "emb.type" to "perf.thread_blockage_sample",
+                    "sample_overhead" to 0,
+                    "sample_code" to when {
+                        index < MAX_SAMPLE_COUNT -> "0"
+                        else -> "1"
+                    }
+                )
+            )
 
             // assert interval time
             val expectedTime = startTime + ANR_THRESHOLD_MS + ((index + 1) * INTERVAL_MS)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
-import io.embrace.android.embracesdk.fakes.createForIntegrationTest
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
@@ -38,7 +38,7 @@ internal class DisableSdkFeatureTest {
     @Before
     fun setUp() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        embraceDirs = StorageLocation.values().map { it.asFile(ctx, createForIntegrationTest()).value }
+        embraceDirs = StorageLocation.values().map { it.asFile(ctx, FakeEmbLogger()).value }
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -28,8 +28,8 @@ internal class LogFeatureTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).apply {
-            executor = getFakedWorkerExecutor()
+        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).also {
+            executor = it.getFakedWorkerExecutor()
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -3,12 +3,9 @@ package io.embrace.android.embracesdk.testcases.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.fakes.createForIntegrationTest
-import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
@@ -26,20 +23,14 @@ import org.junit.runner.RunWith
 internal class LogFeatureTest {
 
     private val instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true))
+    private lateinit var executor: BlockingScheduledExecutorService
 
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        val clock = FakeClock(SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS)
-        val fakeInitModule = FakeInitModule(clock = clock, logger = createForIntegrationTest())
-        EmbraceSetupInterface(
-            overriddenClock = clock,
-            overriddenInitModule = fakeInitModule,
-            overriddenWorkerThreadModule = FakeWorkerThreadModule(
-                fakeInitModule = fakeInitModule,
-                testWorkerName = Worker.Background.LogMessageWorker
-            )
-        )
+        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).apply {
+            executor = getFakedWorkerExecutor()
+        }
     }
 
     @Test
@@ -394,11 +385,8 @@ internal class LogFeatureTest {
     }
 
     private fun flushLogs() {
-        val executor =
-            (testRule.setup.overriddenWorkerThreadModule as FakeWorkerThreadModule).executor
         executor.runCurrentlyBlocked()
-        val logOrchestrator = testRule.bootstrapper.logModule.logOrchestrator
-        logOrchestrator.flush(false)
+        testRule.bootstrapper.logModule.logOrchestrator.flush(false)
     }
 
     private fun getEmbraceSeverity(severityNumber: Int): Severity {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
@@ -125,7 +125,7 @@ internal class UiLoadTest {
             ),
             persistedRemoteConfig = RemoteConfig(uiLoadInstrumentationEnabled = true),
             setupAction = {
-                preLaunchTimeMs = overriddenClock.now()
+                preLaunchTimeMs = getClock().now()
             },
             testCaseAction = {
                 simulateOpeningActivities(
@@ -179,7 +179,7 @@ internal class UiLoadTest {
             ),
             persistedRemoteConfig = RemoteConfig(uiLoadInstrumentationEnabled = true),
             setupAction = {
-                preLaunchTimeMs = overriddenClock.now()
+                preLaunchTimeMs = getClock().now()
             },
             testCaseAction = {
                 simulateOpeningActivities(
@@ -245,7 +245,7 @@ internal class UiLoadTest {
             ),
             persistedRemoteConfig = RemoteConfig(uiLoadInstrumentationEnabled = true),
             setupAction = {
-                preLaunchTimeMs = overriddenClock.now()
+                preLaunchTimeMs = getClock().now()
             },
             testCaseAction = {
                 simulateOpeningActivities(
@@ -300,7 +300,7 @@ internal class UiLoadTest {
             ),
             persistedRemoteConfig = RemoteConfig(uiLoadInstrumentationEnabled = true),
             setupAction = {
-                preLaunchTimeMs = overriddenClock.now()
+                preLaunchTimeMs = getClock().now()
             },
             testCaseAction = {
                 simulateOpeningActivities(
@@ -356,7 +356,7 @@ internal class UiLoadTest {
             ),
             persistedRemoteConfig = RemoteConfig(uiLoadInstrumentationEnabled = true),
             setupAction = {
-                preLaunchTimeMs = overriddenClock.now()
+                preLaunchTimeMs = getClock().now()
             },
             testCaseAction = {
                 simulateOpeningActivities(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -47,8 +47,8 @@ internal class BackgroundActivityDisabledTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).apply {
-            executor = getFakedWorkerExecutor()
+        EmbraceSetupInterface(workerToFake = Worker.Background.LogMessageWorker).also {
+            executor = it.getFakedWorkerExecutor()
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -35,9 +35,9 @@ internal class PeriodicSessionCacheTest {
         EmbraceSetupInterface(
             workerToFake = Worker.Background.PeriodicCacheWorker,
             priorityWorkerToFake = Worker.Priority.DataPersistenceWorker,
-        ).apply {
-            periodicCacheWorkerExecutor = getFakedWorkerExecutor()
-            dataPersistenceWorkerExecutor = getFakedPriorityWorkerExecutor()
+        ).also {
+            periodicCacheWorkerExecutor = it.getFakedWorkerExecutor()
+            dataPersistenceWorkerExecutor = it.getFakedPriorityWorkerExecutor()
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -24,7 +24,7 @@ internal class EmbraceActionInterface(
     val embrace = Embrace.getInstance()
 
     val clock: FakeClock
-        get() = setup.overriddenClock
+        get() = setup.getClock()
 
     /**
      * Starts & ends a session for the purposes of testing. An action can be supplied as a lambda
@@ -43,7 +43,7 @@ internal class EmbraceActionInterface(
         this.action()
 
         // end session 30s later by entering background
-        setup.overriddenClock.tick(30000)
+        setup.getClock().tick(30000)
         onBackground()
     }
 
@@ -83,29 +83,29 @@ internal class EmbraceActionInterface(
             if (startInBackground) {
                 stop()
                 onBackground()
-                setup.overriddenClock.tick(STARTUP_BACKGROUND_TIME)
+                setup.getClock().tick(STARTUP_BACKGROUND_TIME)
             } else {
-                setup.overriddenClock.tick(ACTIVITY_GAP)
+                setup.getClock().tick(ACTIVITY_GAP)
             }
         }
         activitiesAndActions.forEachIndexed { index, (activityController, action) ->
             if (index != 0 || createFirstActivity) {
                 activityController.create()
-                setup.overriddenClock.tick(LIFECYCLE_EVENT_GAP)
+                setup.getClock().tick(LIFECYCLE_EVENT_GAP)
             }
             activityController.start()
-            setup.overriddenClock.tick(LIFECYCLE_EVENT_GAP)
+            setup.getClock().tick(LIFECYCLE_EVENT_GAP)
             if (index == 0 && startInBackground) {
                 onForeground()
             }
             activityController.resume()
 
-            setup.overriddenClock.tick(LIFECYCLE_EVENT_GAP)
+            setup.getClock().tick(LIFECYCLE_EVENT_GAP)
 
             if (invokeManualEnd) {
                 embrace.addLoadTraceAttribute(activityController.get(), "manual-end", "true")
                 val startTime = clock.now()
-                setup.overriddenClock.tick(LIFECYCLE_EVENT_GAP)
+                setup.getClock().tick(LIFECYCLE_EVENT_GAP)
                 val endTime = clock.now()
                 embrace.addLoadTraceChildSpan(
                     activity = activityController.get(),
@@ -119,14 +119,14 @@ internal class EmbraceActionInterface(
 
             action()
 
-            setup.overriddenClock.tick(POST_ACTIVITY_ACTION_DWELL)
+            setup.getClock().tick(POST_ACTIVITY_ACTION_DWELL)
             activityController.pause()
-            setup.overriddenClock.tick(ACTIVITY_GAP)
+            setup.getClock().tick(ACTIVITY_GAP)
             lastActivity = activityController
         }
 
         lastActivity?.stop()
-        setup.overriddenClock.tick()
+        setup.getClock().tick()
 
         if (endInBackground) {
             onBackground()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePreSdkStartInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePreSdkStartInterface.kt
@@ -12,7 +12,7 @@ internal class EmbracePreSdkStartInterface(
     val embrace = Embrace.getInstance()
 
     val clock: FakeClock
-        get() = setup.overriddenClock
+        get() = setup.getClock()
 
     /**
      * Asserts that no config has been persisted on disk yet.

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testframework.actions
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.fakes.createForIntegrationTest
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.fakeEmptyLogEnvelope
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeResource
@@ -32,7 +32,7 @@ internal data class StoredNativeCrashData(
 
     fun getCrashFile(): File {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        val outputDir = StorageLocation.NATIVE.asFile(ctx, createForIntegrationTest()).value.apply {
+        val outputDir = StorageLocation.NATIVE.asFile(ctx, FakeEmbLogger()).value.apply {
             mkdirs()
         }
         return File(outputDir, crashMetadata.filename)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -44,8 +44,3 @@ class FakeEmbLogger(
         errorHandlerProvider()?.trackInternalError(type, throwable)
     }
 }
-
-fun createForIntegrationTest(throwOnInternalError: Boolean = true): FakeEmbLogger = FakeEmbLogger(
-    throwOnInternalError = throwOnInternalError,
-    ignoredErrors = mutableListOf(InternalErrorType.PROCESS_STATE_CALLBACK_FAIL)
-)


### PR DESCRIPTION
## Goal

Simplify how you can use blocking executors for background and priority workers. This allows us to then not have to create new instances of `EmbFakeLogger` for integration tests, thus allowing us to just set the internal error exclusion when instantiating an instance of that for the integration test rule. In turn, this allows us to get rid of the poorly named/documented factory method for `FakeEmbLogger`.