### PR TITLE
Default symbol upload task registration to false if unspecified

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/app/src/main/embrace-config.json
+++ b/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/app/src/main/embrace-config.json
@@ -1,4 +1,5 @@
 {
-    "app_id": "abcde",
-    "api_token": "12345123451234512345123451234512"
+  "app_id": "abcde",
+  "api_token": "12345123451234512345123451234512",
+  "ndk_enabled": true
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -37,110 +37,110 @@ class NdkUploadTasksRegistration(
      * build process.
      */
     fun RegistrationParams.execute() {
-        // Skip registration if NDK is disabled
-        if (variantConfig.embraceConfig?.ndkEnabled == false) return
+        // Only proceed if the NDK is enabled - if the config or attribute is unspecified, the default is false
+        if (variantConfig.embraceConfig?.ndkEnabled == true) {
+            val sharedObjectFilesProvider = getSharedObjectFilesProvider(project, data)
 
-        val sharedObjectFilesProvider = getSharedObjectFilesProvider(project, data)
-
-        val compressionTaskProvider = project.registerTask(
-            CompressSharedObjectFilesTask.NAME,
-            CompressSharedObjectFilesTask::class.java,
-            data
-        ) { task ->
-            task.architecturesDirectory.set(project.layout.dir(sharedObjectFilesProvider))
-            task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
-            task.compressedSharedObjectFilesDirectory.set(
-                project.layout.buildDirectory.dir("intermediates/embrace/compressed/${data.name}")
-            )
-        }
-
-        compressionTaskProvider.configure { compressionTask: CompressSharedObjectFilesTask ->
-            val shouldExecuteCompressionTaskProvider = getShouldExecuteCompressionTaskProvider()
-            compressionTask.onlyIf { shouldExecuteCompressionTaskProvider.orNull ?: true }
-            // TODO: check if these are only needed for Unity and comment accordingly.
-            compressionTask.mustRunAfter(object : Callable<Any> {
-                override fun call(): Any {
-                    return listOfNotNull(
-                        project.tryGetTaskProvider(
-                            "merge${variantConfig.variantName.capitalizedString()}JniLibFolders"
-                        ),
-                        project.tryGetTaskProvider(
-                            "transformNativeLibsWithMergeJniLibsFor${variantConfig.variantName.capitalizedString()}"
-                        ),
-                        project.tryGetTaskProvider(
-                            "merge${variantConfig.variantName.capitalizedString()}NativeLibs"
-                        )
-                    )
-                }
-            })
-        }
-
-        val hashTaskProvider = project.registerTask(
-            HashSharedObjectFilesTask.NAME,
-            HashSharedObjectFilesTask::class.java,
-            data
-        ) { task ->
-            task.compressedSharedObjectFilesDirectory.set(
-                compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory }
-            )
-            task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
-            task.architecturesToHashedSharedObjectFilesMap.set(
-                project.layout.buildDirectory.file("intermediates/embrace/hashes/${data.name}/hashes.json")
-            )
-        }
-
-        val uploadTask = project.registerTask(
-            UploadSharedObjectFilesTask.NAME,
-            UploadSharedObjectFilesTask::class.java,
-            data
-        ) { task ->
-            // TODO: Check why this is needed for 7.5.1. For Gradle 8+ Gradle detects automatically when the other tasks aren't executed
-            task.onlyIf {
-                task.compressedSharedObjectFilesDirectory.asFile.get().exists() &&
-                    task.architecturesToHashedSharedObjectFilesMapJson.asFile.get().exists()
+            val compressionTaskProvider = project.registerTask(
+                CompressSharedObjectFilesTask.NAME,
+                CompressSharedObjectFilesTask::class.java,
+                data
+            ) { task ->
+                task.architecturesDirectory.set(project.layout.dir(sharedObjectFilesProvider))
+                task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
+                task.compressedSharedObjectFilesDirectory.set(
+                    project.layout.buildDirectory.dir("intermediates/embrace/compressed/${data.name}")
+                )
             }
-            // TODO: An error thrown in registration will make the build will fail. Should we use failBuildOnUploadErrors for this too?
-            task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
-            task.requestParams.set(
-                behavior.failBuildOnUploadErrors.map { failBuildOnUploadErrors ->
-                    RequestParams(
-                        appId = variantConfig.embraceConfig?.appId.orEmpty(),
-                        apiToken = variantConfig.embraceConfig?.apiToken.orEmpty(),
-                        endpoint = EmbraceEndpoint.NDK,
-                        failBuildOnUploadErrors = failBuildOnUploadErrors,
-                        baseUrl = behavior.baseUrl,
-                    )
+
+            compressionTaskProvider.configure { compressionTask: CompressSharedObjectFilesTask ->
+                val shouldExecuteCompressionTaskProvider = getShouldExecuteCompressionTaskProvider()
+                compressionTask.onlyIf { shouldExecuteCompressionTaskProvider.orNull ?: true }
+                // TODO: check if these are only needed for Unity and comment accordingly.
+                compressionTask.mustRunAfter(object : Callable<Any> {
+                    override fun call(): Any {
+                        return listOfNotNull(
+                            project.tryGetTaskProvider(
+                                "merge${variantConfig.variantName.capitalizedString()}JniLibFolders"
+                            ),
+                            project.tryGetTaskProvider(
+                                "transformNativeLibsWithMergeJniLibsFor${variantConfig.variantName.capitalizedString()}"
+                            ),
+                            project.tryGetTaskProvider(
+                                "merge${variantConfig.variantName.capitalizedString()}NativeLibs"
+                            )
+                        )
+                    }
+                })
+            }
+
+            val hashTaskProvider = project.registerTask(
+                HashSharedObjectFilesTask.NAME,
+                HashSharedObjectFilesTask::class.java,
+                data
+            ) { task ->
+                task.compressedSharedObjectFilesDirectory.set(
+                    compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory }
+                )
+                task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
+                task.architecturesToHashedSharedObjectFilesMap.set(
+                    project.layout.buildDirectory.file("intermediates/embrace/hashes/${data.name}/hashes.json")
+                )
+            }
+
+            val uploadTask = project.registerTask(
+                UploadSharedObjectFilesTask.NAME,
+                UploadSharedObjectFilesTask::class.java,
+                data
+            ) { task ->
+                // TODO: Check why this is needed for 7.5.1. For Gradle 8+ Gradle detects automatically when the other tasks aren't executed
+                task.onlyIf {
+                    task.compressedSharedObjectFilesDirectory.asFile.get().exists() &&
+                        task.architecturesToHashedSharedObjectFilesMapJson.asFile.get().exists()
                 }
-            )
+                // TODO: An error thrown in registration will make the build will fail. Should we use failBuildOnUploadErrors for this too?
+                task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
+                task.requestParams.set(
+                    behavior.failBuildOnUploadErrors.map { failBuildOnUploadErrors ->
+                        RequestParams(
+                            appId = variantConfig.embraceConfig.appId.orEmpty(),
+                            apiToken = variantConfig.embraceConfig.apiToken.orEmpty(),
+                            endpoint = EmbraceEndpoint.NDK,
+                            failBuildOnUploadErrors = failBuildOnUploadErrors,
+                            baseUrl = behavior.baseUrl,
+                        )
+                    }
+                )
 
-            task.compressedSharedObjectFilesDirectory.set(
-                compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory }
-            )
+                task.compressedSharedObjectFilesDirectory.set(
+                    compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory }
+                )
 
-            task.architecturesToHashedSharedObjectFilesMapJson.set(
-                hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap }
-            )
-        }
+                task.architecturesToHashedSharedObjectFilesMapJson.set(
+                    hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap }
+                )
+            }
 
