### PR TITLE
Maven central portal migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ nexusPublishing {
         sonatype {
             username = System.getenv("SONATYPE_USERNAME")
             password = System.getenv("SONATYPE_PASSWORD")
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
         }
     }
     transitionCheckOptions {

--- a/embrace-gradle-plugin/build.gradle.kts
+++ b/embrace-gradle-plugin/build.gradle.kts
@@ -155,7 +155,7 @@ publishing {
                 password = System.getenv("SONATYPE_PASSWORD")
             }
             name = "sonatype"
-            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2")
+            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
         }
     }
     signing {


### PR DESCRIPTION
## Goal

The legacy OSSRH publishing service will be sunset on June 30th, 2025. [[Notice here]](https://central.sonatype.org/publish/publish-guide/)

[[Here]](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/) are the differences between Legacy OSSRH and Central Portal.

I already migrated the repo through self-service migration and generated a new token, which will be set as a secret in this repo. 

This PR follows the docs on [[this page]](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) to use the new URLs. It seems like it's a short-term solution for the migration, as they intend users to use another API for publication. I'd wait until there's an official Gradle plugin released for Central Portal publication, or we could also migrate everything to use https://github.com/vanniktech/gradle-maven-publish-plugin. 

In the meantime, this should allow us to release after June 30th.