### PR TITLE
Use failBuildOnUploadTask in HashSharedObjectFilesTask

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/hash-shared-object-files/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/hash-shared-object-files/build.gradle
@@ -6,11 +6,14 @@ plugins {
     id("io.embrace.android.testplugin")
 }
 
+def failBuildOnUploadErrors = (project.findProperty("failBuildOnUploadErrors") ?: "true").toBoolean()
+
 // Register the hashing task
 project.tasks.register("hashTask", HashSharedObjectFilesTask) { task ->
     task.compressedSharedObjectFilesDirectory.set(
         project.layout.projectDirectory.dir("compressedSharedObjectFiles")
     )
+    task.failBuildOnUploadErrors.set(failBuildOnUploadErrors)
     task.architecturesToHashedSharedObjectFilesMap.set(
         project.layout.buildDirectory.file("output.json")
     )

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/HashSharedObjectFilesTaskTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/HashSharedObjectFilesTaskTest.kt
@@ -98,4 +98,22 @@ class HashSharedObjectFilesTaskTest {
             }
         )
     }
+
+    @Test
+    fun `don't throw an error when failBuildOnUploadErrors is disabled`() {
+        rule.runTest(
+            fixture = "hash-shared-object-files",
+            task = "hashTask",
+            additionalArgs = listOf("-PfailBuildOnUploadErrors=false"),
+            setup = { projectDir ->
+                // delete architecture directories
+                projectDir.file("compressedSharedObjectFiles").listFiles()?.forEach { it.deleteRecursively() }
+                // create a file instead of a directory
+                projectDir.file("compressedSharedObjectFiles/aFile.txt").writeText("not a directory")
+            },
+            assertions = {
+                verifyNoUploads()
+            }
+        )
+    }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -87,6 +87,7 @@ class NdkUploadTasksRegistration(
             task.compressedSharedObjectFilesDirectory.set(
                 compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory }
             )
+            task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
             task.architecturesToHashedSharedObjectFilesMap.set(
                 project.layout.buildDirectory.file("intermediates/embrace/hashes/${data.name}/hashes.json")
             )


### PR DESCRIPTION
Use a custom property to enable and disable the task in tests.