### PR TITLE
Begin modularising otel usage

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriter.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch.destination
 
+import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.opentelemetry.api.logs.Severity
 
 /**
  * Declares functions for writing a log to the current session span.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embState
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.setAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.EmbraceProcessStateService.Companion.BACKGROUND_STATE
 import io.embrace.android.embracesdk.internal.session.lifecycle.EmbraceProcessStateService.Companion.FOREGROUND_STATE
@@ -28,17 +29,18 @@ class LogWriterImpl(
 
     override fun addLog(
         schemaType: SchemaType,
-        severity: Severity,
+        severity: io.embrace.android.embracesdk.Severity,
         message: String,
         isPrivate: Boolean,
         addCurrentSessionInfo: Boolean,
         timestampMs: Long?,
     ) {
         val logTimeMs = timestampMs ?: clock.now()
+        val otelSeverity = severity.toOtelSeverity()
         val builder = logger.logRecordBuilder()
             .setBody(message)
-            .setSeverity(severity)
-            .setSeverityText(getSeverityText(severity))
+            .setSeverity(otelSeverity)
+            .setSeverityText(getSeverityText(otelSeverity))
             .setTimestamp(logTimeMs, TimeUnit.MILLISECONDS)
 
         builder.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID, Uuid.getEmbUuid())

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
@@ -3,9 +3,7 @@ package io.embrace.android.embracesdk.internal.arch.schema
 import io.embrace.android.embracesdk.internal.capture.session.toSessionPropertyAttributeName
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.otel.attrs.EmbraceAttributeKey
-import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.utils.isBlankish
-import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Object that aggregates various attributes and returns a [Map] that represents the values at the current state
@@ -15,7 +13,7 @@ class TelemetryAttributes(
     private val sessionPropertiesProvider: () -> Map<String, String>? = { null },
     private val customAttributes: Map<String, String>? = null,
 ) {
-    private val map: MutableMap<AttributeKey<String>, String> = mutableMapOf()
+    private val map: MutableMap<String, String> = mutableMapOf()
 
     /**
      * Return a snapshot of the current values of the attributes set on this as a [Map]. Schema keys will always overwrite any previous
@@ -36,22 +34,22 @@ class TelemetryAttributes(
             }
         }
 
-        result.putAll(map.mapKeys { it.key.key })
+        result.putAll(map.mapKeys { it.key })
 
         return result
     }
 
     fun setAttribute(key: EmbraceAttributeKey, value: String, keepBlankishValues: Boolean = true) {
-        setAttribute(key.asOtelAttributeKey(), value, keepBlankishValues)
+        setAttribute(key.name, value, keepBlankishValues)
     }
 
-    fun setAttribute(key: AttributeKey<String>, value: String, keepBlankishValues: Boolean = true) {
+    fun setAttribute(key: String, value: String, keepBlankishValues: Boolean = true) {
         if (keepBlankishValues || !value.isBlankish()) {
             map[key] = value
         }
     }
 
-    fun getAttribute(key: EmbraceAttributeKey): String? = map[key.asOtelAttributeKey()]
+    fun getAttribute(key: EmbraceAttributeKey): String? = map[key.name]
 
-    fun getAttribute(key: AttributeKey<String>): String? = map[key]
+    fun getAttribute(key: String): String? = map[key]
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.logs.attachments.Attachment
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
-import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Creates log records to be sent using the Open Telemetry Logs data model.
@@ -19,7 +18,7 @@ interface LogService : MemoryCleanerListener {
         severity: Severity,
         logExceptionType: LogExceptionType,
         properties: Map<String, Any>? = null,
-        customLogAttrs: Map<AttributeKey<String>, String> = emptyMap(),
+        customLogAttrs: Map<String, String> = emptyMap(),
         logAttachment: Attachment.EmbraceHosted? = null,
     )
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.ndk
 
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
-import io.opentelemetry.api.common.AttributeKey
 
 /**
  * Service to retrieve and delivery native crash data
@@ -25,7 +24,7 @@ interface NativeCrashService {
     fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
-        metadata: Map<AttributeKey<String>, String>,
+        metadata: Map<String, String>,
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureDataSourceImpl.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
 import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.embrace.android.embracesdk.internal.payload.NetworkCapturedCall
 
 internal class NetworkCaptureDataSourceImpl(
@@ -27,7 +26,7 @@ internal class NetworkCaptureDataSourceImpl(
     override fun logNetworkCapturedCall(networkCapturedCall: NetworkCapturedCall) {
         return logWriter.addLog(
             SchemaType.NetworkCapturedRequest(networkCapturedCall),
-            Severity.INFO.toOtelSeverity(),
+            Severity.INFO,
             networkCapturedCall.networkId
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageSer
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
-import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.otel.attrs.embCrashId
 import io.embrace.android.embracesdk.internal.otel.attrs.embHeartbeatTimeUnixNano
 import io.embrace.android.embracesdk.internal.otel.attrs.embProcessIdentifier
@@ -127,7 +126,7 @@ internal class PayloadResurrectionServiceImpl(
                         nativeCrash = nativeCrash,
                         sessionProperties = emptyMap(),
                         metadata = mapOf(
-                            embState.asOtelAttributeKey() to ApplicationState.BACKGROUND.name.lowercase(Locale.ENGLISH)
+                            embState.name to ApplicationState.BACKGROUND.name.lowercase(Locale.ENGLISH)
                         ),
                     )
                 }
@@ -181,8 +180,8 @@ internal class PayloadResurrectionServiceImpl(
                             sessionProperties = deadSession.getSessionProperties(),
                             metadata = if (appState != null) {
                                 mapOf(
-                                    embState.asOtelAttributeKey() to appState,
-                                    embProcessIdentifier.asOtelAttributeKey() to processId
+                                    embState.name to appState,
+                                    embProcessIdentifier.name to processId
                                 )
                             } else {
                                 emptyMap()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.arch.destination
 
+import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.assertions.findAttributeValue
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
@@ -16,8 +17,8 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embState
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.getAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.embrace.android.embracesdk.internal.session.id.SessionData
-import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
@@ -64,7 +65,7 @@ internal class LogWriterImplTest {
         )
         with(logger.builders.single()) {
             assertEquals("test", body)
-            assertEquals(Severity.ERROR, severity)
+            assertEquals(Severity.ERROR.toOtelSeverity(), severity)
             assertEquals(Severity.ERROR.name, severity.name)
             assertEquals("fake-session-id", attributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
             assertNotNull(attributes.getAttribute(embState))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
@@ -37,14 +37,14 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             configService = configService,
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
-        telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, "exceptionValue")
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
+        telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE.key, "exceptionValue")
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
         assertEquals(sessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
         assertEquals("exceptionValue", attributes[ExceptionAttributes.EXCEPTION_TYPE.key])
-        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
-        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE))
+        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID.key))
+        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE.key))
     }
 
     @Test
@@ -54,7 +54,8 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        val sessionIdKey = SessionIncubatingAttributes.SESSION_ID.key
+        telemetryAttributes.setAttribute(sessionIdKey, sessionId)
         sessionPropertiesService.addProperty("perm", "permVal", true)
         sessionPropertiesService.addProperty("temp", "tempVal", false)
 
@@ -62,7 +63,7 @@ internal class TelemetryAttributesTest {
         assertEquals("attributeValue", attributes["custom"])
         assertEquals("permVal", attributes.getSessionProperty("perm"))
         assertEquals("tempVal", attributes.getSessionProperty("temp"))
-        assertEquals(sessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
+        assertEquals(sessionId, attributes[sessionIdKey])
         sessionPropertiesService.addProperty("temp", "newVal", false)
         assertEquals("newVal", telemetryAttributes.snapshot().getSessionProperty("temp"))
     }
@@ -74,8 +75,9 @@ internal class TelemetryAttributesTest {
             configService = configService,
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, newSessionId)
+        val sessionIdKey = SessionIncubatingAttributes.SESSION_ID.key
+        telemetryAttributes.setAttribute(sessionIdKey, sessionId)
+        telemetryAttributes.setAttribute(sessionIdKey, newSessionId)
         sessionPropertiesService.addProperty("perm", "permVal", true)
         sessionPropertiesService.addProperty("temp", "tempVal", false)
         sessionPropertiesService.addProperty("perm", "newPermVal", true)
@@ -85,7 +87,7 @@ internal class TelemetryAttributesTest {
         assertEquals(3, attributes.size)
         assertEquals("newPermVal", attributes.getSessionProperty("perm"))
         assertEquals("newTempVal", attributes.getSessionProperty("temp"))
-        assertEquals(newSessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
+        assertEquals(newSessionId, attributes[sessionIdKey])
     }
 
     @Test
@@ -95,7 +97,7 @@ internal class TelemetryAttributesTest {
             configService = configService,
             customAttributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to sessionId)
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, newSessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, newSessionId)
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
         assertEquals(newSessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
@@ -121,7 +123,7 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
@@ -147,7 +149,7 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(4, attributes.size)
@@ -161,16 +163,17 @@ internal class TelemetryAttributesTest {
         val blankishValues = listOf("", " ", "null", "NULL")
 
         // Give me Union types, plz
+        val sessionIdKey = SessionIncubatingAttributes.SESSION_ID.key
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, value, true)
-            assertEquals(value, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
+            telemetryAttributes.setAttribute(sessionIdKey, value, true)
+            assertEquals(value, telemetryAttributes.getAttribute(sessionIdKey))
         }
 
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, "test")
+        telemetryAttributes.setAttribute(sessionIdKey, "test")
 
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID, value, false)
-            assertEquals("test", telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID))
+            telemetryAttributes.setAttribute(sessionIdKey, value, false)
+            assertEquals("test", telemetryAttributes.getAttribute(sessionIdKey))
         }
 
         blankishValues.forEach { value ->

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImpl.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType.AeiLog
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
-import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.embrace.android.embracesdk.internal.payload.AppExitInfoData
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
@@ -72,7 +71,7 @@ internal class AeiDataSourceImpl(
                     val capture = configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled() || !obj.hasNativeTombstone()
                     if (capture) {
                         val schemaType = AeiLog(obj, crashNumber, aeiNumber)
-                        addLog(schemaType, INFO.toOtelSeverity(), obj.trace ?: "")
+                        addLog(schemaType, INFO, obj.trace ?: "")
                     }
 
                     // always count AEI as delivered once we process it & submit to the OTel logging system, or discard

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embAndroidThreads
 import io.embrace.android.embracesdk.internal.otel.attrs.embCrashNumber
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType.System.ReactNativeCrash.embAndroidReactNativeCrashJsException
-import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.embrace.android.embracesdk.internal.payload.JsException
 import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
 import io.embrace.android.embracesdk.internal.payload.ThreadInfo
@@ -71,19 +70,19 @@ internal class CrashDataSourceImpl(
             )
 
             val crashException = LegacyExceptionInfo.ofThrowable(exception)
-            crashAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, crashException.name)
+            crashAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE.key, crashException.name)
             crashAttributes.setAttribute(
-                ExceptionAttributes.EXCEPTION_MESSAGE,
+                ExceptionAttributes.EXCEPTION_MESSAGE.key,
                 crashException.message
                     ?: ""
             )
             crashAttributes.setAttribute(
-                ExceptionAttributes.EXCEPTION_STACKTRACE,
+                ExceptionAttributes.EXCEPTION_STACKTRACE.key,
                 encodeToUTF8String(
                     serializer.toJson(crashException.lines, List::class.java),
                 ),
             )
-            crashAttributes.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID, crashId)
+            crashAttributes.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key, crashId)
             crashAttributes.setAttribute(embCrashNumber, crashNumber.toString())
             crashAttributes.setAttribute(
                 EmbType.System.Crash.embAndroidCrashExceptionCause,
@@ -107,7 +106,7 @@ internal class CrashDataSourceImpl(
                 )
             }
 
-            logWriter.addLog(getSchemaType(crashAttributes), Severity.ERROR.toOtelSeverity(), "")
+            logWriter.addLog(getSchemaType(crashAttributes), Severity.ERROR, "")
 
             // finally, notify other services that need to perform tear down
             handlers.forEach { it.value?.handleCrash(crashId) }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/telemetry/InternalErrorDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/telemetry/InternalErrorDataSourceImpl.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
-import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 
 /**
  * Tracks internal errors & sends them as OTel logs.
@@ -26,7 +25,7 @@ internal class InternalErrorDataSourceImpl(
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {
         captureData(NoInputValidation) {
             val schemaType = SchemaType.InternalError(throwable)
-            addLog(schemaType, Severity.ERROR.toOtelSeverity(), "", true)
+            addLog(schemaType, Severity.ERROR, "", true)
         }
     }
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
@@ -10,11 +10,9 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.otel.attrs.embCrashNumber
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
-import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 internal class NativeCrashDataSourceImpl(
@@ -40,7 +38,7 @@ internal class NativeCrashDataSourceImpl(
     override fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
-        metadata: Map<AttributeKey<String>, String>,
+        metadata: Map<String, String>,
     ) {
         val nativeCrashNumber = preferencesService.incrementAndGetNativeCrashNumber()
         val crashAttributes = TelemetryAttributes(
@@ -48,7 +46,7 @@ internal class NativeCrashDataSourceImpl(
             sessionPropertiesProvider = { sessionProperties }
         )
         crashAttributes.setAttribute(
-            key = SessionIncubatingAttributes.SESSION_ID,
+            key = SessionIncubatingAttributes.SESSION_ID.key,
             value = nativeCrash.sessionId,
             keepBlankishValues = false,
         )
@@ -85,7 +83,7 @@ internal class NativeCrashDataSourceImpl(
 
         logWriter.addLog(
             schemaType = SchemaType.NativeCrash(crashAttributes),
-            severity = Severity.ERROR.toOtelSeverity(),
+            severity = Severity.ERROR,
             message = "",
             addCurrentSessionInfo = false,
             timestampMs = nativeCrash.timestamp

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/aei/AeiDataSourceImplTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -352,7 +353,7 @@ internal class AeiDataSourceImplTest {
 
     private fun getAeiLogAttrs(): Map<String, String> {
         val logEventData = logWriter.logEvents.single()
-        assertEquals(Severity.INFO, logEventData.severity)
+        assertEquals(Severity.INFO, logEventData.severity.toOtelSeverity())
         logEventData.assertIsType(EmbType.System.Exit)
         return logEventData.schemaType.attributes()
     }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/InternalErrorDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/InternalErrorDataSourceImplTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.toOtelSeverity
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
@@ -59,7 +60,7 @@ internal class InternalErrorDataSourceImplTest {
     }
 
     private fun assertInternalErrorLogged(data: LogEventData): Map<String, String> {
-        assertEquals(Severity.ERROR, data.severity)
+        assertEquals(Severity.ERROR, data.severity.toOtelSeverity())
         assertEquals("", data.message)
         assertEquals(EmbType.System.InternalError, data.schemaType.telemetryType)
         assertEquals("internal-error", data.schemaType.fixedObjectName)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.internal.capture.session.toSessionPropertyA
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.otel.attrs.embCrashNumber
 import io.embrace.android.embracesdk.internal.otel.attrs.embState
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
@@ -92,7 +91,7 @@ internal class NativeCrashDataSourceImplTest {
         nativeCrashDataSource.sendNativeCrash(
             nativeCrash = testNativeCrashData,
             sessionProperties = mapOf("prop" to "value"),
-            metadata = mapOf(embState.asOtelAttributeKey() to "background")
+            metadata = mapOf(embState.name to "background")
         )
 
         with(otelLogger.builders.single()) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -45,7 +45,6 @@ import io.embrace.android.embracesdk.internal.utils.EmbTrace.end
 import io.embrace.android.embracesdk.internal.utils.EmbTrace.start
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.spans.TracingApi
-import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -269,7 +268,7 @@ internal class EmbraceImpl @JvmOverloads constructor(
         logExceptionType: LogExceptionType = LogExceptionType.NONE,
         exceptionName: String? = null,
         exceptionMessage: String? = null,
-        customLogAttrs: Map<AttributeKey<String>, String> = emptyMap(),
+        customLogAttrs: Map<String, String> = emptyMap(),
     ) {
         logsApiDelegate.logMessageImpl(
             severity = severity,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
@@ -7,10 +7,8 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.FlutterInternalInterface
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType.System.FlutterException.embFlutterExceptionContext
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType.System.FlutterException.embFlutterExceptionLibrary
-import io.opentelemetry.api.common.AttributeKey
 
 internal class FlutterInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
@@ -68,9 +66,9 @@ internal class FlutterInternalInterfaceImpl(
         exceptionType: LogExceptionType,
     ) {
         if (embrace.isStarted) {
-            val attrs = mutableMapOf<AttributeKey<String>, String>()
-            context?.let { attrs[embFlutterExceptionContext.asOtelAttributeKey()] = it }
-            library?.let { attrs[embFlutterExceptionLibrary.asOtelAttributeKey()] = it }
+            val attrs = mutableMapOf<String, String>()
+            context?.let { attrs[embFlutterExceptionContext.name] = it }
+            library?.let { attrs[embFlutterExceptionLibrary.name] = it }
 
             embrace.logMessage(
                 severity = Severity.ERROR,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
@@ -10,11 +10,9 @@ import io.embrace.android.embracesdk.internal.logs.attachments.Attachment.Embrac
 import io.embrace.android.embracesdk.internal.logs.attachments.AttachmentErrorCode.ATTACHMENT_TOO_LARGE
 import io.embrace.android.embracesdk.internal.logs.attachments.AttachmentErrorCode.OVER_MAX_ATTACHMENTS
 import io.embrace.android.embracesdk.internal.logs.attachments.AttachmentErrorCode.UNKNOWN
-import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.payload.PushNotificationBreadcrumb
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.ExceptionAttributes
 
 internal class LogsApiDelegate(
@@ -180,21 +178,21 @@ internal class LogsApiDelegate(
         logExceptionType: LogExceptionType = LogExceptionType.NONE,
         exceptionName: String? = null,
         exceptionMessage: String? = null,
-        customLogAttrs: Map<AttributeKey<String>, String> = emptyMap(),
+        customLogAttrs: Map<String, String> = emptyMap(),
         attachment: Attachment? = null,
     ) {
         if (sdkCallChecker.check("log_message")) {
             runCatching {
-                val attrs = mutableMapOf<AttributeKey<String>, String>()
-                exceptionName?.let { attrs[ExceptionAttributes.EXCEPTION_TYPE] = it }
-                exceptionMessage?.let { attrs[ExceptionAttributes.EXCEPTION_MESSAGE] = it }
+                val attrs = mutableMapOf<String, String>()
+                exceptionName?.let { attrs[ExceptionAttributes.EXCEPTION_TYPE.key] = it }
+                exceptionMessage?.let { attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key] = it }
 
                 val stacktrace =
                     stackTraceElements?.let(checkNotNull(serializer)::truncatedStacktrace) ?: customStackTrace
-                stacktrace?.let { attrs[ExceptionAttributes.EXCEPTION_STACKTRACE] = it }
+                stacktrace?.let { attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key] = it }
 
                 if (attachment != null) {
-                    attrs.putAll(attachment.attributes.mapKeys { it.key.asOtelAttributeKey() })
+                    attrs.putAll(attachment.attributes.mapKeys { it.key.name })
                 }
 
                 val logAttachment = when {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakePreferenceService
 import io.embrace.android.embracesdk.internal.api.delegate.FlutterInternalInterfaceImpl
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType.System.FlutterException.embFlutterExceptionContext
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType.System.FlutterException.embFlutterExceptionLibrary
 import io.embrace.android.embracesdk.internal.payload.AppFramework
@@ -73,8 +72,8 @@ internal class FlutterInternalInterfaceImplTest {
                 "exception name",
                 "message",
                 mapOf(
-                    embFlutterExceptionContext.asOtelAttributeKey() to "ctx",
-                    embFlutterExceptionLibrary.asOtelAttributeKey() to "lib"
+                    embFlutterExceptionContext.name to "ctx",
+                    embFlutterExceptionLibrary.name to "lib"
                 ),
             )
         }
@@ -94,8 +93,8 @@ internal class FlutterInternalInterfaceImplTest {
                 exceptionName = "exception name",
                 exceptionMessage = "message",
                 customLogAttrs = mapOf(
-                    embFlutterExceptionContext.asOtelAttributeKey() to "ctx",
-                    embFlutterExceptionLibrary.asOtelAttributeKey() to "lib"
+                    embFlutterExceptionContext.name to "ctx",
+                    embFlutterExceptionLibrary.name to "lib"
                 ),
             )
         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.logs.LogService
 import io.embrace.android.embracesdk.internal.logs.attachments.Attachment
-import io.opentelemetry.api.common.AttributeKey
 
 class FakeLogService : LogService {
     class LogData(
@@ -23,7 +22,7 @@ class FakeLogService : LogService {
         severity: Severity,
         logExceptionType: LogExceptionType,
         properties: Map<String, Any>?,
-        customLogAttrs: Map<AttributeKey<String>, String>,
+        customLogAttrs: Map<String, String>,
         logAttachment: Attachment.EmbraceHosted?,
     ) {
         loggedMessages.add(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogWriter.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.arch.destination.LogWriter
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.opentelemetry.api.logs.Severity
 
 class FakeLogWriter : LogWriter {
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeCrashService.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
-import io.opentelemetry.api.common.AttributeKey
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class FakeNativeCrashService : NativeCrashService {
@@ -21,7 +20,7 @@ class FakeNativeCrashService : NativeCrashService {
     override fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
-        metadata: Map<AttributeKey<String>, String>,
+        metadata: Map<String, String>,
     ) {
         nativeCrashesSent.add(Pair(nativeCrash, metadata.mapKeys { it.value } + sessionProperties))
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/LogEventData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/LogEventData.kt
@@ -1,11 +1,10 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.opentelemetry.api.logs.Severity
 
 /**
  * Represents a Log event that can be added to the current session span.
- *
  *
  * @param schemaType the type of the span. Used to differentiate data from different sources
  * by the backend.


### PR DESCRIPTION
## Goal

Tweaks the implementation to avoid referencing several OpenTelemetry concepts from within `embrace-android-features`.

## Testing

Relied on existing test coverage.
