### PR TITLE
Ignore obsolete properties on swazzler extension

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,9 @@ below:
 | `SwazzlerExtension.Variant.swazzlerOff`               | `embrace.buildVariantFilter.disablePluginForVariant()`                  |
 | `SwazzlerExtension.Variant.setSwazzlingEnabled()`     | `embrace.buildVariantFilter.disableBytecodeInstrumentationForVariant()` |
 | `SwazzlerExtension.Variant.disablePluginForVariant()` | `embrace.buildVariantFilter.disablePluginForVariant()`                  |
+| `swazzler.forceIncrementalOverwrite`                  | Obsolete - no alternative provided.                                     |
+| `swazzler.disableRNBundleRetriever`                   | Obsolete - no alternative provided.                                     |
+| `swazzler.customSymbolsDirectory`                     | Obsolete - no alternative provided.                                     |
 
 The following project properties are now ignored and have no effect. You should remove them from your `gradle.properties` file:
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin
 
 import io.embrace.android.gradle.plugin.api.EmbraceExtension

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin
 
 import io.embrace.android.gradle.plugin.agp.AgpUtils

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
@@ -3,12 +3,6 @@ package io.embrace.android.gradle.plugin.config
 interface InstrumentationBehavior {
 
     /**
-     * Whether the project should poison the bytecode instrumentation cache to force
-     * things to run again
-     */
-    val invalidateBytecode: Boolean
-
-    /**
      * Whether OkHttp should be auto-instrumented
      */
     val okHttpEnabled: Boolean

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
@@ -1,17 +1,14 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin.config
 
 import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 
-@Suppress("DEPRECATION")
 class InstrumentationBehaviorImpl(
     private val extension: SwazzlerExtension,
     private val embrace: EmbraceExtension,
 ) : InstrumentationBehavior {
-
-    override val invalidateBytecode: Boolean by lazy {
-        extension.forceIncrementalOverwrite.get()
-    }
 
     private val instrumentation by lazy {
         embrace.bytecodeInstrumentation

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin.config
 
 import io.embrace.android.gradle.plugin.api.EmbraceExtension
@@ -5,7 +7,6 @@ import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import org.gradle.api.Project
 import java.io.File
 
-@Suppress("DEPRECATION")
 class PluginBehaviorImpl(
     private val project: Project,
     private val extension: SwazzlerExtension,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTasks.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTasks.kt
@@ -1,5 +1,3 @@
-@file:JvmName("AsmTasks")
-
 package io.embrace.android.gradle.plugin.instrumentation
 
 import com.android.build.api.instrumentation.FramesComputationMode
@@ -42,18 +40,11 @@ fun registerAsmTasks(
                 )
                 params.disabled.set(
                     project.provider {
-                        behavior.isPluginDisabledForVariant(variant.name) ||
-                            behavior.isInstrumentationDisabledForVariant(variant.name)
+                        behavior.isPluginDisabledForVariant(variant.name) || behavior.isInstrumentationDisabledForVariant(variant.name)
                     }
                 )
                 params.classInstrumentationFilter.set(
                     ClassInstrumentationFilter(behavior.instrumentation.ignoredClasses)
-                )
-                params.invalidate.set(
-                    when {
-                        behavior.instrumentation.invalidateBytecode -> System.currentTimeMillis()
-                        else -> -1L // use a predictable input each time
-                    }
                 )
                 params.shouldInstrumentFirebaseMessaging.set(behavior.instrumentation.fcmPushNotificationsEnabled)
                 params.shouldInstrumentWebview.set(behavior.instrumentation.webviewEnabled)
@@ -64,8 +55,7 @@ fun registerAsmTasks(
             project.logger.debug("Asm transformClassesWith successfully called.")
         } catch (e: TransformClassesWithReflectionException) {
             project.logger.warn(
-                "There was a reflection issue while performing ASM bytecode transformation.\nThis " +
-                    "shouldn't affect build output.",
+                "There was a reflection issue while performing ASM bytecode transformation.\nThis " + "shouldn't affect build output.",
                 e
             )
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
@@ -33,17 +33,6 @@ interface BytecodeInstrumentationParams : InstrumentationParameters {
     @get:Input
     val classInstrumentationFilter: Property<ClassInstrumentationFilter>
 
-    /**
-     * Allows for invalidating the cache if the user wants to force the Transform to run from
-     * scratch.
-     *
-     * This may be useful if the bytecode params have not changed but the library dependencies have.
-     * Gradle's default behaviour is that these changed library dependencies will not be
-     * instrumented unless we alter at least one parameter value here.
-     */
-    @get:Input
-    val invalidate: Property<Long>
-
     @get:Input
     val shouldInstrumentFirebaseMessaging: Property<Boolean>
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/swazzler/plugin/extension/SwazzlerExtension.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/swazzler/plugin/extension/SwazzlerExtension.kt
@@ -9,10 +9,11 @@ import org.gradle.api.provider.Property
  * An extension that can be used to configure the plugin.
  */
 @Suppress("DEPRECATION")
+@Deprecated("Deprecated. Use EmbraceExtension instead.")
 abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
 
-    val forceIncrementalOverwrite: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(false)
+    @Deprecated("This property is deprecated and is no longer respected.")
+    val forceIncrementalOverwrite: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
     @Deprecated("Use embrace.autoAddEmbraceDependencies instead.")
     val disableDependencyInjection: Property<Boolean> = objectFactory.property(Boolean::class.java)
@@ -20,8 +21,8 @@ abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
     @Deprecated("Use embrace.autoAddEmbraceComposeDependency instead.")
     val disableComposeDependencyInjection: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
-    val disableRNBundleRetriever: Property<Boolean> =
-        objectFactory.property(Boolean::class.java).convention(false)
+    @Deprecated("This property is deprecated and is no longer respected.")
+    val disableRNBundleRetriever: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
     @Deprecated("Use embrace.bytecodeInstrumentation.okhttpEnabled instead.")
     val instrumentOkHttp: Property<Boolean> = objectFactory.property(Boolean::class.java)
@@ -38,8 +39,7 @@ abstract class SwazzlerExtension(objectFactory: ObjectFactory) {
     @Deprecated("Use embrace.bytecodeInstrumentation.firebasePushNotificationsEnabled instead.")
     val instrumentFirebaseMessaging: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
-    // It is now ignored because we're automatically detecting all native symbols. This can be removed.
-    @Deprecated("")
+    @Deprecated("This property is deprecated and is no longer respected.")
     val customSymbolsDirectory: Property<String> =
         objectFactory.property(String::class.java).convention(DEFAULT_CUSTOM_SYMBOLS_DIRECTORY)
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImplTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImplTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin.config
 
 import io.embrace.android.gradle.plugin.api.EmbraceExtension
@@ -10,7 +12,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@Suppress("DEPRECATION")
 class InstrumentationBehaviorImplTest {
 
     private lateinit var project: Project
@@ -24,17 +25,6 @@ class InstrumentationBehaviorImplTest {
         extension = project.extensions.create("swazzler", SwazzlerExtension::class.java)
         embrace = project.extensions.create("embrace", EmbraceExtension::class.java)
         behavior = InstrumentationBehaviorImpl(extension, embrace)
-    }
-
-    @Test
-    fun `invalidateBytecode default`() {
-        assertFalse(behavior.invalidateBytecode)
-    }
-
-    @Test
-    fun `invalidateBytecode true`() {
-        extension.forceIncrementalOverwrite.set(true)
-        assertTrue(behavior.invalidateBytecode)
     }
 
     @Test

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImplTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImplTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin.config
 
 import io.embrace.android.gradle.plugin.api.EmbraceExtension
@@ -12,7 +14,6 @@ import org.junit.Before
 import org.junit.Test
 import java.io.File
 
-@Suppress("DEPRECATION")
 class PluginBehaviorImplTest {
 
     private lateinit var project: Project

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin.instrumentation.fakes
 
 import io.embrace.android.gradle.plugin.instrumentation.BytecodeInstrumentationParams
@@ -11,7 +13,6 @@ import org.gradle.api.provider.Property
 class TestBytecodeInstrumentationParams(
     disabled: Boolean = false,
     classInstrumentationFilter: ClassInstrumentationFilter = ClassInstrumentationFilter(emptyList()),
-    invalidate: Long = -1,
     instrumentFirebaseMessaging: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_FIREBASE_MESSAGING,
     instrumentWebview: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_WEBVIEW,
     instrumentOkHttp: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_OKHTTP,
@@ -29,8 +30,6 @@ class TestBytecodeInstrumentationParams(
         DefaultProperty(PropertyHost.NO_OP, ClassInstrumentationFilter::class.javaObjectType).convention(
             classInstrumentationFilter
         )
-    override val invalidate: Property<Long> =
-        DefaultProperty(PropertyHost.NO_OP, Long::class.javaObjectType).convention(invalidate)
     override val shouldInstrumentFirebaseMessaging: Property<Boolean> =
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentFirebaseMessaging)
     override val shouldInstrumentWebview: Property<Boolean> =

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTaskRegistrationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin.ndk
 
 import com.android.build.api.variant.Variant


### PR DESCRIPTION
## Goal

Ignores some obsolete properties on swazzler extension and marks them as deprecated.

## Testing

Relied on existing test coverage.
