### PR TITLE
Use kotlin API for SeverityNumber

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExt.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.trace.data.SpanData

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -90,6 +90,10 @@ dependencies {
     implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.profileinstaller)
 
+    implementation(libs.opentelemetry.kotlin.api)
+    implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.compat)
+
     testImplementation(project(":embrace-test-fakes"))
     testImplementation(libs.protobuf.java)
     testImplementation(libs.protobuf.java.util)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import io.embrace.android.embracesdk.testframework.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.testframework.assertions.getLogOfType
-import io.opentelemetry.api.logs.Severity
+import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -179,8 +179,7 @@ internal class FlutterInternalInterfaceTest {
                 assertOtelLogReceived(
                     logReceived = log,
                     expectedMessage = "Dart error",
-                    expectedSeverityNumber = Severity.ERROR.severityNumber,
-                    expectedSeverityText = Severity.ERROR.name,
+                    expectedSeverityNumber = SeverityNumber.ERROR,
                     expectedTimeMs = sessionStartTimeMs,
                     expectedType = LogExceptionType.HANDLED.value,
                     expectedExceptionName = expectedName,
@@ -226,8 +225,7 @@ internal class FlutterInternalInterfaceTest {
                 assertOtelLogReceived(
                     logReceived = log,
                     expectedMessage = "Dart error",
-                    expectedSeverityNumber = Severity.ERROR.severityNumber,
-                    expectedSeverityText = Severity.ERROR.name,
+                    expectedSeverityNumber = SeverityNumber.ERROR,
                     expectedTimeMs = sessionStartTimeMs,
                     expectedType = LogExceptionType.UNHANDLED.value,
                     expectedExceptionName = expectedName,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FileAttachmentFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FileAttachmentFeatureTest.kt
@@ -9,8 +9,11 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.testframework.assertions.getLogOfType
-import io.embrace.android.embracesdk.testframework.assertions.getOtelSeverity
 import io.embrace.android.embracesdk.testframework.server.FormPart
+import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
+import java.util.LinkedList
+import java.util.Queue
+import java.util.UUID
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -18,9 +21,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.LinkedList
-import java.util.Queue
-import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 internal class FileAttachmentFeatureTest {
@@ -248,15 +248,14 @@ internal class FileAttachmentFeatureTest {
         assertOtelLogReceived(
             logReceived = log,
             expectedMessage = "test message",
-            expectedSeverityNumber = getOtelSeverity(Severity.INFO).severityNumber,
-            expectedSeverityText = Severity.INFO.name,
-            expectedState = "foreground",
+            expectedSeverityNumber = SeverityNumber.INFO,
             expectedTimeMs = timestamp,
             expectedProperties = mapOf(
                 "key" to "value",
                 ATTR_KEY_URL to url,
                 ATTR_KEY_ID to id,
             ),
+            expectedState = "foreground",
         )
     }
 
@@ -268,14 +267,13 @@ internal class FileAttachmentFeatureTest {
         assertOtelLogReceived(
             logReceived = log,
             expectedMessage = "test message",
-            expectedSeverityNumber = getOtelSeverity(Severity.INFO).severityNumber,
-            expectedSeverityText = Severity.INFO.name,
-            expectedState = "foreground",
+            expectedSeverityNumber = SeverityNumber.INFO,
             expectedTimeMs = timestamp,
             expectedProperties = mapOf(
                 "key" to "value",
                 ATTR_KEY_SIZE to size.toString(),
             ),
+            expectedState = "foreground",
         )
         val id = log.attributes?.findAttributeValue(ATTR_KEY_ID)
         checkNotNull(UUID.fromString(id))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -21,7 +21,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertMatches
 import io.embrace.android.embracesdk.testframework.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.testframework.assertions.getLastLog
-import io.opentelemetry.api.logs.Severity
+import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -112,8 +112,7 @@ internal class JvmCrashFeatureTest {
                 assertOtelLogReceived(
                     logReceived = log,
                     expectedMessage = "",
-                    expectedSeverityNumber = Severity.ERROR.severityNumber,
-                    expectedSeverityText = Severity.ERROR.name,
+                    expectedSeverityNumber = SeverityNumber.ERROR,
                     expectedTimeMs = crashTimeMs,
                     expectedExceptionName = testException.javaClass.canonicalName,
                     expectedExceptionMessage = checkNotNull(testException.message),
@@ -154,8 +153,7 @@ internal class JvmCrashFeatureTest {
         assertOtelLogReceived(
             logReceived = this,
             expectedMessage = "",
-            expectedSeverityNumber = Severity.ERROR.severityNumber,
-            expectedSeverityText = Severity.ERROR.name,
+            expectedSeverityNumber = SeverityNumber.ERROR,
             expectedTimeMs = crashTimeMs,
             expectedExceptionName = testException.javaClass.canonicalName,
             expectedExceptionMessage = checkNotNull(testException.message),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.testframework.assertions.getLogOfType
 import io.embrace.android.embracesdk.testframework.assertions.getOtelSeverity
+import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -56,7 +57,7 @@ internal class LogFeatureTest {
                     logReceived = log,
                     expectedTimeMs = logTimestamps.remove(),
                     expectedMessage = "test message",
-                    expectedSeverityNumber = getOtelSeverity(Severity.INFO).severityNumber,
+                    expectedSeverityNumber = SeverityNumber.INFO,
                     expectedSeverityText = Severity.INFO.name,
                     expectedState = "foreground",
                 )
@@ -78,7 +79,7 @@ internal class LogFeatureTest {
                 assertOtelLogReceived(
                     logReceived = log,
                     expectedMessage = "test message",
-                    expectedSeverityNumber = getOtelSeverity(Severity.WARNING).severityNumber,
+                    expectedSeverityNumber = SeverityNumber.WARN,
                     expectedSeverityText = Severity.WARNING.name,
                     expectedTimeMs = logTimestamps.remove(),
                 )
@@ -101,7 +102,7 @@ internal class LogFeatureTest {
                 assertOtelLogReceived(
                     log,
                     expectedMessage = "test message",
-                    expectedSeverityNumber = getOtelSeverity(Severity.ERROR).severityNumber,
+                    expectedSeverityNumber = SeverityNumber.ERROR,
                     expectedSeverityText = Severity.ERROR.name,
                     expectedTimeMs = logTimestamps.remove(),
                 )
@@ -129,7 +130,7 @@ internal class LogFeatureTest {
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = expectedMessage,
-                        expectedSeverityNumber = getOtelSeverity(severity).severityNumber,
+                        expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                     )
@@ -158,7 +159,7 @@ internal class LogFeatureTest {
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = expectedMessage,
-                        expectedSeverityNumber = getOtelSeverity(severity).severityNumber,
+                        expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedProperties = customProperties,
@@ -181,7 +182,7 @@ internal class LogFeatureTest {
                 assertOtelLogReceived(
                     log,
                     expectedMessage = checkNotNull(testException.message),
-                    expectedSeverityNumber = io.opentelemetry.api.logs.Severity.ERROR.severityNumber,
+                    expectedSeverityNumber = SeverityNumber.ERROR,
                     expectedSeverityText = Severity.ERROR.name,
                     expectedTimeMs = logTimestamps.remove(),
                     expectedType = LogExceptionType.HANDLED.value,
@@ -208,7 +209,7 @@ internal class LogFeatureTest {
                 assertOtelLogReceived(
                     log,
                     expectedMessage = checkNotNull(testException.message),
-                    expectedSeverityNumber = io.opentelemetry.api.logs.Severity.INFO.severityNumber,
+                    expectedSeverityNumber = SeverityNumber.INFO,
                     expectedSeverityText = Severity.INFO.name,
                     expectedTimeMs = logTimestamps.remove(),
                     expectedType = LogExceptionType.HANDLED.value,
@@ -242,7 +243,7 @@ internal class LogFeatureTest {
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = checkNotNull(testException.message),
-                        expectedSeverityNumber = getOtelSeverity(severity).severityNumber,
+                        expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedType = LogExceptionType.HANDLED.value,
@@ -277,7 +278,7 @@ internal class LogFeatureTest {
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = expectedMessage,
-                        expectedSeverityNumber = getOtelSeverity(severity).severityNumber,
+                        expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedType = LogExceptionType.HANDLED.value,
@@ -306,7 +307,7 @@ internal class LogFeatureTest {
                 assertOtelLogReceived(
                     log,
                     expectedMessage = "",
-                    expectedSeverityNumber = getOtelSeverity(Severity.ERROR).severityNumber,
+                    expectedSeverityNumber = getOtelSeverity(Severity.ERROR),
                     expectedSeverityText = Severity.ERROR.name,
                     expectedTimeMs = logTimestamps.remove(),
                     expectedType = LogExceptionType.HANDLED.value,
@@ -335,7 +336,7 @@ internal class LogFeatureTest {
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = "",
-                        expectedSeverityNumber = getOtelSeverity(severity).severityNumber,
+                        expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedType = LogExceptionType.HANDLED.value,
@@ -365,7 +366,7 @@ internal class LogFeatureTest {
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = "",
-                        expectedSeverityNumber = getOtelSeverity(severity).severityNumber,
+                        expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedType = LogExceptionType.HANDLED.value,
@@ -404,7 +405,7 @@ internal class LogFeatureTest {
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = expectedMessage,
-                        expectedSeverityNumber = getOtelSeverity(severity).severityNumber,
+                        expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedType = LogExceptionType.HANDLED.value,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/OTelLogAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/OTelLogAssertions.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
+import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
@@ -17,9 +18,9 @@ import org.junit.Assert.assertNotNull
 internal fun assertOtelLogReceived(
     logReceived: Log?,
     expectedMessage: String,
-    expectedSeverityNumber: Int,
-    expectedSeverityText: String,
+    expectedSeverityNumber: SeverityNumber,
     expectedTimeMs: Long,
+    expectedSeverityText: String? = null,
     expectedType: String? = null,
     expectedExceptionName: String? = null,
     expectedExceptionMessage: String? = null,
@@ -32,8 +33,8 @@ internal fun assertOtelLogReceived(
     logReceived?.let { log ->
         assertEquals(expectedEmbType, log.attributes?.find { it.key == "emb.type" }?.data)
         assertEquals(expectedMessage, log.body)
-        assertEquals(expectedSeverityNumber, log.severityNumber)
-        assertEquals(expectedSeverityText, log.severityText)
+        assertEquals(expectedSeverityNumber.severityNumber, log.severityNumber)
+        assertEquals(expectedSeverityText ?: expectedSeverityNumber.name, log.severityText)
         assertEquals(expectedTimeMs.millisToNanos(), log.timeUnixNano)
         assertFalse(log.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key).isNullOrBlank())
         expectedType?.let { assertAttribute(log, embExceptionHandling.name, it) }
@@ -54,11 +55,11 @@ internal fun assertOtelLogReceived(
     }
 }
 
-internal fun getOtelSeverity(severity: Severity): io.opentelemetry.api.logs.Severity {
+internal fun getOtelSeverity(severity: Severity): SeverityNumber {
     return when (severity) {
-        Severity.INFO -> io.opentelemetry.api.logs.Severity.INFO
-        Severity.WARNING -> io.opentelemetry.api.logs.Severity.WARN
-        Severity.ERROR -> io.opentelemetry.api.logs.Severity.ERROR
+        Severity.INFO -> SeverityNumber.INFO
+        Severity.WARNING -> SeverityNumber.WARN
+        Severity.ERROR -> SeverityNumber.ERROR
     }
 }
 


### PR DESCRIPTION
## Goal

Uses the Kotlin API for `SeverityNumber` rather than the OTel Java API.

## Testing

Relied on existing test coverage.
