### PR TITLE
Rename OTel conversion functions

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.session.captureDataSafely
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
@@ -73,11 +73,11 @@ internal class SessionPayloadSourceImpl(
                         startNewSession = startNewSession,
                         appTerminationCause = appTerminationCause
                     )
-                    spans.map(EmbraceSpanData::toNewPayload)
+                    spans.map(EmbraceSpanData::toEmbracePayload)
                 }
 
                 else -> spanSink.completedSpans()
-                    .map(EmbraceSpanData::toNewPayload)
+                    .map(EmbraceSpanData::toEmbracePayload)
                     .plus(otelPayloadMapper.snapshotSpans())
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogSinkImpl.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.SendMode
 import io.embrace.android.embracesdk.internal.arch.schema.toSendMode
 import io.embrace.android.embracesdk.internal.opentelemetry.embSendMode
 import io.embrace.android.embracesdk.internal.payload.Log
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.data.LogRecordData
@@ -23,12 +23,12 @@ class LogSinkImpl : LogSink {
                 if (sendMode != SendMode.DEFAULT) {
                     logRequests.add(
                         LogRequest(
-                            payload = log.toNewPayload(),
+                            payload = log.toEmbracePayload(),
                             defer = sendMode == SendMode.DEFER
                         )
                     )
                 } else {
-                    storedLogs.add(log.toNewPayload())
+                    storedLogs.add(log.toEmbracePayload())
                 }
             }
             onLogsStored?.invoke()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/LogMapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/LogMapper.kt
@@ -4,7 +4,7 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.logs.data.LogRecordData
 
 @Suppress("DEPRECATION") // suppress for backwards compat
