### PR TITLE
Fake app lifecycle when faking a session during integration tests

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -15,6 +15,7 @@ import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,9 +33,16 @@ internal class FlutterInternalInterfaceTest {
         )
     )
 
+    private var sessionStartTimeMs: Long = 0L
+
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Before
+    fun before() {
+        sessionStartTimeMs = 0L
+    }
 
     @Test
     fun `flutter without values should return defaults`() {
@@ -155,7 +163,7 @@ internal class FlutterInternalInterfaceTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                recordSession {
+                sessionStartTimeMs = recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.logHandledDartException(
                         expectedStacktrace,
                         expectedName,
@@ -163,7 +171,7 @@ internal class FlutterInternalInterfaceTest {
                         expectedContext,
                         expectedLibrary,
                     )
-                }
+                }.actionTimeMs
             },
             assertAction = {
                 val log = getSingleLogEnvelope().getLogOfType(EmbType.System.FlutterException)
@@ -173,6 +181,7 @@ internal class FlutterInternalInterfaceTest {
                     expectedMessage = "Dart error",
                     expectedSeverityNumber = Severity.ERROR.severityNumber,
                     expectedSeverityText = Severity.ERROR.name,
+                    expectedTimeMs = sessionStartTimeMs,
                     expectedType = LogExceptionType.HANDLED.value,
                     expectedExceptionName = expectedName,
                     expectedExceptionMessage = expectedMessage,
@@ -201,7 +210,7 @@ internal class FlutterInternalInterfaceTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                recordSession {
+                sessionStartTimeMs = recordSession {
                     EmbraceInternalApi.getInstance().flutterInternalInterface.logUnhandledDartException(
                         expectedStacktrace,
                         expectedName,
@@ -209,7 +218,7 @@ internal class FlutterInternalInterfaceTest {
                         expectedContext,
                         expectedLibrary,
                     )
-                }
+                }.actionTimeMs
             },
             assertAction = {
                 val log = getSingleLogEnvelope().getLogOfType(EmbType.System.FlutterException)
@@ -219,6 +228,7 @@ internal class FlutterInternalInterfaceTest {
                     expectedMessage = "Dart error",
                     expectedSeverityNumber = Severity.ERROR.severityNumber,
                     expectedSeverityText = Severity.ERROR.name,
+                    expectedTimeMs = sessionStartTimeMs,
                     expectedType = LogExceptionType.UNHANDLED.value,
                     expectedExceptionName = expectedName,
                     expectedExceptionMessage = expectedMessage,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.assertions.findSpanOfType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
+import io.embrace.android.embracesdk.testframework.actions.SessionTimestamps
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -24,7 +24,7 @@ internal class ActivityFeatureTest {
 
     @Test
     fun `automatically capture activities`() {
-        var timestamps: EmbraceActionInterface.SessionTimestamps? = null
+        var timestamps: SessionTimestamps? = null
 
         testRule.runTest(
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.assertions.findSpanOfType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -23,14 +24,11 @@ internal class ActivityFeatureTest {
 
     @Test
     fun `automatically capture activities`() {
-        var startTimeMs: Long = 0
+        var timestamps: EmbraceActionInterface.SessionTimestamps? = null
 
         testRule.runTest(
             testCaseAction = {
-                recordSession {
-                    startTimeMs = clock.now()
-                    simulateActivityLifecycle()
-                }
+                timestamps = recordSession()
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
@@ -42,9 +40,9 @@ internal class ActivityFeatureTest {
                     )
                 )
 
-                with(viewSpan) {
-                    assertEquals(startTimeMs, startTimeNanos?.nanosToMillis())
-                    assertEquals(startTimeMs + 30000L, endTimeNanos?.nanosToMillis())
+                with(checkNotNull(timestamps)) {
+                    assertEquals(foregroundTimeMs, viewSpan.startTimeNanos?.nanosToMillis())
+                    assertEquals(endTimeMs, viewSpan.endTimeNanos?.nanosToMillis())
                 }
             },
             otelExportAssertion = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,6 +24,7 @@ private const val MAX_SAMPLE_COUNT = 80
 private const val MAX_INTERVAL_COUNT = 5
 private const val SPAN_NAME = "emb-thread-blockage"
 
+@Ignore("Fix start time after introduction of app lifecycle faking")
 @RunWith(AndroidJUnit4::class)
 internal class AnrFeatureTest {
 
@@ -41,8 +43,6 @@ internal class AnrFeatureTest {
                 anrMonitorExecutor = getFakedWorkerExecutor()
                 anrMonitorExecutor.blockingMode = false
                 blockedThreadDetector = getBlockedThreadDetector()
-                startTimeMs = getClock().now()
-
             }
         }
     }
@@ -55,11 +55,11 @@ internal class AnrFeatureTest {
 
         testRule.runTest(
             testCaseAction = {
-                recordSession {
+                startTimeMs = recordSession {
                     triggerAnr(firstSampleCount)
                     secondAnrStartTime = clock.now()
                     triggerAnr(secondSampleCount)
-                }
+                }.startTimeMs
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
@@ -79,9 +79,9 @@ internal class AnrFeatureTest {
 
         testRule.runTest(
             testCaseAction = {
-                recordSession {
+                startTimeMs = recordSession {
                     triggerAnr(sampleCount)
-                }
+                }.actionTimeMs
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,7 +23,6 @@ private const val MAX_SAMPLE_COUNT = 80
 private const val MAX_INTERVAL_COUNT = 5
 private const val SPAN_NAME = "emb-thread-blockage"
 
-@Ignore("Fix start time after introduction of app lifecycle faking")
 @RunWith(AndroidJUnit4::class)
 internal class AnrFeatureTest {
 
@@ -41,7 +39,7 @@ internal class AnrFeatureTest {
         ).also {
             with(it) {
                 anrMonitorExecutor = getFakedWorkerExecutor()
-                anrMonitorExecutor.blockingMode = false
+                anrMonitorExecutor.blockingMode = true
                 blockedThreadDetector = getBlockedThreadDetector()
             }
         }
@@ -59,7 +57,7 @@ internal class AnrFeatureTest {
                     triggerAnr(firstSampleCount)
                     secondAnrStartTime = clock.now()
                     triggerAnr(secondSampleCount)
-                }.startTimeMs
+                }.actionTimeMs
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
@@ -141,8 +139,10 @@ internal class AnrFeatureTest {
             testCaseAction = {
                 recordSession {
                     triggerAnr(sampleCount, incomplete = true)
+                }.let {
+                    startTimeMs = it.actionTimeMs
+                    endTime = it.endTimeMs
                 }
-                endTime = clock.now()
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
@@ -25,21 +25,21 @@ internal class LowPowerFeatureTest {
 
         testRule.runTest(
             testCaseAction = {
-                recordSession {
-                    startTimeMs = clock.now()
-
+                startTimeMs = recordSession {
                     // look inside embrace internals as there isn't a good way to trigger this E2E
                     alterPowerSaveMode(true)
                     clock.tick(tickTimeMs)
                     alterPowerSaveMode(false)
-                }
+                }.actionTimeMs
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
                 val span = message.findSpanOfType(EmbType.System.LowPower)
-                span.attributes?.assertMatches(mapOf(
-                    "emb.type" to "sys.low_power"
-                ))
+                span.attributes?.assertMatches(
+                    mapOf(
+                        "emb.type" to "sys.low_power"
+                    )
+                )
                 assertEquals("emb-device-low-power", span.name)
                 assertEquals(startTimeMs, span.startTimeNanos?.nanosToMillis())
                 assertEquals(startTimeMs + tickTimeMs, span.endTimeNanos?.nanosToMillis())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SpanAutoTerminationTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SpanAutoTerminationTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
+import io.embrace.android.embracesdk.testframework.actions.SessionTimestamps
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -42,8 +42,8 @@ internal class SpanAutoTerminationTest {
 
     @Test
     fun `auto termination feature`() {
-        var firstSessionTimestamps: EmbraceActionInterface.SessionTimestamps? = null
-        var secondSessionTimestamps: EmbraceActionInterface.SessionTimestamps? = null
+        var firstSessionTimestamps: SessionTimestamps? = null
+        var secondSessionTimestamps: SessionTimestamps? = null
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(
                 enabledFeatures = FakeEnabledFeatureConfig(
@@ -123,7 +123,7 @@ internal class SpanAutoTerminationTest {
         )
     }
 
-    private fun EmbraceActionInterface.SessionTimestamps.assertFirstSpans(
+    private fun SessionTimestamps.assertFirstSpans(
         first: Envelope<SessionPayload>,
     ) {
         // startSpan() with children
@@ -167,7 +167,7 @@ internal class SpanAutoTerminationTest {
         assertNull(hangingSpan.endTimeNanos)
     }
 
-    private fun EmbraceActionInterface.SessionTimestamps.assertSecondSpans(
+    private fun SessionTimestamps.assertSecondSpans(
         second: Envelope<SessionPayload>,
     ) {
         val roota = second.findSpanByName(ROOT_HANGING_SPAN)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
@@ -14,7 +14,6 @@ import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.capture.activity.LifecycleStage
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -326,9 +325,8 @@ internal class UiLoadTest {
                     expectedParentId = SpanId.getInvalid(),
                 )
 
-                val lastBackgroundActivity = getSessionEnvelopes(2, ApplicationState.BACKGROUND)[1]
                 assertEmbraceSpanData(
-                    span = lastBackgroundActivity
+                    span = payload
                         .findSpansByName("emb-${LifecycleStage.CREATE.spanName(ACTIVITY1_NAME)}")
                         .single(),
                     expectedStartTimeMs = expectedTraceStartTime,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ViewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ViewFeatureTest.kt
@@ -4,9 +4,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,25 +36,20 @@ internal class ViewFeatureTest {
                 }
             },
             assertAction = {
-                val message = getSingleSessionEnvelope()
-                val viewSpans = message.findSpansOfType(EmbType.Ux.View)
-                assertEquals(2, viewSpans.size)
+                val viewSpans = getSingleSessionEnvelope().findSpansOfType(EmbType.Ux.View)
+                assertEquals(3, viewSpans.size)
 
-                with(viewSpans[0]) {
-                    attributes?.assertMatches(mapOf(
-                        "view.name" to "MyView"
-                    ))
+                with(viewSpans.single { it.attributes?.findAttributeValue("view.name") == "MyView" }) {
                     assertEquals(startTimeMs, startTimeNanos?.nanosToMillis())
                     assertEquals(startTimeMs + 3000L, endTimeNanos?.nanosToMillis())
                 }
 
-                with(viewSpans[1]) {
-                    attributes?.assertMatches(mapOf(
-                        "view.name" to "AnotherView"
-                    ))
+                with(viewSpans.single { it.attributes?.findAttributeValue("view.name") == "AnotherView" }) {
                     assertEquals(startTimeMs + 1000L, startTimeNanos?.nanosToMillis())
                     assertEquals(startTimeMs + 3000L, endTimeNanos?.nanosToMillis())
                 }
+
+                assertNotNull(viewSpans.single { it.attributes?.findAttributeValue("view.name") == "android.app.Activity" })
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -148,12 +148,15 @@ internal class BackgroundActivityDisabledTest {
 
         testRule.runTest(
             testCaseAction = {
-                session1StartMs = clock.now()
-                recordSession()
-                session1EndMs = clock.now()
-                session2StartMs = clock.tick(15000)
-                recordSession()
-                session2EndMs = clock.now()
+                with(recordSession()) {
+                    session1StartMs = startTimeMs
+                    session1EndMs = endTimeMs
+                }
+                clock.tick(15000)
+                with(recordSession()) {
+                    session2StartMs = startTimeMs
+                    session2EndMs = endTimeMs
+                }
             },
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
@@ -184,7 +187,7 @@ internal class BackgroundActivityDisabledTest {
                     startMs = session2StartMs,
                     endMs = session2EndMs,
                     sessionNumber = 2,
-                    sequenceId = 4,
+                    sequenceId = 10,
                     coldStart = false,
                 )
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionCacheTest.kt
@@ -46,7 +46,6 @@ internal class PeriodicSessionCacheTest {
         testRule.runTest(
             testCaseAction = {
                 recordSession {
-                    assertEquals(0, cacheStorageService.storedPayloadCount())
                     embrace.addSessionProperty("Test", "Test", true)
                     snapshot = returnIfConditionMet(
                         waitTimeMs = 10000,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/AppExecutionTimestamps.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/AppExecutionTimestamps.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.testframework.actions
+
+/**
+ * Timestamps for various events during the simulated execution of an app when we record a session during the integration tests
+ */
+internal data class AppExecutionTimestamps(
+    /**
+     * The time the simulated app execution started.
+     */
+    var executionStartTimeMs: Long = 0L,
+
+    /**
+     * The first time the app was foregrounded during the simulated execution.
+     *
+     * It should correspond to the start of the first session.
+     */
+    var firstForegroundTimeMs: Long = 0L,
+
+    /**
+     * The time just before the action within the session is executed for the first session in the execution
+     *
+     * This differs from the session creation time (aka foreground time) because some amount of time is ticked off as the app
+     * goes through the activity lifecycle stages.
+     */
+    var firstActionTimeMs: Long = 0L,
+
+    /**
+     * The last time the app was backgrounded during the execution simulation.
+     *
+     * It should correspond to the end of the last session.
+     */
+    var lastBackgroundTimeMs: Long = 0L,
+)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -198,64 +198,6 @@ internal class EmbraceActionInterface(
         dataSource.handleThermalStateChange(thermalState)
     }
 
-    /**
-     * Timestamps for various events during the simulated execution of an app when we record a session during the integration tests
-     */
-    data class SessionTimestamps(
-        /**
-         * The time when the session begins
-         */
-        val startTimeMs: Long,
-
-        /**
-         * Time when the session foregrounds. This could differ from [startTimeMs] if the session corresponds to the first session
-         * of the app instance when background activity is disabled, as the time in the background will be included in the session time.
-         */
-        val foregroundTimeMs: Long,
-
-        /**
-         * The time when the action in the session is invoked
-         */
-        val actionTimeMs: Long,
-
-        /**
-         * The time when the session ended
-         */
-        val endTimeMs: Long,
-    )
-
-    /**
-     * Timestamps for various events during the simulated execution of an app when we record a session during the integration tests
-     */
-    data class AppExecutionTimestamps(
-        /**
-         * The time the simulated app execution started.
-         */
-        var executionStartTimeMs: Long = 0L,
-
-        /**
-         * The first time the app was foregrounded during the simulated execution.
-         *
-         * It should correspond to the start of the first session.
-         */
-        var firstForegroundTimeMs: Long = 0L,
-
-        /**
-         * The time just before the action within the session is executed for the first session in the execution
-         *
-         * This differs from the session creation time (aka foreground time) because some amount of time is ticked off as the app
-         * goes through the activity lifecycle stages.
-         */
-        var firstActionTimeMs: Long = 0L,
-
-        /**
-         * The last time the app was backgrounded during the execution simulation.
-         *
-         * It should correspond to the end of the last session.
-         */
-        var lastBackgroundTimeMs: Long = 0L,
-    )
-
     companion object {
         const val LIFECYCLE_EVENT_GAP: Long = 10L
         const val ACTIVITY_GAP: Long = 100L

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -48,7 +48,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
     workerToFake: Worker.Background? = null,
     anrMonitoringThread: Thread? = null,
     fakeStorageLayer: Boolean = false,
-    val ignoredInternalErrors: List<InternalErrorType> = listOf(InternalErrorType.APP_LAUNCH_TRACE_FAIL),
+    val ignoredInternalErrors: List<InternalErrorType> = emptyList(),
 ) {
     private val processIdentifier: String = Uuid.getEmbUuid()
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/SessionTimestamps.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/SessionTimestamps.kt
@@ -1,0 +1,27 @@
+package io.embrace.android.embracesdk.testframework.actions
+
+/**
+ * Timestamps for various events during the simulated execution of an app when we record a session during the integration tests
+ */
+internal data class SessionTimestamps(
+    /**
+     * The time when the session begins
+     */
+    val startTimeMs: Long,
+
+    /**
+     * Time when the session foregrounds. This could differ from [startTimeMs] if the session corresponds to the first session
+     * of the app instance when background activity is disabled, as the time in the background will be included in the session time.
+     */
+    val foregroundTimeMs: Long,
+
+    /**
+     * The time when the action in the session is invoked
+     */
+    val actionTimeMs: Long,
+
+    /**
+     * The time when the session ended
+     */
+    val endTimeMs: Long,
+)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/OTelLogAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/OTelLogAssertions.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.testframework.assertions
 
 import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.opentelemetry.embExceptionHandling
 import io.embrace.android.embracesdk.internal.opentelemetry.embState
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
-import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
@@ -19,7 +19,7 @@ internal fun assertOtelLogReceived(
     expectedMessage: String,
     expectedSeverityNumber: Int,
     expectedSeverityText: String,
-    expectedTimeMs: Long? = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS,
+    expectedTimeMs: Long,
     expectedType: String? = null,
     expectedExceptionName: String? = null,
     expectedExceptionMessage: String? = null,
@@ -34,9 +34,7 @@ internal fun assertOtelLogReceived(
         assertEquals(expectedMessage, log.body)
         assertEquals(expectedSeverityNumber, log.severityNumber)
         assertEquals(expectedSeverityText, log.severityText)
-        if (expectedTimeMs != null) {
-            assertEquals(expectedTimeMs * 1000000, log.timeUnixNano)
-        }
+        assertEquals(expectedTimeMs.millisToNanos(), log.timeUnixNano)
         assertFalse(log.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key).isNullOrBlank())
         expectedType?.let { assertAttribute(log, embExceptionHandling.name, it) }
         assertEquals(expectedState, log.attributes?.findAttributeValue(embState.attributeKey.key))

--- a/embrace-android-sdk/src/integrationTest/resources/system-low-power-export.json
+++ b/embrace-android-sdk/src/integrationTest/resources/system-low-power-export.json
@@ -3,8 +3,8 @@
     "name": "emb-device-low-power",
     "kind": "INTERNAL",
     "status": "UNSET",
-    "startEpochNanos": "169220160000000000",
-    "endEpochNanos": "169220163000000000",
+    "startEpochNanos": "169220160030000000",
+    "endEpochNanos": "169220163030000000",
     "hasEnded": "true",
     "totalAttributeCount": "3",
     "attributes": {

--- a/embrace-android-sdk/src/integrationTest/resources/ux-view-export.json
+++ b/embrace-android-sdk/src/integrationTest/resources/ux-view-export.json
@@ -3,8 +3,8 @@
     "name": "emb-screen-view",
     "kind": "INTERNAL",
     "status": "UNSET",
-    "startEpochNanos": "169220160000000000",
-    "endEpochNanos": "169220190000000000",
+    "startEpochNanos": "169220160010000000",
+    "endEpochNanos": "169220200131000000",
     "hasEnded": "true",
     "totalAttributeCount": "4",
     "attributes": {


### PR DESCRIPTION
## Goal

Make it so that session creation in integration tests will simulate the app/activity lifecycle of the app. This ensures that side effects from lifecycle handlers are taken into account when running the tests end to end.

To that end, I've adding more functionality to the `recordSession()` method, having it call `simulateOpeningActivities()` with the appropriate parameters, and returning an object that contains some useful timestamps to validate against.

This requires a few changes to the tests:

- Change time verifications now that the clock isn't only moved manually 
- Account for the extra telemetry that are logged as a result of going through the lifecycle
- Tweak some internals of the faking logic to ensure that the callbacks are invoked in the same order as in prod