### PR TITLE
Add new embrace extension

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.gradle.plugin.api
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+/**
+ * DSL for configuring the Embrace Gradle Plugin's bytecode instrumentation behavior.
+ */
+abstract class EmbraceBytecodeInstrumentation @Inject internal constructor(objectFactory: ObjectFactory) {
+
+    /**
+     * Global flag that overrides all others & decides whether Embrace should perform any bytecode instrumentation.
+     * Defaults to true.
+     */
+    val enabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether Embrace should automatically instrument OkHttp requests. Defaults to true.
+     */
+    val okhttpEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether Embrace should automatically instrument android.view.View click events. Defaults to true.
+     */
+    val onClickEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether Embrace should automatically instrument android.view.View long click events. Defaults to true.
+     */
+    val onLongClickEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether Embrace should automatically instrument onPageStarted() in webviews. Defaults to true.
+     */
+    val webviewOnPageStartedEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether Embrace should automatically instrument push notifications from Firebase. Defaults to false.
+     */
+    val firebasePushNotificationsEnabled: Property<Boolean> =
+        objectFactory.property(Boolean::class.java)
+
+    /**
+     * A list of string patterns that are used to filter classes during bytecode instrumentation. For example, 'com.example.foo.*'
+     * would avoid instrumenting any classes in the 'com.example.foo' package.
+     *
+     * This can be useful if you wish to avoid instrumenting certain parts of your codebase.
+     *
+     * Defaults to an empty list.
+     */
+    val classIgnorePatterns: ListProperty<String> =
+        objectFactory.listProperty(String::class.java)
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceExtension.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceExtension.kt
@@ -1,0 +1,93 @@
+package io.embrace.android.gradle.plugin.api
+
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+/**
+ * An extension that is used to configure the Embrace Gradle Plugin's behavior.
+ */
+abstract class EmbraceExtension @Inject internal constructor(objectFactory: ObjectFactory) {
+
+    /**
+     * Whether the Embrace Gradle Plugin should automatically add Embrace dependencies to this module's classpath.
+     * Defaults to true.
+     */
+    val autoAddEmbraceDependencies: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether the Embrace Gradle Plugin should automatically add the embrace-android-compose dependency to this module's classpath.
+     * Defaults to false.
+     */
+    val autoAddEmbraceComposeDependency: Property<Boolean> =
+        objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether the Embrace Gradle Plugin should automatically upload mapping files for stacktrace deobfuscation.
+     * Defaults to true.
+     */
+    val mappingFileUploadEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether the Embrace Gradle Plugin should report telemetry on its own performance.
+     * Defaults to true.
+     */
+    val telemetryEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * Whether the Embrace Gradle Plugin should fail the build if it encounters an error during a HTTP request.
+     * Defaults to true.
+     */
+    val failBuildOnUploadErrors: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
+     * DSL for configuring how Embrace instruments bytecode.
+     */
+    val bytecodeInstrumentation: EmbraceBytecodeInstrumentation =
+        objectFactory.newInstance(EmbraceBytecodeInstrumentation::class.java)
+
+    /**
+     * DSL for configuring how Embrace instruments bytecode.
+     */
+    fun bytecodeInstrumentation(action: Action<EmbraceBytecodeInstrumentation>) {
+        action.execute(bytecodeInstrumentation)
+    }
+
+    /**
+     * DSL for configuring the Embrace Gradle Plugin's behavior on a per build variant basis.
+     */
+    internal var buildVariantFilter: Action<BuildVariant> = Action { }
+
+    /**
+     * DSL for configuring the Embrace Gradle Plugin's behavior on a per build variant basis.
+     */
+    fun EmbraceExtension.buildVariantFilter(buildVariantFilter: Action<BuildVariant>) {
+        this.buildVariantFilter = buildVariantFilter
+    }
+
+    /**
+     * DSL for how the Embrace Gradle Plugin behaves on a specific build variant. You can use this by checking the
+     * variant name, and then configuring the build variant as required.
+     */
+    class BuildVariant internal constructor(val name: String) {
+
+        internal var bytecodeInstrumentationEnabled = true
+        internal var pluginEnabled = true
+
+        /**
+         * Disables bytecode instrumentation entirely for this specific build variant.
+         */
+        fun disableBytecodeInstrumentationForVariant() {
+            bytecodeInstrumentationEnabled = false
+        }
+
+        /**
+         * Disables the plugin entirely for this specific build variant, on a best-effort basis
+         * given Gradle build lifecycle restrictions.
+         */
+        fun disablePluginForVariant() {
+            pluginEnabled = false
+        }
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/swazzler/plugin/extension/SwazzlerExtension.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/swazzler/plugin/extension/SwazzlerExtension.kt
@@ -12,20 +12,28 @@ abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
 
     val forceIncrementalOverwrite: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(false)
+
     val disableDependencyInjection: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(false)
+
     val disableComposeDependencyInjection: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(true)
+
     val disableRNBundleRetriever: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(false)
+
     val instrumentOkHttp: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_OKHTTP)
+
     val instrumentOnClick: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_ON_CLICK)
+
     val instrumentOnLongClick: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_ON_LONG_CLICK)
+
     val instrumentWebview: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_WEBVIEW)
+
     val instrumentFirebaseMessaging: Property<Boolean> =
         objectFactory.property(Boolean::class.java)
             .convention(DEFAULT_INSTRUMENT_FIREBASE_MESSAGING)
@@ -34,6 +42,7 @@ abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
     @get:Deprecated("")
     val customSymbolsDirectory: Property<String> =
         objectFactory.property(String::class.java).convention(DEFAULT_CUSTOM_SYMBOLS_DIRECTORY)
+
     val classSkipList: ListProperty<String> =
         objectFactory.listProperty(String::class.java).convention(emptyList())
 


### PR DESCRIPTION
## Goal

Adds the new extension that will form our plugin's public API. This is not publicly exposed as part of the plugin yet & the changeset is kept small so we can review the particulars of each property and its documentation.

