### PR TITLE
Only export if there is a configured exporter

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogRecordExporter.kt
@@ -11,7 +11,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter
  */
 internal class EmbraceLogRecordExporter(
     private val logSink: LogSink,
-    private val externalLogRecordExporter: LogRecordExporter,
+    private val externalLogRecordExporter: LogRecordExporter?,
     private val exportCheck: () -> Boolean,
 ) : LogRecordExporter {
 
@@ -20,7 +20,7 @@ internal class EmbraceLogRecordExporter(
             return CompletableResultCode.ofSuccess()
         }
         val result = logSink.storeLogs(logs.toList())
-        if (result == CompletableResultCode.ofSuccess()) {
+        if (externalLogRecordExporter != null && result == CompletableResultCode.ofSuccess()) {
             return externalLogRecordExporter.export(
                 logs.filterNot {
                     it.hasFixedAttribute(PrivateSpan)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfiguration.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/OpenTelemetryConfiguration.kt
@@ -67,7 +67,11 @@ class OpenTelemetryConfiguration(
         EmbraceSpanProcessor(
             EmbraceSpanExporter(
                 spanSink = spanSink,
-                externalSpanExporter = SpanExporter.composite(externalSpanExporters),
+                externalSpanExporter = if (externalSpanExporters.isNotEmpty()) {
+                    SpanExporter.composite(externalSpanExporters)
+                } else {
+                    null
+                },
                 exportCheck = exportCheck,
             ),
             processIdentifier
@@ -78,7 +82,11 @@ class OpenTelemetryConfiguration(
         EmbraceLogRecordProcessor(
             EmbraceLogRecordExporter(
                 logSink = logSink,
-                externalLogRecordExporter = LogRecordExporter.composite(externalLogExporters),
+                externalLogRecordExporter = if (externalLogExporters.isNotEmpty()) {
+                    LogRecordExporter.composite(externalLogExporters)
+                } else {
+                    null
+                },
                 exportCheck = exportCheck,
             )
         )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanExporter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanExporter.kt
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
  */
 internal class EmbraceSpanExporter(
     private val spanSink: SpanSink,
-    private val externalSpanExporter: SpanExporter,
+    private val externalSpanExporter: SpanExporter?,
     private val exportCheck: () -> Boolean,
 ) : SpanExporter {
     @Synchronized
@@ -21,7 +21,7 @@ internal class EmbraceSpanExporter(
             return CompletableResultCode.ofSuccess()
         }
         val result = spanSink.storeCompletedSpans(spans.toList())
-        if (result == CompletableResultCode.ofSuccess()) {
+        if (externalSpanExporter != null && result == CompletableResultCode.ofSuccess()) {
             return EmbTrace.trace("otel-external-export") {
                 externalSpanExporter.export(spans.filterNot { it.hasFixedAttribute(PrivateSpan) })
             }


### PR DESCRIPTION
## Goal

Don't create a composite exporter if there are no custom exporters that will use it. That way, we save pushing data to an empty composite exporter.
