### PR TITLE
Removed afterEvaluate from AsmTaskRegistration

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/TaskRegistrationUtils.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/TaskRegistrationUtils.kt
@@ -3,6 +3,7 @@ package io.embrace.android.gradle.plugin.gradle
 import io.embrace.android.gradle.plugin.util.capitalizedString
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 
@@ -44,4 +45,18 @@ fun <T : Task> Project.tryGetTaskProvider(taskName: String, taskType: Class<T>):
     } catch (e: Exception) {
         null
     }
+}
+
+/**
+ * Lazily looks up a task by name and type, returning a [Provider] that yields the task if it exists,
+ * or `null` if not found. Useful for wiring optional tasks into the task graph without realizing them early.
+ *
+ * @param T The expected type of the task.
+ * @param name The name of the task to look up.
+ * @return A [Provider] of the task, or `provider { null }` if the task is not present.
+ */
+inline fun <reified T : Task> Project.lazyTaskLookup(name: String): Provider<T?> {
+    return provider {
+        tryGetTaskProvider(name, T::class.java)
+    }.safeFlatMap { it as Provider<T?> }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.gradle.plugin.tasks.ndk
 
 import io.embrace.android.gradle.plugin.config.PluginBehavior
+import io.embrace.android.gradle.plugin.gradle.lazyTaskLookup
 import io.embrace.android.gradle.plugin.gradle.nullSafeMap
 import io.embrace.android.gradle.plugin.gradle.registerTask
 import io.embrace.android.gradle.plugin.gradle.safeFlatMap
@@ -37,9 +38,7 @@ class NdkUploadTasksRegistration(
         // Bail if ndk_enabled is not true.
         if (variantConfig.embraceConfig?.ndkEnabled != true) return
 
-        val mergeNativeLibsTaskProvider: Provider<Task?> = project.provider {
-            project.tryGetTaskProvider("merge${variant.name.capitalizedString()}NativeLibs")
-        }.safeFlatMap { it as Provider<Task?> }
+        val mergeNativeLibsTaskProvider = project.lazyTaskLookup<Task>("merge${variant.name.capitalizedString()}NativeLibs")
 
         val sharedObjectFilesProvider = getSharedObjectFilesProvider(project, mergeNativeLibsTaskProvider)
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin.tasks.reactnative
 
+import io.embrace.android.gradle.plugin.gradle.lazyTaskLookup
 import io.embrace.android.gradle.plugin.gradle.nullSafeMap
 import io.embrace.android.gradle.plugin.gradle.registerTask
 import io.embrace.android.gradle.plugin.gradle.safeFlatMap
@@ -58,9 +59,7 @@ class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
             )
 
             val variantCapitalized = variant.name.capitalizedString()
-            val generatorTaskProvider: Provider<Task?> = project.provider {
-                project.tryGetTaskProvider("createBundle${variantCapitalized}JsAndAssets")
-            }.safeFlatMap { it as Provider<Task?> }
+            val generatorTaskProvider = project.lazyTaskLookup<Task>("createBundle${variantCapitalized}JsAndAssets")
 
             rnTask.bundleFile.set(project.layout.file(getBundleFileProvider(generatorTaskProvider, project)))
             rnTask.sourcemap.set(project.layout.file(getSourcemapFileProvider(generatorTaskProvider, project, data)))


### PR DESCRIPTION
## Goal

Mapped task outputs correctly to asm task parameters without using afterEvaluate. Also added a lazyTaskLookup utility function.

