### PR TITLE
Get configuration cache telemetry from BuildFeatures

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildFeaturesWrapper.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildFeaturesWrapper.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.gradle.plugin.buildreporter
+
+import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
+import org.gradle.api.provider.Provider
+import org.gradle.invocation.DefaultGradle
+
+/**
+ * A wrapper around the BuildFeatures API, used to check if the configuration cache is enabled.
+ * BuildFeatures API is available for Gradle 8.5 and above.
+ */
+class BuildFeaturesWrapper {
+    fun isConfigurationCacheEnabled(project: Project): Provider<Boolean> {
+        return try {
+            (project.gradle as DefaultGradle).services.get(BuildFeatures::class.java).configurationCache.active
+        } catch (e: Exception) {
+            project.provider { false }
+        }
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
@@ -79,7 +79,9 @@ class BuildTelemetryCollector {
 
     private fun Project.isConfigurationCacheEnabled(): Boolean {
         return try {
-            if (isAtLeast(GradleVersion.GRADLE_7_6)) {
+            if (isAtLeast(GradleVersion.GRADLE_8_5)) {
+                return BuildFeaturesWrapper().isConfigurationCacheEnabled(project).get()
+            } else if (isAtLeast(GradleVersion.GRADLE_7_6)) {
                 val isConfigurationCacheRequestedMethod =
                     this.gradle.startParameter::class.java.getMethod("isConfigurationCacheRequested")
                 return isConfigurationCacheRequestedMethod.invoke(this.gradle.startParameter) as Boolean

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/GradleVersion.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/GradleVersion.kt
@@ -9,6 +9,7 @@ sealed class GradleVersion(private val version: org.gradle.util.GradleVersion) :
     object CURRENT : GradleVersion(org.gradle.util.GradleVersion.current())
     object GRADLE_7_6 : GradleVersion(version("7.6"))
     object GRADLE_8_0 : GradleVersion(version("8.0"))
+    object GRADLE_8_5 : GradleVersion(version("8.5"))
 
     override fun compareTo(other: GradleVersion): Int {
         return version.compareTo(other.version)


### PR DESCRIPTION
BuildFeatures was introduced after Gradle 8.5 to fetch information about the build. Use that instead of StartParameter, which will be deprecated in Gradle 10.

Should fix issue #2207.

## Testing

In the ExampleApp, the warning following warning was showing up when running `./gradlew build --warning-mode all`:
```
The StartParameter.isConfigurationCacheRequested property has been deprecated. This is scheduled to be removed in Gradle 10.0.
```

It doesn't show up anymore after this change.