### PR TITLE
flatMap the encode file task so it doesn't get resolved too early within the ASM task

### DIFF
--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
@@ -3,6 +3,7 @@ package io.embrace.gradle.plugin.instrumentation
 import io.embrace.android.gradle.plugin.instrumentation.BytecodeInstrumentationParams
 import io.embrace.android.gradle.plugin.instrumentation.ClassInstrumentationFilter
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 
 class FakeBytecodeInstrumentationParams(
@@ -15,7 +16,7 @@ class FakeBytecodeInstrumentationParams(
 ) : BytecodeInstrumentationParams {
     override val config: Property<VariantConfig>
         get() = TODO("Not yet implemented")
-    override val encodedSharedObjectFilesMap: Property<String>
+    override val encodedSharedObjectFilesMap: RegularFileProperty
         get() = TODO("Not yet implemented")
     override val classInstrumentationFilter: Property<ClassInstrumentationFilter>
         get() = TODO("Not yet implemented")

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -2,7 +2,6 @@ package io.embrace.android.gradle.plugin.instrumentation
 
 import com.android.build.api.instrumentation.FramesComputationMode
 import com.android.build.api.instrumentation.InstrumentationScope
-import io.embrace.android.gradle.plugin.gradle.nullSafeMap
 import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
 import io.embrace.android.gradle.plugin.tasks.ndk.EncodeFileToBase64Task
 import io.embrace.android.gradle.plugin.tasks.registration.EmbraceTaskRegistration
@@ -50,16 +49,11 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                     val asmTransformationTask = project.tryGetTaskProvider(
                         "transform${variant.name.capitalizedString()}ClassesWithAsm"
                     ) ?: error("Unable to find ASM transformation task for variant ${variant.name}.")
-
                     asmTransformationTask.configure { it.dependsOn(encodeFileToBase64Task) }
 
                     params.encodedSharedObjectFilesMap.set(
-                        encodeFileToBase64Task.nullSafeMap { encodeTask ->
-                            encodeTask.outputFile.asFile.orNull?.let { file ->
-                                file.takeIf { it.exists() }
-                                    ?.bufferedReader()
-                                    ?.use { it.readText() }
-                            }
+                        encodeFileToBase64Task.flatMap {
+                            it.outputFile
                         }
                     )
                 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
@@ -2,9 +2,13 @@ package io.embrace.android.gradle.plugin.instrumentation
 
 import com.android.build.api.instrumentation.InstrumentationParameters
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 
 /**
  * Contains parameters that affect how bytecode is manipulated during instrumentation.
@@ -25,8 +29,9 @@ interface BytecodeInstrumentationParams : InstrumentationParameters {
      * Base64 encoded string of the shared object files map to be injected in the SDK.
      */
     @get:Optional
-    @get:Input
-    val encodedSharedObjectFilesMap: Property<String>
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    val encodedSharedObjectFilesMap: RegularFileProperty
 
     /**
      * Whether or not the plugin should operate for this variant.

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
@@ -29,6 +29,10 @@ abstract class EmbraceClassVisitorFactory : AsmClassVisitorFactory<BytecodeInstr
         val params = parameters.get()
         val cfg = params.config.get()
         val encodedSharedObjectFilesMap = parameters.get().encodedSharedObjectFilesMap.orNull
+            ?.asFile
+            ?.takeIf { it.exists() }
+            ?.bufferedReader()
+            ?.use { it.readText() }
         ConfigClassVisitorFactory.createClassVisitor(className, cfg, encodedSharedObjectFilesMap, api, visitor)?.let {
             visitor = it
         }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -6,9 +6,11 @@ import io.embrace.android.gradle.plugin.instrumentation.BytecodeInstrumentationP
 import io.embrace.android.gradle.plugin.instrumentation.ClassInstrumentationFilter
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.provider.Property
+import org.gradle.testfixtures.ProjectBuilder
 
 class TestBytecodeInstrumentationParams(
     disabled: Boolean = false,
@@ -24,8 +26,7 @@ class TestBytecodeInstrumentationParams(
         DefaultProperty(PropertyHost.NO_OP, VariantConfig::class.javaObjectType).convention(
             VariantConfig("", "", null, null, null, null)
         )
-    override val encodedSharedObjectFilesMap: Property<String> =
-        DefaultProperty(PropertyHost.NO_OP, String::class.javaObjectType).convention("")
+    override val encodedSharedObjectFilesMap: RegularFileProperty = ProjectBuilder.builder().build().objects.fileProperty()
     override val disabled: Property<Boolean> =
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(disabled)
     override val classInstrumentationFilter: Property<ClassInstrumentationFilter> =


### PR DESCRIPTION
## Goal

```
params.encodedSharedObjectFilesMap.set(
    encodeFileToBase64Task.nullSafeMap { encodeTask ->
        encodeTask.outputFile.asFile.orNull?.let { file ->
            file.takeIf { it.exists() }
                ?.bufferedReader()
                ?.use { it.readText() }
        }
    }
)
```

Here, outputFile.asFile.orNull eagerly resolved the output file without considering whether the encode task had already produced an output. 
Now, we flatMap the task output to the Asm param input, so Gradle will consider the dependencies and avoid early resolution.

I had to move the file reading to the params class, because if it happened inside the provider, it was resolved too early. 

I still have to test this on a configuration-cache project.
 