### PR TITLE
Bump versions on AGP/Gradle support tests

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.integration.testcases
 
+import io.embrace.android.gradle.config.TestMatrix
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.ProjectType
 import io.embrace.android.gradle.integration.framework.smali.SmaliConfigReader
@@ -106,6 +107,7 @@ class AndroidNdkTest {
             fixture = "android-3rd-party-symbols",
             task = "build",
             projectType = ProjectType.ANDROID,
+            testMatrix = TestMatrix.NewerVersion,
             setup = {
                 setupMockResponses(
                     defaultExpectedLibs,
@@ -114,7 +116,7 @@ class AndroidNdkTest {
                 )
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(defaultExpectedVariants, testMatrix = TestMatrix.NewerVersion)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             }
@@ -128,12 +130,13 @@ class AndroidNdkTest {
         rule.runTest(
             fixture = "android-local-and-3rd-party-symbols",
             task = "build",
+            testMatrix = TestMatrix.NewerVersion,
             projectType = ProjectType.ANDROID,
             setup = {
                 setupMockResponses(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(defaultExpectedVariants, testMatrix = TestMatrix.NewerVersion)
                 verifyHandshakes(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             }

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.integration.testcases
 
+import io.embrace.android.gradle.config.TestMatrix
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.smali.SmaliConfigReader
 import io.embrace.android.gradle.integration.framework.smali.SmaliMethod
@@ -44,12 +45,13 @@ class ReactNativeAndroidTest {
             fixture = "react-native-android",
             androidProjectRoot = "android",
             task = "build",
+            testMatrix = TestMatrix.NewerVersion,
             setup = { projectDir ->
                 installNodeModules(projectDir)
                 setupMockResponses(handshakeLibs, handshakeArchs, defaultExpectedVariants)
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(defaultExpectedVariants, testMatrix = TestMatrix.NewerVersion)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(handshakeLibs, handshakeArchs, defaultExpectedVariants)
             }
@@ -62,6 +64,7 @@ class ReactNativeAndroidTest {
             fixture = "react-native-android",
             androidProjectRoot = "android",
             task = "assembleRelease",
+            testMatrix = TestMatrix.NewerVersion,
             setup = { projectDir ->
                 setupEmptyHandshakeResponse()
                 installNodeModules(projectDir)

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
@@ -39,11 +39,11 @@ sealed class TestMatrix(
     /**
      * Not the latest, but newer than the middle of the pack.
      */
-    object NewerVersion : TestMatrix("8.5.2", "8.7", "2.0.0", JdkEnv.JAVA_17)
+    object NewerVersion : TestMatrix("8.6.0", "8.14.2", "2.0.0", JdkEnv.JAVA_17)
 
     /**
      * The maximum version we currently run tests against. Newer versions may work, but are not
      * explicitly tested.
      */
-    object MaxVersion : TestMatrix("8.9.1", "8.13", "2.1.20", JdkEnv.JAVA_17)
+    object MaxVersion : TestMatrix("8.10.1", "9.0.0-rc-1", "2.1.21", JdkEnv.JAVA_17)
 }


### PR DESCRIPTION
## Goal

Bumps the versions used on the AGP/Gradle support tests given that Gradle 9 will be released imminently.