### PR TITLE
Tweak error message for auth error in http request

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/HttpCallResultHandler.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/HttpCallResultHandler.kt
@@ -21,11 +21,24 @@ fun handleHttpCallResult(
     failBuildOnUploadErrors: Boolean,
 ) {
     val msg = when (result) {
-        is Failure -> "failed: ${endpoint.url}, status=${result.code}"
+        is Failure -> handleHttpFailure(endpoint, result)
         is Error -> "errored: ${endpoint.url}, stacktrace=${result.exception.stackTrace.joinToString("\n")}"
         is Success<*> -> null
     }
     if (msg != null && failBuildOnUploadErrors) {
         error("Embrace HTTP request $msg")
     }
+}
+
+private fun handleHttpFailure(
+    endpoint: EmbraceEndpoint,
+    result: Failure,
+): String {
+    val msg = "failed: ${endpoint.url}, status=${result.code}"
+
+    if (result.code == 403) {
+        return "$msg. Please check that your embrace-config.json contains an " +
+            "app_id and api_token that match the settings page of your Embrace dashboard."
+    }
+    return msg
 }


### PR DESCRIPTION
## Goal

Tweaks the error message if a HTTP request has an auth error (403).

## Testing

Before:
>Embrace HTTP request failed: /v2/store/ndk/handshake, status=403

After:
>Embrace HTTP request failed: /v2/store/ndk/handshake, status=403. Please check that src/main/embrace-config.json contains an app_id and api_token that match the settings page of your Embrace dashboard.


