### PR TITLE
Remove thread sampler installer internal API for Unity

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
@@ -119,8 +119,4 @@ internal class UnityInternalInterfaceImpl(
             )
         )
     }
-
-    @Deprecated("Obsolete, will be removed in a future release.")
-    override fun installUnityThreadSampler() {
-    }
 }

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/UnityInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/UnityInternalInterface.kt
@@ -57,10 +57,4 @@ interface UnityInternalInterface :
         statusCode: Int,
         traceId: String?,
     )
-
-    /**
-     * @suppress
-     */
-    @Deprecated("Obsolete, will be removed in a future release.")
-    fun installUnityThreadSampler()
 }

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopUnityInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopUnityInternalInterface.kt
@@ -38,8 +38,4 @@ internal class NoopUnityInternalInterface(
         traceId: String?,
     ) {
     }
-
-    @Deprecated("Obsolete, will be removed in a future release.")
-    override fun installUnityThreadSampler() {
-    }
 }

--- a/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopUnityInternalInterfaceTest.kt
+++ b/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopUnityInternalInterfaceTest.kt
@@ -19,7 +19,6 @@ internal class NoopUnityInternalInterfaceTest {
         )
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun `check no errors thrown when invoked`() {
         impl.setUnityMetaData("unityVersion", "buildGuid", "unitySdkVersion")
@@ -44,6 +43,5 @@ internal class NoopUnityInternalInterfaceTest {
             200,
             "traceId"
         )
-        impl.installUnityThreadSampler()
     }
 }


### PR DESCRIPTION
## Goal

Remove API that is no logger needed as Unity thread sampling is no longer supported
