### PR TITLE
Use failBuildOnUploadTask in InjectSharedObjectFilesTask

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/inject-shared-object-files/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/inject-shared-object-files/build.gradle
@@ -6,9 +6,11 @@ plugins {
     id("io.embrace.android.testplugin")
 }
 
+def failBuildOnUploadErrors = (project.findProperty("failBuildOnUploadErrors") ?: "true").toBoolean()
+
 project.tasks.register("testTask", InjectSharedObjectFilesTask) { task ->
     integrationTest.configureEmbraceTask(task)
-    task.failBuildOnUploadErrors.set(true)
+    task.failBuildOnUploadErrors.set(failBuildOnUploadErrors)
     task.generatedEmbraceResourcesDirectory.set(
             project.layout.buildDirectory.dir("generated-embrace-resources")
     )

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/InjectSharedObjectFilesTaskIntegrationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/InjectSharedObjectFilesTaskIntegrationTest.kt
@@ -39,4 +39,18 @@ class InjectSharedObjectFilesTaskIntegrationTest {
             }
         )
     }
+
+    @Test
+    fun `don't throw an error when failBuildOnUploadErrors is disabled`() {
+        rule.runTest(
+            fixture = "inject-shared-object-files",
+            additionalArgs = listOf("-PfailBuildOnUploadErrors=false"),
+            setup = { projectDir ->
+                projectDir.file("architecturesMap.json").writeText("invalid json")
+            },
+            assertions = {
+                verifyNoUploads()
+            }
+        )
+    }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/CompressSharedObjectFilesTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/CompressSharedObjectFilesTask.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin.tasks.ndk
 
+import io.embrace.android.gradle.plugin.Logger
 import io.embrace.android.gradle.plugin.tasks.EmbraceTaskImpl
 import io.embrace.android.gradle.plugin.util.compression.ZstdFileCompressor
 import org.gradle.api.file.DirectoryProperty
@@ -23,6 +24,7 @@ abstract class CompressSharedObjectFilesTask @Inject constructor(
 ) : EmbraceTaskImpl(objectFactory) {
 
     private val compressor = ZstdFileCompressor()
+    private val logger = Logger(CompressSharedObjectFilesTask::class.java)
 
     @get:InputDirectory
     @get:SkipWhenEmpty
@@ -45,7 +47,7 @@ abstract class CompressSharedObjectFilesTask @Inject constructor(
                     compressSharedObjectFiles(archDir)
                 }
         } catch (exception: Exception) {
-            logger.error(exception.message)
+            logger.error("An error has occurred while compressing shared object files", exception)
             if (failBuildOnUploadErrors.get()) {
                 throw exception
             }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/HashSharedObjectFilesTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/HashSharedObjectFilesTask.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin.tasks.ndk
 
+import io.embrace.android.gradle.plugin.Logger
 import io.embrace.android.gradle.plugin.hash.calculateSha1ForFile
 import io.embrace.android.gradle.plugin.tasks.EmbraceTaskImpl
 import io.embrace.android.gradle.plugin.util.serialization.MoshiSerializer
@@ -25,6 +26,7 @@ abstract class HashSharedObjectFilesTask @Inject constructor(
 ) : EmbraceTaskImpl(objectFactory) {
 
     private val serializer = MoshiSerializer()
+    private val logger = Logger(HashSharedObjectFilesTask::class.java)
 
     @get:InputDirectory
     @get:SkipWhenEmpty
@@ -46,7 +48,7 @@ abstract class HashSharedObjectFilesTask @Inject constructor(
                 serializer.toJson(serializableMap, ArchitecturesToHashedSharedObjectFilesMap::class.java, outputStream)
             }
         } catch (exception: Exception) {
-            logger.error(exception.message)
+            logger.error("An error has occurred while hashing shared object files", exception)
             if (failBuildOnUploadErrors.get()) {
                 throw exception
             }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/InjectSharedObjectFilesTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/InjectSharedObjectFilesTask.kt
@@ -47,8 +47,15 @@ abstract class InjectSharedObjectFilesTask @Inject constructor(
 
     @TaskAction
     fun onRun() {
-        architecturesToHashedSharedObjectFilesMap = getArchToFilenameToHashMap()
-        injectSymbolsAsResources()
+        try {
+            architecturesToHashedSharedObjectFilesMap = getArchToFilenameToHashMap()
+            injectSymbolsAsResources()
+        } catch (exception: Exception) {
+            logger.error("An error has occurred while injecting shared object files", exception)
+            if (failBuildOnUploadErrors.get()) {
+                throw exception
+            }
+        }
     }
 
     private fun getArchToFilenameToHashMap() = try {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/UploadSharedObjectFilesTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/UploadSharedObjectFilesTask.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin.tasks.ndk
 
+import io.embrace.android.gradle.plugin.Logger
 import io.embrace.android.gradle.plugin.network.OkHttpNetworkService
 import io.embrace.android.gradle.plugin.tasks.EmbraceUploadTask
 import io.embrace.android.gradle.plugin.tasks.EmbraceUploadTaskImpl
@@ -34,6 +35,7 @@ abstract class UploadSharedObjectFilesTask @Inject constructor(
 ) : EmbraceUploadTask, EmbraceUploadTaskImpl(objectFactory) {
 
     private val serializer = MoshiSerializer()
+    private val logger = Logger(UploadSharedObjectFilesTask::class.java)
 
     @get:Input
     val failBuildOnUploadErrors: Property<Boolean> = objectFactory.property(Boolean::class.java)
@@ -60,7 +62,7 @@ abstract class UploadSharedObjectFilesTask @Inject constructor(
             val foundRequestedSharedObjectFiles = findRequestedSharedObjectFiles(requestedSharedObjectFiles)
             uploadSharedObjectFiles(foundRequestedSharedObjectFiles)
         } catch (exception: Exception) {
-            logger.error(exception.message)
+            logger.error("An error has occurred while uploading shared object files", exception)
             if (failBuildOnUploadErrors.get()) {
                 throw exception
             }


### PR DESCRIPTION
## Goal

Use a custom property to enable and disable the task in tests.

Also used correct logging class in all of the upload classes.