### PR TITLE
Store compressed jvm outputs in different locations for every obfuscation task

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -70,7 +70,7 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
             task.originalFile.fileProvider(mappingFile)
             task.compressedFile.convention(
                 project.layout.buildDirectory.file(
-                    "outputs/embrace/mapping/compressed/${variant.name}/$FILE_NAME_MAPPING_TXT"
+                    "outputs/embrace/mapping/compressed/${variant.name}/$anchorTaskWithoutVariant/$FILE_NAME_MAPPING_TXT"
                 )
             )
         }


### PR DESCRIPTION
## Goal

When running `./gradlew assembleRelease bundleRelease`, users where getting an exception: 

```
Task ':app:jvmMappingUploadTaskForFordexguardApkOnVariantUsProduction' uses this output of task ':app:jvmMappingCompressionTaskForFordexguardAabOnVariantUsProduction' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

The issue was that different obfuscation tasks (APK vs AAB) were sharing the same output file path:

```
"outputs/embrace/mapping/compressed/${variant.name}/$anchorTaskWithoutVariant/$FILE_NAME_MAPPING_TXT"
```

When running both assembleRelease and bundleRelease in sequence:
- The AAB compression task creates the mapping file
- The APK compression task tries to write to the same file
- The APK upload task tries to read from a file created by a different compression task
Gradle detects this cross-task dependency without a declaration, and fails the build.

With this PR, the compression task output includes the anchor task name, so each obfuscation task type has its own output location.

## Testing

Verified locally on a dexguard test app.

