### PR TITLE
Fix a bug where disabling the sdk might cause a background exception

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk
 import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import io.embrace.android.embracesdk.core.BuildConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
@@ -246,13 +247,13 @@ internal class EmbraceImpl @JvmOverloads constructor(
         if (sdkCallChecker.started.get()) {
             bootstrapper.openTelemetryModule.otelSdkConfig.disableDataExport()
             stop()
-        }
-
-        // delete any persisted data
-        runCatching {
             Executors.newSingleThreadExecutor().execute {
-                StorageLocation.values().map { it.asFile(bootstrapper.coreModule.context, logger).value }.forEach {
-                    it.deleteRecursively()
+                runCatching {
+                    StorageLocation.values().map { it.asFile(bootstrapper.coreModule.context, logger).value }.forEach {
+                        it.deleteRecursively()
+                    }
+                }.onFailure { exception ->
+                    Log.e("[Embrace]", "An error occurred while trying to disable Embrace SDK.", exception)
                 }
             }
         }


### PR DESCRIPTION
## Goal

`runCatching` doesn't handle exceptions happening on another thread. This PR fixes that issue.
