### PR TITLE
Use keep annotation for proguard

### DIFF
--- a/embrace-android-api/src/main/java/io/embrace/android/embracesdk/Severity.kt
+++ b/embrace-android-api/src/main/java/io/embrace/android/embracesdk/Severity.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk
 
+import androidx.annotation.Keep
+
 /**
  * The severity of the log message.
  */
+@Keep
 public enum class Severity {
 
     /**

--- a/embrace-android-api/src/main/java/io/embrace/android/embracesdk/network/EmbraceNetworkRequest.kt
+++ b/embrace-android-api/src/main/java/io/embrace/android/embracesdk/network/EmbraceNetworkRequest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.network
 
+import androidx.annotation.Keep
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import java.util.Locale
@@ -7,6 +8,7 @@ import java.util.Locale
 /**
  * This class is used to create manually-recorded network requests.
  */
+@Keep
 public class EmbraceNetworkRequest private constructor(
 
     /**

--- a/embrace-android-api/src/main/java/io/embrace/android/embracesdk/network/http/HttpMethod.kt
+++ b/embrace-android-api/src/main/java/io/embrace/android/embracesdk/network/http/HttpMethod.kt
@@ -1,11 +1,14 @@
 package io.embrace.android.embracesdk.network.http
 
+import androidx.annotation.Keep
+
 /**
  * Enumeration of supported HTTP request methods.
  *
  *
  * This class is part of the Embrace Public API.
  */
+@Keep
 public enum class HttpMethod {
     GET,
     HEAD,

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/ErrorCode.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/ErrorCode.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.spans
 
+import androidx.annotation.Keep
+
 /**
  * Categorize the broad reason a Span completed unsuccessfully.
  */
+@Keep
 public enum class ErrorCode {
     /**
      * An application failure caused the Span to terminate

--- a/embrace-android-core/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
+++ b/embrace-android-core/src/main/java/io/embrace/android/embracesdk/WebViewChromeClientSwazzledHooks.java
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk;
 
 import android.webkit.ConsoleMessage;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
@@ -10,6 +11,7 @@ import io.embrace.android.embracesdk.annotation.InternalApi;
  * @hide
  */
 @InternalApi
+@Keep
 public final class WebViewChromeClientSwazzledHooks {
 
     private WebViewChromeClientSwazzledHooks() {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/LogExceptionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/LogExceptionType.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk
 
+import androidx.annotation.Keep
+
 /**
  * Enum representing the type of exception that occurred.
  * NONE is for a native android log, whether have or not an exception.
@@ -7,6 +9,7 @@ package io.embrace.android.embracesdk
  *
  * @suppress
  */
+@Keep
 enum class LogExceptionType(val value: String) {
     NONE("none"),
     HANDLED("handled"),

--- a/embrace-android-fcm/src/main/java/io/embrace/android/embracesdk/fcm/swazzle/callback/com/android/fcm/FirebaseSwazzledHooks.java
+++ b/embrace-android-fcm/src/main/java/io/embrace/android/embracesdk/fcm/swazzle/callback/com/android/fcm/FirebaseSwazzledHooks.java
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fcm.swazzle.callback.com.android.fcm;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
 import com.google.firebase.messaging.RemoteMessage;
@@ -7,6 +8,7 @@ import com.google.firebase.messaging.RemoteMessage;
 import io.embrace.android.embracesdk.Embrace;
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi;
 
+@Keep
 public final class FirebaseSwazzledHooks {
 
     private FirebaseSwazzledHooks() {

--- a/embrace-android-payload/build.gradle.kts
+++ b/embrace-android-payload/build.gradle.kts
@@ -24,4 +24,6 @@ dependencies {
     testImplementation(libs.opentelemetry.sdk)
     testImplementation(libs.opentelemetry.semconv)
     testImplementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.lifecycle.runtime)
+    implementation(libs.lifecycle.process)
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/EmbraceInstrumented.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/EmbraceInstrumented.kt
@@ -1,6 +1,0 @@
-package io.embrace.android.embracesdk.internal.config.instrumented
-
-/**
- * Documentation that notes a class is instrumented by the embrace gradle plugin, or used in some other way.
- */
-annotation class EmbraceInstrumented

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/InstrumentedConfigImpl.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/InstrumentedConfigImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.config.instrumented
 
+import androidx.annotation.Keep
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.Base64SharedObjectFilesMap
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.BaseUrlConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.EnabledFeatureConfig
@@ -20,7 +21,7 @@ import io.embrace.android.embracesdk.internal.config.instrumented.schema.Session
  * (1) always use functions, as this is somewhat easier to instrument than Kotlin properties
  * (2) always keep the embrace gradle plugin in sync when adding new config values or altering existing ones
  */
-@EmbraceInstrumented
+@Keep
 object InstrumentedConfigImpl : InstrumentedConfig {
     override val baseUrls: BaseUrlConfig = BaseUrlConfigImpl
     override val enabledFeatures: EnabledFeatureConfig = EnabledFeatureConfigImpl
@@ -32,26 +33,26 @@ object InstrumentedConfigImpl : InstrumentedConfig {
     override val symbols: Base64SharedObjectFilesMap = Base64SharedObjectFilesMapImpl
 }
 
-@EmbraceInstrumented
+@Keep
 object BaseUrlConfigImpl : BaseUrlConfig
 
-@EmbraceInstrumented
+@Keep
 object EnabledFeatureConfigImpl : EnabledFeatureConfig
 
-@EmbraceInstrumented
+@Keep
 object NetworkCaptureConfigImpl : NetworkCaptureConfig
 
-@EmbraceInstrumented
+@Keep
 object OtelLimitsConfigImpl : OtelLimitsConfig
 
-@EmbraceInstrumented
+@Keep
 object ProjectConfigImpl : ProjectConfig
 
-@EmbraceInstrumented
+@Keep
 object RedactionConfigImpl : RedactionConfig
 
-@EmbraceInstrumented
+@Keep
 object SessionConfigImpl : SessionConfig
 
-@EmbraceInstrumented
+@Keep
 object Base64SharedObjectFilesMapImpl : Base64SharedObjectFilesMap

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/Base64SharedObjectFilesMap.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/Base64SharedObjectFilesMap.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * A Base64 encoded string of the shared object files that are used to symbolicate crashes.
  */
+@Keep
 interface Base64SharedObjectFilesMap {
 
     /**

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/BaseUrlConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/BaseUrlConfig.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Declares the base URLs the SDK should use in HTTP requests
  */
+@Keep
 interface BaseUrlConfig {
 
     /**

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Declares what features are enabled/disabled across the entire SDK.
  */
+@Keep
 interface EnabledFeatureConfig {
 
     /**

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/InstrumentedConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/InstrumentedConfig.kt
@@ -1,9 +1,12 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Defines the locally set configuration for the SDK. This is typically set from embrace-config.json
  * and instrumented by the embrace gradle plugin, but can be overridden for test purposes.
  */
+@Keep
 interface InstrumentedConfig {
     val baseUrls: BaseUrlConfig
     val enabledFeatures: EnabledFeatureConfig

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/NetworkCaptureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/NetworkCaptureConfig.kt
@@ -1,9 +1,12 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Declares how the SDK should capture network requests
  */
 @Suppress("FunctionOnlyReturningConstant")
+@Keep
 interface NetworkCaptureConfig {
 
     /**

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/OtelLimitsConfig.kt
@@ -1,11 +1,14 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Declares the limits for OTel data capture.
  *
  * Currently this is not instrumented by the gradle plugin so the values won't change - that will
  * be implemented in a future PR.
  */
+@Keep
 interface OtelLimitsConfig {
     fun getMaxInternalNameLength(): Int = 2000
     fun getMaxNameLength(): Int = 50

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/ProjectConfig.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Declares metadata about the app project
  */
+@Keep
 interface ProjectConfig {
 
     /**

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/RedactionConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/RedactionConfig.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Declares how the SDK should redact sensitive data
  */
+@Keep
 interface RedactionConfig {
 
     /**

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/SessionConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/SessionConfig.kt
@@ -1,8 +1,11 @@
 package io.embrace.android.embracesdk.internal.config.instrumented.schema
 
+import androidx.annotation.Keep
+
 /**
  * Declares metadata about the app project
  */
+@Keep
 interface SessionConfig {
 
     /**

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -1,29 +1,13 @@
 -keepattributes LineNumberTable, SourceFile, RuntimeVisibleAnnotations
 
-## Keep public API including enums
--keep class io.embrace.android.embracesdk.Embrace { *; }
--keep class io.embrace.android.embracesdk.network.http.HttpMethod { *; }
--keep class io.embrace.android.embracesdk.network.EmbraceNetworkRequest { *; }
--keep class io.embrace.android.embracesdk.Severity { *; }
--keep class io.embrace.android.embracesdk.LogType { *; }
--keep class io.embrace.android.embracesdk.LogExceptionType { *; }
--keep class io.embrace.android.embracesdk.spans.ErrorCode { *; }
-
 ## Keep classes used by hosted SDKs
--keep class io.embrace.android.embracesdk.Embrace$AppFramework { *; }
--keep class io.embrace.android.embracesdk.Embrace$LastRunEndState { *; }
--keep class io.embrace.android.embracesdk.Severity { *; }
 -keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface { *; }
 
-## Keep classes used from native code
--keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrSample { *; }
--keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrStackframe { *; }
--keep class io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSource { *; }
--keep class io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSourceImpl { *; }
+## Keep gradle plugin hooks
+-keep class io.embrace.android.embracesdk.okhttp3.** { *; }
 
-## Keep classes with JNI calls to native code
--keep class io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerNdkDelegate { *; }
--keep class io.embrace.android.embracesdk.internal.ndk.jni.JniDelegateImpl { *; }
+## Keep internal files for tracing
+-keep class io.embrace.android.embracesdk.internal.injection.** { *; }
 
 ## OpenTelemetry Java SDK
 -keep class io.opentelemetry.api.trace.StatusCode { *; }
@@ -46,14 +30,3 @@
 -dontwarn com.google.errorprone.annotations.MustBeClosed
 -dontwarn com.google.firebase.messaging.RemoteMessage$Notification
 -dontwarn com.google.firebase.messaging.RemoteMessage
-
-## Keep gradle plugin hooks
--keep class io.embrace.android.embracesdk.okhttp3.** { *; }
--keep class io.embrace.android.embracesdk.ViewSwazzledHooks { *; }
--keep class io.embrace.android.embracesdk.WebViewClientSwazzledHooks { *; }
--keep class io.embrace.android.embracesdk.WebViewChromeClientSwazzledHooks { *; }
--keep class io.embrace.android.embracesdk.fcm.swazzle.callback.com.android.fcm.FirebaseSwazzledHooks { *; }
--keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; }
-
-## Keep internal files for tracing
--keep class io.embrace.android.embracesdk.internal.injection.** { *; }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -6,6 +6,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.webkit.ConsoleMessage
+import androidx.annotation.Keep
 import io.embrace.android.embracesdk.internal.Systrace
 import io.embrace.android.embracesdk.internal.api.SdkApi
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
@@ -23,6 +24,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
  * Contains a singleton instance of itself, and is used for initializing the SDK.
  */
 @SuppressLint("EmbracePublicApiPackageRule")
+@Keep
 public class Embrace private constructor(
     internal var impl: EmbraceImpl = Systrace.traceSynchronous("embrace-impl-init") { EmbraceImpl() },
 ) : SdkApi {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/ViewSwazzledHooks.java
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
@@ -11,6 +12,7 @@ import kotlin.Pair;
  * @hide
  */
 @InternalApi
+@Keep
 public final class ViewSwazzledHooks {
 
     private static final String UNKNOWN_ELEMENT_NAME = "Unknown element";

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewClientSwazzledHooks.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/WebViewClientSwazzledHooks.java
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 
 import io.embrace.android.embracesdk.annotation.InternalApi;
@@ -8,6 +9,7 @@ import io.embrace.android.embracesdk.annotation.InternalApi;
  * @hide
  */
 @InternalApi
+@Keep
 public final class WebViewClientSwazzledHooks {
 
     private WebViewClientSwazzledHooks() {

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-instrumentation/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-instrumentation/build.gradle
@@ -49,6 +49,7 @@ android {
 dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.google.firebase:firebase-messaging:23.1.0")
+    implementation("io.embrace:embrace-android-sdk:+")
     implementation("io.embrace:embrace-android-fcm:+")
 }
 

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-instrumentation/proguard-rules.pro
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-instrumentation/proguard-rules.pro
@@ -1,6 +1,2 @@
 -keep class com.example.app.** { *; }
 -keep class okhttp3.** { *; }
--keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; }
--keep class io.embrace.android.embracesdk.ViewSwazzledHooks$OnClickListener { *; }
--keep class io.embrace.android.embracesdk.ViewSwazzledHooks$OnLongClickListener { *; }
--keep class com.google.firebase.messaging.RemoteMessage

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/proguard-rules.pro
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/proguard-rules.pro
@@ -1,2 +1,0 @@
--keep class com.example.app.Foo { *; }
--keep class io.embrace.android.embracesdk.internal.config.instrumented.* { *; }

--- a/embrace-internal-api/build.gradle.kts
+++ b/embrace-internal-api/build.gradle.kts
@@ -13,4 +13,6 @@ android {
 dependencies {
     compileOnly(project(":embrace-android-api"))
     testImplementation(project(":embrace-android-api"))
+    implementation(libs.lifecycle.runtime)
+    implementation(libs.lifecycle.process)
 }

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/LogType.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/LogType.kt
@@ -1,11 +1,14 @@
 package io.embrace.android.embracesdk
 
+import androidx.annotation.Keep
+
 /**
  * Deprecated: use Severity instead. This enum is deprecated and will be removed in
  * a future release.
  *
  * Will flag the message as one of info, warning, or error for filtering on the dashboard
  */
+@Keep
 @Deprecated("")
 enum class LogType {
     INFO,


### PR DESCRIPTION
## Goal

Uses the [Keep annotation](https://developer.android.com/reference/androidx/annotation/Keep) instead of writing custom ProGuard rules for each class. This should make it simpler to identify when a class needs to be retained for Embrace's use.

