### PR TITLE
Rename embrace otel java implementations

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -4,9 +4,9 @@ import io.embrace.android.embracesdk.core.BuildConfig
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
-import io.embrace.android.embracesdk.internal.otel.impl.EmbClock
-import io.embrace.android.embracesdk.internal.otel.impl.EmbOpenTelemetry
-import io.embrace.android.embracesdk.internal.otel.impl.EmbTracerProvider
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaClock
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaOpenTelemetry
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaTracerProvider
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
@@ -33,7 +33,7 @@ import io.embrace.opentelemetry.kotlin.tracing.Tracer
 @OptIn(ExperimentalApi::class)
 internal class OpenTelemetryModuleImpl(
     private val initModule: InitModule,
-    override val openTelemetryClock: OtelJavaClock = EmbClock(
+    override val openTelemetryClock: OtelJavaClock = EmbOtelJavaClock(
         embraceClock = initModule.clock
     ),
 ) : OpenTelemetryModule {
@@ -151,13 +151,13 @@ internal class OpenTelemetryModuleImpl(
     }
 
     override val externalOpenTelemetry: OtelJavaOpenTelemetry by lazy {
-        EmbOpenTelemetry(
+        EmbOtelJavaOpenTelemetry(
             traceProviderSupplier = { externalTracerProvider }
         )
     }
 
     override val externalTracerProvider: OtelJavaTracerProvider by lazy {
-        EmbTracerProvider(
+        EmbOtelJavaTracerProvider(
             sdkTracerProvider = otelSdkWrapper.sdkTracerProvider,
             spanService = spanService,
             clock = openTelemetryClock,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImplTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.otel.impl.EmbOpenTelemetry
-import io.embrace.android.embracesdk.internal.otel.impl.EmbTracerProvider
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaOpenTelemetry
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaTracerProvider
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSinkImpl
@@ -20,8 +20,8 @@ internal class OpenTelemetryModuleImplTest {
         assertTrue(openTelemetryModule.spanService is EmbraceSpanService)
         assertTrue(openTelemetryModule.currentSessionSpan is CurrentSessionSpanImpl)
         assertTrue(openTelemetryModule.logSink is LogSinkImpl)
-        assertTrue(openTelemetryModule.externalOpenTelemetry is EmbOpenTelemetry)
-        assertTrue(openTelemetryModule.externalTracerProvider is EmbTracerProvider)
+        assertTrue(openTelemetryModule.externalOpenTelemetry is EmbOtelJavaOpenTelemetry)
+        assertTrue(openTelemetryModule.externalTracerProvider is EmbOtelJavaTracerProvider)
         assertNotNull(openTelemetryModule.logger)
         assertNotNull(openTelemetryModule.sdkTracer)
     }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaClock.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaClock.kt
@@ -12,7 +12,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
  * The one caveat about this implementation is that the precision for obtaining the current time only goes to the millisecond, which is
  * considered enough for client side operation timings at this time.
  */
-class EmbClock(
+class EmbOtelJavaClock(
     private val embraceClock: Clock,
 ) : OtelJavaClock {
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaOpenTelemetry.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaOpenTelemetry.kt
@@ -7,7 +7,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 /**
  * Embrace-specific implementation that can be used to obtain working Tracer implementations that will record spans for Embrace sessions
  */
-class EmbOpenTelemetry(
+class EmbOtelJavaOpenTelemetry(
     private val traceProviderSupplier: () -> OtelJavaTracerProvider,
 ) : OtelJavaOpenTelemetry {
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpan.kt
@@ -13,7 +13,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import java.util.concurrent.TimeUnit
 
-class EmbSpan(
+class EmbOtelJavaSpan(
     private val embraceSpan: EmbraceSdkSpan,
     private val clock: OtelJavaClock,
 ) : OtelJavaSpan {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpanBuilder.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpanBuilder.kt
@@ -12,7 +12,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import java.util.concurrent.TimeUnit
 
-class EmbSpanBuilder(
+class EmbOtelJavaSpanBuilder(
     private val otelSpanCreator: OtelSpanCreator,
     private val spanService: SpanService,
     private val clock: OtelJavaClock,
@@ -61,7 +61,7 @@ class EmbSpanBuilder(
     override fun startSpan(): OtelJavaSpan {
         spanService.createSpan(otelSpanCreator)?.let { embraceSpan ->
             if (embraceSpan.start()) {
-                return EmbSpan(
+                return EmbOtelJavaSpan(
                     embraceSpan = embraceSpan,
                     clock = clock,
                 )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracer.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracer.kt
@@ -10,14 +10,14 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanBuilder
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.k2j.ClockAdapter
 
-class EmbTracer(
+class EmbOtelJavaTracer(
     private val sdkTracer: OtelJavaTracer,
     private val spanService: SpanService,
     private val clock: OtelJavaClock,
 ) : OtelJavaTracer {
 
     override fun spanBuilder(spanName: String): OtelJavaSpanBuilder =
-        EmbSpanBuilder(
+        EmbOtelJavaSpanBuilder(
             otelSpanCreator = sdkTracer.otelSpanCreator(
                 name = spanName,
                 type = EmbType.Performance.Default,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerBuilder.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerBuilder.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerBuilder
 
-internal class EmbTracerBuilder(
+internal class EmbOtelJavaTracerBuilder(
     instrumentationScopeName: String,
     private val tracerSupplier: (tracerKey: TracerKey) -> OtelJavaTracer,
 ) : OtelJavaTracerBuilder {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerProvider.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerProvider.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerBuilder
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import java.util.concurrent.ConcurrentHashMap
 
-class EmbTracerProvider(
+class EmbOtelJavaTracerProvider(
     private val sdkTracerProvider: OtelJavaTracerProvider,
     private val spanService: SpanService,
     private val clock: OtelJavaClock,
@@ -22,7 +22,7 @@ class EmbTracerProvider(
         tracerBuilder(instrumentationScopeName).setInstrumentationVersion(instrumentationScopeVersion).build()
 
     override fun tracerBuilder(instrumentationScopeName: String): OtelJavaTracerBuilder {
-        return EmbTracerBuilder(
+        return EmbOtelJavaTracerBuilder(
             instrumentationScopeName = instrumentationScopeName,
             tracerSupplier = ::getTracer
         )
@@ -36,7 +36,7 @@ class EmbTracerProvider(
     }
 
     private fun createTracer(key: TracerKey): OtelJavaTracer {
-        val tracer = EmbTracer(
+        val tracer = EmbOtelJavaTracer(
             sdkTracer = buildSdkTracer(key),
             spanService = spanService,
             clock = clock

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbClockTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbClockTest.kt
@@ -15,12 +15,12 @@ import java.util.concurrent.TimeUnit
 internal class EmbClockTest {
 
     private lateinit var embraceClock: Clock
-    private lateinit var openTelemetryClock: EmbClock
+    private lateinit var openTelemetryClock: EmbOtelJavaClock
 
     @Before
     fun setup() {
         embraceClock = NormalizedIntervalClock(systemClock = io.embrace.android.embracesdk.internal.clock.SystemClock())
-        openTelemetryClock = EmbClock(embraceClock = embraceClock)
+        openTelemetryClock = EmbOtelJavaClock(embraceClock = embraceClock)
     }
 
     @Config(sdk = [TIRAMISU])

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetryTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetryTest.kt
@@ -13,12 +13,12 @@ import org.junit.Test
 
 internal class EmbOpenTelemetryTest {
     private lateinit var tracerProvider: FakeTracerProvider
-    private lateinit var openTelemetry: EmbOpenTelemetry
+    private lateinit var openTelemetry: EmbOtelJavaOpenTelemetry
 
     @Before
     fun setup() {
         tracerProvider = FakeTracerProvider()
-        openTelemetry = EmbOpenTelemetry { tracerProvider }
+        openTelemetry = EmbOtelJavaOpenTelemetry { tracerProvider }
     }
 
     @Test

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanBuilderTest.kt
@@ -36,7 +36,7 @@ internal class EmbSpanBuilderTest {
     private lateinit var tracer: Tracer
     private lateinit var spanService: FakeSpanService
     private lateinit var creator: OtelSpanCreator
-    private lateinit var embSpanBuilder: EmbSpanBuilder
+    private lateinit var embSpanBuilder: EmbOtelJavaSpanBuilder
 
     @Before
     fun setup() {
@@ -51,7 +51,7 @@ internal class EmbSpanBuilderTest {
                 private = false,
             ),
         )
-        embSpanBuilder = EmbSpanBuilder(
+        embSpanBuilder = EmbOtelJavaSpanBuilder(
             otelSpanCreator = creator,
             spanService = spanService,
             clock = openTelemetryClock
@@ -72,7 +72,7 @@ internal class EmbSpanBuilderTest {
                 autoTerminationMode = AutoTerminationMode.ON_BACKGROUND,
             )
         )
-        embSpanBuilder = EmbSpanBuilder(
+        embSpanBuilder = EmbOtelJavaSpanBuilder(
             otelSpanCreator = newOtelSpanStartArgs,
             spanService = spanService,
             clock = openTelemetryClock
@@ -105,7 +105,7 @@ internal class EmbSpanBuilderTest {
                 parentSpan = oldParent,
             )
         )
-        embSpanBuilder = EmbSpanBuilder(
+        embSpanBuilder = EmbOtelJavaSpanBuilder(
             otelSpanCreator = newOtelSpanStartArgs,
             spanService = spanService,
             clock = openTelemetryClock
@@ -137,7 +137,7 @@ internal class EmbSpanBuilderTest {
                 private = false,
             )
         )
-        embSpanBuilder = EmbSpanBuilder(
+        embSpanBuilder = EmbOtelJavaSpanBuilder(
             otelSpanCreator = newOtelSpanStartArgs,
             spanService = spanService,
             clock = openTelemetryClock

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
@@ -24,14 +24,14 @@ internal class EmbSpanTest {
     private lateinit var fakeClock: FakeClock
     private lateinit var openTelemetryClock: OtelJavaClock
     private lateinit var fakeEmbraceSpan: FakeEmbraceSdkSpan
-    private lateinit var embSpan: EmbSpan
+    private lateinit var embSpan: EmbOtelJavaSpan
 
     @Before
     fun setup() {
         fakeClock = FakeClock()
         openTelemetryClock = FakeOpenTelemetryClock(fakeClock)
         fakeEmbraceSpan = FakeEmbraceSdkSpan.started(clock = fakeClock)
-        embSpan = EmbSpan(
+        embSpan = EmbOtelJavaSpan(
             embraceSpan = fakeEmbraceSpan,
             clock = openTelemetryClock
         )

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerBuilderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerBuilderTest.kt
@@ -10,7 +10,7 @@ internal class EmbTracerBuilderTest {
     @Test
     fun `check tracer attributes from builder`() {
         val expectedKey = TracerKey("foo", "v1", "url")
-        val embTracerBuilder = EmbTracerBuilder(
+        val embTracerBuilder = EmbOtelJavaTracerBuilder(
             instrumentationScopeName = "foo",
             tracerSupplier = ::createTracer
         )

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
@@ -16,13 +16,13 @@ internal class EmbTracerProviderTest {
 
     private lateinit var spanService: FakeSpanService
     private lateinit var sdkTracerProvider: FakeTracerProvider
-    private lateinit var embTracerProvider: EmbTracerProvider
+    private lateinit var embTracerProvider: EmbOtelJavaTracerProvider
 
     @Before
     fun setup() {
         spanService = FakeSpanService()
         sdkTracerProvider = FakeTracerProvider()
-        embTracerProvider = EmbTracerProvider(
+        embTracerProvider = EmbOtelJavaTracerProvider(
             sdkTracerProvider = sdkTracerProvider,
             spanService = spanService,
             clock = openTelemetryClock
@@ -32,7 +32,7 @@ internal class EmbTracerProviderTest {
     @Test
     fun `same instrumentation scope names return the same tracer instance`() {
         val tracer = embTracerProvider.get("foo")
-        assertTrue(tracer is EmbTracer)
+        assertTrue(tracer is EmbOtelJavaTracer)
         val dupeTracer = embTracerProvider.get("foo")
         val differentTracer = embTracerProvider.get("food")
         assertSame(tracer, dupeTracer)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
@@ -16,13 +16,13 @@ internal class EmbTracerTest {
 
     private lateinit var spanService: FakeSpanService
     private lateinit var sdkTracer: FakeTracer
-    private lateinit var tracer: EmbTracer
+    private lateinit var tracer: EmbOtelJavaTracer
 
     @Before
     fun setup() {
         spanService = FakeSpanService()
         sdkTracer = FakeTracer()
-        tracer = EmbTracer(
+        tracer = EmbOtelJavaTracer(
             sdkTracer = sdkTracer,
             spanService = spanService,
             clock = openTelemetryClock,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -4,9 +4,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.internal.otel.impl.EmbSpan
-import io.embrace.android.embracesdk.internal.otel.impl.EmbSpanBuilder
-import io.embrace.android.embracesdk.internal.otel.impl.EmbTracer
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaSpan
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaSpanBuilder
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaTracer
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
@@ -68,11 +68,11 @@ internal class ExternalTracerTest {
                     otelTracer,
                     embOpenTelemetry.getTracer("foo")
                 )
-                assertTrue(embTracer is EmbTracer)
+                assertTrue(embTracer is EmbOtelJavaTracer)
                 val spanBuilder = embTracer.spanBuilder("test")
                 val span = spanBuilder.startSpan()
-                assertTrue(spanBuilder is EmbSpanBuilder)
-                assertTrue(span is EmbSpan)
+                assertTrue(spanBuilder is EmbOtelJavaSpanBuilder)
+                assertTrue(span is EmbOtelJavaSpan)
             }
         )
     }
@@ -192,11 +192,11 @@ internal class ExternalTracerTest {
                 initializeTracer()
             },
             assertAction = {
-                assertTrue(embTracer is EmbTracer)
+                assertTrue(embTracer is EmbOtelJavaTracer)
                 val spanBuilder = embTracer.spanBuilder("test")
                 val span = spanBuilder.startSpan()
-                assertTrue(spanBuilder is EmbSpanBuilder)
-                assertTrue(span is EmbSpan)
+                assertTrue(spanBuilder is EmbOtelJavaSpanBuilder)
+                assertTrue(span is EmbOtelJavaSpan)
             }
         )
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryClock.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryClock.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.otel.impl.EmbClock
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaClock
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
 
 /**
@@ -13,7 +13,7 @@ class FakeOpenTelemetryClock(
     private val startingElapsedTimeNanos: Long = 0L,
 ) : OtelJavaClock {
 
-    private val realOpenTelemetryClock = EmbClock(embraceClock = embraceClock)
+    private val realOpenTelemetryClock = EmbOtelJavaClock(embraceClock = embraceClock)
     private val startingTimeNanos = now()
     override fun now(): Long = realOpenTelemetryClock.now()
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
-import io.embrace.android.embracesdk.internal.otel.impl.EmbOpenTelemetry
+import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaOpenTelemetry
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
@@ -47,7 +47,7 @@ class FakeOpenTelemetryModule(
     override val logger: Logger
         get() = FakeOtelLogger()
     override val externalOpenTelemetry: OtelJavaOpenTelemetry
-        get() = EmbOpenTelemetry(traceProviderSupplier = { FakeTracerProvider() })
+        get() = EmbOtelJavaOpenTelemetry(traceProviderSupplier = { FakeTracerProvider() })
     override val externalTracerProvider: OtelJavaTracerProvider
         get() = FakeTracerProvider()
     override val openTelemetryClock: OtelJavaClock


### PR DESCRIPTION
## Goal

Renames embrace implementations of opentelemetry-java interfaces to make it more explicit that they come from opentelemetry-java.
