### PR TITLE
Really ignore startup trace recording error in integration tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -38,9 +38,7 @@ internal class AppStartupTraceTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        EmbraceSetupInterface().apply {
-            getEmbLogger().ignoredErrors.clear()
-        }
+        EmbraceSetupInterface(ignoredInternalErrors = emptyList())
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -55,6 +55,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
     var useMockWebServer: Boolean = true,
     var cacheStorageServiceProvider: Provider<PayloadStorageService>? = null,
     var payloadStorageServiceProvider: Provider<PayloadStorageService>? = null,
+    val ignoredInternalErrors: List<InternalErrorType> = listOf(InternalErrorType.APP_LAUNCH_TRACE_FAIL),
 ) {
     val fakeNetworkConnectivityService = FakeNetworkConnectivityService()
     val fakeJniDelegate = FakeJniDelegate()
@@ -63,7 +64,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
 
     private val fakeInitModule: FakeInitModule = FakeInitModule(
         clock = FakeClock(currentTime = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS),
-        logger = FakeEmbLogger(ignoredErrors = mutableListOf(InternalErrorType.PROCESS_STATE_CALLBACK_FAIL)),
+        logger = FakeEmbLogger(ignoredErrors = ignoredInternalErrors),
         processIdentifierProvider = { processIdentifier }
     )
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -42,8 +42,8 @@ class FakeEmbLogger(
                 throw IllegalStateException("Internal error: $type", throwable)
             } else {
                 internalErrorMessages.add(LogMessage(type.toString(), throwable))
+                errorHandlerProvider()?.trackInternalError(type, throwable)
             }
         }
-        errorHandlerProvider()?.trackInternalError(type, throwable)
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbLogger.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 class FakeEmbLogger(
     var throwOnInternalError: Boolean = true,
     override var errorHandlerProvider: Provider<InternalErrorHandler?> = { null },
-    val ignoredErrors: MutableList<InternalErrorType> = mutableListOf()
+    val ignoredErrors: List<InternalErrorType> = emptyList()
 ) : EmbLogger {
 
     data class LogMessage(
@@ -37,10 +37,13 @@ class FakeEmbLogger(
     }
 
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {
-        if (throwOnInternalError && !ignoredErrors.contains(type)) {
-            throw IllegalStateException("Internal error: $type", throwable)
+        if (!ignoredErrors.contains(type)) {
+            if (throwOnInternalError) {
+                throw IllegalStateException("Internal error: $type", throwable)
+            } else {
+                internalErrorMessages.add(LogMessage(type.toString(), throwable))
+            }
         }
-        internalErrorMessages.add(LogMessage(type.toString(), throwable))
         errorHandlerProvider()?.trackInternalError(type, throwable)
     }
 }


### PR DESCRIPTION
## Goal

Don't log an internal error for any that are supposed to be ignored. And ignore the right error, not the error that is generated if that error isn't ignore, duh.

