### PR TITLE
Create bidirection relationships between spans and sessions

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpan.kt
@@ -33,4 +33,9 @@ interface CurrentSessionSpan : Initializable, SessionSpanWriter {
      * Returns the current session ID
      */
     fun getSessionId(): String
+
+    /**
+     * Callback to be invoked when a span is just about to be stopped
+     */
+    fun spanStopCallback(spanId: String)
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.arch.assertIsType
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.assertions.findEventOfType
 import io.embrace.android.embracesdk.assertions.validatePreviousSessionLink
+import io.embrace.android.embracesdk.assertions.validateSystemLink
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSpanFactory
@@ -19,6 +20,7 @@ import io.embrace.android.embracesdk.internal.otel.config.getMaxTotalAttributeCo
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.schema.LinkType
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanBuilderWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
@@ -559,6 +561,48 @@ internal class CurrentSessionSpanImplTests {
 
         // verify event was added to the span
         assertEquals(limit, span.toEmbracePayload().attributes?.size)
+    }
+
+    @Test
+    fun `span stop callback creates the correct span links`() {
+        val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val span = spanService.startSpan("test")?.apply {
+            stop()
+        }
+
+        val spanSnapshot = checkNotNull(span?.snapshot())
+        val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
+
+        checkNotNull(spanSnapshot.links).single().validateSystemLink(sessionSpanSnapshot, LinkType.EndSession)
+        checkNotNull(sessionSpanSnapshot.links).single().validateSystemLink(spanSnapshot, LinkType.EndedIn)
+    }
+
+    @Test
+    fun `session ending will not create span link to its own session span`() {
+        val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        currentSessionSpan.endSession(startNewSession = true)
+        val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
+        assertEquals(0, sessionSpanSnapshot.links?.size)
+    }
+
+    @Test
+    fun `span stop callback will not create links for untracked span`() {
+        val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        currentSessionSpan.spanStopCallback(checkNotNull(FakeEmbraceSdkSpan.started().spanId))
+
+        val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
+        assertEquals(0, sessionSpanSnapshot.links?.size)
+    }
+
+    @Test
+    fun `span stop callback will not create links if there's no active session`() {
+        val span = spanService.startSpan("test")?.apply {
+            currentSessionSpan.endSession(false)
+            stop()
+        }
+
+        val spanSnapshot = checkNotNull(span?.snapshot())
+        assertEquals(0, spanSnapshot.links?.size)
     }
 
     private fun CurrentSessionSpan.assertNoSessionSpan() {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/schema/LinkType.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/schema/LinkType.kt
@@ -3,10 +3,27 @@ package io.embrace.android.embracesdk.internal.otel.schema
 import io.embrace.android.embracesdk.internal.otel.attrs.EmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.attrs.EmbraceAttributeKey
 
+/**
+ * A type that gives semantic meaning to a Span Link instance, defining the nature of the relationship between the span that contains the
+ * link and the span that is being linked to.
+ */
 sealed class LinkType(
     override val value: String,
 ) : EmbraceAttribute {
     override val key: EmbraceAttributeKey = EmbraceAttributeKey.create(id = "link_type")
 
+    /**
+     * On a session span, it links to the previous valid session span for this app instance.
+     */
     object PreviousSession : LinkType("PREV_SESSION")
+
+    /**
+     * On a span that is not a session span, it links to the session span of the session in which it ended.
+     */
+    object EndSession : LinkType("END_SESSION")
+
+    /**
+     * On a session span, it links to a span that ended during the session associated this the session span.
+     */
+    object EndedIn : LinkType("ENDED_IN")
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
@@ -30,8 +30,12 @@ fun String.isValidLongValueAttribute(): Boolean = longValueAttributes.contains(t
 
 private val longValueAttributes: Set<String> = setOf(ExceptionAttributes.EXCEPTION_STACKTRACE.key)
 
+fun List<Attribute>.hasEmbraceAttributeKey(embraceAttributeKey: EmbraceAttributeKey): Boolean = any {
+    it.key == embraceAttributeKey.name
+}
+
 fun List<Attribute>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean = any {
-    it.key == embraceAttribute.key.name
+    it.key == embraceAttribute.key.name && it.data == embraceAttribute.value
 }
 
 fun List<Attribute>.findAttributeValue(key: String): String? = singleOrNull { it.key == key }?.data

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -47,6 +47,7 @@ class EmbraceSpanFactoryImpl(
     private val tracer: Tracer,
     private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
+    private val stopCallback: ((spanId: String) -> Unit)? = null,
     private var redactionFunction: ((key: String, value: String) -> String)? = null,
 ) : EmbraceSpanFactory {
 
@@ -76,6 +77,7 @@ class EmbraceSpanFactoryImpl(
             otelSpanBuilderWrapper = otelSpanBuilderWrapper,
             openTelemetryClock = openTelemetryClock,
             spanRepository = spanRepository,
+            stopCallback = stopCallback,
             redactionFunction = redactionFunction,
             autoTerminationMode = autoTerminationMode
         )
@@ -85,6 +87,7 @@ private class EmbraceSpanImpl(
     private val otelSpanBuilderWrapper: OtelSpanBuilderWrapper,
     private val openTelemetryClock: Clock,
     private val spanRepository: SpanRepository,
+    private val stopCallback: ((spanId: String) -> Unit)? = null,
     private val redactionFunction: ((key: String, value: String) -> String)? = null,
     private val limits: OtelLimitsConfig = InstrumentedConfigImpl.otelLimits,
     override val autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
@@ -180,6 +183,7 @@ private class EmbraceSpanImpl(
                 }
 
                 startedSpan.get()?.let { spanToStop ->
+                    spanId?.let { stopCallback?.invoke(it) }
                     populateAttributes(spanToStop)
                     populateEvents(spanToStop)
                     populateLinks(spanToStop)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
@@ -48,9 +48,9 @@ class SpanRepository {
     }
 
     /**
-     * Return the [EmbraceSpan] with the corresponding [spanId] if it's tracked. Return null otherwise.
+     * Return the [EmbraceSdkSpan] with the corresponding [spanId] if it's tracked. Return null otherwise.
      */
-    fun getSpan(spanId: String): EmbraceSpan? =
+    fun getSpan(spanId: String): EmbraceSdkSpan? =
         spanIdsInProcess.lockAndRun(spanId) {
             activeSpans[spanId] ?: completedSpans[spanId]
         }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpanTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpanTest.kt
@@ -1,12 +1,15 @@
 package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.hasLinkToEmbraceSpan
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.internal.otel.schema.LinkType
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,6 +57,47 @@ internal class SessionSpanTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 assertEquals(100, session.getSessionSpan()?.events?.size)
+            }
+        )
+    }
+
+    @Test
+    fun `correct span links created when a span ends`() {
+        testRule.runTest(
+            testCaseAction = {
+                val startInSessionEndInBackground = checkNotNull(embrace.createSpan("startInSessionEndInBackground"))
+                val startAndEndInDifferentSessions = checkNotNull(embrace.createSpan("startAndEndInDifferentSessions"))
+                recordSession {
+                    embrace.recordSpan("startAndEndInSession") {
+                        assertTrue(startInSessionEndInBackground.start())
+                        assertTrue(startAndEndInDifferentSessions.start())
+                    }
+                }
+                assertTrue(startInSessionEndInBackground.stop())
+                recordSession {
+                    assertTrue(startAndEndInDifferentSessions.stop())
+                }
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+                val firstSession = sessions[0]
+                val secondSession = sessions[1]
+                val firstSessionSpan = checkNotNull(firstSession.getSessionSpan())
+                val startAndEndInSession = checkNotNull(firstSession.data.spans?.single { it.name == "startAndEndInSession"})
+
+                assertTrue(firstSessionSpan.hasLinkToEmbraceSpan(startAndEndInSession, LinkType.EndedIn))
+                assertFalse(firstSessionSpan.hasLinkToEmbraceSpan(firstSessionSpan, LinkType.EndedIn))
+                assertTrue(startAndEndInSession.hasLinkToEmbraceSpan(firstSessionSpan, LinkType.EndSession))
+
+                val secondSessionSpan = checkNotNull(secondSession.getSessionSpan())
+                val startInSessionEndInBackground =
+                    checkNotNull(secondSession.data.spans?.single { it.name == "startInSessionEndInBackground"})
+                val startAndEndInDifferentSessions =
+                    checkNotNull(secondSession.data.spans?.single { it.name == "startAndEndInDifferentSessions"})
+                assertTrue(secondSessionSpan.hasLinkToEmbraceSpan(startAndEndInDifferentSessions, LinkType.EndedIn))
+                assertFalse(secondSessionSpan.hasLinkToEmbraceSpan(secondSessionSpan, LinkType.EndedIn))
+                assertTrue(startAndEndInDifferentSessions.hasLinkToEmbraceSpan(secondSessionSpan, LinkType.EndSession))
+                assertEquals(0, startInSessionEndInBackground.links?.size)
             }
         )
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionSpan.kt
@@ -14,9 +14,10 @@ import java.util.concurrent.atomic.AtomicInteger
 class FakeCurrentSessionSpan(
     private val clock: FakeClock = FakeClock(),
 ) : CurrentSessionSpan {
+    val addedEvents = mutableListOf<SpanEventData>()
+    val attributes = mutableMapOf<String, String>()
+    val stoppedSpans = mutableSetOf<String>()
     var initializedCallCount: Int = 0
-    var addedEvents: MutableList<SpanEventData> = mutableListOf()
-    var attributes: MutableMap<String, String> = mutableMapOf()
     var sessionSpan: FakeEmbraceSdkSpan? = null
 
     private val sessionIteration = AtomicInteger(1)
@@ -75,6 +76,10 @@ class FakeCurrentSessionSpan(
 
     override fun getSessionId(): String {
         return "testSessionId$sessionIteration"
+    }
+
+    override fun spanStopCallback(spanId: String) {
+        stoppedSpans.add(spanId)
     }
 
     fun getAttribute(key: String): String? = attributes[key]


### PR DESCRIPTION
## Goal

When a span ends, add a span link to the session span as well as a span link to the current session on the span about to end. Added a bunch of test infra and tests so testing future span link features will be easier.

