### PR TITLE
Update instrumented-config json files to account for new OTelLimitsConfig fields

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-default.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-default.json
@@ -121,6 +121,9 @@
           "signature": "getMaxCustomEventCount()I"
         },
         {
+          "signature": "getMaxCustomLinkCount()I"
+        },
+        {
           "signature": "getMaxInternalAttributeKeyLength()I"
         },
         {
@@ -133,10 +136,13 @@
           "signature": "getMaxNameLength()I"
         },
         {
-          "signature": "getMaxTotalAttributeCount()I"
+          "signature": "getMaxSystemAttributeCount()I"
         },
         {
-          "signature": "getMaxTotalEventCount()I"
+          "signature": "getMaxSystemEventCount()I"
+        },
+        {
+          "signature": "getMaxSystemLinkCount()I"
         }
       ]
     },

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-overrides.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-overrides.json
@@ -150,6 +150,9 @@
           "signature": "getMaxCustomEventCount()I"
         },
         {
+          "signature": "getMaxCustomLinkCount()I"
+        },
+        {
           "signature": "getMaxInternalAttributeKeyLength()I"
         },
         {
@@ -162,10 +165,13 @@
           "signature": "getMaxNameLength()I"
         },
         {
-          "signature": "getMaxTotalAttributeCount()I"
+          "signature": "getMaxSystemAttributeCount()I"
         },
         {
-          "signature": "getMaxTotalEventCount()I"
+          "signature": "getMaxSystemEventCount()I"
+        },
+        {
+          "signature": "getMaxSystemLinkCount()I"
         }
       ]
     },


### PR DESCRIPTION
## Goal

New fields were added to OTelLimitsConfig, so I added them to the instrumented-config json files in the order they get parsed in the tests. 

I'm not sure why the tests weren't broken in CI though.