### PR TITLE
Fix react native tests

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/build.gradle
+++ b/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"
-        kotlinVersion = "1.9.24"
+        kotlinVersion = "2.0.0"
     }
     repositories {
         google()
@@ -17,7 +17,7 @@ buildscript {
         classpath "io.embrace:embrace-swazzler:$plugin_snapshot_version"
         classpath "io.embrace:embrace-gradle-plugin-integration-tests:$plugin_snapshot_version"
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 

--- a/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/package.json
+++ b/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/package.json
@@ -8,16 +8,16 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "@embrace-io/react-native": "^5.1.0",
-    "react": "18.3.1",
-    "react-native": "0.76.5"
+    "@embrace-io/react-native": "^5.2.0",
+    "react": "19.0.0",
+    "react-native": "0.79.0"
   },
   "devDependencies": {
     "@react-native-community/cli": "15.0.1",
     "@react-native-community/cli-platform-android": "15.0.1",
-    "@react-native/metro-config": "0.76.5",
-    "@react-native/typescript-config": "0.76.5",
-    "@types/react": "^18.2.6",
+    "@react-native/metro-config": "0.79.0",
+    "@react-native/typescript-config": "0.79.0",
+    "@types/react": "^19.0.0",
     "typescript": "5.0.4"
   },
   "engines": {

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
@@ -67,7 +67,7 @@ class ReactNativeAndroidTest {
                 installNodeModules(projectDir)
             },
             assertions = { projectDir ->
-                verifyAsmInjection(File(projectDir, "app"), "765FB008173DC25D016D112F67250241")
+                verifyAsmInjection(File(projectDir, "app"), "5B412C6876E5040DD603052BAD052A6F")
             }
         )
     }


### PR DESCRIPTION
## Goal

The React Native integration test cases were failing as they used a version of Kotlin that's incompatible with what is supplied via opentelemetry-kotlin.
