### PR TITLE
Use failBuildOnUploadTask in CompressSharedObjectFilesTask

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/compress-shared-object-files/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/compress-shared-object-files/build.gradle
@@ -6,10 +6,13 @@ plugins {
     id("io.embrace.android.testplugin")
 }
 
+def failBuildOnUploadErrors = (project.findProperty("failBuildOnUploadErrors") ?: "true").toBoolean()
+
 project.tasks.register("compressTask", CompressSharedObjectFilesTask) { task ->
     task.architecturesDirectory.set(
         project.layout.projectDirectory.dir("testArchitecturesDir")
     )
+    task.failBuildOnUploadErrors.set(failBuildOnUploadErrors)
     task.compressedSharedObjectFilesDirectory.set(
         project.layout.buildDirectory.dir("compressedSharedObjectFiles")
     )

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/CompressSharedObjectFilesTaskTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/CompressSharedObjectFilesTaskTest.kt
@@ -224,4 +224,22 @@ class CompressSharedObjectFilesTaskTest {
             }
         )
     }
+
+    @Test
+    fun `don't throw an error when failBuildOnUploadErrors is disabled`() {
+        rule.runTest(
+            fixture = "compress-shared-object-files",
+            task = "compressTask",
+            additionalArgs = listOf("-PfailBuildOnUploadErrors=false"),
+            setup = { projectDir ->
+                // delete architecture directories
+                projectDir.file("testArchitecturesDir").listFiles()?.forEach { it.deleteRecursively() }
+                // create a file instead of a directory
+                projectDir.file("testArchitecturesDir/aFile.txt").writeText("not a directory")
+            },
+            assertions = {
+                verifyNoUploads()
+            }
+        )
+    }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -52,6 +52,7 @@ class NdkUploadTasksRegistration(
             data
         ) { task ->
             task.architecturesDirectory.set(project.layout.dir(sharedObjectFilesProvider))
+            task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
             task.compressedSharedObjectFilesDirectory.set(
                 project.layout.buildDirectory.dir("intermediates/embrace/compressed/${data.name}")
             )


### PR DESCRIPTION
## Goal

Use a custom property to enable and disable the task in tests. Will use this approach for the other tests too