### PR TITLE
Use opentelemetry-kotlin implementation of Tracer

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -12,9 +12,9 @@ import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
 /**
  * Module that instantiates various OpenTelemetry related components
@@ -40,7 +40,7 @@ interface OpenTelemetryModule {
     /**
      * An instance of the OpenTelemetry component obtained from the wrapped SDK to create spans
      */
-    val sdkTracer: OtelJavaTracer
+    val sdkTracer: Tracer
 
     /**
      * Component that manages and provides access to the current session span

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -26,9 +26,9 @@ import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
 @OptIn(ExperimentalApi::class)
 internal class OpenTelemetryModuleImpl(
@@ -75,7 +75,7 @@ internal class OpenTelemetryModuleImpl(
         }
     }
 
-    override val sdkTracer: OtelJavaTracer by lazy {
+    override val sdkTracer: Tracer by lazy {
         otelSdkWrapper.sdkTracer
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -31,8 +31,9 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpanImpl.Compa
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -42,14 +43,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalApi::class)
 internal class CurrentSessionSpanImplTests {
+
     private lateinit var spanRepository: SpanRepository
     private lateinit var spanSink: SpanSink
     private lateinit var telemetryService: TelemetryService
     private lateinit var openTelemetryClock: OtelJavaClock
     private lateinit var currentSessionSpan: CurrentSessionSpanImpl
     private lateinit var spanService: SpanService
-    private lateinit var tracer: OtelJavaTracer
+    private lateinit var tracer: Tracer
     private val clock = FakeClock(1000L)
 
     @Before

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
@@ -8,6 +8,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanBuilder
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 
 class EmbTracer(
     private val sdkTracer: OtelJavaTracer,
@@ -23,6 +24,7 @@ class EmbTracer(
                 private = false,
                 internal = false,
                 parent = OtelJavaContext.current().getEmbraceSpan(),
+                clock = ClockAdapter(clock),
             ),
             spanService = spanService,
             clock = clock,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
@@ -15,7 +15,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
 /**
  * Wrapper that instantiates a copy of the OpenTelemetry SDK configured with the appropriate settings and the given components so
@@ -53,9 +53,12 @@ class OtelSdkWrapper(
         }
     }
 
-    val sdkTracer: OtelJavaTracer by lazy {
+    val sdkTracer: Tracer by lazy {
         EmbTrace.trace("otel-tracer-init") {
-            sdk.getTracer(configuration.sdkName, configuration.sdkVersion)
+            kotlinApi.tracerProvider.getTracer(
+                name = configuration.sdkName,
+                version = configuration.sdkVersion
+            )
         }
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/TracerExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/TracerExt.kt
@@ -5,12 +5,17 @@ import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanCreator
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanStartArgs
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
+import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerAdapter
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
 /**
  * Creates a new [OtelSpanCreator] that marks the resulting span as private if [internal] is true
  */
