### PR TITLE
Dexguard fix: pass dependencies correctly between tasks

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -149,9 +149,7 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
         val targetObfuscationTasks = listOf(
             "dexguardApk$name",
             "dexguardAab$name",
-            "transformClassesAndResourcesWithProguardFor$name",
             "minify${name}WithProguard",
-            "transformClassesAndResourcesWithR8For$name",
             "minify${name}WithR8"
         )
         val tasks = targetObfuscationTasks.filter { taskName ->

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -98,10 +98,8 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
 
             // link output of compression task to the input of this task
             // dependencies to mapping file compression will be added automatically
-            task.uploadFile.fileProvider(
-                compressionTask.nullSafeMap {
-                    it.compressedFile.orNull?.asFile
-                }
+            task.uploadFile.set(
+                compressionTask.flatMap { it.compressedFile }
             )
         }
 


### PR DESCRIPTION
## Goal

Using flatMap instead of map should carry dependencies from the compression task to the upload task in JvmMappingUploadTaskRegistration.kt.

This should fix the following issue: 

```
Task ':app:jvmMappingUploadTaskForFordexguardApkOnVariantUsProduction' uses this output of task ':app:jvmMappingCompressionTaskForFordexguardAabOnVariantUsProduction' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

Also removed old obfuscation tasks that are not present in the gradle versions we support.