### PR TITLE
Clarified scope of OtelSpanBuilderWrapper and EmbraceSpanFactory

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkLoggingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkLoggingService.kt
@@ -77,9 +77,9 @@ internal class EmbraceNetworkLoggingService(
                 name = "${networkRequest.httpMethod} ${getUrlPath(strippedUrl)}",
                 startTimeMs = networkRequest.startTime,
                 endTimeMs = networkRequest.endTime,
-                errorCode = errorCode,
-                attributes = networkRequestSchemaType.attributes(),
                 type = EmbType.Performance.Network,
+                attributes = networkRequestSchemaType.attributes(),
+                errorCode = errorCode,
             )
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceSpanService.kt
@@ -50,19 +50,19 @@ internal class EmbraceSpanService(
 
     override fun createSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
+        autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan? =
         currentDelegate.createSpan(
             name = name,
-            autoTerminationMode = autoTerminationMode,
             parent = parent,
             type = type,
             internal = internal,
-            private = private
+            private = private,
+            autoTerminationMode = autoTerminationMode
         )
 
     override fun createSpan(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan? =
@@ -72,23 +72,23 @@ internal class EmbraceSpanService(
 
     override fun <T> recordSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        autoTerminationMode: AutoTerminationMode,
         code: () -> T,
     ): T = currentDelegate.recordSpan(
         name = name,
-        autoTerminationMode = autoTerminationMode,
         parent = parent,
         type = type,
         internal = internal,
         private = private,
         attributes = attributes,
         events = events,
+        autoTerminationMode = autoTerminationMode,
         code = code
     )
 
@@ -96,7 +96,6 @@ internal class EmbraceSpanService(
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
@@ -108,7 +107,6 @@ internal class EmbraceSpanService(
         name = name,
         startTimeMs = startTimeMs,
         endTimeMs = endTimeMs,
-        autoTerminationMode = autoTerminationMode,
         parent = parent,
         type = type,
         internal = internal,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/SpanServiceImpl.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanFactory
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
+import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -41,11 +42,11 @@ internal class SpanServiceImpl(
 
     override fun createSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
+        autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan? {
         EmbTrace.trace("span-create") {
             return if (limits.isNameValid(name, internal) && currentSessionSpan.canStartNewSpan(parent, internal)) {
@@ -66,8 +67,11 @@ internal class SpanServiceImpl(
     override fun createSpan(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan? {
         EmbTrace.trace("span-create") {
             return if (
-                limits.isNameValid(otelSpanBuilderWrapper.spanName, otelSpanBuilderWrapper.internal) &&
-                currentSessionSpan.canStartNewSpan(otelSpanBuilderWrapper.getParentSpan(), otelSpanBuilderWrapper.internal)
+                limits.isNameValid(otelSpanBuilderWrapper.initialSpanName, otelSpanBuilderWrapper.internal) &&
+                currentSessionSpan.canStartNewSpan(
+                    otelSpanBuilderWrapper.getParentContext().getEmbraceSpan(),
+                    otelSpanBuilderWrapper.internal
+                )
             ) {
                 embraceSpanFactory.create(otelSpanBuilderWrapper)
             } else {
@@ -78,23 +82,23 @@ internal class SpanServiceImpl(
 
     override fun <T> recordSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        autoTerminationMode: AutoTerminationMode,
         code: () -> T,
     ): T {
         val returnValue: T
         val span = createSpan(
             name = name,
-            autoTerminationMode = autoTerminationMode,
             parent = parent,
             type = type,
             internal = internal,
-            private = private
+            private = private,
+            autoTerminationMode = autoTerminationMode
         )
         try {
             val started = span?.start() ?: false
@@ -124,7 +128,6 @@ internal class SpanServiceImpl(
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
@@ -145,7 +148,6 @@ internal class SpanServiceImpl(
                     internal = internal,
                     private = private,
                     parent = parent,
-                    autoTerminationMode = autoTerminationMode,
                 )
                 if (newSpan.start(startTimeMs)) {
                     attributes.forEach {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/UninitializedSdkSpanService.kt
@@ -26,24 +26,24 @@ internal class UninitializedSdkSpanService : SpanService {
 
     override fun createSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
+        autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan? = null
 
     override fun createSpan(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan? = null
 
     override fun <T> recordSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        autoTerminationMode: AutoTerminationMode,
         code: () -> T,
     ) = code()
 
@@ -51,7 +51,6 @@ internal class UninitializedSdkSpanService : SpanService {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
@@ -64,7 +63,6 @@ internal class UninitializedSdkSpanService : SpanService {
             name = name,
             startTimeMs = startTimeMs,
             endTimeMs = endTimeMs,
-            autoTerminationMode = autoTerminationMode,
             parent = parent,
             type = type,
             internal = internal,
@@ -81,7 +79,6 @@ internal class UninitializedSdkSpanService : SpanService {
                         name = name,
                         startTimeMs = startTimeMs,
                         endTimeMs = endTimeMs,
-                        autoTerminationMode = autoTerminationMode,
                         parent = parent,
                         type = type,
                         internal = internal,
@@ -112,7 +109,6 @@ internal class UninitializedSdkSpanService : SpanService {
                         name = it.name,
                         startTimeMs = it.startTimeMs,
                         endTimeMs = it.endTimeMs,
-                        autoTerminationMode = it.autoTerminationMode,
                         parent = it.parent,
                         type = it.type,
                         internal = it.internal,
@@ -133,11 +129,10 @@ internal class UninitializedSdkSpanService : SpanService {
     /**
      * Represents a call to [SpanService.recordCompletedSpan] that can be saved and replayed later when the SDK is initialized.
      */
-    data class BufferedRecordCompletedSpan(
+    private data class BufferedRecordCompletedSpan(
         val name: String,
         val startTimeMs: Long,
         val endTimeMs: Long,
-        val autoTerminationMode: AutoTerminationMode,
         val parent: EmbraceSpan?,
         val type: TelemetryType,
         val internal: Boolean,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -569,11 +569,10 @@ internal class CurrentSessionSpanImplTests {
             type: TelemetryType,
             internal: Boolean,
             private: Boolean,
-            autoTerminationMode: AutoTerminationMode,
             parent: EmbraceSpan?,
+            autoTerminationMode: AutoTerminationMode,
         ): EmbraceSdkSpan = stoppedSpan
 
-        override fun create(otelSpanBuilderWrapper: OtelSpanBuilderWrapper) = stoppedSpan
-        override fun setRedactionFunction(redactionFunction: (key: String, value: String) -> String) {}
+        override fun create(otelSpanBuilderWrapper: OtelSpanBuilderWrapper, autoTerminationMode: AutoTerminationMode) = stoppedSpan
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -562,8 +562,8 @@ internal class SpanServiceImplTest {
                 name = "too many events",
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                events = tooBigCustomEvents,
                 internal = false,
+                events = tooBigCustomEvents,
             )
         )
         assertTrue(
@@ -571,8 +571,8 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                events = maxSizeCustomEvents,
                 internal = false,
+                events = maxSizeCustomEvents,
             )
         )
 
@@ -595,8 +595,8 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                events = events,
                 internal = false,
+                events = events,
             )
         )
 
@@ -613,8 +613,8 @@ internal class SpanServiceImplTest {
                 name = "too many attributes",
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                attributes = tooBigCustomAttributes,
                 internal = false,
+                attributes = tooBigCustomAttributes,
             )
         )
         assertTrue(
@@ -622,8 +622,8 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                attributes = maxSizeCustomAttributes,
                 internal = false,
+                attributes = maxSizeCustomAttributes,
             )
         )
 
@@ -642,8 +642,8 @@ internal class SpanServiceImplTest {
                 name = MAX_LENGTH_SPAN_NAME,
                 startTimeMs = 100L,
                 endTimeMs = 200L,
-                attributes = attributesMap,
                 internal = false,
+                attributes = attributesMap,
             )
         )
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitter.kt
@@ -228,8 +228,8 @@ class UiLoadTraceEmitter(
                 name = name,
                 startTimeMs = startTimeMs,
                 endTimeMs = endTimeMs,
-                internal = false,
                 parent = root,
+                internal = false,
                 attributes = attributes,
                 events = events,
                 errorCode = errorCode
@@ -252,8 +252,8 @@ class UiLoadTraceEmitter(
 
             spanService.startSpan(
                 name = traceName(activityName, uiLoadType),
-                type = EmbType.Performance.UiLoad,
                 startTimeMs = timestampMs,
+                type = EmbType.Performance.UiLoad,
             )?.let { root ->
                 activeTraces[instanceId] = UiLoadTrace(
                     root = root,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -321,9 +321,9 @@ internal class AppStartupTraceEmitter(
             additionalTrackedIntervals.poll()?.let { trackedInterval ->
                 spanService.recordCompletedSpan(
                     name = trackedInterval.name,
-                    parent = startupTrace,
                     startTimeMs = trackedInterval.startTimeMs,
                     endTimeMs = trackedInterval.endTimeMs,
+                    parent = startupTrace,
                     internal = false,
                     attributes = trackedInterval.attributes,
                     events = trackedInterval.events,
@@ -357,9 +357,9 @@ internal class AppStartupTraceEmitter(
                 if (applicationInitEndMs != null) {
                     spanService.recordCompletedSpan(
                         name = PROCESS_INIT_SPAN,
-                        parent = this,
                         startTimeMs = traceStartTimeMs,
                         endTimeMs = applicationInitEndMs,
+                        parent = this,
                     )
                 }
             }
@@ -367,9 +367,9 @@ internal class AppStartupTraceEmitter(
             if (sdkInitStartMs != null && sdkInitEndMs != null) {
                 spanService.recordCompletedSpan(
                     name = EMBRACE_INIT_SPAN,
-                    parent = this,
                     startTimeMs = sdkInitStartMs,
                     endTimeMs = sdkInitEndMs,
+                    parent = this,
                 )
             }
 
@@ -377,18 +377,18 @@ internal class AppStartupTraceEmitter(
             if (lastEventBeforeActivityInit != null && firstActivityInitMs != null) {
                 spanService.recordCompletedSpan(
                     name = ACTIVITY_INIT_DELAY_SPAN,
-                    parent = this,
                     startTimeMs = lastEventBeforeActivityInit,
                     endTimeMs = firstActivityInitMs,
+                    parent = this,
                 )
             }
 
             if (activityInitStartMs != null && activityInitEndMs != null) {
                 spanService.recordCompletedSpan(
                     name = ACTIVITY_INIT_SPAN,
-                    parent = this,
                     startTimeMs = activityInitStartMs,
                     endTimeMs = activityInitEndMs,
+                    parent = this,
                 )
             }
 
@@ -404,18 +404,18 @@ internal class AppStartupTraceEmitter(
                 }
                 spanService.recordCompletedSpan(
                     name = uiLoadSpanName,
-                    parent = this,
                     startTimeMs = activityInitEndMs,
                     endTimeMs = uiLoadedMs,
+                    parent = this,
                 )
             }
 
             if (traceEnd == TraceEnd.READY && uiLoadedMs != null && completed) {
                 spanService.recordCompletedSpan(
                     name = APP_READY_SPAN,
-                    parent = this,
                     startTimeMs = uiLoadedMs,
                     endTimeMs = traceEndTimeMs,
+                    parent = this,
                 )
             }
         }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilder.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilder.kt
@@ -33,7 +33,7 @@ class EmbSpanBuilder(
     override fun addLink(spanContext: SpanContext, attributes: Attributes): SpanBuilder = this
 
     override fun setAttribute(key: String, value: String): SpanBuilder {
-        otelSpanBuilderWrapper.setCustomAttribute(key, value)
+        otelSpanBuilderWrapper.customAttributes[key] = value
         return this
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/TracerExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/TracerExt.kt
@@ -1,28 +1,57 @@
 package io.embrace.android.embracesdk.internal.otel.sdk
 
+import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.schema.TelemetryType
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanBuilderWrapper
-import io.embrace.android.embracesdk.spans.AutoTerminationMode
+import io.embrace.android.embracesdk.internal.otel.spans.toEmbraceObjectName
 import io.embrace.android.embracesdk.spans.EmbraceSpan
-import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
 
 /**
- * Creates a new [SpanBuilder] that marks the resulting span as private if [internal] is true
+ * Factory method for the wrapper for the OTel SpanBuilder
  */
 fun Tracer.otelSpanBuilderWrapper(
     name: String,
     type: TelemetryType,
     internal: Boolean,
     private: Boolean,
-    autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     parent: EmbraceSpan? = null,
-): OtelSpanBuilderWrapper = OtelSpanBuilderWrapper(
-    tracer = this,
-    name = name,
-    telemetryType = type,
-    internal = internal,
-    private = private,
-    autoTerminationMode = autoTerminationMode,
-    parentSpan = parent,
-)
+): OtelSpanBuilderWrapper {
+    val spanName: String = if (internal) {
+        name.toEmbraceObjectName()
+    } else {
+        name
+    }
+
+    // If there is a parent, extract the wrapped OTel span and set it as the parent in the wrapped OTel SpanBuilder
+    val parentContext = if (parent is EmbraceSdkSpan) {
+        val newParentContext = parent.asNewContext() ?: Context.root()
+        newParentContext.with(parent)
+    } else {
+        Context.root()
+    }
+
+    val spanBuilder = spanBuilder(spanName).apply {
+        if (parentContext != null) {
+            setParent(parentContext)
+        } else {
+            setNoParent()
+        }
+    }
+
+    val embraceAttributes = listOf(type) + if (private) {
+        listOf(PrivateSpan)
+    } else {
+        emptyList()
+    }
+
+    return OtelSpanBuilderWrapper(
+        spanBuilder = spanBuilder,
+        parentContext = parentContext,
+        initialSpanName = spanName,
+        internal = internal,
+        embraceAttributes = embraceAttributes
+    )
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactory.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactory.kt
@@ -14,11 +14,12 @@ interface EmbraceSpanFactory {
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         parent: EmbraceSpan? = null,
+        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE
     ): EmbraceSdkSpan
 
-    fun create(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan
-
-    fun setRedactionFunction(redactionFunction: (key: String, value: String) -> String)
+    fun create(
+        otelSpanBuilderWrapper: OtelSpanBuilderWrapper,
+        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE
+    ): EmbraceSdkSpan
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -19,8 +19,8 @@ class EmbraceSpanFactoryImpl(
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
+        autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan = create(
         otelSpanBuilderWrapper = tracer.otelSpanBuilderWrapper(
             name = name,
@@ -28,19 +28,19 @@ class EmbraceSpanFactoryImpl(
             internal = internal,
             private = private,
             parent = parent,
-            autoTerminationMode = autoTerminationMode
-        )
+        ),
+        autoTerminationMode = autoTerminationMode
     )
 
-    override fun create(otelSpanBuilderWrapper: OtelSpanBuilderWrapper): EmbraceSdkSpan =
+    override fun create(
+        otelSpanBuilderWrapper: OtelSpanBuilderWrapper,
+        autoTerminationMode: AutoTerminationMode
+    ): EmbraceSdkSpan =
         EmbraceSpanImpl(
             otelSpanBuilderWrapper = otelSpanBuilderWrapper,
             openTelemetryClock = openTelemetryClock,
             spanRepository = spanRepository,
-            redactionFunction = redactionFunction
+            redactionFunction = redactionFunction,
+            autoTerminationMode = autoTerminationMode
         )
-
-    override fun setRedactionFunction(redactionFunction: (key: String, value: String) -> String) {
-        this.redactionFunction = redactionFunction
-    }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanBuilderWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanBuilderWrapper.kt
@@ -1,84 +1,45 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.otel.attrs.EmbraceAttribute
-import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
-import io.embrace.android.embracesdk.internal.otel.schema.TelemetryType
-import io.embrace.android.embracesdk.spans.AutoTerminationMode
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import java.util.concurrent.TimeUnit
 
 /**
- * Wrapper for the [SpanBuilder] that stores the input data so that they can be accessed
+ * Wrapper for the [SpanBuilder] that stores the input data so that they can be accessed.
+ *
+ * This should only access OTel concepts that have to to proxied or altered for interoperability with Embrace concepts.
  */
-class OtelSpanBuilderWrapper(
-    tracer: Tracer,
-    name: String,
-    telemetryType: TelemetryType,
+class OtelSpanBuilderWrapper internal constructor(
+    private val spanBuilder: SpanBuilder,
+    private var parentContext: Context,
+    val initialSpanName: String,
     val internal: Boolean,
-    private: Boolean,
-    val autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-    parentSpan: EmbraceSpan?,
+    val embraceAttributes: List<EmbraceAttribute>,
 ) {
-    lateinit var parentContext: Context
-        private set
-
-    val spanName: String = if (internal) {
-        name.toEmbraceObjectName()
-    } else {
-        name
-    }
-
     var startTimeMs: Long? = null
-
-    private val sdkSpanBuilder = tracer.spanBuilder(spanName)
-    private val embraceAttributes = mutableListOf<EmbraceAttribute>(telemetryType)
-    private val customAttributes = mutableMapOf<String, String>()
-
-    init {
-        // If there is a parent, extract the wrapped OTel span and set it as the parent in the wrapped OTel SpanBuilder
-        if (parentSpan is EmbraceSdkSpan) {
-            val newParentContext = parentSpan.asNewContext() ?: Context.root()
-            setParentContext(newParentContext.with(parentSpan))
-        } else {
-            setNoParent()
-        }
-
-        if (private) {
-            embraceAttributes.add(PrivateSpan)
-        }
-    }
+    val customAttributes = mutableMapOf<String, String>()
 
     fun startSpan(startTimeMs: Long): Span {
-        sdkSpanBuilder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
-        return sdkSpanBuilder.startSpan()
+        spanBuilder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
+        return spanBuilder.startSpan()
     }
 
-    fun getEmbraceAttributes(): List<EmbraceAttribute> = embraceAttributes
-
-    fun getCustomAttributes(): Map<String, String> = customAttributes
-
-    fun setCustomAttribute(key: String, value: String) {
-        customAttributes[key] = value
-    }
-
-    fun getParentSpan(): EmbraceSpan? = parentContext.getEmbraceSpan()
+    fun getParentContext(): Context = parentContext
 
     fun setParentContext(context: Context) {
         parentContext = context
-        sdkSpanBuilder.setParent(parentContext)
+        spanBuilder.setParent(context)
     }
 
     fun setNoParent() {
         parentContext = Context.root()
-        sdkSpanBuilder.setNoParent()
+        spanBuilder.setNoParent()
     }
 
     fun setSpanKind(spanKind: SpanKind) {
-        sdkSpanBuilder.setSpanKind(spanKind)
+        spanBuilder.setSpanKind(spanKind)
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanService.kt
@@ -19,11 +19,11 @@ interface SpanService : Initializable {
      */
     fun createSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
         private: Boolean = false,
+        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): EmbraceSdkSpan?
 
     /**
@@ -37,20 +37,20 @@ interface SpanService : Initializable {
      */
     fun startSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         parent: EmbraceSpan? = null,
         startTimeMs: Long? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
         private: Boolean = false,
+        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     ): EmbraceSdkSpan? {
         createSpan(
             name = name,
-            autoTerminationMode = autoTerminationMode,
             parent = parent,
             type = type,
             internal = internal,
             private = private,
+            autoTerminationMode = autoTerminationMode,
         )?.let { newSpan ->
             if (newSpan.start(startTimeMs)) {
                 return newSpan
@@ -66,13 +66,13 @@ interface SpanService : Initializable {
      */
     fun <T> recordSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,
         private: Boolean = false,
         attributes: Map<String, String> = emptyMap(),
         events: List<EmbraceSpanEvent> = emptyList(),
+        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         code: () -> T,
     ): T
 
@@ -84,7 +84,6 @@ interface SpanService : Initializable {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
         parent: EmbraceSpan? = null,
         type: TelemetryType = EmbType.Performance.Default,
         internal: Boolean = true,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilderTest.kt
@@ -8,9 +8,9 @@ import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.fixtures.fakeContextKey
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
-import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -36,13 +36,12 @@ internal class EmbSpanBuilderTest {
     fun setup() {
         spanService = FakeSpanService()
         tracer = FakeTracer()
-        otelSpanBuilderWrapper = OtelSpanBuilderWrapper(
-            tracer = tracer,
+        otelSpanBuilderWrapper = tracer.otelSpanBuilderWrapper(
             name = "test",
-            telemetryType = EmbType.Performance.Default,
+            type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            parentSpan = null,
+            parent = null,
         )
         embSpanBuilder = EmbSpanBuilder(
             otelSpanBuilderWrapper = otelSpanBuilderWrapper,
@@ -54,14 +53,12 @@ internal class EmbSpanBuilderTest {
     @Test
     fun `parameters set on embrace span builder respected`() {
         val spanParent = FakeEmbraceSdkSpan.started()
-        val newOtelSpanBuilderWrapper = OtelSpanBuilderWrapper(
-            tracer = tracer,
+        val newOtelSpanBuilderWrapper = tracer.otelSpanBuilderWrapper(
             name = "custom",
-            telemetryType = EmbType.Performance.Default,
+            type = EmbType.Performance.Default,
             internal = true,
             private = true,
-            parentSpan = spanParent,
-            autoTerminationMode = AutoTerminationMode.ON_BACKGROUND,
+            parent = spanParent,
         )
         embSpanBuilder = EmbSpanBuilder(
             otelSpanBuilderWrapper = newOtelSpanBuilderWrapper,
@@ -75,7 +72,6 @@ internal class EmbSpanBuilderTest {
             assertEquals(spanParent, parent)
             assertEquals("emb-custom", name)
             assertEquals(EmbType.Performance.Default, type)
-            assertEquals(AutoTerminationMode.ON_BACKGROUND, autoTerminationMode)
         }
     }
 
@@ -87,13 +83,12 @@ internal class EmbSpanBuilderTest {
                 "value"
             )
         )
-        val newOtelSpanBuilderWrapper = OtelSpanBuilderWrapper(
-            tracer = tracer,
+        val newOtelSpanBuilderWrapper = tracer.otelSpanBuilderWrapper(
             name = "custom",
-            telemetryType = EmbType.Performance.Default,
+            type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            parentSpan = oldParent,
+            parent = oldParent,
         )
         embSpanBuilder = EmbSpanBuilder(
             otelSpanBuilderWrapper = newOtelSpanBuilderWrapper,
@@ -118,13 +113,12 @@ internal class EmbSpanBuilderTest {
         )
         val newParentContext = checkNotNull(newParentSpan.asNewContext())
 
-        val newOtelSpanBuilderWrapper = OtelSpanBuilderWrapper(
-            tracer = tracer,
+        val newOtelSpanBuilderWrapper = tracer.otelSpanBuilderWrapper(
             name = "custom",
-            telemetryType = EmbType.Performance.Default,
+            type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            parentSpan = null,
+            parent = null,
         )
         embSpanBuilder = EmbSpanBuilder(
             otelSpanBuilderWrapper = newOtelSpanBuilderWrapper,
@@ -167,7 +161,7 @@ internal class EmbSpanBuilderTest {
             setAttribute(AttributeKey.stringArrayKey("stringArray"), listOf("value", "vee"))
         }
 
-        assertEquals(10, otelSpanBuilderWrapper.getCustomAttributes().count())
+        assertEquals(10, otelSpanBuilderWrapper.customAttributes.count())
     }
 
     @Test

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -435,7 +435,7 @@ internal class EmbraceSpanImplTest {
     @Test
     fun `validate context objects are propagated from the parent to the child span`() {
         val spanBuilder = createEmbraceSpanBuilder()
-        val newParentContext = spanBuilder.parentContext.with(fakeContextKey, "fake-value")
+        val newParentContext = spanBuilder.getParentContext().with(fakeContextKey, "fake-value")
         spanBuilder.setParentContext(newParentContext)
 
         embraceSpan = createEmbraceSpanImpl(spanBuilder)
@@ -450,8 +450,8 @@ internal class EmbraceSpanImplTest {
     fun `custom attributes are redacted if their key is sensitive when getting a span snapshot`() {
         // given a span with a sensitive key
         val spanBuilder = createEmbraceSpanBuilder()
-        spanBuilder.setCustomAttribute("password", "123456")
-        spanBuilder.setCustomAttribute("status", "ok")
+        spanBuilder.customAttributes["password"] = "123456"
+        spanBuilder.customAttributes["status"] = "ok"
         embraceSpan = createEmbraceSpanImpl(spanBuilder)
         embraceSpan.start()
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -22,11 +22,11 @@ class FakeSpanService : SpanService {
 
     override fun createSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
+        autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
         name = name,
         parentContext = parent?.run { Context.root().with(parent as EmbraceSdkSpan) } ?: Context.root(),
@@ -41,25 +41,24 @@ class FakeSpanService : SpanService {
     override fun createSpan(
         otelSpanBuilderWrapper: OtelSpanBuilderWrapper,
     ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
-        name = otelSpanBuilderWrapper.spanName,
-        parentContext = otelSpanBuilderWrapper.parentContext,
-        type = otelSpanBuilderWrapper.getEmbraceAttributes().filterIsInstance<TelemetryType>().single(),
+        name = otelSpanBuilderWrapper.initialSpanName,
+        parentContext = otelSpanBuilderWrapper.getParentContext(),
+        type = otelSpanBuilderWrapper.embraceAttributes.filterIsInstance<TelemetryType>().single(),
         internal = otelSpanBuilderWrapper.internal,
-        private = otelSpanBuilderWrapper.getEmbraceAttributes().contains(PrivateSpan),
-        autoTerminationMode = otelSpanBuilderWrapper.autoTerminationMode,
+        private = otelSpanBuilderWrapper.embraceAttributes.contains(PrivateSpan),
     ).apply {
         createdSpans.add(this)
     }
 
     override fun <T> recordSpan(
         name: String,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,
         private: Boolean,
         attributes: Map<String, String>,
         events: List<EmbraceSpanEvent>,
+        autoTerminationMode: AutoTerminationMode,
         code: () -> T,
     ): T {
         return code()
@@ -69,7 +68,6 @@ class FakeSpanService : SpanService {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        autoTerminationMode: AutoTerminationMode,
         parent: EmbraceSpan?,
         type: TelemetryType,
         internal: Boolean,


### PR DESCRIPTION
## Goal

Make `OtelSpanBuilderWrapper` hold only OTel API concepts and data, and move the business logic as well as any Embrace specific concepts to the factory method (i.e. `Tracer.otelSpanBuilderWrapper()` as well as the factory class for `EmbraceSpanImpl`, i.e. `EmbraceSpanFactoryImpl`. This allows the wrapper to only hold the mapped values from the OTel API, making it a lot simpler to be replaced by the Kotlin version.

This entailed moving concepts like `AutoTerminationMode` to the right layer, including cleaning the internal API that exposes it.

## Testing
Rely on existing tests