### PR TITLE
Update expected bundle id for ReactNativeAndroidTest.kt

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
@@ -67,7 +67,7 @@ class ReactNativeAndroidTest {
                 installNodeModules(projectDir)
             },
             assertions = { projectDir ->
-                verifyAsmInjection(File(projectDir, "app"), "5B412C6876E5040DD603052BAD052A6F")
+                verifyAsmInjection(File(projectDir, "app"), "27D4D89A18B0426A47151D4888D4E40A")
             }
         )
     }


### PR DESCRIPTION
Update expected react native bundle ID for tests. 

I'm not quite sure about what changed, but we do have some unpinned dependencies in our package.json for this test. We could pin dependencies to a specific version, but that wouldn't allow npm fetch the latest version of embrace.

I'll just fix the test for now, and do some research later to check if there's a better way.
 