### PR TITLE
Set correct total limits on OTel layer

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SessionSpanWriter.kt
@@ -12,20 +12,20 @@ interface SessionSpanWriter {
      * Add a span event for the given [schemaType] to the session span. If [spanStartTimeMs] is null, the
      * current time will be used. Returns true if the event was added, otherwise false.
      */
-    fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean
+    fun addSessionEvent(schemaType: SchemaType, startTimeMs: Long): Boolean
 
     /**
      * Remove all span events with the given [EmbType].
      */
-    fun removeEvents(type: EmbType)
+    fun removeSessionEvents(type: EmbType)
 
     /**
      * Add the given key-value pair as an Attribute to the session span
      */
-    fun addSystemAttribute(attribute: SpanAttributeData)
+    fun addSessionAttribute(attribute: SpanAttributeData)
 
     /**
      * Remove the attribute with the given key
      */
-    fun removeSystemAttribute(key: String)
+    fun removeSessionAttribute(key: String)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionProperties.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionProperties.kt
@@ -56,7 +56,7 @@ internal class EmbraceSessionProperties(
                 }
                 temporary[sanitizedKey] = sanitizedValue
             }
-            writer.addSystemAttribute(
+            writer.addSessionAttribute(
                 SpanAttributeData(
                     sanitizedKey.toSessionPropertyAttributeName(),
                     sanitizedValue
@@ -79,7 +79,7 @@ internal class EmbraceSessionProperties(
                 preferencesService.permanentSessionProperties = permanentProperties()
                 existed = true
             }
-            writer.removeSystemAttribute(sanitizedKey.toSessionPropertyAttributeName())
+            writer.removeSessionAttribute(sanitizedKey.toSessionPropertyAttributeName())
             return existed
         }
     }
@@ -98,7 +98,7 @@ internal class EmbraceSessionProperties(
 
     fun addPermPropsToSessionSpan() {
         permanentProperties().entries.forEach {
-            writer.addSystemAttribute(
+            writer.addSessionAttribute(
                 SpanAttributeData(
                     it.key.toSessionPropertyAttributeName(),
                     it.value

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetrySdk.kt
@@ -3,6 +3,9 @@ package io.embrace.android.embracesdk.internal.opentelemetry
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
+import io.embrace.android.embracesdk.internal.spans.getMaxTotalAttributeCount
+import io.embrace.android.embracesdk.internal.spans.getMaxTotalEventCount
+import io.embrace.android.embracesdk.internal.spans.getMaxTotalLinkCount
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -38,6 +41,7 @@ internal class OpenTelemetrySdk(
                         .toBuilder()
                         .setMaxNumberOfEvents(limits.getMaxTotalEventCount())
                         .setMaxNumberOfAttributes(limits.getMaxTotalAttributeCount())
+                        .setMaxNumberOfLinks(limits.getMaxTotalLinkCount())
                         .build()
                 )
                 .setClock(openTelemetryClock)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
@@ -45,7 +45,7 @@ fun Map<String, String>.toNewPayload(): List<Attribute> =
 fun List<Attribute>.toOldPayload(): Map<String, String> =
     associate { Pair(it.key ?: "", it.data ?: "") }.filterKeys { it.isNotBlank() }
 
-fun EmbraceLinkData.toPayload() = Link(spanContext.spanId, attributes?.toNewPayload())
+fun EmbraceLinkData.toPayload() = Link(spanContext.spanId, attributes.toNewPayload())
 
 fun Span.toOldPayload(): EmbraceSpanData {
     return EmbraceSpanData(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -247,7 +247,7 @@ internal class SessionOrchestratorImpl(
     private fun updatePeriodicCacheAttrs() {
         val now = clock.now().millisToNanos()
         val attr = SpanAttributeData(embHeartbeatTimeUnixNano.name, now.toString())
-        sessionSpanWriter.addSystemAttribute(attr)
-        sessionSpanWriter.addSystemAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+        sessionSpanWriter.addSessionAttribute(attr)
+        sessionSpanWriter.addSessionAttribute(SpanAttributeData(embTerminated.name, true.toString()))
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
@@ -29,39 +29,39 @@ internal class SessionSpanAttrPopulatorImpl(
 
     override fun populateSessionSpanStartAttrs(session: SessionZygote) {
         with(sessionSpanWriter) {
-            addSystemAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
-            addSystemAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
-            addSystemAttribute(SpanAttributeData(embState.name, session.appState.name.lowercase(Locale.US)))
-            addSystemAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
-            addSystemAttribute(SpanAttributeData(embTerminated.name, true.toString()))
+            addSessionAttribute(SpanAttributeData(embColdStart.name, session.isColdStart.toString()))
+            addSessionAttribute(SpanAttributeData(embSessionNumber.name, session.number.toString()))
+            addSessionAttribute(SpanAttributeData(embState.name, session.appState.name.lowercase(Locale.US)))
+            addSessionAttribute(SpanAttributeData(embCleanExit.name, false.toString()))
+            addSessionAttribute(SpanAttributeData(embTerminated.name, true.toString()))
 
             session.startType.toString().lowercase(Locale.US).let {
-                addSystemAttribute(SpanAttributeData(embSessionStartType.name, it))
+                addSessionAttribute(SpanAttributeData(embSessionStartType.name, it))
             }
         }
     }
 
     override fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean) {
         with(sessionSpanWriter) {
-            addSystemAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
-            addSystemAttribute(SpanAttributeData(embTerminated.name, false.toString()))
+            addSessionAttribute(SpanAttributeData(embCleanExit.name, true.toString()))
+            addSessionAttribute(SpanAttributeData(embTerminated.name, false.toString()))
             crashId?.let {
-                addSystemAttribute(SpanAttributeData(embCrashId.name, crashId))
+                addSessionAttribute(SpanAttributeData(embCrashId.name, crashId))
             }
             endType?.toString()?.lowercase(Locale.US)?.let {
-                addSystemAttribute(SpanAttributeData(embSessionEndType.name, it))
+                addSessionAttribute(SpanAttributeData(embSessionEndType.name, it))
             }
             if (coldStart) {
                 startupService.getSdkStartupDuration()?.let { duration ->
-                    addSystemAttribute(SpanAttributeData(embSessionStartupDuration.name, duration.toString()))
+                    addSessionAttribute(SpanAttributeData(embSessionStartupDuration.name, duration.toString()))
                 }
             }
 
             val logCount = logService.getErrorLogsCount()
-            addSystemAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
+            addSessionAttribute(SpanAttributeData(embErrorLogCount.name, logCount.toString()))
 
             metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
-                addSystemAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
+                addSessionAttribute(SpanAttributeData(embFreeDiskBytes.name, free.toString()))
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -137,7 +137,7 @@ internal class CurrentSessionSpanImpl(
         }
     }
 
-    override fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean {
+    override fun addSessionEvent(schemaType: SchemaType, startTimeMs: Long): Boolean {
         val currentSession = sessionSpan.get() ?: return false
         return currentSession.addSystemEvent(
             schemaType.fixedObjectName.toEmbraceObjectName(),
@@ -146,17 +146,17 @@ internal class CurrentSessionSpanImpl(
         )
     }
 
-    override fun removeEvents(type: EmbType) {
+    override fun removeSessionEvents(type: EmbType) {
         val currentSession = sessionSpan.get() ?: return
         currentSession.removeSystemEvents(type)
     }
 
-    override fun addSystemAttribute(attribute: SpanAttributeData) {
+    override fun addSessionAttribute(attribute: SpanAttributeData) {
         val currentSession = sessionSpan.get() ?: return
         currentSession.addSystemAttribute(attribute.key, attribute.value)
     }
 
-    override fun removeSystemAttribute(key: String) {
+    override fun removeSessionAttribute(key: String) {
         val currentSession = sessionSpan.get() ?: return
         currentSession.removeSystemAttribute(key)
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -104,3 +104,9 @@ fun StatusCode.toStatus(): Span.Status {
         StatusCode.ERROR -> io.embrace.android.embracesdk.internal.payload.Span.Status.ERROR
     }
 }
+
+fun OtelLimitsConfig.getMaxTotalAttributeCount() = getMaxSystemAttributeCount() + getMaxCustomAttributeCount()
+
+fun OtelLimitsConfig.getMaxTotalEventCount() = getMaxSystemEventCount() + getMaxCustomEventCount()
+
+fun OtelLimitsConfig.getMaxTotalLinkCount() = getMaxSystemLinkCount() + getMaxCustomLinkCount()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceLinkData.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceLinkData.kt
@@ -4,5 +4,5 @@ import io.opentelemetry.api.trace.SpanContext
 
 data class EmbraceLinkData(
     val spanContext: SpanContext,
-    val attributes: Map<String, String>?
+    val attributes: Map<String, String>
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
@@ -71,6 +72,14 @@ interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
     fun setStatus(statusCode: StatusCode, description: String = "")
 
     fun getStartTimeMs(): Long?
+
+    /**
+     * Add a system link to the span that will subjected to a different maximum than typical links.
+     */
+    fun addSystemLink(
+        linkedSpanContext: SpanContext,
+        attributes: Map<String, String> = emptyMap(),
+    ): Boolean
 
     override fun storeInContext(context: Context): Context = context.with(embraceSpanContextKey, this)
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -480,7 +480,7 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add event forwarded to span`() {
-        currentSessionSpan.addEvent(SchemaType.Breadcrumb("test-event"), 1000L)
+        currentSessionSpan.addSessionEvent(SchemaType.Breadcrumb("test-event"), 1000L)
         val span = currentSessionSpan.endSession(true).single()
         assertEquals("emb-session", span.name)
 
@@ -495,9 +495,9 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `validate maximum events on session span`() {
-        val limit = InstrumentedConfigImpl.otelLimits.getMaxTotalEventCount()
+        val limit = InstrumentedConfigImpl.otelLimits.getMaxSystemEventCount()
         repeat(limit + 1) {
-            currentSessionSpan.addEvent(SchemaType.Breadcrumb("test-event"), 1000L + it)
+            currentSessionSpan.addSessionEvent(SchemaType.Breadcrumb("test-event"), 1000L + it)
         }
 
         val span = currentSessionSpan.endSession(true).single()
@@ -509,9 +509,9 @@ internal class CurrentSessionSpanImplTests {
 
     @Test
     fun `add and remove attribute forwarded to span`() {
-        currentSessionSpan.addSystemAttribute(SpanAttributeData("my_key", "my_value"))
-        currentSessionSpan.addSystemAttribute(SpanAttributeData("missing", "my_value"))
-        currentSessionSpan.removeSystemAttribute("missing")
+        currentSessionSpan.addSessionAttribute(SpanAttributeData("my_key", "my_value"))
+        currentSessionSpan.addSessionAttribute(SpanAttributeData("missing", "my_value"))
+        currentSessionSpan.removeSessionAttribute("missing")
         val span = currentSessionSpan.endSession(true).single()
         assertEquals("emb-session", span.name)
 
@@ -524,7 +524,7 @@ internal class CurrentSessionSpanImplTests {
     fun `validate maximum attributes on session span`() {
         val limit = InstrumentedConfigImpl.otelLimits.getMaxTotalAttributeCount()
         repeat(limit + 1) {
-            currentSessionSpan.addSystemAttribute(SpanAttributeData("attribute-$it", "value"))
+            currentSessionSpan.addSessionAttribute(SpanAttributeData("attribute-$it", "value"))
         }
 
         val span = currentSessionSpan.endSession(true).single()
@@ -538,21 +538,21 @@ internal class CurrentSessionSpanImplTests {
         assertEquals("", getSessionId())
         assertFalse(canStartNewSpan(parent = null, internal = true))
         assertTrue(endSession(true).isEmpty())
-        assertFalse(addEvent(SchemaType.Breadcrumb("test"), clock.now()))
+        assertFalse(addSessionEvent(SchemaType.Breadcrumb("test"), clock.now()))
         // check doesn't throw exception
-        addSystemAttribute(attribute = SpanAttributeData("test", "test"))
-        removeSystemAttribute("test")
-        removeEvents(EmbType.System.Breadcrumb)
+        addSessionAttribute(attribute = SpanAttributeData("test", "test"))
+        removeSessionAttribute("test")
+        removeSessionEvents(EmbType.System.Breadcrumb)
     }
 
     private fun CurrentSessionSpan.assertSessionSpan() {
         assertTrue(getSessionId().isNotBlank())
         assertTrue(canStartNewSpan(parent = null, internal = true))
-        assertTrue(addEvent(SchemaType.Breadcrumb("test"), clock.now()))
+        assertTrue(addSessionEvent(SchemaType.Breadcrumb("test"), clock.now()))
         // check doesn't throw exception
-        addSystemAttribute(attribute = SpanAttributeData("test", "test"))
-        removeSystemAttribute("test")
-        removeEvents(EmbType.System.Breadcrumb)
+        addSessionAttribute(attribute = SpanAttributeData("test", "test"))
+        removeSessionAttribute("test")
+        removeSessionEvents(EmbType.System.Breadcrumb)
     }
 
     private class BadEmbraceSpanFactory : EmbraceSpanFactory {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/BreadcrumbDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/BreadcrumbDataSource.kt
@@ -27,7 +27,7 @@ class BreadcrumbDataSource(
             },
             captureAction = {
                 val sanitizedMessage = ellipsizeBreadcrumbMessage(message)
-                addEvent(SchemaType.Breadcrumb(sanitizedMessage ?: ""), timestamp)
+                addSessionEvent(SchemaType.Breadcrumb(sanitizedMessage ?: ""), timestamp)
             }
         )
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/PushNotificationDataSource.kt
@@ -36,7 +36,7 @@ class PushNotificationDataSource(
             inputValidation = NoInputValidation,
             captureAction = {
                 val captureFcmPiiData = breadcrumbBehavior.isFcmPiiDataCaptureEnabled()
-                addEvent(
+                addSessionEvent(
                     SchemaType.PushNotification(
                         title = if (captureFcmPiiData) title else null,
                         type = type.type,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/TapDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/TapDataSource.kt
@@ -40,7 +40,7 @@ class TapDataSource(
                     val second = finalPoint.second?.toInt()?.toFloat() ?: 0.0f
                     first.toInt().toString() + "," + second.toInt()
                 }
-                addEvent(SchemaType.Tap(element, type.value, coords), timestamp)
+                addSessionEvent(SchemaType.Tap(element, type.value, coords), timestamp)
             }
         )
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/WebViewUrlDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/WebViewUrlDataSource.kt
@@ -39,7 +39,7 @@ class WebViewUrlDataSource(
                             parsedUrl = url?.substring(0, queryOffset) ?: ""
                         }
                     }
-                    addEvent(SchemaType.WebViewUrl(parsedUrl), startTime)
+                    addSessionEvent(SchemaType.WebViewUrl(parsedUrl), startTime)
                 }
             )
         }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/memory/MemoryWarningDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/memory/MemoryWarningDataSource.kt
@@ -39,7 +39,7 @@ internal class MemoryWarningDataSource(
         captureData(
             inputValidation = NoInputValidation,
             captureAction = {
-                addEvent(SchemaType.MemoryWarning(), timestamp)
+                addSessionEvent(SchemaType.MemoryWarning(), timestamp)
             }
         )
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/webview/WebViewDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/webview/WebViewDataSource.kt
@@ -28,7 +28,7 @@ class WebViewDataSource(
 
     fun loadDataIntoSession(webViewInfoList: List<WebViewInfo>) {
         runCatching {
-            writer.removeEvents(EmbType.System.WebViewInfo)
+            writer.removeSessionEvents(EmbType.System.WebViewInfo)
             webViewInfoList.forEach { webViewInfo ->
                 captureData(
                     inputValidation = NoInputValidation,
@@ -38,7 +38,7 @@ class WebViewDataSource(
                             .toByteArray()
                             .toUTF8String()
 
-                        addEvent(
+                        addSessionEvent(
                             SchemaType.WebViewInfo(
                                 url = webViewInfo.url,
                                 webVitals = webVitalsString,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
@@ -10,10 +10,11 @@ interface OtelLimitsConfig {
     fun getMaxInternalNameLength(): Int = 2000
     fun getMaxNameLength(): Int = 50
     fun getMaxCustomEventCount(): Int = 10
-    fun getMaxTotalEventCount(): Int = 11000
+    fun getMaxSystemEventCount(): Int = 11000
     fun getMaxCustomAttributeCount(): Int = 50
-    fun getMaxTotalAttributeCount(): Int = 300
-    fun getMaxTotalLinkCount(): Int = 100
+    fun getMaxSystemAttributeCount(): Int = 300
+    fun getMaxCustomLinkCount(): Int = 10
+    fun getMaxSystemLinkCount(): Int = 100
     fun getMaxInternalAttributeKeyLength(): Int = 1000
     fun getMaxInternalAttributeValueLength(): Int = 2000
     fun getMaxCustomAttributeKeyLength(): Int = 50

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -25,20 +25,20 @@ class FakeCurrentSessionSpan(
         sessionSpan = newSessionSpan(sdkInitStartTimeMs)
     }
 
-    override fun addEvent(schemaType: SchemaType, startTimeMs: Long): Boolean {
+    override fun addSessionEvent(schemaType: SchemaType, startTimeMs: Long): Boolean {
         addedEvents.add(SpanEventData(schemaType, startTimeMs))
         return true
     }
 
-    override fun removeEvents(type: EmbType) {
+    override fun removeSessionEvents(type: EmbType) {
         addedEvents.removeAll { it.schemaType.telemetryType.key == type.key }
     }
 
-    override fun addSystemAttribute(attribute: SpanAttributeData) {
+    override fun addSessionAttribute(attribute: SpanAttributeData) {
         attributes[attribute.key] = attribute.value
     }
 
-    override fun removeSystemAttribute(key: String) {
+    override fun removeSessionAttribute(key: String) {
         attributes.remove(key)
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -36,7 +36,7 @@ class FakeDataSource(
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         captureData(inputValidation = { true }) {
-            addSystemAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
+            addSessionAttribute(SpanAttributeData("orientation", newConfig.orientation.toString()))
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -143,6 +143,9 @@ class FakePersistableEmbraceSpan(
         return true
     }
 
+    override fun addSystemLink(linkedSpanContext: SpanContext, attributes: Map<String, String>): Boolean =
+        addLink(linkedSpanContext, attributes)
+
     override fun asNewContext(): Context? = sdkSpan?.let { parentContext.with(this).with(it) }
 
     override fun snapshot(): Span? {
@@ -211,7 +214,7 @@ class FakePersistableEmbraceSpan(
             lastHeartbeatTimeMs: Long?,
             endTimeMs: Long? = null,
             sessionProperties: Map<String, String>? = null,
-            processIdentifier: String = "fake-process-id"
+            processIdentifier: String = "fake-process-id",
         ): FakePersistableEmbraceSpan =
             FakePersistableEmbraceSpan(
                 name = "emb-session",


### PR DESCRIPTION
## Goal

Apply the total limits of attributes, event, and links correctly on the OTel layer, separating the ones added by users and others added by the SDK. The notion of system links was also added in this PR.

We were using the system one for the total when applying it at the OTel layer, which theoretically should be way more than needed, and should easily absorb the user ones without issue. Fixing this makes the OTel layer agree with the SDK layer, so if you can add an attribute through the SDK, it will be exported for sure.

Some method names on the `CurrentSessionSpan` interface was also renamed to clarify what it's doing