### PR TITLE
Alter AEI delivery priority

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStore.kt
@@ -76,6 +76,7 @@ internal class V2PayloadStore(
             System.ReactNativeCrash.value -> SupportedEnvelopeType.CRASH
             System.FlutterException.value -> SupportedEnvelopeType.CRASH
             System.NetworkCapturedRequest.value -> SupportedEnvelopeType.BLOB
+            System.Exit.value -> SupportedEnvelopeType.AEI
             else -> SupportedEnvelopeType.LOG
         }
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -95,7 +95,6 @@ class V2PayloadStoreTest {
 
         // log
         listOf(
-            System.Exit,
             System.Exception,
             System.Log
         ).forEach { type ->
@@ -103,6 +102,11 @@ class V2PayloadStoreTest {
             assertEquals(SupportedEnvelopeType.LOG, getLastLogMetadata().envelopeType)
             assertEquals(type.value, getLastLogMetadata().payloadType.value)
         }
+
+        // aei
+        storeLogWithType(System.Exit)
+        assertEquals(SupportedEnvelopeType.AEI, getLastLogMetadata().envelopeType)
+        assertEquals(System.Exit.value, getLastLogMetadata().payloadType.value)
 
         // network
         storeLogWithType(System.NetworkCapturedRequest)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
@@ -14,6 +14,7 @@ enum class SupportedEnvelopeType(
 ) {
 
     CRASH(Envelope.logEnvelopeType, "p1", Endpoint.LOGS),
+    AEI(Envelope.logEnvelopeType, "p2", Endpoint.LOGS),
     SESSION(Envelope.sessionEnvelopeType, "p3", Endpoint.SESSIONS),
     ATTACHMENT(null, "p4", Endpoint.ATTACHMENTS),
     LOG(Envelope.logEnvelopeType, "p5", Endpoint.LOGS),

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryComparatorTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery
 
+import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.AEI
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.BLOB
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
@@ -16,16 +17,17 @@ class StoredTelemetryComparatorTest {
     private val session2 = StoredTelemetryMetadata(100, "session2", "pid", SESSION)
     private val session3 = StoredTelemetryMetadata(1000, "session3", "pid", SESSION)
     private val log = StoredTelemetryMetadata(1, "log", "pid", LOG)
+    private val aei = StoredTelemetryMetadata(1, "aei", "pid", AEI)
     private val network = StoredTelemetryMetadata(1, "network", "pid", BLOB)
 
     @Test
     fun `sort values`() {
-        val result = listOf(network, log, session2, crash, session3, session)
+        val result = listOf(network, log, session2, crash, aei, session3, session)
             .map { PriorityRunnableFuture<StoredTelemetryMetadata>(mockk(relaxed = true), it) }
             .sortedWith(storedTelemetryRunnableComparator)
             .map { it.priorityInfo as StoredTelemetryMetadata }
             .map(StoredTelemetryMetadata::uuid)
-        val expected = listOf(crash, session, session2, session3, log, network)
+        val expected = listOf(crash, aei, session, session2, session3, log, network)
             .map(StoredTelemetryMetadata::uuid)
         assertEquals(expected, result)
     }


### PR DESCRIPTION
## Goal

Alters the priority of delivering AEI payloads. Currently these are delivered as log priority but if they contain native crashes/ANRs these deserve higher priority.

## Testing

Added unit test coverage.

