### PR TITLE
Use flatMap instead of map to make the getSharedObjectFilesProvider depend on the outputs of merge[Variant]NativeLibs

### DIFF
--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
@@ -187,7 +187,6 @@ class NdkUploadTasksRegistrationTest {
         assertTaskRegistered(EncodeFileToBase64Task.NAME, testAndroidCompactedVariantData.name)
     }
 
-    // TODO: Do all Unity projects have a mergeNativeLibs task?
     @Test
     fun `an error is thrown when merge native libs task is not found`() {
         // Given a project where merge native libs task is not registered


### PR DESCRIPTION
## Goal

Using flatMap wires a dependency between the result and the outputs of the mergeNativeLibs task. 

Using map doesn't do that, so I think that's why the provider was realized before the outputs where available, causing the exception: 

```
* What went wrong:
  Configuration cache state could not be cached: field `architecturesDirectory` of task `:app:compressSharedObjectFilesRelease` of type `io.embrace.android.gradle.plugin.tasks.ndk.CompressSharedObjectFilesTask`: error writing value of type 'org.gradle.api.internal.file.DefaultFilePropertyFactory$DefaultDirectoryVar'
> Shared object file not found
```

Also use elements.map so we don't resolve the task output files too early.

## Testing

Tested manually: now the example app builds correctly. We will add additional configuration cache testing later.