### PR TITLE
Setup exporters correctly via Kotlin API

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
@@ -20,6 +20,8 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
 import io.embrace.opentelemetry.kotlin.compatWithOtelJava
+import io.embrace.opentelemetry.kotlin.j2k.logging.export.OtelJavaLogRecordExporterAdapter
+import io.embrace.opentelemetry.kotlin.j2k.tracing.export.OtelJavaSpanExporterAdapter
 import io.embrace.opentelemetry.kotlin.kotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
@@ -97,14 +99,14 @@ class OtelSdkWrapper(
      * Creates an instance of opentelemetry-kotlin using the Kotlin API's DSL, rather than the opentelemetry-java
      * API.
      */
-    @Suppress("unused", "UNREACHABLE_CODE")
+    @Suppress("unused")
     private val kotlinApiViaDsl: OpenTelemetry by lazy {
         OpenTelemetryInstance.kotlinApi(
             loggerProvider = {
                 resource(configuration.resourceAction)
                 addLogRecordProcessor(
                     DefaultLogRecordProcessor(
-                        TODO()
+                        OtelJavaLogRecordExporterAdapter(configuration.otelJavaLogRecordExporter)
                     )
                 )
             },
@@ -117,7 +119,7 @@ class OtelSdkWrapper(
                 }
                 addSpanProcessor(
                     DefaultSpanProcessor(
-                        TODO(),
+                        OtelJavaSpanExporterAdapter(configuration.otelJavaSpanExporter),
                         configuration.processIdentifier
                     )
                 )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanProcessor.kt
@@ -34,4 +34,6 @@ class DefaultSpanProcessor(
 
     override fun forceFlush(): OperationResultCode = OperationResultCode.Success
     override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override fun isEndRequired(): Boolean = true
+    override fun isStartRequired(): Boolean = true
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinSpanContextWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinSpanContextWrapper.kt
@@ -1,10 +1,12 @@
 package io.embrace.android.embracesdk.internal.otel.wrapper
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
+@OptIn(ExperimentalApi::class)
 class KotlinSpanContextWrapper(
     private val impl: SpanContext,
 ) : OtelJavaSpanContext {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceStateWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/wrapper/KotlinTraceStateWrapper.kt
@@ -1,11 +1,13 @@
 package io.embrace.android.embracesdk.internal.otel.wrapper
 
 import android.os.Build
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceStateBuilder
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
 import java.util.function.BiConsumer
 
+@OptIn(ExperimentalApi::class)
 class KotlinTraceStateWrapper(
     private val impl: TraceState,
 ) : OtelJavaTraceState {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
@@ -2,15 +2,18 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.resource.Resource
-import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
-class FakeReadWriteLogRecord : ReadWriteLogRecord {
-    override val attributes: MutableMap<String, Any> = mutableMapOf()
+class FakeReadWriteLogRecord(
+    private val attributeContainer: AttributeContainer = FakeAttributeContainer()
+) : ReadWriteLogRecord, AttributeContainer by attributeContainer {
+
     override var body: String? = null
     override val context: Context? = null
     override val instrumentationScopeInfo: InstrumentationScopeInfo? = null
@@ -18,8 +21,7 @@ class FakeReadWriteLogRecord : ReadWriteLogRecord {
     override val resource: Resource? = null
     override var severityNumber: SeverityNumber? = null
     override var severityText: String? = null
-    override var spanId: String? = null
     override var timestamp: Long? = null
-    override var traceFlags: TraceFlags? = null
-    override var traceId: String? = null
+    override var spanContext: SpanContext = FakeSpanContext()
+    override val attributes: Map<String, Any> = attributeContainer.attributes()
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteSpan.kt
@@ -22,4 +22,5 @@ class FakeReadWriteSpan(
         get() = throw UnsupportedOperationException()
 
     override fun hasEnded(): Boolean = true
+    override val endTimestamp: Long? = null
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanContext.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanContext.kt
@@ -1,9 +1,11 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.embrace.opentelemetry.kotlin.tracing.model.TraceState
 
+@ExperimentalApi
 class FakeSpanContext : SpanContext {
     override val isRemote: Boolean = false
     override val isValid: Boolean = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ openTelemetryCore = "1.51.0"
 openTelementrySemConv = "1.29.0-alpha"
 moshi = "1.15.2"
 lifecycle = "2.7.0" # version pinned to 2.7.0 because of AGP bug
-otelKotlin = "0.1.4"
+otelKotlin = "0.2.0"
 protobuf = "4.31.1"
 profileinstaller = "1.3.1" # version pinned to 1.3.1 because of AGP bug
 okhttp = "4.12.0"
@@ -85,7 +85,7 @@ apktool-lib = { module = "org.apktool:apktool-lib", version.ref = "apktoolLib" }
 bundletool = { module = "com.android.tools.build:bundletool", version.ref = "bundletool" }
 opentelemetry-kotlin-api = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api", version.ref = "otelKotlin" }
 opentelemetry-kotlin-api-ext = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api-ext", version.ref = "otelKotlin" }
-opentelemetry-kotlin-compat = { module = "io.embrace.opentelemetry.kotlin:compat-kotlin-to-official", version.ref = "otelKotlin" }
+opentelemetry-kotlin-compat = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-compat", version.ref = "otelKotlin" }
 opentelemetry-java-aliases = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-java-typealiases", version.ref = "otelKotlin" }
 
 [plugins]


### PR DESCRIPTION
## Goal

Builds on https://github.com/embrace-io/opentelemetry-kotlin/pull/140 by using exporters to create an OpenTelemetry object via the Kotlin API.

