### PR TITLE
Schedules a delayed check to stop ANR monitoring if the app is still in background after service start.

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/EmbraceAnrService.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.AnrInterval
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
+import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.Callable
 import java.util.concurrent.CopyOnWriteArrayList
@@ -31,11 +32,15 @@ internal class EmbraceAnrService(
     private val state: ThreadMonitoringState,
     private val clock: Clock,
     private val stacktraceSampler: AnrStacktraceSampler,
+    private val processStateService: ProcessStateService,
 ) : AnrService, MemoryCleanerListener, ProcessStateListener, BlockedThreadListener {
 
     private val listeners: CopyOnWriteArrayList<BlockedThreadListener> = CopyOnWriteArrayList<BlockedThreadListener>()
 
     init {
+        if (processStateService.isInBackground) {
+            scheduleDelayedBackgroundCheck()
+        }
         // add listeners
         listeners.add(stacktraceSampler)
         livenessCheckScheduler.listener = this
@@ -131,6 +136,24 @@ internal class EmbraceAnrService(
         // Invoke callbacks
         for (listener in listeners) {
             listener.onThreadBlockedInterval(looper.thread, timestamp)
+        }
+    }
+
+    /**
+     * Schedules a delayed check to stop ANR monitoring if the app is still in background.
+     * This handles slow app startup scenarios where the app takes time to transition to foreground.
+     */
+    private fun scheduleDelayedBackgroundCheck() {
+        anrMonitorWorker.schedule<Unit>(::stopMonitoringIfStillInBackground, 10, TimeUnit.SECONDS)
+    }
+
+    /**
+     * Stops ANR monitoring if the app is currently in background state.
+     * Called after a 10-second delay to handle slow startup scenarios.
+     */
+    private fun stopMonitoringIfStillInBackground() {
+        if (processStateService.isInBackground) {
+            livenessCheckScheduler.stopMonitoringThread()
         }
     }
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleImpl.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.anr.detection.LivenessCheckSchedul
 import io.embrace.android.embracesdk.internal.anr.detection.TargetThreadHandler
 import io.embrace.android.embracesdk.internal.anr.detection.ThreadMonitoringState
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
 import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class AnrModuleImpl(
@@ -17,6 +18,7 @@ internal class AnrModuleImpl(
     openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
     workerModule: WorkerThreadModule,
+    processStateService: ProcessStateService,
 ) : AnrModule {
 
     private val anrMonitorWorker = workerModule.backgroundWorker(Worker.Background.AnrWatchdogWorker)
@@ -33,7 +35,8 @@ internal class AnrModuleImpl(
                 anrMonitorWorker = anrMonitorWorker,
                 state = state,
                 clock = initModule.clock,
-                stacktraceSampler = stacktraceSampler
+                stacktraceSampler = stacktraceSampler,
+                processStateService = processStateService,
             )
         } else {
             null

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AnrModuleSupplier.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
 
 /**
  * Function that returns an instance of [AnrModule]. Matches the signature of the constructor for [AnrModuleImpl]
@@ -10,6 +11,7 @@ typealias AnrModuleSupplier = (
     openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
     workerModule: WorkerThreadModule,
+    processStateService: ProcessStateService
 ) -> AnrModule
 
 fun createAnrModule(
@@ -17,4 +19,5 @@ fun createAnrModule(
     openTelemetryModule: OpenTelemetryModule,
     configService: ConfigService,
     workerModule: WorkerThreadModule,
-): AnrModule = AnrModuleImpl(initModule, openTelemetryModule, configService, workerModule)
+    processStateService: ProcessStateService
+): AnrModule = AnrModuleImpl(initModule, openTelemetryModule, configService, workerModule, processStateService)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceRule.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceRule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.anr
 import android.os.Looper
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.internal.anr.detection.BlockedThreadDetector
 import io.embrace.android.embracesdk.internal.anr.detection.LivenessCheckScheduler
@@ -29,6 +30,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
     val logger = EmbLoggerImpl()
 
     lateinit var fakeConfigService: FakeConfigService
+    lateinit var fakeProcessStateService: FakeProcessStateService
     lateinit var anrService: EmbraceAnrService
     lateinit var livenessCheckScheduler: LivenessCheckScheduler
     lateinit var state: ThreadMonitoringState
@@ -45,6 +47,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
         anrBehavior = FakeAnrBehavior()
         anrMonitorThread = AtomicReference(Thread.currentThread())
         fakeConfigService = FakeConfigService(anrBehavior = anrBehavior)
+        fakeProcessStateService = FakeProcessStateService(false)
         anrExecutorService = scheduledExecutorSupplier.invoke()
         state = ThreadMonitoringState(clock)
         val worker =
@@ -83,7 +86,8 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             anrMonitorWorker = worker,
             state = state,
             clock = clock,
-            stacktraceSampler = stacktraceSampler
+            stacktraceSampler = stacktraceSampler,
+            processStateService = fakeProcessStateService
         )
     }
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/AnrModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/AnrModuleImplTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import android.os.Looper
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
+import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
@@ -28,7 +29,8 @@ internal class AnrModuleImplTest {
             FakeInitModule(),
             FakeOpenTelemetryModule(),
             FakeConfigService(),
-            FakeWorkerThreadModule()
+            FakeWorkerThreadModule(),
+            FakeProcessStateService()
         )
         assertNotNull(module.anrService)
         assertNotNull(module.anrOtelMapper)
@@ -42,7 +44,8 @@ internal class AnrModuleImplTest {
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(anrServiceEnabled = false)
             ),
-            FakeWorkerThreadModule()
+            FakeWorkerThreadModule(),
+            FakeProcessStateService()
         )
         assertNull(module.anrService)
         assertNull(module.anrOtelMapper)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeJniDelegate
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
+import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
 import io.embrace.android.embracesdk.fakes.FakeSymbolService
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
@@ -85,7 +86,8 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
             fakeInitModule,
             fakeInitModule.openTelemetryModule,
             FakeConfigService(),
-            workerThreadModule
+            workerThreadModule,
+            FakeProcessStateService()
         )
     } else {
         val fakeAnrService = FakeAnrService()
@@ -145,7 +147,7 @@ internal class EmbraceSetupInterface @JvmOverloads constructor(
                 deliveryTracer = deliveryTracer,
             )
         },
-        anrModuleSupplier = { _, _, _, _ -> anrModule },
+        anrModuleSupplier = { _, _, _, _, _ -> anrModule },
         nativeCoreModuleSupplier = { initModule, coreModule, payloadSourceModule, workerThreadModule, configModule, storageModule, essentialServiceModule, openTelemetryModule, _, _, _ ->
             createNativeCoreModule(
                 initModule = initModule,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -219,7 +219,8 @@ internal class ModuleInitBootstrapper(
                             initModule,
                             openTelemetryModule,
                             configModule.configService,
-                            workerThreadModule
+                            workerThreadModule,
+                            essentialServiceModule.processStateService
                         )
                     }
 

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -47,7 +47,7 @@ internal fun fakeModuleInitBootstrapper(
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
-    anrModuleSupplier: AnrModuleSupplier = { _, _, _, _ -> FakeAnrModule() },
+    anrModuleSupplier: AnrModuleSupplier = { _, _, _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _, _ -> FakeLogModule() },
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier =


### PR DESCRIPTION
## Goal

Stop tracking ANRs when they happen in the background, unless the ANR starts on app startup.

## Testing

Working on another PR with integration tests