### PR TITLE
Fix build on CI

### DIFF
--- a/embrace-android-infra/build.gradle.kts
+++ b/embrace-android-infra/build.gradle.kts
@@ -11,5 +11,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.annotation.jvm)
+    implementation(libs.lifecycle.runtime)
+    implementation(libs.lifecycle.process)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ buildconfig = "5.6.4"
 agp-api = "7.4.2"
 apktoolLib = "2.11.1"
 bundletool = "1.18.1"
-annotationJvm = "1.8.2"
 
 [libraries]
 binary-compatibility-validator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
@@ -82,7 +81,6 @@ zstd-jni = { module = "com.github.luben:zstd-jni", version.ref = "zstdJni" }
 agp-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp-api" }
 apktool-lib = { module = "org.apktool:apktool-lib", version.ref = "apktoolLib" }
 bundletool = { module = "com.android.tools.build:bundletool", version.ref = "bundletool" }
-androidx-annotation-jvm = { group = "androidx.annotation", name = "annotation-jvm", version.ref = "annotationJvm" }
 
 [plugins]
 google-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Goal

The recently added androidx-annotation-jvm dependency was causing a conflict in the gradle plugin integration tests that failed the build. I've added the lifecycle/runtime as a dependency instead as this brings in the annotation library as a transitive dependency.

## Testing

Ran tests manually & waited on CI.

