### PR TITLE
Further simplify the usage of the integration test rule

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashProcessorImplTest.kt
@@ -54,7 +54,7 @@ internal class NativeCrashProcessorImplTest {
             logger,
             delegate,
             serializer,
-            FakeSymbolService(mapOf("symbol1" to "test")),
+            FakeSymbolService(mutableMapOf("symbol1" to "test")),
             lazy { storageDir },
             worker
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DeliveryConnectivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DeliveryConnectivityFeatureTest.kt
@@ -34,7 +34,7 @@ internal class DeliveryConnectivityFeatureTest {
         val envelope = fakeSessionEnvelope(startMs = startMs)
         testRule.runTest(
             setupAction = {
-                networkConnectivityService.networkStatus = NetworkStatus.NOT_REACHABLE
+                fakeNetworkConnectivityService.networkStatus = NetworkStatus.NOT_REACHABLE
                 payloadStorageService.addPayload(sessionMetadata, envelope)
                 payloadStorageServiceProvider = { payloadStorageService }
             },
@@ -49,7 +49,7 @@ internal class DeliveryConnectivityFeatureTest {
     fun `new payload not sent with no connection`() {
         testRule.runTest(
             setupAction = {
-                networkConnectivityService.networkStatus = NetworkStatus.NOT_REACHABLE
+                fakeNetworkConnectivityService.networkStatus = NetworkStatus.NOT_REACHABLE
             },
             testCaseAction = {
                 recordSession()
@@ -67,7 +67,7 @@ internal class DeliveryConnectivityFeatureTest {
         val envelope = fakeSessionEnvelope(startMs = startMs)
         testRule.runTest(
             setupAction = {
-                networkConnectivityService.networkStatus = NetworkStatus.NOT_REACHABLE
+                fakeNetworkConnectivityService.networkStatus = NetworkStatus.NOT_REACHABLE
                 payloadStorageService.addPayload(sessionMetadata, envelope)
                 payloadStorageServiceProvider = { payloadStorageService }
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -35,6 +35,7 @@ import org.robolectric.annotation.Config
 internal class ResurrectionFeatureTest {
 
     private val serializer = TestPlatformSerializer()
+    private val fakeSymbols = mapOf("libfoo.so" to "symbol_content")
     private lateinit var cacheStorageService: FakePayloadStorageService
 
     @Rule
@@ -43,6 +44,8 @@ internal class ResurrectionFeatureTest {
         EmbraceSetupInterface().apply {
             getEmbLogger().throwOnInternalError = false
             cacheStorageService = FakePayloadStorageService(processIdProvider = getProcessIdentifierProvider())
+        }.also {
+            it.fakeSymbolService.symbolsForCurrentArch.putAll(fakeSymbols)
         }
     }
 
@@ -72,7 +75,7 @@ internal class ResurrectionFeatureTest {
                 }
 
                 val log = envelope.getLastLog()
-                assertNativeCrashSent(log, crashData, testRule.setup.symbols)
+                assertNativeCrashSent(log, crashData, fakeSymbols)
             }
         )
     }
@@ -99,7 +102,7 @@ internal class ResurrectionFeatureTest {
                 }
 
                 val log = envelope.getLastLog()
-                assertNativeCrashSent(log, crashData, testRule.setup.symbols)
+                assertNativeCrashSent(log, crashData, fakeSymbols)
             }
         )
     }
@@ -135,7 +138,7 @@ internal class ResurrectionFeatureTest {
                     assertEquals(session.resource, resource)
                     assertEquals(session.metadata, metadata)
                     val crash = getLastLog()
-                    assertNativeCrashSent(crash, crashData, testRule.setup.symbols)
+                    assertNativeCrashSent(crash, crashData, fakeSymbols)
                 }
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -48,11 +48,11 @@ internal class EmbraceActionInterface(
     }
 
     private fun onForeground() {
-        setup.lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        setup.fakeLifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
     }
 
     private fun onBackground() {
-        setup.lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        setup.fakeLifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
     }
 
     fun simulateNetworkChange(status: NetworkStatus) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSymbolService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSymbolService.kt
@@ -3,5 +3,5 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.ndk.symbols.SymbolService
 
 class FakeSymbolService(
-    override val symbolsForCurrentArch: Map<String, String> = emptyMap(),
+    override val symbolsForCurrentArch: MutableMap<String, String> = mutableMapOf(),
 ) : SymbolService


### PR DESCRIPTION
## Goal

Instantiate fakes we always use within the setup interface and expose them for reading/altering. In addition, we don't prepopulate native symbols and instead rely on the tests to do the setup..

