### PR TITLE
Add integration tests for background ANR monitoring stop

### DIFF
--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTimingTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/EmbraceAnrServiceTimingTest.kt
@@ -9,6 +9,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.lang.Thread.currentThread
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -65,6 +66,83 @@ internal class EmbraceAnrServiceTimingTest {
             anrExecutorService.runCurrentlyBlocked()
             anrExecutorService.runCurrentlyBlocked()
             assertEquals(1, anrExecutorService.scheduledTasksCount())
+        }
+    }
+
+    @Test
+    fun `test delayed background check stops monitoring when app remains in background`() {
+        with(rule) {
+            // Set background state and recreate service
+            fakeProcessStateService.isInBackground = true
+            recreateService()
+
+            // Start ANR capture - this should trigger scheduleDelayedBackgroundCheck
+            anrService.startAnrCapture()
+            anrExecutorService.runCurrentlyBlocked()
+
+            // Monitoring is initially started (even in background)
+            assertTrue(state.started.get())
+
+            // Advance time by 9 seconds - monitoring should still be active
+            anrExecutorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(9))
+            assertTrue(state.started.get())
+
+            // Advance time by 2 more second to trigger the 10-second delayed check
+            anrExecutorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(1))
+
+            // Run any pending tasks to ensure the delayed check executes
+            anrExecutorService.runCurrentlyBlocked()
+
+            // Verify that monitoring is now stopped because app is still in background
+            assertFalse(state.started.get())
+        }
+    }
+
+    @Test
+    fun `test delayed background check does not stop monitoring when app transitions to foreground`() {
+        with(rule) {
+            // Set background state and recreate service
+            fakeProcessStateService.isInBackground = true
+            recreateService()
+
+            // Start ANR capture - this should trigger scheduleDelayedBackgroundCheck
+            anrService.startAnrCapture()
+            anrExecutorService.runCurrentlyBlocked()
+
+            // Monitoring is initially started (even in background)
+            assertTrue(state.started.get())
+
+            // Advance time by 5 seconds
+            anrExecutorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(5))
+
+            // Transition to foreground before the 10-second delay
+            fakeProcessStateService.isInBackground = false
+            anrService.onForeground(false, clock.now())
+            anrExecutorService.runCurrentlyBlocked()
+
+            // Advance time by 5 more seconds to reach the 10-second mark
+            anrExecutorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(5))
+
+            // Verify that monitoring is still active because app is now in foreground
+            assertTrue(state.started.get())
+        }
+    }
+
+    @Test
+    fun `test delayed background check is not scheduled when app starts in foreground`() {
+        with(rule) {
+            // Start ANR capture - this won't trigger scheduleDelayedBackgroundCheck as the default state is foreground
+            anrService.startAnrCapture()
+            anrExecutorService.runCurrentlyBlocked()
+
+            // Verify that monitoring is started
+            assertTrue(state.started.get())
+
+            // Advance time by 15 seconds to ensure any delayed check would have triggered
+            anrExecutorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(15))
+
+            // Verify that monitoring is still active (no delayed check was scheduled)
+            assertTrue(state.started.get())
         }
     }
 }


### PR DESCRIPTION
Adds testing for previous PR (https://github.com/embrace-io/embrace-android-sdk/pull/2260)