### PR TITLE
Add push notification bytecode example

### DIFF
--- a/examples/ExampleApp/app/build.gradle.kts
+++ b/examples/ExampleApp/app/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     alias(libs.plugins.embrace)
 }
 
+embrace {
+    bytecodeInstrumentation {
+        firebasePushNotificationsEnabled.set(true)
+    }
+}
+
 android {
     namespace = "io.embrace.android.exampleapp"
     compileSdk = 35
@@ -60,6 +66,7 @@ dependencies {
     implementation(platform(libs.opentelemetry.bom))
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
+    implementation(libs.firebase.messaging)
 
     // uncomment to enable debugging through source contained in those modules
 //    implementation(libs.embrace.android.api)
@@ -68,6 +75,7 @@ dependencies {
 //    implementation(libs.embrace.android.features)
 //    implementation(libs.embrace.android.payload)
 //    implementation(libs.embrace.android.delivery)
+    implementation(libs.embrace.android.fcm)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/examples/ExampleApp/app/src/main/AndroidManifest.xml
+++ b/examples/ExampleApp/app/src/main/AndroidManifest.xml
@@ -37,6 +37,12 @@
         <activity
             android:name=".ui.examples.bytecode.BytecodeOkHttpActivity"
             android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".ui.examples.bytecode.BytecodeFcmPushNotificationActivity"
+            android:theme="@style/Theme.ExampleApp" />
+
+        <service android:name=".ui.examples.bytecode.ExamplePushNotificationService"
+            />
     </application>
 
 </manifest>

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/bytecode/BytecodeFcmPushNotificationActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/bytecode/BytecodeFcmPushNotificationActivity.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.exampleapp.ui.examples.bytecode
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.ComponentActivity
+import com.google.firebase.messaging.RemoteMessage
+import io.embrace.android.exampleapp.R
+
+class BytecodeFcmPushNotificationActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_bytecode_fcm_push_notification)
+
+        findViewById<View>(R.id.btn_bytecode_fcm_push_notification).setOnClickListener {
+            val msg = RemoteMessage.Builder("my-id")
+                .setMessageId("my-message-id")
+                .setMessageType("my-message-type")
+                .setData(mapOf("key" to "value"))
+                .build()
+            ExamplePushNotificationService().onMessageReceived(msg)
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/bytecode/BytecodeInstrumentationExample.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/bytecode/BytecodeInstrumentationExample.kt
@@ -15,6 +15,7 @@ private val items = listOf(
     BytecodeSample("OnClick/OnLongClick", BytecodeViewClickActivity::class),
     BytecodeSample("WebView", BytecodeWebViewActivity::class),
     BytecodeSample("OkHttp", BytecodeOkHttpActivity::class),
+    BytecodeSample("FCM Push Notifications", BytecodeFcmPushNotificationActivity::class),
 )
 
 @Composable

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/bytecode/ExamplePushNotificationService.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/bytecode/ExamplePushNotificationService.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.exampleapp.ui.examples.bytecode
+
+import android.annotation.SuppressLint
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+@SuppressLint("MissingFirebaseInstanceTokenRefresh")
+class ExamplePushNotificationService : FirebaseMessagingService() {
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+        Log.d("EmbraceExample", "Message received: ${message.data}")
+    }
+}

--- a/examples/ExampleApp/app/src/main/res/layout/activity_bytecode_fcm_push_notification.xml
+++ b/examples/ExampleApp/app/src/main/res/layout/activity_bytecode_fcm_push_notification.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/target_activity_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/target_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:gravity="center_horizontal"
+        android:text="Click the button to simulate a FCM push notification."
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <Button
+        android:id="@+id/btn_bytecode_fcm_push_notification"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:padding="8dp"
+        android:text="Click me" />
+
+</LinearLayout>

--- a/examples/ExampleApp/gradle/libs.versions.toml
+++ b/examples/ExampleApp/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ embrace = "7.3.0"
 navigationCompose = "2.8.9"
 okhttp = "4.12.0"
 otel = "1.49.0"
+firebase = "24.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -33,6 +34,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 opentelemetry-bom = { group = "io.opentelemetry", name = "opentelemetry-bom", version.ref = "otel" }
 opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api"}
 opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk"}
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging", version.ref = "firebase" }
 
 embrace-android-api = { group = "io.embrace", name = "embrace-android-api", version.ref = "embrace" }
 embrace-android-sdk = { group = "io.embrace", name = "embrace-android-sdk", version.ref = "embrace" }
@@ -40,6 +42,7 @@ embrace-android-core = { group = "io.embrace", name = "embrace-android-core", ve
 embrace-android-features = { group = "io.embrace", name = "embrace-android-features", version.ref = "embrace" }
 embrace-android-payload = { group = "io.embrace", name = "embrace-android-payload", version.ref = "embrace" }
 embrace-android-delivery = { group = "io.embrace", name = "embrace-android-delivery", version.ref = "embrace" }
+embrace-android-fcm = { module = "io.embrace:embrace-android-fcm", version.ref = "embrace" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Goal

Adds an example that simulates receiving a push notification, so that we can exercise the bytecode instrumentation API.
