### PR TITLE
Adds support for render detect for Android 6+

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -46,14 +46,6 @@ fun createActivityLoadEventEmitter(
 fun traceInstanceId(activity: Activity): Int = activity.hashCode()
 
 /**
- * Determine if the current instance of the app will fire render events
- *
- * Disabled temporarily as we figure out how it interacts with Compose navigation
- */
-@Suppress("FunctionOnlyReturningConstant", "UNUSED_PARAMETER")
-fun hasRenderEvent(versionChecker: VersionChecker): Boolean = false
-
-/**
  * Determine if the current instance of the app will pre and post lifecycle events
  */
 fun hasPrePostEvents(versionChecker: VersionChecker) = versionChecker.isAtLeast(VERSION_CODES.Q)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -1,16 +1,13 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import android.os.Build.VERSION_CODES
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.capture.activity.UiLoadDataListener
 import io.embrace.android.embracesdk.internal.capture.activity.UiLoadTraceEmitter
 import io.embrace.android.embracesdk.internal.capture.activity.createActivityLoadEventEmitter
-import io.embrace.android.embracesdk.internal.capture.activity.hasRenderEvent
 import io.embrace.android.embracesdk.internal.capture.crumbs.ActivityBreadcrumbTracker
 import io.embrace.android.embracesdk.internal.capture.crumbs.PushNotificationCaptureService
 import io.embrace.android.embracesdk.internal.capture.startup.AppStartupDataCollector
 import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmitter
-import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmitter.Companion.startupHasRenderEvent
 import io.embrace.android.embracesdk.internal.capture.startup.StartupService
 import io.embrace.android.embracesdk.internal.capture.startup.StartupServiceImpl
 import io.embrace.android.embracesdk.internal.capture.startup.StartupTracker
@@ -18,7 +15,7 @@ import io.embrace.android.embracesdk.internal.capture.webview.EmbraceWebViewServ
 import io.embrace.android.embracesdk.internal.capture.webview.WebViewService
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
-import io.embrace.android.embracesdk.internal.ui.FirstDrawDetector
+import io.embrace.android.embracesdk.internal.ui.createDrawEventEmitter
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 
@@ -69,11 +66,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         StartupTracker(
             appStartupDataCollector = appStartupDataCollector,
             activityLoadEventEmitter = activityLoadEventEmitter,
-            drawEventEmitter = if (startupHasRenderEvent(versionChecker)) {
-                FirstDrawDetector(logger = initModule.logger)
-            } else {
-                null
-            }
+            drawEventEmitter = createDrawEventEmitter(versionChecker, initModule.logger)
         )
     }
 
