### PR TITLE
Gate AEI native crashes by ndk_enabled flag

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImpl.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.NoInputValidation
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType.AeiLog
-import io.embrace.android.embracesdk.internal.config.behavior.AppExitInfoBehavior
+import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppExitInfoData
@@ -23,7 +23,7 @@ import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 @RequiresApi(VERSION_CODES.R)
 internal class AeiDataSourceImpl(
     private val backgroundWorker: BackgroundWorker,
-    private val appExitInfoBehavior: AppExitInfoBehavior,
+    private val configService: ConfigService,
     private val activityManager: ActivityManager,
     private val preferencesService: PreferencesService,
     logWriter: LogWriter,
@@ -50,7 +50,7 @@ internal class AeiDataSourceImpl(
     }
 
     private fun processAeiRecords() {
-        val maxNum = appExitInfoBehavior.appExitInfoMaxNum()
+        val maxNum = configService.appExitInfoBehavior.appExitInfoMaxNum()
         val records = activityManager.getHistoricalProcessExitReasons(null, 0, maxNum).take(SDK_AEI_SEND_LIMIT)
         val deliveredIds = preferencesService.deliveredAeiIds
 
@@ -60,7 +60,7 @@ internal class AeiDataSourceImpl(
         preferencesService.deliveredAeiIds = sentRecords.map { it.getAeiId() }.toSet()
 
         unsentRecords.forEach {
-            val obj = it.constructAeiObject(versionChecker, appExitInfoBehavior.getTraceMaxLimit())
+            val obj = it.constructAeiObject(versionChecker, configService.appExitInfoBehavior.getTraceMaxLimit())
             val crashNumber = obj?.getOrdinal(preferencesService::incrementAndGetCrashNumber)
             val aeiNumber = obj?.getOrdinal(preferencesService::incrementAndGetAeiCrashNumber)
             if (obj == null) {
@@ -69,10 +69,13 @@ internal class AeiDataSourceImpl(
             captureData(
                 inputValidation = NoInputValidation,
                 captureAction = {
-                    val schemaType = AeiLog(obj, crashNumber, aeiNumber)
-                    addLog(schemaType, INFO.toOtelSeverity(), obj.trace ?: "")
+                    val capture = configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled() || !obj.hasNativeTombstone()
+                    if (capture) {
+                        val schemaType = AeiLog(obj, crashNumber, aeiNumber)
+                        addLog(schemaType, INFO.toOtelSeverity(), obj.trace ?: "")
+                    }
 
-                    // count AEI as delivered once submitted to the OTel logging system
+                    // always count AEI as delivered once we process it & submit to the OTel logging system, or discard
                     preferencesService.deliveredAeiIds = preferencesService.deliveredAeiIds.plus(obj.getAeiId())
                 }
             )

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
@@ -185,7 +185,7 @@ internal class FeatureModuleImpl(
         if (BuildVersionChecker.isAtLeast(Build.VERSION_CODES.R) && activityManager != null) {
             AeiDataSourceImpl(
                 workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
-                configService.appExitInfoBehavior,
+                configService,
                 activityManager,
                 androidServicesModule.preferencesService,
                 logWriter,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
@@ -73,7 +73,7 @@ internal class AeiDataSourceImplTest {
         logWriter = FakeLogWriter()
         applicationExitInfoService = AeiDataSourceImpl(
             worker,
-            configService.appExitInfoBehavior,
+            configService,
             mockActivityManager,
             preferenceService,
             logWriter,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiNdkCrashProtobufSendTest.kt
@@ -4,9 +4,10 @@ import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import com.android.server.os.TombstoneProtos
 import io.embrace.android.embracesdk.ResourceReader
+import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogWriter
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
-import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.TypeUtils
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
@@ -134,7 +135,7 @@ internal class AeiNdkCrashProtobufSendTest {
         val logWriter = FakeLogWriter()
         AeiDataSourceImpl(
             fakeBackgroundWorker(),
-            FakeAppExitInfoBehavior(enabled = true),
+            FakeConfigService(autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(ndkEnabled = true)),
             activityManager,
             FakePreferenceService(),
             logWriter,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -10,6 +10,8 @@ import android.os.Build
 import android.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -125,6 +127,7 @@ internal class AeiFeatureTest {
     @Test
     fun `native crash`() {
         testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(nativeCrashCapture = true)),
             setupAction = {
                 setupFakeAeiData(listOf(nativeCrash.toAeiObject(), nativeCrash.toAeiObject()))
             },
@@ -135,6 +138,22 @@ internal class AeiFeatureTest {
                 val logs = getLogEnvelopes(2).flatMap { it.getLogsOfType(EmbType.System.Exit) }
                 logs[0].assertContainsAeiData(nativeCrash, "1", "1")
                 logs[1].assertContainsAeiData(nativeCrash, "2", "2")
+            }
+        )
+    }
+
+    @Test
+    fun `native crash disabled`() {
+        testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(nativeCrashCapture = false)),
+            setupAction = {
+                setupFakeAeiData(listOf(nativeCrash.toAeiObject()))
+            },
+            testCaseAction = {
+                recordSession()
+            },
+            assertAction = {
+                assertEquals(0, getLogEnvelopes(0).size)
             }
         )
     }


### PR DESCRIPTION
## Goal

If `ndk_enabled` is false then AEI native crashes should not be delivered.

## Testing

Added a test case.

