### PR TITLE
Preparatory work for kotlin api

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.otel
 
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.opentelemetry.kotlin.StatusCode
+import io.embrace.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.api.common.AttributeKey
 
 internal fun StatusCode.toOtelJava(): io.opentelemetry.api.trace.StatusCode = when (this) {
@@ -14,6 +15,14 @@ internal fun io.opentelemetry.api.trace.StatusCode.toOtelKotlin(): StatusCode = 
     io.opentelemetry.api.trace.StatusCode.UNSET -> StatusCode.Unset
     io.opentelemetry.api.trace.StatusCode.OK -> StatusCode.Ok
     io.opentelemetry.api.trace.StatusCode.ERROR -> StatusCode.Error(null)
+}
+
+fun io.opentelemetry.api.trace.SpanKind.toOtelKotlin(): SpanKind = when (this) {
+    io.opentelemetry.api.trace.SpanKind.SERVER -> SpanKind.SERVER
+    io.opentelemetry.api.trace.SpanKind.CLIENT -> SpanKind.CLIENT
+    io.opentelemetry.api.trace.SpanKind.PRODUCER -> SpanKind.PRODUCER
+    io.opentelemetry.api.trace.SpanKind.CONSUMER -> SpanKind.CONSUMER
+    io.opentelemetry.api.trace.SpanKind.INTERNAL -> SpanKind.INTERNAL
 }
 
 fun StatusCode.toEmbracePayload(): Span.Status = when (this) {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData.Compani
 import io.embrace.android.embracesdk.internal.otel.toOtelKotlin
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.utils.isBlankish
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
@@ -78,6 +79,10 @@ fun Span.setEmbraceAttribute(key: EmbraceAttributeKey, value: String): Span {
 
 fun Span.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): Span =
     this@setEmbraceAttribute.setEmbraceAttribute(embraceAttribute.key, embraceAttribute.value)
+
+@OptIn(ExperimentalApi::class)
+fun io.embrace.opentelemetry.kotlin.tracing.Span.setEmbraceAttribute(embraceAttribute: EmbraceAttribute) =
+    setStringAttribute(embraceAttribute.key.name, embraceAttribute.value)
 
 fun SpanData.toEmbraceSpanData(): EmbraceSpanData = EmbraceSpanData(
     traceId = spanContext.traceId,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinSpanContextWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinSpanContextWrapper.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.internal.otel.wrapper
+
+import io.embrace.opentelemetry.kotlin.tracing.SpanContext
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+
+class KotlinSpanContextWrapper(
+    private val impl: SpanContext,
+) : io.opentelemetry.api.trace.SpanContext {
+
+    override fun getTraceId(): String = impl.traceId
+    override fun getSpanId(): String = impl.spanId
+    override fun isRemote(): Boolean = impl.isRemote
+
+    override fun getTraceFlags(): TraceFlags = KotlinTraceFlagsWrapper(impl.traceFlags)
+    override fun getTraceState(): TraceState = KotlinTraceStateWrapper(impl.traceState)
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceFlagsWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceFlagsWrapper.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.internal.otel.wrapper
+
+import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
+
+class KotlinTraceFlagsWrapper(
+    private val impl: TraceFlags,
+) : io.opentelemetry.api.trace.TraceFlags {
+    override fun isSampled(): Boolean = impl.isSampled
+
+    // FIXME: temporary. requires change in opentelemetry-kotlin first
+    override fun asHex(): String = throw UnsupportedOperationException()
+
+    override fun asByte(): Byte = asHex().toByte()
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceStateWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceStateWrapper.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.internal.otel.wrapper
+
+import android.os.Build
+import io.embrace.opentelemetry.kotlin.tracing.TraceState
+import io.opentelemetry.api.trace.TraceStateBuilder
+import java.util.function.BiConsumer
+
+class KotlinTraceStateWrapper(
+    private val impl: TraceState,
+) : io.opentelemetry.api.trace.TraceState {
+
+    override fun get(key: String): String? = impl.get(key)
+
+    override fun size(): Int = impl.asMap().size
+
+    override fun isEmpty(): Boolean = impl.asMap().isEmpty()
+
+    override fun forEach(consumer: BiConsumer<String, String>) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            impl.asMap().forEach(consumer)
+        }
+    }
+
+    override fun asMap(): MutableMap<String, String> = impl.asMap().toMutableMap()
+
+    override fun toBuilder(): TraceStateBuilder {
+        val builder = io.opentelemetry.api.trace.TraceState.builder()
+        asMap().forEach { entry ->
+            builder.put(entry.key, entry.value)
+        }
+        return builder
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinSpan.kt
@@ -1,0 +1,71 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.StatusCode
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.Link
+import io.embrace.opentelemetry.kotlin.tracing.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
+import io.embrace.opentelemetry.kotlin.tracing.SpanKind
+
+@ExperimentalApi
+class FakeKotlinSpan(
+    override var name: String,
+    override var parent: SpanContext?,
+    val spanKind: SpanKind,
+    val startTimestamp: Long?,
+) : io.embrace.opentelemetry.kotlin.tracing.Span {
+
+    private var inProgress = true
+
+    override fun attributes(): Map<String, Any> = emptyMap()
+
+    // FIXME: temp, requires access to SpanContextAdapter in opentelemetry-kotlin
+    override val spanContext: SpanContext = throw UnsupportedOperationException()
+
+    override var status: StatusCode = StatusCode.Unset
+
+    override fun addEvent(name: String, timestamp: Long?, action: AttributeContainer.() -> Unit) {
+    }
+
+    override fun addLink(spanContext: SpanContext, action: AttributeContainer.() -> Unit) {
+    }
+
+    override fun end() {
+        inProgress = false
+    }
+
+    override fun end(timestamp: Long) {
+        inProgress = false
+    }
+
+    override fun events(): List<SpanEvent> = emptyList()
+
+    override fun isRecording(): Boolean = inProgress
+
+    override fun links(): List<Link> = emptyList()
+
+    override fun setBooleanAttribute(key: String, value: Boolean) {
+    }
+
+    override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
+    }
+
+    override fun setDoubleAttribute(key: String, value: Double) {
+    }
+
+    override fun setDoubleListAttribute(key: String, value: List<Double>) {
+    }
+
+    override fun setLongAttribute(key: String, value: Long) {
+    }
+
+    override fun setLongListAttribute(key: String, value: List<Long>) {
+    }
+
+    override fun setStringAttribute(key: String, value: String) {
+    }
+
+    override fun setStringListAttribute(key: String, value: List<String>) {
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinTracer.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinTracer.kt
@@ -1,0 +1,24 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.Span
+import io.embrace.opentelemetry.kotlin.tracing.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.SpanKind
+import io.embrace.opentelemetry.kotlin.tracing.SpanRelationships
+
+@ExperimentalApi
+class FakeKotlinTracer : io.embrace.opentelemetry.kotlin.tracing.Tracer {
+
+    override fun createSpan(
+        name: String,
+        parent: SpanContext?,
+        spanKind: SpanKind,
+        startTimestamp: Long?,
+        action: SpanRelationships.() -> Unit,
+    ): Span = FakeKotlinSpan(
+        name,
+        parent,
+        spanKind,
+        startTimestamp,
+    )
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinTracerProvider.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinTracerProvider.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
+
+@ExperimentalApi
+class FakeKotlinTracerProvider : io.embrace.opentelemetry.kotlin.tracing.TracerProvider {
+    override fun getTracer(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: AttributeContainer.() -> Unit,
+    ): Tracer = FakeKotlinTracer()
+}


### PR DESCRIPTION
## Goal

Creates some wrappers + fakes that are required to move over to using the Kotlin API.

## Testing

This will be covered by existing tests once the internal implementation uses these objects.

