### PR TITLE
Use typealiases for opentelemetry-java

### DIFF
--- a/embrace-android-api/build.gradle.kts
+++ b/embrace-android-api/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.sdk)
     implementation(libs.lifecycle.process)
+    implementation(libs.opentelemetry.java.aliases)
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/OTelApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/OTelApi.kt
@@ -1,12 +1,10 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.annotation.InternalApi
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
-import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 
 /**
  * Methods that enable integration with the the large OTel ecosystem through standard OTel APIs and concepts.
@@ -17,18 +15,18 @@ public interface OTelApi {
     /**
      * Add a [LogRecordExporter] that OTel Logs will be exported to after logging
      */
-    public fun addLogRecordExporter(logRecordExporter: LogRecordExporter)
+    public fun addLogRecordExporter(logRecordExporter: OtelJavaLogRecordExporter)
 
     /**
      * Adds a [SpanExporter] that OTel Spans will be exported to after completion
      */
-    public fun addSpanExporter(spanExporter: SpanExporter)
+    public fun addSpanExporter(spanExporter: OtelJavaSpanExporter)
 
     /**
      * Returns an [OpenTelemetry] that provides working [Tracer] implementations that will record spans that fit into the Embrace data
      * model.
      */
-    public fun getOpenTelemetry(): OpenTelemetry
+    public fun getOpenTelemetry(): OtelJavaOpenTelemetry
 
     /**
      * Set an attribute on the [Resource] used by the OTel SDK instance with the given [AttributeKey] key and String value.
@@ -36,7 +34,7 @@ public interface OTelApi {
      * This must be called before the SDK is started in order for it to take effect.
      */
     public fun setResourceAttribute(
-        key: AttributeKey<String>,
+        key: OtelJavaAttributeKey<String>,
         value: String
     ): Unit = setResourceAttribute(key.key, value)
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpan.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.spans
 
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.SpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 
 /**
  * Represents a Span that can be started and stopped with the appropriate [ErrorCode] if applicable. This wraps the OpenTelemetry Span
@@ -12,7 +11,7 @@ public interface EmbraceSpan {
     /**
      * The [SpanContext] for this [EmbraceSpan] instance. This is null if the span has not been started.
      */
-    public val spanContext: SpanContext?
+    public val spanContext: OtelJavaSpanContext?
 
     /**
      * ID of the Trace that this Span belongs to. The format adheres to the OpenTelemetry standard for Trace IDs
@@ -141,7 +140,7 @@ public interface EmbraceSpan {
      * Add a link to the span with the given [SpanContext]
      */
     public fun addLink(
-        linkedSpanContext: SpanContext
+        linkedSpanContext: OtelJavaSpanContext
     ): Boolean = addLink(linkedSpanContext = linkedSpanContext, attributes = null)
 
     /**
@@ -159,5 +158,5 @@ public interface EmbraceSpan {
     /**
      * Add a link to the span with the given [SpanContext] with the given attributes
      */
-    public fun addLink(linkedSpanContext: SpanContext, attributes: Map<String, String>?): Boolean
+    public fun addLink(linkedSpanContext: OtelJavaSpanContext, attributes: Map<String, String>?): Boolean
 }

--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
     implementation(libs.opentelemetry.kotlin.compat)
+    implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -10,10 +10,11 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerProvider
 
 /**
  * Module that instantiates various OpenTelemetry related components
@@ -39,7 +40,7 @@ interface OpenTelemetryModule {
     /**
      * An instance of the OpenTelemetry component obtained from the wrapped SDK to create spans
      */
-    val sdkTracer: Tracer
+    val sdkTracer: OtelJavaTracer
 
     /**
      * Component that manages and provides access to the current session span
@@ -76,17 +77,17 @@ interface OpenTelemetryModule {
      * Embrace APIs. Currently, only the APIs related [Tracer] have operational implementations. Every other method will return no-op
      * implementations that records no data.
      */
-    val externalOpenTelemetry: OpenTelemetry
+    val externalOpenTelemetry: OtelJavaOpenTelemetry
 
     /**
      * Provides [Tracer] instances for instrumentation external to the Embrace SDK to create spans
      */
-    val externalTracerProvider: TracerProvider
+    val externalTracerProvider: OtelJavaTracerProvider
 
     /**
      * OpenTelemetry SDK compatible clock based on the internal Embrace clock instance
      */
