### PR TITLE
Reduce the usage of fake workers in integration tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/FakeCacheStorageService.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/FakeCacheStorageService.kt
@@ -7,11 +7,13 @@ import io.embrace.android.embracesdk.internal.injection.SerializationAction
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 internal class FakeCacheStorageService : PayloadStorageService {
 
-    val storedPayloads = mutableMapOf<StoredTelemetryMetadata, SerializationAction>()
-    val deletedPayloads = mutableListOf<StoredTelemetryMetadata>()
+    val storedPayloads = ConcurrentHashMap<StoredTelemetryMetadata, SerializationAction>()
+    val deletedPayloads = CopyOnWriteArrayList<StoredTelemetryMetadata>()
 
     override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
         storedPayloads[metadata] = action


### PR DESCRIPTION
## Goal

Most workflows don't require faking workers anymore since we have a wait-for-payload mechanism in the integration tests now, which is more representative of the actual workflow.

The one remaining worker to fake is for ANR testing. Not sure if we can do without it but leaving it in for now.
