### PR TITLE
Start using kotlin api for creating OTel object

### DIFF
--- a/embrace-android-core/lint-baseline.xml
+++ b/embrace-android-core/lint-baseline.xml
@@ -1,5 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.9.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.2)" variant="all" version="8.9.2">
+<issues format="6" by="lint 8.10.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.10.1">
+
+    <issue
+        id="TrimLambda"
+        message="The lambda argument (`{ it &lt;= &apos; &apos; }`) is unnecessary"
+        errorLine1="        packageInfo.versionName.toString().trim { it &lt;= &apos; &apos; }"
+        errorLine2="                                                ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PackageVersionInfo.kt"
+            line="15"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="TrimLambda"
+        message="The lambda argument (`{ it &lt;= &apos; &apos; }`) is unnecessary"
+        errorLine1="        packageInfo.versionName.toString().trim { it &lt;= &apos; &apos; }"
+        errorLine2="                                                ~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PackageVersionInfo.kt"
+            line="15"
+            column="49"/>
+    </issue>
 
     <issue
         id="EmbracePublicApiPackageRule"
@@ -10,17 +32,6 @@
             file="src/main/kotlin/io/embrace/android/embracesdk/LogExceptionType.kt"
             line="10"
             column="12"/>
-    </issue>
-
-    <issue
-        id="UnclosedTrace"
-        message="The `beginSection()` call is not always closed with a matching `endSection()` because the code in between may return early"
-        errorLine1="            Trace.beginSection(&quot;emb-$name&quot;.take(127))"
-        errorLine2="                  ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/internal/EmbTrace.kt"
-            line="47"
-            column="19"/>
     </issue>
 
 </issues>

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -61,7 +61,7 @@ internal class OpenTelemetryModuleImpl(
         EmbTrace.trace("otel-sdk-wrapper-init") {
             try {
                 OtelSdkWrapper(
-                    openTelemetryClock = openTelemetryClock,
+                    otelClock = openTelemetryClock,
                     configuration = otelSdkConfig
                 )
             } catch (exc: NoClassDefFoundError) {

--- a/embrace-android-otel/lint-baseline.xml
+++ b/embrace-android-otel/lint-baseline.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.9.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.2)" variant="all" version="8.9.2">
+<issues format="6" by="lint 8.10.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.10.1">
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="                addLogRecordProcessor(TODO())"
+        errorLine2="                                      ~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt"
+            line="102"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="StopShip"
+        message="`TODO` call found; points to code which must be fixed prior to release"
+        errorLine1="                addSpanProcessor(TODO())"
+        errorLine2="                                 ~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt"
+            line="111"
+            column="34"/>
+    </issue>
 
 </issues>

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -9,18 +9,21 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanExporter
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanProcessor
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaResourceBuilder
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
 import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
 
+@OptIn(ExperimentalApi::class)
 class OtelSdkConfig(
     spanSink: SpanSink,
     logSink: LogSink,
@@ -29,7 +32,7 @@ class OtelSdkConfig(
     systemInfo: SystemInfo,
     private val processIdentifierProvider: () -> String = IdGenerator.Companion::generateLaunchInstanceId,
 ) {
-    val resourceBuilder: OtelJavaResourceBuilder = OtelJavaResource.getDefault().toBuilder()
+    val otelJavaResourceBuilder: OtelJavaResourceBuilder = OtelJavaResource.getDefault().toBuilder()
         .put(ServiceAttributes.SERVICE_NAME, sdkName)
         .put(ServiceAttributes.SERVICE_VERSION, sdkVersion)
         .put(OsIncubatingAttributes.OS_NAME, systemInfo.osName)
@@ -42,6 +45,21 @@ class OtelSdkConfig(
         .put(DeviceIncubatingAttributes.DEVICE_MODEL_NAME, systemInfo.deviceModel)
         .put(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME, sdkName)
         .put(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION, sdkVersion)
+
+    val resourceAction: AttributeContainer.() -> Unit = {
+        setStringAttribute(ServiceAttributes.SERVICE_NAME.key, sdkName)
+        setStringAttribute(ServiceAttributes.SERVICE_VERSION.key, sdkVersion)
+        setStringAttribute(OsIncubatingAttributes.OS_NAME.key, systemInfo.osName)
+        setStringAttribute(OsIncubatingAttributes.OS_VERSION.key, systemInfo.osVersion)
+        setStringAttribute(OsIncubatingAttributes.OS_TYPE.key, systemInfo.osType)
+        setStringAttribute(OsIncubatingAttributes.OS_BUILD_ID.key, systemInfo.osBuild)
+        setStringAttribute(AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL.key, systemInfo.androidOsApiLevel)
+        setStringAttribute(DeviceIncubatingAttributes.DEVICE_MANUFACTURER.key, systemInfo.deviceManufacturer)
+        setStringAttribute(DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER.key, systemInfo.deviceModel)
+        setStringAttribute(DeviceIncubatingAttributes.DEVICE_MODEL_NAME.key, systemInfo.deviceModel)
+        setStringAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME.key, sdkName)
+        setStringAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION.key, sdkVersion)
+    }
 
     /**
      * Unique ID generated for an instance of the app process and not related to the actual process ID assigned by the OS.

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaClock.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaClock.kt
@@ -15,7 +15,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaClock
  */
 class EmbOtelJavaClock(
     private val embraceClock: Clock,
-) : OtelJavaClock {
+) : OtelJavaClock, io.embrace.opentelemetry.kotlin.Clock {
 
     override fun now(): Long = embraceClock.now().millisToNanos()
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
@@ -33,7 +33,7 @@ internal class OtelSdkConfigTest {
             systemInfo = systemInfo
         )
 
-        val resource = configuration.resourceBuilder.build()
+        val resource = configuration.otelJavaResourceBuilder.build()
 
         assertEquals(configuration.sdkName, resource.getAttribute(ServiceAttributes.SERVICE_NAME))
         assertEquals(

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -46,7 +46,7 @@ internal class OpenTelemetrySdkTest {
         configuration.addLogExporter(logExporter)
 
         sdk = OtelSdkWrapper(
-            openTelemetryClock = FakeOpenTelemetryClock(FakeClock()),
+            otelClock = FakeOpenTelemetryClock(FakeClock()),
             configuration = configuration
         )
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -48,7 +48,7 @@ internal class EmbraceSpanServiceTest {
             processIdentifierProvider = { "fake-pid" }
         )
         val otelSdkWrapper = OtelSdkWrapper(
-            openTelemetryClock = fakeClock,
+            otelClock = fakeClock,
             configuration = otelSdkConfig,
         )
         val dataValidator = DataValidator()

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -613,7 +613,7 @@ internal class SpanServiceImplTest {
             processIdentifierProvider = { "fake-pid" }
         )
         val otelSdkWrapper = OtelSdkWrapper(
-            openTelemetryClock = fakeClock,
+            otelClock = fakeClock,
             configuration = otelSdkConfig,
         )
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
@@ -37,6 +37,6 @@ internal class OTelApiDelegate(
         if (sdkCallChecker.started.get()) {
             return
         }
-        bootstrapper.openTelemetryModule.otelSdkConfig.resourceBuilder.put(key, value)
+        bootstrapper.openTelemetryModule.otelSdkConfig.otelJavaResourceBuilder.put(key, value)
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -86,19 +86,24 @@ internal class OTelApiDelegateTest {
     fun `set resource attribute before sdk starts`() {
         sdkCallChecker.started.set(false)
         delegate.setResourceAttribute("test", "foo")
-        assertEquals("foo", cfg.resourceBuilder.build().attributes.asMap().filter { it.key.key == "test" }.values.single())
+        assertEquals(
+            "foo",
+            cfg.otelJavaResourceBuilder.build().attributes.asMap().filter {
+                it.key.key == "test"
+            }.values.single()
+        )
     }
 
     @Test
     fun `override resource attribute before sdk starts`() {
         sdkCallChecker.started.set(false)
         delegate.setResourceAttribute(ServiceAttributes.SERVICE_NAME, "foo")
-        assertEquals("foo", cfg.resourceBuilder.build().attributes[ServiceAttributes.SERVICE_NAME])
+        assertEquals("foo", cfg.otelJavaResourceBuilder.build().attributes[ServiceAttributes.SERVICE_NAME])
     }
 
     @Test
     fun `set resource attribute after sdk starts`() {
         delegate.setResourceAttribute("test", "foo")
-        assertTrue(cfg.resourceBuilder.build().attributes.asMap().filter { it.key.key == "test" }.isEmpty())
+        assertTrue(cfg.otelJavaResourceBuilder.build().attributes.asMap().filter { it.key.key == "test" }.isEmpty())
     }
 }

--- a/embrace-test-fakes/lint-baseline.xml
+++ b/embrace-test-fakes/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.9.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.2)" variant="all" version="8.9.2">
+<issues format="6" by="lint 8.10.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.10.1">
 
     <issue
         id="StopShip"
@@ -139,72 +139,6 @@
         errorLine1="        TODO(&quot;Not yet implemented&quot;)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt"
-            line="12"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt"
-            line="16"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt"
-            line="20"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt"
-            line="24"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt"
-            line="28"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNativeThreadSamplerService.kt"
-            line="38"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureDataSource.kt"
             line="19"
             column="9"/>
@@ -250,7 +184,7 @@
         errorLine2="                ~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt"
-            line="41"
+            line="44"
             column="17"/>
     </issue>
 
@@ -261,7 +195,7 @@
         errorLine2="                ~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt"
-            line="43"
+            line="46"
             column="17"/>
     </issue>
 
@@ -296,50 +230,6 @@
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrationModule.kt"
             line="20"
             column="17"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt"
-            line="36"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt"
-            line="40"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt"
-            line="50"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="StopShip"
-        message="`TODO` call found; points to code which must be fixed prior to release"
-        errorLine1="        TODO(&quot;Not yet implemented&quot;)"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt"
-            line="54"
-            column="9"/>
     </issue>
 
     <issue
@@ -495,28 +385,6 @@
 
     <issue
         id="NewApi"
-        message="Call requires API level 26, or core library desugaring (current min is 21): `java.time.Instant#toEpochMilli`"
-        errorLine1="        timestampEpochNanos = instant.toEpochMilli() * 1_000_000"
-        errorLine2="                                      ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordBuilder.kt"
-            line="27"
-            column="39"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 26, or core library desugaring (current min is 21): `java.time.Instant#toEpochMilli`"
-        errorLine1="        observedTimestampEpochNanos = instant.toEpochMilli() * 1_000_000"
-        errorLine2="                                              ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordBuilder.kt"
-            line="37"
-            column="47"/>
-    </issue>
-
-    <issue
-        id="NewApi"
         message="Call requires API level 24, or core library desugaring (current min is 21): `java.util.Collection#removeIf`"
         errorLine1="            latches.removeIf { it.count == 0L }"
         errorLine2="                    ~~~~~~~~">
@@ -573,23 +441,23 @@
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `newTraceRootContext` of class `Companion` requires synthetic accessor"
-        errorLine1="    private var spanContext: SpanContext = newTraceRootContext(),"
-        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~">
+        errorLine1="    private var spanContext: OtelJavaSpanContext = newTraceRootContext(),"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt"
-            line="27"
-            column="44"/>
+            line="29"
+            column="52"/>
     </issue>
 
     <issue
         id="SyntheticAccessor"
         message="Access to `private` method `newTraceRootContext` of class `Companion` requires synthetic accessor"
-        errorLine1="    private var spanContext: SpanContext = newTraceRootContext(),"
-        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~">
+        errorLine1="    private var spanContext: OtelJavaSpanContext = newTraceRootContext(),"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanData.kt"
-            line="27"
-            column="44"/>
+            line="29"
+            column="52"/>
     </issue>
 
 </issues>


### PR DESCRIPTION
## Goal

Starts using the kotlin api for creating the OTel object. In a future changeset I'll swap over the API calls so that we're no longer using `OpenTelemetryJavaBuilder`.

