### PR TITLE
Fix eager resolution of unitySymbolsDir in shared object file provider

### DIFF
--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
@@ -213,32 +213,6 @@ class NdkUploadTasksRegistrationTest {
     }
 
     @Test
-    fun `an error is thrown when unitySymbolsDir provider returns null for a unity project`() {
-        // Given a unity project where unitySymbolsDir provider returns null
-        val unitySymbolsDirProvider: Provider<UnitySymbolsDir> = project.provider { null }
-        val projectTypeProvider = project.provider { ProjectType.UNITY }
-        val variantName = testAndroidCompactedVariantData.name.capitalizedString()
-
-        // When NDK upload tasks are registered
-        val registration = createNdkUploadTasksRegistration(
-            unitySymbolsDir = unitySymbolsDirProvider,
-            projectType = projectTypeProvider
-        )
-        registration.register(testRegistrationParams)
-        registerTestTask(project, "merge${variantName}NativeLibs")
-
-        // Then an exception is thrown when trying to access architecturesDirectory
-        val compressionTask = project.tasks.findByName(
-            "${CompressSharedObjectFilesTask.NAME}$variantName"
-        ) as CompressSharedObjectFilesTask
-
-        val exception = assertThrows(PropertyQueryException::class.java) {
-            compressionTask.architecturesDirectory.get()
-        }
-        assertEquals("Unity shared objects directory not found", exception.cause?.message)
-    }
-
-    @Test
     fun `an error is thrown when getSymbolFiles doesn't find any file`() {
         // Given a Unity project with an empty UnitySymbolsDir
         val projectTypeProvider = project.provider { ProjectType.UNITY }


### PR DESCRIPTION
## Goal

`getUnitySharedObjectFiles` was accessing `unitySymbolsDir` (using `orNull`) too early, which could mess with the build or with configuration cache if the symbols directory isn't ready yet.
This change switches to using `flatMap` so `unitySymbolsDir` is resolved lazily, only when needed.

Also removed a test that didn't make sense, as the provider we receive can't be null.

