### PR TITLE
Add auto start instrumentation

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -1,3 +1,7 @@
+public final class io/embrace/android/embracesdk/AutoStartInstrumentationHook {
+	public static fun _preOnCreate (Landroid/app/Application;)V
+}
+
 public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/embracesdk/internal/api/SdkApi {
 	public static final field Companion Lio/embrace/android/embracesdk/Embrace$Companion;
 	public fun activityLoaded (Landroid/app/Activity;)V

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -50,6 +50,7 @@
 ## Keep gradle plugin hooks
 -keep class io.embrace.android.embracesdk.okhttp3.** { *; }
 -keep class io.embrace.android.embracesdk.ViewSwazzledHooks { *; }
+-keep class io.embrace.android.embracesdk.AutoStartInstrumentationHook { *; }
 -keep class io.embrace.android.embracesdk.WebViewClientSwazzledHooks { *; }
 -keep class io.embrace.android.embracesdk.WebViewChromeClientSwazzledHooks { *; }
 -keep class io.embrace.android.embracesdk.fcm.swazzle.callback.com.android.fcm.FirebaseSwazzledHooks { *; }

--- a/embrace-android-sdk/lint-baseline.xml
+++ b/embrace-android-sdk/lint-baseline.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.7.3" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.3)" variant="all" version="8.7.3">
+<issues format="6" by="lint 8.9.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.1)" variant="all" version="8.9.1">
+
+    <issue
+        id="EmbracePublicApiPackageRule"
+        message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
+        errorLine1="public final class AutoStartInstrumentationHook {"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/io/embrace/android/embracesdk/AutoStartInstrumentationHook.java"
+            line="12"
+            column="20"/>
+    </issue>
 
     <issue
         id="EmbracePublicApiPackageRule"
@@ -65,6 +76,17 @@
             file="src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java"
             line="66"
             column="88"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://developer.android.com/kotlin/interop#nullability_annotations"
+        errorLine1="    public static void _preOnCreate(android.app.Application application) {"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/io/embrace/android/embracesdk/AutoStartInstrumentationHook.java"
+            line="17"
+            column="37"/>
     </issue>
 
     <issue

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/AutoStartInstrumentationHook.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/AutoStartInstrumentationHook.java
@@ -1,0 +1,28 @@
+package io.embrace.android.embracesdk;
+
+import androidx.annotation.NonNull;
+
+import io.embrace.android.embracesdk.annotation.InternalApi;
+import io.embrace.android.embracesdk.internal.EmbraceInternalApi;
+
+/**
+ * @hide
+ */
+@InternalApi
+public final class AutoStartInstrumentationHook {
+
+    private AutoStartInstrumentationHook() {
+    }
+
+    public static void _preOnCreate(android.app.Application application) {
+        try {
+            Embrace.getInstance().start(application);
+        } catch (Exception exception) {
+            logError(exception);
+        }
+    }
+
+    private static void logError(@NonNull Throwable throwable) {
+        EmbraceInternalApi.getInstance().getInternalInterface().logInternalError(throwable);
+    }
+}

--- a/embrace-bytecode-instrumentation-tests/src/main/java/io/embrace/test/fixtures/TestApplication.kt
+++ b/embrace-bytecode-instrumentation-tests/src/main/java/io/embrace/test/fixtures/TestApplication.kt
@@ -1,0 +1,9 @@
+package io.embrace.test.fixtures
+
+import android.app.Application
+
+class TestApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+    }
+}

--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/InstrumentedBytecodeTestCases.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/InstrumentedBytecodeTestCases.kt
@@ -1,5 +1,6 @@
 package io.embrace.gradle.plugin.instrumentation
 
+import io.embrace.android.gradle.plugin.instrumentation.visitor.ApplicationClassAdapter
 import io.embrace.android.gradle.plugin.instrumentation.visitor.OkHttpClassAdapter
 import io.embrace.android.gradle.plugin.instrumentation.visitor.OnClickClassAdapter
 import io.embrace.android.gradle.plugin.instrumentation.visitor.OnLongClickClassAdapter
