### PR TITLE
Use the draw complete time for missing activity init timestamps

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/DrawEventEmitter.kt
@@ -18,7 +18,7 @@ interface DrawEventEmitter {
     fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        firstFrameDeliveredCallback: () -> Unit
+        drawCompleteCallback: () -> Unit
     )
 
     /**

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/FirstDrawDetector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/FirstDrawDetector.kt
@@ -30,7 +30,7 @@ class FirstDrawDetector(
     override fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        firstFrameDeliveredCallback: () -> Unit
+        drawCompleteCallback: () -> Unit
     ) {
         val instanceId = traceInstanceId(activity)
         if (!trackingLoad(instanceId)) {
@@ -41,8 +41,8 @@ class FirstDrawDetector(
                     decorView.onNextDraw {
                         if (!trackingLoad(instanceId)) {
                             drawBeginCallback()
-                            loadingActivities[instanceId] = Runnable { firstFrameDeliveredCallback() }
-                            decorView.viewTreeObserver.registerFrameCommitCallback(firstFrameDeliveredCallback)
+                            loadingActivities[instanceId] = Runnable { drawCompleteCallback() }
+                            decorView.viewTreeObserver.registerFrameCommitCallback(drawCompleteCallback)
                         }
                     }
                 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetector.kt
@@ -14,11 +14,11 @@ class HandlerMessageDrawDetector(
     override fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        firstFrameDeliveredCallback: () -> Unit,
+        drawCompleteCallback: () -> Unit,
     ) {
         drawBeginCallback()
         handler.sendMessageAtFrontOfQueue(
-            Message.obtain(handler.wrappedHandler, firstFrameDeliveredCallback).apply {
+            Message.obtain(handler.wrappedHandler, drawCompleteCallback).apply {
                 isAsynchronous = true
             }
         )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetectorTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ui/HandlerMessageDrawDetectorTest.kt
@@ -30,7 +30,7 @@ internal class HandlerMessageDrawDetectorTest {
         detector.registerFirstDrawCallback(
             activity = Robolectric.buildActivity(Activity::class.java).get(),
             drawBeginCallback = { beginCallbackInvoked = true },
-            firstFrameDeliveredCallback = { endCallbackInvoked = true }
+            drawCompleteCallback = { endCallbackInvoked = true }
         )
         assertTrue(beginCallbackInvoked)
         with(handler.messageQueue.single()) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDrawEventEmitter.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDrawEventEmitter.kt
@@ -15,11 +15,11 @@ class FakeDrawEventEmitter : DrawEventEmitter {
     override fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        firstFrameDeliveredCallback: () -> Unit
+        drawCompleteCallback: () -> Unit
     ) {
-        registeredActivities[traceInstanceId(activity)] = drawBeginCallback to firstFrameDeliveredCallback
+        registeredActivities[traceInstanceId(activity)] = drawBeginCallback to drawCompleteCallback
         lastRegisteredActivity = activity
-        lastFirstFrameDeliveredCallback = firstFrameDeliveredCallback
+        lastFirstFrameDeliveredCallback = drawCompleteCallback
     }
 
     override fun unregisterFirstDrawCallback(activity: Activity) {


### PR DESCRIPTION
## Goal

Activity init events might not be processed when the onDraw event fires because the latter jumps in front of the main thread handler queue. In these rare cases, use that timestamp in place of the activityInit timestamps.