### PR TITLE
Use kotlin API for attribute key

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
@@ -53,15 +53,15 @@ class LogWriterImpl(
                         BACKGROUND_STATE
                     }
                 }
-                setStringAttribute(embState.attributeKey.key, sessionState ?: processStateService.getAppState())
+                setStringAttribute(embState.attributeKey, sessionState ?: processStateService.getAppState())
             }
 
             if (isPrivate) {
-                setStringAttribute(PrivateSpan.key.attributeKey.key, PrivateSpan.value)
+                setStringAttribute(PrivateSpan.key.attributeKey, PrivateSpan.value)
             }
 
             with(schemaType) {
-                setStringAttribute(telemetryType.key.attributeKey.key, telemetryType.value)
+                setStringAttribute(telemetryType.key.attributeKey, telemetryType.value)
                 attributes().forEach {
                     setStringAttribute(it.key, it.value)
                 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbraceAttributeKey.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbraceAttributeKey.kt
@@ -1,24 +1,22 @@
 package io.embrace.android.embracesdk.internal.arch.schema
 
-import io.opentelemetry.api.common.AttributeKey
-
 /**
  * Defines a unique object to represent a [EmbraceAttribute]
  */
 class EmbraceAttributeKey(
     override val id: String,
-    otelAttributeKey: AttributeKey<String>? = null,
+    otelAttributeKey: String? = null,
     useIdAsAttributeName: Boolean = false,
     isPrivate: Boolean = false,
 ) : EmbraceAttribute {
-    override val name: String = if (!useIdAsAttributeName && otelAttributeKey?.key != null) {
-        otelAttributeKey.key
+    override val name: String = if (!useIdAsAttributeName && otelAttributeKey != null) {
+        otelAttributeKey
     } else {
         id.toEmbraceAttributeName(isPrivate)
     }
 
     /**
-     * The [AttributeKey] equivalent for this object to be used in conjunction with OTel objects
+     * The key equivalent for this object to be used in conjunction with OTel objects
      */
-    val attributeKey: AttributeKey<String> = otelAttributeKey ?: AttributeKey.stringKey(name)
+    val attributeKey: String = otelAttributeKey ?: name
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -130,8 +130,8 @@ sealed class SchemaType(
             "timestamp" to message.timestamp.toString(),
             "description" to message.description,
             "trace_status" to message.traceStatus,
-            embCrashNumber.attributeKey.key to crashNumber.toString(),
-            embAeiNumber.attributeKey.key to aeiNumber.toString()
+            embCrashNumber.attributeKey to crashNumber.toString(),
+            embAeiNumber.attributeKey to aeiNumber.toString()
         ).toNonNullMap()
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.arch.schema
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.utils.isBlankish
-import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Object that aggregates various attributes and returns a [Map] that represents the values at the current state
@@ -12,7 +11,7 @@ class TelemetryAttributes(
     private val sessionPropertiesProvider: () -> Map<String, String>? = { null },
     private val customAttributes: Map<String, String>? = null,
 ) {
-    private val map: MutableMap<AttributeKey<String>, String> = mutableMapOf()
+    private val map: MutableMap<String, String> = mutableMapOf()
 
     /**
      * Return a snapshot of the current values of the attributes set on this as a [Map]. Schema keys will always overwrite any previous
@@ -33,7 +32,7 @@ class TelemetryAttributes(
             }
         }
 
-        result.putAll(map.mapKeys { it.key.key })
+        result.putAll(map.mapKeys { it.key })
 
         return result
     }
@@ -42,7 +41,7 @@ class TelemetryAttributes(
         setAttribute(key.attributeKey, value, keepBlankishValues)
     }
 
-    fun setAttribute(key: AttributeKey<String>, value: String, keepBlankishValues: Boolean = true) {
+    fun setAttribute(key: String, value: String, keepBlankishValues: Boolean = true) {
         if (keepBlankishValues || !value.isBlankish()) {
             map[key] = value
         }
@@ -50,5 +49,5 @@ class TelemetryAttributes(
 
     fun getAttribute(key: EmbraceAttributeKey): String? = map[key.attributeKey]
 
-    fun getAttribute(key: AttributeKey<String>): String? = map[key]
+    fun getAttribute(key: String): String? = map[key]
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.logs.attachments.Attachment
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
-import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Creates log records to be sent using the Open Telemetry Logs data model.
@@ -19,7 +18,7 @@ interface LogService : MemoryCleanerListener {
         severity: Severity,
         logExceptionType: LogExceptionType,
         properties: Map<String, Any>? = null,
-        customLogAttrs: Map<AttributeKey<String>, String> = emptyMap(),
+        customLogAttrs: Map<String, String> = emptyMap(),
         logAttachment: Attachment.EmbraceHosted? = null,
     )
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.logs
 import io.embrace.android.embracesdk.internal.arch.schema.SendMode
 import io.embrace.android.embracesdk.internal.arch.schema.toSendMode
 import io.embrace.android.embracesdk.internal.opentelemetry.embSendMode
+import io.embrace.android.embracesdk.internal.opentelemetry.toOtelJavaAttributeKey
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.toNewPayload
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
@@ -19,7 +20,7 @@ class LogSinkImpl : LogSink {
     override fun storeLogs(logs: List<LogRecordData>): CompletableResultCode {
         try {
             logs.forEach { log ->
-                val sendMode = log.attributes[embSendMode.attributeKey]?.toSendMode() ?: SendMode.DEFAULT
+                val sendMode = log.attributes[embSendMode.attributeKey.toOtelJavaAttributeKey()]?.toSendMode() ?: SendMode.DEFAULT
                 if (sendMode != SendMode.DEFAULT) {
                     logRequests.add(
                         LogRequest(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.ndk
 
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
-import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Service to retrieve and delivery native crash data
@@ -25,7 +24,7 @@ interface NativeCrashService {
     fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
-        metadata: Map<AttributeKey<String>, String>,
+        metadata: Map<String, String>,
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/KotlinApiConversions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/KotlinApiConversions.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
 import io.embrace.opentelemetry.kotlin.StatusCode
+import io.opentelemetry.api.common.AttributeKey
 
 internal fun StatusCode.toOtelJava(): io.opentelemetry.api.trace.StatusCode = when (this) {
     is StatusCode.Unset -> io.opentelemetry.api.trace.StatusCode.UNSET
@@ -13,3 +14,5 @@ internal fun io.opentelemetry.api.trace.StatusCode.toOtelKotlin(): StatusCode = 
     io.opentelemetry.api.trace.StatusCode.OK -> StatusCode.Ok
     io.opentelemetry.api.trace.StatusCode.ERROR -> StatusCode.Error(null)
 }
+
+internal fun String.toOtelJavaAttributeKey() = AttributeKey.stringKey(this)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -271,7 +271,7 @@ internal class PayloadResurrectionServiceImpl(
         val sessionSpan = envelope.getSessionSpan() ?: return 0L
         val endTimeMs = sessionSpan.endTimeNanos ?: 0L
         val lastHeartbeatTimeMs =
-            sessionSpan.attributes?.findAttributeValue(embHeartbeatTimeUnixNano.attributeKey.key)?.toLongOrNull() ?: 0L
+            sessionSpan.attributes?.findAttributeValue(embHeartbeatTimeUnixNano.attributeKey)?.toLongOrNull() ?: 0L
         return max(endTimeMs, lastHeartbeatTimeMs).nanosToMillis()
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -82,7 +82,7 @@ internal class CurrentSessionSpanImpl(
     }
 
     override fun getSessionId(): String {
-        return sessionSpan.get()?.getSystemAttribute(SessionIncubatingAttributes.SESSION_ID) ?: ""
+        return sessionSpan.get()?.getSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key) ?: ""
     }
 
     override fun readySession(): Boolean {
@@ -175,7 +175,7 @@ internal class CurrentSessionSpanImpl(
             private = false,
         ).apply {
             start(startTimeMs = startTimeMs)
-            setSystemAttribute(SessionIncubatingAttributes.SESSION_ID, Uuid.getEmbUuid())
+            setSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key, Uuid.getEmbUuid())
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExt.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
+import io.embrace.android.embracesdk.internal.opentelemetry.toOtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -53,7 +54,7 @@ internal fun Span.setFixedAttribute(fixedAttribute: FixedAttribute): Span =
     setEmbraceAttribute(fixedAttribute.key, fixedAttribute.value)
 
 internal fun SpanData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
-    attributes.asMap()[fixedAttribute.key.attributeKey] == fixedAttribute.value
+    attributes.asMap()[fixedAttribute.key.attributeKey.toOtelJavaAttributeKey()] == fixedAttribute.value
 
 fun LogRecordData.hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
-    attributes[fixedAttribute.key.attributeKey] == fixedAttribute.value
+    attributes[fixedAttribute.key.attributeKey.toOtelJavaAttributeKey()] == fixedAttribute.value

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceExtensions.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.internal.arch.schema.EmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
@@ -12,7 +11,6 @@ import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.utils.isBlankish
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.semconv.ExceptionAttributes
@@ -24,7 +22,7 @@ import io.opentelemetry.semconv.ExceptionAttributes
  */
 
 internal fun LogRecordBuilder.setAttribute(
-    attributeKey: AttributeKey<String>,
+    attributeKey: String,
     value: String,
     keepBlankishValues: Boolean = true,
 ): LogRecordBuilder {
@@ -83,10 +81,6 @@ fun MutableMap<String, String>.setFixedAttribute(fixedAttribute: FixedAttribute)
 }
 
 fun Map<String, String>.getSessionProperty(key: String): String? = this[key.toSessionPropertyAttributeName()]
-
-fun Map<String, String>.getAttribute(key: AttributeKey<String>): String? = this[key.key]
-
-fun Map<String, String>.getAttribute(key: EmbraceAttributeKey): String? = getAttribute(key.attributeKey)
 
 private fun String.isValidLongValueAttribute(): Boolean = longValueAttributes.contains(this)
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -24,7 +24,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.SpanId
@@ -61,7 +60,7 @@ internal class EmbraceSpanImpl(
     private val systemEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     private val customEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     private val systemAttributes = ConcurrentHashMap<String, String>().apply {
-        putAll(spanBuilder.getFixedAttributes().associate { it.key.attributeKey.key to it.value })
+        putAll(spanBuilder.getFixedAttributes().associate { it.key.attributeKey to it.value })
     }
     private val customAttributes = ConcurrentHashMap<String, String>().apply {
         putAll(spanBuilder.getCustomAttributes())
@@ -288,12 +287,12 @@ internal class EmbraceSpanImpl(
     }
 
     override fun hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
-        systemAttributes[fixedAttribute.key.attributeKey.key] == fixedAttribute.value
+        systemAttributes[fixedAttribute.key.attributeKey] == fixedAttribute.value
 
-    override fun getSystemAttribute(key: AttributeKey<String>): String? = systemAttributes[key.key]
+    override fun getSystemAttribute(key: String): String? = systemAttributes[key]
 
-    override fun setSystemAttribute(key: AttributeKey<String>, value: String) {
-        addSystemAttribute(key.key, value)
+    override fun setSystemAttribute(key: String, value: String) {
+        addSystemAttribute(key, value)
     }
 
     override fun addSystemAttribute(key: String, value: String) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/PersistableEmbraceSpan.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.FixedAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
@@ -35,12 +34,12 @@ interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
     /**
      * Get the value of the attribute with the given key. Returns null if the attribute does not exist.
      */
-    fun getSystemAttribute(key: AttributeKey<String>): String?
+    fun getSystemAttribute(key: String): String?
 
     /**
      * Set the value of the attribute with the given key, overwriting the original value if it's already set
      */
-    fun setSystemAttribute(key: AttributeKey<String>, value: String)
+    fun setSystemAttribute(key: String, value: String)
 
     /**
      * Add the given key value pair as a system attribute to ths span

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
@@ -64,9 +64,9 @@ internal class LogWriterImplTest {
             assertEquals(SeverityNumber.ERROR, severityNumber)
             assertEquals(SeverityNumber.ERROR.name, severityNumber?.name)
             assertEquals("fake-session-id", attributes()[SessionIncubatingAttributes.SESSION_ID.key])
-            assertNotNull(attributes()[embState.attributeKey.key])
+            assertNotNull(attributes()[embState.attributeKey])
             assertNotNull(attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key])
-            assertTrue(attributes()[PrivateSpan.key.attributeKey.key] != null)
+            assertTrue(attributes()[PrivateSpan.key.attributeKey] != null)
             assertEquals(clock.nowInNanos(), timestampNs)
             assertNull(observedTimestampNs)
         }
@@ -85,7 +85,7 @@ internal class LogWriterImplTest {
             isPrivate = true
         )
         with(logger.logs.single()) {
-            assertTrue(attributes()[PrivateSpan.key.attributeKey.key] != null)
+            assertTrue(attributes()[PrivateSpan.key.attributeKey] != null)
         }
         logWriterImpl.addLog(
             schemaType = SchemaType.Log(
@@ -98,7 +98,7 @@ internal class LogWriterImplTest {
             isPrivate = false
         )
         with(logger.logs.last()) {
-            assertFalse(attributes()[PrivateSpan.key.attributeKey.key] != null)
+            assertFalse(attributes()[PrivateSpan.key.attributeKey] != null)
         }
     }
 
@@ -121,7 +121,7 @@ internal class LogWriterImplTest {
                 "foreground-session",
                 attributes()[SessionIncubatingAttributes.SESSION_ID.key]
             )
-            assertEquals("foreground", attributes()[embState.attributeKey.key])
+            assertEquals("foreground", attributes()[embState.attributeKey])
         }
     }
 
@@ -141,7 +141,7 @@ internal class LogWriterImplTest {
 
         with(logger.logs.last()) {
             assertNull(attributes()[SessionIncubatingAttributes.SESSION_ID.key])
-            assertEquals("background", attributes()[embState.attributeKey.key])
+            assertEquals("background", attributes()[embState.attributeKey])
         }
     }
 
@@ -181,7 +181,7 @@ internal class LogWriterImplTest {
 
         with(logger.logs.last()) {
             assertNull(attributes()[SessionIncubatingAttributes.SESSION_ID.key])
-            assertNull(attributes()[embState.attributeKey.key])
+            assertNull(attributes()[embState.attributeKey])
         }
     }
 
@@ -200,7 +200,7 @@ internal class LogWriterImplTest {
 
         with(logger.logs.last()) {
             assertNull(attributes()[SessionIncubatingAttributes.SESSION_ID.key])
-            assertEquals("background", attributes()[embState.attributeKey.key])
+            assertEquals("background", attributes()[embState.attributeKey])
         }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
@@ -37,14 +37,14 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
-        telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, "exceptionValue")
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
+        telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE.key, "exceptionValue")
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
         assertEquals(sessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
         assertEquals("exceptionValue", attributes[ExceptionAttributes.EXCEPTION_TYPE.key])
-        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
-        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE))
+        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID.key))
+        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE.key))
     }
 
     @Test
@@ -54,7 +54,7 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
         sessionPropertiesService.addProperty("perm", "permVal", true)
         sessionPropertiesService.addProperty("temp", "tempVal", false)
 
@@ -74,8 +74,8 @@ internal class TelemetryAttributesTest {
             configService = configService,
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, newSessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, newSessionId)
         sessionPropertiesService.addProperty("perm", "permVal", true)
         sessionPropertiesService.addProperty("temp", "tempVal", false)
         sessionPropertiesService.addProperty("perm", "newPermVal", true)
@@ -95,7 +95,7 @@ internal class TelemetryAttributesTest {
             configService = configService,
             customAttributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to sessionId)
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, newSessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, newSessionId)
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
         assertEquals(newSessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
@@ -121,7 +121,7 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
@@ -147,7 +147,7 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(4, attributes.size)
@@ -162,15 +162,15 @@ internal class TelemetryAttributesTest {
 
         // Give me Union types, plz
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, value, true)
-            assertEquals(value, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
+            telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, value, true)
+            assertEquals(value, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID.key))
         }
 
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, "test")
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, "test")
 
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, value, false)
-            assertEquals("test", telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
+            telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, value, false)
+            assertEquals("test", telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID.key))
         }
 
         blankishValues.forEach { value ->

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
@@ -70,19 +70,19 @@ internal class CrashDataSourceImpl(
             )
 
             val crashException = LegacyExceptionInfo.ofThrowable(exception)
-            crashAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, crashException.name)
+            crashAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE.key, crashException.name)
             crashAttributes.setAttribute(
-                ExceptionAttributes.EXCEPTION_MESSAGE,
+                ExceptionAttributes.EXCEPTION_MESSAGE.key,
                 crashException.message
                     ?: ""
             )
             crashAttributes.setAttribute(
-                ExceptionAttributes.EXCEPTION_STACKTRACE,
+                ExceptionAttributes.EXCEPTION_STACKTRACE.key,
                 encodeToUTF8String(
                     serializer.toJson(crashException.lines, List::class.java),
                 ),
             )
-            crashAttributes.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID, crashId)
+            crashAttributes.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key, crashId)
             crashAttributes.setAttribute(embCrashNumber, crashNumber.toString())
             crashAttributes.setAttribute(
                 EmbType.System.Crash.embAndroidCrashExceptionCause,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
@@ -14,7 +14,6 @@ import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.spans.toOtelSeverity
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 internal class NativeCrashDataSourceImpl(
@@ -40,7 +39,7 @@ internal class NativeCrashDataSourceImpl(
     override fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
-        metadata: Map<AttributeKey<String>, String>,
+        metadata: Map<String, String>,
     ) {
         val nativeCrashNumber = preferencesService.incrementAndGetNativeCrashNumber()
         val crashAttributes = TelemetryAttributes(
@@ -48,7 +47,7 @@ internal class NativeCrashDataSourceImpl(
             sessionPropertiesProvider = { sessionProperties }
         )
         crashAttributes.setAttribute(
-            key = SessionIncubatingAttributes.SESSION_ID,
+            key = SessionIncubatingAttributes.SESSION_ID.key,
             value = nativeCrash.sessionId,
             keepBlankishValues = false,
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.ServiceAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -84,7 +85,7 @@ internal class OTelExportTest {
                 }
             },
             otelExportAssertion = {
-                val log = awaitLogs(1) { it.attributes.get(EmbType.System.Log.key.attributeKey) == EmbType.System.Log.value }
+                val log = awaitLogs(1) { it.attributes.get(AttributeKey.stringKey(EmbType.System.Log.key.attributeKey)) == EmbType.System.Log.value }
                 with(log.single()) {
                     assertEquals("test message", body.asString())
                     assertEquals(logTimestampNanos, timestampEpochNanos)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -107,7 +107,7 @@ internal class SessionApiTest {
 
         // Attributes that are unstable that we should not try to verify
         val ignoredAttributes = setOf(
-            embFreeDiskBytes.attributeKey.key
+            embFreeDiskBytes.attributeKey
         ).plus(validateExistenceOnly)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -331,8 +331,8 @@ internal class AeiFeatureTest {
                     "description" to description,
                     "reason" to reason,
                     "emb.type" to "sys.exit",
-                    embCrashNumber.attributeKey.key to crashNumber,
-                    embAeiNumber.attributeKey.key to aeiNumber,
+                    embCrashNumber.attributeKey to crashNumber,
+                    embAeiNumber.attributeKey to aeiNumber,
                 )
             )
             assertEquals(trace, body)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -167,7 +167,7 @@ internal class JvmCrashFeatureTest {
         val expectedExceptionCause = serializer.toJson(listOf(exceptionInfo), List::class.java)
 
         attributes?.assertMatches(mapOf(
-            embState.attributeKey.key to state,
+            embState.attributeKey to state,
             "emb.android.crash_number" to 1,
             "emb.android.crash.exception_cause" to expectedExceptionCause,
             LogIncubatingAttributes.LOG_RECORD_UID.key to crashId

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -84,7 +84,7 @@ internal class BackgroundActivityDisabledTest {
                     assertEquals("error", body)
                     attributes?.assertMatches(
                         mapOf(
-                            embState.attributeKey.key to "background"
+                            embState.attributeKey to "background"
                         )
                     )
                     assertNull(attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
@@ -93,7 +93,7 @@ internal class BackgroundActivityDisabledTest {
                     assertEquals("info", body)
                     attributes?.assertMatches(
                         mapOf(
-                            embState.attributeKey.key to "background"
+                            embState.attributeKey to "background"
                         )
                     )
                     assertNull(attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
@@ -102,7 +102,7 @@ internal class BackgroundActivityDisabledTest {
                     assertEquals("warning", body)
                     attributes?.assertMatches(
                         mapOf(
-                            embState.attributeKey.key to "foreground",
+                            embState.attributeKey to "foreground",
                             SessionIncubatingAttributes.SESSION_ID.key to sessions[1].getSessionId()
                         )
                     )
@@ -113,7 +113,7 @@ internal class BackgroundActivityDisabledTest {
                     assertEquals("sent-after-session", body)
                     attributes?.assertMatches(
                         mapOf(
-                            embState.attributeKey.key to "foreground",
+                            embState.attributeKey to "foreground",
                             SessionIncubatingAttributes.SESSION_ID.key to secondSession.getSessionId()
                         )
                     )
@@ -197,8 +197,8 @@ internal class BackgroundActivityDisabledTest {
                 )
 
                 assertEquals(
-                    sessionSpan1.attributes?.findAttributeValue(embProcessIdentifier.attributeKey.key),
-                    sessionSpan2.attributes?.findAttributeValue(embProcessIdentifier.attributeKey.key)
+                    sessionSpan1.attributes?.findAttributeValue(embProcessIdentifier.attributeKey),
+                    sessionSpan2.attributes?.findAttributeValue(embProcessIdentifier.attributeKey)
                 )
             }
         )
@@ -215,18 +215,18 @@ internal class BackgroundActivityDisabledTest {
         assertEquals(endMs, endTimeNanos?.nanosToMillis())
         attributes?.assertMatches(
             mapOf(
-                embSessionNumber.attributeKey.key to sessionNumber,
-                embSequenceId.attributeKey.key to sequenceId,
-                embColdStart.attributeKey.key to coldStart,
-                embState.attributeKey.key to "foreground",
-                embCleanExit.attributeKey.key to "true",
-                embTerminated.attributeKey.key to "false",
-                embSessionStartType.attributeKey.key to "state",
-                embSessionEndType.attributeKey.key to "state",
+                embSessionNumber.attributeKey to sessionNumber,
+                embSequenceId.attributeKey to sequenceId,
+                embColdStart.attributeKey to coldStart,
+                embState.attributeKey to "foreground",
+                embCleanExit.attributeKey to "true",
+                embTerminated.attributeKey to "false",
+                embSessionStartType.attributeKey to "state",
+                embSessionEndType.attributeKey to "state",
             )
         )
         with(checkNotNull(attributes)) {
-            assertFalse(findAttributeValue(embProcessIdentifier.attributeKey.key).isNullOrBlank())
+            assertFalse(findAttributeValue(embProcessIdentifier.attributeKey).isNullOrBlank())
             assertFalse(findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key).isNullOrBlank())
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/OTelLogAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/OTelLogAssertions.kt
@@ -38,7 +38,7 @@ internal fun assertOtelLogReceived(
         assertEquals(expectedTimeMs.millisToNanos(), log.timeUnixNano)
         assertFalse(log.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key).isNullOrBlank())
         expectedType?.let { assertAttribute(log, embExceptionHandling.name, it) }
-        assertEquals(expectedState, log.attributes?.findAttributeValue(embState.attributeKey.key))
+        assertEquals(expectedState, log.attributes?.findAttributeValue(embState.attributeKey))
         expectedExceptionName?.let {
             assertAttribute(log, ExceptionAttributes.EXCEPTION_TYPE.key, expectedExceptionName)
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -46,7 +46,6 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.spans.TracingApi
-import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -275,7 +274,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
         logExceptionType: LogExceptionType = LogExceptionType.NONE,
         exceptionName: String? = null,
         exceptionMessage: String? = null,
-        customLogAttrs: Map<AttributeKey<String>, String> = emptyMap(),
+        customLogAttrs: Map<String, String> = emptyMap(),
     ) {
         logsApiDelegate.logMessageImpl(
             severity = severity,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.Flutter
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.FlutterException.embFlutterExceptionLibrary
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.opentelemetry.api.common.AttributeKey
 
 internal class FlutterInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
@@ -67,7 +66,7 @@ internal class FlutterInternalInterfaceImpl(
         exceptionType: LogExceptionType,
     ) {
         if (embrace.isStarted) {
-            val attrs = mutableMapOf<AttributeKey<String>, String>()
+            val attrs = mutableMapOf<String, String>()
             context?.let { attrs[embFlutterExceptionContext.attributeKey] = it }
             library?.let { attrs[embFlutterExceptionLibrary.attributeKey] = it }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.internal.logs.attachments.AttachmentErrorCo
 import io.embrace.android.embracesdk.internal.payload.PushNotificationBreadcrumb
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.ExceptionAttributes
 
 internal class LogsApiDelegate(
@@ -179,18 +178,18 @@ internal class LogsApiDelegate(
         logExceptionType: LogExceptionType = LogExceptionType.NONE,
         exceptionName: String? = null,
         exceptionMessage: String? = null,
-        customLogAttrs: Map<AttributeKey<String>, String> = emptyMap(),
+        customLogAttrs: Map<String, String> = emptyMap(),
         attachment: Attachment? = null,
     ) {
         if (sdkCallChecker.check("log_message")) {
             runCatching {
-                val attrs = mutableMapOf<AttributeKey<String>, String>()
-                exceptionName?.let { attrs[ExceptionAttributes.EXCEPTION_TYPE] = it }
-                exceptionMessage?.let { attrs[ExceptionAttributes.EXCEPTION_MESSAGE] = it }
+                val attrs = mutableMapOf<String, String>()
+                exceptionName?.let { attrs[ExceptionAttributes.EXCEPTION_TYPE.key] = it }
+                exceptionMessage?.let { attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key] = it }
 
                 val stacktrace =
                     stackTraceElements?.let(checkNotNull(serializer)::truncatedStacktrace) ?: customStackTrace
-                stacktrace?.let { attrs[ExceptionAttributes.EXCEPTION_STACKTRACE] = it }
+                stacktrace?.let { attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key] = it }
 
                 if (attachment != null) {
                     attrs.putAll(attachment.attributes.mapKeys { it.key.attributeKey })

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
@@ -1,10 +1,7 @@
 package io.embrace.android.embracesdk.assertions
 
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.internal.arch.schema.EmbraceAttributeKey
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
@@ -29,8 +26,4 @@ fun Resource.assertExpectedAttributes(
     assertEquals(systemInfo.deviceManufacturer, getAttribute(DeviceIncubatingAttributes.DEVICE_MANUFACTURER))
     assertEquals(systemInfo.deviceModel, getAttribute(DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER))
     assertEquals(systemInfo.deviceModel, getAttribute(DeviceIncubatingAttributes.DEVICE_MODEL_NAME))
-}
-
-fun SpanData.assertHasEmbraceAttribute(key: EmbraceAttributeKey, value: String) {
-    assertEquals(value, attributes.get(AttributeKey.stringKey(key.name)))
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPayloadEnvelopeAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPayloadEnvelopeAssertions.kt
@@ -42,7 +42,7 @@ fun Envelope<SessionPayload>.getStartTime(): Long {
  */
 fun Envelope<SessionPayload>.getLastHeartbeatTimeMs(): Long {
     return checkNotNull(
-        findSessionSpan().attributes?.findAttributeValue(embHeartbeatTimeUnixNano.attributeKey.key)?.toLongOrNull()
+        findSessionSpan().attributes?.findAttributeValue(embHeartbeatTimeUnixNano.attributeKey)?.toLongOrNull()
             ?.nanosToMillis()
     ) {
         "No last heartbeat time found in session payload"

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.logs.LogService
 import io.embrace.android.embracesdk.internal.logs.attachments.Attachment
-import io.opentelemetry.api.common.AttributeKey
 
 class FakeLogService : LogService {
     class LogData(
@@ -23,7 +22,7 @@ class FakeLogService : LogService {
         severity: Severity,
         logExceptionType: LogExceptionType,
         properties: Map<String, Any>?,
-        customLogAttrs: Map<AttributeKey<String>, String>,
+        customLogAttrs: Map<String, String>,
         logAttachment: Attachment.EmbraceHosted?,
     ) {
         loggedMessages.add(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
-import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class FakeNativeCrashService : NativeCrashService {
@@ -21,7 +20,7 @@ class FakeNativeCrashService : NativeCrashService {
     override fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
-        metadata: Map<AttributeKey<String>, String>,
+        metadata: Map<String, String>,
     ) {
         nativeCrashesSent.add(Pair(nativeCrash, metadata.mapKeys { it.value } + sessionProperties))
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -24,7 +24,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.context.Context
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
@@ -170,10 +169,10 @@ class FakePersistableEmbraceSpan(
     override fun hasFixedAttribute(fixedAttribute: FixedAttribute): Boolean =
         attributes.hasFixedAttribute(fixedAttribute)
 
-    override fun getSystemAttribute(key: AttributeKey<String>): String? = attributes[key.key]
+    override fun getSystemAttribute(key: String): String? = attributes[key]
 
-    override fun setSystemAttribute(key: AttributeKey<String>, value: String) {
-        addSystemAttribute(key.key, value)
+    override fun setSystemAttribute(key: String, value: String) {
+        addSystemAttribute(key, value)
     }
 
     override fun addSystemAttribute(key: String, value: String) {
@@ -228,7 +227,7 @@ class FakePersistableEmbraceSpan(
                     )
                 }
 
-                setSystemAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+                setSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
                 setSystemAttribute(embProcessIdentifier.attributeKey, processIdentifier)
                 setSystemAttribute(embState.attributeKey, "foreground")
                 setSystemAttribute(


### PR DESCRIPTION
## Goal

Uses the Kotlin API for `AttributeKey` rather than the OTel Java API.

## Testing

Relied on existing test coverage.
