### PR TITLE
Further simplify the integration test rule

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.arch.assertError
 import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.fakes.FakeActivity
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
@@ -40,7 +39,7 @@ internal class AppStartupTraceTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface().apply {
-            (overriddenInitModule.logger as FakeEmbLogger).ignoredErrors.clear()
+            getEmbLogger().ignoredErrors.clear()
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -61,7 +61,7 @@ internal class PublicApiTest {
                 recordSession {
                     assertEquals(
                         embrace.currentSessionId,
-                        testRule.setup.overriddenOpenTelemetryModule.currentSessionSpan.getSessionId()
+                        testRule.setup.getCurrentSessionSpan().getSessionId()
                     )
                     assertNotNull(embrace.currentSessionId)
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -151,8 +151,7 @@ internal class TracingApiTest {
                 )
                 val allSpans = getSdkInitSpanFromBackgroundActivity() +
                     checkNotNull(session.data.spans) +
-                    testRule.setup.overriddenOpenTelemetryModule.spanSink.completedSpans()
-                        .map(EmbraceSpanData::toNewPayload)
+                    testRule.setup.getSpanSink().completedSpans().map(EmbraceSpanData::toNewPayload)
 
                 val spansMap = allSpans.associateBy { it.name }
                 val sessionSpan = checkNotNull(spansMap["emb-session"])

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.getLogWithAttributeValue
@@ -22,7 +21,7 @@ internal class InternalErrorLogTest {
     fun `internal error log delivered`() {
         testRule.runTest(
             setupAction = {
-                (overriddenInitModule.logger as FakeEmbLogger).throwOnInternalError = false
+                getEmbLogger().throwOnInternalError = false
 
             },
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getSessionId
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
@@ -11,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.fakeEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeResource
 import io.embrace.android.embracesdk.fakes.fakeLaterEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeLaterEnvelopeResource
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAsserti
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.actions.StoredNativeCrashData
 import io.embrace.android.embracesdk.testframework.actions.createStoredNativeCrashData
-import io.embrace.android.embracesdk.testframework.assertions.getLastLog
+import io.embrace.android.embracesdk.testframework.assertions.getLogOfType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -103,7 +103,7 @@ internal class NativeCrashFeatureTest {
         EmbraceSetupInterface(
             processIdentifier = "8115ec91-3e5e-4d8a-816d-cc40306f9822"
         ).apply {
-            (overriddenInitModule.logger as FakeEmbLogger).throwOnInternalError = false
+            getEmbLogger().throwOnInternalError = false
         }
     }
 
@@ -133,7 +133,7 @@ internal class NativeCrashFeatureTest {
                     assertEquals(fakeEnvelopeResource, resource)
                     assertEquals(fakeEnvelopeMetadata, metadata)
                 }
-                val log = envelope.getLastLog()
+                val log = envelope.getLogOfType(EmbType.System.NativeCrash)
                 assertNativeCrashSent(log, crashData, testRule.setup.symbols)
             }
         )
@@ -160,7 +160,7 @@ internal class NativeCrashFeatureTest {
                     assertEquals(fakeEnvelopeResource, resource)
                     assertEquals(fakeEnvelopeMetadata, metadata)
                 }
-                val log = envelope.getLastLog()
+                val log = envelope.getLogOfType(EmbType.System.NativeCrash)
                 assertNativeCrashSent(log, crashData, testRule.setup.symbols)
             }
         )
@@ -212,8 +212,8 @@ internal class NativeCrashFeatureTest {
                     assertEquals(fakeLaterEnvelopeMetadata, metadata)
                 }
 
-                val log1 = crashEnvelope1.getLastLog()
-                val log2 = crashEnvelope2.getLastLog()
+                val log1 = crashEnvelope1.getLogOfType(EmbType.System.NativeCrash)
+                val log2 = crashEnvelope2.getLogOfType(EmbType.System.NativeCrash)
 
                 assertNativeCrashSent(log1, crashData, testRule.setup.symbols)
                 assertNativeCrashSent(log2, crashData2, testRule.setup.symbols)
@@ -291,7 +291,7 @@ internal class NativeCrashFeatureTest {
     }
 
     private fun findMatchingSessionId(it: Envelope<LogPayload>, data: StoredNativeCrashData): Boolean {
-        return it.getLastLog().attributes?.findAttributeValue("session.id") == data.nativeCrash.sessionId
+        return it.getLogOfType(EmbType.System.NativeCrash).attributes?.findAttributeValue("session.id") == data.nativeCrash.sessionId
     }
 
     private fun EmbracePayloadAssertionInterface.assertNoNativeCrashSent(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
@@ -19,7 +19,7 @@ internal class PersonaFeaturesTest {
     fun `personas found in metadata`() {
         testRule.runTest(
             setupAction = {
-                overriddenAndroidServicesModule.preferencesService.userPersonas = setOf("preloaded")
+                getPreferencesService().userPersonas = setOf("preloaded")
             },
             testCaseAction = {
                 embrace.addUserPersona("payer")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
@@ -26,7 +26,7 @@ internal class PruningFeatureTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface().apply {
-            (overriddenInitModule.logger as FakeEmbLogger).throwOnInternalError = false
+            getEmbLogger().throwOnInternalError = false
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.testcases.features
 
+import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
@@ -24,12 +24,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
+@Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
 internal class ResurrectionFeatureTest {
 
@@ -40,18 +41,9 @@ internal class ResurrectionFeatureTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface().apply {
-            (overriddenInitModule.logger as FakeEmbLogger).throwOnInternalError = false
+            getEmbLogger().throwOnInternalError = false
+            cacheStorageService = FakePayloadStorageService(processIdProvider = getProcessIdentifierProvider())
         }
-    }
-
-    @Before
-    fun setUp() {
-        cacheStorageService =
-            FakePayloadStorageService(
-                processIdProvider = {
-                    testRule.setup.overriddenOpenTelemetryModule.openTelemetryConfiguration.processIdentifier
-                }
-            )
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
@@ -128,7 +128,7 @@ internal class SessionPropertiesTest {
     }
 
     private fun EmbraceSetupInterface.setupPermanentProperties() {
-        overriddenAndroidServicesModule.preferencesService.permanentSessionProperties =
+        getPreferencesService().permanentSessionProperties =
             mapOf(
                 EXISTING_KEY_1 to VALUE,
                 EXISTING_KEY_2 to VALUE,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
@@ -21,7 +21,7 @@ internal class UserFeaturesTest {
     fun `user info setting and clearing`() {
         testRule.runTest(
             setupAction = {
-                overriddenAndroidServicesModule.preferencesService.apply {
+                getPreferencesService().apply {
                     userIdentifier = "customId"
                     username = "customUserName"
                     userEmailAddress = "custom@domain.com"

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -29,11 +29,11 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.export.FilteredLogExporter
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
-import java.io.File
 import okhttp3.Protocol
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
 import org.junit.rules.ExternalResource
+import java.io.File
 
 /**
  * A [org.junit.Rule] that is responsible for setting up and tearing down the Embrace SDK for use in
@@ -156,7 +156,7 @@ internal class SdkIntegrationTestRule(
             persistConfig(persistedRemoteConfig)
 
             if (startSdk) {
-                embraceImpl.start(overriddenCoreModule.context)
+                embraceImpl.start(getContext())
                 assertEquals(
                     "SDK did not start in integration test.",
                     expectSdkToStart,


### PR DESCRIPTION
## Goal

Miscellaneous changes to reduce the number of things you can override in the integration test setup. Most of what's being overridden was just so the tests can read the data, so either we provide the fake right in the setup object, or we expose the real component so it can be read.

These components were being faked universally in the integration tests anyway, so this doesn't make the tests less comprehensive.

Note: more changes are coming. I just had to break them up as I wanted to do some more targeted changes later on so they can be more easily reviewed.
