### PR TITLE
Create class visit strategy hierarchy

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/ClassVisitBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/ClassVisitBehavior.kt
@@ -1,21 +1,30 @@
 package io.embrace.android.gradle.plugin.instrumentation
 
 import com.android.build.api.instrumentation.ClassContext
-import io.embrace.android.gradle.plugin.instrumentation.visitor.WebViewClientClassAdapter
+import io.embrace.android.gradle.plugin.instrumentation.strategy.ClassVisitStrategy
 
 internal class ClassVisitBehavior(private val params: BytecodeInstrumentationParams) {
 
-    fun shouldInstrumentFirebasePushNotifications(classContext: ClassContext): Boolean {
+    fun shouldInstrumentFirebasePushNotifications(ctx: ClassContext): Boolean {
         return params.shouldInstrumentFirebaseMessaging.get() &&
-            classContext.currentClassData.superClasses.contains("com.google.firebase.messaging.FirebaseMessagingService")
+            ClassVisitStrategy.MatchSuperClassName("com.google.firebase.messaging.FirebaseMessagingService").shouldVisit(ctx)
     }
 
-    fun shouldInstrumentWebview(classContext: ClassContext): Boolean {
+    fun shouldInstrumentWebview(ctx: ClassContext): Boolean {
         return params.shouldInstrumentWebview.get() &&
-            classContext.currentClassData.superClasses.contains(WebViewClientClassAdapter.CLASS_NAME)
+            ClassVisitStrategy.MatchSuperClassName("android.webkit.WebViewClient").shouldVisit(ctx)
     }
 
-    fun shouldInstrumentOkHttp(classContext: ClassContext): Boolean {
-        return params.shouldInstrumentOkHttp.get() && classContext.currentClassData.className == "okhttp3.OkHttpClient\$Builder"
+    fun shouldInstrumentOkHttp(ctx: ClassContext): Boolean {
+        return params.shouldInstrumentOkHttp.get() &&
+            ClassVisitStrategy.MatchClassName("okhttp3.OkHttpClient\$Builder").shouldVisit(ctx)
+    }
+
+    fun shouldInstrumentOnClick(ctx: ClassContext): Boolean {
+        return params.shouldInstrumentOnClick.get() && ClassVisitStrategy.Exhaustive.shouldVisit(ctx)
+    }
+
+    fun shouldInstrumentOnLongClick(ctx: ClassContext): Boolean {
+        return params.shouldInstrumentOnLongClick.get() && ClassVisitStrategy.Exhaustive.shouldVisit(ctx)
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
@@ -77,10 +77,10 @@ abstract class EmbraceClassVisitorFactory : AsmClassVisitorFactory<BytecodeInstr
                 )
             )
         }
-        if (params.shouldInstrumentOnLongClick.get()) {
+        if (behavior.shouldInstrumentOnClick(classContext)) {
             visitor = OnLongClickClassAdapter(api, visitor)
         }
-        if (params.shouldInstrumentOnClick.get()) {
+        if (behavior.shouldInstrumentOnLongClick(classContext)) {
             visitor = OnClickClassAdapter(api, visitor)
         }
         return visitor

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/strategy/ClassVisitStrategy.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/strategy/ClassVisitStrategy.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.gradle.plugin.instrumentation.strategy
+
+import com.android.build.api.instrumentation.ClassContext
+
+/**
+ * Defines all the potential strategies for deciding whether a class should be visited by a particular feature
+ * during bytecode instrumentation.
+ */
+internal sealed class ClassVisitStrategy {
+
+    /**
+     * Returns true if the class should be visited for _potential_ instrumentation.
+     */
+    abstract fun shouldVisit(ctx: ClassContext): Boolean
+
+    /**
+     * Visits every class.
+     */
+    internal object Exhaustive : ClassVisitStrategy() {
+        override fun shouldVisit(ctx: ClassContext): Boolean = true
+    }
+
+    /**
+     * Visits every class matching the given name.
+     */
+    internal class MatchClassName(private val name: String) : ClassVisitStrategy() {
+        override fun shouldVisit(ctx: ClassContext): Boolean {
+            return ctx.currentClassData.className == name
+        }
+    }
+
+    /**
+     * Visits every class that has a superclass matching the given name.
+     */
+    internal class MatchSuperClassName(private val name: String) : ClassVisitStrategy() {
+        override fun shouldVisit(ctx: ClassContext): Boolean {
+            return ctx.currentClassData.superClasses.contains(name)
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Formalises the strategies that we use to decide whether a class should be visited by a feature during instrumentation. This is an intermediate step towards making it easier to define this via config.