@@ -93,11 +86,7 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
         if (uiLoadEventListener != null) {
             createActivityLoadEventEmitter(
                 uiLoadEventListener = uiLoadEventListener,
-                firstDrawDetector = if (versionChecker.isAtLeast(VERSION_CODES.Q) && hasRenderEvent(versionChecker)) {
-                    FirstDrawDetector(initModule.logger)
-                } else {
-                    null
-                },
+                firstDrawDetector = createDrawEventEmitter(versionChecker, initModule.logger),
                 autoTraceEnabled = configService.autoDataCaptureBehavior.isUiLoadTracingTraceAll(),
                 clock = openTelemetryModule.openTelemetryClock,
                 versionChecker = versionChecker

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.ui
 import android.app.Activity
 import android.os.Build
 import android.os.Build.VERSION_CODES
-import android.os.Looper
+import io.embrace.android.embracesdk.internal.handler.AndroidMainThreadHandler
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 
@@ -33,7 +33,7 @@ fun createDrawEventEmitter(
 ): DrawEventEmitter? = if (supportFrameCommitCallback(versionChecker)) {
     FirstDrawDetector(logger)
 } else if (hasRenderEvent(versionChecker)) {
-    HandlerMessageDrawDetector(Looper.getMainLooper())
+    HandlerMessageDrawDetector(AndroidMainThreadHandler())
 } else {
     null
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
@@ -1,6 +1,11 @@
 package io.embrace.android.embracesdk.internal.ui
 
 import android.app.Activity
+import android.os.Build
+import android.os.Build.VERSION_CODES
+import android.os.Looper
+import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
 
 /**
  * Interface that allows callbacks to be registered and invoked when UI draw events happen
@@ -21,3 +26,19 @@ interface DrawEventEmitter {
      */
     fun unregisterFirstDrawCallback(activity: Activity)
 }
+
+fun createDrawEventEmitter(
+    versionChecker: VersionChecker,
+    logger: EmbLogger,
+): DrawEventEmitter? = if (supportFrameCommitCallback(versionChecker)) {
+    FirstDrawDetector(logger)
+} else if (hasRenderEvent(versionChecker)) {
+    HandlerMessageDrawDetector(Looper.getMainLooper())
+} else {
+    null
+}
+
+fun hasRenderEvent(versionChecker: VersionChecker) = versionChecker.isAtLeast(VERSION_CODES.M)
+
+private fun supportFrameCommitCallback(versionChecker: VersionChecker) = versionChecker.isAtLeast(VERSION_CODES.Q) &&
+    (Build.VERSION.SDK_INT != VERSION_CODES.S && Build.VERSION.SDK_INT != VERSION_CODES.S_V2)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetector.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.internal.ui
+
+import android.app.Activity
+import android.os.Build.VERSION_CODES.M
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import androidx.annotation.RequiresApi
+
+@RequiresApi(M)
+class HandlerMessageDrawDetector(
+    mainLooper: Looper
+) : DrawEventEmitter {
+
+    private val handler = Handler(mainLooper)
+
+    override fun registerFirstDrawCallback(
+        activity: Activity,
+        drawBeginCallback: () -> Unit,
+        firstFrameDeliveredCallback: () -> Unit
+    ) {
+        drawBeginCallback()
+        handler.sendMessageAtFrontOfQueue(
+            Message.obtain(handler, firstFrameDeliveredCallback).apply {
+                isAsynchronous = true
+            }
+        )
+    }
+
+    override fun unregisterFirstDrawCallback(activity: Activity) {
+    }
+}

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetector.kt
@@ -2,26 +2,23 @@ package io.embrace.android.embracesdk.internal.ui
 
 import android.app.Activity
 import android.os.Build.VERSION_CODES.M
-import android.os.Handler
-import android.os.Looper
 import android.os.Message
 import androidx.annotation.RequiresApi
+import io.embrace.android.embracesdk.internal.handler.MainThreadHandler
 
 @RequiresApi(M)
 class HandlerMessageDrawDetector(
-    mainLooper: Looper
+    private val handler: MainThreadHandler
 ) : DrawEventEmitter {
-
-    private val handler = Handler(mainLooper)
 
     override fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        firstFrameDeliveredCallback: () -> Unit
+        firstFrameDeliveredCallback: () -> Unit,
     ) {
         drawBeginCallback()
         handler.sendMessageAtFrontOfQueue(
-            Message.obtain(handler, firstFrameDeliveredCallback).apply {
+            Message.obtain(handler.wrappedHandler, firstFrameDeliveredCallback).apply {
                 isAsynchronous = true
             }
         )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExtTest.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.ClockTickingActivityLifecycleCallb
 import io.embrace.android.embracesdk.internal.ClockTickingActivityLifecycleCallbacks.Companion.PRE_DURATION
 import io.embrace.android.embracesdk.internal.ClockTickingActivityLifecycleCallbacks.Companion.STATE_DURATION
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
+import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -223,21 +224,17 @@ internal class UiLoadExtTest {
                 stage = "resumeEnd",
                 timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
             ),
-//            createEvent(
-//                stage = "render",
-//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
-//            ),
-//            createEvent(
-//                stage = "renderEnd",
-//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION
-//            ),
-//            createEvent(
-//                stage = "discard",
-//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION + PRE_DURATION
-//            ),
+            createEvent(
+                stage = "render",
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
+            ),
+            createEvent(
+                stage = "renderEnd",
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION
+            ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + PRE_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION + PRE_DURATION
             ),
         )
 
@@ -258,21 +255,17 @@ internal class UiLoadExtTest {
                 stage = "resumeEnd",
                 timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
             ),
-//            createEvent(
-//                stage = "render",
-//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
-//            ),
-//            createEvent(
-//                stage = "renderEnd",
-//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION
-//            ),
-//            createEvent(
-//                stage = "discard",
-//                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION + PRE_DURATION
-//            ),
+            createEvent(
+                stage = "render",
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
+            ),
+            createEvent(
+                stage = "renderEnd",
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION
+            ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + PRE_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION + PRE_DURATION
             ),
         )
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
+import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupTrackerTest.kt
@@ -11,8 +11,8 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeDrawEventEmitter
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
-import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmitter.Companion.startupHasRenderEvent
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -96,6 +96,7 @@ internal class StartupTrackerTest {
                 createTime = createTime,
                 startTime = startTime,
                 resumeTime = resumeTime,
+                renderTime = renderTime,
             )
         }
     }
