### PR TITLE
Map projectType correctly in getShouldExecuteCompressionTaskProvider

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -55,7 +55,7 @@ class NdkUploadTasksRegistration(
         }
 
         compressionTaskProvider.configure { compressionTask: CompressSharedObjectFilesTask ->
-            val shouldExecuteCompressionTaskProvider = getShouldExecuteCompressionTaskProvider(project)
+            val shouldExecuteCompressionTaskProvider = getShouldExecuteCompressionTaskProvider()
             compressionTask.onlyIf { shouldExecuteCompressionTaskProvider.orNull ?: true }
             // TODO: check if these are only needed for Unity and comment accordingly.
             compressionTask.mustRunAfter(object : Callable<Any> {
@@ -102,12 +102,12 @@ class NdkUploadTasksRegistration(
             // TODO: An error thrown in registration will make the build will fail. Should we use failBuildOnUploadErrors for this too?
             task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
             task.requestParams.set(
-                project.provider {
+                behavior.failBuildOnUploadErrors.map { failBuildOnUploadErrors ->
                     RequestParams(
                         appId = variantConfig.embraceConfig?.appId.orEmpty(),
                         apiToken = variantConfig.embraceConfig?.apiToken.orEmpty(),
                         endpoint = EmbraceEndpoint.NDK,
-                        failBuildOnUploadErrors = behavior.failBuildOnUploadErrors.get(),
+                        failBuildOnUploadErrors = failBuildOnUploadErrors,
                         baseUrl = behavior.baseUrl,
                     )
                 }
@@ -221,7 +221,7 @@ class NdkUploadTasksRegistration(
         "${variantData.flavorName}/${variantData.buildTypeName}"
     }
 
-    private fun getShouldExecuteCompressionTaskProvider(project: Project) = project.provider {
-        (projectType.orNull == ProjectType.NATIVE || projectType.orNull == ProjectType.UNITY)
+    private fun getShouldExecuteCompressionTaskProvider() = projectType.map {
+        (it == ProjectType.NATIVE || it == ProjectType.UNITY)
     }
 }


### PR DESCRIPTION
## Goal

We were using `project.provider { projectType.orNull == ... }`, which could cause early resolution of projectType, ignoring its dependencies. Using map wires it correctly.

I think onlyIf might only be resolved in execution time, so we wouldn't be facing any issues here, but just in case, this is a more correct way of doing things.

Also, use map for failBuildOnUploadErrors instead of resolving it early.
