### PR TITLE
Improve validation with internally recorded completed spans

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/OtelLimitsConfigExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/OtelLimitsConfigExt.kt
@@ -1,9 +1,30 @@
 package io.embrace.android.embracesdk.internal.config.instrumented
 
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
+import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 internal fun OtelLimitsConfig.isNameValid(str: String, internal: Boolean): Boolean =
     str.isNotBlank() && ((internal && str.length <= getMaxInternalNameLength()) || str.length <= getMaxNameLength())
+
+internal fun OtelLimitsConfig.isEventCountValid(events: List<EmbraceSpanEvent>, internal: Boolean): Boolean {
+    val max = if (internal) {
+        getMaxSystemEventCount()
+    } else {
+        getMaxCustomEventCount()
+    }
+
+    return events.size <= max
+}
+
+internal fun OtelLimitsConfig.isAttributeCountValid(attributes: Map<String, String>, internal: Boolean): Boolean {
+    val max = if (internal) {
+        getMaxSystemAttributeCount()
+    } else {
+        getMaxCustomAttributeCount()
+    }
+
+    return attributes.size <= max
+}
 
 internal fun OtelLimitsConfig.isAttributeValid(key: String, value: String, internal: Boolean) =
     ((internal && key.length <= getMaxInternalAttributeKeyLength()) || key.length <= getMaxCustomAttributeKeyLength()) &&

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -14,10 +14,14 @@ import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_INTERNAL_SPAN_NAME
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_SPAN_NAME
-import io.embrace.android.embracesdk.fixtures.maxSizeAttributes
-import io.embrace.android.embracesdk.fixtures.maxSizeEvents
-import io.embrace.android.embracesdk.fixtures.tooBigAttributes
-import io.embrace.android.embracesdk.fixtures.tooBigEvents
+import io.embrace.android.embracesdk.fixtures.maxSizeCustomAttributes
+import io.embrace.android.embracesdk.fixtures.maxSizeCustomEvents
+import io.embrace.android.embracesdk.fixtures.maxSizeSystemAttributes
+import io.embrace.android.embracesdk.fixtures.maxSizeSystemEvents
+import io.embrace.android.embracesdk.fixtures.tooBigCustomAttributes
+import io.embrace.android.embracesdk.fixtures.tooBigCustomEvents
+import io.embrace.android.embracesdk.fixtures.tooBigSystemAttributes
+import io.embrace.android.embracesdk.fixtures.tooBigSystemEvents
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -495,7 +499,7 @@ internal class SpanServiceImplTest {
     }
 
     @Test
-    fun `check name length limit for spans by internally by the SDK`() {
+    fun `check limits for internal spans`() {
         assertNull(spansService.createSpan(name = TOO_LONG_INTERNAL_SPAN_NAME, internal = true))
         assertFalse(
             spansService.recordCompletedSpan(
@@ -503,6 +507,24 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = true,
+            )
+        )
+        assertFalse(
+            spansService.recordCompletedSpan(
+                name = MAX_LENGTH_INTERNAL_SPAN_NAME,
+                startTimeMs = 100L,
+                endTimeMs = 200L,
+                internal = true,
+                attributes = tooBigSystemAttributes
+            )
+        )
+        assertFalse(
+            spansService.recordCompletedSpan(
+                name = MAX_LENGTH_INTERNAL_SPAN_NAME,
+                startTimeMs = 100L,
+                endTimeMs = 200L,
+                internal = true,
+                events = tooBigSystemEvents
             )
         )
         assertNotNull(
@@ -523,6 +545,8 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = true,
+                attributes = maxSizeSystemAttributes,
+                events = maxSizeSystemEvents
             )
         )
         assertEquals(2, spanSink.completedSpans().size)
@@ -535,7 +559,7 @@ internal class SpanServiceImplTest {
                 name = "too many events",
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                events = tooBigEvents,
+                events = tooBigCustomEvents,
                 internal = false,
             )
         )
@@ -544,7 +568,7 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                events = maxSizeEvents,
+                events = maxSizeCustomEvents,
                 internal = false,
             )
         )
@@ -586,7 +610,7 @@ internal class SpanServiceImplTest {
                 name = "too many attributes",
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                attributes = tooBigAttributes,
+                attributes = tooBigCustomAttributes,
                 internal = false,
             )
         )
@@ -595,7 +619,7 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                attributes = maxSizeAttributes,
+                attributes = maxSizeCustomAttributes,
                 internal = false,
             )
         )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -536,6 +536,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 events = tooBigEvents,
+                internal = false,
             )
         )
         assertTrue(
@@ -544,6 +545,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 events = maxSizeEvents,
+                internal = false,
             )
         )
 
@@ -585,6 +587,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 attributes = tooBigAttributes,
+                internal = false,
             )
         )
         assertTrue(
@@ -593,6 +596,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 attributes = maxSizeAttributes,
+                internal = false,
             )
         )
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -94,9 +94,13 @@ val MAX_LENGTH_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN: String =
 val TOO_LONG_ATTRIBUTE_VALUE_FOR_INTERNAL_SPAN: String =
     "s".repeat(limits.getMaxInternalAttributeValueLength() + 1)
 
-val maxSizeAttributes: Map<String, String> = createMapOfSize(limits.getMaxCustomAttributeCount())
-val tooBigAttributes: Map<String, String> = createMapOfSize(limits.getMaxCustomAttributeCount() + 1)
+val maxSizeCustomAttributes: Map<String, String> = createMapOfSize(limits.getMaxCustomAttributeCount())
+val tooBigCustomAttributes: Map<String, String> = createMapOfSize(limits.getMaxCustomAttributeCount() + 1)
 val maxSizeEventAttributes: Map<String, String> = createMapOfSize(MAX_EVENT_ATTRIBUTE_COUNT)
 val tooBigEventAttributes: Map<String, String> = createMapOfSize(MAX_EVENT_ATTRIBUTE_COUNT + 1)
-val maxSizeEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxCustomEventCount())
-val tooBigEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxCustomEventCount() + 1)
+val maxSizeSystemAttributes: Map<String, String> = createMapOfSize(limits.getMaxSystemAttributeCount())
+val tooBigSystemAttributes: Map<String, String> = createMapOfSize(limits.getMaxSystemAttributeCount() + 1)
+val maxSizeCustomEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxCustomEventCount())
+val tooBigCustomEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxCustomEventCount() + 1)
+val maxSizeSystemEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxSystemEventCount())
+val tooBigSystemEvents: List<EmbraceSpanEvent> = createEventsListOfSize(limits.getMaxSystemEventCount() + 1)


### PR DESCRIPTION
## Goal

Internally created spans are able to have more attributes and span events than ones created via the SDK APIs, but the validation logic for `recordCompletedSpan()` did not take that into consideration. Allow for this to happen and create tests to validate the the higher limits.
