### PR TITLE
Use the new EncodeMapTask output in the SDK and stop using resources

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImpl.kt
@@ -38,7 +38,6 @@ internal class NativeCoreModuleImpl(
 
     override val symbolService: SymbolService by singleton {
         symbolServiceProvider() ?: SymbolServiceImpl(
-            coreModule.context,
             payloadSourceModule.deviceArchitecture,
             initModule.jsonSerializer,
             initModule.logger

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/symbols/SymbolServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/symbols/SymbolServiceImpl.kt
@@ -1,19 +1,19 @@
 package io.embrace.android.embracesdk.internal.ndk.symbols
 
-import android.annotation.SuppressLint
-import android.content.Context
 import android.util.Base64
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.NativeSymbols
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 
 class SymbolServiceImpl(
-    private val context: Context,
     private val deviceArchitecture: DeviceArchitecture,
     private val serializer: PlatformSerializer,
     private val logger: EmbLogger,
+    private val instrumentedConfig: InstrumentedConfig = InstrumentedConfigImpl,
 ) : SymbolService {
 
     override val symbolsForCurrentArch: Map<String, String>? by lazy {
@@ -34,30 +34,19 @@ class SymbolServiceImpl(
         }
     }
 
-    @SuppressLint("DiscouragedApi")
     private fun getNativeSymbols(): NativeSymbols? {
-        val resources = context.resources
-        val resourceId = resources.getIdentifier(KEY_NDK_SYMBOLS, "string", context.packageName)
-        if (resourceId != 0) {
-            try {
-                val encodedSymbols: String = Base64.decode(
-                    context.resources.getString(resourceId),
-                    Base64.DEFAULT
-                ).decodeToString()
-                return serializer.fromJson(encodedSymbols, NativeSymbols::class.java)
-            } catch (ex: Exception) {
-                logger.trackInternalError(InternalErrorType.INVALID_NATIVE_SYMBOLS, ex)
-            }
+        try {
+            val encodedSymbols = instrumentedConfig.symbols.getBase64SharedObjectFilesMap() ?: return null
+            val decodedSymbols: String = Base64.decode(encodedSymbols, Base64.DEFAULT).decodeToString()
+            return serializer.fromJson(decodedSymbols, NativeSymbols::class.java)
+        } catch (ex: Exception) {
+            logger.trackInternalError(InternalErrorType.INVALID_NATIVE_SYMBOLS, ex)
         }
+
         return null
     }
 
     private companion object {
-
-        /**
-         * The NDK symbols name that matches with the resource name injected by the plugin.
-         */
-        private const val KEY_NDK_SYMBOLS = "emb_ndk_symbols"
         private const val ARM_ABI_V7_NAME = "armeabi-v7a"
         private const val ARM_64_NAME = "arm64-v8a"
         private const val ARCH_X86_NAME = "x86"

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/ndk/symbols/SymbolServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/ndk/symbols/SymbolServiceImplTest.kt
@@ -1,28 +1,21 @@
 package io.embrace.android.embracesdk.internal.ndk.symbols
 
-import android.content.Context
-import android.content.res.Resources
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeDeviceArchitecture
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.fakes.config.FakeBase64SharedObjectFilesMap
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.payload.NativeSymbols
-import io.mockk.every
-import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 
+// Needed for android.util.Base64
 @RunWith(AndroidJUnit4::class)
 class SymbolServiceImplTest {
-
-    private companion object {
-        private const val PACKAGE_NAME = "com.example.app"
-        private const val SYMBOL_RES_ID = "emb_ndk_symbols"
-        private const val RES_INT_VALUE = 1602934923
-    }
 
     private val symbolMap = mapOf(
         "armeabi-v7a" to mapOf("symbol" to "armeabi-v7a-value"),
@@ -31,11 +24,13 @@ class SymbolServiceImplTest {
         "x86_64" to mapOf("symbol" to "x86_64-value")
     )
 
+    private val serializer = TestPlatformSerializer()
+
     private val limitedMap = symbolMap.filter { it.key != "arm64-v8a" }
 
     @Test
     fun `missing symbols`() {
-        val service = createService(symbolMap, resId = 0)
+        val service = createServiceWithNullSymbols()
         assertNull(service.symbolsForCurrentArch)
     }
 
@@ -66,26 +61,24 @@ class SymbolServiceImplTest {
     private fun createService(
         symbolMap: Map<String, Map<String, String>>,
         arch: String = "arm64-v8a",
-        resId: Int = RES_INT_VALUE,
     ): SymbolService {
-        val res = mockk<Resources>(relaxed = true)
-        val ctx = mockk<Context>(relaxed = true) {
-            every { packageName } returns PACKAGE_NAME
-            every { resources } returns res
-        }
-
-        val serializer = TestPlatformSerializer()
         val json = serializer.toJson(NativeSymbols(symbols = symbolMap))
         val encodedSymbols = Base64.encodeToString(json.toByteArray(), Base64.DEFAULT)
 
-        every { res.getIdentifier(SYMBOL_RES_ID, "string", PACKAGE_NAME) } returns resId
-        every { res.getString(resId) } returns encodedSymbols
-
         return SymbolServiceImpl(
-            ctx,
             FakeDeviceArchitecture(arch),
             serializer,
-            FakeEmbLogger()
+            FakeEmbLogger(),
+            FakeInstrumentedConfig(symbols = FakeBase64SharedObjectFilesMap(encodedSymbols)),
+        )
+    }
+
+    private fun createServiceWithNullSymbols(): SymbolService {
+        return SymbolServiceImpl(
+            FakeDeviceArchitecture("arm64-v8a"),
+            serializer,
+            FakeEmbLogger(),
+            FakeInstrumentedConfig(symbols = FakeBase64SharedObjectFilesMap(null)),
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id("com.android.application")
+    id("io.embrace.swazzler")
+    id("io.embrace.android.testplugin")
+}
+
+integrationTest.configureAndroidProject(project)
+
+repositories {
+    google()
+    mavenCentral()
+    mavenLocal()
+}
+
+embrace {
+    autoAddEmbraceDependencies.set(true)
+}
+
+android {
+    externalNativeBuild {
+        cmake {
+            path("src/main/cpp/CMakeLists.txt")
+        }
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/AndroidManifest.xml
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/cpp/CMakeLists.txt
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+add_library(
+        emb-crisps
+        SHARED
+        crisps.c
+)
+
+add_library(
+        emb-donuts
+        SHARED
+        donuts.c
+)

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/cpp/crisps.c
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/cpp/crisps.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int foo() {
+    return 2;
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/cpp/donuts.c
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/cpp/donuts.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int bar() {
+    return 2;
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/embrace-config.json
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/embrace-config.json
@@ -1,0 +1,5 @@
+{
+  "app_id": "abcde",
+  "api_token": "12345123451234512345123451234512",
+  "ndk_enabled": true
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/java/com/example/app/Bar.java
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/java/com/example/app/Bar.java
@@ -1,0 +1,7 @@
+package com.example.app;
+
+public class Bar {
+    public static String getBar() {
+        return "bar";
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/java/com/example/app/Foo.java
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-cmake-with-code/src/main/java/com/example/app/Foo.java
@@ -1,0 +1,7 @@
+package com.example.app;
+
+public class Foo {
+    public static String getFoo() {
+        return "foo";
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppTaskSource.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppTaskSource.kt
@@ -2,7 +2,7 @@ package io.embrace.android.gradle.plugin.tasks.il2cpp
 
 import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
-import io.embrace.android.gradle.plugin.tasks.ndk.InjectSharedObjectFilesTask
+import io.embrace.android.gradle.plugin.tasks.ndk.EncodeSharedObjectFilesTask
 import io.embrace.android.gradle.plugin.util.capitalizedString
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -14,7 +14,7 @@ import org.gradle.api.tasks.TaskProvider
  */
 class Il2CppTaskSource {
     fun fetchTask(project: Project, variant: AndroidCompactedVariantData): TaskProvider<Task>? {
-        val taskName = "${InjectSharedObjectFilesTask.NAME}${variant.name.capitalizedString()}"
+        val taskName = "${EncodeSharedObjectFilesTask.NAME}${variant.name.capitalizedString()}"
         return project.tryGetTaskProvider(taskName)
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -20,8 +20,6 @@ import org.gradle.api.provider.Provider
 import java.io.File
 import java.util.concurrent.Callable
 
-private const val GENERATED_RESOURCE_PATH = "generated/embrace/res"
-
 /**
  * In charge of registering tasks for ndk mapping file upload and injection.
  */
@@ -126,9 +124,9 @@ class NdkUploadTasksRegistration(
             )
         }
 
-        val injectSharedObjectFilesTaskProvider = project.registerTask(
-            InjectSharedObjectFilesTask.NAME,
-            InjectSharedObjectFilesTask::class.java,
+        project.registerTask(
+            EncodeSharedObjectFilesTask.NAME,
+            EncodeSharedObjectFilesTask::class.java,
             data
         ) { task ->
             // TODO: Check why this is needed for 7.5.1. For Gradle 8+ Gradle detects automatically when the other tasks aren't executed
@@ -140,18 +138,11 @@ class NdkUploadTasksRegistration(
 
             task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
 
-            task.generatedEmbraceResourcesDirectory.set(
-                project.layout.buildDirectory.dir("$GENERATED_RESOURCE_PATH/${data.name}/ndk")
+            task.encodedSharedObjectFilesMap.set(
+                project.layout.buildDirectory.file("intermediates/embrace/ndk/${data.name}/encoded_map.txt")
             )
 
             task.dependsOn(uploadTask)
-        }
-
-        injectSharedObjectFilesTaskProvider.let {
-            variant.sources.res?.addGeneratedSourceDirectory(
-                it,
-                InjectSharedObjectFilesTask::generatedEmbraceResourcesDirectory
-            )
         }
     }
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
@@ -15,8 +15,8 @@ import io.embrace.android.gradle.plugin.instrumentation.config.model.UnityConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
 import io.embrace.android.gradle.plugin.tasks.ndk.CompressSharedObjectFilesTask
+import io.embrace.android.gradle.plugin.tasks.ndk.EncodeSharedObjectFilesTask
 import io.embrace.android.gradle.plugin.tasks.ndk.HashSharedObjectFilesTask
-import io.embrace.android.gradle.plugin.tasks.ndk.InjectSharedObjectFilesTask
 import io.embrace.android.gradle.plugin.tasks.ndk.NdkUploadTasksRegistration
 import io.embrace.android.gradle.plugin.tasks.ndk.UploadSharedObjectFilesTask
 import io.embrace.android.gradle.plugin.tasks.registration.RegistrationParams
@@ -115,7 +115,7 @@ class NdkUploadTasksRegistrationTest {
         assertTaskNotRegistered(CompressSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
         assertTaskNotRegistered(HashSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
         assertTaskNotRegistered(UploadSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
-        assertTaskNotRegistered(InjectSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
+        assertTaskNotRegistered(EncodeSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
     }
 
     @Test
@@ -144,10 +144,10 @@ class NdkUploadTasksRegistrationTest {
         assertFalse(uploadTask.onlyIf.isSatisfiedBy(uploadTask))
 
         // The injection task should not run
-        val injectionTask = project.tasks.findByName(
-            "${InjectSharedObjectFilesTask.NAME}${testAndroidCompactedVariantData.name.capitalizedString()}"
-        ) as InjectSharedObjectFilesTask
-        assertFalse(injectionTask.onlyIf.isSatisfiedBy(injectionTask))
+        val encodingTask = project.tasks.findByName(
+            "${EncodeSharedObjectFilesTask.NAME}${testAndroidCompactedVariantData.name.capitalizedString()}"
+        ) as EncodeSharedObjectFilesTask
+        assertFalse(encodingTask.onlyIf.isSatisfiedBy(encodingTask))
     }
 
     @Test
@@ -184,7 +184,7 @@ class NdkUploadTasksRegistrationTest {
         assertTaskRegistered(CompressSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
         assertTaskRegistered(HashSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
         assertTaskRegistered(UploadSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
-        assertTaskRegistered(InjectSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
+        assertTaskRegistered(EncodeSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
     }
 
     // TODO: Do all Unity projects have a mergeNativeLibs task?

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeBase64SharedObjectFilesMap.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeBase64SharedObjectFilesMap.kt
@@ -2,4 +2,8 @@ package io.embrace.android.embracesdk.fakes.config
 
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.Base64SharedObjectFilesMap
 
-class FakeBase64SharedObjectFilesMap : Base64SharedObjectFilesMap
+class FakeBase64SharedObjectFilesMap(private val symbols: String?) : Base64SharedObjectFilesMap {
+    override fun getBase64SharedObjectFilesMap(): String? {
+        return symbols
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
@@ -21,5 +21,6 @@ data class FakeInstrumentedConfig(
     override val project: ProjectConfig = FakeProjectConfig(base.project, appId = "abcde"),
     override val redaction: RedactionConfig = FakeRedactionConfig(base.redaction),
     override val session: SessionConfig = FakeSessionConfig(base.session),
-    override val symbols: Base64SharedObjectFilesMap = FakeBase64SharedObjectFilesMap(),
+    override val symbols: Base64SharedObjectFilesMap =
+        FakeBase64SharedObjectFilesMap(base.symbols.getBase64SharedObjectFilesMap()),
 ) : InstrumentedConfig


### PR DESCRIPTION
I tried to keep this small but I had to replace many parts at once so it doesn't stop working.

- Stop looking into resources in the SDK, fetch symbols from the new instrumentedConfig field.
- Update SymbolService tests to verify behavior of the new injected symbols.
- Use project.afterEvaluate in AsmTaskRegistration to ensure that the AsmTask is found.
- Register EncodeSharedObjectFilesTask instead of InjectSharedObjectFilesTask (will remove this one in a following PR).
- Modify AndroidNdkTest: Now we're disassembling the apk and parsing the Smali to ensure the map is injected as expected. Removed resources verification.