@@ -27,6 +28,7 @@ import io.embrace.test.fixtures.MissingInterfaceOnLongClickListener
 import io.embrace.test.fixtures.MissingOverrideOnClickListener
 import io.embrace.test.fixtures.MissingOverrideOnLongClickListener
 import io.embrace.test.fixtures.NoOverrideWebViewClient
+import io.embrace.test.fixtures.TestApplication
 import io.embrace.test.fixtures.VirtualMethodRefNamedOnClick
 import okhttp3.OkHttpClient
 import org.objectweb.asm.ClassVisitor
@@ -47,6 +49,10 @@ private val okHttpFactory: ClassVisitorFactory = { visitor ->
     OkHttpClassAdapter(ASM_API_VERSION, visitor) {}
 }
 
+private val applicationFactory: ClassVisitorFactory = { visitor ->
+    ApplicationClassAdapter(ASM_API_VERSION, visitor)
+}
+
 /**
  * Declares the test cases for bytecode in [InstrumentedBytecodeTest]. You should define the
  * input class, the expected output, and the [ClassVisitor] which will instrument the bytecode.
@@ -60,8 +66,15 @@ internal fun instrumentedBytecodeTestCases(): List<BytecodeTestParams> {
         .plus(onLongClickInnerTestCases)
         .plus(webclientTestCases)
         .plus(okHttpTestCases)
+        .plus(applicationTestCases)
         .distinct() // filter out any unintentional duplicate test cases
         .sortedBy(BytecodeTestParams::simpleClzName)
+}
+
+private val applicationTestCases = listOf(
+    TestApplication::class
+).map {
+    BytecodeTestParams(it.java, factory = applicationFactory)
 }
 
 private val okHttpTestCases = listOf(
@@ -69,6 +82,7 @@ private val okHttpTestCases = listOf(
 ).map {
     BytecodeTestParams(it.java, factory = okHttpFactory)
 }
+
 private val webclientTestCases = listOf(
     CustomWebViewClient::class,
     ExtendedCustomWebViewClient::class,

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/TestApplication_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/TestApplication_expected.txt
@@ -1,0 +1,36 @@
+// class version 55.0 (55)
+// access flags 0x31
+public final class io/embrace/test/fixtures/TestApplication extends android/app/Application {
+
+  // compiled from: TestApplication.kt
+
+  @Lkotlin/Metadata;(mv={1, 8, 0}, k=1, xi=48, d1={"\u0000\u0012\n\u0002\u0018\u0002\n\u0002\u0018\u0002\n\u0002\u0008\u0002\n\u0002\u0010\u0002\n\u0000\u0018\u00002\u00020\u0001B\u0005\u00a2\u0006\u0002\u0010\u0002J\u0008\u0010\u0003\u001a\u00020\u0004H\u0016\u00a8\u0006\u0005"}, d2={"Lio/embrace/test/fixtures/TestApplication;", "Landroid/app/Application;", "()V", "onCreate", "", "embrace-bytecode-instrumentation-tests_release"})
+
+  // access flags 0x1
+  public <init>()V
+   L0
+    LINENUMBER 5 L0
+    ALOAD 0
+    INVOKESPECIAL android/app/Application.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TestApplication; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x1
+  public onCreate()V
+    ALOAD 0
+    INVOKESTATIC io/embrace/android/embracesdk/AutoStartInstrumentationHook._preOnCreate (Landroid/app/Application;)V
+   L0
+    LINENUMBER 7 L0
+    ALOAD 0
+    INVOKESPECIAL android/app/Application.onCreate ()V
+   L1
+    LINENUMBER 8 L1
+    RETURN
+   L2
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TestApplication; L0 L2 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-instrumentation/src/main/kotlin/com/example/app/ApplicationFixture.kt
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-instrumentation/src/main/kotlin/com/example/app/ApplicationFixture.kt
@@ -1,0 +1,9 @@
+package com.example.app
+
+import android.app.Application
+
+class ApplicationFixture : Application() {
+    override fun onCreate() {
+
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/BytecodeInstrumentationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/BytecodeInstrumentationTest.kt
@@ -22,6 +22,7 @@ class BytecodeInstrumentationTest {
         "/com/example/app/OnLongClickListenerFixture",
         "/okhttp3/OkHttpClient\$Builder",
         "/com/example/app/FcmServiceFixture",
+        "/com/example/app/ApplicationFixture"
     )
     private val defaultArgs = listOf("-x", "lintVitalRelease")
 

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/bytecode-instrumentation-enabled.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/bytecode-instrumentation-enabled.json
@@ -45,6 +45,15 @@
           "embraceHook": "invoke-static {p1}, Lio/embrace/android/embracesdk/fcm/swazzle/callback/com/android/fcm/FirebaseSwazzledHooks;->_onMessageReceived(Lcom/google/firebase/messaging/RemoteMessage;)V"
         }
       ]
+    },
+    {
+      "className": "ApplicationFixture",
+      "methods": [
+        {
+          "signature": "onCreate()V",
+          "embraceHook": "invoke-static {p0}, Lio/embrace/android/embracesdk/AutoStartInstrumentationHook;->_preOnCreate(Landroid/app/Application;)V"
+        }
+      ]
     }
   ]
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
@@ -43,6 +43,11 @@ abstract class EmbraceBytecodeInstrumentation @Inject internal constructor(objec
         objectFactory.property(Boolean::class.java)
 
     /**
+     * Whether Embrace should automatically start in the Application class. Defaults to true.
+     */
+    val autoStartEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
+
+    /**
      * A list of string patterns that are used to filter classes during bytecode instrumentation. For example, 'com.example.foo.*'
      * would avoid instrumenting any classes in the 'com.example.foo' package.
      *

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
@@ -31,4 +31,6 @@ interface InstrumentationBehavior {
      * A list of string regexes that are used to filter classes during bytecode instrumentation
      */
     val ignoredClasses: List<String>
