### PR TITLE
Add additional attributes to internal span link JSON

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
@@ -63,4 +63,9 @@ fun Map<String, String>.toEmbracePayload(): List<Attribute> =
 fun List<Attribute>.toEmbracePayload(): Map<String, String> =
     associate { Pair(it.key ?: "", it.data ?: "") }.filterKeys { it.isNotBlank() }
 
-fun EmbraceLinkData.toEmbracePayload() = Link(spanContext.spanId, attributes.toEmbracePayload())
+fun EmbraceLinkData.toEmbracePayload() = Link(
+    spanId = spanContext.spanId,
+    traceId = spanContext.traceId,
+    attributes = attributes.toEmbracePayload(),
+    isRemote = spanContext.isRemote
+)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
@@ -18,6 +18,7 @@ import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.opentelemetry.sdk.trace.data.LinkData
 import io.opentelemetry.sdk.trace.data.SpanData
 
 /**
@@ -42,6 +43,13 @@ fun AttributesBuilder.fromMap(
 fun Attributes.toStringMap(): Map<String, String> = asMap().entries.associate {
     it.key.key.toString() to it.value.toString()
 }
+
+fun LinkData.toEmbracePayload() = Link(
+    spanId = spanContext.spanId,
+    traceId = spanContext.traceId,
+    attributes = attributes.toEmbracePayload(),
+    isRemote = spanContext.isRemote
+)
 
 fun LogRecordBuilder.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): LogRecordBuilder {
     setAttribute(embraceAttribute.key.asOtelAttributeKey(), embraceAttribute.value)
@@ -80,7 +88,7 @@ fun SpanData.toEmbraceSpanData(): EmbraceSpanData = EmbraceSpanData(
     status = status.statusCode,
     events = fromEventData(eventDataList = events),
     attributes = attributes.toStringMap(),
-    links = links.map { Link(it.spanContext.spanId, it.attributes.toEmbracePayload()) }
+    links = links.map { it.toEmbracePayload() }
 )
 
 fun SpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
@@ -183,10 +183,9 @@ internal class EmbSpanTest {
             val linkedSpanContext = checkNotNull(FakeEmbraceSdkSpan.started().spanContext)
             addLink(linkedSpanContext, Attributes.builder().put("boolean", true).build())
             with(fakeEmbraceSpan.links.single()) {
-                assertEquals(linkedSpanContext.spanId, spanId)
-                val attribute = checkNotNull(attributes?.single())
-                assertEquals("boolean", attribute.key)
-                assertEquals("true", attribute.data)
+                assertEquals(linkedSpanContext.spanId, spanContext.spanId)
+                assertEquals(1, attributes.size)
+                assertEquals("true", attributes["boolean"])
             }
         }
     }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Link.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Link.kt
@@ -10,6 +10,12 @@ data class Link(
     @Json(name = "span_id")
     val spanId: String? = null,
 
+    @Json(name = "trace_id")
+    val traceId: String? = null,
+
     @Json(name = "attributes")
     val attributes: List<Attribute>? = null,
+
+    @Json(name = "is_remote")
+    val isRemote: Boolean? = null,
 )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -16,9 +16,9 @@ import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute.Failure.fromErrorCode
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.toStatus
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceLinkData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
-import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -50,7 +50,7 @@ class FakeEmbraceSdkSpan(
     var errorCode: ErrorCode? = null
     val attributes: MutableMap<String, String> = mutableMapOf(type.asPair())
     val events: ConcurrentLinkedQueue<EmbraceSpanEvent> = ConcurrentLinkedQueue()
-    val links: ConcurrentLinkedQueue<Link> = ConcurrentLinkedQueue()
+    val links: ConcurrentLinkedQueue<EmbraceLinkData> = ConcurrentLinkedQueue()
 
     override val parent: EmbraceSpan?
         get() = parentContext.getEmbraceSpan()
@@ -140,7 +140,7 @@ class FakeEmbraceSdkSpan(
     }
 
     override fun addLink(linkedSpanContext: SpanContext, attributes: Map<String, String>?): Boolean {
-        links.add(Link(linkedSpanContext.spanId, attributes?.toEmbracePayload()))
+        links.add(EmbraceLinkData(linkedSpanContext, attributes ?: emptyMap()))
         return true
     }
 
@@ -163,7 +163,7 @@ class FakeEmbraceSdkSpan(
                 status = status,
                 events = events.map(EmbraceSpanEvent::toEmbracePayload),
                 attributes = attributes.toEmbracePayload(),
-                links = links.toList()
+                links = links.toList().map { it.toEmbracePayload() }
             )
         }
     }


### PR DESCRIPTION
## Goal

Add additional attributes to Span Link serialized form to support linking to spans created remotely

## Testing
Add unit and integration tests