-    val openTelemetryClock: io.opentelemetry.sdk.common.Clock
+    val openTelemetryClock: OtelJavaClock
 
     /**
      * Setup configuration configuration-dependent behavior

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -24,16 +24,16 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerProvider
-import io.opentelemetry.sdk.common.Clock
 
 @OptIn(ExperimentalApi::class)
 internal class OpenTelemetryModuleImpl(
     private val initModule: InitModule,
-    override val openTelemetryClock: Clock = EmbClock(
+    override val openTelemetryClock: OtelJavaClock = EmbClock(
         embraceClock = initModule.clock
     ),
 ) : OpenTelemetryModule {
@@ -75,7 +75,7 @@ internal class OpenTelemetryModuleImpl(
         }
     }
 
-    override val sdkTracer: Tracer by lazy {
+    override val sdkTracer: OtelJavaTracer by lazy {
         otelSdkWrapper.sdkTracer
     }
 
@@ -150,13 +150,13 @@ internal class OpenTelemetryModuleImpl(
         LogSinkImpl()
     }
 
-    override val externalOpenTelemetry: OpenTelemetry by lazy {
+    override val externalOpenTelemetry: OtelJavaOpenTelemetry by lazy {
         EmbOpenTelemetry(
             traceProviderSupplier = { externalTracerProvider }
         )
     }
 
-    override val externalTracerProvider: TracerProvider by lazy {
+    override val externalTracerProvider: OtelJavaTracerProvider by lazy {
         EmbTracerProvider(
             sdkTracerProvider = otelSdkWrapper.sdkTracerProvider,
             spanService = spanService,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -19,14 +19,14 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 internal class CurrentSessionSpanImpl(
-    private val openTelemetryClock: Clock,
+    private val openTelemetryClock: OtelJavaClock,
     private val telemetryService: TelemetryService,
     private val spanRepository: SpanRepository,
     private val spanSink: SpanSink,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
@@ -27,6 +27,7 @@ internal class LogPayloadSourceImplTest {
         impl = LogPayloadSourceImpl(sink)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `getBatchedLogPayload returns a correct payload`() {
         sink.storeLogs(listOf(fakeLog))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSourceImpl
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -58,7 +58,7 @@ internal class LogOrchestratorTest {
 
     @Test
     fun `send a batch of logs when the batch max size is reached`() {
-        val logs = mutableListOf<LogRecordData>()
+        val logs = mutableListOf<OtelJavaLogRecordData>()
 
         // Fill the sink with max batch size - 1 logs
         repeat(LogOrchestratorImpl.MAX_LOGS_PER_BATCH - 1) {
@@ -157,7 +157,7 @@ internal class LogOrchestratorTest {
     @Test
     fun `simulate race condition`() {
         val fakeLog = FakeLogRecordData()
-        val fakeLogs = mutableListOf<LogRecordData>()
+        val fakeLogs = mutableListOf<OtelJavaLogRecordData>()
         val threads = mutableListOf<ScheduledExecutorService>()
         val latch = CountDownLatch(49)
         repeat(49) {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -31,8 +31,8 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl.Compa
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -46,10 +46,10 @@ internal class CurrentSessionSpanImplTests {
     private lateinit var spanRepository: SpanRepository
     private lateinit var spanSink: SpanSink
     private lateinit var telemetryService: TelemetryService
-    private lateinit var openTelemetryClock: Clock
+    private lateinit var openTelemetryClock: OtelJavaClock
     private lateinit var currentSessionSpan: CurrentSessionSpanImpl
     private lateinit var spanService: SpanService
-    private lateinit var tracer: Tracer
+    private lateinit var tracer: OtelJavaTracer
     private val clock = FakeClock(1000L)
 
     @Before

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
     implementation(libs.opentelemetry.kotlin.compat)
+    implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(project(":embrace-android-api"))
     testImplementation(project(":embrace-android-core"))

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/activity/UiLoadExt.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.ui.DrawEventEmitter
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -24,7 +24,7 @@ fun createActivityLoadEventEmitter(
     uiLoadEventListener: UiLoadEventListener,
     firstDrawDetector: DrawEventEmitter?,
     autoTraceEnabled: Boolean,
-    clock: Clock,
+    clock: OtelJavaClock,
     versionChecker: VersionChecker,
 ): ActivityLifecycleListener {
     val lifecycleEventEmitter = LifecycleEventEmitter(
@@ -120,7 +120,7 @@ private class LifecycleEventEmitter(
     private val uiLoadEventListener: UiLoadEventListener,
     private val drawEventEmitter: DrawEventEmitter?,
     private val autoTraceEnabled: Boolean,
-    private val clock: Clock,
+    private val clock: OtelJavaClock,
 ) {
 
     private val instanceStartTime: MutableMap<Int, Long> = ConcurrentHashMap()

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicReference
  *
  */
 internal class AppStartupTraceEmitter(
-    private val clock: Clock,
+    private val clock: OtelJavaClock,
     private val startupServiceProvider: Provider<StartupService?>,
     private val spanService: SpanService,
     private val versionChecker: VersionChecker,

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -31,7 +31,7 @@ import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.ui.supportFrameCommitCallback
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -60,7 +60,7 @@ internal class AppStartupTraceEmitterTest {
     private var hasFrameCommitEvent = true
 
     private lateinit var clock: FakeClock
-    private lateinit var otelClock: Clock
+    private lateinit var otelClock: OtelJavaClock
     private lateinit var spanSink: SpanSink
     private lateinit var spanService: SpanService
     private lateinit var logger: FakeEmbLogger

--- a/embrace-android-otel/build.gradle.kts
+++ b/embrace-android-otel/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     compileOnly(libs.opentelemetry.sdk)
     compileOnly(libs.opentelemetry.semconv)
     compileOnly(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
@@ -1,34 +1,36 @@
 package io.embrace.android.embracesdk.internal.otel
 
-import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.payload.Span.Status
 import io.embrace.opentelemetry.kotlin.StatusCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
-import io.opentelemetry.api.common.AttributeKey
 
-internal fun StatusCode.toOtelJava(): io.opentelemetry.api.trace.StatusCode = when (this) {
-    is StatusCode.Unset -> io.opentelemetry.api.trace.StatusCode.UNSET
-    is StatusCode.Ok -> io.opentelemetry.api.trace.StatusCode.OK
-    is StatusCode.Error -> io.opentelemetry.api.trace.StatusCode.ERROR
+internal fun StatusCode.toOtelJava(): OtelJavaStatusCode = when (this) {
+    is StatusCode.Unset -> OtelJavaStatusCode.UNSET
+    is StatusCode.Ok -> OtelJavaStatusCode.OK
+    is StatusCode.Error -> OtelJavaStatusCode.ERROR
 }
 
-internal fun io.opentelemetry.api.trace.StatusCode.toOtelKotlin(): StatusCode = when (this) {
-    io.opentelemetry.api.trace.StatusCode.UNSET -> StatusCode.Unset
-    io.opentelemetry.api.trace.StatusCode.OK -> StatusCode.Ok
-    io.opentelemetry.api.trace.StatusCode.ERROR -> StatusCode.Error(null)
+internal fun OtelJavaStatusCode.toOtelKotlin(): StatusCode = when (this) {
+    OtelJavaStatusCode.UNSET -> StatusCode.Unset
+    OtelJavaStatusCode.OK -> StatusCode.Ok
+    OtelJavaStatusCode.ERROR -> StatusCode.Error(null)
 }
 
-fun io.opentelemetry.api.trace.SpanKind.toOtelKotlin(): SpanKind = when (this) {
-    io.opentelemetry.api.trace.SpanKind.SERVER -> SpanKind.SERVER
-    io.opentelemetry.api.trace.SpanKind.CLIENT -> SpanKind.CLIENT
-    io.opentelemetry.api.trace.SpanKind.PRODUCER -> SpanKind.PRODUCER
-    io.opentelemetry.api.trace.SpanKind.CONSUMER -> SpanKind.CONSUMER
-    io.opentelemetry.api.trace.SpanKind.INTERNAL -> SpanKind.INTERNAL
+fun OtelJavaSpanKind.toOtelKotlin(): SpanKind = when (this) {
+    OtelJavaSpanKind.SERVER -> SpanKind.SERVER
+    OtelJavaSpanKind.CLIENT -> SpanKind.CLIENT
+    OtelJavaSpanKind.PRODUCER -> SpanKind.PRODUCER
+    OtelJavaSpanKind.CONSUMER -> SpanKind.CONSUMER
+    OtelJavaSpanKind.INTERNAL -> SpanKind.INTERNAL
 }
 
-fun StatusCode.toEmbracePayload(): Span.Status = when (this) {
-    is StatusCode.Error -> io.embrace.android.embracesdk.internal.payload.Span.Status.ERROR
-    StatusCode.Ok -> io.embrace.android.embracesdk.internal.payload.Span.Status.OK
-    StatusCode.Unset -> io.embrace.android.embracesdk.internal.payload.Span.Status.UNSET
+fun StatusCode.toEmbracePayload(): Status = when (this) {
+    is StatusCode.Error -> Status.ERROR
+    StatusCode.Ok -> Status.OK
+    StatusCode.Unset -> Status.UNSET
 }
 
-internal fun String.toOtelJavaAttributeKey() = AttributeKey.stringKey(this)
+internal fun String.toOtelJavaAttributeKey() = OtelJavaAttributeKey.stringKey(this)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/attrs/EmbraceAttributeKeyExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/attrs/EmbraceAttributeKeyExt.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.otel.attrs
 
-import io.opentelemetry.api.common.AttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 
 /**
  * Converts an [EmbraceAttributeKey] to an OTel Java [AttributeKey].
  */
-fun EmbraceAttributeKey.asOtelAttributeKey(): AttributeKey<String> = AttributeKey.stringKey(name)
+fun EmbraceAttributeKey.asOtelAttributeKey(): OtelJavaAttributeKey<String> = OtelJavaAttributeKey.stringKey(name)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -9,12 +9,12 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanExporter
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanProcessor
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
-import io.opentelemetry.sdk.logs.LogRecordProcessor
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
-import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.sdk.resources.ResourceBuilder
-import io.opentelemetry.sdk.trace.SpanProcessor
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResourceBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
 import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
@@ -29,7 +29,7 @@ class OtelSdkConfig(
     systemInfo: SystemInfo,
     private val processIdentifierProvider: () -> String = IdGenerator.Companion::generateLaunchInstanceId,
 ) {
-    val resourceBuilder: ResourceBuilder = Resource.getDefault().toBuilder()
+    val resourceBuilder: OtelJavaResourceBuilder = OtelJavaResource.getDefault().toBuilder()
         .put(ServiceAttributes.SERVICE_NAME, sdkName)
         .put(ServiceAttributes.SERVICE_VERSION, sdkVersion)
         .put(OsIncubatingAttributes.OS_NAME, systemInfo.osName)
@@ -52,8 +52,8 @@ class OtelSdkConfig(
         EmbTrace.trace("process-identifier-init", processIdentifierProvider)
     }
 
-    private val externalSpanExporters = mutableListOf<SpanExporter>()
-    private val externalLogExporters = mutableListOf<LogRecordExporter>()
+    private val externalSpanExporters = mutableListOf<OtelJavaSpanExporter>()
+    private val externalLogExporters = mutableListOf<OtelJavaLogRecordExporter>()
 
     private var exportEnabled: Boolean = true
     private val exportCheck: () -> Boolean = { exportEnabled }
@@ -62,12 +62,12 @@ class OtelSdkConfig(
         exportEnabled = false
     }
 
-    val spanProcessor: SpanProcessor by lazy {
+    val spanProcessor: OtelJavaSpanProcessor by lazy {
         EmbraceSpanProcessor(
             EmbraceSpanExporter(
                 spanSink = spanSink,
                 externalSpanExporter = if (externalSpanExporters.isNotEmpty()) {
-                    SpanExporter.composite(externalSpanExporters)
+                    OtelJavaSpanExporter.composite(externalSpanExporters)
                 } else {
                     null
                 },
@@ -77,12 +77,12 @@ class OtelSdkConfig(
         )
     }
 
-    val logProcessor: LogRecordProcessor by lazy {
+    val logProcessor: OtelJavaLogRecordProcessor by lazy {
         EmbraceLogRecordProcessor(
             EmbraceLogRecordExporter(
                 logSink = logSink,
                 externalLogRecordExporter = if (externalLogExporters.isNotEmpty()) {
-                    LogRecordExporter.composite(externalLogExporters)
+                    OtelJavaLogRecordExporter.composite(externalLogExporters)
                 } else {
                     null
                 },
@@ -91,11 +91,11 @@ class OtelSdkConfig(
         )
     }
 
-    fun addSpanExporter(spanExporter: SpanExporter) {
+    fun addSpanExporter(spanExporter: OtelJavaSpanExporter) {
         externalSpanExporters.add(spanExporter)
     }
 
-    fun addLogExporter(logExporter: LogRecordExporter) {
+    fun addLogExporter(logExporter: OtelJavaLogRecordExporter) {
         externalLogExporters.add(logExporter)
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbClock.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbClock.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.otel.impl
 
 import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 
 /**
  * A clock that is compatible with the OpenTelemetry SDK that defers to the internal clock used by Embrace. This allows the times recorded
@@ -13,7 +14,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
  */
 class EmbClock(
     private val embraceClock: Clock,
-) : io.opentelemetry.sdk.common.Clock {
+) : OtelJavaClock {
 
     override fun now(): Long = embraceClock.nowInNanos()
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetry.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetry.kt
@@ -1,17 +1,17 @@
 package io.embrace.android.embracesdk.internal.otel.impl
 
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.TracerProvider
-import io.opentelemetry.context.propagation.ContextPropagators
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextPropagators
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 
 /**
  * Embrace-specific implementation that can be used to obtain working Tracer implementations that will record spans for Embrace sessions
  */
 class EmbOpenTelemetry(
-    private val traceProviderSupplier: () -> TracerProvider,
-) : OpenTelemetry {
+    private val traceProviderSupplier: () -> OtelJavaTracerProvider,
+) : OtelJavaOpenTelemetry {
 
-    override fun getTracerProvider(): TracerProvider = traceProviderSupplier()
+    override fun getTracerProvider(): OtelJavaTracerProvider = traceProviderSupplier()
 
-    override fun getPropagators(): ContextPropagators = ContextPropagators.noop()
+    override fun getPropagators(): OtelJavaContextPropagators = OtelJavaContextPropagators.noop()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
@@ -3,34 +3,34 @@ package io.embrace.android.embracesdk.internal.otel.impl
 import io.embrace.android.embracesdk.internal.otel.sdk.toStringMap
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.toOtelKotlin
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.context.Context
-import io.opentelemetry.context.Scope
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaScope
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import java.util.concurrent.TimeUnit
 
 class EmbSpan(
     private val embraceSpan: EmbraceSdkSpan,
-    private val clock: Clock,
-) : Span {
+    private val clock: OtelJavaClock,
+) : OtelJavaSpan {
 
-    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T?): Span {
+    override fun <T : Any> setAttribute(key: OtelJavaAttributeKey<T>, value: T?): OtelJavaSpan {
         embraceSpan.addAttribute(key = key.key, value = value.toString())
         return this
     }
 
-    override fun addEvent(name: String, attributes: Attributes): Span = addEvent(
+    override fun addEvent(name: String, attributes: OtelJavaAttributes): OtelJavaSpan = addEvent(
         name = name,
         attributes = attributes,
         timestamp = clock.now(),
         unit = TimeUnit.NANOSECONDS
     )
 
-    override fun addEvent(name: String, attributes: Attributes, timestamp: Long, unit: TimeUnit): Span {
+    override fun addEvent(name: String, attributes: OtelJavaAttributes, timestamp: Long, unit: TimeUnit): OtelJavaSpan {
         embraceSpan.addEvent(
             name = name,
             timestampMs = unit.toMillis(timestamp),
@@ -39,24 +39,24 @@ class EmbSpan(
         return this
     }
 
-    override fun addLink(spanContext: SpanContext, attributes: Attributes): Span {
+    override fun addLink(spanContext: OtelJavaSpanContext, attributes: OtelJavaAttributes): OtelJavaSpan {
         embraceSpan.addLink(spanContext, attributes.toStringMap())
         return this
     }
 
-    override fun setStatus(statusCode: StatusCode, description: String): Span {
+    override fun setStatus(statusCode: OtelJavaStatusCode, description: String): OtelJavaSpan {
         if (isRecording) {
             embraceSpan.setStatus(statusCode.toOtelKotlin(), description)
         }
         return this
     }
 
-    override fun recordException(exception: Throwable, additionalAttributes: Attributes): Span {
+    override fun recordException(exception: Throwable, additionalAttributes: OtelJavaAttributes): OtelJavaSpan {
         embraceSpan.recordException(exception, additionalAttributes.toStringMap())
         return this
     }
 
-    override fun updateName(name: String): Span {
+    override fun updateName(name: String): OtelJavaSpan {
         embraceSpan.updateName(name)
         return this
     }
@@ -69,9 +69,9 @@ class EmbSpan(
         }
     }
 
-    override fun getSpanContext(): SpanContext = embraceSpan.spanContext ?: SpanContext.getInvalid()
+    override fun getSpanContext(): OtelJavaSpanContext = embraceSpan.spanContext ?: OtelJavaSpanContext.getInvalid()
 
     override fun isRecording(): Boolean = embraceSpan.isRecording
 
-    override fun makeCurrent(): Scope = Context.current().with(this).with(embraceSpan).makeCurrent()
+    override fun makeCurrent(): OtelJavaScope = OtelJavaContext.current().with(this).with(embraceSpan).makeCurrent()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilder.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilder.kt
@@ -2,63 +2,63 @@ package io.embrace.android.embracesdk.internal.otel.impl
 
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanCreator
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanBuilder
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.context.Context
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import java.util.concurrent.TimeUnit
 
 class EmbSpanBuilder(
     private val otelSpanCreator: OtelSpanCreator,
     private val spanService: SpanService,
-    private val clock: Clock,
-) : SpanBuilder {
+    private val clock: OtelJavaClock,
+) : OtelJavaSpanBuilder {
 
     private val otelSpanStartArgs = otelSpanCreator.spanStartArgs
 
-    override fun setParent(context: Context): SpanBuilder {
+    override fun setParent(context: OtelJavaContext): OtelJavaSpanBuilder {
         otelSpanStartArgs.parentContext = context
         return this
     }
 
-    override fun setNoParent(): SpanBuilder {
-        otelSpanStartArgs.parentContext = Context.root()
+    override fun setNoParent(): OtelJavaSpanBuilder {
+        otelSpanStartArgs.parentContext = OtelJavaContext.root()
         return this
     }
 
-    override fun addLink(spanContext: SpanContext): SpanBuilder = addLink(spanContext, Attributes.empty())
+    override fun addLink(spanContext: OtelJavaSpanContext): OtelJavaSpanBuilder = addLink(spanContext, OtelJavaAttributes.empty())
 
-    override fun addLink(spanContext: SpanContext, attributes: Attributes): SpanBuilder = this
+    override fun addLink(spanContext: OtelJavaSpanContext, attributes: OtelJavaAttributes): OtelJavaSpanBuilder = this
 
-    override fun setAttribute(key: String, value: String): SpanBuilder {
+    override fun setAttribute(key: String, value: String): OtelJavaSpanBuilder {
         otelSpanStartArgs.customAttributes[key] = value
         return this
     }
 
-    override fun setAttribute(key: String, value: Long): SpanBuilder = setAttribute(key, value.toString())
+    override fun setAttribute(key: String, value: Long): OtelJavaSpanBuilder = setAttribute(key, value.toString())
 
-    override fun setAttribute(key: String, value: Double): SpanBuilder = setAttribute(key, value.toString())
+    override fun setAttribute(key: String, value: Double): OtelJavaSpanBuilder = setAttribute(key, value.toString())
 
-    override fun setAttribute(key: String, value: Boolean): SpanBuilder = setAttribute(key, value.toString())
+    override fun setAttribute(key: String, value: Boolean): OtelJavaSpanBuilder = setAttribute(key, value.toString())
 
-    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T): SpanBuilder =
+    override fun <T : Any> setAttribute(key: OtelJavaAttributeKey<T>, value: T): OtelJavaSpanBuilder =
         setAttribute(key.key, value.toString())
 
-    override fun setSpanKind(spanKind: SpanKind): SpanBuilder {
+    override fun setSpanKind(spanKind: OtelJavaSpanKind): OtelJavaSpanBuilder {
         otelSpanStartArgs.spanKind = spanKind
         return this
     }
 
-    override fun setStartTimestamp(startTimestamp: Long, unit: TimeUnit): SpanBuilder {
+    override fun setStartTimestamp(startTimestamp: Long, unit: TimeUnit): OtelJavaSpanBuilder {
         otelSpanStartArgs.startTimeMs = unit.toMillis(startTimestamp)
         return this
     }
 
-    override fun startSpan(): Span {
+    override fun startSpan(): OtelJavaSpan {
         spanService.createSpan(otelSpanCreator)?.let { embraceSpan ->
             if (embraceSpan.start()) {
                 return EmbSpan(
@@ -68,6 +68,6 @@ class EmbSpanBuilder(
             }
         }
 
-        return Span.getInvalid()
+        return OtelJavaSpan.getInvalid()
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
@@ -4,25 +4,25 @@ import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanCreator
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
-import io.opentelemetry.api.trace.SpanBuilder
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.context.Context
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 
 class EmbTracer(
-    private val sdkTracer: Tracer,
+    private val sdkTracer: OtelJavaTracer,
     private val spanService: SpanService,
-    private val clock: Clock,
-) : Tracer {
+    private val clock: OtelJavaClock,
+) : OtelJavaTracer {
 
-    override fun spanBuilder(spanName: String): SpanBuilder =
+    override fun spanBuilder(spanName: String): OtelJavaSpanBuilder =
         EmbSpanBuilder(
             otelSpanCreator = sdkTracer.otelSpanCreator(
                 name = spanName,
                 type = EmbType.Performance.Default,
                 private = false,
                 internal = false,
-                parent = Context.current().getEmbraceSpan(),
+                parent = OtelJavaContext.current().getEmbraceSpan(),
             ),
             spanService = spanService,
             clock = clock,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerBuilder.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerBuilder.kt
@@ -1,25 +1,25 @@
 package io.embrace.android.embracesdk.internal.otel.impl
 
 import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerBuilder
 
 internal class EmbTracerBuilder(
     instrumentationScopeName: String,
-    private val tracerSupplier: (tracerKey: TracerKey) -> Tracer,
-) : TracerBuilder {
+    private val tracerSupplier: (tracerKey: TracerKey) -> OtelJavaTracer,
+) : OtelJavaTracerBuilder {
 
     private val tracerKey: TracerKey = TracerKey(instrumentationScopeName = instrumentationScopeName)
 
-    override fun setSchemaUrl(schemaUrl: String): TracerBuilder {
+    override fun setSchemaUrl(schemaUrl: String): OtelJavaTracerBuilder {
         tracerKey.schemaUrl = schemaUrl
         return this
     }
 
-    override fun setInstrumentationVersion(instrumentationScopeVersion: String): TracerBuilder {
+    override fun setInstrumentationVersion(instrumentationScopeVersion: String): OtelJavaTracerBuilder {
         tracerKey.instrumentationScopeVersion = instrumentationScopeVersion
         return this
     }
 
-    override fun build(): Tracer = tracerSupplier(tracerKey)
+    override fun build(): OtelJavaTracer = tracerSupplier(tracerKey)
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProvider.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProvider.kt
@@ -2,40 +2,40 @@ package io.embrace.android.embracesdk.internal.otel.impl
 
 import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerBuilder
-import io.opentelemetry.api.trace.TracerProvider
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import java.util.concurrent.ConcurrentHashMap
 
 class EmbTracerProvider(
-    private val sdkTracerProvider: TracerProvider,
+    private val sdkTracerProvider: OtelJavaTracerProvider,
     private val spanService: SpanService,
-    private val clock: Clock,
-) : TracerProvider {
+    private val clock: OtelJavaClock,
+) : OtelJavaTracerProvider {
 
-    private val tracers = ConcurrentHashMap<TracerKey, Tracer>()
+    private val tracers = ConcurrentHashMap<TracerKey, OtelJavaTracer>()
 
-    override fun get(instrumentationScopeName: String): Tracer = tracerBuilder(instrumentationScopeName).build()
+    override fun get(instrumentationScopeName: String): OtelJavaTracer = tracerBuilder(instrumentationScopeName).build()
 
-    override fun get(instrumentationScopeName: String, instrumentationScopeVersion: String): Tracer =
+    override fun get(instrumentationScopeName: String, instrumentationScopeVersion: String): OtelJavaTracer =
         tracerBuilder(instrumentationScopeName).setInstrumentationVersion(instrumentationScopeVersion).build()
 
-    override fun tracerBuilder(instrumentationScopeName: String): TracerBuilder {
+    override fun tracerBuilder(instrumentationScopeName: String): OtelJavaTracerBuilder {
         return EmbTracerBuilder(
             instrumentationScopeName = instrumentationScopeName,
             tracerSupplier = ::getTracer
         )
     }
 
-    private fun getTracer(key: TracerKey): Tracer {
+    private fun getTracer(key: TracerKey): OtelJavaTracer {
         return tracers[key]
             ?: synchronized(tracers) {
                 return tracers[key] ?: createTracer(key)
             }
     }
 
-    private fun createTracer(key: TracerKey): Tracer {
+    private fun createTracer(key: TracerKey): OtelJavaTracer {
         val tracer = EmbTracer(
             sdkTracer = buildSdkTracer(key),
             spanService = spanService,
@@ -45,7 +45,7 @@ class EmbTracerProvider(
         return tracer
     }
 
-    private fun buildSdkTracer(key: TracerKey): Tracer {
+    private fun buildSdkTracer(key: TracerKey): OtelJavaTracer {
         val builder = sdkTracerProvider.tracerBuilder(key.instrumentationScopeName)
         key.instrumentationScopeVersion?.apply {
             builder.setInstrumentationVersion(this)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporter.kt
@@ -2,25 +2,25 @@ package io.embrace.android.embracesdk.internal.otel.logs
 
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.logs.data.LogRecordData
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 
 /**
  * Exports the given [LogRecordData] to a [LogSink]
  */
 internal class EmbraceLogRecordExporter(
     private val logSink: LogSink,
-    private val externalLogRecordExporter: LogRecordExporter?,
+    private val externalLogRecordExporter: OtelJavaLogRecordExporter?,
     private val exportCheck: () -> Boolean,
-) : LogRecordExporter {
+) : OtelJavaLogRecordExporter {
 
-    override fun export(logs: Collection<LogRecordData>): CompletableResultCode {
+    override fun export(logs: Collection<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
         if (!exportCheck()) {
-            return CompletableResultCode.ofSuccess()
+            return OtelJavaCompletableResultCode.ofSuccess()
         }
         val result = logSink.storeLogs(logs.toList())
-        if (externalLogRecordExporter != null && result == CompletableResultCode.ofSuccess()) {
+        if (externalLogRecordExporter != null && result == OtelJavaCompletableResultCode.ofSuccess()) {
             return externalLogRecordExporter.export(
                 logs.filterNot {
                     it.hasEmbraceAttribute(PrivateSpan)
@@ -31,7 +31,7 @@ internal class EmbraceLogRecordExporter(
         return result
     }
 
-    override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
+    override fun flush(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
 
-    override fun shutdown(): CompletableResultCode = CompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessor.kt
@@ -1,18 +1,18 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
-import io.opentelemetry.context.Context
-import io.opentelemetry.sdk.logs.LogRecordProcessor
-import io.opentelemetry.sdk.logs.ReadWriteLogRecord
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 
 /**
  * [LogRecordProcessor] that exports log records it to the given [LogRecordExporter]
  */
 internal class EmbraceLogRecordProcessor(
-    private val logRecordExporter: LogRecordExporter,
-) : LogRecordProcessor {
+    private val logRecordExporter: OtelJavaLogRecordExporter,
+) : OtelJavaLogRecordProcessor {
 
-    override fun onEmit(context: Context, logRecord: ReadWriteLogRecord) {
+    override fun onEmit(context: OtelJavaContext, logRecord: OtelJavaReadWriteLogRecord) {
         logRecordExporter.export(mutableListOf(logRecord.toLogRecordData()))
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
 import io.embrace.android.embracesdk.internal.payload.Log
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 
 /**
  * A service that stores exported logs and provides access to them so they
@@ -13,7 +13,7 @@ interface LogSink {
     /**
      * Store [Log] objects to be sent in the nexdt batch. Implementations must support concurrent invocations.
      */
-    fun storeLogs(logs: List<LogRecordData>): CompletableResultCode
+    fun storeLogs(logs: List<OtelJavaLogRecordData>): OtelJavaCompletableResultCode
 
     /**
      * Returns the list of currently stored [Log] objects, waiting to be sent in the next batch

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
@@ -6,8 +6,8 @@ import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.SendMode
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class LogSinkImpl : LogSink {
@@ -16,7 +16,7 @@ class LogSinkImpl : LogSink {
     private var onLogsStored: (() -> Unit)? = null
     private val flushLock = Any()
 
-    override fun storeLogs(logs: List<LogRecordData>): CompletableResultCode {
+    override fun storeLogs(logs: List<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
         try {
             logs.forEach { log ->
                 val mode = log.attributes[embSendMode.asOtelAttributeKey()]
@@ -34,10 +34,10 @@ class LogSinkImpl : LogSink {
             }
             onLogsStored?.invoke()
         } catch (t: Throwable) {
-            return CompletableResultCode.ofFailure()
+            return OtelJavaCompletableResultCode.ofFailure()
         }
 
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
     override fun logsForNextBatch(): List<Log> {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/LogMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/LogMapper.kt
@@ -2,11 +2,11 @@ package io.embrace.android.embracesdk.internal.otel.payload
 
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Log
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 
 @Suppress("DEPRECATION") // suppress for backwards compat
-fun LogRecordData.toEmbracePayload(): Log {
+fun OtelJavaLogRecordData.toEmbracePayload(): Log {
     val isSpanContextValid = spanContext.isValid
     return Log(
         traceId = if (isSpanContextValid) spanContext.traceId else null,
@@ -19,5 +19,5 @@ fun LogRecordData.toEmbracePayload(): Log {
     )
 }
 
-fun Attributes.toEmbracePayload(): List<Attribute> =
+fun OtelJavaAttributes.toEmbracePayload(): List<Attribute> =
     this.asMap().entries.map { Attribute(it.key.key, it.value.toString()) }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
@@ -17,7 +17,7 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.api.trace.SpanId
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
 
 fun EmbraceSpanData.toEmbracePayload(): Span = Span(
     traceId = traceId,
@@ -61,7 +61,7 @@ fun Span.toEmbracePayload(): EmbraceSpanData {
     return EmbraceSpanData(
         traceId = traceId ?: "",
         spanId = spanId ?: "",
-        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
+        parentSpanId = parentSpanId ?: OtelJavaSpanId.getInvalid(),
         name = name ?: "",
         startTimeNanos = startTimeNanos ?: 0,
         endTimeNanos = endTimeNanos ?: 0L,
@@ -87,7 +87,7 @@ fun Span.toFailedSpan(endTimeMs: Long): Span {
 
     return copy(
         endTimeNanos = endTimeMs.millisToNanos(),
-        parentSpanId = parentSpanId ?: SpanId.getInvalid(),
+        parentSpanId = parentSpanId ?: OtelJavaSpanId.getInvalid(),
         status = Span.Status.ERROR,
         attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
     )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
@@ -7,7 +7,8 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.opentelemetry.api.common.AttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.opentelemetry.semconv.ExceptionAttributes
 
 fun EmbraceSpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
@@ -43,7 +44,7 @@ fun List<Attribute>.findAttributeValue(key: String): String? = singleOrNull { it
 fun Map<String, String>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
     this[embraceAttribute.key.name] == embraceAttribute.value
 
-fun Map<String, String>.getAttribute(key: AttributeKey<String>): String? = this[key.key]
+fun Map<String, String>.getAttribute(key: OtelJavaAttributeKey<String>): String? = this[key.key]
 
 fun Map<String, String>.getAttribute(key: EmbraceAttributeKey): String? = this[key.name]
 
@@ -52,10 +53,10 @@ fun MutableMap<String, String>.setEmbraceAttribute(embraceAttribute: EmbraceAttr
     return this
 }
 
-fun Severity.toOtelSeverity(): io.opentelemetry.api.logs.Severity = when (this) {
-    Severity.INFO -> io.opentelemetry.api.logs.Severity.INFO
-    Severity.WARNING -> io.opentelemetry.api.logs.Severity.WARN
-    Severity.ERROR -> io.opentelemetry.api.logs.Severity.ERROR
+fun Severity.toOtelSeverity(): OtelJavaSeverity = when (this) {
+    Severity.INFO -> OtelJavaSeverity.INFO
+    Severity.WARNING -> OtelJavaSeverity.WARN
+    Severity.ERROR -> OtelJavaSeverity.ERROR
 }
 
 fun SpanEvent.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/IdGenerator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/IdGenerator.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.sdk
 
-import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.TraceId
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceId
 import kotlin.random.Random
 
 class IdGenerator(
@@ -13,12 +13,12 @@ class IdGenerator(
      * Note: because Embrace may be recording a span on our side for the given traceparent, we have set the "sampled" flag to indicate that.
      */
     fun generateTraceparent(): String =
-        "00-" + TraceId.fromLongs(
+        "00-" + OtelJavaTraceId.fromLongs(
             validRandomLong(),
             validRandomLong()
-        ) + "-" + SpanId.fromLong(validRandomLong()) + "-01"
+        ) + "-" + OtelJavaSpanId.fromLong(validRandomLong()) + "-01"
 
-    fun generateUUID(): String = SpanId.fromLong(validRandomLong())
+    fun generateUUID(): String = OtelJavaSpanId.fromLong(validRandomLong())
 
     private fun validRandomLong(): Long {
         var value: Long

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
@@ -8,26 +8,27 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData.Companion.fromEventData
 import io.embrace.android.embracesdk.internal.otel.toOtelKotlin
 import io.embrace.android.embracesdk.internal.payload.Link
+import io.embrace.android.embracesdk.internal.payload.Span.Status
 import io.embrace.android.embracesdk.internal.utils.isBlankish
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.common.AttributesBuilder
-import io.opentelemetry.api.logs.LogRecordBuilder
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.sdk.logs.data.LogRecordData
-import io.opentelemetry.sdk.trace.data.LinkData
-import io.opentelemetry.sdk.trace.data.SpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributesBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLinkData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 
 /**
  * Populate an [AttributesBuilder] with String key-value pairs from a [Map]
  */
-fun AttributesBuilder.fromMap(
+fun OtelJavaAttributesBuilder.fromMap(
     attributes: Map<String, String>,
     internal: Boolean,
     limitsValidator: DataValidator
-): AttributesBuilder {
+): OtelJavaAttributesBuilder {
     attributes.filter {
         limitsValidator.isAttributeValid(it.key, it.value, internal) || it.key.isValidLongValueAttribute()
     }.forEach {
@@ -39,49 +40,49 @@ fun AttributesBuilder.fromMap(
 /**
  * Returns the attributes as a new Map<String, String>
  */
-fun Attributes.toStringMap(): Map<String, String> = asMap().entries.associate {
+fun OtelJavaAttributes.toStringMap(): Map<String, String> = asMap().entries.associate {
     it.key.key.toString() to it.value.toString()
 }
 
-fun LinkData.toEmbracePayload() = Link(
+fun OtelJavaLinkData.toEmbracePayload() = Link(
     spanId = spanContext.spanId,
     traceId = spanContext.traceId,
     attributes = attributes.toEmbracePayload(),
     isRemote = spanContext.isRemote
 )
 
-fun LogRecordBuilder.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): LogRecordBuilder {
+fun OtelJavaLogRecordBuilder.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): OtelJavaLogRecordBuilder {
     setAttribute(embraceAttribute.key.asOtelAttributeKey(), embraceAttribute.value)
     return this
 }
 
-fun LogRecordBuilder.setAttribute(
-    attributeKey: AttributeKey<String>,
+fun OtelJavaLogRecordBuilder.setAttribute(
+    attributeKey: OtelJavaAttributeKey<String>,
     value: String,
     keepBlankishValues: Boolean = true,
-): LogRecordBuilder {
+): OtelJavaLogRecordBuilder {
     if (keepBlankishValues || !value.isBlankish()) {
         setAttribute(attributeKey, value)
     }
     return this
 }
 
-fun LogRecordData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
+fun OtelJavaLogRecordData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
     attributes[embraceAttribute.key.asOtelAttributeKey()] == embraceAttribute.value
 
-fun Span.setEmbraceAttribute(key: EmbraceAttributeKey, value: String): Span {
+fun OtelJavaSpan.setEmbraceAttribute(key: EmbraceAttributeKey, value: String): OtelJavaSpan {
     setAttribute(key.name, value)
     return this
 }
 
-fun Span.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): Span =
+fun OtelJavaSpan.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): OtelJavaSpan =
     this@setEmbraceAttribute.setEmbraceAttribute(embraceAttribute.key, embraceAttribute.value)
 
 @OptIn(ExperimentalApi::class)
 fun io.embrace.opentelemetry.kotlin.tracing.Span.setEmbraceAttribute(embraceAttribute: EmbraceAttribute) =
     setStringAttribute(embraceAttribute.key.name, embraceAttribute.value)
 
-fun SpanData.toEmbraceSpanData(): EmbraceSpanData = EmbraceSpanData(
+fun OtelJavaSpanData.toEmbraceSpanData(): EmbraceSpanData = EmbraceSpanData(
     traceId = spanContext.traceId,
     spanId = spanContext.spanId,
     parentSpanId = parentSpanId,
@@ -94,13 +95,13 @@ fun SpanData.toEmbraceSpanData(): EmbraceSpanData = EmbraceSpanData(
     links = links.map { it.toEmbracePayload() }
 )
 
-fun SpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
+fun OtelJavaSpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
     attributes.asMap()[embraceAttribute.key.asOtelAttributeKey()] == embraceAttribute.value
 
-fun StatusCode.toStatus(): io.embrace.android.embracesdk.internal.payload.Span.Status {
+fun OtelJavaStatusCode.toStatus(): Status {
     return when (this) {
-        StatusCode.UNSET -> io.embrace.android.embracesdk.internal.payload.Span.Status.UNSET
-        StatusCode.OK -> io.embrace.android.embracesdk.internal.payload.Span.Status.OK
-        StatusCode.ERROR -> io.embrace.android.embracesdk.internal.payload.Span.Status.ERROR
+        OtelJavaStatusCode.UNSET -> Status.UNSET
+        OtelJavaStatusCode.OK -> Status.OK
+        OtelJavaStatusCode.ERROR -> Status.ERROR
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
@@ -9,13 +9,13 @@ import io.embrace.android.embracesdk.internal.otel.config.getMaxTotalLinkCount
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.sdk.OpenTelemetrySdk
-import io.opentelemetry.sdk.common.Clock
-import io.opentelemetry.sdk.logs.SdkLoggerProvider
-import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.sdk.trace.SdkTracerProvider
-import io.opentelemetry.sdk.trace.SpanLimits
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 
 /**
  * Wrapper that instantiates a copy of the OpenTelemetry SDK configured with the appropriate settings and the given components so
@@ -24,7 +24,7 @@ import io.opentelemetry.sdk.trace.SpanLimits
  */
 @OptIn(ExperimentalApi::class)
 class OtelSdkWrapper(
-    openTelemetryClock: Clock,
+    openTelemetryClock: OtelJavaClock,
     configuration: OtelSdkConfig,
     limits: OtelLimitsConfig = InstrumentedConfigImpl.otelLimits,
 ) {
@@ -33,14 +33,14 @@ class OtelSdkWrapper(
         System.setProperty("io.opentelemetry.context.contextStorageProvider", "default")
     }
 
-    val sdkTracerProvider: SdkTracerProvider by lazy {
+    val sdkTracerProvider: OtelJavaSdkTracerProvider by lazy {
         EmbTrace.trace("otel-tracer-provider-init") {
-            SdkTracerProvider
+            OtelJavaSdkTracerProvider
                 .builder()
                 .addResource(resource)
                 .addSpanProcessor(configuration.spanProcessor)
                 .setSpanLimits(
-                    SpanLimits
+                    OtelJavaSpanLimits
                         .getDefault()
                         .toBuilder()
                         .setMaxNumberOfEvents(limits.getMaxTotalEventCount())
@@ -53,23 +53,23 @@ class OtelSdkWrapper(
         }
     }
 
-    val sdkTracer: Tracer by lazy {
+    val sdkTracer: OtelJavaTracer by lazy {
         EmbTrace.trace("otel-tracer-init") {
             sdk.getTracer(configuration.sdkName, configuration.sdkVersion)
         }
     }
 
-    private val resource: Resource by lazy {
+    private val resource: OtelJavaResource by lazy {
         configuration.resourceBuilder.build()
     }
 
-    private val sdk: OpenTelemetrySdk by lazy {
+    private val sdk: OtelJavaOpenTelemetrySdk by lazy {
         EmbTrace.trace("otel-sdk-init") {
-            OpenTelemetrySdk
+            OtelJavaOpenTelemetrySdk
                 .builder()
                 .setTracerProvider(sdkTracerProvider)
                 .setLoggerProvider(
-                    SdkLoggerProvider
+                    OtelJavaSdkLoggerProvider
                         .builder()
                         .addResource(resource)
                         .addLogRecordProcessor(configuration.logProcessor)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/TracerExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/TracerExt.kt
@@ -5,12 +5,12 @@ import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanCreator
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanStartArgs
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
-import io.opentelemetry.api.trace.Tracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 
 /**
  * Creates a new [OtelSpanCreator] that marks the resulting span as private if [internal] is true
  */
-fun Tracer.otelSpanCreator(
+fun OtelJavaTracer.otelSpanCreator(
     name: String,
     type: EmbType,
     internal: Boolean,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/id/OtelIds.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/id/OtelIds.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.otel.sdk.id
 
-import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.sdk.trace.IdGenerator
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
 
 object OtelIds {
 
-    private val generator = IdGenerator.random()
+    private val generator = OtelJavaIdGenerator.random()
 
     /**
      * Generates a new valid SpanId.
@@ -20,5 +20,5 @@ object OtelIds {
     /**
      * An invalid SpanId.
      */
-    val invalidSpanId: String = SpanId.getInvalid()
+    val invalidSpanId: String = OtelJavaSpanId.getInvalid()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceLinkData.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceLinkData.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
-import io.opentelemetry.api.trace.SpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 
 data class EmbraceLinkData(
-    val spanContext: SpanContext,
+    val spanContext: OtelJavaSpanContext,
     val attributes: Map<String, String>
 )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
@@ -6,21 +6,21 @@ import io.embrace.android.embracesdk.internal.otel.schema.LinkType
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.context.Context
-import io.opentelemetry.context.ContextKey
-import io.opentelemetry.context.ImplicitContextKeyed
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaImplicitContextKeyed
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 
 /**
  * An [EmbraceSpan] that has additional functionality to be used internally by the SDK
  */
-interface EmbraceSdkSpan : EmbraceSpan, ImplicitContextKeyed {
+interface EmbraceSdkSpan : EmbraceSpan, OtelJavaImplicitContextKeyed {
 
     /**
      * Create a new [Context] object based in this span and its parent's context. This can be used for the parent [Context] for a new span
      * with this span as its parent.
      */
-    fun asNewContext(): Context?
+    fun asNewContext(): OtelJavaContext?
 
     /**
      * Create a snapshot of the current state of the object
@@ -77,14 +77,14 @@ interface EmbraceSdkSpan : EmbraceSpan, ImplicitContextKeyed {
      * Add a system link to the span that will subjected to a different maximum than typical links.
      */
     fun addSystemLink(
-        linkedSpanContext: SpanContext,
+        linkedSpanContext: OtelJavaSpanContext,
         type: LinkType,
         attributes: Map<String, String> = emptyMap(),
     ): Boolean
 
-    override fun storeInContext(context: Context): Context = context.with(embraceSpanContextKey, this)
+    override fun storeInContext(context: OtelJavaContext): OtelJavaContext = context.with(embraceSpanContextKey, this)
 }
 
-fun Context.getEmbraceSpan(): EmbraceSdkSpan? = get(embraceSpanContextKey)
+fun OtelJavaContext.getEmbraceSpan(): EmbraceSdkSpan? = get(embraceSpanContextKey)
 
-private val embraceSpanContextKey = ContextKey.named<EmbraceSdkSpan>("embrace-span-key")
+private val embraceSpanContextKey = OtelJavaContextKey.named<EmbraceSdkSpan>("embrace-span-key")

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanData.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanData.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.toStringMap
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.sdk.trace.data.EventData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
 
 /**
  * Serializable representation of [EmbraceSpanData]
@@ -33,7 +33,7 @@ data class EmbraceSpanData(
 ) {
 
     companion object {
-        fun fromEventData(eventDataList: List<EventData>?): List<EmbraceSpanEvent> {
+        fun fromEventData(eventDataList: List<OtelJavaEventData>?): List<EmbraceSpanEvent> {
             val events = mutableListOf<EmbraceSpanEvent>()
             eventDataList?.forEach { eventData ->
                 val event = EmbraceSpanEvent.create(

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanExporter.kt
@@ -3,26 +3,26 @@ package io.embrace.android.embracesdk.internal.otel.spans
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 
 /**
  * Exports the given completed [Span] to the given [SpanSink] as well as any configured external [SpanExporter]
  */
 internal class EmbraceSpanExporter(
     private val spanSink: SpanSink,
-    private val externalSpanExporter: SpanExporter?,
+    private val externalSpanExporter: OtelJavaSpanExporter?,
     private val exportCheck: () -> Boolean,
-) : SpanExporter {
+) : OtelJavaSpanExporter {
+
     @Synchronized
-    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
+    override fun export(spans: MutableCollection<OtelJavaSpanData>): OtelJavaCompletableResultCode {
         if (!exportCheck()) {
-            return CompletableResultCode.ofSuccess()
+            return OtelJavaCompletableResultCode.ofSuccess()
         }
         val result = spanSink.storeCompletedSpans(spans.toList())
-        if (externalSpanExporter != null && result == CompletableResultCode.ofSuccess()) {
+        if (externalSpanExporter != null && result == OtelJavaCompletableResultCode.ofSuccess()) {
             return EmbTrace.trace("otel-external-export") {
                 externalSpanExporter.export(spans.filterNot { it.hasEmbraceAttribute(PrivateSpan) })
             }
@@ -31,8 +31,8 @@ internal class EmbraceSpanExporter(
         return result
     }
 
-    override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
+    override fun flush(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
 
     @Synchronized
-    override fun shutdown(): CompletableResultCode = CompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
@@ -3,30 +3,29 @@ package io.embrace.android.embracesdk.internal.otel.spans
 import io.embrace.android.embracesdk.internal.otel.attrs.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.otel.attrs.embSequenceId
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.context.Context
-import io.opentelemetry.sdk.trace.ReadWriteSpan
-import io.opentelemetry.sdk.trace.ReadableSpan
-import io.opentelemetry.sdk.trace.SpanProcessor
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
 import java.util.concurrent.atomic.AtomicLong
 
 /**
  * [SpanProcessor] that adds custom attributes to a [Span] when it starts, and exports it to the given [SpanExporter] when it finishes
  */
 class EmbraceSpanProcessor(
-    private val spanExporter: SpanExporter,
+    private val spanExporter: OtelJavaSpanExporter,
     private val processIdentifier: String,
-) : SpanProcessor {
+) : OtelJavaSpanProcessor {
 
     private val counter = AtomicLong(1)
 
-    override fun onStart(parentContext: Context, span: ReadWriteSpan) {
+    override fun onStart(parentContext: OtelJavaContext, span: OtelJavaReadWriteSpan) {
         span.setEmbraceAttribute(embSequenceId, counter.getAndIncrement().toString())
         span.setEmbraceAttribute(embProcessIdentifier, processIdentifier)
     }
 
-    override fun onEnd(span: ReadableSpan) {
+    override fun onEnd(span: OtelJavaReadableSpan) {
         spanExporter.export(mutableListOf(span.toSpanData()))
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreator.kt
@@ -1,19 +1,19 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.context.Context
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import java.util.concurrent.TimeUnit
 
 class OtelSpanCreator(
     val spanStartArgs: OtelSpanStartArgs,
-    private val tracer: Tracer,
+    private val tracer: OtelJavaTracer,
 ) {
 
-    internal fun startSpan(startTimeMs: Long): Span {
+    internal fun startSpan(startTimeMs: Long): OtelJavaSpan {
         with(spanStartArgs) {
             val builder = tracer.spanBuilder(spanName)
-            if (parentContext == Context.root()) {
+            if (parentContext == OtelJavaContext.root()) {
                 builder.setNoParent()
             } else {
                 builder.setParent(parentContext)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgs.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgs.kt
@@ -6,8 +6,8 @@ import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceObjectName
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.context.Context
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 
 /**
  * Wrapper for the SpanBuilder that stores the input data so that they can be accessed
@@ -20,7 +20,7 @@ class OtelSpanStartArgs(
     val autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
     parentSpan: EmbraceSpan? = null,
 ) {
-    var parentContext: Context = Context.root()
+    var parentContext: OtelJavaContext = OtelJavaContext.root()
 
     val spanName: String = if (internal) {
         name.toEmbraceObjectName()
@@ -29,7 +29,7 @@ class OtelSpanStartArgs(
     }
 
     var startTimeMs: Long? = null
-    var spanKind: SpanKind? = null
+    var spanKind: OtelJavaSpanKind? = null
 
     val embraceAttributes = mutableListOf<EmbraceAttribute>(type)
     val customAttributes = mutableMapOf<String, String>()
@@ -37,10 +37,10 @@ class OtelSpanStartArgs(
     init {
         // If there is a parent, extract the wrapped OTel span and set it as the parent in the wrapped OTel SpanBuilder
         if (parentSpan is EmbraceSdkSpan) {
-            val newParentContext = parentSpan.asNewContext() ?: Context.root()
+            val newParentContext = parentSpan.asNewContext() ?: OtelJavaContext.root()
             parentContext = newParentContext.with(parentSpan)
         } else {
-            parentContext = Context.root()
+            parentContext = OtelJavaContext.root()
         }
 
         if (private) {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 
 /**
  * A service that stores all the spans that are completed and exported via [EmbraceSpanExporter], and provides access to them so they
@@ -11,7 +11,7 @@ interface SpanSink {
     /**
      * Stores spans that have been completed. Implementations must support concurrent invocations.
      */
-    fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode
+    fun storeCompletedSpans(spans: List<OtelJavaSpanData>): OtelJavaCompletableResultCode
 
     /**
      * Returns the list of the currently stored completed spans.

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicReference
@@ -12,14 +12,14 @@ class SpanSinkImpl : SpanSink {
     private val completedSpans: Queue<EmbraceSpanData> = ConcurrentLinkedQueue()
     private val spansToFlush = AtomicReference<List<EmbraceSpanData>>(listOf())
 
-    override fun storeCompletedSpans(spans: List<SpanData>): CompletableResultCode {
+    override fun storeCompletedSpans(spans: List<OtelJavaSpanData>): OtelJavaCompletableResultCode {
         try {
             completedSpans += spans.map { it.toEmbraceSpanData() }
         } catch (t: Throwable) {
-            return CompletableResultCode.ofFailure()
+            return OtelJavaCompletableResultCode.ofFailure()
         }
 
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
     override fun completedSpans(): List<EmbraceSpanData> {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinSpanContextWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinSpanContextWrapper.kt
@@ -1,17 +1,18 @@
 package io.embrace.android.embracesdk.internal.otel.wrapper
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceState
 
 class KotlinSpanContextWrapper(
     private val impl: SpanContext,
-) : io.opentelemetry.api.trace.SpanContext {
+) : OtelJavaSpanContext {
 
     override fun getTraceId(): String = impl.traceId
     override fun getSpanId(): String = impl.spanId
     override fun isRemote(): Boolean = impl.isRemote
 
-    override fun getTraceFlags(): TraceFlags = KotlinTraceFlagsWrapper(impl.traceFlags)
-    override fun getTraceState(): TraceState = KotlinTraceStateWrapper(impl.traceState)
+    override fun getTraceFlags(): OtelJavaTraceFlags = KotlinTraceFlagsWrapper(impl.traceFlags)
+    override fun getTraceState(): OtelJavaTraceState = KotlinTraceStateWrapper(impl.traceState)
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceFlagsWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceFlagsWrapper.kt
@@ -1,10 +1,11 @@
 package io.embrace.android.embracesdk.internal.otel.wrapper
 
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.TraceFlags
 
 class KotlinTraceFlagsWrapper(
     private val impl: TraceFlags,
-) : io.opentelemetry.api.trace.TraceFlags {
+) : OtelJavaTraceFlags {
     override fun isSampled(): Boolean = impl.isSampled
 
     // FIXME: temporary. requires change in opentelemetry-kotlin first

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceStateWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceStateWrapper.kt
@@ -1,13 +1,14 @@
 package io.embrace.android.embracesdk.internal.otel.wrapper
 
 import android.os.Build
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceStateBuilder
 import io.embrace.opentelemetry.kotlin.tracing.TraceState
-import io.opentelemetry.api.trace.TraceStateBuilder
 import java.util.function.BiConsumer
 
 class KotlinTraceStateWrapper(
     private val impl: TraceState,
-) : io.opentelemetry.api.trace.TraceState {
+) : OtelJavaTraceState {
 
     override fun get(key: String): String? = impl.get(key)
 
@@ -23,8 +24,8 @@ class KotlinTraceStateWrapper(
 
     override fun asMap(): MutableMap<String, String> = impl.asMap().toMutableMap()
 
-    override fun toBuilder(): TraceStateBuilder {
-        val builder = io.opentelemetry.api.trace.TraceState.builder()
+    override fun toBuilder(): OtelJavaTraceStateBuilder {
+        val builder = OtelJavaTraceState.builder()
         asMap().forEach { entry ->
             builder.put(entry.key, entry.value)
         }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetryTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetryTest.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.otel.impl
 
 import io.embrace.android.embracesdk.fakes.FakeTracerProvider
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.logs.LoggerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextPropagators
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.opentelemetry.api.metrics.MeterProvider
-import io.opentelemetry.api.trace.TracerProvider
-import io.opentelemetry.context.propagation.ContextPropagators
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertSame
 import org.junit.Before
@@ -23,10 +23,10 @@ internal class EmbOpenTelemetryTest {
 
     @Test
     fun `tracer provider is a real implementation`() {
-        assertNotEquals(OpenTelemetry.noop(), openTelemetry)
-        assertNotEquals(TracerProvider.noop(), openTelemetry.tracerProvider)
+        assertNotEquals(OtelJavaOpenTelemetry.noop(), openTelemetry)
+        assertNotEquals(OtelJavaTracerProvider.noop(), openTelemetry.tracerProvider)
         assertSame(MeterProvider.noop(), openTelemetry.meterProvider)
-        assertSame(LoggerProvider.noop(), openTelemetry.logsBridge)
-        assertSame(ContextPropagators.noop(), openTelemetry.propagators)
+        assertSame(OtelJavaLoggerProvider.noop(), openTelemetry.logsBridge)
+        assertSame(OtelJavaContextPropagators.noop(), openTelemetry.propagators)
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilderTest.kt
@@ -12,11 +12,11 @@ import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanCreator
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanStartArgs
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.context.Context
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -85,7 +85,7 @@ internal class EmbSpanBuilderTest {
     @Test
     fun `set parent to root`() {
         val oldParent = FakeEmbraceSdkSpan.started(
-            parentContext = Context.root().with(
+            parentContext = OtelJavaContext.root().with(
                 fakeContextKey,
                 "value"
             )
@@ -119,7 +119,7 @@ internal class EmbSpanBuilderTest {
     @Test
     fun `replace parent`() {
         val newParentSpan = FakeEmbraceSdkSpan.started(
-            parentContext = Context.root().with(fakeContextKey, "value")
+            parentContext = OtelJavaContext.root().with(fakeContextKey, "value")
         )
         val newParentContext = checkNotNull(newParentSpan.asNewContext())
 
@@ -144,7 +144,7 @@ internal class EmbSpanBuilderTest {
             assertEquals(newParentSpan, parent)
             assertEquals(checkNotNull(newParentContext.getEmbraceSpan()?.traceId), spanContext?.traceId)
             assertEquals("value", checkNotNull(asNewContext()).get(fakeContextKey))
-            assertEquals(checkNotNull(Span.fromContext(newParentContext).spanContext?.traceId), spanContext?.traceId)
+            assertEquals(checkNotNull(OtelJavaSpan.fromContext(newParentContext).spanContext?.traceId), spanContext?.traceId)
         }
     }
 
@@ -166,11 +166,11 @@ internal class EmbSpanBuilderTest {
             setAttribute("long", 2L)
             setAttribute("double", 3.0)
             setAttribute("string", "value")
-            setAttribute(AttributeKey.booleanArrayKey("booleanArray"), listOf(true, false))
-            setAttribute(AttributeKey.longArrayKey("integerArray"), listOf(1, 2))
-            setAttribute(AttributeKey.longArrayKey("longArray"), listOf(2L, 3L))
-            setAttribute(AttributeKey.doubleArrayKey("doubleArray"), listOf(3.0, 4.0))
-            setAttribute(AttributeKey.stringArrayKey("stringArray"), listOf("value", "vee"))
+            setAttribute(OtelJavaAttributeKey.booleanArrayKey("booleanArray"), listOf(true, false))
+            setAttribute(OtelJavaAttributeKey.longArrayKey("integerArray"), listOf(1, 2))
+            setAttribute(OtelJavaAttributeKey.longArrayKey("longArray"), listOf(2L, 3L))
+            setAttribute(OtelJavaAttributeKey.doubleArrayKey("doubleArray"), listOf(3.0, 4.0))
+            setAttribute(OtelJavaAttributeKey.stringArrayKey("stringArray"), listOf("value", "vee"))
         }
 
         assertEquals(10, creator.spanStartArgs.customAttributes.count())
@@ -178,9 +178,9 @@ internal class EmbSpanBuilderTest {
 
     @Test
     fun `set span kind`() {
-        embSpanBuilder.setSpanKind(SpanKind.CLIENT)
+        embSpanBuilder.setSpanKind(OtelJavaSpanKind.CLIENT)
         val fakeSpan = creator.startSpan(clock.now()) as FakeSpan
-        assertEquals(SpanKind.CLIENT, fakeSpan.fakeSpanBuilder.spanKind)
+        assertEquals(OtelJavaSpanKind.CLIENT, fakeSpan.fakeSpanBuilder.spanKind)
     }
 
     @Test
@@ -188,7 +188,7 @@ internal class EmbSpanBuilderTest {
         embSpanBuilder.addLink(checkNotNull(FakeEmbraceSdkSpan.started().spanContext))
         embSpanBuilder.addLink(
             checkNotNull(FakeEmbraceSdkSpan.started().spanContext),
-            Attributes.of(AttributeKey.stringKey("key"), "value")
+            OtelJavaAttributes.of(OtelJavaAttributeKey.stringKey("key"), "value")
         )
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
@@ -7,10 +7,10 @@ import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedCo
 import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.sdk.common.Clock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 internal class EmbSpanTest {
     private lateinit var fakeClock: FakeClock
-    private lateinit var openTelemetryClock: Clock
+    private lateinit var openTelemetryClock: OtelJavaClock
     private lateinit var fakeEmbraceSpan: FakeEmbraceSdkSpan
     private lateinit var embSpan: EmbSpan
 
@@ -66,7 +66,7 @@ internal class EmbSpanTest {
     @Test
     fun `set error status before end`() {
         with(embSpan) {
-            setStatus(StatusCode.ERROR, "error")
+            setStatus(OtelJavaStatusCode.ERROR, "error")
             end()
         }
         with(fakeEmbraceSpan) {
@@ -79,7 +79,7 @@ internal class EmbSpanTest {
     fun `status can only be set on a span that is recording`() {
         with(embSpan) {
             end()
-            setStatus(StatusCode.ERROR, "error")
+            setStatus(OtelJavaStatusCode.ERROR, "error")
             end()
         }
 
@@ -92,7 +92,7 @@ internal class EmbSpanTest {
     @Test
     fun `check adding events`() {
         val attributesBuilder =
-            Attributes
+            OtelJavaAttributes
                 .builder()
                 .put("boolean", true)
                 .put("integer", 1)
@@ -139,7 +139,7 @@ internal class EmbSpanTest {
         val firstExceptionTime = openTelemetryClock.now()
         embSpan.recordException(IllegalStateException())
         val secondExceptionTime = openTelemetryClock.now()
-        embSpan.recordException(RuntimeException(), Attributes.builder().put("myKey", "myValue").build())
+        embSpan.recordException(RuntimeException(), OtelJavaAttributes.builder().put("myKey", "myValue").build())
 
         with(checkNotNull(fakeEmbraceSpan.events)) {
             assertEquals(2, size)
@@ -167,11 +167,11 @@ internal class EmbSpanTest {
             setAttribute("long", 2L)
             setAttribute("double", 3.0)
             setAttribute("string", "value")
-            setAttribute(AttributeKey.booleanArrayKey("booleanArray"), listOf(true, false))
-            setAttribute(AttributeKey.longArrayKey("integerArray"), listOf(1, 2))
-            setAttribute(AttributeKey.longArrayKey("longArray"), listOf(2L, 3L))
-            setAttribute(AttributeKey.doubleArrayKey("doubleArray"), listOf(3.0, 4.0))
-            setAttribute(AttributeKey.stringArrayKey("stringArray"), listOf("value", "vee"))
+            setAttribute(OtelJavaAttributeKey.booleanArrayKey("booleanArray"), listOf(true, false))
+            setAttribute(OtelJavaAttributeKey.longArrayKey("integerArray"), listOf(1, 2))
+            setAttribute(OtelJavaAttributeKey.longArrayKey("longArray"), listOf(2L, 3L))
+            setAttribute(OtelJavaAttributeKey.doubleArrayKey("doubleArray"), listOf(3.0, 4.0))
+            setAttribute(OtelJavaAttributeKey.stringArrayKey("stringArray"), listOf("value", "vee"))
         }
 
         assertEquals(attributesCount + 10, fakeEmbraceSpan.attributes.size)
@@ -181,7 +181,7 @@ internal class EmbSpanTest {
     fun `add span link`() {
         with(embSpan) {
             val linkedSpanContext = checkNotNull(FakeEmbraceSdkSpan.started().spanContext)
-            addLink(linkedSpanContext, Attributes.builder().put("boolean", true).build())
+            addLink(linkedSpanContext, OtelJavaAttributes.builder().put("boolean", true).build())
             with(fakeEmbraceSpan.links.single()) {
                 assertEquals(linkedSpanContext.spanId, spanContext.spanId)
                 assertEquals(1, attributes.size)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporterTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.fixtures.testLog
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.payload.Attribute
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
@@ -17,7 +17,7 @@ internal class EmbraceLogRecordExporterTest {
     fun `export() should store logs in LogSink`() {
         val logSink: LogSink = LogSinkImpl()
         val embraceLogRecordExporter =
-            EmbraceLogRecordExporter(logSink, LogRecordExporter.composite(emptyList())) { true }
+            EmbraceLogRecordExporter(logSink, OtelJavaLogRecordExporter.composite(emptyList())) { true }
         val logRecordData = FakeLogRecordData()
 
         embraceLogRecordExporter.export(listOf(logRecordData))
@@ -31,7 +31,7 @@ internal class EmbraceLogRecordExporterTest {
         val logSink: LogSink = LogSinkImpl()
         val externalExporter = FakeLogRecordExporter()
         val embraceLogRecordExporter =
-            EmbraceLogRecordExporter(logSink, LogRecordExporter.composite(externalExporter)) { true }
+            EmbraceLogRecordExporter(logSink, OtelJavaLogRecordExporter.composite(externalExporter)) { true }
         val logRecordData = FakeLogRecordData()
         val privateLogRecordData = FakeLogRecordData(
             log = testLog.copy(

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImplTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fixtures.deferredLogRecordData
 import io.embrace.android.embracesdk.fixtures.sendImmediatelyLogRecordData
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
-import io.opentelemetry.sdk.common.CompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -25,13 +25,13 @@ internal class LogSinkImplTest {
     fun `verify default state`() {
         assertEquals(0, logSink.logsForNextBatch().size)
         assertEquals(0, logSink.flushBatch().size)
-        assertEquals(CompletableResultCode.ofSuccess(), logSink.storeLogs(listOf()))
+        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), logSink.storeLogs(listOf()))
     }
 
     @Test
     fun `storing logs adds to stored logs`() {
         val resultCode = logSink.storeLogs(listOf(FakeLogRecordData()))
-        assertEquals(CompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
         assertEquals(1, logSink.logsForNextBatch().size)
         assertEquals(FakeLogRecordData().toEmbracePayload(), logSink.logsForNextBatch().first())
     }
@@ -61,7 +61,7 @@ internal class LogSinkImplTest {
     @Test
     fun `logs with IMMEDIATE SendMode are stored in priority log queue`() {
         val resultCode = logSink.storeLogs(listOf(sendImmediatelyLogRecordData))
-        assertEquals(CompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
         assertEquals(0, logSink.logsForNextBatch().size)
         val logRequest = checkNotNull(logSink.pollUnbatchedLog())
         assertEquals(sendImmediatelyLogRecordData.log, logRequest.payload)
@@ -72,7 +72,7 @@ internal class LogSinkImplTest {
     @Test
     fun `logs with DEFER SendMode are stored in priority log queue`() {
         val resultCode = logSink.storeLogs(listOf(deferredLogRecordData))
-        assertEquals(CompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
         assertEquals(0, logSink.logsForNextBatch().size)
         val logRequest = checkNotNull(logSink.pollUnbatchedLog())
         assertEquals(deferredLogRecordData.log, logRequest.payload)
@@ -83,7 +83,7 @@ internal class LogSinkImplTest {
     @Test
     fun `unbatchable logs are stored in the unbatched log queue`() {
         val resultCode = logSink.storeLogs(listOf(sendImmediatelyLogRecordData))
-        assertEquals(CompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
         assertEquals(0, logSink.logsForNextBatch().size)
         assertEquals(sendImmediatelyLogRecordData.log, checkNotNull(logSink.pollUnbatchedLog()).payload)
         assertNull(logSink.pollUnbatchedLog())

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/LogMapperTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/LogMapperTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 
 internal class LogMapperTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun `convert to new payload`() {
         val input = FakeLogRecordData()

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -34,8 +34,8 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.sdk.OpenTelemetrySdk
-import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -53,8 +53,8 @@ internal class EmbraceSpanImplTest {
     private lateinit var embraceSpanFactory: EmbraceSpanFactory
     private var updateNotified: Boolean = false
     private var stoppedSpanId: String? = null
-    private val tracer = OpenTelemetrySdk.builder()
-        .setTracerProvider(SdkTracerProvider.builder().build()).build()
+    private val tracer = OtelJavaOpenTelemetrySdk.builder()
+        .setTracerProvider(OtelJavaSdkTracerProvider.builder().build()).build()
         .getTracer(EmbraceSpanImplTest::class.java.name)
 
     @Before

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreatorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreatorTest.kt
@@ -7,9 +7,9 @@ import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.fixtures.fakeContextKey
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.context.Context
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -91,7 +91,7 @@ internal class OtelSpanCreatorTest {
             spanStartArgs = args,
         )
 
-        args.parentContext = Context.root()
+        args.parentContext = OtelJavaContext.root()
         with(creator.startSpan(startTime)) {
             assertFakeSpanBuilder(
                 expectedName = "test",
@@ -111,7 +111,7 @@ internal class OtelSpanCreatorTest {
             spanStartArgs = uxArgs,
         )
 
-        uxArgs.parentContext = Context.root()
+        uxArgs.parentContext = OtelJavaContext.root()
         with(uxSpanBuilder.startSpan(startTime)) {
             assertFakeSpanBuilder(
                 expectedName = "ux-test",
@@ -134,11 +134,11 @@ internal class OtelSpanCreatorTest {
         )
 
         val startTime = clock.now()
-        args.spanKind = SpanKind.CLIENT
+        args.spanKind = OtelJavaSpanKind.CLIENT
         creator.startSpan(startTime).assertFakeSpanBuilder(
             expectedName = "test",
             expectedStartTimeMs = startTime,
-            expectedSpanKind = SpanKind.CLIENT
+            expectedSpanKind = OtelJavaSpanKind.CLIENT
         )
     }
 
@@ -156,7 +156,7 @@ internal class OtelSpanCreatorTest {
 
     @Test
     fun `context value propagated even if it does not context a span`() {
-        val fakeRootContext = Context.root().with(fakeContextKey, "fake-value")
+        val fakeRootContext = OtelJavaContext.root().with(fakeContextKey, "fake-value")
         val args = OtelSpanStartArgs(
             name = "parent",
             type = EmbType.Performance.Default,
@@ -175,10 +175,10 @@ internal class OtelSpanCreatorTest {
         assertEquals("fake-value", span.fakeSpanBuilder.parentContext.get(fakeContextKey))
     }
 
-    private fun Span.assertFakeSpanBuilder(
+    private fun OtelJavaSpan.assertFakeSpanBuilder(
         expectedName: String,
-        expectedParentContext: Context = Context.root(),
-        expectedSpanKind: SpanKind? = null,
+        expectedParentContext: OtelJavaContext = OtelJavaContext.root(),
+        expectedSpanKind: OtelJavaSpanKind? = null,
         expectedStartTimeMs: Long,
         expectedTraceId: String? = null,
     ) {

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
@@ -2,10 +2,10 @@ package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
 import io.embrace.android.embracesdk.fakes.FakeSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.unmockkObject
-import io.opentelemetry.sdk.common.CompletableResultCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Before
@@ -26,7 +26,7 @@ internal class SpanSinkImplTests {
     fun `verify default state`() {
         assertEquals(0, spanSink.completedSpans().size)
         assertEquals(0, spanSink.flushSpans().size)
-        assertEquals(CompletableResultCode.ofSuccess(), spanSink.storeCompletedSpans(listOf()))
+        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), spanSink.storeCompletedSpans(listOf()))
     }
 
     @Test

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation(project(":embrace-android-otel"))
 
     implementation(platform(libs.opentelemetry.bom))
+    implementation(libs.opentelemetry.java.aliases)
 
     // lifecycle
     implementation(libs.lifecycle.runtime)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -15,7 +15,6 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
-import io.embrace.android.embracesdk.internal.otel.sdk.toStatus
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -23,7 +22,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.POST_ACTIVITY_ACTION_DWELL
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.opentelemetry.sdk.trace.data.SpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -408,13 +407,13 @@ internal class AppStartupTraceTest {
         )
     }
 
-    private fun Map<String, SpanData?>.coldAppStartupRootSpan() = getSpan("emb-app-startup-cold")
-    private fun Map<String, SpanData?>.warmAppStartupRootSpan() = getSpan("emb-app-startup-warm")
-    private fun Map<String, SpanData?>.processInitSpan() = getSpan("emb-process-init")
-    private fun Map<String, SpanData?>.embraceInitSpan() = getSpan("emb-embrace-init")
-    private fun Map<String, SpanData?>.initGapSpan() = getSpan("emb-activity-init-delay")
-    private fun Map<String, SpanData?>.activityInitSpan() = getSpan("emb-activity-init")
-    private fun Map<String, SpanData?>.activityResumeSpan() = getSpan("emb-activity-load")
-    private fun Map<String, SpanData?>.appReadySpan() = getSpan("emb-app-ready")
-    private fun Map<String, SpanData?>.getSpan(name: String) = this[name] ?: error("Span missing")
+    private fun Map<String, OtelJavaSpanData?>.coldAppStartupRootSpan() = getSpan("emb-app-startup-cold")
+    private fun Map<String, OtelJavaSpanData?>.warmAppStartupRootSpan() = getSpan("emb-app-startup-warm")
+    private fun Map<String, OtelJavaSpanData?>.processInitSpan() = getSpan("emb-process-init")
+    private fun Map<String, OtelJavaSpanData?>.embraceInitSpan() = getSpan("emb-embrace-init")
+    private fun Map<String, OtelJavaSpanData?>.initGapSpan() = getSpan("emb-activity-init-delay")
+    private fun Map<String, OtelJavaSpanData?>.activityInitSpan() = getSpan("emb-activity-init")
+    private fun Map<String, OtelJavaSpanData?>.activityResumeSpan() = getSpan("emb-activity-load")
+    private fun Map<String, OtelJavaSpanData?>.appReadySpan() = getSpan("emb-app-ready")
+    private fun Map<String, OtelJavaSpanData?>.getSpan(name: String) = this[name] ?: error("Span missing")
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.ServiceAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -32,10 +32,10 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceState
-import io.opentelemetry.context.Context
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -298,11 +298,11 @@ internal class TracingApiTest {
                     val parentThreadId = Thread.currentThread().id
                     var childThreadId: Long = -1L
                     val parent = checkNotNull(embrace.startSpan("parent"))
-                    val currentContext = Context.current()
-                    var currentContext2: Context? = null
+                    val currentContext = OtelJavaContext.current()
+                    var currentContext2: OtelJavaContext? = null
                     executor.submit {
                         childThreadId = Thread.currentThread().id
-                        currentContext2 = Context.current()
+                        currentContext2 = OtelJavaContext.current()
                         val child = checkNotNull(embrace.startSpan(name = "child", parent = parent))
                         assertTrue(child.stop())
                         latch.countDown()
@@ -346,11 +346,11 @@ internal class TracingApiTest {
     @Test
     fun `span links`() {
         val fakeSpan = FakeEmbraceSdkSpan.started()
-        val remoteSpanContext = SpanContext.createFromRemoteParent(
+        val remoteSpanContext = OtelJavaSpanContext.createFromRemoteParent(
             checkNotNull(fakeSpan.traceId),
             checkNotNull(fakeSpan.spanId),
-            TraceFlags.getDefault(),
-            TraceState.getDefault()
+            OtelJavaTraceFlags.getDefault(),
+            OtelJavaTraceState.getDefault()
         )
         testRule.runTest(
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRe
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.otel.attrs.embCrashId
 import io.embrace.android.embracesdk.internal.otel.attrs.embState
-import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.payload.ApplicationState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
@@ -22,7 +21,6 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLastLog
-import io.opentelemetry.api.logs.Severity
 import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
 import org.junit.Assert.assertEquals

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLogOfType
 import io.embrace.android.embracesdk.assertions.getOtelSeverity
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.embrace.opentelemetry.kotlin.logging.SeverityNumber
 import org.junit.Before
 import org.junit.Rule
@@ -420,9 +421,9 @@ internal class LogFeatureTest {
 
     private fun getEmbraceSeverity(severityNumber: Int): Severity {
         return when (severityNumber) {
-            io.opentelemetry.api.logs.Severity.INFO.severityNumber -> Severity.INFO
-            io.opentelemetry.api.logs.Severity.WARN.severityNumber -> Severity.WARNING
-            io.opentelemetry.api.logs.Severity.ERROR.severityNumber -> Severity.ERROR
+            OtelJavaSeverity.INFO.severityNumber -> Severity.INFO
+            OtelJavaSeverity.WARN.severityNumber -> Severity.WARNING
+            OtelJavaSeverity.ERROR.severityNumber -> Severity.ERROR
             else -> error("Unexpected severityNumber $severityNumber")
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceOtelExportAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceOtelExportAssertionInterface.kt
@@ -4,8 +4,8 @@ import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.testframework.export.ExportedSpanValidator
 import io.embrace.android.embracesdk.testframework.export.FilteredLogExporter
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
-import io.opentelemetry.sdk.logs.data.LogRecordData
-import io.opentelemetry.sdk.trace.data.SpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 
 /**
  * Provides assertions that can be used in integration tests to validate the behavior of the SDK,
@@ -17,14 +17,14 @@ internal class EmbraceOtelExportAssertionInterface(
     private val validator: ExportedSpanValidator = ExportedSpanValidator(),
 ) {
 
-    fun awaitLogs(expectedCount: Int, filter: (LogRecordData) -> Boolean) = logExporter.awaitLogs(expectedCount, filter)
-    fun awaitSpans(expectedCount: Int, filter: (SpanData) -> Boolean) = spanExporter.awaitSpans(expectedCount, filter)
+    fun awaitLogs(expectedCount: Int, filter: (OtelJavaLogRecordData) -> Boolean) = logExporter.awaitLogs(expectedCount, filter)
+    fun awaitSpans(expectedCount: Int, filter: (OtelJavaSpanData) -> Boolean) = spanExporter.awaitSpans(expectedCount, filter)
     fun awaitSpansWithType(expectedCount: Int, type: EmbType) = spanExporter.awaitSpansWithType(expectedCount, type)
 
     /**
      * Asserts that the provided spans match the golden file.
      */
-    fun assertSpansMatchGoldenFile(spans: List<SpanData>, goldenFile: String) {
+    fun assertSpansMatchGoldenFile(spans: List<OtelJavaSpanData>, goldenFile: String) {
         validator.validate(spans, goldenFile)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Types
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.threadLocal
-import io.opentelemetry.sdk.trace.data.SpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import org.junit.Assert.assertEquals
 
 internal class ExportedSpanValidator {
@@ -17,7 +17,7 @@ internal class ExportedSpanValidator {
         Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java)
     private val listType = Types.newParameterizedType(List::class.java, type)
 
-    fun validate(spanDataList: List<SpanData>, goldenFile: String) {
+    fun validate(spanDataList: List<OtelJavaSpanData>, goldenFile: String) {
         val expected: List<Map<String, Any>> = readExpectedSpan(goldenFile)
         val actual = spanDataList.map { it.representAsMap() }
         assertEquals(expected, actual)
@@ -28,7 +28,7 @@ internal class ExportedSpanValidator {
         return serializer.fromJson(inputStream, listType)
     }
 
-    private fun SpanData.representAsMap(): Map<String, Any> {
+    private fun OtelJavaSpanData.representAsMap(): Map<String, Any> {
         val attrs: Map<String, String> = representAttributes()
         return mapOf(
             "name" to name,
@@ -45,7 +45,7 @@ internal class ExportedSpanValidator {
         )
     }
 
-    private fun SpanData.representAttributes(): Map<String, String> {
+    private fun OtelJavaSpanData.representAttributes(): Map<String, String> {
         val ignoreList = listOf("emb.process_identifier", "emb.private.sequence_id")
         val attrs: Map<String, String> = attributes.asMap().map {
             it.key.key to it.value.toString()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredLogExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredLogExporter.kt
@@ -1,28 +1,28 @@
 package io.embrace.android.embracesdk.testframework.export
 
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.logs.data.LogRecordData
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 
-internal class FilteredLogExporter: LogRecordExporter {
+internal class FilteredLogExporter: OtelJavaLogRecordExporter {
 
-    private val logData = mutableListOf<LogRecordData>()
+    private val logData = mutableListOf<OtelJavaLogRecordData>()
 
-    override fun export(logs: MutableCollection<LogRecordData>): CompletableResultCode {
+    override fun export(logs: MutableCollection<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
         logData.addAll(logs)
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun flush(): CompletableResultCode {
-        return CompletableResultCode.ofSuccess()
+    override fun flush(): OtelJavaCompletableResultCode {
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun shutdown(): CompletableResultCode {
-        return CompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode {
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    fun awaitLogs(expectedCount: Int, filter: (LogRecordData) -> Boolean): List<LogRecordData> {
+    fun awaitLogs(expectedCount: Int, filter: (OtelJavaLogRecordData) -> Boolean): List<OtelJavaLogRecordData> {
         val supplier = { logData.filter(filter) }
         return returnIfConditionMet(
             desiredValueSupplier = supplier,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/FilteredSpanExporter.kt
@@ -2,33 +2,33 @@ package io.embrace.android.embracesdk.testframework.export
 
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * A [SpanExporter] used in the integration tests that allows retrieving exported spans
  * to perform assertions against.
  */
-internal class FilteredSpanExporter : SpanExporter {
+internal class FilteredSpanExporter : OtelJavaSpanExporter {
 
-    private val spanData = CopyOnWriteArrayList<SpanData>()
+    private val spanData = CopyOnWriteArrayList<OtelJavaSpanData>()
 
-    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
+    override fun export(spans: MutableCollection<OtelJavaSpanData>): OtelJavaCompletableResultCode {
         spanData.addAll(spans)
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun flush(): CompletableResultCode {
-        return CompletableResultCode.ofSuccess()
+    override fun flush(): OtelJavaCompletableResultCode {
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun shutdown(): CompletableResultCode {
-        return CompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode {
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    fun awaitSpans(expectedCount: Int, filter: (SpanData) -> Boolean): List<SpanData> {
+    fun awaitSpans(expectedCount: Int, filter: (OtelJavaSpanData) -> Boolean): List<OtelJavaSpanData> {
         val supplier = { spanData.filter(filter) }
         return returnIfConditionMet(
             desiredValueSupplier = supplier,
@@ -44,7 +44,7 @@ internal class FilteredSpanExporter : SpanExporter {
         )
     }
 
-    fun awaitSpansWithType(expectedCount: Int, type: EmbType): List<SpanData> {
+    fun awaitSpansWithType(expectedCount: Int, type: EmbType): List<OtelJavaSpanData> {
         return awaitSpans(expectedCount) { data ->
             data.attributes?.asMap()?.mapKeys { it.key.key }?.get("emb.type") == type.value
         }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -13,9 +13,9 @@ import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 
 /**
  * Entry point for the SDK. This class is part of the Embrace Public API.
@@ -382,11 +382,11 @@ public class Embrace private constructor(
      *
      * @param spanExporter the span exporter to add
      */
-    override fun addSpanExporter(spanExporter: SpanExporter) {
+    override fun addSpanExporter(spanExporter: OtelJavaSpanExporter) {
         impl.addSpanExporter(spanExporter)
     }
 
-    override fun getOpenTelemetry(): OpenTelemetry {
+    override fun getOpenTelemetry(): OtelJavaOpenTelemetry {
         return impl.getOpenTelemetry()
     }
 
@@ -399,7 +399,7 @@ public class Embrace private constructor(
      *
      * @param logRecordExporter the LogRecord exporter to add
      */
-    override fun addLogRecordExporter(logRecordExporter: LogRecordExporter) {
+    override fun addLogRecordExporter(logRecordExporter: OtelJavaLogRecordExporter) {
         impl.addLogRecordExporter(logRecordExporter)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
@@ -2,34 +2,34 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import io.embrace.android.embracesdk.internal.api.OTelApi
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 
 internal class OTelApiDelegate(
     private val bootstrapper: ModuleInitBootstrapper,
     private val sdkCallChecker: SdkCallChecker,
 ) : OTelApi {
 
-    override fun addSpanExporter(spanExporter: SpanExporter) {
+    override fun addSpanExporter(spanExporter: OtelJavaSpanExporter) {
         if (sdkCallChecker.started.get()) {
             return
         }
         bootstrapper.openTelemetryModule.otelSdkConfig.addSpanExporter(spanExporter)
     }
 
-    override fun addLogRecordExporter(logRecordExporter: LogRecordExporter) {
+    override fun addLogRecordExporter(logRecordExporter: OtelJavaLogRecordExporter) {
         if (sdkCallChecker.started.get()) {
             return
         }
         bootstrapper.openTelemetryModule.otelSdkConfig.addLogExporter(logRecordExporter)
     }
 
-    override fun getOpenTelemetry(): OpenTelemetry {
+    override fun getOpenTelemetry(): OtelJavaOpenTelemetry {
         return if (sdkCallChecker.started.get()) {
             bootstrapper.openTelemetryModule.externalOpenTelemetry
         } else {
-            OpenTelemetry.noop()
+            OtelJavaOpenTelemetry.noop()
         }
     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.opentelemetry.api.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.opentelemetry.semconv.ServiceAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -63,12 +63,12 @@ internal class OTelApiDelegateTest {
     @Test
     fun `get opentelemetry before start`() {
         sdkCallChecker.started.set(false)
-        assertEquals(OpenTelemetry.noop(), delegate.getOpenTelemetry())
+        assertEquals(OtelJavaOpenTelemetry.noop(), delegate.getOpenTelemetry())
     }
 
     @Test
     fun `get opentelemetry after start`() {
-        assertNotEquals(OpenTelemetry.noop(), delegate.getOpenTelemetry())
+        assertNotEquals(OtelJavaOpenTelemetry.noop(), delegate.getOpenTelemetry())
     }
 
     @Test

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     compileOnly(libs.opentelemetry.sdk)
     compileOnly(libs.opentelemetry.semconv)
     compileOnly(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.java.aliases)
 
     implementation(libs.junit)
     implementation(libs.okhttp)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.otel.attrs.asPair
 import io.embrace.android.embracesdk.internal.otel.schema.LinkType
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.opentelemetry.api.trace.SpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertTrue
 
@@ -40,7 +40,7 @@ fun Link.validateLinkToSpan(
 }
 
 fun Link.validateLinkToSpanContext(
-    linkedSpanContext: SpanContext,
+    linkedSpanContext: OtelJavaSpanContext,
     expectedAttributes: Map<String, String> = emptyMap(),
 ) {
     assertTrue(isLinkedToSpanContext(linkedSpanContext))
@@ -50,5 +50,5 @@ fun Link.validateLinkToSpanContext(
 fun Link.isLinkedToSpan(expectedSpan: Span, expectedIsRemote: Boolean): Boolean =
     traceId == expectedSpan.traceId && spanId == expectedSpan.spanId && isRemote == expectedIsRemote
 
-fun Link.isLinkedToSpanContext(expectedSpanContext: SpanContext): Boolean =
+fun Link.isLinkedToSpanContext(expectedSpanContext: OtelJavaSpanContext): Boolean =
     traceId == expectedSpanContext.traceId && spanId == expectedSpanContext.spanId && isRemote == expectedSpanContext.isRemote

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.assertions
 
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.opentelemetry.sdk.resources.Resource
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
@@ -9,7 +9,7 @@ import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
 import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
 import org.junit.Assert.assertEquals
 
-fun Resource.assertExpectedAttributes(
+fun OtelJavaResource.assertExpectedAttributes(
     expectedServiceName: String,
     expectedServiceVersion: String,
     systemInfo: SystemInfo,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -7,10 +7,10 @@ import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
 import io.embrace.android.embracesdk.internal.otel.sdk.fromMap
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.sdk.trace.data.EventData
-import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.data.StatusData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -29,7 +29,7 @@ class FakeAppStartupDataCollector(
     var firstFrameRenderedMs: Long? = null
     var appReadyMs: Long? = null
     var appStartupCompleteCallback: (() -> Unit)? = null
-    var customChildSpans = ConcurrentLinkedQueue<SpanData>()
+    var customChildSpans = ConcurrentLinkedQueue<OtelJavaSpanData>()
     var customAttributes: MutableMap<String, String> = ConcurrentHashMap()
     var dataValidator: DataValidator = DataValidator()
 
@@ -93,7 +93,7 @@ class FakeAppStartupDataCollector(
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?,
     ) {
-        val attributesBuilder = Attributes.builder().fromMap(
+        val attributesBuilder = OtelJavaAttributes.builder().fromMap(
             attributes = attributes,
             internal = false,
             limitsValidator = dataValidator
@@ -101,9 +101,9 @@ class FakeAppStartupDataCollector(
         val status = if (errorCode != null) {
             val errorCodeAttr = errorCode.fromErrorCode()
             attributesBuilder.put(errorCodeAttr.key.name, errorCodeAttr.value)
-            StatusData.error()
+            OtelJavaStatusData.error()
         } else {
-            StatusData.unset()
+            OtelJavaStatusData.unset()
         }
         customChildSpans.add(
             FakeSpanData(
@@ -112,10 +112,10 @@ class FakeAppStartupDataCollector(
                 endTimeNanos = endTimeMs.millisToNanos(),
                 attributes = attributesBuilder.build(),
                 events = events.map {
-                    EventData.create(
+                    OtelJavaEventData.create(
                         it.timestampNanos,
                         it.name,
-                        Attributes.builder().fromMap(
+                        OtelJavaAttributes.builder().fromMap(
                             attributes = it.attributes,
                             internal = false,
                             limitsValidator = dataValidator

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordData.kt
@@ -1,32 +1,32 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("TYPEALIAS_EXPANSION_DEPRECATION")
 
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.fixtures.testLog
 import io.embrace.android.embracesdk.internal.payload.Log
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaBody
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSeverity
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.opentelemetry.api.internal.ImmutableSpanContext
 import io.opentelemetry.api.internal.ImmutableSpanContext.INVALID
-import io.opentelemetry.api.logs.Severity
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceState
-import io.opentelemetry.sdk.common.InstrumentationScopeInfo
-import io.opentelemetry.sdk.logs.data.Body
-import io.opentelemetry.sdk.logs.data.LogRecordData
-import io.opentelemetry.sdk.resources.Resource
 
 class FakeLogRecordData(
     val log: Log = testLog,
-) : LogRecordData {
+) : OtelJavaLogRecordData {
 
-    override fun getResource(): Resource {
-        return Resource.builder().build()
+    override fun getResource(): OtelJavaResource {
+        return OtelJavaResource.builder().build()
     }
 
-    override fun getInstrumentationScopeInfo(): InstrumentationScopeInfo {
-        return InstrumentationScopeInfo.create("TestLogRecordData")
+    override fun getInstrumentationScopeInfo(): OtelJavaInstrumentationScopeInfo {
+        return OtelJavaInstrumentationScopeInfo.create("TestLogRecordData")
     }
 
     override fun getTimestampEpochNanos(): Long {
@@ -37,15 +37,15 @@ class FakeLogRecordData(
         return checkNotNull(log.timeUnixNano)
     }
 
-    override fun getSpanContext(): SpanContext {
+    override fun getSpanContext(): OtelJavaSpanContext {
         val traceId = log.traceId
         val spanId = log.spanId
         return if (traceId != null && spanId != null) {
             ImmutableSpanContext.create(
                 traceId,
                 spanId,
-                TraceFlags.getDefault(),
-                TraceState.getDefault(),
+                OtelJavaTraceFlags.getDefault(),
+                OtelJavaTraceState.getDefault(),
                 false,
                 true
             )
@@ -54,22 +54,23 @@ class FakeLogRecordData(
         }
     }
 
-    override fun getSeverity(): Severity {
-        return Severity.INFO
+    override fun getSeverity(): OtelJavaSeverity {
+        return OtelJavaSeverity.INFO
     }
 
     override fun getSeverityText(): String? {
         return log.severityText
     }
 
-    override fun getBody(): Body {
-        return Body.string(checkNotNull(log.body))
+    @Deprecated("Deprecated in Java")
+    override fun getBody(): OtelJavaBody {
+        return OtelJavaBody.string(checkNotNull(log.body))
     }
 
-    override fun getAttributes(): Attributes {
-        val attrBuilder = Attributes.builder()
+    override fun getAttributes(): OtelJavaAttributes {
+        val attrBuilder = OtelJavaAttributes.builder()
         log.attributes?.forEach { (key, value) ->
-            attrBuilder.put(AttributeKey.stringKey(checkNotNull(key)), checkNotNull(value))
+            attrBuilder.put(OtelJavaAttributeKey.stringKey(checkNotNull(key)), checkNotNull(value))
         }
         return attrBuilder.build()
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordExporter.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordExporter.kt
@@ -1,19 +1,19 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.logs.data.LogRecordData
-import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 
-class FakeLogRecordExporter : LogRecordExporter {
+class FakeLogRecordExporter : OtelJavaLogRecordExporter {
 
-    var exportedLogs: Collection<LogRecordData>? = null
+    var exportedLogs: Collection<OtelJavaLogRecordData>? = null
 
-    override fun export(logs: MutableCollection<LogRecordData>): CompletableResultCode {
+    override fun export(logs: MutableCollection<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
         exportedLogs = logs
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
+    override fun flush(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
 
-    override fun shutdown(): CompletableResultCode = CompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryClock.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryClock.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.otel.impl.EmbClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 
 /**
  * An OpenTelemetry-compatible clock used for tests that calculates the elapsed time using the difference between the current time and when
@@ -10,7 +11,7 @@ import io.embrace.android.embracesdk.internal.otel.impl.EmbClock
 class FakeOpenTelemetryClock(
     embraceClock: Clock,
     private val startingElapsedTimeNanos: Long = 0L,
-) : io.opentelemetry.sdk.common.Clock {
+) : OtelJavaClock {
 
     private val realOpenTelemetryClock = EmbClock(embraceClock = embraceClock)
     private val startingTimeNanos = now()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -17,11 +17,11 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerProvider
-import io.opentelemetry.sdk.common.Clock
 
 class FakeOpenTelemetryModule(
     override val currentSessionSpan: CurrentSessionSpan = FakeCurrentSessionSpan(),
@@ -36,7 +36,7 @@ class FakeOpenTelemetryModule(
         // no-op
     }
 
-    override val sdkTracer: Tracer
+    override val sdkTracer: OtelJavaTracer
         get() = FakeTracer()
     override val spanService: SpanService
         get() = FakeSpanService()
@@ -46,10 +46,10 @@ class FakeOpenTelemetryModule(
         get() = TODO()
     override val logger: Logger
         get() = FakeOtelLogger()
-    override val externalOpenTelemetry: OpenTelemetry
+    override val externalOpenTelemetry: OtelJavaOpenTelemetry
         get() = EmbOpenTelemetry(traceProviderSupplier = { FakeTracerProvider() })
-    override val externalTracerProvider: TracerProvider
+    override val externalTracerProvider: OtelJavaTracerProvider
         get() = FakeTracerProvider()
-    override val openTelemetryClock: Clock
+    override val openTelemetryClock: OtelJavaClock
         get() = FakeOpenTelemetryClock(FakeClock())
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
@@ -1,21 +1,21 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.sdk.logs.ReadWriteLogRecord
-import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 
-class FakeReadWriteLogRecord : ReadWriteLogRecord {
+class FakeReadWriteLogRecord : OtelJavaReadWriteLogRecord {
 
     val attributes: MutableMap<String, String> = mutableMapOf()
 
     private val logRecordData = FakeLogRecordData()
 
-    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T): ReadWriteLogRecord {
+    override fun <T : Any> setAttribute(key: OtelJavaAttributeKey<T>, value: T): OtelJavaReadWriteLogRecord {
         attributes[key.key] = value.toString()
         return this
     }
 
-    override fun toLogRecordData(): LogRecordData {
+    override fun toLogRecordData(): OtelJavaLogRecordData {
         return logRecordData
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
@@ -2,32 +2,32 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceState
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import java.util.concurrent.TimeUnit
 
 class FakeSpan(
     val fakeSpanBuilder: FakeSpanBuilder,
-) : Span {
+) : OtelJavaSpan {
 
-    private val spanContext: SpanContext =
-        SpanContext.create(
+    private val spanContext: OtelJavaSpanContext =
+        OtelJavaSpanContext.create(
             fakeSpanBuilder.parentContext.getEmbraceSpan()?.traceId ?: OtelIds.generateTraceId(),
             OtelIds.generateSpanId(),
-            TraceFlags.getDefault(),
-            TraceState.getDefault()
+            OtelJavaTraceFlags.getDefault(),
+            OtelJavaTraceState.getDefault()
         )
 
     private var isRecording = true
-    private var status: StatusCode = StatusCode.UNSET
+    private var status: OtelJavaStatusCode = OtelJavaStatusCode.UNSET
     private var statusDescription: String = ""
 
-    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T?): Span {
+    override fun <T : Any> setAttribute(key: OtelJavaAttributeKey<T>, value: T?): OtelJavaSpan {
         if (value != null) {
             fakeSpanBuilder.setAttribute(key, value)
         }
@@ -35,25 +35,25 @@ class FakeSpan(
         return this
     }
 
-    override fun addEvent(name: String, attributes: Attributes): Span {
+    override fun addEvent(name: String, attributes: OtelJavaAttributes): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
-    override fun addEvent(name: String, attributes: Attributes, timestamp: Long, unit: TimeUnit): Span {
+    override fun addEvent(name: String, attributes: OtelJavaAttributes, timestamp: Long, unit: TimeUnit): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
-    override fun setStatus(statusCode: StatusCode, description: String): Span {
+    override fun setStatus(statusCode: OtelJavaStatusCode, description: String): OtelJavaSpan {
         status = statusCode
         statusDescription = description
         return this
     }
 
-    override fun recordException(exception: Throwable, additionalAttributes: Attributes): Span {
+    override fun recordException(exception: Throwable, additionalAttributes: OtelJavaAttributes): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
-    override fun updateName(name: String): Span {
+    override fun updateName(name: String): OtelJavaSpan {
         TODO("Not yet implemented")
     }
 
@@ -63,7 +63,7 @@ class FakeSpan(
 
     override fun end(timestamp: Long, unit: TimeUnit): Unit = end()
 
-    override fun getSpanContext(): SpanContext = spanContext
+    override fun getSpanContext(): OtelJavaSpanContext = spanContext
 
     override fun isRecording(): Boolean = isRecording
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
@@ -1,71 +1,71 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.SpanBuilder
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.context.Context
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import java.util.concurrent.TimeUnit
 
 class FakeSpanBuilder(
     val spanName: String,
     val tracerKey: TracerKey = TracerKey("fake-scope"),
-) : SpanBuilder {
+) : OtelJavaSpanBuilder {
 
-    var spanKind: SpanKind? = null
-    var parentContext: Context = Context.root()
+    var spanKind: OtelJavaSpanKind? = null
+    var parentContext: OtelJavaContext = OtelJavaContext.root()
     var startTimestampMs: Long? = null
     var attributes: MutableMap<Any, Any> = mutableMapOf()
 
-    override fun setParent(context: Context): SpanBuilder {
+    override fun setParent(context: OtelJavaContext): OtelJavaSpanBuilder {
         parentContext = context
         return this
     }
 
-    override fun setNoParent(): SpanBuilder {
-        parentContext = Context.root()
+    override fun setNoParent(): OtelJavaSpanBuilder {
+        parentContext = OtelJavaContext.root()
         return this
     }
 
-    override fun addLink(spanContext: SpanContext): SpanBuilder {
+    override fun addLink(spanContext: OtelJavaSpanContext): OtelJavaSpanBuilder {
         TODO("Not yet implemented")
     }
 
-    override fun addLink(spanContext: SpanContext, attributes: Attributes): SpanBuilder {
+    override fun addLink(spanContext: OtelJavaSpanContext, attributes: OtelJavaAttributes): OtelJavaSpanBuilder {
         TODO("Not yet implemented")
     }
 
-    override fun setAttribute(key: String, value: String): SpanBuilder {
+    override fun setAttribute(key: String, value: String): OtelJavaSpanBuilder {
         TODO("Not yet implemented")
     }
 
-    override fun setAttribute(key: String, value: Long): SpanBuilder {
+    override fun setAttribute(key: String, value: Long): OtelJavaSpanBuilder {
         TODO("Not yet implemented")
     }
 
-    override fun setAttribute(key: String, value: Double): SpanBuilder {
+    override fun setAttribute(key: String, value: Double): OtelJavaSpanBuilder {
         TODO("Not yet implemented")
     }
 
-    override fun setAttribute(key: String, value: Boolean): SpanBuilder {
+    override fun setAttribute(key: String, value: Boolean): OtelJavaSpanBuilder {
         TODO("Not yet implemented")
     }
 
-    override fun setSpanKind(spanKind: SpanKind): SpanBuilder {
+    override fun setSpanKind(spanKind: OtelJavaSpanKind): OtelJavaSpanBuilder {
         this.spanKind = spanKind
         return this
     }
 
-    override fun setStartTimestamp(startTimestamp: Long, unit: TimeUnit): SpanBuilder {
+    override fun setStartTimestamp(startTimestamp: Long, unit: TimeUnit): OtelJavaSpanBuilder {
         startTimestampMs = unit.toMillis(startTimestamp)
         return this
     }
 
     override fun startSpan(): FakeSpan = FakeSpan(this)
 
-    override fun <T : Any> setAttribute(key: AttributeKey<T>, value: T): SpanBuilder {
+    override fun <T : Any> setAttribute(key: OtelJavaAttributeKey<T>, value: T): OtelJavaSpanBuilder {
         attributes[key] = value
         return this
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("TYPEALIAS_EXPANSION_DEPRECATION")
 
 package io.embrace.android.embracesdk.fakes
 
@@ -7,30 +7,30 @@ import io.embrace.android.embracesdk.internal.otel.attrs.asPair
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
 import io.embrace.android.embracesdk.internal.otel.sdk.fromMap
-import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanId
-import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceId
-import io.opentelemetry.api.trace.TraceState
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
-import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.sdk.trace.data.EventData
-import io.opentelemetry.sdk.trace.data.LinkData
-import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.data.StatusData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaInstrumentationLibraryInfo
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLinkData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceId
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import kotlin.random.Random
 
 class FakeSpanData(
     private var name: String = "fake-started-span",
-    private var kind: SpanKind = SpanKind.INTERNAL,
+    private var kind: OtelJavaSpanKind = OtelJavaSpanKind.INTERNAL,
     private var type: EmbType = EmbType.Performance.Default,
-    private var spanContext: SpanContext = newTraceRootContext(),
-    private var parentSpanContext: SpanContext = SpanContext.getInvalid(),
+    private var spanContext: OtelJavaSpanContext = newTraceRootContext(),
+    private var parentSpanContext: OtelJavaSpanContext = OtelJavaSpanContext.getInvalid(),
     private var startEpochNanos: Long = DEFAULT_START_TIME_MS.millisToNanos(),
-    private var attributes: Attributes =
-        Attributes.builder().fromMap(
+    private var attributes: OtelJavaAttributes =
+        OtelJavaAttributes.builder().fromMap(
             attributes = mapOf(
                 type.asPair(),
                 Pair("my-key", "my-value")
@@ -38,36 +38,37 @@ class FakeSpanData(
             internal = true,
             limitsValidator = DataValidator()
         ).build(),
-    private var events: MutableList<EventData> = mutableListOf(
-        EventData.create(
+    private var events: MutableList<OtelJavaEventData> = mutableListOf(
+        OtelJavaEventData.create(
             startEpochNanos + 1000000L,
             "fake-event",
-            Attributes.builder().put("my-key", "my-value").build()
+            OtelJavaAttributes.builder().put("my-key", "my-value").build()
         )
     ),
-    private var links: MutableList<LinkData> = mutableListOf(),
-    private var resource: Resource = Resource.empty(),
-    var spanStatus: StatusData = StatusData.unset(),
+    private var links: MutableList<OtelJavaLinkData> = mutableListOf(),
+    private var resource: OtelJavaResource = OtelJavaResource.empty(),
+    var spanStatus: OtelJavaStatusData = OtelJavaStatusData.unset(),
     var endTimeNanos: Long = 0L,
-) : SpanData {
+) : OtelJavaSpanData {
     override fun getName(): String = name
-    override fun getKind(): SpanKind = kind
-    override fun getSpanContext(): SpanContext = spanContext
-    override fun getParentSpanContext(): SpanContext = parentSpanContext
-    override fun getStatus(): StatusData = spanStatus
+    override fun getKind(): OtelJavaSpanKind = kind
+    override fun getSpanContext(): OtelJavaSpanContext = spanContext
+    override fun getParentSpanContext(): OtelJavaSpanContext = parentSpanContext
+    override fun getStatus(): OtelJavaStatusData = spanStatus
     override fun getStartEpochNanos(): Long = startEpochNanos
-    override fun getAttributes(): Attributes = attributes
-    override fun getEvents(): MutableList<EventData> = events
-    override fun getLinks(): MutableList<LinkData> = links
+    override fun getAttributes(): OtelJavaAttributes = attributes
+    override fun getEvents(): MutableList<OtelJavaEventData> = events
+    override fun getLinks(): MutableList<OtelJavaLinkData> = links
     override fun getEndEpochNanos(): Long = endTimeNanos
     override fun hasEnded(): Boolean = endTimeNanos > 0
     override fun getTotalRecordedEvents(): Int = events.size
     override fun getTotalRecordedLinks(): Int = links.size
     override fun getTotalAttributeCount(): Int = attributes.size()
 
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun getInstrumentationLibraryInfo(): InstrumentationLibraryInfo = InstrumentationLibraryInfo.empty()
-    override fun getResource(): Resource = resource
+    @Deprecated("Deprecated in Java")
+    @Suppress("TYPEALIAS_EXPANSION_DEPRECATION")
+    override fun getInstrumentationLibraryInfo(): OtelJavaInstrumentationLibraryInfo = OtelJavaInstrumentationLibraryInfo.empty()
+    override fun getResource(): OtelJavaResource = resource
 
     companion object {
         private const val DEFAULT_START_TIME_MS = FakeClock.DEFAULT_FAKE_CURRENT_TIME
@@ -78,11 +79,11 @@ class FakeSpanData(
                 endTimeNanos = (DEFAULT_START_TIME_MS + 60000L).millisToNanos()
             )
 
-        private fun newTraceRootContext() = SpanContext.create(
-            TraceId.fromLongs(Random.nextLong(), Random.nextLong()).toString(),
-            SpanId.fromLong(Random.nextLong()).toString(),
-            TraceFlags.getDefault(),
-            TraceState.getDefault()
+        private fun newTraceRootContext() = OtelJavaSpanContext.create(
+            OtelJavaTraceId.fromLongs(Random.nextLong(), Random.nextLong()).toString(),
+            OtelJavaSpanId.fromLong(Random.nextLong()).toString(),
+            OtelJavaTraceFlags.getDefault(),
+            OtelJavaTraceState.getDefault()
         )
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
@@ -1,19 +1,19 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.trace.data.SpanData
-import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.math.min
 
-class FakeSpanExporter : SpanExporter {
-    val exportedSpans: MutableList<SpanData> = mutableListOf()
+class FakeSpanExporter : OtelJavaSpanExporter {
+    val exportedSpans: MutableList<OtelJavaSpanData> = mutableListOf()
 
     private val latches = mutableListOf<CountDownLatch>()
     private var totalExported = 0
 
-    override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
+    override fun export(spans: MutableCollection<OtelJavaSpanData>): OtelJavaCompletableResultCode {
         synchronized(exportedSpans) {
             exportedSpans.addAll(spans)
             latches.forEach { latch ->
@@ -24,18 +24,18 @@ class FakeSpanExporter : SpanExporter {
             latches.removeIf { it.count == 0L }
             totalExported += spans.size
         }
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun flush(): CompletableResultCode {
+    override fun flush(): OtelJavaCompletableResultCode {
         synchronized(exportedSpans) {
             exportedSpans.clear()
         }
-        return CompletableResultCode.ofSuccess()
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
-    override fun shutdown(): CompletableResultCode {
-        return CompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode {
+        return OtelJavaCompletableResultCode.ofSuccess()
     }
 
     /**

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.context.Context
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 
 class FakeSpanService : SpanService {
 
@@ -29,7 +29,7 @@ class FakeSpanService : SpanService {
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
         name = name,
-        parentContext = parent?.run { Context.root().with(parent as EmbraceSdkSpan) } ?: Context.root(),
+        parentContext = parent?.run { OtelJavaContext.root().with(parent as EmbraceSdkSpan) } ?: OtelJavaContext.root(),
         type = type,
         internal = internal,
         private = private,
@@ -83,7 +83,7 @@ class FakeSpanService : SpanService {
         createdSpans.add(
             FakeEmbraceSdkSpan(
                 name = name,
-                parentContext = parent?.run { Context.root().with(parent as EmbraceSdkSpan) } ?: Context.root(),
+                parentContext = parent?.run { OtelJavaContext.root().with(parent as EmbraceSdkSpan) } ?: OtelJavaContext.root(),
                 type = type,
                 internal = internal,
                 private = private

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracer.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracer.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
-import io.opentelemetry.api.trace.Tracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 
 class FakeTracer(
     val tracerKey: TracerKey = TracerKey(instrumentationScopeName = "fake-scope"),
-) : Tracer {
+) : OtelJavaTracer {
     override fun spanBuilder(spanName: String): FakeSpanBuilder = FakeSpanBuilder(spanName, tracerKey)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracerBuilder.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracerBuilder.kt
@@ -1,27 +1,27 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerBuilder
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerBuilder
 
 class FakeTracerBuilder(
     val instrumentationScopeName: String,
-) : TracerBuilder {
+) : OtelJavaTracerBuilder {
 
     var scopeVersion: String? = null
     var schema: String? = null
 
-    override fun setInstrumentationVersion(instrumentationScopeVersion: String): TracerBuilder {
+    override fun setInstrumentationVersion(instrumentationScopeVersion: String): OtelJavaTracerBuilder {
         scopeVersion = instrumentationScopeVersion
         return this
     }
 
-    override fun setSchemaUrl(schemaUrl: String): TracerBuilder {
+    override fun setSchemaUrl(schemaUrl: String): OtelJavaTracerBuilder {
         schema = schemaUrl
         return this
     }
 
-    override fun build(): Tracer =
+    override fun build(): OtelJavaTracer =
         FakeTracer(
             TracerKey(
                 instrumentationScopeName = instrumentationScopeName,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracerProvider.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracerProvider.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.api.trace.TracerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 
-class FakeTracerProvider : TracerProvider {
-    override fun get(instrumentationScopeName: String): Tracer = tracerBuilder(instrumentationScopeName).build()
+class FakeTracerProvider : OtelJavaTracerProvider {
+    override fun get(instrumentationScopeName: String): OtelJavaTracer = tracerBuilder(instrumentationScopeName).build()
 
-    override fun get(instrumentationScopeName: String, instrumentationScopeVersion: String): Tracer =
+    override fun get(instrumentationScopeName: String, instrumentationScopeVersion: String): OtelJavaTracer =
         tracerBuilder(instrumentationScopeName).setInstrumentationVersion(instrumentationScopeVersion).build()
 
     override fun tracerBuilder(instrumentationScopeName: String): FakeTracerBuilder =

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.opentelemetry.kotlin.StatusCode
-import io.opentelemetry.context.ContextKey
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
 
 val testSpan: Span = EmbraceSpanData(
     traceId = "19bb482ec1c7e6b2f10fb89e0ccc85fa",
@@ -55,7 +55,7 @@ val testSpanSnapshot: Span = Span(
     attributes = emptyList()
 )
 
-val fakeContextKey: ContextKey<String> = ContextKey.named<String>("fake-context-key")
+val fakeContextKey: OtelJavaContextKey<String> = OtelJavaContextKey.named<String>("fake-context-key")
 
 private fun createMapOfSize(size: Int): Map<String, String> {
     val mutableMap = mutableMapOf<String, String>()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ bundletool = { module = "com.android.tools.build:bundletool", version.ref = "bun
 opentelemetry-kotlin-api = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api", version.ref = "otelKotlin" }
 opentelemetry-kotlin-api-ext = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api-ext", version.ref = "otelKotlin" }
 opentelemetry-kotlin-compat = { module = "io.embrace.opentelemetry.kotlin:compat-kotlin-to-official", version.ref = "otelKotlin" }
+opentelemetry-java-aliases = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-java-typealiases", version.ref = "otelKotlin" }
 
 [plugins]
 google-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Goal

Relies on typealiases when using symbols from opentelemetry-java as this was causing confusion now that opentelemetry-kotlin is also a thing.

## Testing

Relied on existing test coverage.
