### PR TITLE
Add ordinal for AEI native crashes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch.schema
 
+import io.embrace.android.embracesdk.internal.opentelemetry.embAeiNumber
+import io.embrace.android.embracesdk.internal.opentelemetry.embCrashNumber
 import io.embrace.android.embracesdk.internal.opentelemetry.embSendMode
 import io.embrace.android.embracesdk.internal.payload.AppExitInfoData
 import io.embrace.android.embracesdk.internal.payload.NetworkCapturedCall
@@ -50,9 +52,7 @@ sealed class SchemaType(
 
     /**
      * Represents a push notification event.
-     * @param viewName The name of the view that the tap event occurred in.
      * @param type The type of tap event. "tap"/"long_press". "tap" is the default.
-     * @param coords The coordinates of the tap event.
      */
     class PushNotification(
         title: String?,
@@ -111,10 +111,14 @@ sealed class SchemaType(
         telemetryType = EmbType.Performance.MemoryWarning,
         fixedObjectName = "memory-warning"
     ) {
-        override val schemaAttributes: Map<String, String> = emptyMap<String, String>()
+        override val schemaAttributes: Map<String, String> = emptyMap()
     }
 
-    class AeiLog(message: AppExitInfoData) : SchemaType(EmbType.System.Exit) {
+    class AeiLog(
+        message: AppExitInfoData,
+        crashNumber: Int?,
+        aeiNumber: Int?,
+    ) : SchemaType(EmbType.System.Exit) {
         override val schemaAttributes: Map<String, String> = mapOf(
             "aei_session_id" to message.sessionId,
             "session_id_error" to message.sessionIdError,
@@ -125,7 +129,9 @@ sealed class SchemaType(
             "exit_status" to message.status.toString(),
             "timestamp" to message.timestamp.toString(),
             "description" to message.description,
-            "trace_status" to message.traceStatus
+            "trace_status" to message.traceStatus,
+            embCrashNumber.attributeKey.key to crashNumber.toString(),
+            embAeiNumber.attributeKey.key to aeiNumber.toString()
         ).toNonNullMap()
     }
 
@@ -165,7 +171,7 @@ sealed class SchemaType(
         telemetryType = EmbType.System.LowPower,
         fixedObjectName = "device-low-power"
     ) {
-        override val schemaAttributes: Map<String, String> = emptyMap<String, String>()
+        override val schemaAttributes: Map<String, String> = emptyMap()
     }
 
     class NetworkCapturedRequest(networkCapturedCall: NetworkCapturedCall) : SchemaType(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbraceAttributeKeys.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbraceAttributeKeys.kt
@@ -14,6 +14,11 @@ val embAndroidThreads: EmbraceAttributeKey = EmbraceAttributeKey("android.thread
 val embCrashNumber: EmbraceAttributeKey = EmbraceAttributeKey("android.crash_number")
 
 /**
+ * Sequence number for the number of AEI crashes captured by Embrace on the device, reported on every AEI crash
+ */
+val embAeiNumber: EmbraceAttributeKey = EmbraceAttributeKey("android.aei_crash_number")
+
+/**
  * Attribute name for the exception handling type - whether it's handled or unhandled
  */
 val embExceptionHandling: EmbraceAttributeKey = EmbraceAttributeKey("exception_handling")

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
@@ -171,6 +171,10 @@ internal class EmbracePreferencesService(
         return incrementAndGetOrdinal(LAST_NATIVE_CRASH_NUMBER_KEY)
     }
 
+    override fun incrementAndGetAeiCrashNumber(): Int {
+        return incrementAndGetOrdinal(LAST_AEI_CRASH_NUMBER_KEY)
+    }
+
     private fun incrementAndGetOrdinal(key: String): Int {
         return try {
             val ordinal = (prefs.getIntegerPreference(key) ?: 0) + 1
@@ -278,6 +282,7 @@ internal class EmbracePreferencesService(
         private const val LAST_BACKGROUND_ACTIVITY_NUMBER_KEY = "io.embrace.bgactivitynumber"
         private const val LAST_CRASH_NUMBER_KEY = "io.embrace.crashnumber"
         private const val LAST_NATIVE_CRASH_NUMBER_KEY = "io.embrace.nativecrashnumber"
+        private const val LAST_AEI_CRASH_NUMBER_KEY = "io.embrace.aeicrashnumber"
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"
         private const val JAVA_SCRIPT_BUNDLE_ID_KEY = "io.embrace.jsbundle.id"
         private const val JAVA_SCRIPT_PATCH_NUMBER_KEY = "io.embrace.javascript.patch"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/PreferencesService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/PreferencesService.kt
@@ -86,6 +86,13 @@ interface PreferencesService {
     fun incrementAndGetNativeCrashNumber(): Int
 
     /**
+     * Increments and returns the AEI crash number ordinal. This is an integer that
+     * increments on every NDK tombstone detected via an AEI trace. It allows us to check the % of AEI crashes that
+     * didn't get delivered to the backend.
+     */
+    fun incrementAndGetAeiCrashNumber(): Int
+
+    /**
      * Last javaScript bundle string url.
      */
     var javaScriptBundleURL: String?

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
@@ -185,6 +185,14 @@ internal class EmbracePreferencesServiceTest {
     }
 
     @Test
+    fun `test aei crash number is saved`() {
+        assertEquals(1, service.incrementAndGetAeiCrashNumber())
+        assertEquals(2, service.incrementAndGetAeiCrashNumber())
+        assertEquals(3, service.incrementAndGetAeiCrashNumber())
+        assertEquals(4, service.incrementAndGetAeiCrashNumber())
+    }
+
+    @Test
     fun `test incrementAndGet returns -1 on an exception`() {
         service = EmbracePreferencesService(
             FakeSharedPreferences(throwExceptionOnGet = true),

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType.AeiLog
 import io.embrace.android.embracesdk.internal.config.behavior.AppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.payload.AppExitInfoData
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.spans.toOtelSeverity
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
@@ -54,15 +55,29 @@ internal class AeiDataSourceImpl(
         val unsentRecords = getUnsentRecords(records)
 
         unsentRecords.forEach {
-            val obj = it.constructAeiObject(versionChecker, appExitInfoBehavior.getTraceMaxLimit()) ?: return@forEach
+            val obj = it.constructAeiObject(versionChecker, appExitInfoBehavior.getTraceMaxLimit())
+            val crashNumber = obj?.getOrdinal(preferencesService::incrementAndGetCrashNumber)
+            val aeiNumber = obj?.getOrdinal(preferencesService::incrementAndGetAeiCrashNumber)
+            if (obj == null) {
+                return@forEach
+            }
             captureData(
                 inputValidation = NoInputValidation,
                 captureAction = {
-                    val schemaType = AeiLog(obj)
+                    val schemaType = AeiLog(obj, crashNumber, aeiNumber)
                     addLog(schemaType, INFO.toOtelSeverity(), obj.trace ?: "")
                 }
             )
         }
+    }
+
+    private fun AppExitInfoData.hasNativeTombstone(): Boolean {
+        return trace != null && reason == ApplicationExitInfo.REASON_CRASH_NATIVE
+    }
+
+    private inline fun AppExitInfoData.getOrdinal(provider: () -> Int) = when (hasNativeTombstone()) {
+        true -> provider()
+        else -> null
     }
 
     /**

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -58,5 +58,9 @@ class FakePreferenceService(
         return 1
     }
 
+    override fun incrementAndGetAeiCrashNumber(): Int {
+        return 1
+    }
+
     override fun isUsersFirstDay(): Boolean = firstDay
 }


### PR DESCRIPTION
## Goal

Adds an ordinal as an OTel attribute for AEIs containing a native crash. This will be incremented whenever an AEI object contains an NDK protobuf file - assumed by checking `reason == REASON_CRASH_NATIVE` and the `trace` property not being null.

Additionally, the existing `android.crash_number` attribute will be incremented for AEI crashes.

If the AEI object does not have an NDK protobuf file, the attribute value will be explicitly set as `"null"`.

## Testing

Added test coverage.
