### PR TITLE
Use kotlin symbol for SpanContext links

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 
@@ -44,6 +45,7 @@ fun Map<String, String>.toEmbracePayload(): List<Attribute> =
 fun List<Attribute>.toEmbracePayload(): Map<String, String> =
     associate { Pair(it.key ?: "", it.data ?: "") }.filterKeys { it.isNotBlank() }
 
+@OptIn(ExperimentalApi::class)
 fun EmbraceLinkData.toEmbracePayload() = Link(
     spanId = spanContext.spanId,
     traceId = spanContext.traceId,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceLinkData.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceLinkData.kt
@@ -1,8 +1,10 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
+@OptIn(ExperimentalApi::class)
 data class EmbraceLinkData(
-    val spanContext: OtelJavaSpanContext,
-    val attributes: Map<String, String>
+    val spanContext: SpanContext,
+    val attributes: Map<String, String>,
 )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
@@ -5,11 +5,12 @@ import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.LinkType
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaImplicitContextKeyed
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 /**
  * An [EmbraceSpan] that has additional functionality to be used internally by the SDK
@@ -76,8 +77,9 @@ interface EmbraceSdkSpan : EmbraceSpan, OtelJavaImplicitContextKeyed {
     /**
      * Add a system link to the span that will subjected to a different maximum than typical links.
      */
+    @OptIn(ExperimentalApi::class)
     fun addSystemLink(
-        linkedSpanContext: OtelJavaSpanContext,
+        linkedSpanContext: SpanContext,
         type: LinkType,
         attributes: Map<String, String> = emptyMap(),
     ): Boolean

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.opentelemetry.kotlin.Clock
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
@@ -20,6 +21,7 @@ import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 internal class EmbSpanTest {
     private lateinit var fakeClock: FakeClock
     private lateinit var openTelemetryClock: Clock

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -36,6 +36,7 @@ import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
+import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.kotlinApi
 import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
@@ -213,7 +214,7 @@ internal class EmbraceSpanImplTest {
             assertTrue(start())
             val linkedSpan = FakeEmbraceSdkSpan.stopped()
             val spanContext = checkNotNull(linkedSpan.spanContext)
-            assertTrue(embraceSpan.addSystemLink(spanContext, LinkType.PreviousSession))
+            assertTrue(embraceSpan.addSystemLink(SpanContextAdapter(spanContext), LinkType.PreviousSession))
             assertTrue(updateNotified)
         }
     }
@@ -386,10 +387,12 @@ internal class EmbraceSpanImplTest {
         assertTrue(embraceSpan.start())
         repeat(InstrumentedConfigImpl.otelLimits.getMaxSystemLinkCount()) {
             val spanContext = checkNotNull(FakeEmbraceSdkSpan.stopped().spanContext)
-            assertTrue(embraceSpan.addSystemLink(spanContext, LinkType.PreviousSession))
+            assertTrue(embraceSpan.addSystemLink(SpanContextAdapter(spanContext), LinkType.PreviousSession))
         }
 
-        assertFalse(embraceSpan.addSystemLink(checkNotNull(FakeEmbraceSdkSpan.stopped().spanContext), LinkType.PreviousSession))
+        assertFalse(
+            embraceSpan.addSystemLink(SpanContextAdapter(checkNotNull(FakeEmbraceSdkSpan.stopped().spanContext)), LinkType.PreviousSession)
+        )
     }
 
     @Test
@@ -424,7 +427,7 @@ internal class EmbraceSpanImplTest {
             val linkAttrs = mapOf("link-attr" to "value")
             val spanContext = checkNotNull(linkedSpan.spanContext)
             assertTrue(embraceSpan.addLink(spanContext, linkAttrs))
-            assertTrue(embraceSpan.addSystemLink(spanContext, LinkType.PreviousSession))
+            assertTrue(embraceSpan.addSystemLink(SpanContextAdapter(spanContext), LinkType.PreviousSession))
 
             val snapshot = checkNotNull(embraceSpan.snapshot())
 


### PR DESCRIPTION
## Goal

Uses the kotlin symbol for `SpanContext` links in our implementation.