-fun LogRecordData.toNewPayload(): Log {
+fun LogRecordData.toEmbracePayload(): Log {
     val isSpanContextValid = spanContext.isValid
     return Log(
         traceId = if (isSpanContextValid) spanContext.traceId else null,
@@ -13,9 +13,9 @@ fun LogRecordData.toNewPayload(): Log {
         severityNumber = severity.severityNumber,
         severityText = severityText,
         body = body.asString(),
-        attributes = attributes.toNewPayload()
+        attributes = attributes.toEmbracePayload()
     )
 }
 
-fun Attributes.toNewPayload(): List<Attribute> =
+fun Attributes.toEmbracePayload(): List<Attribute> =
     this.asMap().entries.map { Attribute(it.key.key, it.value.toString()) }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/SpanMapper.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 
-fun EmbraceSpanData.toNewPayload(): Span = Span(
+fun EmbraceSpanData.toEmbracePayload(): Span = Span(
     traceId = traceId,
     spanId = spanId,
     parentSpanId = parentSpanId ?: SpanId.getInvalid(),
@@ -22,32 +22,32 @@ fun EmbraceSpanData.toNewPayload(): Span = Span(
     startTimeNanos = startTimeNanos,
     endTimeNanos = endTimeNanos,
     status = status.toStatus(),
-    events = events.map(EmbraceSpanEvent::toNewPayload),
-    attributes = attributes.toNewPayload(),
+    events = events.map(EmbraceSpanEvent::toEmbracePayload),
+    attributes = attributes.toEmbracePayload(),
     links = links,
 )
 
-fun EmbraceSpanEvent.toNewPayload(): SpanEvent = SpanEvent(
+fun EmbraceSpanEvent.toEmbracePayload(): SpanEvent = SpanEvent(
     name = name,
     timestampNanos = timestampNanos,
-    attributes = attributes.toNewPayload()
+    attributes = attributes.toEmbracePayload()
 )
 
-fun SpanEvent.toOldPayload(): EmbraceSpanEvent? = EmbraceSpanEvent.create(
+fun SpanEvent.toEmbracePayload(): EmbraceSpanEvent? = EmbraceSpanEvent.create(
     name = name ?: "",
     timestampMs = (timestampNanos ?: 0).nanosToMillis(),
-    attributes = attributes?.toOldPayload() ?: emptyMap()
+    attributes = attributes?.toEmbracePayload() ?: emptyMap()
 )
 
-fun Map<String, String>.toNewPayload(): List<Attribute> =
+fun Map<String, String>.toEmbracePayload(): List<Attribute> =
     map { (key, value) -> Attribute(key, value) }
 
-fun List<Attribute>.toOldPayload(): Map<String, String> =
+fun List<Attribute>.toEmbracePayload(): Map<String, String> =
     associate { Pair(it.key ?: "", it.data ?: "") }.filterKeys { it.isNotBlank() }
 
-fun EmbraceLinkData.toPayload() = Link(spanContext.spanId, attributes.toNewPayload())
+fun EmbraceLinkData.toEmbracePayload() = Link(spanContext.spanId, attributes.toEmbracePayload())
 
-fun Span.toOldPayload(): EmbraceSpanData {
+fun Span.toEmbracePayload(): EmbraceSpanData {
     return EmbraceSpanData(
         traceId = traceId ?: "",
         spanId = spanId ?: "",
@@ -61,8 +61,8 @@ fun Span.toOldPayload(): EmbraceSpanData {
             Span.Status.ERROR -> StatusCode.ERROR
             else -> StatusCode.UNSET
         },
-        events = events?.mapNotNull { it.toOldPayload() } ?: emptyList(),
-        attributes = attributes?.toOldPayload() ?: emptyMap(),
+        events = events?.mapNotNull { it.toEmbracePayload() } ?: emptyList(),
+        attributes = attributes?.toEmbracePayload() ?: emptyMap(),
         links = links ?: emptyList()
     )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -15,8 +15,7 @@ import io.embrace.android.embracesdk.internal.config.instrumented.isNameValid
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
-import io.embrace.android.embracesdk.internal.payload.toPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -277,9 +276,10 @@ internal class EmbraceSpanImpl(
                 startTimeNanos = spanStartTimeMs?.millisToNanos(),
                 endTimeNanos = spanEndTimeMs?.millisToNanos(),
                 status = status,
-                events = systemEvents.map(EmbraceSpanEvent::toNewPayload) + redactedCustomEvents.map(EmbraceSpanEvent::toNewPayload),
+                events = systemEvents.map(EmbraceSpanEvent::toEmbracePayload) +
+                    redactedCustomEvents.map(EmbraceSpanEvent::toEmbracePayload),
                 attributes = getAttributesPayload(),
-                links = (systemLinks + redactedCustomLinks).map(EmbraceLinkData::toPayload)
+                links = (systemLinks + redactedCustomLinks).map(EmbraceLinkData::toEmbracePayload)
             )
         } else {
             null
@@ -306,7 +306,7 @@ internal class EmbraceSpanImpl(
     }
 
     private fun getAttributesPayload(): List<Attribute> =
-        systemAttributes.map { Attribute(it.key, it.value) } + customAttributes.redactIfSensitive().toNewPayload()
+        systemAttributes.map { Attribute(it.key, it.value) } + customAttributes.redactIfSensitive().toEmbracePayload()
 
     private fun canSnapshot(): Boolean = spanId != null && spanStartTimeMs != null
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanDataExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanDataExt.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.internal.payload.Link
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData.Companion.fromEventData
 import io.opentelemetry.sdk.trace.data.SpanData
 
@@ -15,5 +15,5 @@ fun SpanData.toEmbraceSpanData(): EmbraceSpanData = EmbraceSpanData(
     status = status.statusCode,
     events = fromEventData(eventDataList = events),
     attributes = attributes.toStringMap(),
-    links = links.map { Link(it.spanContext.spanId, it.attributes.toNewPayload()) }
+    links = links.map { Link(it.spanContext.spanId, it.attributes.toEmbracePayload()) }
 )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordDataTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordDataTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.logs
 
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fixtures.testLog
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -10,7 +10,7 @@ internal class EmbraceLogRecordDataTest {
 
     @Test
     fun testCreationFromLogRecordData() {
-        val embraceLogRecordData = FakeLogRecordData().toNewPayload()
+        val embraceLogRecordData = FakeLogRecordData().toEmbracePayload()
         assertEquals(testLog, embraceLogRecordData)
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporterTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporterTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fixtures.testLog
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.payload.Attribute
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.opentelemetry.sdk.logs.export.LogRecordExporter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -23,7 +23,7 @@ internal class EmbraceLogRecordExporterTest {
         embraceLogRecordExporter.export(listOf(logRecordData))
 
         assertFalse(logSink.logsForNextBatch().isEmpty())
-        assertEquals(logRecordData.toNewPayload(), logSink.logsForNextBatch()[0])
+        assertEquals(logRecordData.toEmbracePayload(), logSink.logsForNextBatch()[0])
     }
 
     @Test
@@ -47,8 +47,8 @@ internal class EmbraceLogRecordExporterTest {
         embraceLogRecordExporter.export(listOf(logRecordData, privateLogRecordData))
 
         assertEquals(2, logSink.logsForNextBatch().size)
-        assertEquals(logRecordData.toNewPayload(), logSink.logsForNextBatch()[0])
-        assertEquals(privateLogRecordData.toNewPayload(), logSink.logsForNextBatch()[1])
+        assertEquals(logRecordData.toEmbracePayload(), logSink.logsForNextBatch()[0])
+        assertEquals(privateLogRecordData.toEmbracePayload(), logSink.logsForNextBatch()[1])
 
         assertEquals(1, externalExporter.exportedLogs?.size)
         assertEquals(logRecordData, externalExporter.exportedLogs?.first())

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogSinkImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogSinkImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.logs
 import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fixtures.deferredLogRecordData
 import io.embrace.android.embracesdk.fixtures.sendImmediatelyLogRecordData
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.opentelemetry.sdk.common.CompletableResultCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -33,7 +33,7 @@ internal class LogSinkImplTest {
         val resultCode = logSink.storeLogs(listOf(FakeLogRecordData()))
         assertEquals(CompletableResultCode.ofSuccess(), resultCode)
         assertEquals(1, logSink.logsForNextBatch().size)
-        assertEquals(FakeLogRecordData().toNewPayload(), logSink.logsForNextBatch().first())
+        assertEquals(FakeLogRecordData().toEmbracePayload(), logSink.logsForNextBatch().first())
     }
 
     @Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/LogMapperTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/LogMapperTest.kt
@@ -10,7 +10,7 @@ internal class LogMapperTest {
     @Test
     fun `convert to new payload`() {
         val input = FakeLogRecordData()
-        val output = input.toNewPayload()
+        val output = input.toEmbracePayload()
         assertEquals(input.timestampEpochNanos, output.timeUnixNano)
         assertEquals(input.severity.severityNumber, output.severityNumber)
         assertEquals(input.severityText, output.severityText)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/payload/SpanMapperTest.kt
@@ -16,7 +16,7 @@ internal class SpanMapperTest {
     @Test
     fun toSpan() {
         val input = FakeSpanData.perfSpanCompleted.toEmbraceSpanData()
-        val output = input.toNewPayload()
+        val output = input.toEmbracePayload()
 
         assertEquals(input.traceId, output.traceId)
         assertEquals(input.spanId, output.spanId)
@@ -29,7 +29,7 @@ internal class SpanMapperTest {
         // validate event copied
         val inputEvent = input.events.single()
         val outputEvent = checkNotNull(output.events).single()
-        assertEquals(inputEvent, outputEvent.toOldPayload())
+        assertEquals(inputEvent, outputEvent.toEmbracePayload())
 
         // test attributes
         output.assertSuccessful()
@@ -42,7 +42,7 @@ internal class SpanMapperTest {
 
     @Test
     fun `terminating span snapshot works as expected`() {
-        val snapshot = FakeSpanData.perfSpanSnapshot.toEmbraceSpanData().toNewPayload()
+        val snapshot = FakeSpanData.perfSpanSnapshot.toEmbraceSpanData().toEmbracePayload()
         val terminationTimeMs = snapshot.startTimeNanos!!.nanosToMillis() + 60000L
         val failedSpan = snapshot.toFailedSpan(terminationTimeMs)
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -34,7 +34,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
@@ -383,9 +383,9 @@ class PayloadResurrectionServiceImplTest {
             copy(
                 data = data.copy(
                     spans = listOf(
-                        startedSnapshot.copy(endTimeNanos = startedSnapshot.startTimeNanos + 10000000L).toNewPayload()
+                        startedSnapshot.copy(endTimeNanos = startedSnapshot.startTimeNanos + 10000000L).toEmbracePayload()
                     ),
-                    spanSnapshots = data.spanSnapshots?.plus(listOfNotNull(startedSnapshot).map(EmbraceSpanData::toNewPayload))
+                    spanSnapshots = data.spanSnapshots?.plus(listOfNotNull(startedSnapshot).map(EmbraceSpanData::toEmbracePayload))
                 )
             )
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.opentelemetry.embraceSpanBuilder
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -377,7 +377,7 @@ internal class CurrentSessionSpanImplTests {
         val flushedSpans = currentSessionSpan.endSession(true, AppTerminationCause.Crash).associateBy { it.name }
 
         assertEmbraceSpanData(
-            span = flushedSpans["emb-session"]?.toNewPayload(),
+            span = flushedSpans["emb-session"]?.toEmbracePayload(),
             expectedStartTimeMs = sessionStartTimeMs,
             expectedEndTimeMs = crashTimeMs,
             expectedParentId = SpanId.getInvalid(),
@@ -390,7 +390,7 @@ internal class CurrentSessionSpanImplTests {
         )
 
         assertEmbraceSpanData(
-            span = flushedSpans[crashedSpanName]?.toNewPayload(),
+            span = flushedSpans[crashedSpanName]?.toEmbracePayload(),
             expectedStartTimeMs = crashSpanStartTimeMs,
             expectedEndTimeMs = crashTimeMs,
             expectedParentId = SpanId.getInvalid(),
@@ -485,7 +485,7 @@ internal class CurrentSessionSpanImplTests {
         assertEquals("emb-session", span.name)
 
         // verify event was added to the span
-        val testEvent = span.toNewPayload().findEventOfType(EmbType.System.Breadcrumb)
+        val testEvent = span.toEmbracePayload().findEventOfType(EmbType.System.Breadcrumb)
         assertEquals(1000L, testEvent.timestampNanos?.nanosToMillis())
 
         val attrs = checkNotNull(testEvent.attributes)
@@ -504,7 +504,7 @@ internal class CurrentSessionSpanImplTests {
         assertEquals("emb-session", span.name)
 
         // verify event was added to the span
-        assertEquals(limit, span.toNewPayload().events?.size)
+        assertEquals(limit, span.toEmbracePayload().events?.size)
     }
 
     @Test
@@ -531,7 +531,7 @@ internal class CurrentSessionSpanImplTests {
         assertEquals("emb-session", span.name)
 
         // verify event was added to the span
-        assertEquals(limit, span.toNewPayload().attributes?.size)
+        assertEquals(limit, span.toEmbracePayload().attributes?.size)
     }
 
     private fun CurrentSessionSpan.assertNoSessionSpan() {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrOtelMapper.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrOtelMapper.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.payload.AnrSample
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
-import io.embrace.android.embracesdk.internal.payload.toOldPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.sdk.trace.IdGenerator
@@ -44,8 +44,8 @@ class AnrOtelMapper(
 
     fun record() = EmbTrace.trace("anr-record") {
         anrService.getCapturedData().forEach { interval ->
-            val attributes = mapIntervalToSpanAttributes(interval).toOldPayload()
-            val events = interval.anrSampleList?.samples?.mapNotNull { mapSampleToSpanEvent(it).toOldPayload() }
+            val attributes = mapIntervalToSpanAttributes(interval).toEmbracePayload()
+            val events = interval.anrSampleList?.samples?.mapNotNull { mapSampleToSpanEvent(it).toEmbracePayload() }
             spanService.recordCompletedSpan(
                 name = "thread-blockage",
                 startTimeMs = interval.startTime,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
@@ -217,10 +217,10 @@ internal class UiLoadTraceEmitterTest {
                     timestampMs = timestamps.first,
                     attributes = customAttributes
                 )
-            ).toNewPayload()
+            ).toEmbracePayload()
 
             assertEmbraceSpanData(
-                span = trace.toNewPayload(),
+                span = trace.toEmbracePayload(),
                 expectedStartTimeMs = timestamps.first,
                 expectedEndTimeMs = timestamps.second,
                 expectedParentId = SpanId.getInvalid(),
@@ -228,7 +228,7 @@ internal class UiLoadTraceEmitterTest {
             )
 
             assertEmbraceSpanData(
-                span = checkNotNull(spanMap["custom-span"]).toNewPayload(),
+                span = checkNotNull(spanMap["custom-span"]).toEmbracePayload(),
                 expectedStartTimeMs = timestamps.first,
                 expectedEndTimeMs = timestamps.first + 1,
                 expectedParentId = trace.spanId,
@@ -243,7 +243,7 @@ internal class UiLoadTraceEmitterTest {
             if (uiLoadType == UiLoadType.COLD) {
                 checkNotNull(events[LifecycleStage.CREATE]).run {
                     assertEmbraceSpanData(
-                        span = checkNotNull(spanMap["emb-$activityName-create"]).toNewPayload(),
+                        span = checkNotNull(spanMap["emb-$activityName-create"]).toEmbracePayload(),
                         expectedStartTimeMs = startMs(),
                         expectedEndTimeMs = endMs(),
                         expectedParentId = trace.spanId
@@ -255,7 +255,7 @@ internal class UiLoadTraceEmitterTest {
 
             checkNotNull(events[LifecycleStage.START]).run {
                 assertEmbraceSpanData(
-                    span = checkNotNull(spanMap["emb-$activityName-start"]).toNewPayload(),
+                    span = checkNotNull(spanMap["emb-$activityName-start"]).toEmbracePayload(),
                     expectedStartTimeMs = startMs(),
                     expectedEndTimeMs = endMs(),
                     expectedParentId = trace.spanId
@@ -265,7 +265,7 @@ internal class UiLoadTraceEmitterTest {
             if (hasPreAndPostEvents) {
                 checkNotNull(events[LifecycleStage.RESUME]).run {
                     assertEmbraceSpanData(
-                        span = checkNotNull(spanMap["emb-$activityName-resume"]).toNewPayload(),
+                        span = checkNotNull(spanMap["emb-$activityName-resume"]).toEmbracePayload(),
                         expectedStartTimeMs = startMs(),
                         expectedEndTimeMs = endMs(),
                         expectedParentId = trace.spanId
@@ -278,7 +278,7 @@ internal class UiLoadTraceEmitterTest {
             if (hasRenderEvent) {
                 checkNotNull(events[LifecycleStage.RENDER]).run {
                     assertEmbraceSpanData(
-                        span = checkNotNull(spanMap["emb-$activityName-render"]).toNewPayload(),
+                        span = checkNotNull(spanMap["emb-$activityName-render"]).toEmbracePayload(),
                         expectedStartTimeMs = startMs(),
                         expectedEndTimeMs = endMs(),
                         expectedParentId = trace.spanId
@@ -301,7 +301,7 @@ internal class UiLoadTraceEmitterTest {
             val traceEndTime = trace.endTimeNanos.nanosToMillis()
             if (manualEnd) {
                 assertEmbraceSpanData(
-                    span = checkNotNull(spanMap["emb-$activityName-ready"]).toNewPayload(),
+                    span = checkNotNull(spanMap["emb-$activityName-ready"]).toEmbracePayload(),
                     expectedStartTimeMs = lastEventEndTimeMs,
                     expectedEndTimeMs = traceEndTime,
                     expectedParentId = trace.spanId

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmi
 import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmitter.Companion.WARM_APP_STARTUP_ROOT_SPAN
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.opentelemetry.embStartupActivityName
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.spans.SpanSink
@@ -880,7 +880,7 @@ internal class AppStartupTraceEmitterTest {
         expectedCustomAttributes: Map<String, String> = emptyMap(),
     ) {
         checkNotNull(input)
-        val trace = input.toNewPayload()
+        val trace = input.toEmbracePayload()
         assertEquals(expectedStartTimeMs, trace.startTimeNanos?.nanosToMillis())
         assertEquals(expectedEndTimeMs, trace.endTimeNanos?.nanosToMillis())
         trace.assertDoesNotHaveEmbraceAttribute(PrivateSpan)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.findAttributeValue
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
 import io.embrace.android.embracesdk.internal.spans.toStatus
@@ -83,7 +83,7 @@ internal class AppStartupTraceTest {
             },
             otelExportAssertion = {
                 with(awaitSpansWithType(7, EmbType.Performance.Default).associateBy { it.name }) {
-                    assertEquals("yes", coldAppStartupRootSpan().attributes.toNewPayload().findAttributeValue("custom-attribute"))
+                    assertEquals("yes", coldAppStartupRootSpan().attributes.toEmbracePayload().findAttributeValue("custom-attribute"))
                     assertNotNull(embraceInitSpan())
                     with(initGapSpan()) {
                         assertEquals(sdkStartTimeMs, startEpochNanos.nanosToMillis())
@@ -91,7 +91,7 @@ internal class AppStartupTraceTest {
                     }
                     assertNotNull(getSpan("custom-span"))
                     with(getSpan("custom-span-with-stuff")) {
-                        val attributesList = attributes.toNewPayload()
+                        val attributesList = attributes.toEmbracePayload()
                         assertEquals("attribute", attributesList.findAttributeValue("custom"))
                         assertEquals(true, attributesList.hasFixedAttribute(ErrorCodeAttribute.Failure))
                         assertNotNull(events?.single())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.opentelemetry.EmbSpanBuilder
 import io.embrace.android.embracesdk.internal.opentelemetry.EmbTracer
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
-import io.embrace.android.embracesdk.internal.payload.toOldPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -172,7 +172,7 @@ internal class ExternalTracerTest {
 
                 assertTrue("Timed out waiting for the span to be exported", spanExporter.awaitSpanExport(3))
                 val exportedSpan: SpanData = spanExporter.exportedSpans.single { it.name == "external-span" }
-                assertEquals(parent.toOldPayload(), exportedSpan.toEmbraceSpanData())
+                assertEquals(parent.toEmbracePayload(), exportedSpan.toEmbraceSpanData())
                 with(exportedSpan.instrumentationScopeInfo) {
                     assertEquals("external-tracer", name)
                     assertEquals("1.0.0", version)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -155,7 +155,7 @@ internal class TracingApiTest {
                 )
                 val allSpans = getSdkInitSpanFromBackgroundActivity() +
                     checkNotNull(session.data.spans) +
-                    testRule.setup.getSpanSink().completedSpans().map(EmbraceSpanData::toNewPayload)
+                    testRule.setup.getSpanSink().completedSpans().map(EmbraceSpanData::toEmbracePayload)
 
                 val spansMap = allSpans.associateBy { it.name }
                 val sessionSpan = checkNotNull(spansMap["emb-session"])
@@ -360,7 +360,7 @@ internal class TracingApiTest {
                 val spanWithLink = awaitSpans(1) { it.links.size == 1 }.single()
                 with(spanWithLink.links.single()) {
                     assertEquals(linkedSpanId, spanContext.spanId)
-                    assertEquals("value", attributes.toNewPayload().single().data)
+                    assertEquals("value", attributes.toEmbracePayload().single().data)
                 }
             }
         )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.embrace.android.embracesdk.internal.payload.toOldPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -63,7 +63,7 @@ class FakeCurrentSessionSpan(
             null
         }
         endingSessionSpan.stop(errorCode, clock.now())
-        val payload = listOf(checkNotNull(endingSessionSpan.snapshot()).toOldPayload())
+        val payload = listOf(checkNotNull(endingSessionSpan.snapshot()).toEmbracePayload())
         sessionIteration.incrementAndGet()
         sessionSpan = if (appTerminationCause == null) newSessionSpan(clock.now()) else null
         return payload

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePersistableEmbraceSpan.kt
@@ -14,7 +14,7 @@ import io.embrace.android.embracesdk.internal.opentelemetry.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.opentelemetry.embState
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
 import io.embrace.android.embracesdk.internal.spans.getEmbraceSpan
 import io.embrace.android.embracesdk.internal.spans.hasFixedAttribute
@@ -139,7 +139,7 @@ class FakePersistableEmbraceSpan(
     }
 
     override fun addLink(linkedSpanContext: SpanContext, attributes: Map<String, String>?): Boolean {
-        links.add(Link(linkedSpanContext.spanId, attributes?.toNewPayload()))
+        links.add(Link(linkedSpanContext.spanId, attributes?.toEmbracePayload()))
         return true
     }
 
@@ -160,8 +160,8 @@ class FakePersistableEmbraceSpan(
                 startTimeNanos = spanStartTimeMs?.millisToNanos(),
                 endTimeNanos = spanEndTimeMs?.millisToNanos(),
                 status = status,
-                events = events.map(EmbraceSpanEvent::toNewPayload),
-                attributes = attributes.toNewPayload(),
+                events = events.map(EmbraceSpanEvent::toEmbracePayload),
+                attributes = attributes.toEmbracePayload(),
                 links = links.toList()
             )
         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.opentelemetry.embSequenceId
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.payload.toNewPayload
+import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.trace.SpanId
@@ -40,7 +40,7 @@ val testSpan: Span = EmbraceSpanData(
         Pair(embSequenceId.name, "3"),
         EmbType.Performance.Default.toEmbraceKeyValuePair(),
     )
-).toNewPayload()
+).toEmbracePayload()
 
 val testSpanSnapshot: Span = Span(
     traceId = "snapshot-trace-id",


### PR DESCRIPTION
## Goal

Renames some functions that convert OpenTelemetry/Embrace model classes into Embrace payload classes, so that the naming better reflects the action taken.

## Testing

Relied on existing test coverage.