### PR TITLE
EmbraceAnrService cleanup

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
@@ -100,18 +100,6 @@ internal class EmbraceAnrService(
         }
     }
 
-    fun processAnrTick(timestamp: Long) {
-        // Check if ANR capture is enabled
-        if (!configService.anrBehavior.isAnrCaptureEnabled()) {
-            return
-        }
-
-        // Invoke callbacks
-        for (listener in listeners) {
-            listener.onThreadBlockedInterval(looper.thread, timestamp)
-        }
-    }
-
     /**
      * When app goes to foreground, we need to monitor the target thread again to
      * capture ANRs.
@@ -131,6 +119,18 @@ internal class EmbraceAnrService(
     override fun onBackground(timestamp: Long) {
         this.anrMonitorWorker.submit {
             livenessCheckScheduler.stopMonitoringThread()
+        }
+    }
+
+    private fun processAnrTick(timestamp: Long) {
+        // Check if ANR capture is enabled
+        if (!configService.anrBehavior.isAnrCaptureEnabled()) {
+            return
+        }
+
+        // Invoke callbacks
+        for (listener in listeners) {
+            listener.onThreadBlockedInterval(looper.thread, timestamp)
         }
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
@@ -33,7 +33,7 @@ internal class EmbraceAnrService(
     private val stacktraceSampler: AnrStacktraceSampler,
 ) : AnrService, MemoryCleanerListener, ProcessStateListener, BlockedThreadListener {
 
-    val listeners: CopyOnWriteArrayList<BlockedThreadListener> = CopyOnWriteArrayList<BlockedThreadListener>()
+    private val listeners: CopyOnWriteArrayList<BlockedThreadListener> = CopyOnWriteArrayList<BlockedThreadListener>()
 
     init {
         // add listeners

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
@@ -30,14 +30,8 @@ internal class EmbraceAnrService(
     private val anrMonitorWorker: BackgroundWorker,
     private val state: ThreadMonitoringState,
     private val clock: Clock,
+    private val stacktraceSampler: AnrStacktraceSampler,
 ) : AnrService, MemoryCleanerListener, ProcessStateListener, BlockedThreadListener {
-
-    val stacktraceSampler: AnrStacktraceSampler = AnrStacktraceSampler(
-        configService,
-        clock,
-        looper.thread,
-        anrMonitorWorker
-    )
 
     val listeners: CopyOnWriteArrayList<BlockedThreadListener> = CopyOnWriteArrayList<BlockedThreadListener>()
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import android.os.Looper
 import io.embrace.android.embracesdk.internal.anr.AnrOtelMapper
 import io.embrace.android.embracesdk.internal.anr.AnrService
+import io.embrace.android.embracesdk.internal.anr.AnrStacktraceSampler
 import io.embrace.android.embracesdk.internal.anr.EmbraceAnrService
 import io.embrace.android.embracesdk.internal.anr.detection.BlockedThreadDetector
 import io.embrace.android.embracesdk.internal.anr.detection.LivenessCheckScheduler
@@ -31,7 +32,8 @@ internal class AnrModuleImpl(
                 livenessCheckScheduler = livenessCheckScheduler,
                 anrMonitorWorker = anrMonitorWorker,
                 state = state,
-                clock = initModule.clock
+                clock = initModule.clock,
+                stacktraceSampler = stacktraceSampler
             )
         } else {
             null
@@ -49,6 +51,15 @@ internal class AnrModuleImpl(
     private val looper by singleton { Looper.getMainLooper() }
 
     private val state by singleton { ThreadMonitoringState(initModule.clock) }
+
+    private val stacktraceSampler by singleton {
+        AnrStacktraceSampler(
+            configService = configService,
+            clock = initModule.clock,
+            targetThread = looper.thread,
+            anrMonitorWorker = anrMonitorWorker
+        )
+    }
 
     private val targetThreadHandler by singleton {
         TargetThreadHandler(

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceRule.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceRule.kt
@@ -37,6 +37,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
     lateinit var anrExecutorService: T
     lateinit var targetThreadHandler: TargetThreadHandler
     lateinit var anrMonitorThread: AtomicReference<Thread>
+    lateinit var stacktraceSampler: AnrStacktraceSampler
 
     override fun before() {
         clock.setCurrentTime(0)
@@ -68,6 +69,12 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             blockedThreadDetector = blockedThreadDetector,
             logger = logger
         )
+        stacktraceSampler = AnrStacktraceSampler(
+            configService = fakeConfigService,
+            clock = clock,
+            targetThread = looper.thread,
+            anrMonitorWorker = worker
+        )
         anrService = EmbraceAnrService(
             configService = fakeConfigService,
             looper = looper,
@@ -75,7 +82,8 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             livenessCheckScheduler = livenessCheckScheduler,
             anrMonitorWorker = worker,
             state = state,
-            clock = clock
+            clock = clock,
+            stacktraceSampler = stacktraceSampler
         )
     }
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
@@ -158,7 +158,7 @@ internal class EmbraceAnrServiceTest {
             blockedThreadDetector.listener = anrService
             state.anrInProgress = true
             state.lastTargetThreadResponseMs = 15000000L
-            anrService.processAnrTick(clock.now())
+            anrService.onThreadBlockedInterval(currentThread(), clock.now())
             assertEquals(1, stacktraceSampler.size())
 
             // assert only one anr interval was added from the anrInProgress flag
@@ -291,7 +291,7 @@ internal class EmbraceAnrServiceTest {
             // create an ANR service with config that disables ANR capture
             rule.anrBehavior.anrCaptureEnabled = false
             clock.setCurrentTime(15020000L)
-            anrService.processAnrTick(clock.now())
+            anrService.onThreadBlockedInterval(currentThread(), clock.now())
             assertEquals(0, stacktraceSampler.size())
 
             // assert no anr intervals were added

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
@@ -75,7 +75,7 @@ internal class EmbraceAnrServiceTest {
             anrService.onForeground(true, 0L)
 
             // assert no ANR interval was added
-            assertEquals(0, anrService.stacktraceSampler.anrIntervals.size)
+            assertEquals(0, stacktraceSampler.anrIntervals.size)
         }
     }
 
@@ -83,7 +83,7 @@ internal class EmbraceAnrServiceTest {
     fun testCleanCollections() {
         with(rule) {
             // assert the ANR interval was added
-            val anrIntervals = anrService.stacktraceSampler.anrIntervals
+            val anrIntervals = stacktraceSampler.anrIntervals
             anrIntervals.add(AnrInterval(startTime = 15000000, endTime = 15000100))
             val inProgressInterval = AnrInterval(startTime = 15000000, lastKnownTime = 15000100)
             anrIntervals.add(inProgressInterval)
@@ -101,7 +101,7 @@ internal class EmbraceAnrServiceTest {
     @Test
     fun testGetIntervals() {
         with(rule) {
-            populateAnrIntervals(anrService)
+            populateAnrIntervals()
 
             val anrIntervals = anrService.getCapturedData()
             assertEquals(5, anrIntervals.size)
@@ -154,7 +154,7 @@ internal class EmbraceAnrServiceTest {
             state.anrInProgress = true
             state.lastTargetThreadResponseMs = 15000000L
             anrService.processAnrTick(clock.now())
-            assertEquals(1, anrService.stacktraceSampler.size())
+            assertEquals(1, stacktraceSampler.size())
 
             // assert only one anr interval was added from the anrInProgress flag
             val anrIntervals = anrService.getCapturedData()
@@ -257,10 +257,9 @@ internal class EmbraceAnrServiceTest {
                 }
                 anrService.onThreadUnblocked(currentThread(), clock.now())
 
-                val sampler = anrService.stacktraceSampler
-                assertEquals(1, sampler.anrIntervals.size)
+                assertEquals(1, stacktraceSampler.anrIntervals.size)
 
-                val interval = checkNotNull(sampler.anrIntervals.first())
+                val interval = checkNotNull(stacktraceSampler.anrIntervals.first())
                 val samples = checkNotNull(interval.anrSampleList).samples
                 assertEquals(count, samples.size)
 
@@ -288,7 +287,7 @@ internal class EmbraceAnrServiceTest {
             rule.anrBehavior.anrCaptureEnabled = false
             clock.setCurrentTime(15020000L)
             anrService.processAnrTick(clock.now())
-            assertEquals(0, anrService.stacktraceSampler.size())
+            assertEquals(0, stacktraceSampler.size())
 
             // assert no anr intervals were added
             val anrIntervals = anrService.getCapturedData()
@@ -300,16 +299,15 @@ internal class EmbraceAnrServiceTest {
     fun testReachedAnrCaptureLimit() {
         with(rule) {
             rule.anrBehavior.anrPerSessionImpl = 3
-            val state = anrService.stacktraceSampler
-            assertFalse(state.reachedAnrStacktraceCaptureLimit())
+            assertFalse(stacktraceSampler.reachedAnrStacktraceCaptureLimit())
 
-            state.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
-            state.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
-            state.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
-            assertFalse(state.reachedAnrStacktraceCaptureLimit())
+            stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
+            stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
+            stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
+            assertFalse(stacktraceSampler.reachedAnrStacktraceCaptureLimit())
 
-            state.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
-            assertTrue(state.reachedAnrStacktraceCaptureLimit())
+            stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
+            assertTrue(stacktraceSampler.reachedAnrStacktraceCaptureLimit())
         }
     }
 
@@ -401,7 +399,7 @@ internal class EmbraceAnrServiceTest {
             anrExecutorService.submit {
                 assertTrue(state.started.get())
             }
-            populateAnrIntervals(anrService)
+            populateAnrIntervals()
             anrService.handleCrash("")
             val anrIntervals = anrService.getCapturedData()
             assertEquals(5, anrIntervals.size)
@@ -409,13 +407,15 @@ internal class EmbraceAnrServiceTest {
         }
     }
 
-    private fun populateAnrIntervals(anrService: EmbraceAnrService) {
-        val state = anrService.stacktraceSampler
-        state.anrIntervals.add(AnrInterval(startTime = 14000000L))
-        state.anrIntervals.add(AnrInterval(startTime = 15000000L))
-        state.anrIntervals.add(AnrInterval(startTime = 15000500L))
-        state.anrIntervals.add(AnrInterval(startTime = 15001000L))
-        state.anrIntervals.add(AnrInterval(startTime = 16000000L))
+    private fun populateAnrIntervals() {
+        with(rule) {
+            val state = stacktraceSampler
+            state.anrIntervals.add(AnrInterval(startTime = 14000000L))
+            state.anrIntervals.add(AnrInterval(startTime = 15000000L))
+            state.anrIntervals.add(AnrInterval(startTime = 15000500L))
+            state.anrIntervals.add(AnrInterval(startTime = 15001000L))
+            state.anrIntervals.add(AnrInterval(startTime = 16000000L))
+        }
     }
 
     /**

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTest.kt
@@ -62,8 +62,13 @@ internal class EmbraceAnrServiceTest {
         with(rule) {
             val listener = FakeBlockedThreadListener()
             anrService.addBlockedThreadListener(listener)
-            assertEquals(anrService, blockedThreadDetector.listener)
-            assertTrue(anrService.listeners.contains(listener))
+
+            // Test that the listener actually gets notified when thread blocking events occur
+            anrService.onThreadBlocked(currentThread(), 1000L)
+            assertEquals(1, listener.blockedCount)
+
+            anrService.onThreadUnblocked(currentThread(), 2000L)
+            assertEquals(1, listener.unblockedCount)
         }
     }
 


### PR DESCRIPTION
## Goal

I'll start working on a new use case for EmbraceAnrService tomorrow, so I'm doing some preparatory cleanup. No behavior changes, just tidying up fields initialization and access modifiers.