### PR TITLE
Reduce usage of spanid.getinvalid

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/gating/SpanSanitizer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/gating/SpanSanitizer.kt
@@ -4,10 +4,10 @@ import io.embrace.android.embracesdk.internal.gating.SessionGatingKeys.BREADCRUM
 import io.embrace.android.embracesdk.internal.gating.SessionGatingKeys.BREADCRUMBS_TAPS
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
-import io.opentelemetry.api.trace.SpanId
 
 internal class SpanSanitizer(
     private val spans: List<Span>?,
@@ -29,7 +29,7 @@ internal class SpanSanitizer(
         val sanitizedSessionSpan = Span(
             sessionSpan.traceId,
             sessionSpan.spanId,
-            sessionSpan.parentSpanId ?: SpanId.getInvalid(),
+            sessionSpan.parentSpanId ?: OtelIds.invalidSpanId,
             sessionSpan.name,
             sessionSpan.startTimeNanos,
             sessionSpan.endTimeNanos,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -33,6 +33,7 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embState
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -40,7 +41,6 @@ import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -95,7 +95,7 @@ class PayloadResurrectionServiceImplTest {
             span = sessionSpan,
             expectedStartTimeMs = expectedStartTimeMs,
             expectedEndTimeMs = expectedEndTimeMs,
-            expectedParentId = SpanId.getInvalid(),
+            expectedParentId = OtelIds.invalidSpanId,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
                 EmbType.Ux.Session.asPair()
@@ -137,7 +137,7 @@ class PayloadResurrectionServiceImplTest {
             span = resurrectedSnapshot,
             expectedStartTimeMs = checkNotNull(spanSnapshot.startTimeNanos?.nanosToMillis()),
             expectedEndTimeMs = checkNotNull(sessionSpan.endTimeNanos?.nanosToMillis()),
-            expectedParentId = SpanId.getInvalid(),
+            expectedParentId = OtelIds.invalidSpanId,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
                 EmbType.Performance.Default.asPair()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.otel.config.getMaxTotalAttributeCo
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanFactory
@@ -28,7 +29,6 @@ import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
 import org.junit.Assert.assertEquals
@@ -386,7 +386,7 @@ internal class CurrentSessionSpanImplTests {
             span = flushedSpans["emb-session"]?.toEmbracePayload(),
             expectedStartTimeMs = sessionStartTimeMs,
             expectedEndTimeMs = crashTimeMs,
-            expectedParentId = SpanId.getInvalid(),
+            expectedParentId = OtelIds.invalidSpanId,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
                 AppTerminationCause.Crash.asPair(),
@@ -399,7 +399,7 @@ internal class CurrentSessionSpanImplTests {
             span = flushedSpans[crashedSpanName]?.toEmbracePayload(),
             expectedStartTimeMs = crashSpanStartTimeMs,
             expectedEndTimeMs = crashTimeMs,
-            expectedParentId = SpanId.getInvalid(),
+            expectedParentId = OtelIds.invalidSpanId,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
                 EmbType.Performance.Default.asPair()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -9,13 +9,13 @@ import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_SPAN_NAME
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -354,7 +354,7 @@ internal class EmbraceTracerTest {
         assertEquals(name, currentSpan.name)
         currentSpan.assertIsTypePerformance()
         if (traceRoot) {
-            assertEquals(SpanId.getInvalid(), currentSpan.parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, currentSpan.parentSpanId)
         } else {
             assertNotNull(currentSpan.parentSpanId)
         }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/SpanServiceImplTest.kt
@@ -26,12 +26,12 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanFactoryImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -73,7 +73,7 @@ internal class SpanServiceImplTest {
         assertTrue(embraceSpan.start())
         assertTrue(embraceSpan.stop())
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
-            assertEquals(SpanId.getInvalid(), parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, parentSpanId)
             assertIsTypePerformance()
             assertNotPrivateSpan()
         }
@@ -125,7 +125,7 @@ internal class SpanServiceImplTest {
         assertTrue(embraceSpan.start())
         assertTrue(embraceSpan.stop())
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
-            assertEquals(SpanId.getInvalid(), parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, parentSpanId)
             assertIsTypePerformance()
         }
     }
@@ -154,7 +154,7 @@ internal class SpanServiceImplTest {
 
         with(currentSpans[1]) {
             assertEquals("emb-test-span", name)
-            assertEquals(SpanId.getInvalid(), parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, parentSpanId)
             assertEquals(parentSpan.spanId, spanId)
             assertEquals(parentSpan.traceId, traceId)
             assertNotPrivateSpan()
@@ -260,7 +260,7 @@ internal class SpanServiceImplTest {
             assertEquals(expectedStartTimeMs, startTimeNanos.nanosToMillis())
             assertEquals(expectedEndTimeMs, endTimeNanos.nanosToMillis())
             assertIsTypePerformance()
-            assertEquals(SpanId.getInvalid(), parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, parentSpanId)
             assertNotPrivateSpan()
             expectedAttributes.forEach {
                 assertEquals(it.value, attributes[it.key])
@@ -384,7 +384,7 @@ internal class SpanServiceImplTest {
 
         assertEquals(returnThis, lambdaReturn)
         with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
-            assertEquals(SpanId.getInvalid(), parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, parentSpanId)
             assertIsTypePerformance()
             assertNotPrivateSpan()
         }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrOtelMapper.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrOtelMapper.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.payload.AnrInterval
 import io.embrace.android.embracesdk.internal.payload.AnrSample
@@ -11,8 +12,6 @@ import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
-import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.sdk.trace.IdGenerator
 import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.JvmAttributes
 
@@ -29,9 +28,9 @@ class AnrOtelMapper(
             val attrs = mapIntervalToSpanAttributes(interval)
             val events = mapIntervalToSpanEvents(interval)
             Span(
-                traceId = IdGenerator.random().generateTraceId(),
-                spanId = IdGenerator.random().generateSpanId(),
-                parentSpanId = SpanId.getInvalid(),
+                traceId = OtelIds.generateTraceId(),
+                spanId = OtelIds.generateSpanId(),
+                parentSpanId = OtelIds.invalidSpanId,
                 name = "emb-thread-blockage",
                 startTimeNanos = interval.startTime.millisToNanos(),
                 endTimeNanos = (interval.endTime ?: clock.now()).millisToNanos(),

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/AnrOtelMapperTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/AnrOtelMapperTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.payload.AnrInterval
 import io.embrace.android.embracesdk.internal.payload.AnrSample
 import io.embrace.android.embracesdk.internal.payload.AnrSampleList
@@ -13,7 +14,6 @@ import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.payload.ThreadInfo
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.JvmAttributes
 import org.junit.Assert.assertEquals
@@ -215,7 +215,7 @@ internal class AnrOtelMapperTest {
     private fun Span.assertCommonOtelCharacteristics() {
         assertNotNull(traceId)
         assertNotNull(spanId)
-        assertEquals(SpanId.getInvalid(), parentSpanId)
+        assertEquals(OtelIds.invalidSpanId, parentSpanId)
         assertEquals("emb-thread-blockage", name)
         assertEquals(START_TIME_MS, startTimeNanos?.nanosToMillis())
         assertSuccessful()

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/activity/UiLoadTraceEmitterTest.kt
@@ -7,12 +7,12 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -223,7 +223,7 @@ internal class UiLoadTraceEmitterTest {
                 span = trace.toEmbracePayload(),
                 expectedStartTimeMs = timestamps.first,
                 expectedEndTimeMs = timestamps.second,
-                expectedParentId = SpanId.getInvalid(),
+                expectedParentId = OtelIds.invalidSpanId,
                 expectedCustomAttributes = customAttributes,
             )
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImplTest.kt
@@ -8,10 +8,10 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -51,7 +51,7 @@ internal class StartupServiceImplTest {
         assertEquals(1, currentSpans.size)
         with(currentSpans[0]) {
             assertEquals("emb-sdk-init", name)
-            assertEquals(SpanId.getInvalid(), parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, parentSpanId)
             assertEquals(startTimeMillis, startTimeNanos.nanosToMillis())
             assertEquals(endTimeMillis, endTimeNanos.nanosToMillis())
             assertIsTypePerformance()

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.payload
 
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.toStatus
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceLinkData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
@@ -9,14 +10,13 @@ import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 
 fun Span.toEmbracePayload(): EmbraceSpanData {
     return EmbraceSpanData(
         traceId = traceId ?: "",
         spanId = spanId ?: "",
-        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
+        parentSpanId = parentSpanId ?: OtelIds.invalidSpanId,
         name = name ?: "",
         startTimeNanos = startTimeNanos ?: 0,
         endTimeNanos = endTimeNanos ?: 0L,
@@ -35,7 +35,7 @@ fun Span.toEmbracePayload(): EmbraceSpanData {
 fun EmbraceSpanData.toEmbracePayload(): Span = Span(
     traceId = traceId,
     spanId = spanId,
-    parentSpanId = parentSpanId ?: SpanId.getInvalid(),
+    parentSpanId = parentSpanId ?: OtelIds.invalidSpanId,
     name = name,
     startTimeNanos = startTimeNanos,
     endTimeNanos = endTimeNanos,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/id/OtelIds.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/id/OtelIds.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.embracesdk.internal.otel.sdk.id
+
+import io.opentelemetry.api.trace.SpanId
+import io.opentelemetry.sdk.trace.IdGenerator
+
+object OtelIds {
+
+    private val generator = IdGenerator.random()
+
+    /**
+     * Generates a new valid SpanId.
+     */
+    fun generateSpanId(): String = generator.generateSpanId()
+
+    /**
+     * Generates a new valid TraceId.
+     */
+    fun generateTraceId(): String = generator.generateTraceId()
+
+    /**
+     * An invalid SpanId.
+     */
+    val invalidSpanId: String = SpanId.getInvalid()
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute.Failure.fromErrorCode
 import io.embrace.android.embracesdk.internal.otel.sdk.fromMap
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.toStatus
@@ -28,7 +29,6 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
@@ -324,7 +324,7 @@ private class EmbraceSpanImpl(
             io.embrace.android.embracesdk.internal.payload.Span(
                 traceId = traceId,
                 spanId = spanId,
-                parentSpanId = parent?.spanId ?: SpanId.getInvalid(),
+                parentSpanId = parent?.spanId ?: OtelIds.invalidSpanId,
                 name = getSpanName(),
                 startTimeNanos = spanStartTimeMs?.millisToNanos(),
                 endTimeNanos = spanEndTimeMs?.millisToNanos(),

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
@@ -6,10 +6,10 @@ import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.opentelemetry.api.trace.SpanId
 
 fun Span.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean {
     return embraceAttribute.value == attributes?.singleOrNull { it.key == embraceAttribute.key.name }?.data
@@ -25,7 +25,7 @@ fun Span.toFailedSpan(endTimeMs: Long): Span {
 
     return copy(
         endTimeNanos = endTimeMs.millisToNanos(),
-        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
+        parentSpanId = parentSpanId ?: OtelIds.invalidSpanId,
         status = Span.Status.ERROR,
         attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
     )

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -23,13 +23,13 @@ import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedCo
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceObjectName
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.semconv.ExceptionAttributes
@@ -377,7 +377,7 @@ internal class EmbraceSpanImplTest {
 
             assertEquals(traceId, snapshot.traceId)
             assertEquals(spanId, snapshot.spanId)
-            assertEquals(SpanId.getInvalid(), snapshot.parentSpanId)
+            assertEquals(OtelIds.invalidSpanId, snapshot.parentSpanId)
             assertEquals(EXPECTED_SPAN_NAME.toEmbraceObjectName(), snapshot.name)
             assertTrue(hasEmbraceAttribute(EmbType.System.LowPower))
             assertTrue(hasEmbraceAttribute(PrivateSpan))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.impl.EmbSpan
 import io.embrace.android.embracesdk.internal.otel.impl.EmbSpanBuilder
 import io.embrace.android.embracesdk.internal.otel.impl.EmbTracer
@@ -19,7 +20,6 @@ import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInt
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
@@ -143,7 +143,7 @@ internal class ExternalTracerTest {
                     span = parent,
                     expectedStartTimeMs = checkNotNull(startTimeMs),
                     expectedEndTimeMs = checkNotNull(endTimeMs),
-                    expectedParentId = SpanId.getInvalid(),
+                    expectedParentId = OtelIds.invalidSpanId,
                     expectedCustomAttributes = mapOf("failures" to "1")
                 )
                 assertEmbraceSpanData(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -184,7 +185,7 @@ internal class TracingApiTest {
                     span = traceRootSpan,
                     expectedStartTimeMs = testStartTimeMs + 1,
                     expectedEndTimeMs = testStartTimeMs + 300,
-                    expectedParentId = SpanId.getInvalid(),
+                    expectedParentId = OtelIds.invalidSpanId,
                     expectedCustomAttributes = mapOf(Pair("oMg", "OmG")),
                     expectedEvents = listOf(
                         SpanEvent(
@@ -250,7 +251,7 @@ internal class TracingApiTest {
                     span = sessionSpan,
                     expectedStartTimeMs = sessionStartTimeMs,
                     expectedEndTimeMs = sessionEndTimeMs,
-                    expectedParentId = SpanId.getInvalid(),
+                    expectedParentId = OtelIds.invalidSpanId,
                     private = false
                 )
 
@@ -261,7 +262,7 @@ internal class TracingApiTest {
                     span = unendingSpanSnapshot,
                     expectedStartTimeMs = testStartTimeMs + 600,
                     expectedEndTimeMs = null,
-                    expectedParentId = SpanId.getInvalid(),
+                    expectedParentId = OtelIds.invalidSpanId,
                     expectedStatus = Span.Status.UNSET,
                     expectedCustomAttributes = mapOf(Pair("unending-key", "unending-value")),
                     expectedEvents = listOf(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UiLoadTest.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.capture.activity.LifecycleStage
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -21,7 +22,6 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.POST_ACTIVITY_ACTION_DWELL
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.STARTUP_BACKGROUND_TIME
-import io.opentelemetry.api.trace.SpanId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -145,7 +145,7 @@ internal class UiLoadTest {
                         span = trace,
                         expectedStartTimeMs = expectedTraceStartTime,
                         expectedEndTimeMs = expectedTraceStartTime + calculateTotalTime(lifecycleStages = 4),
-                        expectedParentId = SpanId.getInvalid(),
+                        expectedParentId = OtelIds.invalidSpanId,
                         expectedCustomAttributes = mapOf("manual-end" to "true")
                     )
 
@@ -200,7 +200,7 @@ internal class UiLoadTest {
                             lifecycleStages = 3,
                             activitiesFullyLoaded = 1
                         ),
-                        expectedParentId = SpanId.getInvalid(),
+                        expectedParentId = OtelIds.invalidSpanId,
                         expectedStatus = Span.Status.ERROR,
                         expectedErrorCode = ErrorCode.USER_ABANDON,
                     )
@@ -269,7 +269,7 @@ internal class UiLoadTest {
                     span = trace,
                     expectedStartTimeMs = expectedTraceStartTime,
                     expectedEndTimeMs = expectedTraceStartTime + calculateTotalTime(lifecycleStages = 2),
-                    expectedParentId = SpanId.getInvalid(),
+                    expectedParentId = OtelIds.invalidSpanId,
                 )
 
                 assertEmbraceSpanData(
@@ -322,7 +322,7 @@ internal class UiLoadTest {
                     span = trace,
                     expectedStartTimeMs = expectedTraceStartTime,
                     expectedEndTimeMs = expectedTraceStartTime + calculateTotalTime(lifecycleStages = 2),
-                    expectedParentId = SpanId.getInvalid(),
+                    expectedParentId = OtelIds.invalidSpanId,
                 )
 
                 assertEmbraceSpanData(
@@ -377,7 +377,7 @@ internal class UiLoadTest {
                     span = trace,
                     expectedStartTimeMs = expectedTraceStartTime,
                     expectedEndTimeMs = expectedTraceStartTime + calculateTotalTime(lifecycleStages = 1),
-                    expectedParentId = SpanId.getInvalid(),
+                    expectedParentId = OtelIds.invalidSpanId,
                 )
 
                 assertEmbraceSpanData(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -8,7 +9,6 @@ import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.TraceFlags
 import io.opentelemetry.api.trace.TraceState
-import io.opentelemetry.sdk.trace.IdGenerator
 import java.util.concurrent.TimeUnit
 
 class FakeSpan(
@@ -17,8 +17,8 @@ class FakeSpan(
 
     private val spanContext: SpanContext =
         SpanContext.create(
-            fakeSpanBuilder.parentContext.getEmbraceSpan()?.traceId ?: IdGenerator.random().generateTraceId(),
-            IdGenerator.random().generateSpanId(),
+            fakeSpanBuilder.parentContext.getEmbraceSpan()?.traceId ?: OtelIds.generateTraceId(),
+            OtelIds.generateSpanId(),
             TraceFlags.getDefault(),
             TraceState.getDefault()
         )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -6,17 +6,17 @@ import io.embrace.android.embracesdk.internal.otel.attrs.asPair
 import io.embrace.android.embracesdk.internal.otel.attrs.embSequenceId
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.opentelemetry.api.trace.SpanId
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.context.ContextKey
 
 val testSpan: Span = EmbraceSpanData(
     traceId = "19bb482ec1c7e6b2f10fb89e0ccc85fa",
     spanId = "342eb9c7f8cb54ff",
-    parentSpanId = SpanId.getInvalid(),
+    parentSpanId = OtelIds.invalidSpanId,
     name = "emb-sdk-init",
     startTimeNanos = 1681972471806000000L,
     endTimeNanos = 1681972471871000000L,


### PR DESCRIPTION
## Goal

Reduces the direct usage of `SpanId.getInvalid()` so that it's confined to the `embrace-android-otel` module.

