### PR TITLE
Add ability to track application init time before SDK startup

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -47,6 +47,8 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Bread
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi {
+	public abstract fun applicationInitEnd ()V
+	public abstract fun applicationInitStart ()V
 	public abstract fun disable ()V
 	public abstract fun endView (Ljava/lang/String;)Z
 	public abstract fun start (Landroid/content/Context;)V
@@ -63,7 +65,6 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Instr
 	public abstract fun addStartupTraceChildSpan (Ljava/lang/String;JJ)V
 	public abstract fun addStartupTraceChildSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
 	public abstract fun appReady ()V
-	public abstract fun applicationInitEnd ()V
 	public abstract fun getSdkCurrentTimeMs ()J
 }
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi.kt
@@ -89,4 +89,18 @@ public interface EmbraceAndroidApi {
      * due to technical reasons, but any captured data will not be exported.
      */
     public fun disable()
+
+    /**
+     * Notify the Embrace SDK that the application is starting to initialize. This is typically called at the beginning of the
+     * Application.onCreate() function, before the Embrace SDK is started. Calling this will allow the SDK to more accurately gauge
+     * when the application began to start.
+     */
+    public fun applicationInitStart()
+
+    /**
+     * Notify the Embrace SDK that the application has been fully created. This is typically called at the end of the
+     * Application.onCreate() function. Calling this will allow the SDK to more accurately gather the details of the
+     * trace recorded for app startup.
+     */
+    public fun applicationInitEnd()
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
@@ -10,14 +10,6 @@ import io.embrace.android.embracesdk.spans.ErrorCode
  */
 @InternalApi
 public interface InstrumentationApi {
-
-    /**
-     * Notify the Embrace SDK that the application has been fully created. This is typically called at the end of the
-     * Application.onCreate() function. Calling this will allow the SDK to more accurately gather the details of the
-     * trace recorded for app startup.
-     */
-    public fun applicationInitEnd()
-
     /**
      * Notify the Embrace SDK that app startup has completed and the UI is ready to be used.
      */

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -14,6 +14,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun addUserPersona (Ljava/lang/String;)V
 	public fun appReady ()V
 	public fun applicationInitEnd ()V
+	public fun applicationInitStart ()V
 	public fun clearAllUserPersonas ()V
 	public fun clearUserEmail ()V
 	public fun clearUserIdentifier ()V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -28,11 +28,11 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.export.FilteredLogExporter
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
-import java.io.File
 import okhttp3.Protocol
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
 import org.junit.rules.ExternalResource
+import java.io.File
 
 /**
  * A [org.junit.Rule] that is responsible for setting up and tearing down the Embrace SDK for use in
@@ -146,7 +146,7 @@ internal class SdkIntegrationTestRule(
 
         setupAction(setup)
         with(setup) {
-            embraceImpl = EmbraceImpl(bootstrapper)
+            embraceImpl = EmbraceImpl(clock = setup.fakeClock, bootstrapper = bootstrapper)
             EmbraceHooks.setImpl(embraceImpl)
             preSdkStartAction(preSdkStart)
             embraceImpl.addSpanExporter(spanExporter)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -378,7 +378,7 @@ public class Embrace private constructor(
     }
 
     /**
-     * Adds a [SpanExporter] to the tracer.
+     * Adds a [OtelJavaSpanExporter] to the tracer.
      *
      * @param spanExporter the span exporter to add
      */
@@ -395,7 +395,7 @@ public class Embrace private constructor(
     }
 
     /**
-     * Adds a [LogRecordExporter] to the open telemetry logger.
+     * Adds a [OtelJavaLogRecordExporter] to the open telemetry logger.
      *
      * @param logRecordExporter the LogRecord exporter to add
      */
@@ -431,6 +431,10 @@ public class Embrace private constructor(
 
     override fun trackWebViewPerformance(tag: String, message: String) {
         impl.trackWebViewPerformance(tag, message)
+    }
+
+    override fun applicationInitStart() {
+        impl.applicationInitStart()
     }
 
     override fun applicationInitEnd() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
@@ -14,18 +14,12 @@ internal class InstrumentationApiDelegate(
     private val sdkCallChecker: SdkCallChecker,
 ) : InstrumentationApi {
 
-    private val clock: Clock = bootstrapper.initModule.clock
+    private val clock: Clock = bootstrapper.clock
     private val uiLoadTraceEmitter by embraceImplInject(sdkCallChecker) {
         bootstrapper.dataCaptureServiceModule.uiLoadDataListener
     }
     private val appStartupDataCollector by embraceImplInject(sdkCallChecker) {
         bootstrapper.dataCaptureServiceModule.appStartupDataCollector
-    }
-
-    override fun applicationInitEnd() {
-        if (sdkCallChecker.check("application_init_end")) {
-            appStartupDataCollector?.applicationInitEnd()
-        }
     }
 
     override fun appReady() {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.internal.injection
 
 import android.content.Context
 import io.embrace.android.embracesdk.internal.capture.envelope.session.OtelPayloadMapperImpl
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -21,7 +23,8 @@ import kotlin.reflect.KClass
  */
 internal class ModuleInitBootstrapper(
     val logger: EmbLogger = EmbTrace.trace("logger-init", ::EmbLoggerImpl),
-    val initModule: InitModule = EmbTrace.trace("init-module") { createInitModule(logger = logger) },
+    val clock: Clock = NormalizedIntervalClock(),
+    val initModule: InitModule = EmbTrace.trace("init-module") { createInitModule(clock = clock, logger = logger) },
     val openTelemetryModule: OpenTelemetryModule = EmbTrace.trace("otel-module") {
         createOpenTelemetryModule(initModule)
     },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -35,7 +35,8 @@ import io.embrace.android.embracesdk.internal.injection.WorkerThreadModuleSuppli
 @Suppress("LongParameterList")
 internal fun fakeModuleInitBootstrapper(
     fakeEmbLogger: FakeEmbLogger = FakeEmbLogger(),
-    fakeInitModule: FakeInitModule = FakeInitModule(logger = fakeEmbLogger),
+    fakeClock: FakeClock = FakeClock(),
+    fakeInitModule: FakeInitModule = FakeInitModule(clock = fakeClock, logger = fakeEmbLogger),
     fakeOpenTelemetryModule: FakeOpenTelemetryModule = FakeOpenTelemetryModule(),
     coreModuleSupplier: CoreModuleSupplier = { _, _ -> FakeCoreModule() },
     systemServiceModuleSupplier: SystemServiceModuleSupplier = { _, _ -> FakeSystemServiceModule() },
@@ -57,6 +58,7 @@ internal fun fakeModuleInitBootstrapper(
         { _, _, _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() },
 ) = ModuleInitBootstrapper(
     logger = fakeEmbLogger,
+    clock = fakeClock,
     initModule = fakeInitModule,
     openTelemetryModule = fakeOpenTelemetryModule,
     configModuleSupplier = configModuleSupplier,

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -3,15 +3,18 @@ package io.embrace.android.embracesdk.injection
 import android.content.Context
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.AppFramework
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -27,18 +30,21 @@ internal class ModuleInitBootstrapperTest {
 
     private lateinit var moduleInitBootstrapper: ModuleInitBootstrapper
     private lateinit var logger: EmbLogger
+    private lateinit var clock: Clock
     private lateinit var coreModule: FakeCoreModule
     private lateinit var context: Context
 
     @Before
     fun setup() {
         logger = EmbLoggerImpl()
+        clock = FakeClock()
         coreModule = FakeCoreModule()
         moduleInitBootstrapper = ModuleInitBootstrapper(
+            logger = logger,
+            clock = clock,
             configModuleSupplier = { _, _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
             coreModuleSupplier = { _, _ -> coreModule },
             nativeFeatureModuleSupplier = { _, _, _, _, _ -> FakeNativeFeatureModule() },
-            logger = logger
         )
         context = RuntimeEnvironment.getApplication().applicationContext
     }
@@ -63,6 +69,8 @@ internal class ModuleInitBootstrapperTest {
             assertNotNull(dataCaptureServiceModule)
             assertNotNull(deliveryModule)
             assertNotNull(payloadSourceModule)
+            assertEquals(clock, moduleInitBootstrapper.clock)
+            assertEquals(clock, moduleInitBootstrapper.initModule.clock)
         }
     }
 


### PR DESCRIPTION
## Goal

Expose the application object init start time tracking without needing the SDK to be started or do a lot of initialization that is deferred to the SDK startup time. This involves plumbing through a clock instance created in `EmbraceImpl` as well as moving some methods around so the application init start time won't result in a set of cascading inits. This time is cached and will be used when the `applicationInitEnd()` method is called.

Right now, this allows for a better fallback for Android 23 or earlier for when the app started up, but in the future, we can track how long the application object took to initialize (or even earlier).

## Testing

Added integration tests - unit tests already exist for this, as this functionality existed but just not exposed publicly.
