### PR TITLE
Add session.id attribute to spans to denote starting session

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -52,6 +52,7 @@ internal class OpenTelemetryModuleImpl(
             sdkName = BuildConfig.LIBRARY_PACKAGE_NAME,
             sdkVersion = BuildConfig.VERSION_NAME,
             systemInfo = initModule.systemInfo,
+            sessionIdProvider = { currentSessionSpan.getSessionId() },
             processIdentifierProvider = initModule.processIdentifierProvider
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -103,8 +103,15 @@ internal class CurrentSessionSpanImpl(
                 currentSessionSpan?.addSystemLink(spanToStopContext, LinkType.EndedIn)
             }
 
-            currentSessionSpan?.spanContext?.let { sessionSpanContext ->
-                spanToStop?.addSystemLink(sessionSpanContext, LinkType.EndSession)
+            val sessionId = currentSessionSpan?.getSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key)
+            if (sessionId != null) {
+                currentSessionSpan.spanContext?.let { sessionSpanContext ->
+                    spanToStop?.addSystemLink(
+                        linkedSpanContext = sessionSpanContext,
+                        type = LinkType.EndSession,
+                        attributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to sessionId)
+                    )
+                }
             }
         }
     }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -30,6 +30,7 @@ class OtelSdkConfig(
     val sdkName: String,
     val sdkVersion: String,
     systemInfo: SystemInfo,
+    private val sessionIdProvider: () -> String? = { null },
     private val processIdentifierProvider: () -> String = IdGenerator.Companion::generateLaunchInstanceId,
 ) {
     val otelJavaResourceBuilder: OtelJavaResourceBuilder = OtelJavaResource.getDefault().toBuilder()
@@ -94,6 +95,7 @@ class OtelSdkConfig(
     val otelJavaSpanProcessor: OtelJavaSpanProcessor by lazy {
         EmbraceOtelJavaSpanProcessor(
             otelJavaSpanExporter,
+            sessionIdProvider,
             processIdentifier
         )
     }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceOtelJavaSpanProcessor.kt
@@ -8,13 +8,12 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import java.util.concurrent.atomic.AtomicLong
 
-/**
- * [SpanProcessor] that adds custom attributes to a [Span] when it starts, and exports it to the given [SpanExporter] when it finishes
- */
 class EmbraceOtelJavaSpanProcessor(
     private val spanExporter: OtelJavaSpanExporter,
+    private val sessionIdProvider: () -> String?,
     private val processIdentifier: String,
 ) : OtelJavaSpanProcessor {
 
@@ -23,6 +22,9 @@ class EmbraceOtelJavaSpanProcessor(
     override fun onStart(parentContext: OtelJavaContext, span: OtelJavaReadWriteSpan) {
         span.setEmbraceAttribute(embSequenceId, counter.getAndIncrement().toString())
         span.setEmbraceAttribute(embProcessIdentifier, processIdentifier)
+        sessionIdProvider()?.let { sessionId ->
+            span.setAttribute(SessionIncubatingAttributes.SESSION_ID, sessionId)
+        }
     }
 
     override fun onEnd(span: OtelJavaReadableSpan) {

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -45,6 +45,7 @@ internal class EmbraceSpanServiceTest {
             sdkName = "test-sdk",
             sdkVersion = "1.0",
             systemInfo = SystemInfo(),
+            sessionIdProvider = { "fake-session-id" },
             processIdentifierProvider = { "fake-pid" }
         )
         val otelSdkWrapper = OtelSdkWrapper(

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -533,7 +533,7 @@ internal class SpanServiceImplTest {
 
         val completedSpans = spanSink.completedSpans()
         assertEquals(1, completedSpans.size)
-        assertEquals(48, completedSpans[0].attributes.filterNot { it.key.startsWith("emb.") }.size)
+        assertEquals(49, completedSpans[0].attributes.filterNot { it.key.startsWith("emb.") }.size)
     }
 
     @Test
@@ -610,6 +610,7 @@ internal class SpanServiceImplTest {
             sdkName = "test-sdk",
             sdkVersion = "1.0",
             systemInfo = SystemInfo(),
+            sessionIdProvider = { "fake-session-id" },
             processIdentifierProvider = { "fake-pid" }
         )
         val otelSdkWrapper = OtelSdkWrapper(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
@@ -46,7 +46,7 @@ internal class ExportedSpanValidator {
     }
 
     private fun OtelJavaSpanData.representAttributes(): Map<String, String> {
-        val ignoreList = listOf("emb.process_identifier", "emb.private.sequence_id")
+        val ignoreList = listOf("emb.process_identifier", "emb.private.sequence_id", "session.id")
         val attrs: Map<String, String> = attributes.asMap().map {
             it.key.key to it.value.toString()
         }.toMap()

--- a/embrace-android-sdk/src/integrationTest/resources/system-low-power-export.json
+++ b/embrace-android-sdk/src/integrationTest/resources/system-low-power-export.json
@@ -6,7 +6,7 @@
     "startEpochNanos": "169220160030000000",
     "endEpochNanos": "169220163030000000",
     "hasEnded": "true",
-    "totalAttributeCount": "3",
+    "totalAttributeCount": "4",
     "attributes": {
       "emb.type": "sys.low_power"
     },

--- a/embrace-android-sdk/src/integrationTest/resources/ux-view-export.json
+++ b/embrace-android-sdk/src/integrationTest/resources/ux-view-export.json
@@ -6,7 +6,7 @@
     "startEpochNanos": "169220160010000000",
     "endEpochNanos": "169220200131000000",
     "hasEnded": "true",
-    "totalAttributeCount": "4",
+    "totalAttributeCount": "5",
     "attributes": {
       "emb.type": "ux.view",
       "view.name": "android.app.Activity"

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 
@@ -26,6 +27,7 @@ fun assertEmbraceSpanData(
     expectedErrorCode: ErrorCode? = null,
     expectedCustomAttributes: Map<String, String> = emptyMap(),
     expectedEvents: List<SpanEvent> = emptyList(),
+    expectedSessionId: String? = null,
     private: Boolean = false,
 ) {
     checkNotNull(span)
@@ -50,6 +52,11 @@ fun assertEmbraceSpanData(
             assertEquals(entry.value, attributes?.findAttributeValue(entry.key))
         }
         assertEquals(expectedEvents, events)
+
+        if (expectedSessionId != null) {
+            assertEquals(expectedSessionId, attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+        }
+
         if (private) {
             assertIsPrivateSpan()
         } else {


### PR DESCRIPTION
## Goal

Add `session.id` attribute to all spans that corresponds to the session in which they were started in
