### PR TITLE
Update test fixtures to use embrace extension

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/android-disable-product-flavor/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-disable-product-flavor/build.gradle
@@ -20,8 +20,8 @@ android {
     }
 }
 
-swazzler {
-    variantFilter {
+embrace {
+    buildVariantFilter {
         if (it.name.contains("demoRelease")) {
             it.disablePluginForVariant()
         }

--- a/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/app/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/app/build.gradle
@@ -115,8 +115,8 @@ android {
     }
 }
 
-swazzler {
-    disableDependencyInjection = true
+embrace {
+    autoAddEmbraceDependencies.set(false)
 }
 
 dependencies {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceExtension.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceExtension.kt
@@ -57,7 +57,7 @@ abstract class EmbraceExtension @Inject internal constructor(objectFactory: Obje
     /**
      * DSL for configuring the Embrace Gradle Plugin's behavior on a per build variant basis.
      */
-    internal var buildVariantFilter: Action<BuildVariant> = Action { }
+    var buildVariantFilter: Action<BuildVariant> = Action { }
 
     /**
      * DSL for configuring the Embrace Gradle Plugin's behavior on a per build variant basis.


### PR DESCRIPTION
## Goal

Updates the test fixtures to use the embrace extension rather than swazzler.

## Testing

Relied on existing test coverage.
