### PR TITLE
Ensure ANR spans are exported when a session ends

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/OtelPayloadMapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/OtelPayloadMapper.kt
@@ -4,5 +4,14 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
 interface OtelPayloadMapper {
-    fun getSessionPayload(endType: SessionSnapshotType, crashId: String?): List<Span>
+    /**
+     * Return collected data as Spans but outside the OTel SDK pipeline so that it can be used to for payload snapshots or check
+     * current state
+     */
+    fun snapshotSpans(endType: SessionSnapshotType, crashId: String?): List<Span>
+
+    /**
+     * Push collected data through the OTel SDK pipeline.
+     */
+    fun record()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/OtelPayloadMapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/OtelPayloadMapper.kt
@@ -1,14 +1,13 @@
 package io.embrace.android.embracesdk.internal.envelope.session
 
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
 interface OtelPayloadMapper {
     /**
      * Return collected data as Spans but outside the OTel SDK pipeline so that it can be used to for payload snapshots or check
      * current state
      */
-    fun snapshotSpans(endType: SessionSnapshotType, crashId: String?): List<Span>
+    fun snapshotSpans(): List<Span>
 
     /**
      * Push collected data through the OTel SDK pipeline.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
@@ -47,7 +47,7 @@ internal class SessionPayloadSourceImpl(
         }
 
         // Ensure the span retrieving is last as that potentially ends the session span, which effectively ends the session
-        val spans: List<Span>? = retrieveSpanData(isCacheAttempt, endType, startNewSession, crashId)
+        val spans: List<Span>? = retrieveSpanData(isCacheAttempt, startNewSession, crashId)
 
         return SessionPayload(
             spans = spans,
@@ -58,7 +58,6 @@ internal class SessionPayloadSourceImpl(
 
     private fun retrieveSpanData(
         isCacheAttempt: Boolean,
-        endType: SessionSnapshotType,
         startNewSession: Boolean,
         crashId: String?,
     ): List<Span>? {
@@ -79,7 +78,7 @@ internal class SessionPayloadSourceImpl(
 
                 else -> spanSink.completedSpans()
                     .map(EmbraceSpanData::toNewPayload)
-                    .plus(otelPayloadMapper.snapshotSpans(endType, crashId))
+                    .plus(otelPayloadMapper.snapshotSpans())
             }
         }
         return spans

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
@@ -2,13 +2,13 @@ package io.embrace.android.embracesdk.internal.envelope.session
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.spans.SpanSinkImpl
@@ -45,12 +45,7 @@ internal class SessionPayloadSourceImplTest {
             sink,
             currentSessionSpan,
             spanRepository,
-            object : OtelPayloadMapper {
-                override fun getSessionPayload(
-                    endType: SessionSnapshotType,
-                    crashId: String?,
-                ): List<Span> = emptyList()
-            },
+            FakeOtelPayloadMapper(),
             FakeProcessStateService(),
             FakeClock(),
             EmbLoggerImpl()

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.capture.envelope.session
 import io.embrace.android.embracesdk.internal.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
 /**
  * Handles logic for features that are not fully integrated into the OTel pipeline.
@@ -12,7 +11,7 @@ class OtelPayloadMapperImpl(
     private val anrOtelMapper: AnrOtelMapper?,
 ) : OtelPayloadMapper {
 
-    override fun snapshotSpans(endType: SessionSnapshotType, crashId: String?): List<Span> {
+    override fun snapshotSpans(): List<Span> {
         return anrOtelMapper?.snapshot() ?: emptyList()
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/envelope/session/OtelPayloadMapperImpl.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.capture.envelope.session
 
 import io.embrace.android.embracesdk.internal.anr.AnrOtelMapper
-import io.embrace.android.embracesdk.internal.anr.ndk.NativeAnrOtelMapper
 import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
@@ -11,12 +10,13 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapsh
  */
 class OtelPayloadMapperImpl(
     private val anrOtelMapper: AnrOtelMapper?,
-    private val nativeAnrOtelMapper: NativeAnrOtelMapper?,
 ) : OtelPayloadMapper {
 
-    override fun getSessionPayload(endType: SessionSnapshotType, crashId: String?): List<Span> {
-        val cacheAttempt = endType == SessionSnapshotType.PERIODIC_CACHE
-        return anrOtelMapper?.snapshot(!cacheAttempt) ?: emptyList<Span>()
-            .plus(nativeAnrOtelMapper?.snapshot(!cacheAttempt) ?: emptyList())
+    override fun snapshotSpans(endType: SessionSnapshotType, crashId: String?): List<Span> {
+        return anrOtelMapper?.snapshot() ?: emptyList()
+    }
+
+    override fun record() {
+        anrOtelMapper?.record()
     }
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class AnrModuleImpl(
     initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
     workerModule: WorkerThreadModule,
 ) : AnrModule {
@@ -39,7 +40,7 @@ internal class AnrModuleImpl(
 
     override val anrOtelMapper: AnrOtelMapper? by singleton {
         if (configService.autoDataCaptureBehavior.isAnrCaptureEnabled()) {
-            AnrOtelMapper(checkNotNull(anrService), initModule.clock)
+            AnrOtelMapper(checkNotNull(anrService), initModule.clock, openTelemetryModule.spanService)
         } else {
             null
         }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleSupplier.kt
@@ -7,12 +7,14 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
  */
 typealias AnrModuleSupplier = (
     initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
     workerModule: WorkerThreadModule,
 ) -> AnrModule
 
 fun createAnrModule(
     initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
     workerModule: WorkerThreadModule,
-): AnrModule = AnrModuleImpl(initModule, configService, workerModule)
+): AnrModule = AnrModuleImpl(initModule, openTelemetryModule, configService, workerModule)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/AnrModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/AnrModuleImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import android.os.Looper
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
@@ -25,6 +26,7 @@ internal class AnrModuleImplTest {
     fun testDefaultImplementations() {
         val module = AnrModuleImpl(
             FakeInitModule(),
+            FakeOpenTelemetryModule(),
             FakeConfigService(),
             FakeWorkerThreadModule()
         )
@@ -36,6 +38,7 @@ internal class AnrModuleImplTest {
     fun testBehaviorDisabled() {
         val module = AnrModuleImpl(
             FakeInitModule(),
+            FakeOpenTelemetryModule(),
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(anrServiceEnabled = false)
             ),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.testcases.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.internal.anr.detection.BlockedThreadDetector
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -67,6 +68,9 @@ internal class AnrFeatureTest {
                 assertEquals(2, spans.size)
                 assertAnrReceived(spans[0], startTimeMs, firstSampleCount)
                 assertAnrReceived(spans[1], checkNotNull(secondAnrStartTime), secondSampleCount)
+            },
+            otelExportAssertion = {
+                awaitSpansWithType(2, EmbType.Performance.ThreadBlockage)
             }
         )
     }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -21,10 +21,10 @@ import kotlin.reflect.KClass
  */
 internal class ModuleInitBootstrapper(
     val logger: EmbLogger = EmbTrace.trace("logger-init", ::EmbLoggerImpl),
-    val initModule: InitModule = EmbTrace.trace("init-module", { createInitModule(logger = logger) }),
-    val openTelemetryModule: OpenTelemetryModule = EmbTrace.trace("otel-module", {
+    val initModule: InitModule = EmbTrace.trace("init-module") { createInitModule(logger = logger) },
+    val openTelemetryModule: OpenTelemetryModule = EmbTrace.trace("otel-module") {
         createOpenTelemetryModule(initModule)
-    }),
+    },
     private val coreModuleSupplier: CoreModuleSupplier = ::createCoreModule,
     private val configModuleSupplier: ConfigModuleSupplier = ::createConfigModule,
     private val systemServiceModuleSupplier: SystemServiceModuleSupplier = ::createSystemServiceModule,
@@ -214,6 +214,7 @@ internal class ModuleInitBootstrapper(
                     anrModule = init(AnrModule::class) {
                         anrModuleSupplier(
                             initModule,
+                            openTelemetryModule,
                             configModule.configService,
                             workerThreadModule
                         )
@@ -311,7 +312,7 @@ internal class ModuleInitBootstrapper(
                             configModule,
                             { nativeFeatureModule.nativeThreadSamplerService?.getNativeSymbols() },
                             openTelemetryModule,
-                            { OtelPayloadMapperImpl(anrModule.anrOtelMapper, nativeFeatureModule.nativeAnrOtelMapper) },
+                            { OtelPayloadMapperImpl(anrModule.anrOtelMapper) },
                             deliveryModule
                         )
                     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -47,7 +47,7 @@ internal fun fakeModuleInitBootstrapper(
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
-    anrModuleSupplier: AnrModuleSupplier = { _, _, _ -> FakeAnrModule() },
+    anrModuleSupplier: AnrModuleSupplier = { _, _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier =

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAnrOtelMapper.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAnrOtelMapper.kt
@@ -1,9 +1,5 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.anr.AnrOtelMapper
-import io.embrace.android.embracesdk.internal.anr.ndk.NativeAnrOtelMapper
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 
-fun fakeAnrOtelMapper(): AnrOtelMapper = AnrOtelMapper(FakeAnrService(), FakeClock())
-fun fakeNativeAnrOtelMapper(): NativeAnrOtelMapper =
-    NativeAnrOtelMapper(null, EmbraceSerializer(), FakeClock())
+fun fakeAnrOtelMapper(): AnrOtelMapper = AnrOtelMapper(FakeAnrService(), FakeClock(), FakeSpanService())

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelPayloadMapper.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelPayloadMapper.kt
@@ -5,5 +5,6 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
 class FakeOtelPayloadMapper : OtelPayloadMapper {
-    override fun getSessionPayload(endType: SessionSnapshotType, crashId: String?): List<Span> = emptyList()
+    override fun snapshotSpans(endType: SessionSnapshotType, crashId: String?): List<Span> = emptyList()
+    override fun record() { }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelPayloadMapper.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelPayloadMapper.kt
@@ -2,9 +2,8 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
 class FakeOtelPayloadMapper : OtelPayloadMapper {
-    override fun snapshotSpans(endType: SessionSnapshotType, crashId: String?): List<Span> = emptyList()
+    override fun snapshotSpans(): List<Span> = emptyList()
     override fun record() { }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes.injection
 import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.fakeAnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.AnrService
 import io.embrace.android.embracesdk.internal.anr.detection.BlockedThreadDetector
@@ -11,7 +12,7 @@ import io.embrace.android.embracesdk.internal.injection.AnrModule
 
 class FakeAnrModule(
     override val anrService: AnrService = FakeAnrService(),
-    override val anrOtelMapper: AnrOtelMapper = AnrOtelMapper(anrService, FakeClock()),
+    override val anrOtelMapper: AnrOtelMapper = fakeAnrOtelMapper(),
     override val blockedThreadDetector: BlockedThreadDetector = BlockedThreadDetector(
         FakeConfigService(),
         FakeClock(),


### PR DESCRIPTION
## Goal

Log ANRs as real spans through the SDK if we are producing a final session payload. This allows for ANRs to be exported as spans when a session ends. To that end, I added a new method to take the `AnrInterval` objects and log them as real spans that will be used when a session is ending, and only use the method to produce the fake spans to stuff in a session payload snapshot before it ends when we are doing a snapshot. 

## Testing

Existing tests validate that the logic change doesn't affect the final payload. Additional tests added to validate the exported spans.

