### PR TITLE
Increase limit for log properties to 100

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/PropertyUtils.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/PropertyUtils.kt
@@ -8,7 +8,7 @@ import java.io.Serializable
  */
 object PropertyUtils {
 
-    const val MAX_PROPERTY_SIZE: Int = 10
+    const val MAX_PROPERTY_SIZE: Int = 50
 
     fun sanitizeProperties(properties: Map<String, Any>?, bypassPropertyLimit: Boolean = false): Map<String, Any> {
         return if (properties == null) {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/PropertyUtilsTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/PropertyUtilsTest.kt
@@ -16,8 +16,8 @@ internal class PropertyUtilsTest {
 
     @Test
     fun testPropertyLimitExceeded() {
-        val input = (0..20).associateBy { "$it" }
-        val expected = (0..9).associateBy { "$it" }
+        val input = (0..70).associateBy { "$it" }
+        val expected = (0..49).associateBy { "$it" }
         assertEquals(expected, sanitizeProperties(input as Map<String, Any>?))
     }
 
@@ -44,7 +44,7 @@ internal class PropertyUtilsTest {
         sourceMap[""] = "Empty key"
         sourceMap["EmptyValue"] = ""
         sourceMap["NullValue"] = ""
-        for (i in 1..9) {
+        for (i in 1..99) {
             sourceMap["Key$i"] = "Value$i"
         }
         val resultMap = sanitizeProperties(sourceMap)


### PR DESCRIPTION
## Goal

Change the hardcoded limit for the number of properties set on Embrace logs to 50 and up the limit of total attributes on OTel logs to support the case of setting over 100 session properties

