### PR TITLE
Disable render tracking in UI loading

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
@@ -4,7 +4,6 @@ import android.app.Application.ActivityLifecycleCallbacks
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
-import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -52,7 +51,7 @@ class UiLoadTraceEmitter(
 
     private val activeTraces: MutableMap<Int, UiLoadTrace> = ConcurrentHashMap()
     private var currentInstance: AtomicReference<UiInstance?> = AtomicReference()
-    private val trackRender = hasRenderEvent(versionChecker)
+    private val trackRender = false
     private val hasPrePostEvents = hasPrePostEvents(versionChecker)
 
     override fun create(instanceId: Int, activityName: String, timestampMs: Long, manualEnd: Boolean) {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
-import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -37,7 +36,7 @@ internal class UiLoadTraceEmitterTest {
     @Before
     fun setUp() {
         clock = FakeClock()
-        hasRenderEvent = hasRenderEvent(BuildVersionChecker)
+        hasRenderEvent = false
         hasPreAndPostEvents = hasPrePostEvents(BuildVersionChecker)
         val initModule = FakeInitModule(clock = clock)
         spanSink = initModule.openTelemetryModule.spanSink


### PR DESCRIPTION
## Goal

Compose navigation isn't compatible with frame render detection, so I needed to disable it again because it'll be inconsistent,

Apparently I forgot why I disabled it in the first place....

## Testing

Existing tests cover it.