-        project.registerTask(
-            EncodeFileToBase64Task.NAME,
-            EncodeFileToBase64Task::class.java,
-            data
-        ) { task ->
-            // TODO: Check why this is needed for 7.5.1. For Gradle 8+ Gradle detects automatically when the other tasks aren't executed
-            task.onlyIf { task.inputFile.asFile.get().exists() }
+            project.registerTask(
+                EncodeFileToBase64Task.NAME,
+                EncodeFileToBase64Task::class.java,
+                data
+            ) { task ->
+                // TODO: Check why this is needed for 7.5.1. For Gradle 8+ Gradle detects automatically when the other tasks aren't executed
+                task.onlyIf { task.inputFile.asFile.get().exists() }
 
-            task.inputFile.set(
-                hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap }
-            )
+                task.inputFile.set(
+                    hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap }
+                )
 
-            task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
+                task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
 
-            task.outputFile.set(
-                project.layout.buildDirectory.file("intermediates/embrace/ndk/${data.name}/encoded_map.txt")
-            )
+                task.outputFile.set(
+                    project.layout.buildDirectory.file("intermediates/embrace/ndk/${data.name}/encoded_map.txt")
+                )
 
-            task.dependsOn(uploadTask)
+                task.dependsOn(uploadTask)
+            }
         }
     }
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
@@ -101,21 +101,27 @@ class NdkUploadTasksRegistrationTest {
 
     @Test
     fun `skip registration when NDK is disabled`() {
-        // Given a variantConfig with NDK disabled
-        val variantConfig = VariantConfig(
-            testVariantName,
-            embraceConfig = createEmbraceVariantConfig(ndkEnabled = false)
+        verifyNoUploadTasksRegistered(
+            VariantConfig(
+                variantName = testVariantName,
+                embraceConfig = createEmbraceVariantConfig(ndkEnabled = false)
+            )
         )
+    }
 
-        // When NDK upload tasks are registered
-        val ndkUploadTasksRegistration = createNdkUploadTasksRegistration(variantConfig = variantConfig)
-        ndkUploadTasksRegistration.register(testRegistrationParams)
+    @Test
+    fun `skip registration if NDK property not specified`() {
+        verifyNoUploadTasksRegistered(
+            VariantConfig(
+                variantName = testVariantName,
+                embraceConfig = createEmbraceVariantConfig(ndkEnabled = null)
+            )
+        )
+    }
 
-        // Then no tasks should be registered
-        assertTaskNotRegistered(CompressSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
-        assertTaskNotRegistered(HashSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
-        assertTaskNotRegistered(UploadSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
-        assertTaskNotRegistered(EncodeFileToBase64Task.NAME, testAndroidCompactedVariantData.name)
+    @Test
+    fun `skip registration if no config file specified`() {
+        verifyNoUploadTasksRegistered(VariantConfig(testVariantName))
     }
 
     @Test
@@ -297,5 +303,17 @@ class NdkUploadTasksRegistrationTest {
     private fun assertTaskRegistered(taskName: String, variantName: String) {
         assertTrue(project.isTaskRegistered(taskName, variantName))
         assertNotNull(project.tasks.findByName("${taskName}${variantName.capitalizedString()}"))
+    }
+
+    private fun verifyNoUploadTasksRegistered(variantConfig: VariantConfig) {
+        // When NDK upload tasks are registered
+        val ndkUploadTasksRegistration = createNdkUploadTasksRegistration(variantConfig = variantConfig)
+        ndkUploadTasksRegistration.register(testRegistrationParams)
+
+        // Then no tasks should be registered
+        assertTaskNotRegistered(CompressSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
+        assertTaskNotRegistered(HashSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
+        assertTaskNotRegistered(UploadSharedObjectFilesTask.NAME, testAndroidCompactedVariantData.name)
+        assertTaskNotRegistered(EncodeFileToBase64Task.NAME, testAndroidCompactedVariantData.name)
     }
 }


### PR DESCRIPTION
## Goal

Change the logic to only register if the attribute is defined and true. The early return logic is difficult to read given that the object not being specified doesn't match and the logic proceeds.

## Testing
Added unit tests

