### PR TITLE
Publish embrace-android-otel so integration tests can use it

### DIFF
--- a/embrace-gradle-plugin-integration-tests/build.gradle.kts
+++ b/embrace-gradle-plugin-integration-tests/build.gradle.kts
@@ -44,6 +44,7 @@ tasks.withType(Test::class.java).configureEach {
         ":embrace-android-features",
         ":embrace-android-payload",
         ":embrace-android-delivery",
+        ":embrace-android-otel",
         ":embrace-internal-api"
     )
     modules.forEach { dependsOn("$it:publishToMavenLocal") }


### PR DESCRIPTION
Add embrace-android-otel to the modules added in the integration tests