### PR TITLE
Make ASM task depend on EncodeSharedObjectFilesTask if it exists

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/TaskRegistrationUtils.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/TaskRegistrationUtils.kt
@@ -3,8 +3,6 @@ package io.embrace.android.gradle.plugin.gradle
 import io.embrace.android.gradle.plugin.util.capitalizedString
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.UnknownDomainObjectException
-import org.gradle.api.UnknownTaskException
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 
@@ -30,17 +28,20 @@ fun isTaskRegistered(taskProvider: TaskProvider<Task>?) = taskProvider != null
  * It returns task provider for given taskName without realizing the task.
  */
 fun Project.tryGetTaskProvider(taskName: String): TaskProvider<Task>? {
-    logger.debug("Will try to get TaskProvider for taskName=$taskName")
     return try {
-        val task = tasks.named(taskName)
-        logger.debug("TaskProvider obtained with name=${task.name}")
-
-        task
-    } catch (e: UnknownDomainObjectException) {
-        logger.debug("Task provider not found")
+        tasks.named(taskName)
+    } catch (e: Exception) {
         null
-    } catch (e: UnknownTaskException) {
-        logger.debug("Task provider not found")
+    }
+}
+
+/**
+ * Returns a task provider for given taskName and type without realizing the task.
+ */
+fun <T : Task> Project.tryGetTaskProvider(taskName: String, taskType: Class<T>): TaskProvider<T>? {
+    return try {
+        tasks.named(taskName, taskType)
+    } catch (e: Exception) {
         null
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -2,8 +2,12 @@ package io.embrace.android.gradle.plugin.instrumentation
 
 import com.android.build.api.instrumentation.FramesComputationMode
 import com.android.build.api.instrumentation.InstrumentationScope
+import io.embrace.android.gradle.plugin.gradle.nullSafeMap
+import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
+import io.embrace.android.gradle.plugin.tasks.ndk.EncodeSharedObjectFilesTask
 import io.embrace.android.gradle.plugin.tasks.registration.EmbraceTaskRegistration
 import io.embrace.android.gradle.plugin.tasks.registration.RegistrationParams
+import io.embrace.android.gradle.plugin.util.capitalizedString
 
 class AsmTaskRegistration : EmbraceTaskRegistration {
     override fun register(params: RegistrationParams) {
@@ -22,6 +26,7 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                         variantConfigs.first { it.variantName == variant.name }
                     }
                 )
+                // TODO: why are we passing disabled to ASM, if we could just not use transformClassesWith if behavior is disabled?
                 params.disabled.set(
                     project.provider {
                         behavior.isPluginDisabledForVariant(variant.name) || behavior.isInstrumentationDisabledForVariant(variant.name)
@@ -35,6 +40,28 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                 params.shouldInstrumentOkHttp.set(behavior.instrumentation.okHttpEnabled)
                 params.shouldInstrumentOnLongClick.set(behavior.instrumentation.onLongClickEnabled)
                 params.shouldInstrumentOnClick.set(behavior.instrumentation.onClickEnabled)
+
+                // Find the Asm transformation task by name and make it depend on encodeSharedObjectFilesTask
+                val encodeSharedObjectFilesTask = project.tryGetTaskProvider(
+                    "${EncodeSharedObjectFilesTask.NAME}${data.name.capitalizedString()}",
+                    EncodeSharedObjectFilesTask::class.java
+                ) ?: return@transformClassesWith
+
+                val asmTransformationTask = project.tryGetTaskProvider(
+                    "transform${variant.name.capitalizedString()}ClassesWithAsm"
+                ) ?: error("Unable to find ASM transformation task for variant ${variant.name}")
+
+                asmTransformationTask.configure { it.dependsOn(encodeSharedObjectFilesTask) }
+
+                params.encodedSharedObjectFilesMap.set(
+                    encodeSharedObjectFilesTask.nullSafeMap { task ->
+                        task.encodedSharedObjectFilesMap.asFile.orNull?.let { file ->
+                            file.takeIf { it.exists() }
+                                ?.bufferedReader()
+                                ?.use { it.readText() }
+                        }
+                    }
+                )
             }
         } catch (exception: Exception) {
             project.logger.error("An error has occurred while performing ASM bytecode transformation.", exception)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
@@ -4,6 +4,7 @@ import com.android.build.api.instrumentation.InstrumentationParameters
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 /**
  * Contains parameters that affect how bytecode is manipulated during instrumentation.
@@ -19,6 +20,13 @@ interface BytecodeInstrumentationParams : InstrumentationParameters {
      */
     @get:Input
     val config: Property<VariantConfig>
+
+    /**
+     * Base64 encoded string of the shared object files map to be injected in the SDK.
+     */
+    @get:Optional
+    @get:Input
+    val encodedSharedObjectFilesMap: Property<String>
 
     /**
      * Whether or not the plugin should operate for this variant.

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -24,6 +24,8 @@ class TestBytecodeInstrumentationParams(
         DefaultProperty(PropertyHost.NO_OP, VariantConfig::class.javaObjectType).convention(
             VariantConfig("", "", null, null, null, null)
         )
+    override val encodedSharedObjectFilesMap: Property<String> =
+        DefaultProperty(PropertyHost.NO_OP, String::class.javaObjectType).convention("")
     override val disabled: Property<Boolean> =
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(disabled)
     override val classInstrumentationFilter: Property<ClassInstrumentationFilter> =


### PR DESCRIPTION
- Add an encodedSharedObjectFilesMap property to the params passed to ASM.
- Add a tryGetTaskProvider with class information.
- If the encodeSharedObjectFilesTask is found, make the asmTransformationTask depend on it, and wire the encodedSharedObjectFilesMap properties.

The build will fail if the encodeSharedObjectFilesTask is found but the asmTransformationTask is not, because symbols won't be injected as they should.

We are currently not using failBuildOnUploadTask on configuration time, but we should review this in the future. 