### PR TITLE
Rename internal OTel concepts

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanDataSource.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -39,7 +39,7 @@ fun SpanService.startSpanCapture(
     schemaType: SchemaType,
     startTimeMs: Long,
     autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-): PersistableEmbraceSpan? {
+): EmbraceSdkSpan? {
     return startSpan(
         name = schemaType.fixedObjectName,
         startTimeMs = startTimeMs,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpan.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
-import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.spans.toStringMap
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -13,7 +13,7 @@ import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.TimeUnit
 
 class EmbSpan(
-    private val embraceSpan: PersistableEmbraceSpan,
+    private val embraceSpan: EmbraceSdkSpan,
     private val clock: Clock,
 ) : Span {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanBuilder.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanBuilder.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanBuilder
+import io.embrace.android.embracesdk.internal.spans.OtelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -13,18 +13,18 @@ import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.TimeUnit
 
 class EmbSpanBuilder(
-    private val embraceSpanBuilder: EmbraceSpanBuilder,
+    private val otelSpanBuilderWrapper: OtelSpanBuilderWrapper,
     private val spanService: SpanService,
     private val clock: Clock,
 ) : SpanBuilder {
 
     override fun setParent(context: Context): SpanBuilder {
-        embraceSpanBuilder.setParentContext(context)
+        otelSpanBuilderWrapper.setParentContext(context)
         return this
     }
 
     override fun setNoParent(): SpanBuilder {
-        embraceSpanBuilder.setNoParent()
+        otelSpanBuilderWrapper.setNoParent()
         return this
     }
 
@@ -33,7 +33,7 @@ class EmbSpanBuilder(
     override fun addLink(spanContext: SpanContext, attributes: Attributes): SpanBuilder = this
 
     override fun setAttribute(key: String, value: String): SpanBuilder {
-        embraceSpanBuilder.setCustomAttribute(key, value)
+        otelSpanBuilderWrapper.setCustomAttribute(key, value)
         return this
     }
 
@@ -47,17 +47,17 @@ class EmbSpanBuilder(
         setAttribute(key.key, value.toString())
 
     override fun setSpanKind(spanKind: SpanKind): SpanBuilder {
-        embraceSpanBuilder.setSpanKind(spanKind)
+        otelSpanBuilderWrapper.setSpanKind(spanKind)
         return this
     }
 
     override fun setStartTimestamp(startTimestamp: Long, unit: TimeUnit): SpanBuilder {
-        embraceSpanBuilder.startTimeMs = unit.toMillis(startTimestamp)
+        otelSpanBuilderWrapper.startTimeMs = unit.toMillis(startTimestamp)
         return this
     }
 
     override fun startSpan(): Span {
-        spanService.createSpan(embraceSpanBuilder)?.let { embraceSpan ->
+        spanService.createSpan(otelSpanBuilderWrapper)?.let { embraceSpan ->
             if (embraceSpan.start()) {
                 return EmbSpan(
                     embraceSpan = embraceSpan,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbTracer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/EmbTracer.kt
@@ -16,7 +16,7 @@ class EmbTracer(
 
     override fun spanBuilder(spanName: String): SpanBuilder =
         EmbSpanBuilder(
-            embraceSpanBuilder = sdkTracer.embraceSpanBuilder(
+            otelSpanBuilderWrapper = sdkTracer.embraceSpanBuilder(
                 name = spanName,
                 type = EmbType.Performance.Default,
                 private = false,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/TracerExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/opentelemetry/TracerExt.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanBuilder
+import io.embrace.android.embracesdk.internal.spans.OtelSpanBuilderWrapper
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.api.trace.SpanBuilder
@@ -17,7 +17,7 @@ internal fun Tracer.embraceSpanBuilder(
     private: Boolean,
     autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     parent: EmbraceSpan? = null,
-): EmbraceSpanBuilder = EmbraceSpanBuilder(
+): OtelSpanBuilderWrapper = OtelSpanBuilderWrapper(
     tracer = this,
     name = name,
     telemetryType = type,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -37,7 +37,7 @@ internal class CurrentSessionSpanImpl(
     /**
      * The span that models the lifetime of the current session or background activity
      */
-    private val sessionSpan: AtomicReference<PersistableEmbraceSpan?> = AtomicReference(null)
+    private val sessionSpan: AtomicReference<EmbraceSdkSpan?> = AtomicReference(null)
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
         if (!initialized.get()) {
@@ -166,7 +166,7 @@ internal class CurrentSessionSpanImpl(
     /**
      * This method should always be used when starting a new session span
      */
-    private fun startSessionSpan(startTimeMs: Long): PersistableEmbraceSpan {
+    private fun startSessionSpan(startTimeMs: Long): EmbraceSdkSpan {
         traceCount.set(0)
         internalTraceCount.set(0)
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSdkSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSdkSpan.kt
@@ -12,9 +12,9 @@ import io.opentelemetry.context.ContextKey
 import io.opentelemetry.context.ImplicitContextKeyed
 
 /**
- * An [EmbraceSpan] that has can generate a snapshot of its current state for persistence
+ * An [EmbraceSpan] that has additional functionality to be used internally by the SDK
  */
-interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
+interface EmbraceSdkSpan : EmbraceSpan, ImplicitContextKeyed {
 
     /**
      * Create a new [Context] object based in this span and its parent's context. This can be used for the parent [Context] for a new span
@@ -84,6 +84,6 @@ interface PersistableEmbraceSpan : EmbraceSpan, ImplicitContextKeyed {
     override fun storeInContext(context: Context): Context = context.with(embraceSpanContextKey, this)
 }
 
-fun Context.getEmbraceSpan(): PersistableEmbraceSpan? = get(embraceSpanContextKey)
+fun Context.getEmbraceSpan(): EmbraceSdkSpan? = get(embraceSpanContextKey)
 
-private val embraceSpanContextKey = ContextKey.named<PersistableEmbraceSpan>("embrace-span-key")
+private val embraceSpanContextKey = ContextKey.named<EmbraceSdkSpan>("embrace-span-key")

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactory.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
- * Creates instances of [PersistableEmbraceSpan] for internal usage. Using this factory is preferred to invoking the constructor
+ * Creates instances of [EmbraceSdkSpan] for internal usage. Using this factory is preferred to invoking the constructor
  * because of the it requires several services that may not be easily available.
  */
 internal interface EmbraceSpanFactory {
@@ -17,9 +17,9 @@ internal interface EmbraceSpanFactory {
         private: Boolean,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         parent: EmbraceSpan? = null,
-    ): PersistableEmbraceSpan
+    ): EmbraceSdkSpan
 
-    fun create(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan
+    fun create(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan
 
     fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImpl.kt
@@ -22,8 +22,8 @@ internal class EmbraceSpanFactoryImpl(
         private: Boolean,
         autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
-    ): PersistableEmbraceSpan = create(
-        embraceSpanBuilder = tracer.embraceSpanBuilder(
+    ): EmbraceSdkSpan = create(
+        otelSpanBuilderWrapper = tracer.embraceSpanBuilder(
             name = name,
             type = type,
             internal = internal,
@@ -33,9 +33,9 @@ internal class EmbraceSpanFactoryImpl(
         )
     )
 
-    override fun create(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan =
+    override fun create(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan =
         EmbraceSpanImpl(
-            spanBuilder = embraceSpanBuilder,
+            spanBuilder = otelSpanBuilderWrapper,
             openTelemetryClock = openTelemetryClock,
             spanRepository = spanRepository,
             sensitiveKeysBehavior = sensitiveKeysBehavior

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImpl.kt
@@ -38,12 +38,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 internal class EmbraceSpanImpl(
-    private val spanBuilder: EmbraceSpanBuilder,
+    private val spanBuilder: OtelSpanBuilderWrapper,
     private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
     private val sensitiveKeysBehavior: SensitiveKeysBehavior?,
     private val limits: OtelLimitsConfig = InstrumentedConfigImpl.otelLimits,
-) : PersistableEmbraceSpan {
+) : EmbraceSdkSpan {
 
     private val startedSpan: AtomicReference<io.opentelemetry.api.trace.Span?> = AtomicReference(null)
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -50,7 +50,7 @@ internal class EmbraceSpanService(
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
-    ): PersistableEmbraceSpan? =
+    ): EmbraceSdkSpan? =
         currentDelegate.createSpan(
             name = name,
             autoTerminationMode = autoTerminationMode,
@@ -60,9 +60,9 @@ internal class EmbraceSpanService(
             private = private
         )
 
-    override fun createSpan(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan? =
+    override fun createSpan(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan? =
         currentDelegate.createSpan(
-            embraceSpanBuilder
+            otelSpanBuilderWrapper
         )
 
     override fun <T> recordSpan(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/OtelSpanBuilderWrapper.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/OtelSpanBuilderWrapper.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Wrapper for the [SpanBuilder] that stores the input data so that they can be accessed
  */
-class EmbraceSpanBuilder(
+class OtelSpanBuilderWrapper(
     tracer: Tracer,
     name: String,
     telemetryType: TelemetryType,
@@ -41,7 +41,7 @@ class EmbraceSpanBuilder(
 
     init {
         // If there is a parent, extract the wrapped OTel span and set it as the parent in the wrapped OTel SpanBuilder
-        if (parentSpan is PersistableEmbraceSpan) {
+        if (parentSpan is EmbraceSdkSpan) {
             val newParentContext = parentSpan.asNewContext() ?: Context.root()
             setParentContext(newParentContext.with(parentSpan))
         } else {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanRepository.kt
@@ -12,15 +12,15 @@ import java.util.concurrent.atomic.AtomicInteger
  * Allows the tracking of [EmbraceSpan] instances so that their references can be retrieved with its associated spanId
  */
 class SpanRepository {
-    private val activeSpans: MutableMap<String, PersistableEmbraceSpan> = ConcurrentHashMap()
-    private val completedSpans: MutableMap<String, PersistableEmbraceSpan> = ConcurrentHashMap()
+    private val activeSpans: MutableMap<String, EmbraceSdkSpan> = ConcurrentHashMap()
+    private val completedSpans: MutableMap<String, EmbraceSdkSpan> = ConcurrentHashMap()
     private val spanIdsInProcess: MutableMap<String, AtomicInteger> = ConcurrentHashMap()
     private var spanUpdateNotifier: (() -> Unit)? = null
 
     /**
      * Track the [EmbraceSpan] if it has been started and it's not already tracked.
      */
-    fun trackStartedSpan(embraceSpan: PersistableEmbraceSpan) {
+    fun trackStartedSpan(embraceSpan: EmbraceSdkSpan) {
         val spanId = embraceSpan.spanId ?: return
 
         if (notTracked(spanId)) {
@@ -58,14 +58,14 @@ class SpanRepository {
     /**
      * Get a list of active spans that are being tracked
      */
-    fun getActiveSpans(): List<PersistableEmbraceSpan> = synchronized(spanIdsInProcess) {
+    fun getActiveSpans(): List<EmbraceSdkSpan> = synchronized(spanIdsInProcess) {
         activeSpans.values.toList()
     }
 
     /**
      * Get a list of completed spans that are being tracked.
      */
-    fun getCompletedSpans(): List<PersistableEmbraceSpan> = synchronized(spanIdsInProcess) {
+    fun getCompletedSpans(): List<EmbraceSdkSpan> = synchronized(spanIdsInProcess) {
         completedSpans.values.toList()
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanService.kt
@@ -24,13 +24,13 @@ interface SpanService : Initializable {
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
         private: Boolean = false,
-    ): PersistableEmbraceSpan?
+    ): EmbraceSdkSpan?
 
     /**
-     * Return an [EmbraceSpan] instance that can be used to record spans given the [EmbraceSpanBuilder]. Returns null if the builder will
-     * not build a valid span or if the SDK and session is not in a state where a new span can be recorded.
+     * Return an [EmbraceSpan] instance that can be used to record spans given the [OtelSpanBuilderWrapper]. Returns null if the builder
+     * will not build a valid span or if the SDK and session is not in a state where a new span can be recorded.
      */
-    fun createSpan(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan?
+    fun createSpan(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan?
 
     /**
      * Create, start, and return a new [EmbraceSpan] with the given parameters
@@ -43,7 +43,7 @@ interface SpanService : Initializable {
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
         private: Boolean = false,
-    ): PersistableEmbraceSpan? {
+    ): EmbraceSdkSpan? {
         createSpan(
             name = name,
             autoTerminationMode = autoTerminationMode,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -41,7 +41,7 @@ internal class SpanServiceImpl(
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
-    ): PersistableEmbraceSpan? {
+    ): EmbraceSdkSpan? {
         EmbTrace.trace("span-create") {
             return if (limits.isNameValid(name, internal) && currentSessionSpan.canStartNewSpan(parent, internal)) {
                 embraceSpanFactory.create(
@@ -58,13 +58,13 @@ internal class SpanServiceImpl(
         }
     }
 
-    override fun createSpan(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan? {
+    override fun createSpan(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan? {
         EmbTrace.trace("span-create") {
             return if (
-                limits.isNameValid(embraceSpanBuilder.spanName, embraceSpanBuilder.internal) &&
-                currentSessionSpan.canStartNewSpan(embraceSpanBuilder.getParentSpan(), embraceSpanBuilder.internal)
+                limits.isNameValid(otelSpanBuilderWrapper.spanName, otelSpanBuilderWrapper.internal) &&
+                currentSessionSpan.canStartNewSpan(otelSpanBuilderWrapper.getParentSpan(), otelSpanBuilderWrapper.internal)
             ) {
-                embraceSpanFactory.create(embraceSpanBuilder)
+                embraceSpanFactory.create(otelSpanBuilderWrapper)
             } else {
                 null
             }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
@@ -28,9 +28,9 @@ internal class UninitializedSdkSpanService : SpanService {
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
-    ): PersistableEmbraceSpan? = null
+    ): EmbraceSdkSpan? = null
 
-    override fun createSpan(embraceSpanBuilder: EmbraceSpanBuilder): PersistableEmbraceSpan? = null
+    override fun createSpan(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan? = null
 
     override fun <T> recordSpan(
         name: String,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.envelope.session
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
-import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -25,7 +25,7 @@ internal class SessionPayloadSourceImplTest {
     private lateinit var sink: SpanSinkImpl
     private lateinit var currentSessionSpan: FakeCurrentSessionSpan
     private lateinit var spanRepository: SpanRepository
-    private lateinit var activeSpan: FakePersistableEmbraceSpan
+    private lateinit var activeSpan: FakeEmbraceSdkSpan
     private val cacheSpan = FakeSpanData(name = "cache-span")
 
     @Before
@@ -36,7 +36,7 @@ internal class SessionPayloadSourceImplTest {
         currentSessionSpan = FakeCurrentSessionSpan().apply {
             initializeService(1000L)
         }
-        activeSpan = FakePersistableEmbraceSpan.started()
+        activeSpan = FakeEmbraceSdkSpan.started()
         spanRepository = SpanRepository()
         spanRepository.trackStartedSpan(checkNotNull(currentSessionSpan.sessionSpan))
         spanRepository.trackStartedSpan(activeSpan)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.internal.envelope.session
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
-import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
+import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanBuilderTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanBuilderTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
 import io.embrace.android.embracesdk.fakes.FakeSpan
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.FakeTracer

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/opentelemetry/EmbSpanTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.opentelemetry
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
@@ -23,14 +23,14 @@ import java.util.concurrent.TimeUnit
 internal class EmbSpanTest {
     private lateinit var fakeClock: FakeClock
     private lateinit var openTelemetryClock: Clock
-    private lateinit var fakeEmbraceSpan: FakePersistableEmbraceSpan
+    private lateinit var fakeEmbraceSpan: FakeEmbraceSdkSpan
     private lateinit var embSpan: EmbSpan
 
     @Before
     fun setup() {
         fakeClock = FakeClock()
         openTelemetryClock = FakeInitModule(fakeClock).openTelemetryModule.openTelemetryClock
-        fakeEmbraceSpan = FakePersistableEmbraceSpan.started(clock = fakeClock)
+        fakeEmbraceSpan = FakeEmbraceSdkSpan.started(clock = fakeClock)
         embSpan = EmbSpan(
             embraceSpan = fakeEmbraceSpan,
             clock = openTelemetryClock
@@ -180,7 +180,7 @@ internal class EmbSpanTest {
     @Test
     fun `add span link`() {
         with(embSpan) {
-            val linkedSpanContext = checkNotNull(FakePersistableEmbraceSpan.started().spanContext)
+            val linkedSpanContext = checkNotNull(FakeEmbraceSdkSpan.started().spanContext)
             addLink(linkedSpanContext, Attributes.builder().put("boolean", true).build())
             with(fakeEmbraceSpan.links.single()) {
                 assertEquals(linkedSpanContext.spanId, spanId)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeIntakeService
 import io.embrace.android.embracesdk.fakes.FakeNativeCrashService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
-import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeSpanData.Companion.perfSpanSnapshot
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.fakeEmptyLogEnvelope
@@ -399,7 +399,7 @@ class PayloadResurrectionServiceImplTest {
             data = deadSessionEnvelope.data.copy(
                 spanSnapshots = deadSessionEnvelope.data.spanSnapshots?.plus(
                     checkNotNull(
-                        FakePersistableEmbraceSpan.sessionSpan(
+                        FakeEmbraceSdkSpan.sessionSpan(
                             sessionId = "fake-session-span-id",
                             startTimeMs = deadSessionEnvelope.getStartTime() + 1001L,
                             lastHeartbeatTimeMs = deadSessionEnvelope.getStartTime() + 1001L,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -8,10 +8,10 @@ import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.assertions.getStartTime
 import io.embrace.android.embracesdk.fakes.FakeCachedLogEnvelopeStore
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeIntakeService
 import io.embrace.android.embracesdk.fakes.FakeNativeCrashService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
-import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeSpanData.Companion.perfSpanSnapshot
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.fakeEmptyLogEnvelope

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -35,7 +35,7 @@ import io.embrace.android.embracesdk.internal.opentelemetry.embCrashId
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
-import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -453,7 +453,7 @@ internal class SessionOrchestratorTest {
     }
 
     private fun validateSession(
-        sessionSpan: PersistableEmbraceSpan?,
+        sessionSpan: EmbraceSdkSpan?,
         endTimeMs: Long,
         endType: LifeEventType,
     ) {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.assertions.findEventOfType
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.destination.SpanAttributeData
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
@@ -124,7 +124,7 @@ internal class CurrentSessionSpanImplTests {
         repeat(SpanServiceImpl.MAX_NON_INTERNAL_SPANS_PER_SESSION) {
             assertNotNull(
                 spanService.createSpan(
-                    embraceSpanBuilder = tracer.embraceSpanBuilder(
+                    otelSpanBuilderWrapper = tracer.embraceSpanBuilder(
                         name = "external-span",
                         type = EmbType.Performance.Default,
                         parent = null,
@@ -136,7 +136,7 @@ internal class CurrentSessionSpanImplTests {
         }
         assertNull(
             spanService.createSpan(
-                embraceSpanBuilder = tracer.embraceSpanBuilder(
+                otelSpanBuilderWrapper = tracer.embraceSpanBuilder(
                     name = "external-span",
                     type = EmbType.Performance.Default,
                     parent = null,
@@ -147,7 +147,7 @@ internal class CurrentSessionSpanImplTests {
         )
         assertNotNull(
             spanService.createSpan(
-                embraceSpanBuilder = tracer.embraceSpanBuilder(
+                otelSpanBuilderWrapper = tracer.embraceSpanBuilder(
                     name = "internal-span",
                     type = EmbType.Performance.Default,
                     parent = null,
@@ -557,7 +557,7 @@ internal class CurrentSessionSpanImplTests {
     }
 
     private class BadEmbraceSpanFactory : EmbraceSpanFactory {
-        private val stoppedSpan = FakePersistableEmbraceSpan.stopped()
+        private val stoppedSpan = FakeEmbraceSdkSpan.stopped()
         override fun create(
             name: String,
             type: TelemetryType,
@@ -565,9 +565,9 @@ internal class CurrentSessionSpanImplTests {
             private: Boolean,
             autoTerminationMode: AutoTerminationMode,
             parent: EmbraceSpan?,
-        ): PersistableEmbraceSpan = stoppedSpan
+        ): EmbraceSdkSpan = stoppedSpan
 
-        override fun create(embraceSpanBuilder: EmbraceSpanBuilder) = stoppedSpan
+        override fun create(otelSpanBuilderWrapper: OtelSpanBuilderWrapper) = stoppedSpan
         override fun setupSensitiveKeysBehavior(sensitiveKeysBehavior: SensitiveKeysBehavior) {
             // no-op
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakePayloadCachingService
-import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeRedactionConfig
@@ -102,7 +102,7 @@ internal class EmbraceSpanFactoryImplTest {
 
     @Test
     fun `span creation with embrace span builder`() {
-        val spanParent = FakePersistableEmbraceSpan.started()
+        val spanParent = FakeEmbraceSdkSpan.started()
         val spanBuilder = tracer.embraceSpanBuilder(
             name = "from-span-builder",
             type = EmbType.System.LowPower,
@@ -111,7 +111,7 @@ internal class EmbraceSpanFactoryImplTest {
             parent = spanParent,
         )
 
-        with(embraceSpanFactory.create(embraceSpanBuilder = spanBuilder)) {
+        with(embraceSpanFactory.create(otelSpanBuilderWrapper = spanBuilder)) {
             assertTrue(start(clock.now()))
             assertTrue(hasEmbraceAttribute(EmbType.System.LowPower))
             assertEquals(spanParent, parent)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanFactoryImplTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakePayloadCachingService
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
+import io.embrace.android.embracesdk.fakes.FakePayloadCachingService
 import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeRedactionConfig

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceSpanImplTest.kt
@@ -493,7 +493,7 @@ internal class EmbraceSpanImplTest {
     )
 
     private fun createEmbraceSpanImpl(
-        spanBuilder: EmbraceSpanBuilder,
+        spanBuilder: OtelSpanBuilderWrapper,
         clock: Clock = openTelemetryClock,
     ) = EmbraceSpanImpl(
         spanBuilder = spanBuilder,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/OtelSpanBuilderWrapperTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/OtelSpanBuilderWrapperTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeSpan
 import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.fixtures.fakeContextKey
@@ -15,7 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-internal class EmbraceSpanBuilderTest {
+internal class OtelSpanBuilderWrapperTest {
     private val clock = FakeClock()
     private lateinit var tracer: FakeTracer
 
@@ -26,7 +26,7 @@ internal class EmbraceSpanBuilderTest {
 
     @Test
     fun `check private and internal span creation`() {
-        val spanBuilder = EmbraceSpanBuilder(
+        val spanBuilder = OtelSpanBuilderWrapper(
             tracer = tracer,
             name = "test",
             telemetryType = EmbType.Performance.Default,
@@ -51,7 +51,7 @@ internal class EmbraceSpanBuilderTest {
 
     @Test
     fun `add parent after initial creation`() {
-        val spanBuilder = EmbraceSpanBuilder(
+        val spanBuilder = OtelSpanBuilderWrapper(
             tracer = tracer,
             name = "test",
             telemetryType = EmbType.Performance.Default,
@@ -59,7 +59,7 @@ internal class EmbraceSpanBuilderTest {
             private = false,
             parentSpan = null,
         )
-        val parent = FakePersistableEmbraceSpan.started()
+        val parent = FakeEmbraceSdkSpan.started()
         val parentContext = checkNotNull(parent.asNewContext()?.with(fakeContextKey, "value"))
         spanBuilder.setParentContext(parentContext)
         val startTime = clock.now()
@@ -73,9 +73,9 @@ internal class EmbraceSpanBuilderTest {
 
     @Test
     fun `remove parent after initial creation`() {
-        val parent = FakePersistableEmbraceSpan.started()
+        val parent = FakeEmbraceSdkSpan.started()
         val startTime = clock.now()
-        val spanBuilder = EmbraceSpanBuilder(
+        val spanBuilder = OtelSpanBuilderWrapper(
             tracer = tracer,
             name = "test",
             telemetryType = EmbType.Performance.Default,
@@ -92,7 +92,7 @@ internal class EmbraceSpanBuilderTest {
             )
         }
 
-        val uxSpanBuilder = EmbraceSpanBuilder(
+        val uxSpanBuilder = OtelSpanBuilderWrapper(
             tracer = tracer,
             name = "ux-test",
             telemetryType = EmbType.Ux.View,
@@ -112,7 +112,7 @@ internal class EmbraceSpanBuilderTest {
 
     @Test
     fun `add span kind`() {
-        val spanBuilder = EmbraceSpanBuilder(
+        val spanBuilder = OtelSpanBuilderWrapper(
             tracer = tracer,
             name = "test",
             telemetryType = EmbType.Performance.Default,
@@ -131,7 +131,7 @@ internal class EmbraceSpanBuilderTest {
 
     @Test
     fun `custom attribute setting`() {
-        val spanBuilder = EmbraceSpanBuilder(
+        val spanBuilder = OtelSpanBuilderWrapper(
             tracer = tracer,
             name = "test",
             telemetryType = EmbType.Performance.Default,
@@ -146,7 +146,7 @@ internal class EmbraceSpanBuilderTest {
     @Test
     fun `context value propagated even if it does not context a span`() {
         val fakeRootContext = Context.root().with(fakeContextKey, "fake-value")
-        val spanBuilder = EmbraceSpanBuilder(
+        val spanBuilder = OtelSpanBuilderWrapper(
             tracer = tracer,
             name = "parent",
             telemetryType = EmbType.Performance.Default,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanRepositoryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanRepositoryTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.spans
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakePersistableEmbraceSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -29,7 +29,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `started span tracked`() {
-        val startedSpan = FakePersistableEmbraceSpan.started()
+        val startedSpan = FakeEmbraceSdkSpan.started()
         repository.trackStartedSpan(startedSpan)
         assertSame(startedSpan, checkNotNull(repository.getSpan(checkNotNull(startedSpan.spanId))))
         assertEquals(1, repository.getActiveSpans().size)
@@ -38,7 +38,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `completed span tracked`() {
-        val completedSpan = FakePersistableEmbraceSpan.stopped()
+        val completedSpan = FakeEmbraceSdkSpan.stopped()
         repository.trackStartedSpan(completedSpan)
         assertSame(completedSpan, checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId))))
         assertEquals(0, repository.getActiveSpans().size)
@@ -47,14 +47,14 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `not started span not tracked`() {
-        repository.trackStartedSpan(FakePersistableEmbraceSpan.notStarted())
+        repository.trackStartedSpan(FakeEmbraceSdkSpan.notStarted())
         assertEquals(0, repository.getActiveSpans().size)
         assertEquals(0, repository.getCompletedSpans().size)
     }
 
     @Test
     fun `tracked span moved to complete only if it is actually complete`() {
-        val span = FakePersistableEmbraceSpan.started()
+        val span = FakeEmbraceSdkSpan.started()
         val spanId = checkNotNull(span.spanId)
         repository.trackStartedSpan(span)
         repository.trackedSpanStopped(spanId)
@@ -70,7 +70,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `spans not tracked twice`() {
-        val span = FakePersistableEmbraceSpan.started()
+        val span = FakeEmbraceSdkSpan.started()
         val spanId = checkNotNull(span.spanId)
         repository.trackStartedSpan(span)
         repository.trackStartedSpan(span)
@@ -85,7 +85,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `completed span not available after clearing but existing reference still valid`() {
-        val completedSpan = FakePersistableEmbraceSpan.stopped()
+        val completedSpan = FakeEmbraceSdkSpan.stopped()
         repository.trackStartedSpan(completedSpan)
         checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId)))
         assertEquals(1, repository.getCompletedSpans().size)
@@ -96,7 +96,7 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `active spans become failed and complete when they are forced to fail`() {
-        val startedSpan = FakePersistableEmbraceSpan.started()
+        val startedSpan = FakeEmbraceSdkSpan.started()
         repository.trackStartedSpan(startedSpan)
 
         assertSame(startedSpan, repository.getActiveSpans().single())

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.capture.activity
 
 import android.app.Application.ActivityLifecycleCallbacks
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -322,8 +322,8 @@ class UiLoadTraceEmitter(
     private data class UiLoadTrace(
         val activityName: String,
         val traceCompleteTrigger: TraceCompleteTrigger,
-        val root: PersistableEmbraceSpan,
-        val children: Map<LifecycleStage, PersistableEmbraceSpan> = ConcurrentHashMap(),
+        val root: EmbraceSdkSpan,
+        val children: Map<LifecycleStage, EmbraceSdkSpan> = ConcurrentHashMap(),
     )
 
     private data class UiInstance(val name: String, val id: Int)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.opentelemetry.embStartupActivityName
 import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
-import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.ui.supportFrameCommitCallback
@@ -58,7 +58,7 @@ internal class AppStartupTraceEmitter(
     private val customAttributes: MutableMap<String, String> = ConcurrentHashMap()
     private val trackRender = hasRenderEvent(versionChecker)
     private val trackFrameCommit = supportFrameCommitCallback(versionChecker)
-    private val appStartupRootSpan = AtomicReference<PersistableEmbraceSpan?>(null)
+    private val appStartupRootSpan = AtomicReference<EmbraceSdkSpan?>(null)
     private val dataCollectionComplete = AtomicBoolean(false)
     private val traceEnd = if (manualEnd) {
         TraceEnd.READY
@@ -426,7 +426,7 @@ internal class AppStartupTraceEmitter(
 
     private fun nowMs(): Long = clock.now().nanosToMillis()
 
-    private fun PersistableEmbraceSpan.addTraceMetadata() {
+    private fun EmbraceSdkSpan.addTraceMetadata() {
         addCustomAttributes()
 
         startupActivityName?.let { name ->
@@ -434,7 +434,7 @@ internal class AppStartupTraceEmitter(
         }
     }
 
-    private fun PersistableEmbraceSpan.addCustomAttributes() {
+    private fun EmbraceSdkSpan.addCustomAttributes() {
         customAttributes.forEach {
             addAttribute(it.key, it.value)
         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -17,7 +17,7 @@ class FakeCurrentSessionSpan(
     var initializedCallCount: Int = 0
     var addedEvents: MutableList<SpanEventData> = mutableListOf()
     var attributes: MutableMap<String, String> = mutableMapOf()
-    var sessionSpan: FakePersistableEmbraceSpan? = null
+    var sessionSpan: FakeEmbraceSdkSpan? = null
 
     private val sessionIteration = AtomicInteger(1)
 
@@ -82,7 +82,7 @@ class FakeCurrentSessionSpan(
     fun attributeCount(): Int = attributes.size
 
     private fun newSessionSpan(startTimeMs: Long) =
-        FakePersistableEmbraceSpan.sessionSpan(
+        FakeEmbraceSdkSpan.sessionSpan(
             sessionId = "fake-session-span-id",
             startTimeMs = startTimeMs,
             lastHeartbeatTimeMs = startTimeMs

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.internal.otel.attrs.asPair
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.toEmbracePayload
-import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
+import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.spans.getEmbraceSpan
 import io.embrace.android.embracesdk.internal.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.spans.toStatus
@@ -33,7 +33,7 @@ import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 
-class FakePersistableEmbraceSpan(
+class FakeEmbraceSdkSpan(
     var name: String = "fake-span",
     var parentContext: Context = Context.root(),
     val type: TelemetryType = EmbType.Performance.Default,
@@ -41,7 +41,7 @@ class FakePersistableEmbraceSpan(
     val private: Boolean = internal,
     override val autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     private val fakeClock: FakeClock = FakeClock(),
-) : PersistableEmbraceSpan {
+) : EmbraceSdkSpan {
 
     private var sdkSpan: io.opentelemetry.api.trace.Span? = null
     var spanStartTimeMs: Long? = null
@@ -189,14 +189,14 @@ class FakePersistableEmbraceSpan(
     private fun started(): Boolean = sdkSpan != null
 
     companion object {
-        fun notStarted(): FakePersistableEmbraceSpan = FakePersistableEmbraceSpan(name = "not-started")
+        fun notStarted(): FakeEmbraceSdkSpan = FakeEmbraceSdkSpan(name = "not-started")
 
         fun started(
-            parent: PersistableEmbraceSpan? = null,
+            parent: EmbraceSdkSpan? = null,
             parentContext: Context = parent?.run { parent.asNewContext() } ?: Context.root(),
             clock: FakeClock = FakeClock(),
-        ): FakePersistableEmbraceSpan =
-            FakePersistableEmbraceSpan(
+        ): FakeEmbraceSdkSpan =
+            FakeEmbraceSdkSpan(
                 name = "started",
                 fakeClock = clock,
                 parentContext = parentContext
@@ -204,8 +204,8 @@ class FakePersistableEmbraceSpan(
                 start()
             }
 
-        fun stopped(): FakePersistableEmbraceSpan =
-            FakePersistableEmbraceSpan(name = "stopped").apply {
+        fun stopped(): FakeEmbraceSdkSpan =
+            FakeEmbraceSdkSpan(name = "stopped").apply {
                 start()
                 stop()
             }
@@ -217,8 +217,8 @@ class FakePersistableEmbraceSpan(
             endTimeMs: Long? = null,
             sessionProperties: Map<String, String>? = null,
             processIdentifier: String = "fake-process-id",
-        ): FakePersistableEmbraceSpan =
-            FakePersistableEmbraceSpan(
+        ): FakeEmbraceSdkSpan =
+            FakeEmbraceSdkSpan(
                 name = "emb-session",
                 type = EmbType.Ux.Session
             ).apply {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -24,7 +24,7 @@ fun fakeSessionEnvelope(
     endMs: Long = 161000400000L,
     sessionProperties: Map<String, String>? = null,
 ): Envelope<SessionPayload> {
-    val sessionSpan = FakePersistableEmbraceSpan.sessionSpan(
+    val sessionSpan = FakeEmbraceSdkSpan.sessionSpan(
         sessionId = sessionId,
         startTimeMs = startMs,
         lastHeartbeatTimeMs = endMs,
@@ -32,7 +32,7 @@ fun fakeSessionEnvelope(
         sessionProperties = sessionProperties,
     )
     val spans = listOf(testSpan, checkNotNull(sessionSpan.snapshot()))
-    val spanSnapshots = listOfNotNull(FakePersistableEmbraceSpan.started().snapshot())
+    val spanSnapshots = listOfNotNull(FakeEmbraceSdkSpan.started().snapshot())
 
     return Envelope(
         resource = fakeEnvelopeResource,
@@ -56,7 +56,7 @@ fun fakeIncompleteSessionEnvelope(
     metadata: EnvelopeMetadata = fakeEnvelopeMetadata,
 ): Envelope<SessionPayload> {
     val fakeClock = FakeClock(currentTime = startMs)
-    val incompleteSessionSpan = FakePersistableEmbraceSpan.sessionSpan(
+    val incompleteSessionSpan = FakeEmbraceSdkSpan.sessionSpan(
         sessionId = sessionId,
         startTimeMs = startMs,
         lastHeartbeatTimeMs = lastHeartbeatTimeMs,
@@ -71,7 +71,7 @@ fun fakeIncompleteSessionEnvelope(
         data = SessionPayload(
             spanSnapshots = listOfNotNull(
                 incompleteSessionSpan.snapshot(),
-                FakePersistableEmbraceSpan.started(clock = fakeClock).snapshot()
+                FakeEmbraceSdkSpan.started(clock = fakeClock).snapshot()
             )
         )
     )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
-import io.embrace.android.embracesdk.internal.spans.OtelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
+import io.embrace.android.embracesdk.internal.spans.OtelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryType
-import io.embrace.android.embracesdk.internal.spans.EmbraceSpanBuilder
-import io.embrace.android.embracesdk.internal.spans.PersistableEmbraceSpan
+import io.embrace.android.embracesdk.internal.spans.OtelSpanBuilderWrapper
+import io.embrace.android.embracesdk.internal.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.spans.SpanService
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -13,7 +13,7 @@ import io.opentelemetry.context.Context
 
 class FakeSpanService : SpanService {
 
-    val createdSpans: MutableList<FakePersistableEmbraceSpan> = mutableListOf()
+    val createdSpans: MutableList<FakeEmbraceSdkSpan> = mutableListOf()
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
     }
@@ -27,9 +27,9 @@ class FakeSpanService : SpanService {
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
-    ): PersistableEmbraceSpan = FakePersistableEmbraceSpan(
+    ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
         name = name,
-        parentContext = parent?.run { Context.root().with(parent as PersistableEmbraceSpan) } ?: Context.root(),
+        parentContext = parent?.run { Context.root().with(parent as EmbraceSdkSpan) } ?: Context.root(),
         type = type,
         internal = internal,
         private = private,
@@ -39,14 +39,14 @@ class FakeSpanService : SpanService {
     }
 
     override fun createSpan(
-        embraceSpanBuilder: EmbraceSpanBuilder,
-    ): PersistableEmbraceSpan = FakePersistableEmbraceSpan(
-        name = embraceSpanBuilder.spanName,
-        parentContext = embraceSpanBuilder.parentContext,
-        type = embraceSpanBuilder.getEmbraceAttributes().filterIsInstance<TelemetryType>().single(),
-        internal = embraceSpanBuilder.internal,
-        private = embraceSpanBuilder.getEmbraceAttributes().contains(PrivateSpan),
-        autoTerminationMode = embraceSpanBuilder.autoTerminationMode,
+        otelSpanBuilderWrapper: OtelSpanBuilderWrapper,
+    ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
+        name = otelSpanBuilderWrapper.spanName,
+        parentContext = otelSpanBuilderWrapper.parentContext,
+        type = otelSpanBuilderWrapper.getEmbraceAttributes().filterIsInstance<TelemetryType>().single(),
+        internal = otelSpanBuilderWrapper.internal,
+        private = otelSpanBuilderWrapper.getEmbraceAttributes().contains(PrivateSpan),
+        autoTerminationMode = otelSpanBuilderWrapper.autoTerminationMode,
     ).apply {
         createdSpans.add(this)
     }
@@ -79,9 +79,9 @@ class FakeSpanService : SpanService {
         errorCode: ErrorCode?,
     ): Boolean {
         createdSpans.add(
-            FakePersistableEmbraceSpan(
+            FakeEmbraceSdkSpan(
                 name = name,
-                parentContext = parent?.run { Context.root().with(parent as PersistableEmbraceSpan) } ?: Context.root(),
+                parentContext = parent?.run { Context.root().with(parent as EmbraceSdkSpan) } ?: Context.root(),
                 type = type,
                 internal = internal,
                 private = private


### PR DESCRIPTION
## Goal

Rename a couple a classes to prepare for extraction of OTel classes to a separate module specifically:
- EmbraceSpanBuilder -> OtelSpanBuilderWrapper 
- PersistableEmbraceSpan -> EmbraceSdkSpan
