### PR TITLE
Uses the Kotlin API for `StatusCode`

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpan.kt
@@ -45,7 +45,7 @@ class EmbSpan(
 
     override fun setStatus(statusCode: StatusCode, description: String): Span {
         if (isRecording) {
-            embraceSpan.setStatus(statusCode, description)
+            embraceSpan.setStatus(statusCode.toOtelKotlin(), description)
         }
         return this
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/KotlinApiConversions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/KotlinApiConversions.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.internal.opentelemetry
+
+import io.embrace.opentelemetry.kotlin.StatusCode
+
+internal fun StatusCode.toOtelJava(): io.opentelemetry.api.trace.StatusCode = when (this) {
+    is StatusCode.Unset -> io.opentelemetry.api.trace.StatusCode.UNSET
+    is StatusCode.Ok -> io.opentelemetry.api.trace.StatusCode.OK
+    is StatusCode.Error -> io.opentelemetry.api.trace.StatusCode.ERROR
+}
+
+internal fun io.opentelemetry.api.trace.StatusCode.toOtelKotlin(): StatusCode = when (this) {
+    io.opentelemetry.api.trace.StatusCode.UNSET -> StatusCode.Unset
+    io.opentelemetry.api.trace.StatusCode.OK -> StatusCode.Ok
+    io.opentelemetry.api.trace.StatusCode.ERROR -> StatusCode.Error(null)
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
@@ -11,8 +11,8 @@ import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.internal.spans.setFixedAttribute
 import io.embrace.android.embracesdk.internal.spans.toStatus
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 
 fun EmbraceSpanData.toNewPayload(): Span = Span(
     traceId = traceId,
@@ -56,10 +56,10 @@ fun Span.toOldPayload(): EmbraceSpanData {
         startTimeNanos = startTimeNanos ?: 0,
         endTimeNanos = endTimeNanos ?: 0L,
         status = when (status) {
-            Span.Status.UNSET -> StatusCode.UNSET
-            Span.Status.OK -> StatusCode.OK
-            Span.Status.ERROR -> StatusCode.ERROR
-            else -> StatusCode.UNSET
+            Span.Status.UNSET -> StatusCode.Unset
+            Span.Status.OK -> StatusCode.Ok
+            Span.Status.ERROR -> StatusCode.Error(null)
+            else -> StatusCode.Unset
         },
         events = events?.mapNotNull { it.toOldPayload() } ?: emptyList(),
         attributes = attributes?.toOldPayload() ?: emptyMap(),

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -11,10 +11,10 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.utils.isBlankish
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.logs.LogRecordBuilder
-import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.semconv.ExceptionAttributes
 
 /**
@@ -94,9 +94,9 @@ private val longValueAttributes: Set<String> = setOf(ExceptionAttributes.EXCEPTI
 
 fun StatusCode.toStatus(): Span.Status {
     return when (this) {
-        StatusCode.UNSET -> io.embrace.android.embracesdk.internal.payload.Span.Status.UNSET
-        StatusCode.OK -> io.embrace.android.embracesdk.internal.payload.Span.Status.OK
-        StatusCode.ERROR -> io.embrace.android.embracesdk.internal.payload.Span.Status.ERROR
+        StatusCode.Unset -> io.embrace.android.embracesdk.internal.payload.Span.Status.UNSET
+        StatusCode.Ok -> io.embrace.android.embracesdk.internal.payload.Span.Status.OK
+        is StatusCode.Error -> io.embrace.android.embracesdk.internal.payload.Span.Status.ERROR
     }
 }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanData.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.spans
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.opentelemetry.api.trace.StatusCode
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.sdk.trace.data.EventData
 
 /**
@@ -22,7 +22,7 @@ data class EmbraceSpanData(
 
     val endTimeNanos: Long,
 
-    val status: StatusCode = StatusCode.UNSET,
+    val status: StatusCode = StatusCode.Unset,
 
     val events: List<EmbraceSpanEvent> = emptyList(),
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedCo
 import io.embrace.android.embracesdk.internal.config.instrumented.isAttributeValid
 import io.embrace.android.embracesdk.internal.config.instrumented.isNameValid
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
+import io.embrace.android.embracesdk.internal.opentelemetry.toOtelJava
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
@@ -22,11 +23,11 @@ import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.semconv.ExceptionAttributes
@@ -137,7 +138,7 @@ internal class EmbraceSpanImpl(
                 populateLinks(spanToStop)
 
                 if (errorCode != null) {
-                    setStatus(StatusCode.ERROR)
+                    setStatus(StatusCode.Error(null))
                     spanToStop.setFixedAttribute(errorCode.fromErrorCode())
                 } else if (status == Span.Status.ERROR) {
                     spanToStop.setFixedAttribute(ErrorCodeAttribute.Failure)
@@ -216,7 +217,7 @@ internal class EmbraceSpanImpl(
         startedSpan.get()?.let { sdkSpan ->
             synchronized(startedSpan) {
                 status = statusCode.toStatus()
-                sdkSpan.setStatus(statusCode, description)
+                sdkSpan.setStatus(statusCode.toOtelJava(), description)
                 spanRepository.notifySpanUpdate()
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
@@ -4,9 +4,9 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
 import io.opentelemetry.context.ImplicitContextKeyed

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanDataExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanDataExt.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.spans
 
+import io.embrace.android.embracesdk.internal.opentelemetry.toOtelKotlin
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData.Companion.fromEventData
@@ -12,7 +13,7 @@ fun SpanData.toEmbraceSpanData(): EmbraceSpanData = EmbraceSpanData(
     name = name,
     startTimeNanos = startEpochNanos,
     endTimeNanos = endEpochNanos,
-    status = status.statusCode,
+    status = status.statusCode.toOtelKotlin(),
     events = fromEventData(eventDataList = events),
     attributes = attributes.toStringMap(),
     links = links.map { Link(it.spanContext.spanId, it.attributes.toNewPayload()) }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.arch.assertNotPrivateSpan
 import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.opentelemetry.toOtelJava
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.ErrorCode
 import org.junit.Assert.assertEquals
@@ -24,7 +25,7 @@ internal class SpanMapperTest {
         assertEquals(input.name, output.name)
         assertEquals(input.startTimeNanos, output.startTimeNanos)
         assertEquals(input.endTimeNanos, output.endTimeNanos)
-        assertEquals(input.status.name, checkNotNull(output.status).name)
+        assertEquals(input.status.toOtelJava().name, checkNotNull(output.status).name)
 
         // validate event copied
         val inputEvent = input.events.single()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -11,8 +11,8 @@ import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -181,7 +181,7 @@ internal class EmbraceTracerTest {
         with(verifyPublicSpan(expectedName, true, ErrorCode.FAILURE)) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
-            assertEquals(StatusCode.ERROR, status)
+            assertTrue(status is StatusCode.Error)
         }
     }
 
@@ -229,7 +229,7 @@ internal class EmbraceTracerTest {
         with(verifyPublicSpan(expectedName, false, ErrorCode.USER_ABANDON)) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
-            assertEquals(StatusCode.ERROR, status)
+            assertTrue(status is StatusCode.Error)
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/InternalTracerTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.StatusCode
+import io.embrace.opentelemetry.kotlin.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -213,7 +213,7 @@ internal class InternalTracerTest {
         with(verifyPublicSpan(expectedName, ErrorCode.FAILURE)) {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
-            assertEquals(StatusCode.ERROR, status)
+            assertTrue(status is StatusCode.Error)
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -95,7 +95,7 @@ internal class AppStartupTraceTest {
                         assertEquals("attribute", attributesList.findAttributeValue("custom"))
                         assertEquals(true, attributesList.hasFixedAttribute(ErrorCodeAttribute.Failure))
                         assertNotNull(events?.single())
-                        assertEquals(Span.Status.ERROR, status.statusCode.toStatus())
+                        assertEquals(Span.Status.ERROR.name, status.statusCode.name)
                     }
                     assertNotNull(activityInitSpan())
                     assertNotNull(activityResumeSpan())

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/arch/EmbraceAttributeExtensions.kt
@@ -12,8 +12,9 @@ import io.embrace.android.embracesdk.internal.arch.schema.toPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
+import io.embrace.android.embracesdk.internal.spans.toStatus
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.StatusCode
+import io.embrace.opentelemetry.kotlin.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -49,7 +50,7 @@ fun EmbraceSpanData.assertDoesNotHaveEmbraceAttribute(fixedAttribute: FixedAttri
  * Assert [EmbraceSpanData] has ended with the error defined by [errorCode]
  */
 fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
-    assertEquals(StatusCode.ERROR, status)
+    assertEquals(StatusCode.Error(null).toStatus(), status.toStatus())
     assertHasEmbraceAttribute(errorCode.fromErrorCode())
 }
 
@@ -57,7 +58,7 @@ fun EmbraceSpanData.assertError(errorCode: ErrorCode) {
  * Assert [EmbraceSpanData] has ended successfully
  */
 fun EmbraceSpanData.assertSuccessful() {
-    assertNotEquals(StatusCode.ERROR, status)
+    assertNotEquals(StatusCode.Error(null), status)
     assertNull(attributes[ErrorCodeAttribute.Failure.key.name])
 }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -23,9 +23,9 @@ import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.Context
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -84,7 +84,7 @@ class FakePersistableEmbraceSpan(
         if (isRecording) {
             this.errorCode = errorCode
             if (errorCode != null) {
-                setStatus(StatusCode.ERROR)
+                setStatus(StatusCode.Error(null))
             }
 
             if (status == Span.Status.ERROR) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -8,8 +8,8 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.opentelemetry.kotlin.StatusCode
 import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.ContextKey
 
 val testSpan: Span = EmbraceSpanData(
@@ -19,7 +19,7 @@ val testSpan: Span = EmbraceSpanData(
     name = "emb-sdk-init",
     startTimeNanos = 1681972471806000000L,
     endTimeNanos = 1681972471871000000L,
-    status = StatusCode.UNSET,
+    status = StatusCode.Unset,
     events = listOf(
         checkNotNull(
             EmbraceSpanEvent.create(


### PR DESCRIPTION
## Goal

Uses the Kotlin API for `StatusCode` rather than the OTel Java API.

## Testing

Relied on existing test coverage.
