### PR TITLE
Create AsmTaskRegistration to register the ASM task in the same way as the rest of the tasks

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -12,7 +12,6 @@ import io.embrace.android.gradle.plugin.config.PluginBehaviorImpl
 import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurationBuilder
 import io.embrace.android.gradle.plugin.gradle.getProperty
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
-import io.embrace.android.gradle.plugin.instrumentation.registerAsmTasks
 import io.embrace.android.gradle.plugin.tasks.registration.TaskRegistrar
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import org.gradle.api.Project
@@ -42,9 +41,6 @@ class EmbraceGradlePluginDelegate {
             behavior,
             agpWrapper
         )
-
-        // bytecode instrumentation must be registered before project evaluation
-        registerAsmTasks(project, behavior, variantConfigurationsListProperty)
 
         val embraceVariantConfigurationBuilder =
             EmbraceVariantConfigurationBuilder(

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -9,6 +9,7 @@ import io.embrace.android.gradle.plugin.config.UnitySymbolsDir
 import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurationBuilder
 import io.embrace.android.gradle.plugin.dependency.installDependenciesForVariant
 import io.embrace.android.gradle.plugin.gradle.GradleCompatibilityHelper
+import io.embrace.android.gradle.plugin.instrumentation.AsmTaskRegistration
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
 import io.embrace.android.gradle.plugin.tasks.il2cpp.Il2CppUploadTaskRegistration
@@ -74,6 +75,7 @@ class TaskRegistrar(
         if (behavior.isIl2CppMappingFilesUploadEnabled) {
             Il2CppUploadTaskRegistration().register(params)
         }
+        AsmTaskRegistration().register(params)
     }
 
     private fun shouldRegisterUploadTasks(


### PR DESCRIPTION
- Removed the old AsmTasks class. 
- Altered the order in which the tasks run overall. Now ASM will be done last. This will be used to plug the output of the Injection task as an input of the ASM one.