### PR TITLE
Rename less good version of render span for clarity

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateList
 import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
+import io.embrace.android.embracesdk.internal.ui.supportFrameCommitCallback
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -55,6 +56,7 @@ internal class AppStartupTraceEmitter(
     private val additionalTrackedIntervals = ConcurrentLinkedQueue<TrackedInterval>()
     private val customAttributes: MutableMap<String, String> = ConcurrentHashMap()
     private val trackRender = hasRenderEvent(versionChecker)
+    private val trackFrameCommit = supportFrameCommitCallback(versionChecker)
     private val appStartupRootSpan = AtomicReference<PersistableEmbraceSpan?>(null)
     private val dataCollectionComplete = AtomicBoolean(false)
     private val traceEnd = if (manualEnd) {
@@ -365,7 +367,11 @@ internal class AppStartupTraceEmitter(
 
             if (activityInitEndMs != null && uiLoadedMs != null) {
                 val uiLoadSpanName = if (trackRender) {
-                    ACTIVITY_RENDER_SPAN
+                    if (trackFrameCommit) {
+                        ACTIVITY_RENDER_SPAN
+                    } else {
+                        ACTIVITY_FIRST_DRAW_SPAN
+                    }
                 } else {
                     ACTIVITY_LOAD_SPAN
                 }
@@ -436,6 +442,7 @@ internal class AppStartupTraceEmitter(
         const val ACTIVITY_INIT_DELAY_SPAN = "activity-init-delay"
         const val ACTIVITY_INIT_SPAN = "activity-init"
         const val ACTIVITY_RENDER_SPAN = "activity-render"
+        const val ACTIVITY_FIRST_DRAW_SPAN = "activity-first-draw"
         const val ACTIVITY_LOAD_SPAN = "activity-load"
         const val APP_READY_SPAN = "app-ready"
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
@@ -40,5 +40,5 @@ fun createDrawEventEmitter(
 
 fun hasRenderEvent(versionChecker: VersionChecker) = versionChecker.isAtLeast(VERSION_CODES.M)
 
-private fun supportFrameCommitCallback(versionChecker: VersionChecker) = versionChecker.isAtLeast(VERSION_CODES.Q) &&
+fun supportFrameCommitCallback(versionChecker: VersionChecker) = versionChecker.isAtLeast(VERSION_CODES.Q) &&
     (Build.VERSION.SDK_INT != VERSION_CODES.S && Build.VERSION.SDK_INT != VERSION_CODES.S_V2)


### PR DESCRIPTION
## Goal

Rename app startup render child span that tracks less. An alternative implementation is adding a new event to be tracked, and keying off that to create the span.

I don't like that because a new event adds little value for android versions that can do frame commit callbacks, and it adds complication to the code. Basically using one or the other and calling both of them render removes that distinction, so we just have to make sure the name is correct. I prefer this.

