### PR TITLE
Remove unnecessary dependency on mergeNativeLibsTask for customSymbolsDirectory and Unity

### DIFF
--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
@@ -190,7 +190,7 @@ class NdkUploadTasksRegistrationTest {
     @Test
     fun `an error is thrown when merge native libs task is not found`() {
         // Given a project where merge native libs task is not registered
-        val projectTypeProvider = project.provider { ProjectType.UNITY }
+        val projectTypeProvider = project.provider { ProjectType.NATIVE }
 
         // When NDK upload tasks are registered
         val registration = createNdkUploadTasksRegistration(projectType = projectTypeProvider)


### PR DESCRIPTION
## Goal

When using `mergeNativeLibsTask.flatMap` at the start of the shared object files provider, we were enforcing a dependency on the mergeNativeLibs task for Unity projects and projects that set up a custom symbols directory. 

While I think most Unity projects will have that task, I'm not sure if 100% of them will. Also, this would've been an unintended change from our last version.