### PR TITLE
Avoid relying on compat module where not needed

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
-    implementation(libs.opentelemetry.kotlin.compat)
     implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(platform(libs.opentelemetry.bom))

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImpl.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanFactory
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
+import io.embrace.android.embracesdk.internal.otel.toOtelKotlin
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.Uuid
@@ -21,7 +22,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -103,14 +103,14 @@ internal class CurrentSessionSpanImpl(
 
         if (currentSessionSpan != spanToStop) {
             spanToStop?.spanContext?.let { spanToStopContext ->
-                currentSessionSpan?.addSystemLink(SpanContextAdapter(spanToStopContext), LinkType.EndedIn)
+                currentSessionSpan?.addSystemLink(spanToStopContext.toOtelKotlin(), LinkType.EndedIn)
             }
 
             val sessionId = currentSessionSpan?.getSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key)
             if (sessionId != null) {
                 currentSessionSpan.spanContext?.let { sessionSpanContext ->
                     spanToStop?.addSystemLink(
-                        linkedSpanContext = SpanContextAdapter(sessionSpanContext),
+                        linkedSpanContext = sessionSpanContext.toOtelKotlin(),
                         type = LinkType.EndSession,
                         attributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to sessionId)
                     )
@@ -216,7 +216,7 @@ internal class CurrentSessionSpanImpl(
             previousSessionSpan?.spanContext?.let {
                 val prevSessionId = previousSessionSpan.getSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key) ?: ""
                 addSystemLink(
-                    linkedSpanContext = SpanContextAdapter(it),
+                    linkedSpanContext = it.toOtelKotlin(),
                     type = LinkType.PreviousSession,
                     attributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to prevSessionId)
                 )

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
-    implementation(libs.opentelemetry.kotlin.compat)
     implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(project(":embrace-android-api"))

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
@@ -1,9 +1,13 @@
 package io.embrace.android.embracesdk.internal.otel
 
 import io.embrace.android.embracesdk.internal.payload.Span.Status
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 
 internal fun StatusCode.toOtelJava(): OtelJavaStatusCode = when (this) {
@@ -31,3 +35,6 @@ fun StatusCode.toEmbracePayload(): Status = when (this) {
     StatusCode.Ok -> Status.OK
     StatusCode.Unset -> Status.UNSET
 }
+
+@OptIn(ExperimentalApi::class)
+fun OtelJavaSpanContext.toOtelKotlin(): SpanContext = SpanContextAdapter(this)

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -95,7 +95,6 @@ dependencies {
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
-    implementation(libs.opentelemetry.kotlin.compat)
 
     testImplementation(project(":embrace-test-fakes"))
     testImplementation(libs.protobuf.java)

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -36,5 +36,4 @@ dependencies {
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
-    implementation(libs.opentelemetry.kotlin.compat)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceLinkData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
 import io.embrace.android.embracesdk.internal.otel.toEmbracePayload
+import io.embrace.android.embracesdk.internal.otel.toOtelKotlin
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -28,7 +29,6 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
-import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
@@ -144,7 +144,7 @@ class FakeEmbraceSdkSpan(
     }
 
     override fun addLink(linkedSpanContext: OtelJavaSpanContext, attributes: Map<String, String>?): Boolean {
-        links.add(EmbraceLinkData(SpanContextAdapter(linkedSpanContext), attributes ?: emptyMap()))
+        links.add(EmbraceLinkData(linkedSpanContext.toOtelKotlin(), attributes ?: emptyMap()))
         return true
     }
 


### PR DESCRIPTION
## Goal

Removes a dependency on the compat module in everywhere apart from `embrace-android-otel`. In other modules we should purely rely on the public API of the Kotlin SDK.
