### PR TITLE
Alter types for sinks

### DIFF
--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImplTest.kt
@@ -1,10 +1,8 @@
 package io.embrace.android.embracesdk.internal.envelope.log
 
-import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.fixtures.deferredLog
-import io.embrace.android.embracesdk.fixtures.deferredLogRecordData
 import io.embrace.android.embracesdk.fixtures.sendImmediatelyLog
-import io.embrace.android.embracesdk.fixtures.sendImmediatelyLogRecordData
+import io.embrace.android.embracesdk.fixtures.testLog
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import org.junit.Assert.assertEquals
@@ -19,7 +17,6 @@ internal class LogPayloadSourceImplTest {
 
     private lateinit var impl: LogPayloadSourceImpl
     private lateinit var sink: LogSinkImpl
-    private val fakeLog = FakeLogRecordData()
 
     @Before
     fun setUp() {
@@ -27,24 +24,19 @@ internal class LogPayloadSourceImplTest {
         impl = LogPayloadSourceImpl(sink)
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun `getBatchedLogPayload returns a correct payload`() {
-        sink.storeLogs(listOf(fakeLog))
+        sink.storeLogs(listOf(testLog))
         val payload = impl.getBatchedLogPayload()
         val log = checkNotNull(payload.logs?.single())
         assertEquals(0, sink.logsForNextBatch().size)
         assertEquals(1, payload.logs?.size)
-        assertEquals(fakeLog.timestampEpochNanos, log.timeUnixNano)
-        assertEquals(fakeLog.severityText, log.severityText)
-        assertEquals(fakeLog.severity.severityNumber, log.severityNumber)
-        assertEquals(fakeLog.attributes.size(), log.attributes?.size)
-        assertEquals(fakeLog.body.asString(), log.body)
+        assertEquals(testLog, log)
     }
 
     @Test
     fun `log to with IMMEDIATE SendMode returns correctly`() {
-        sink.storeLogs(listOf(sendImmediatelyLogRecordData))
+        sink.storeLogs(listOf(sendImmediatelyLog))
         val payloads = impl.getSingleLogPayloads()
         val logRequest = checkNotNull(payloads.single())
         assertNull(sink.pollUnbatchedLog())
@@ -54,7 +46,7 @@ internal class LogPayloadSourceImplTest {
 
     @Test
     fun `log to with DEFER SendMode returns correctly`() {
-        sink.storeLogs(listOf(deferredLogRecordData))
+        sink.storeLogs(listOf(deferredLog))
         val payloads = impl.getSingleLogPayloads()
         val logRequest = checkNotNull(payloads.single())
         assertNull(sink.pollUnbatchedLog())
@@ -64,7 +56,7 @@ internal class LogPayloadSourceImplTest {
 
     @Test
     fun `getSingleLogPayloads returns the correct payload`() {
-        sink.storeLogs(listOf(sendImmediatelyLogRecordData))
+        sink.storeLogs(listOf(sendImmediatelyLog))
         val payloads = impl.getSingleLogPayloads()
         val log = checkNotNull(payloads.single())
         assertNull(sink.pollUnbatchedLog())
@@ -74,7 +66,7 @@ internal class LogPayloadSourceImplTest {
     @Test
     fun `getSingleLogPayloads returns the maximum number of payloads`() {
         repeat(11) {
-            sink.storeLogs(listOf(sendImmediatelyLogRecordData))
+            sink.storeLogs(listOf(sendImmediatelyLog))
         }
 
         val payloads = impl.getSingleLogPayloads()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
@@ -5,9 +5,9 @@ import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
-import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
@@ -26,7 +26,7 @@ internal class SessionPayloadSourceImplTest {
     private lateinit var currentSessionSpan: FakeCurrentSessionSpan
     private lateinit var spanRepository: SpanRepository
     private lateinit var activeSpan: FakeEmbraceSdkSpan
-    private val cacheSpan = FakeSpanData(name = "cache-span")
+    private val cacheSpan = EmbraceSpanData("", "", "", "cache-span", 0, 0)
 
     @Before
     fun setUp() {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceOtelJavaLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceOtelJavaLogRecordExporter.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
+import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
@@ -21,7 +22,7 @@ internal class EmbraceOtelJavaLogRecordExporter(
         if (!exportCheck()) {
             return StoreDataResult.SUCCESS.toCompleteableResultCode()
         }
-        val result = logSink.storeLogs(logs.toList())
+        val result = logSink.storeLogs(logs.map(OtelJavaLogRecordData::toEmbracePayload))
         if (externalLogRecordExporter != null && result == StoreDataResult.SUCCESS) {
             return externalLogRecordExporter.export(
                 logs.filterNot {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.otel.logs
 
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.payload.Log
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
 
 /**
  * A service that stores exported logs and provides access to them so they
@@ -13,7 +12,7 @@ interface LogSink {
     /**
      * Store [Log] objects to be sent in the nexdt batch. Implementations must support concurrent invocations.
      */
-    fun storeLogs(logs: List<OtelJavaLogRecordData>): StoreDataResult
+    fun storeLogs(logs: List<Log>): StoreDataResult
 
     /**
      * Returns the list of currently stored [Log] objects, waiting to be sent in the next batch

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanExporter.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.toCompleteableResultCode
+import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaCompletableResultCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
@@ -23,7 +24,7 @@ internal class EmbraceOtelJavaSpanExporter(
         if (!exportCheck()) {
             return StoreDataResult.SUCCESS.toCompleteableResultCode()
         }
-        val result = spanSink.storeCompletedSpans(spans.toList())
+        val result = spanSink.storeCompletedSpans(spans.map(OtelJavaSpanData::toEmbraceSpanData))
         if (externalSpanExporter != null && result == StoreDataResult.SUCCESS) {
             return EmbTrace.trace("otel-external-export") {
                 externalSpanExporter.export(spans.filterNot { it.attributes.hasEmbraceAttribute(PrivateSpan) })

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 
 /**
  * A service that stores all the spans that are completed and exported via [EmbraceOtelJavaSpanExporter],
@@ -12,7 +11,7 @@ interface SpanSink {
     /**
      * Stores spans that have been completed. Implementations must support concurrent invocations.
      */
-    fun storeCompletedSpans(spans: List<OtelJavaSpanData>): StoreDataResult
+    fun storeCompletedSpans(spans: List<EmbraceSpanData>): StoreDataResult
 
     /**
      * Returns the list of the currently stored completed spans.

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
-import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicReference
@@ -12,9 +10,9 @@ class SpanSinkImpl : SpanSink {
     private val completedSpans: Queue<EmbraceSpanData> = ConcurrentLinkedQueue()
     private val spansToFlush = AtomicReference<List<EmbraceSpanData>>(listOf())
 
-    override fun storeCompletedSpans(spans: List<OtelJavaSpanData>): StoreDataResult {
+    override fun storeCompletedSpans(spans: List<EmbraceSpanData>): StoreDataResult {
         try {
-            completedSpans += spans.map { it.toEmbraceSpanData() }
+            completedSpans += spans
         } catch (t: Throwable) {
             return StoreDataResult.FAILURE
         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.fixtures
 
 import io.embrace.android.embracesdk.arch.toPayload
-import io.embrace.android.embracesdk.fakes.FakeLogRecordData
 import io.embrace.android.embracesdk.internal.otel.attrs.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.otel.attrs.embSendMode
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
@@ -40,10 +39,6 @@ val deferredLog: Log = Log(
     body = "deferred",
     attributes = listOf(Attribute(embSendMode.name, SendMode.DEFER.name))
 )
-
-val sendImmediatelyLogRecordData: FakeLogRecordData = FakeLogRecordData(log = sendImmediatelyLog)
-
-val deferredLogRecordData: FakeLogRecordData = FakeLogRecordData(log = deferredLog)
 
 val testNativeCrashData: NativeCrashData = NativeCrashData(
     nativeCrashId = "nativeCrashId",


### PR DESCRIPTION
## Goal

Alters the type that is accepted by the log/span sinks to depend on an embrace type rather than an OTel type.

## Testing

Relied on existing test coverage.

