### PR TITLE
Move functions out of EmbraceExt

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/gating/SpanSanitizer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/gating/SpanSanitizer.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.gating.SessionGatingKeys.BREADCRUM
 import io.embrace.android.embracesdk.internal.gating.SessionGatingKeys.BREADCRUMBS_TAPS
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.opentelemetry.api.trace.SpanId

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.payload
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 
 fun Envelope<SessionPayload>.getSessionSpan(): Span? {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -16,8 +16,8 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.otel.attrs.embState
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
-import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
-import io.embrace.android.embracesdk.internal.otel.sdk.toFailedSpan
+import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.spans.toFailedSpan
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Envelope

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
@@ -8,9 +8,9 @@ import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
-import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSinkImpl
+import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import org.junit.Assert.assertEquals

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -13,10 +13,10 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.otel.attrs.asPair
+import io.embrace.android.embracesdk.internal.otel.config.getMaxTotalAttributeCount
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
-import io.embrace.android.embracesdk.internal.otel.sdk.getMaxTotalAttributeCount
 import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanFactory

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelLimitsConfigExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelLimitsConfigExt.kt
@@ -29,3 +29,9 @@ fun OtelLimitsConfig.isAttributeCountValid(attributes: Map<String, String>, inte
 fun OtelLimitsConfig.isAttributeValid(key: String, value: String, internal: Boolean) =
     ((internal && key.length <= getMaxInternalAttributeKeyLength()) || key.length <= getMaxCustomAttributeKeyLength()) &&
         ((internal && value.length <= getMaxInternalAttributeValueLength()) || value.length <= getMaxCustomAttributeValueLength())
+
+fun OtelLimitsConfig.getMaxTotalAttributeCount() = getMaxSystemAttributeCount() + getMaxCustomAttributeCount()
+
+fun OtelLimitsConfig.getMaxTotalEventCount() = getMaxSystemEventCount() + getMaxCustomEventCount()
+
+fun OtelLimitsConfig.getMaxTotalLinkCount() = getMaxSystemLinkCount() + getMaxCustomLinkCount()

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
@@ -1,20 +1,13 @@
 package io.embrace.android.embracesdk.internal.otel.sdk
 
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
 import io.embrace.android.embracesdk.internal.otel.attrs.EmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.attrs.EmbraceAttributeKey
-import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
-import io.embrace.android.embracesdk.internal.otel.schema.EmbType
-import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Attribute
-import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.semconv.ExceptionAttributes
 
 fun EmbraceSpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
@@ -35,6 +28,8 @@ fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_
 
 fun String.isValidLongValueAttribute(): Boolean = longValueAttributes.contains(this)
 
+private val longValueAttributes: Set<String> = setOf(ExceptionAttributes.EXCEPTION_STACKTRACE.key)
+
 fun List<Attribute>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean = any {
     it.key == embraceAttribute.key.name
 }
@@ -53,40 +48,14 @@ fun MutableMap<String, String>.setEmbraceAttribute(embraceAttribute: EmbraceAttr
     return this
 }
 
-fun OtelLimitsConfig.getMaxTotalAttributeCount() = getMaxSystemAttributeCount() + getMaxCustomAttributeCount()
-
-fun OtelLimitsConfig.getMaxTotalEventCount() = getMaxSystemEventCount() + getMaxCustomEventCount()
-
-fun OtelLimitsConfig.getMaxTotalLinkCount() = getMaxSystemLinkCount() + getMaxCustomLinkCount()
-
 fun Severity.toOtelSeverity(): io.opentelemetry.api.logs.Severity = when (this) {
     Severity.INFO -> io.opentelemetry.api.logs.Severity.INFO
     Severity.WARNING -> io.opentelemetry.api.logs.Severity.WARN
     Severity.ERROR -> io.opentelemetry.api.logs.Severity.ERROR
 }
 
-fun Span.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean {
-    return embraceAttribute.value == attributes?.singleOrNull { it.key == embraceAttribute.key.name }?.data
-}
-
 fun SpanEvent.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
     embraceAttribute.value == attributes?.singleOrNull { it.key == embraceAttribute.key.name }?.data
-
-fun Span.toFailedSpan(endTimeMs: Long): Span {
-    val newAttributes = mutableMapOf<String, String>().apply {
-        setEmbraceAttribute(ErrorCodeAttribute.Failure)
-        if (hasEmbraceAttribute(EmbType.Ux.Session)) {
-            setEmbraceAttribute(AppTerminationCause.Crash)
-        }
-    }
-
-    return copy(
-        endTimeNanos = endTimeMs.millisToNanos(),
-        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
-        status = Span.Status.ERROR,
-        attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
-    )
-}
 
 /**
  * Prefix added to OTel signal object names recorded by the SDK
@@ -97,5 +66,3 @@ private const val EMBRACE_OBJECT_NAME_PREFIX = "emb-"
  * Prefix added to all attribute keys for all usage attributes added by the SDK
  */
 private const val EMBRACE_USAGE_ATTRIBUTE_NAME_PREFIX = "emb.usage."
-
-private val longValueAttributes: Set<String> = setOf(ExceptionAttributes.EXCEPTION_STACKTRACE.key)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
@@ -3,6 +3,9 @@ package io.embrace.android.embracesdk.internal.otel.sdk
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
+import io.embrace.android.embracesdk.internal.otel.config.getMaxTotalAttributeCount
+import io.embrace.android.embracesdk.internal.otel.config.getMaxTotalEventCount
+import io.embrace.android.embracesdk.internal.otel.config.getMaxTotalLinkCount
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.trace.Tracer

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.internal.otel.spans
+
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.otel.attrs.EmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
+import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
+import io.embrace.android.embracesdk.internal.payload.Attribute
+import io.embrace.android.embracesdk.internal.payload.Span
+import io.opentelemetry.api.trace.SpanId
+
+fun Span.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean {
+    return embraceAttribute.value == attributes?.singleOrNull { it.key == embraceAttribute.key.name }?.data
+}
+
+fun Span.toFailedSpan(endTimeMs: Long): Span {
+    val newAttributes = mutableMapOf<String, String>().apply {
+        setEmbraceAttribute(ErrorCodeAttribute.Failure)
+        if (hasEmbraceAttribute(EmbType.Ux.Session)) {
+            setEmbraceAttribute(AppTerminationCause.Crash)
+        }
+    }
+
+    return copy(
+        endTimeNanos = endTimeMs.millisToNanos(),
+        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
+        status = Span.Status.ERROR,
+        attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
+    )
+}

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.arch.assertSuccessful
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
-import io.embrace.android.embracesdk.internal.otel.sdk.toFailedSpan
+import io.embrace.android.embracesdk.internal.otel.spans.toFailedSpan
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.ErrorCode
 import org.junit.Assert.assertEquals

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPayloadEnvelopeAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPayloadEnvelopeAssertions.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.attrs.embHeartbeatTimeUnixNano
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
-import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span


### PR DESCRIPTION
## Goal

Moves functions out of `EmbraceExt` where an existing source file for extensions exists.

## Testing

Relied on existing test coverage.
