### PR TITLE
Use new API in T+ to obtain process creation request time

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/process/ProcessInfo.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/process/ProcessInfo.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.embracesdk.internal.process
+
+/**
+ * Runtime-agnostic interface for getting information from the Android Process API
+ */
+interface ProcessInfo {
+    /**
+     * Return the best-available estimated time for the when the app process was requested to fork
+     */
+    fun startRequestedTimeMs(): Long?
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/process/ProcessInfoImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/process/ProcessInfoImpl.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.internal.process
+
+import android.os.Build.VERSION_CODES
+import android.os.Process
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+
+class ProcessInfoImpl(
+    private val deviceStartTimeMs: Long,
+    private val versionChecker: VersionChecker,
+) : ProcessInfo {
+    override fun startRequestedTimeMs(): Long? {
+        return if (versionChecker.isAtLeast(VERSION_CODES.TIRAMISU)) {
+            deviceStartTimeMs + Process.getStartRequestedElapsedRealtime()
+        } else if (versionChecker.isAtLeast(VERSION_CODES.N)) {
+            deviceStartTimeMs + Process.getStartElapsedRealtime()
+        } else {
+            null
+        }
+    }
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/process/ProcessInfoImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/process/ProcessInfoImplTest.kt
@@ -22,7 +22,7 @@ internal class ProcessInfoImplTest {
         processInfo = ProcessInfoImpl(fakeDeviceStartTime, BuildVersionChecker)
     }
 
-    @Config(sdk = [VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Config(sdk = [VERSION_CODES.TIRAMISU])
     @Test
     fun `verify start time in T`() {
         val startRequestElapsedTime = Process.getStartRequestedElapsedRealtime()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/process/ProcessInfoImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/process/ProcessInfoImplTest.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.embracesdk.internal.process
+
+import android.os.Build.VERSION_CODES
+import android.os.Process
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+internal class ProcessInfoImplTest {
+
+    private val fakeDeviceStartTime = 100_000L
+    private lateinit var processInfo: ProcessInfo
+
+    @Before
+    fun setUp() {
+        processInfo = ProcessInfoImpl(fakeDeviceStartTime, BuildVersionChecker)
+    }
+
+    @Config(sdk = [VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `verify start time in T`() {
+        val startRequestElapsedTime = Process.getStartRequestedElapsedRealtime()
+        val startRequestedEpochTime = checkNotNull(processInfo.startRequestedTimeMs())
+        assertEquals(startRequestElapsedTime, startRequestedEpochTime - fakeDeviceStartTime)
+    }
+
+    @Config(sdk = [VERSION_CODES.N])
+    @Test
+    fun `verify start time in N`() {
+        val startElapsedTime = Process.getStartElapsedRealtime()
+        val startRequestedEpochTime = checkNotNull(processInfo.startRequestedTimeMs())
+        assertEquals(startElapsedTime, startRequestedEpochTime - fakeDeviceStartTime)
+    }
+
+    @Config(sdk = [VERSION_CODES.LOLLIPOP])
+    @Test
+    fun `verify start time in L`() {
+        assertNull(processInfo.startRequestedTimeMs())
+    }
+}

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitter.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.internal.capture.startup
 
 import android.os.Build.VERSION_CODES
-import android.os.Process
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.attrs.embStartupActivityName
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
+import io.embrace.android.embracesdk.internal.process.ProcessInfo
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateListener
 import io.embrace.android.embracesdk.internal.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.ui.supportFrameCommitCallback
@@ -49,12 +49,7 @@ internal class AppStartupTraceEmitter(
     private val versionChecker: VersionChecker,
     private val logger: EmbLogger,
     manualEnd: Boolean,
-    deviceStartTimestampMs: Long,
-    private val processCreatedMs: Long? = if (versionChecker.isAtLeast(VERSION_CODES.N)) {
-        deviceStartTimestampMs + Process.getStartElapsedRealtime()
-    } else {
-        null
-    },
+    processInfo: ProcessInfo,
 ) : AppStartupDataCollector, ProcessStateListener {
     private val additionalTrackedIntervals = ConcurrentLinkedQueue<TrackedInterval>()
     private val customAttributes: MutableMap<String, String> = ConcurrentHashMap()
@@ -69,6 +64,8 @@ internal class AppStartupTraceEmitter(
     } else {
         TraceEnd.RESUMED
     }
+
+    private val processCreatedMs: Long? = processInfo.startRequestedTimeMs()
 
     @Volatile
     private var applicationInitStartMs: Long? = null

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.capture.startup.StartupTracker
 import io.embrace.android.embracesdk.internal.capture.webview.EmbraceWebViewService
 import io.embrace.android.embracesdk.internal.capture.webview.WebViewService
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.process.ProcessInfoImpl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.ui.createDrawEventEmitter
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
@@ -59,7 +60,10 @@ internal class DataCaptureServiceModuleImpl @JvmOverloads constructor(
             versionChecker = versionChecker,
             logger = initModule.logger,
             manualEnd = configService.autoDataCaptureBehavior.isEndStartupWithAppReadyEnabled(),
-            deviceStartTimestampMs = openTelemetryModule.deviceStartTimeMs()
+            processInfo = ProcessInfoImpl(
+                deviceStartTimeMs = openTelemetryModule.deviceStartTimeMs(),
+                versionChecker = versionChecker,
+            )
         )
     }
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/startup/AppStartupTraceEmitterTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.arch.assertError
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeProcessInfo
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.capture.activity.hasPrePostEvents
 import io.embrace.android.embracesdk.internal.capture.startup.AppStartupTraceEmitter.Companion.ACTIVITY_FIRST_DRAW_SPAN
@@ -608,12 +609,13 @@ internal class AppStartupTraceEmitterTest {
             versionChecker = BuildVersionChecker,
             logger = logger,
             manualEnd = manualEnd,
-            deviceStartTimestampMs = DEFAULT_FAKE_CURRENT_TIME - 10000000L,
-            processCreatedMs = if (BuildVersionChecker.isAtLeast(VERSION_CODES.N)) {
-                DEFAULT_FAKE_CURRENT_TIME
-            } else {
-                null
-            }
+            processInfo = FakeProcessInfo(
+                if (BuildVersionChecker.isAtLeast(VERSION_CODES.N)) {
+                    DEFAULT_FAKE_CURRENT_TIME
+                } else {
+                    null
+                }
+            )
         )
 
     private fun AppStartupTraceEmitter.simulateAppStartup(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeProcessInfo.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeProcessInfo.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.process.ProcessInfo
+
+class FakeProcessInfo(private val fakeStartRequestedTime: Long?) : ProcessInfo {
+    override fun startRequestedTimeMs(): Long? = fakeStartRequestedTime
+}


### PR DESCRIPTION
## Goal

Create version-aware wrapper around the Android API to get process creation time. This simplifies the app startup instrumentation, and in addition allows us to use a newer API (T+) to obtain more accurate time for when the process zygote is specialized into the app process. The previous one uses the time the process is created, which could be done well before hand to reduce the latency when the app process is created.

## Testing

Unfortunately, there's no way to fake the process start times using Roboletric, so while everything else is unit tested, we can't really differentiate between the two in a test. We just have to trust that API works as expected...