+
+    val autoStartEnabled: Boolean
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
@@ -41,4 +41,8 @@ class InstrumentationBehaviorImpl(
     override val ignoredClasses: List<String> by lazy {
         instrumentation.classIgnorePatterns.get().plus(extension.classSkipList.get())
     }
+
+    override val autoStartEnabled: Boolean by lazy {
+        enabled && (instrumentation.autoStartEnabled.orNull ?: true)
+    }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -39,6 +39,7 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                 params.shouldInstrumentOkHttp.set(behavior.instrumentation.okHttpEnabled)
                 params.shouldInstrumentOnLongClick.set(behavior.instrumentation.onLongClickEnabled)
                 params.shouldInstrumentOnClick.set(behavior.instrumentation.onClickEnabled)
+                params.shouldAutoStart.set(behavior.instrumentation.autoStartEnabled)
 
                 project.afterEvaluate {
                     // Find the Asm transformation task by name and make it depend on encodeSharedObjectFilesTask

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
@@ -55,4 +55,7 @@ interface BytecodeInstrumentationParams : InstrumentationParameters {
 
     @get:Input
     val shouldInstrumentOnClick: Property<Boolean>
+
+    @get:Input
+    val shouldAutoStart: Property<Boolean>
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryDelegate.kt
@@ -3,6 +3,7 @@ package io.embrace.android.gradle.plugin.instrumentation
 import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.InstrumentationContext
 import io.embrace.android.gradle.plugin.instrumentation.config.ConfigClassVisitorFactory
+import io.embrace.android.gradle.plugin.instrumentation.visitor.ApplicationClassAdapter
 import io.embrace.android.gradle.plugin.instrumentation.visitor.FirebaseMessagingServiceClassAdapter
 import io.embrace.android.gradle.plugin.instrumentation.visitor.OkHttpClassAdapter
 import io.embrace.android.gradle.plugin.instrumentation.visitor.OnClickClassAdapter
@@ -31,6 +32,11 @@ internal fun createClassVisitorImpl(
 
     // chain our own visitors to avoid unlikely (but possible) cases such as a custom
     // WebViewClient implementing an OnClickListener
+    if (parameters.get().shouldAutoStart.get() && ApplicationClassAdapter.accept(classContext)) {
+        visitor = ApplicationClassAdapter(api, visitor)
+        logger { "Added ApplicationClassAdapter for $className." }
+    }
+
     if (parameters.get().shouldInstrumentFirebaseMessaging.get() &&
         FirebaseMessagingServiceClassAdapter.accept(classContext)
     ) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
@@ -106,7 +106,13 @@ data class SdkLocalConfig(
     val appExitInfoConfig: AppExitInfoLocalConfig? = null,
 
     @Json(name = "app_framework")
-    val appFramework: String? = null
+    val appFramework: String? = null,
+
+    /**
+     * Whether auto-start instrumentation should be enabled or not
+     */
+    @Json(name = "auto_start")
+    val autoStart: Boolean? = null
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/ApplicationClassAdapter.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/ApplicationClassAdapter.kt
@@ -1,0 +1,37 @@
+package io.embrace.android.gradle.plugin.instrumentation.visitor
+
+import com.android.build.api.instrumentation.ClassContext
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+
+/**
+ * Visits the Application class and returns an [ApplicationMethodAdapter] for the onCreate method.
+ */
+class ApplicationClassAdapter(
+    api: Int,
+    nextClassVisitor: ClassVisitor?,
+) : ClassVisitor(api, nextClassVisitor) {
+
+    companion object : ClassVisitFilter {
+        private const val METHOD_NAME = "onCreate"
+        private const val METHOD_DESC = "()V"
+
+        override fun accept(classContext: ClassContext) = true
+    }
+
+    override fun visitMethod(
+        access: Int,
+        name: String,
+        desc: String,
+        signature: String?,
+        exceptions: Array<String>?
+    ): MethodVisitor? {
+        val nextMethodVisitor = super.visitMethod(access, name, desc, signature, exceptions)
+
+        return if (METHOD_NAME == name && METHOD_DESC == desc) {
+            ApplicationMethodAdapter(api, nextMethodVisitor)
+        } else {
+            nextMethodVisitor
+        }
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/ApplicationMethodAdapter.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/ApplicationMethodAdapter.kt
@@ -1,0 +1,29 @@
+package io.embrace.android.gradle.plugin.instrumentation.visitor
+
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Visits the onCreate method and inserts a call to AutoStartInstrumentationHook._preOnCreate at the very start
+ * of the method. This ensures that Embrace is started before any other initialization code runs.
+ */
+internal class ApplicationMethodAdapter(
+    api: Int,
+    methodVisitor: MethodVisitor?
+) : MethodVisitor(api, methodVisitor) {
+
+    override fun visitCode() {
+        // invoke AutoStartInstrumentationHook$Application._preOnCreate()
+        visitVarInsn(Opcodes.ALOAD, 0) // load 'this' onto the stack
+        visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            "io/embrace/android/embracesdk/AutoStartInstrumentationHook",
+            "_preOnCreate",
+            "(Landroid/app/Application;)V",
+            false
+        )
+
+        // call super last to reduce chance of interference with other bytecode instrumentation
+        super.visitCode()
+    }
+}

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -18,6 +18,7 @@ class TestBytecodeInstrumentationParams(
     instrumentOkHttp: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_OKHTTP,
     instrumentOnLongClick: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_ON_LONG_CLICK,
     instrumentOnClick: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_ON_CLICK,
+    shouldAutoStart: Boolean = false
 ) : BytecodeInstrumentationParams {
 
     override val config: Property<VariantConfig> =
@@ -42,4 +43,6 @@ class TestBytecodeInstrumentationParams(
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentOnLongClick)
     override val shouldInstrumentOnClick: Property<Boolean> =
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentOnClick)
+    override val shouldAutoStart: Property<Boolean> =
+        DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(shouldAutoStart)
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/visitor/ApplicationClassAdapterTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/visitor/ApplicationClassAdapterTest.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.gradle.plugin.instrumentation.visitor
+
+import io.embrace.android.gradle.plugin.instrumentation.ASM_API_VERSION
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.objectweb.asm.Opcodes
+
+class ApplicationClassAdapterTest {
+
+    private val adapter = ApplicationClassAdapter(ASM_API_VERSION, null)
+
+    @Test
+    fun testOnCreateVisited() {
+        val visitor = adapter.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "onCreate",
+            "()V",
+            null,
+            emptyArray()
+        )
+        assertTrue(visitor is ApplicationMethodAdapter)
+    }
+
+    @Test
+    fun testMethodNotVisited() {
+        var visitor = adapter.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "onCreate",
+            "(Landroid/content/Context;)V",
+            null,
+            emptyArray()
+        )
+        assertFalse(visitor is ApplicationMethodAdapter)
+
+        visitor = adapter.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "onStart",
+            "()V",
+            null,
+            emptyArray()
+        )
+        assertFalse(visitor is ApplicationMethodAdapter)
+    }
+}

--- a/embrace-test-fakes/lint-baseline.xml
+++ b/embrace-test-fakes/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.7.3" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.3)" variant="all" version="8.7.3">
+<issues format="6" by="lint 8.9.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.1)" variant="all" version="8.9.1">
 
     <issue
         id="StopShip"
@@ -8,18 +8,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="25"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="29"
+            line="19"
             column="9"/>
     </issue>
 
@@ -30,7 +19,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="33"
+            line="23"
             column="9"/>
     </issue>
 
@@ -41,7 +30,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="37"
+            line="27"
             column="9"/>
     </issue>
 
@@ -52,7 +41,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="41"
+            line="31"
             column="9"/>
     </issue>
 
@@ -63,182 +52,6 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="45"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="49"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
-            line="53"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="12"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="16"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="20"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="24"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="28"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="32"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="36"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="40"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCacheService.kt"
-            line="44"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
-            line="16"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
-            line="20"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
-            line="24"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
-            line="28"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
             line="35"
             column="9"/>
     </issue>
@@ -249,7 +62,18 @@
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
+            line="39"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
             line="43"
             column="9"/>
     </issue>
@@ -260,7 +84,7 @@
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeActivityTracker.kt"
             line="47"
             column="9"/>
     </issue>
@@ -271,8 +95,8 @@
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
-            line="51"
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
+            line="16"
             column="9"/>
     </issue>
 
@@ -282,8 +106,8 @@
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
-            line="55"
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
+            line="20"
             column="9"/>
     </issue>
 
@@ -293,8 +117,8 @@
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
-            line="59"
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
+            line="24"
             column="9"/>
     </issue>
 
@@ -304,8 +128,8 @@
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryCacheManager.kt"
-            line="66"
+            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt"
+            line="28"
             column="9"/>
     </issue>
 


### PR DESCRIPTION
## Goal
Add ASM instrumentation to start the Embrace SDK automatically. 

- Created AutoStartInstrumentationHook, which will be called from the instrumented code.
    - I decided to create this class instead of calling Embrace.start() directly, so the code goes through a different path. We could even add telemetry to log if the app was autostarted if we wanted to.
    - This class was added to the Embrace API like the rest of the hooks in the embracesdk package.
- Use ASM to insert a call to AutoStartInstrumentationHook._preOnCreate() in any onCreate method in any class that extends Application.
- Added a flag to disable auto start instrumentation, though it's turned on by default.

## Testing
Added a unit test, a InstrumentedBytecodeTestCase, and a BytecodeInstrumentationTest, similar to what we use to test other instrumentation.


