### PR TITLE
Alias swazzler extension onto embrace extension

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,28 @@
 
 # Upgrading to the new Embrace Gradle Plugin DSL
 
+The Embrace Gradle Plugin previously had a DSL via the 'swazzler' extension. This has been replaced with a new DSL via the 'embrace'
+extension.
+You can still use the 'swazzler' extension but it is deprecated and will be removed in a future release. It's recommended you use one
+extension or the other, rather than combining their use. Migration instructions are shown
+below:
+
+| Old API                                               | New API                                                                 |
+|-------------------------------------------------------|-------------------------------------------------------------------------|
+| `swazzler.disableDependencyInjection`                 | `embrace.autoAddEmbraceDependencies`                                    |
+| `swazzler.disableComposeDependencyInjection`          | `embrace.autoAddEmbraceComposeDependency`                               |
+| `swazzler.instrumentOkHttp`                           | `embrace.bytecodeInstrumentation.okhttpEnabled`                         |
+| `swazzler.instrumentOnClick`                          | `embrace.bytecodeInstrumentation.onClickEnabled`                        |
+| `swazzler.instrumentOnLongClick`                      | `embrace.bytecodeInstrumentation.onLongClickEnabled`                    |
+| `swazzler.instrumentWebview`                          | `embrace.bytecodeInstrumentation.webviewOnPageStartedEnabled`           |
+| `swazzler.instrumentFirebaseMessaging`                | `embrace.bytecodeInstrumentation.firebasePushNotificationsEnabled`      |
+| `swazzler.classSkipList`                              | `embrace.bytecodeInstrumentation.classIgnorePatterns`                   |
+| `swazzler.variantFilter`                              | `embrace.buildVariantFilter`                                            |
+| `SwazzlerExtension.Variant.enabled`                   | `embrace.buildVariantFilter.disableBytecodeInstrumentationForVariant()` |
+| `SwazzlerExtension.Variant.swazzlerOff`               | `embrace.buildVariantFilter.disablePluginForVariant()`                  |
+| `SwazzlerExtension.Variant.setSwazzlingEnabled()`     | `embrace.buildVariantFilter.disableBytecodeInstrumentationForVariant()` |
+| `SwazzlerExtension.Variant.disablePluginForVariant()` | `embrace.buildVariantFilter.disablePluginForVariant()`                  |
+
 The following project properties are now ignored and have no effect. You should remove them from your `gradle.properties` file:
 
 - `embrace.logLevel`

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/build.gradle
@@ -12,6 +12,6 @@ repositories {
 
 integrationTest.configureAndroidProject(project)
 
-swazzler {
-    disableDependencyInjection = false
+embrace {
+    autoAddEmbraceDependencies.set(true)
 }

--- a/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.gradle.integration.framework
 
 import com.android.build.api.dsl.ApplicationExtension
+import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
 import io.embrace.android.gradle.plugin.network.EmbraceEndpoint
 import io.embrace.android.gradle.plugin.tasks.EmbraceTask
 import io.embrace.android.gradle.plugin.tasks.EmbraceUploadTask
 import io.embrace.android.gradle.plugin.tasks.common.RequestParams
-import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -39,7 +39,7 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
         project: Project,
         task: EmbraceUploadTask,
         endpoint: EmbraceEndpoint = EmbraceEndpoint.PROGUARD,
-        filename: String? = null
+        filename: String? = null,
     ) {
         configureEmbraceTask(task)
         task.requestParams.set(
@@ -63,8 +63,8 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
 
         // disable dependency injection as SNAPSHOT versions of SDK don't necessarily exist
         // whenever unit tests are run
-        val embrace = checkNotNull(project.extensions.findByType(SwazzlerExtension::class.java))
-        embrace.disableDependencyInjection.set(true)
+        val embrace = checkNotNull(project.extensions.findByType(EmbraceExtension::class.java))
+        embrace.autoAddEmbraceDependencies.set(false)
 
         val android = checkNotNull(project.extensions.findByType(ApplicationExtension::class.java))
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin
 
+import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.plugin.gradle.GradleVersion
 import io.embrace.android.gradle.plugin.gradle.GradleVersion.Companion.isAtLeast
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
@@ -28,6 +29,12 @@ class EmbraceGradlePlugin : Plugin<Project> {
             project.objects
         )
 
+        val embrace = project.extensions.create(
+            "embrace",
+            EmbraceExtension::class.java,
+            project.objects
+        )
+
         // this property will hold configuration for each variant. It will be updated each time a new variant
         // is configured
         val variantConfigurationsListProperty =
@@ -39,7 +46,8 @@ class EmbraceGradlePlugin : Plugin<Project> {
             impl.onAndroidPluginApplied(
                 project,
                 variantConfigurationsListProperty,
-                extension
+                extension,
+                embrace,
             )
         }
     }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -4,6 +4,7 @@ import io.embrace.android.gradle.plugin.agp.AgpUtils
 import io.embrace.android.gradle.plugin.agp.AgpVersion
 import io.embrace.android.gradle.plugin.agp.AgpWrapper
 import io.embrace.android.gradle.plugin.agp.AgpWrapperImpl
+import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.plugin.buildreporter.BuildTelemetryService
 import io.embrace.android.gradle.plugin.config.PluginBehaviorImpl
 import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurationBuilder
@@ -26,11 +27,12 @@ class EmbraceGradlePluginDelegate {
         project: Project,
         variantConfigurationsListProperty: ListProperty<VariantConfig>,
         extension: SwazzlerExtension,
+        embrace: EmbraceExtension,
     ) {
         val agpWrapper = AgpWrapperImpl(project)
         validateMinAgpVersion(agpWrapper)
 
-        val behavior = PluginBehaviorImpl(project, extension)
+        val behavior = PluginBehaviorImpl(project, extension, embrace)
 
         BuildTelemetryService.register(
             project,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
@@ -50,6 +50,5 @@ abstract class EmbraceBytecodeInstrumentation @Inject internal constructor(objec
      *
      * Defaults to an empty list.
      */
-    val classIgnorePatterns: ListProperty<String> =
-        objectFactory.listProperty(String::class.java)
+    val classIgnorePatterns: ListProperty<String> = objectFactory.listProperty(String::class.java)
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
@@ -1,36 +1,43 @@
 package io.embrace.android.gradle.plugin.config
 
+import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 
+@Suppress("DEPRECATION")
 class InstrumentationBehaviorImpl(
     private val extension: SwazzlerExtension,
+    private val embrace: EmbraceExtension,
 ) : InstrumentationBehavior {
 
     override val invalidateBytecode: Boolean by lazy {
         extension.forceIncrementalOverwrite.get()
     }
 
+    private val instrumentation by lazy {
+        embrace.bytecodeInstrumentation
+    }
+
     override val okHttpEnabled: Boolean by lazy {
-        extension.instrumentOkHttp.get()
+        instrumentation.okhttpEnabled.orNull ?: extension.instrumentOkHttp.orNull ?: true
     }
 
     override val onClickEnabled: Boolean by lazy {
-        extension.instrumentOnClick.get()
+        instrumentation.onClickEnabled.orNull ?: extension.instrumentOnClick.orNull ?: true
     }
 
     override val onLongClickEnabled: Boolean by lazy {
-        extension.instrumentOnLongClick.get()
+        instrumentation.onLongClickEnabled.orNull ?: extension.instrumentOnLongClick.orNull ?: true
     }
 
     override val webviewEnabled: Boolean by lazy {
-        extension.instrumentWebview.get()
+        instrumentation.webviewOnPageStartedEnabled.orNull ?: extension.instrumentWebview.orNull ?: true
     }
 
     override val fcmPushNotificationsEnabled: Boolean by lazy {
-        extension.instrumentFirebaseMessaging.get()
+        instrumentation.firebasePushNotificationsEnabled.orNull ?: extension.instrumentFirebaseMessaging.orNull ?: false
     }
 
     override val ignoredClasses: List<String> by lazy {
-        extension.classSkipList.get()
+        instrumentation.classIgnorePatterns.get().plus(extension.classSkipList.get())
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/swazzler/plugin/extension/SwazzlerExtension.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/swazzler/plugin/extension/SwazzlerExtension.kt
@@ -8,46 +8,48 @@ import org.gradle.api.provider.Property
 /**
  * An extension that can be used to configure the plugin.
  */
+@Suppress("DEPRECATION")
 abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
 
     val forceIncrementalOverwrite: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(false)
 
-    val disableDependencyInjection: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(false)
+    @Deprecated("Use embrace.autoAddEmbraceDependencies instead.")
+    val disableDependencyInjection: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
-    val disableComposeDependencyInjection: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(true)
+    @Deprecated("Use embrace.autoAddEmbraceComposeDependency instead.")
+    val disableComposeDependencyInjection: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
     val disableRNBundleRetriever: Property<Boolean> =
         objectFactory.property(Boolean::class.java).convention(false)
 
-    val instrumentOkHttp: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_OKHTTP)
+    @Deprecated("Use embrace.bytecodeInstrumentation.okhttpEnabled instead.")
+    val instrumentOkHttp: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
-    val instrumentOnClick: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_ON_CLICK)
+    @Deprecated("Use embrace.bytecodeInstrumentation.onClickEnabled instead.")
+    val instrumentOnClick: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
-    val instrumentOnLongClick: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_ON_LONG_CLICK)
+    @Deprecated("Use embrace.bytecodeInstrumentation.onLongClickEnabled instead.")
+    val instrumentOnLongClick: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
-    val instrumentWebview: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(DEFAULT_INSTRUMENT_WEBVIEW)
+    @Deprecated("Use embrace.bytecodeInstrumentation.webviewOnPageStartedEnabled instead.")
+    val instrumentWebview: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
-    val instrumentFirebaseMessaging: Property<Boolean> =
-        objectFactory.property(Boolean::class.java)
-            .convention(DEFAULT_INSTRUMENT_FIREBASE_MESSAGING)
+    @Deprecated("Use embrace.bytecodeInstrumentation.firebasePushNotificationsEnabled instead.")
+    val instrumentFirebaseMessaging: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
     // It is now ignored because we're automatically detecting all native symbols. This can be removed.
-    @get:Deprecated("")
+    @Deprecated("")
     val customSymbolsDirectory: Property<String> =
         objectFactory.property(String::class.java).convention(DEFAULT_CUSTOM_SYMBOLS_DIRECTORY)
 
-    val classSkipList: ListProperty<String> =
-        objectFactory.listProperty(String::class.java).convention(emptyList())
+    @Deprecated("Use embrace.bytecodeInstrumentation.classIgnorePatterns instead.")
+    val classSkipList: ListProperty<String> = objectFactory.listProperty(String::class.java)
 
+    @Deprecated("Use embrace.buildVariantFilter instead.")
     var variantFilter: Action<Variant>? = null
 
+    @Deprecated("Use embrace.buildVariantFilter instead.")
     fun SwazzlerExtension.variantFilter(variantFilter: Action<Variant>?) {
         this.variantFilter = variantFilter
     }
@@ -55,6 +57,7 @@ abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
     /**
      * @return true if the variant is disabled.
      */
+    @Deprecated("Use embrace.buildVariantFilter instead.")
     fun isSwazzlingDisabled(variantName: String): Boolean {
         val variant = Variant(variantName)
         variantFilter?.execute(variant)
@@ -66,6 +69,7 @@ abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
      *
      * @return true if the plugin should be turned off for given variant.
      */
+    @Deprecated("Use embrace.buildVariantFilter instead.")
     fun isPluginDisabledForVariant(variantName: String): Boolean {
         val variant = Variant(variantName)
         variantFilter?.execute(variant)
@@ -75,14 +79,17 @@ abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
     /**
      * Represents a build variant.
      */
+    @Deprecated("Use embrace.buildVariantFilter instead.")
     class Variant internal constructor(val name: String) {
         var enabled: Boolean = true
         var swazzlerOff: Boolean = false
 
+        @Deprecated("Use embrace.buildVariantFilter.disableBytecodeInstrumentationForVariant() instead.")
         fun setSwazzlingEnabled(enabled: Boolean) {
             this.enabled = enabled
         }
 
+        @Deprecated("Use embrace.buildVariantFilter.disablePluginForVariant() instead.")
         fun disablePluginForVariant() {
             this.swazzlerOff = true
         }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImplTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin.config
 
+import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -9,17 +10,20 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("DEPRECATION")
 class InstrumentationBehaviorImplTest {
 
     private lateinit var project: Project
     private lateinit var extension: SwazzlerExtension
+    private lateinit var embrace: EmbraceExtension
     private lateinit var behavior: InstrumentationBehavior
 
     @Before
     fun setUp() {
         project = ProjectBuilder.builder().build()
         extension = project.extensions.create("swazzler", SwazzlerExtension::class.java)
-        behavior = InstrumentationBehaviorImpl(extension)
+        embrace = project.extensions.create("embrace", EmbraceExtension::class.java)
+        behavior = InstrumentationBehaviorImpl(extension, embrace)
     }
 
     @Test
@@ -39,8 +43,14 @@ class InstrumentationBehaviorImplTest {
     }
 
     @Test
-    fun `okHttpEnabled false`() {
+    fun `okHttpEnabled disabled via swazzler`() {
         extension.instrumentOkHttp.set(false)
+        assertFalse(behavior.okHttpEnabled)
+    }
+
+    @Test
+    fun `okHttpEnabled disabled via embrace`() {
+        embrace.bytecodeInstrumentation.okhttpEnabled.set(false)
         assertFalse(behavior.okHttpEnabled)
     }
 
@@ -50,8 +60,14 @@ class InstrumentationBehaviorImplTest {
     }
 
     @Test
-    fun `onClickEnabled false`() {
+    fun `onClickEnabled via swazzler`() {
         extension.instrumentOnClick.set(false)
+        assertFalse(behavior.onClickEnabled)
+    }
+
+    @Test
+    fun `onClickEnabled via embrace`() {
+        embrace.bytecodeInstrumentation.onClickEnabled.set(false)
         assertFalse(behavior.onClickEnabled)
     }
 
@@ -61,8 +77,14 @@ class InstrumentationBehaviorImplTest {
     }
 
     @Test
-    fun `onLongClickEnabled false`() {
+    fun `onLongClickEnabled via swazzler`() {
         extension.instrumentOnLongClick.set(false)
+        assertFalse(behavior.onLongClickEnabled)
+    }
+
+    @Test
+    fun `onLongClickEnabled via embrace`() {
+        embrace.bytecodeInstrumentation.onLongClickEnabled.set(false)
         assertFalse(behavior.onLongClickEnabled)
     }
 
@@ -72,8 +94,14 @@ class InstrumentationBehaviorImplTest {
     }
 
     @Test
-    fun `webviewEnabled false`() {
+    fun `webviewEnabled via swazzler`() {
         extension.instrumentWebview.set(false)
+        assertFalse(behavior.webviewEnabled)
+    }
+
+    @Test
+    fun `webviewEnabled via embrace`() {
+        embrace.bytecodeInstrumentation.webviewOnPageStartedEnabled.set(false)
         assertFalse(behavior.webviewEnabled)
     }
 
@@ -83,8 +111,14 @@ class InstrumentationBehaviorImplTest {
     }
 
     @Test
-    fun `fcmPushNotificationsEnabled false`() {
+    fun `fcmPushNotificationsEnabled via swazzler`() {
         extension.instrumentFirebaseMessaging.set(true)
+        assertTrue(behavior.fcmPushNotificationsEnabled)
+    }
+
+    @Test
+    fun `fcmPushNotificationsEnabled via embrace`() {
+        embrace.bytecodeInstrumentation.firebasePushNotificationsEnabled.set(true)
         assertTrue(behavior.fcmPushNotificationsEnabled)
     }
 
@@ -94,9 +128,16 @@ class InstrumentationBehaviorImplTest {
     }
 
     @Test
-    fun `ignoredClasses override`() {
+    fun `ignoredClasses override via swazzler`() {
         val values = listOf("foo", "bar")
         extension.classSkipList.set(values)
+        assertEquals(values, behavior.ignoredClasses)
+    }
+
+    @Test
+    fun `ignoredClasses override via embrace`() {
+        val values = listOf("foo", "bar")
+        embrace.bytecodeInstrumentation.classIgnorePatterns.set(values)
         assertEquals(values, behavior.ignoredClasses)
     }
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.gradle.plugin.ndk
 
 import com.android.build.api.variant.Variant
+import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.plugin.config.PluginBehaviorImpl
 import io.embrace.android.gradle.plugin.config.ProjectType
 import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
@@ -37,7 +38,11 @@ class NdkUploadTaskRegistrationTest {
     private val baseUrl = "https://dsym-store.emb-api.com"
     private val project = ProjectBuilder.builder().build()
     private val behavior =
-        PluginBehaviorImpl(project, project.extensions.create("swazzler", SwazzlerExtension::class.java))
+        PluginBehaviorImpl(
+            project,
+            project.extensions.create("swazzler", SwazzlerExtension::class.java),
+            project.extensions.create("embrace", EmbraceExtension::class.java)
+        )
     private lateinit var variantConfigurationsListProperty: ListProperty<VariantConfig>
 
     private val mockVariant = mockk<Variant>(relaxed = true)


### PR DESCRIPTION
## Goal

Aliases existing properties on the `SwazzlerExtension` interface onto the `EmbraceExtension` interface.

## Testing

Added unit test coverage.
