### PR TITLE
[DNM] Add dependency on opentelemetry-kotlin-api

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -42,6 +42,10 @@ dependencies {
     implementation(libs.lifecycle.process)
     implementation(libs.okhttp)
 
+    implementation(libs.opentelemetry.kotlin.api)
+    implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.compat)
+
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)
     testImplementation(libs.opentelemetry.sdk)

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -23,6 +23,10 @@ dependencies {
     compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.lifecycle.process)
 
+    implementation(libs.opentelemetry.kotlin.api)
+    implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.compat)
+
     testImplementation(project(":embrace-android-api"))
     testImplementation(project(":embrace-android-core"))
     testImplementation(project(":embrace-android-infra"))

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -31,4 +31,8 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.robolectric)
     implementation(libs.lifecycle.runtime)
+
+    implementation(libs.opentelemetry.kotlin.api)
+    implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.compat)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAttributeContainer.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAttributeContainer.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+
+@OptIn(ExperimentalApi::class)
+class FakeAttributeContainer(
+    private val impl: MutableMap<String, Any> = mutableMapOf(),
+) : AttributeContainer {
+
+    override fun attributes(): Map<String, Any> = impl.toMap()
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+        impl[key] = value
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+        impl[key] = value
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+        impl[key] = value
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+        impl[key] = value
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+        impl[key] = value
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+        impl[key] = value
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+        impl[key] = value
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+        impl[key] = value
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecord.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecord.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.logging.LogRecord
+import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
+
+@OptIn(ExperimentalApi::class)
+class FakeLogRecord(
+    override val observedTimestampNs: Long?,
+    override val severityNumber: SeverityNumber?,
+    override val timestampNs: Long?,
+    override val body: String?,
+    override val context: io.embrace.opentelemetry.kotlin.context.Context?,
+    override val severityText: String?,
+    private val attrs: Map<String, Any>,
+) : LogRecord {
+    override fun attributes(): Map<String, Any> = attrs
+    override fun setBooleanAttribute(key: String, value: Boolean) = throw UnsupportedOperationException()
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) = throw UnsupportedOperationException()
+    override fun setDoubleAttribute(key: String, value: Double) = throw UnsupportedOperationException()
+    override fun setDoubleListAttribute(key: String, value: List<Double>) = throw UnsupportedOperationException()
+    override fun setLongAttribute(key: String, value: Long) = throw UnsupportedOperationException()
+    override fun setLongListAttribute(key: String, value: List<Long>) = throw UnsupportedOperationException()
+    override fun setStringAttribute(key: String, value: String) = throw UnsupportedOperationException()
+    override fun setStringListAttribute(key: String, value: List<String>) = throw UnsupportedOperationException()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ openTelemetryCore = "1.49.0"
 openTelementrySemConv = "1.29.0-alpha"
 moshi = "1.15.2"
 lifecycle = "2.7.0" # version pinned to 2.7.0 because of AGP bug
+otelKotlin = "0.1.0"
 protobuf = "4.30.2"
 profileinstaller = "1.3.1" # version pinned to 1.3.1 because of AGP bug
 okhttp = "4.12.0"
@@ -81,6 +82,9 @@ zstd-jni = { module = "com.github.luben:zstd-jni", version.ref = "zstdJni" }
 agp-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp-api" }
 apktool-lib = { module = "org.apktool:apktool-lib", version.ref = "apktoolLib" }
 bundletool = { module = "com.android.tools.build:bundletool", version.ref = "bundletool" }
+opentelemetry-kotlin-api = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api", version.ref = "otelKotlin" }
+opentelemetry-kotlin-api-ext = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api-ext", version.ref = "otelKotlin" }
+opentelemetry-kotlin-compat = { module = "io.embrace.opentelemetry.kotlin:compat-kotlin-to-official", version.ref = "otelKotlin" }
 
 [plugins]
 google-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Goal

Adds a dependency on `opentelemetry-kotlin-api`. This will eventually be used to wrap the OTel Java SDK's use within Embrace.

## Testing

Relied on existing test coverage.
