### PR TITLE
Create enum for result code

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporter.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.toCompleteableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
@@ -17,21 +19,20 @@ internal class EmbraceLogRecordExporter(
 
     override fun export(logs: Collection<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
         if (!exportCheck()) {
-            return OtelJavaCompletableResultCode.ofSuccess()
+            return StoreDataResult.SUCCESS.toCompleteableResultCode()
         }
         val result = logSink.storeLogs(logs.toList())
-        if (externalLogRecordExporter != null && result == OtelJavaCompletableResultCode.ofSuccess()) {
+        if (externalLogRecordExporter != null && result == StoreDataResult.SUCCESS) {
             return externalLogRecordExporter.export(
                 logs.filterNot {
                     it.attributes.hasEmbraceAttribute(PrivateSpan)
                 }
             )
         }
-
-        return result
+        return result.toCompleteableResultCode()
     }
 
-    override fun flush(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
+    override fun flush(): OtelJavaCompletableResultCode = StoreDataResult.SUCCESS.toCompleteableResultCode()
 
-    override fun shutdown(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode = StoreDataResult.SUCCESS.toCompleteableResultCode()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.payload.Log
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 
 /**
@@ -13,7 +13,7 @@ interface LogSink {
     /**
      * Store [Log] objects to be sent in the nexdt batch. Implementations must support concurrent invocations.
      */
-    fun storeLogs(logs: List<OtelJavaLogRecordData>): OtelJavaCompletableResultCode
+    fun storeLogs(logs: List<OtelJavaLogRecordData>): StoreDataResult
 
     /**
      * Returns the list of currently stored [Log] objects, waiting to be sent in the next batch

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
@@ -4,9 +4,9 @@ import io.embrace.android.embracesdk.internal.otel.attrs.asOtelAttributeKey
 import io.embrace.android.embracesdk.internal.otel.attrs.embSendMode
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.SendMode
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -16,7 +16,7 @@ class LogSinkImpl : LogSink {
     private var onLogsStored: (() -> Unit)? = null
     private val flushLock = Any()
 
-    override fun storeLogs(logs: List<OtelJavaLogRecordData>): OtelJavaCompletableResultCode {
+    override fun storeLogs(logs: List<OtelJavaLogRecordData>): StoreDataResult {
         try {
             logs.forEach { log ->
                 val mode = log.attributes[embSendMode.asOtelAttributeKey()]
@@ -34,10 +34,9 @@ class LogSinkImpl : LogSink {
             }
             onLogsStored?.invoke()
         } catch (t: Throwable) {
-            return OtelJavaCompletableResultCode.ofFailure()
+            return StoreDataResult.FAILURE
         }
-
-        return OtelJavaCompletableResultCode.ofSuccess()
+        return StoreDataResult.SUCCESS
     }
 
     override fun logsForNextBatch(): List<Log> {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/StoreDataResult.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/StoreDataResult.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.internal.otel.sdk
+
+/**
+ * Models whether an operation to store data was successful or failed.
+ */
+enum class StoreDataResult {
+    SUCCESS,
+    FAILURE
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/StoreDataResultExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/StoreDataResultExt.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.internal.otel.sdk
+
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+
+internal fun StoreDataResult.toCompleteableResultCode() = when (this) {
+    StoreDataResult.SUCCESS -> OtelJavaCompletableResultCode.ofSuccess()
+    StoreDataResult.FAILURE -> OtelJavaCompletableResultCode.ofFailure()
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanExporter.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.toCompleteableResultCode
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
@@ -19,20 +21,19 @@ internal class EmbraceSpanExporter(
     @Synchronized
     override fun export(spans: MutableCollection<OtelJavaSpanData>): OtelJavaCompletableResultCode {
         if (!exportCheck()) {
-            return OtelJavaCompletableResultCode.ofSuccess()
+            return StoreDataResult.SUCCESS.toCompleteableResultCode()
         }
         val result = spanSink.storeCompletedSpans(spans.toList())
-        if (externalSpanExporter != null && result == OtelJavaCompletableResultCode.ofSuccess()) {
+        if (externalSpanExporter != null && result == StoreDataResult.SUCCESS) {
             return EmbTrace.trace("otel-external-export") {
                 externalSpanExporter.export(spans.filterNot { it.attributes.hasEmbraceAttribute(PrivateSpan) })
             }
         }
-
-        return result
+        return result.toCompleteableResultCode()
     }
 
-    override fun flush(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
+    override fun flush(): OtelJavaCompletableResultCode = StoreDataResult.SUCCESS.toCompleteableResultCode()
 
     @Synchronized
-    override fun shutdown(): OtelJavaCompletableResultCode = OtelJavaCompletableResultCode.ofSuccess()
+    override fun shutdown(): OtelJavaCompletableResultCode = StoreDataResult.SUCCESS.toCompleteableResultCode()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 
 /**
@@ -11,7 +11,7 @@ interface SpanSink {
     /**
      * Stores spans that have been completed. Implementations must support concurrent invocations.
      */
-    fun storeCompletedSpans(spans: List<OtelJavaSpanData>): OtelJavaCompletableResultCode
+    fun storeCompletedSpans(spans: List<OtelJavaSpanData>): StoreDataResult
 
     /**
      * Returns the list of the currently stored completed spans.

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -12,14 +12,13 @@ class SpanSinkImpl : SpanSink {
     private val completedSpans: Queue<EmbraceSpanData> = ConcurrentLinkedQueue()
     private val spansToFlush = AtomicReference<List<EmbraceSpanData>>(listOf())
 
-    override fun storeCompletedSpans(spans: List<OtelJavaSpanData>): OtelJavaCompletableResultCode {
+    override fun storeCompletedSpans(spans: List<OtelJavaSpanData>): StoreDataResult {
         try {
             completedSpans += spans.map { it.toEmbraceSpanData() }
         } catch (t: Throwable) {
-            return OtelJavaCompletableResultCode.ofFailure()
+            return StoreDataResult.FAILURE
         }
-
-        return OtelJavaCompletableResultCode.ofSuccess()
+        return StoreDataResult.SUCCESS
     }
 
     override fun completedSpans(): List<EmbraceSpanData> {

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImplTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fixtures.deferredLogRecordData
 import io.embrace.android.embracesdk.fixtures.sendImmediatelyLogRecordData
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -25,13 +25,13 @@ internal class LogSinkImplTest {
     fun `verify default state`() {
         assertEquals(0, logSink.logsForNextBatch().size)
         assertEquals(0, logSink.flushBatch().size)
-        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), logSink.storeLogs(listOf()))
+        assertEquals(StoreDataResult.SUCCESS, logSink.storeLogs(listOf()))
     }
 
     @Test
     fun `storing logs adds to stored logs`() {
         val resultCode = logSink.storeLogs(listOf(FakeLogRecordData()))
-        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(StoreDataResult.SUCCESS, resultCode)
         assertEquals(1, logSink.logsForNextBatch().size)
         assertEquals(FakeLogRecordData().toEmbracePayload(), logSink.logsForNextBatch().first())
     }
@@ -61,7 +61,7 @@ internal class LogSinkImplTest {
     @Test
     fun `logs with IMMEDIATE SendMode are stored in priority log queue`() {
         val resultCode = logSink.storeLogs(listOf(sendImmediatelyLogRecordData))
-        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(StoreDataResult.SUCCESS, resultCode)
         assertEquals(0, logSink.logsForNextBatch().size)
         val logRequest = checkNotNull(logSink.pollUnbatchedLog())
         assertEquals(sendImmediatelyLogRecordData.log, logRequest.payload)
@@ -72,7 +72,7 @@ internal class LogSinkImplTest {
     @Test
     fun `logs with DEFER SendMode are stored in priority log queue`() {
         val resultCode = logSink.storeLogs(listOf(deferredLogRecordData))
-        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(StoreDataResult.SUCCESS, resultCode)
         assertEquals(0, logSink.logsForNextBatch().size)
         val logRequest = checkNotNull(logSink.pollUnbatchedLog())
         assertEquals(deferredLogRecordData.log, logRequest.payload)
@@ -83,7 +83,7 @@ internal class LogSinkImplTest {
     @Test
     fun `unbatchable logs are stored in the unbatched log queue`() {
         val resultCode = logSink.storeLogs(listOf(sendImmediatelyLogRecordData))
-        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), resultCode)
+        assertEquals(StoreDataResult.SUCCESS, resultCode)
         assertEquals(0, logSink.logsForNextBatch().size)
         assertEquals(sendImmediatelyLogRecordData.log, checkNotNull(logSink.pollUnbatchedLog()).payload)
         assertNull(logSink.pollUnbatchedLog())

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
 import io.embrace.android.embracesdk.fakes.FakeSpanData
+import io.embrace.android.embracesdk.internal.otel.sdk.toCompleteableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.mockk.every
 import io.mockk.spyk
@@ -26,7 +27,7 @@ internal class SpanSinkImplTests {
     fun `verify default state`() {
         assertEquals(0, spanSink.completedSpans().size)
         assertEquals(0, spanSink.flushSpans().size)
-        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), spanSink.storeCompletedSpans(listOf()))
+        assertEquals(OtelJavaCompletableResultCode.ofSuccess(), spanSink.storeCompletedSpans(listOf()).toCompleteableResultCode())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Creates an enum that avoids using `CompleteableResultCode` from the opentelemetry-java repo.