### PR TITLE
Rename exporter/processor symbols

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.internal.otel.config
 
 import io.embrace.android.embracesdk.internal.SystemInfo
-import io.embrace.android.embracesdk.internal.otel.logs.EmbraceLogRecordExporter
-import io.embrace.android.embracesdk.internal.otel.logs.EmbraceLogRecordProcessor
+import io.embrace.android.embracesdk.internal.otel.logs.EmbraceOtelJavaLogRecordExporter
+import io.embrace.android.embracesdk.internal.otel.logs.EmbraceOtelJavaLogRecordProcessor
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.sdk.IdGenerator
-import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanExporter
-import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanProcessor
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceOtelJavaSpanExporter
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceOtelJavaSpanProcessor
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
@@ -81,8 +81,8 @@ class OtelSdkConfig(
     }
 
     val spanProcessor: OtelJavaSpanProcessor by lazy {
-        EmbraceSpanProcessor(
-            EmbraceSpanExporter(
+        EmbraceOtelJavaSpanProcessor(
+            EmbraceOtelJavaSpanExporter(
                 spanSink = spanSink,
                 externalSpanExporter = if (externalSpanExporters.isNotEmpty()) {
                     OtelJavaSpanExporter.composite(externalSpanExporters)
@@ -96,8 +96,8 @@ class OtelSdkConfig(
     }
 
     val logProcessor: OtelJavaLogRecordProcessor by lazy {
-        EmbraceLogRecordProcessor(
-            EmbraceLogRecordExporter(
+        EmbraceOtelJavaLogRecordProcessor(
+            EmbraceOtelJavaLogRecordExporter(
                 logSink = logSink,
                 externalLogRecordExporter = if (externalLogExporters.isNotEmpty()) {
                     OtelJavaLogRecordExporter.composite(externalLogExporters)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceOtelJavaLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceOtelJavaLogRecordExporter.kt
@@ -11,7 +11,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 /**
  * Exports the given [LogRecordData] to a [LogSink]
  */
-internal class EmbraceLogRecordExporter(
+internal class EmbraceOtelJavaLogRecordExporter(
     private val logSink: LogSink,
     private val externalLogRecordExporter: OtelJavaLogRecordExporter?,
     private val exportCheck: () -> Boolean,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceOtelJavaLogRecordProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceOtelJavaLogRecordProcessor.kt
@@ -8,7 +8,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 /**
  * [LogRecordProcessor] that exports log records it to the given [LogRecordExporter]
  */
-internal class EmbraceLogRecordProcessor(
+internal class EmbraceOtelJavaLogRecordProcessor(
     private val logRecordExporter: OtelJavaLogRecordExporter,
 ) : OtelJavaLogRecordProcessor {
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanExporter.kt
@@ -12,7 +12,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 /**
  * Exports the given completed [Span] to the given [SpanSink] as well as any configured external [SpanExporter]
  */
-internal class EmbraceSpanExporter(
+internal class EmbraceOtelJavaSpanExporter(
     private val spanSink: SpanSink,
     private val externalSpanExporter: OtelJavaSpanExporter?,
     private val exportCheck: () -> Boolean,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanProcessor.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicLong
 /**
  * [SpanProcessor] that adds custom attributes to a [Span] when it starts, and exports it to the given [SpanExporter] when it finishes
  */
-class EmbraceSpanProcessor(
+class EmbraceOtelJavaSpanProcessor(
     private val spanExporter: OtelJavaSpanExporter,
     private val processIdentifier: String,
 ) : OtelJavaSpanProcessor {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
@@ -4,7 +4,8 @@ import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 
 /**
- * A service that stores all the spans that are completed and exported via [EmbraceSpanExporter], and provides access to them so they
+ * A service that stores all the spans that are completed and exported via [EmbraceOtelJavaSpanExporter],
+ * and provides access to them so they
  * can be sent off-device at the appropriate cadence.
  */
 interface SpanSink {
@@ -19,7 +20,8 @@ interface SpanSink {
     fun completedSpans(): List<EmbraceSpanData>
 
     /**
-     * Returns and clears the currently stored completed Spans. Implementations of this method must make sure the clearing and returning is
+     * Returns and clears the currently stored completed Spans. Implementations of this method must
+     * make sure the clearing and returning is
      * atomic, i.e. spans cannot be added during this operation.
      */
     fun flushSpans(): List<EmbraceSpanData>

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordExporterTest.kt
@@ -16,11 +16,11 @@ internal class EmbraceLogRecordExporterTest {
     @Test
     fun `export() should store logs in LogSink`() {
         val logSink: LogSink = LogSinkImpl()
-        val embraceLogRecordExporter =
-            EmbraceLogRecordExporter(logSink, OtelJavaLogRecordExporter.composite(emptyList())) { true }
+        val embraceOtelJavaLogRecordExporter =
+            EmbraceOtelJavaLogRecordExporter(logSink, OtelJavaLogRecordExporter.composite(emptyList())) { true }
         val logRecordData = FakeLogRecordData()
 
-        embraceLogRecordExporter.export(listOf(logRecordData))
+        embraceOtelJavaLogRecordExporter.export(listOf(logRecordData))
 
         assertFalse(logSink.logsForNextBatch().isEmpty())
         assertEquals(logRecordData.toEmbracePayload(), logSink.logsForNextBatch()[0])
@@ -30,8 +30,8 @@ internal class EmbraceLogRecordExporterTest {
     fun `private logs should be filtered out from external exporters`() {
         val logSink: LogSink = LogSinkImpl()
         val externalExporter = FakeLogRecordExporter()
-        val embraceLogRecordExporter =
-            EmbraceLogRecordExporter(logSink, OtelJavaLogRecordExporter.composite(externalExporter)) { true }
+        val embraceOtelJavaLogRecordExporter =
+            EmbraceOtelJavaLogRecordExporter(logSink, OtelJavaLogRecordExporter.composite(externalExporter)) { true }
         val logRecordData = FakeLogRecordData()
         val privateLogRecordData = FakeLogRecordData(
             log = testLog.copy(
@@ -44,7 +44,7 @@ internal class EmbraceLogRecordExporterTest {
             )
         )
 
-        embraceLogRecordExporter.export(listOf(logRecordData, privateLogRecordData))
+        embraceOtelJavaLogRecordExporter.export(listOf(logRecordData, privateLogRecordData))
 
         assertEquals(2, logSink.logsForNextBatch().size)
         assertEquals(logRecordData.toEmbracePayload(), logSink.logsForNextBatch()[0])

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessorTest.kt
@@ -11,7 +11,7 @@ internal class EmbraceLogRecordProcessorTest {
     @Test
     fun `onEmit() should call export() on the LogRecordExporter`() {
         val logRecordExporter = FakeLogRecordExporter()
-        val logRecordProcessor = EmbraceLogRecordProcessor(logRecordExporter)
+        val logRecordProcessor = EmbraceOtelJavaLogRecordProcessor(logRecordExporter)
         val readWriteLogRecord = FakeReadWriteLogRecord()
 
         logRecordProcessor.onEmit(mockk(), readWriteLogRecord)


### PR DESCRIPTION
## Goal

Renames the processor/exporter implementations so that it's clear they are implementing opentelemetry-java interfaces.
