### PR TITLE
Alter how operand stack indices are specified

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
@@ -54,7 +54,7 @@ abstract class EmbraceClassVisitorFactory : AsmClassVisitorFactory<BytecodeInstr
                     owner = "io/embrace/android/embracesdk/internal/instrumentation/bytecode/FcmBytecodeEntrypoint",
                     name = "onMessageReceived",
                     descriptor = "(Lcom/google/firebase/messaging/RemoteMessage;)V",
-                    startVarIndex = 1,
+                    operandStackIndices = listOf(1),
                 )
             )
         }
@@ -73,6 +73,7 @@ abstract class EmbraceClassVisitorFactory : AsmClassVisitorFactory<BytecodeInstr
                     owner = "io/embrace/android/embracesdk/internal/instrumentation/bytecode/OkHttpBytecodeEntrypoint",
                     name = "build",
                     descriptor = "(Lokhttp3/OkHttpClient\$Builder;)V",
+                    operandStackIndices = listOf(0)
                 )
             )
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/BytecodeMethodInsertionParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/BytecodeMethodInsertionParams.kt
@@ -21,13 +21,14 @@ internal data class BytecodeMethodInsertionParams(
     val descriptor: String,
 
     /**
-     * The starting index of the local variable on the operand stack. We assume that by default the bytecode
-     * entrypoint will take the current object as its first parameter, then all other parameters.
+     * Declares the indices of variables on the operand stack that should be added as part of the inserted call.
+     * This MUST be entered in ascending order.
      *
-     * For example, an instrumentation entrypoint for a View.OnClickListener would have the following
-     * signature: instrumentedMethodName(android.view.View.OnClickListener thiz, android.view.View view).
+     * Virtual methods have an implicit reference as the 0th value on the stack, whereas static methods do not.
+     * After this point, the stack should contain the ordered arguments to the containing method.
      *
-     * In future we can revisit this decision, given that the current object is not usually used.
+     * As an example, listOf(1, 3) should be supplied if we wanted to pass the String and Boolean parameters of this virtual method:
+     * foo(String, Int, Boolean)
      */
-    val startVarIndex: Int = 0,
+    val operandStackIndices: List<Int>,
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodVisitor.kt
@@ -2,7 +2,6 @@ package io.embrace.android.gradle.plugin.instrumentation.visitor
 
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
-import org.objectweb.asm.Type
 
 /**
  * Visits a method that should be rewritten to include an API call to instrumentation
@@ -15,12 +14,9 @@ internal class InstrumentationTargetMethodVisitor(
 ) : MethodVisitor(api, methodVisitor) {
 
     override fun visitCode() {
-        // count how many parameters are in the method descriptor
-        val paramCount = Type.getArgumentTypes(params.descriptor).size
-
-        // load local variables and push onto the operand stack
-        repeat(paramCount) {
-            visitVarInsn(Opcodes.ALOAD, it + params.startVarIndex)
+        // load local variables required for method call (if any) and push onto the operand stack
+        params.operandStackIndices.forEach {
+            visitVarInsn(Opcodes.ALOAD, it)
         }
 
         // invoke the target method

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/OnClickClassAdapter.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/OnClickClassAdapter.kt
@@ -34,6 +34,7 @@ class OnClickClassAdapter(
                     owner = "io/embrace/android/embracesdk/internal/instrumentation/bytecode/OnClickBytecodeEntrypoint",
                     name = "onClick",
                     descriptor = "(Landroid/view/View\$OnClickListener;Landroid/view/View;)V",
+                    operandStackIndices = listOf(0, 1),
                 )
             )
         } else if (METHOD_DESC == desc && isStatic(access) && isSynthetic(access)) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/OnLongClickClassAdapter.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/OnLongClickClassAdapter.kt
@@ -34,6 +34,7 @@ class OnLongClickClassAdapter(
                     owner = "io/embrace/android/embracesdk/internal/instrumentation/bytecode/OnLongClickBytecodeEntrypoint",
                     name = "onLongClick",
                     descriptor = "(Landroid/view/View\$OnLongClickListener;Landroid/view/View;)V",
+                    operandStackIndices = listOf(0, 1),
                 )
             )
         } else if (METHOD_DESC == desc && isStatic(access) && isSynthetic(access)) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/WebViewClientClassAdapter.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/WebViewClientClassAdapter.kt
@@ -40,7 +40,7 @@ class WebViewClientClassAdapter(
                     owner = "io/embrace/android/embracesdk/internal/instrumentation/bytecode/WebViewClientBytecodeEntrypoint",
                     name = "onPageStarted",
                     descriptor = "(Landroid/webkit/WebView;Ljava/lang/String;Landroid/graphics/Bitmap;)V",
-                    startVarIndex = 1,
+                    operandStackIndices = listOf(1, 2, 3),
                 )
             )
         } else {


### PR DESCRIPTION
## Goal

Until now the bytecode instrumentation has assumed that we always want to mirror the function signature of the instrumented method in our own target API. This changes that assumption by allowing us to specify what variables should be loaded onto the operand stack.

Practically speaking, this means we can delete unused parameters such as `View.OnClickListener` in our bytecode API. This should simplify the code & therefore reduce surface area for bugs.

## Testing

Relied on existing test coverage.
