### PR TITLE
Retrieve parent from the context using the context key set by the Java SDK

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreator.kt
@@ -13,10 +13,8 @@ class OtelSpanCreator(
     val spanStartArgs: OtelSpanStartArgs,
     private val tracer: Tracer,
 ) {
-
     internal fun startSpan(startTimeMs: Long): Span {
-        val parentSpanContext = spanStartArgs.parentContext.getEmbraceSpan()?.spanContext
-
+        val parentSpanContext = spanStartArgs.getParentSpanContext()
         return tracer.createSpan(
             name = spanStartArgs.spanName,
             parent = parentSpanContext?.let(::SpanContextAdapter),

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgs.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgs.kt
@@ -7,6 +7,8 @@ import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceObjectName
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 
 /**
@@ -35,7 +37,7 @@ class OtelSpanStartArgs(
     val customAttributes = mutableMapOf<String, String>()
 
     init {
-        // If there is a parent, extract the wrapped OTel span and set it as the parent in the wrapped OTel SpanBuilder
+        // If a EmbraceSpan is passed in as a parent, create a new Context with that span's SpanContext set as the Span in that Context
         if (parentSpan is EmbraceSdkSpan) {
             val newParentContext = parentSpan.asNewContext() ?: OtelJavaContext.root()
             parentContext = newParentContext.with(parentSpan)
@@ -48,5 +50,13 @@ class OtelSpanStartArgs(
         }
     }
 
-    fun getParentSpan(): EmbraceSpan? = parentContext.getEmbraceSpan()
+    fun getParentSpanContext(): OtelJavaSpanContext? {
+        val parentSpanContext = OtelJavaSpan.fromContext(parentContext).spanContext
+
+        return if (parentSpanContext.isValid) {
+            parentSpanContext
+        } else {
+            null
+        }
+    }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreatorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanCreatorTest.kt
@@ -3,8 +3,8 @@ package io.embrace.android.embracesdk.internal.otel.spans
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryClock
+import io.embrace.android.embracesdk.fakes.FakeSpanBuilder
 import io.embrace.android.embracesdk.fakes.FakeTracer
-import io.embrace.android.embracesdk.fixtures.fakeContextKey
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
@@ -16,8 +16,8 @@ import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerAdapter
 import io.embrace.opentelemetry.kotlin.tracing.Span
 import io.embrace.opentelemetry.kotlin.tracing.SpanKind
-import io.opentelemetry.context.ImplicitContextKeyed
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -56,7 +56,9 @@ internal class OtelSpanCreatorTest {
             assertTrue(contains(EmbType.Performance.Default))
         }
         assertEquals("emb-test", args.spanName)
-        creator.startSpan(startTime).assertFakeSpanBuilder(
+        assertNull(creator.spanStartArgs.getParentSpanContext())
+
+        creator.startSpan(startTime).assertSpan(
             expectedName = "emb-test",
             expectedStartTimeMs = startTime
         )
@@ -75,22 +77,18 @@ internal class OtelSpanCreatorTest {
             tracer = TracerAdapter(tracer, otelClock),
             spanStartArgs = args,
         )
-        val parent = FakeEmbraceSdkSpan.started()
-        val parentContext = checkNotNull(parent.asNewContext()?.with(fakeContextKey, "value"))
-        args.parentContext = parentContext
+        val parent = FakeSpanBuilder(spanName = "parent").startSpan()
+        args.parentContext = OtelJavaContext.root().with(parent)
+        assertEquals(parent.spanContext, creator.spanStartArgs.getParentSpanContext())
         val startTime = clock.now()
-        val span = creator.startSpan(startTime)
-        val expectedTraceId = parent.spanContext?.traceId
-        span.assertFakeSpanBuilder(
+        creator.startSpan(startTime).assertSpan(
             expectedName = "test",
-            expectedParentContext = parentContext,
             expectedStartTimeMs = startTime,
-            expectedTraceId = expectedTraceId
         )
     }
 
     @Test
-    fun `remove parent after initial creation`() {
+    fun `change and remove parent after initial creation`() {
         val parent = FakeEmbraceSdkSpan.started()
         val startTime = clock.now()
         val args = OtelSpanStartArgs(
@@ -100,18 +98,22 @@ internal class OtelSpanCreatorTest {
             private = false,
             parentSpan = parent,
         )
+
+        assertEquals(parent.spanContext, args.getParentSpanContext())
+
         val creator = OtelSpanCreator(
             tracer = TracerAdapter(tracer, otelClock),
             spanStartArgs = args,
         )
 
-        args.parentContext = OtelJavaContext.root()
-        with(creator.startSpan(startTime)) {
-            assertFakeSpanBuilder(
-                expectedName = "test",
-                expectedStartTimeMs = startTime
-            )
-        }
+        val newParent = FakeSpanBuilder("new-parent").startSpan()
+        args.parentContext = OtelJavaContext.root().with(newParent)
+        assertEquals(newParent.spanContext, creator.spanStartArgs.getParentSpanContext())
+
+        creator.startSpan(startTime).assertSpan(
+            expectedName = "test",
+            expectedStartTimeMs = startTime
+        )
 
         val uxArgs = OtelSpanStartArgs(
             name = "ux-test",
@@ -120,18 +122,17 @@ internal class OtelSpanCreatorTest {
             private = false,
             parentSpan = parent,
         )
-        val uxSpanBuilder = OtelSpanCreator(
+        val uxCreator = OtelSpanCreator(
             tracer = TracerAdapter(tracer, otelClock),
             spanStartArgs = uxArgs,
         )
 
         uxArgs.parentContext = OtelJavaContext.root()
-        with(uxSpanBuilder.startSpan(startTime)) {
-            assertFakeSpanBuilder(
-                expectedName = "ux-test",
-                expectedStartTimeMs = startTime
-            )
-        }
+        assertNull(uxCreator.spanStartArgs.getParentSpanContext())
+        uxCreator.startSpan(startTime).assertSpan(
+            expectedName = "ux-test",
+            expectedStartTimeMs = startTime
+        )
     }
 
     @Test
@@ -149,7 +150,7 @@ internal class OtelSpanCreatorTest {
 
         val startTime = clock.now()
         args.spanKind = OtelJavaSpanKind.CLIENT
-        creator.startSpan(startTime).assertFakeSpanBuilder(
+        creator.startSpan(startTime).assertSpan(
             expectedName = "test",
             expectedStartTimeMs = startTime,
             expectedSpanKind = SpanKind.CLIENT
@@ -168,45 +169,13 @@ internal class OtelSpanCreatorTest {
         assertEquals("test-value", args.customAttributes["test-key"])
     }
 
-    @Test
-    fun `context value propagated even if it does not context a span`() {
-        val fakeRootContext = OtelJavaContext.root().with(fakeContextKey, "fake-value")
-        val args = OtelSpanStartArgs(
-            name = "parent",
-            type = EmbType.Performance.Default,
-            internal = false,
-            private = false,
-        )
-        val creator = OtelSpanCreator(
-            tracer = TracerAdapter(tracer, otelClock),
-            spanStartArgs = args
-        )
-
-        args.parentContext = fakeRootContext
-        assertEquals("fake-value", args.parentContext.get(fakeContextKey))
-
-        creator.startSpan(clock.now())
-        assertEquals("fake-value", fakeRootContext.get(fakeContextKey))
-    }
-
-    private fun Span.assertFakeSpanBuilder(
+    private fun Span.assertSpan(
         expectedName: String,
-        expectedParentContext: OtelJavaContext = OtelJavaContext.root(),
         expectedSpanKind: SpanKind = SpanKind.INTERNAL,
         expectedStartTimeMs: Long,
-        expectedTraceId: String? = null,
     ) {
-        val fakeSpan = this
-        with(fakeSpan) {
-            assertEquals(expectedName, name)
-            val ctx = expectedParentContext.getEmbraceSpan()?.spanContext
-            assertEquals(ctx?.traceId, parent?.traceId)
-            assertEquals(ctx?.spanId, parent?.spanId)
-            assertEquals(expectedSpanKind, spanKind)
-            assertEquals(expectedStartTimeMs.millisToNanos(), startTimestamp)
-            if (expectedTraceId != null) {
-                assertEquals(expectedTraceId, spanContext.traceId)
-            }
-        }
+        assertEquals(expectedName, name)
+        assertEquals(expectedSpanKind, spanKind)
+        assertEquals(expectedStartTimeMs.millisToNanos(), startTimestamp)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -4,11 +4,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.impl.EmbSpan
 import io.embrace.android.embracesdk.internal.otel.impl.EmbSpanBuilder
 import io.embrace.android.embracesdk.internal.otel.impl.EmbTracer
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.SpanEvent


### PR DESCRIPTION
## Goal

Get the parent `SpanContext` from the context key set by the Java SDK, which will always be there. Previously, it got it from the context key set by the Embrace SDK, which would not exist if the OTel tracing API implementation was used, as is in `ExternalTracerTest`.

## Testing
Fixed the tests to look for the right things. The `SpanAdapter` returned is all correct other than the fake span stored in `impl` because it was created by the FakeTracer. Also deleted an invalid test as we can really only check that the SpanContext is propagated in that test
