### PR TITLE
Fix eager resolution of unitySymbolsDir in getProjectType

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/ProjectTypeVerifier.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/ProjectTypeVerifier.kt
@@ -14,16 +14,18 @@ internal object ProjectTypeVerifier {
         behavior: PluginBehavior,
         variantName: String,
         project: Project,
-    ): ProjectType {
-        return when {
-            isNative(agpWrapper, behavior, variantName, project) -> ProjectType.NATIVE
-            isUnity(unitySymbolsDir.orNull) -> ProjectType.UNITY
-            else -> ProjectType.OTHER
+    ): Provider<ProjectType> {
+        return unitySymbolsDir.map { dir ->
+            when {
+                isNative(agpWrapper, behavior, variantName, project) -> ProjectType.NATIVE
+                isUnity(dir) -> ProjectType.UNITY
+                else -> ProjectType.OTHER
+            }
         }
     }
 
-    private fun isUnity(unitySymbolsDir: UnitySymbolsDir?): Boolean {
-        return unitySymbolsDir != null && unitySymbolsDir.isDirPresent()
+    private fun isUnity(unitySymbolsDir: UnitySymbolsDir): Boolean {
+        return unitySymbolsDir.isDirPresent()
     }
 
     /**

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -112,15 +112,13 @@ class TaskRegistrar(
         agpWrapper: AgpWrapper,
         variantName: String,
         project: Project,
-    ) = this.project.provider {
-        ProjectTypeVerifier.getProjectType(
-            unitySymbolsDirProvider,
-            agpWrapper,
-            behavior,
-            variantName,
-            project
-        )
-    }
+    ) = ProjectTypeVerifier.getProjectType(
+        unitySymbolsDirProvider,
+        agpWrapper,
+        behavior,
+        variantName,
+        project
+    )
 
     private fun setupVariantConfigurationListProperty(
         androidCompactedVariantData: AndroidCompactedVariantData,


### PR DESCRIPTION
## Goal

`getProjectType` was wrapped in a provider, without considering its dependency on `unitySymbolsDir`. As a result, when `projectType` was realized, it would try to realize `unitySymbolsDir` eagerly, potentially resolving it before it was available.

This change updates `getProjectType` to use `unitySymbolsDir.map`, wiring the dependency and ensuring that `unitySymbolsDir` is resolved only when needed.