-fun OtelJavaTracer.otelSpanCreator(
+@OptIn(ExperimentalApi::class)
+fun Tracer.otelSpanCreator(
     name: String,
     type: EmbType,
     internal: Boolean,
@@ -27,4 +32,28 @@ fun OtelJavaTracer.otelSpanCreator(
         parentSpan = parent,
     ),
     tracer = this
+)
+
+/**
+ * Creates a new [OtelSpanCreator] that marks the resulting span as private if [internal] is true
+ */
+@OptIn(ExperimentalApi::class)
+fun OtelJavaTracer.otelSpanCreator(
+    name: String,
+    type: EmbType,
+    internal: Boolean,
+    private: Boolean,
+    clock: Clock,
+    parent: EmbraceSpan? = null,
+    autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
+): OtelSpanCreator = OtelSpanCreator(
+    OtelSpanStartArgs(
+        name = name,
+        type = type,
+        internal = internal,
+        private = private,
+        autoTerminationMode = autoTerminationMode,
+        parentSpan = parent,
+    ),
+    tracer = TracerAdapter(this, clock)
 )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreator.kt
@@ -1,27 +1,34 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
-import java.util.concurrent.TimeUnit
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.otel.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.Span
+import io.embrace.opentelemetry.kotlin.tracing.SpanKind
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
+@OptIn(ExperimentalApi::class)
 class OtelSpanCreator(
     val spanStartArgs: OtelSpanStartArgs,
-    private val tracer: OtelJavaTracer,
+    private val tracer: Tracer,
 ) {
 
-    internal fun startSpan(startTimeMs: Long): OtelJavaSpan {
-        with(spanStartArgs) {
-            val builder = tracer.spanBuilder(spanName)
-            if (parentContext == OtelJavaContext.root()) {
-                builder.setNoParent()
-            } else {
-                builder.setParent(parentContext)
-            }
+    internal fun startSpan(startTimeMs: Long): Span {
+        // FIXME: propagate context correctly
+//        val parentSpanContext = spanStartArgs.parentContext.getEmbraceSpan()?.spanContext
+//        val parent = parentSpanContext?.let(::SpanContextAdapter)
 
-            spanKind?.let(builder::setSpanKind)
-            builder.setStartTimestamp(startTimeMs, TimeUnit.MILLISECONDS)
-            return builder.startSpan()
-        }
+        return tracer.createSpan(
+            name = spanStartArgs.spanName,
+            parent = null,
+            spanKind = spanStartArgs.spanKind?.toOtelKotlin() ?: SpanKind.INTERNAL,
+            startTimestamp = startTimeMs.millisToNanos()
+        )
+//        val builder = tracer.spanBuilder(spanName)
+//        if (parentContext == OtelJavaContext.root()) {
+//            builder.setNoParent()
+//        } else {
+//            builder.setParent(parentContext)
+//        }
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceFlagsWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceFlagsWrapper.kt
@@ -8,8 +8,7 @@ class KotlinTraceFlagsWrapper(
 ) : OtelJavaTraceFlags {
     override fun isSampled(): Boolean = impl.isSampled
 
-    // FIXME: temporary. requires change in opentelemetry-kotlin first
-    override fun asHex(): String = throw UnsupportedOperationException()
+    override fun asHex(): String = impl.hex
 
     override fun asByte(): Byte = asHex().toByte()
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -53,7 +53,7 @@ internal class OpenTelemetrySdkTest {
 
     @Test
     fun `check resource added by sdk tracer`() {
-        sdk.sdkTracer.spanBuilder("test").startSpan().end()
+        sdk.sdkTracer.createSpan("test").end()
         spanExporter.exportedSpans.single().resource.assertExpectedAttributes(
             expectedServiceName = configuration.sdkName,
             expectedServiceVersion = configuration.sdkVersion,
@@ -74,8 +74,7 @@ internal class OpenTelemetrySdkTest {
     @Test
     fun `sdk name and version used as instrumentation scope for tracer instance used by embrace`() {
         sdk.sdkTracer
-            .spanBuilder("test")
-            .startSpan()
+            .createSpan("test")
             .end()
         with(spanExporter.exportedSpans.single().instrumentationScopeInfo) {
             assertEquals(configuration.sdkName, name)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
@@ -7,6 +7,10 @@ import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.otelSpanCreator
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
+import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerAdapter
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -15,11 +19,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalApi::class)
 internal class EmbraceSpanFactoryImplTest {
     private val clock = FakeClock()
     private lateinit var embraceSpanFactory: EmbraceSpanFactoryImpl
     private lateinit var spanRepository: SpanRepository
-    private lateinit var tracer: FakeTracer
+    private lateinit var tracer: Tracer
     private var updateNotified: Boolean = false
 
     @Before
@@ -30,7 +35,7 @@ internal class EmbraceSpanFactoryImplTest {
                 updateNotified = true
             }
         }
-        tracer = FakeTracer()
+        tracer = TracerAdapter(FakeTracer(), ClockAdapter(openTelemetryClock))
         embraceSpanFactory = EmbraceSpanFactoryImpl(
             tracer = tracer,
             openTelemetryClock = openTelemetryClock,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
 import io.embrace.android.embracesdk.internal.otel.sdk.OtelSdkWrapper
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -21,6 +22,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalApi::class)
 internal class EmbraceSpanServiceTest {
     private lateinit var spanSink: SpanSink
     private lateinit var spanService: SpanService

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -34,6 +34,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -44,6 +45,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class SpanServiceImplTest {
     private lateinit var spanSink: SpanSink

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKotlinSpan.kt
@@ -4,6 +4,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.StatusCode
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.tracing.Link
+import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
@@ -14,13 +15,12 @@ class FakeKotlinSpan(
     override var parent: SpanContext?,
     override val spanKind: SpanKind,
     override val startTimestamp: Long,
-) : io.embrace.opentelemetry.kotlin.tracing.Span {
+) : Span {
 
     private var inProgress = true
 
     override fun attributes(): Map<String, Any> = emptyMap()
 
-    // FIXME: temp, requires access to SpanContextAdapter in opentelemetry-kotlin
     override val spanContext: SpanContext = throw UnsupportedOperationException()
 
     override var status: StatusCode = StatusCode.Unset

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -19,9 +19,9 @@ import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
 class FakeOpenTelemetryModule(
     override val currentSessionSpan: CurrentSessionSpan = FakeCurrentSessionSpan(),
@@ -36,8 +36,8 @@ class FakeOpenTelemetryModule(
         // no-op
     }
 
-    override val sdkTracer: OtelJavaTracer
-        get() = FakeTracer()
+    override val sdkTracer: Tracer
+        get() = FakeKotlinTracer()
     override val spanService: SpanService
         get() = FakeSpanService()
     override val embraceTracer: EmbraceTracer

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
@@ -36,11 +36,11 @@ class FakeSpan(
     }
 
     override fun addEvent(name: String, attributes: OtelJavaAttributes): OtelJavaSpan {
-        TODO("Not yet implemented")
+        return this
     }
 
     override fun addEvent(name: String, attributes: OtelJavaAttributes, timestamp: Long, unit: TimeUnit): OtelJavaSpan {
-        TODO("Not yet implemented")
+        return this
     }
 
     override fun setStatus(statusCode: OtelJavaStatusCode, description: String): OtelJavaSpan {
@@ -50,11 +50,11 @@ class FakeSpan(
     }
 
     override fun recordException(exception: Throwable, additionalAttributes: OtelJavaAttributes): OtelJavaSpan {
-        TODO("Not yet implemented")
+        return this
     }
 
     override fun updateName(name: String): OtelJavaSpan {
-        TODO("Not yet implemented")
+        return this
     }
 
     override fun end() {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
@@ -10,7 +10,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import java.util.concurrent.TimeUnit
 
 class FakeSpanBuilder(
-    val spanName: String,
+    var spanName: String,
     val tracerKey: TracerKey = TracerKey("fake-scope"),
 ) : OtelJavaSpanBuilder {
 


### PR DESCRIPTION
## Goal

Alters the SDK to use opentelemetry-kotlin's implementation of `Tracer`. This is not fully complete as the tests are failing due to context propagation not being fully ported over yet. A future PR will address this problem before merging down to the integration branch.