@@ -222,7 +223,7 @@ internal class StartupTrackerTest {
         val resumeTime = clock.now()
         controller.resume()
         clock.tick()
-        val renderTime = if (startupHasRenderEvent(BuildVersionChecker)) {
+        val renderTime = if (hasRenderEvent(BuildVersionChecker)) {
             drawEventEmitter.draw(controller.get()) {
                 clock.tick()
             }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetectorTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetectorTest.kt
@@ -1,0 +1,42 @@
+package io.embrace.android.embracesdk.internal.ui
+
+import android.app.Activity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeMainThreadHandler
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import java.util.concurrent.CountDownLatch
+
+@RunWith(AndroidJUnit4::class)
+internal class HandlerMessageDrawDetectorTest {
+    private lateinit var handler: FakeMainThreadHandler
+    private lateinit var detector: HandlerMessageDrawDetector
+    private lateinit var messageHandlerLatch: CountDownLatch
+
+    @Before
+    fun setUp() {
+        messageHandlerLatch = CountDownLatch(1)
+        handler = FakeMainThreadHandler()
+        detector = HandlerMessageDrawDetector(handler)
+    }
+
+    @Test
+    fun `check invocation`() {
+        var beginCallbackInvoked = false
+        var endCallbackInvoked = false
+        detector.registerFirstDrawCallback(
+            activity = Robolectric.buildActivity(Activity::class.java).get(),
+            drawBeginCallback = { beginCallbackInvoked = true },
+            firstFrameDeliveredCallback = { endCallbackInvoked = true }
+        )
+        assertTrue(beginCallbackInvoked)
+        with(handler.messageQueue.single()) {
+            assertTrue(isAsynchronous)
+            callback.run()
+        }
+        assertTrue(endCallbackInvoked)
+    }
+}

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/AndroidMainThreadHandler.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/AndroidMainThreadHandler.kt
@@ -2,15 +2,20 @@ package io.embrace.android.embracesdk.internal.handler
 
 import android.os.Handler
 import android.os.Looper
+import android.os.Message
 
 class AndroidMainThreadHandler : MainThreadHandler {
-    val handler = Handler(checkNotNull(Looper.getMainLooper()))
+    override val wrappedHandler = Handler(checkNotNull(Looper.getMainLooper()))
 
     override fun postAtFrontOfQueue(function: () -> Unit) {
-        handler.postAtFrontOfQueue(function)
+        wrappedHandler.postAtFrontOfQueue(function)
     }
 
     override fun postDelayed(runnable: Runnable, delayMillis: Long) {
-        handler.postDelayed(runnable, delayMillis)
+        wrappedHandler.postDelayed(runnable, delayMillis)
+    }
+
+    override fun sendMessageAtFrontOfQueue(message: Message): Boolean {
+        return wrappedHandler.sendMessageAtFrontOfQueue(message)
     }
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/MainThreadHandler.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/handler/MainThreadHandler.kt
@@ -1,6 +1,12 @@
 package io.embrace.android.embracesdk.internal.handler
 
+import android.os.Handler
+import android.os.Message
+
 interface MainThreadHandler {
+    val wrappedHandler: Handler
+
     fun postAtFrontOfQueue(function: () -> Unit)
     fun postDelayed(runnable: Runnable, delayMillis: Long)
+    fun sendMessageAtFrontOfQueue(message: Message): Boolean
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
@@ -1,8 +1,21 @@
 package io.embrace.android.embracesdk.fakes
 
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
 import io.embrace.android.embracesdk.internal.handler.MainThreadHandler
+import java.util.LinkedList
+import java.util.Queue
 
-class FakeMainThreadHandler : MainThreadHandler {
+class FakeMainThreadHandler(
+    private val handlerProvider: () -> Handler = ::defaultHandlerProvider
+) : MainThreadHandler {
+
+    override val wrappedHandler: Handler
+        get() = handlerProvider()
+
+    val messageQueue: Queue<Message> = LinkedList()
+
     override fun postAtFrontOfQueue(function: () -> Unit) {
         function()
     }
@@ -11,4 +24,11 @@ class FakeMainThreadHandler : MainThreadHandler {
         Thread.sleep(20L)
         runnable.run()
     }
+
+    override fun sendMessageAtFrontOfQueue(message: Message): Boolean {
+        messageQueue.add(message)
+        return true
+    }
 }
+
+private fun defaultHandlerProvider() = Handler(checkNotNull(Looper.getMainLooper()))


### PR DESCRIPTION
## Goal

Use an alternate way to detect that a frame was been delivered that works for Android 12 and Android 6 to 9. Implement a new `DrawEventEmitter` that uses this alternative method, and supply when the other one doesn't work.

All the unit tests have been updated to reflect this new reality, but the integration tests don't check for hardware based render events. But with this, we may be able to test this by simulating this, so stay tuned!

## Testing
Manually tested for a subset of real devices/apps. Will test it more comprehensively.
