### PR TITLE
Alter otel module

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -13,8 +13,8 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
@@ -79,12 +79,12 @@ interface OpenTelemetryModule {
      * Embrace APIs. Currently, only the APIs related [Tracer] have operational implementations. Every other method will return no-op
      * implementations that records no data.
      */
-    val externalOpenTelemetry: OtelJavaOpenTelemetry
+    val openTelemetryJava: OtelJavaOpenTelemetry
 
     /**
-     * Provides [Tracer] instances for instrumentation external to the Embrace SDK to create spans
+     * Provides an OpenTelemetry instance that provides a Kotlin API.
      */
-    val externalTracerProvider: OtelJavaTracerProvider
+    val openTelemetryKotlin: OpenTelemetry
 
     /**
      * OpenTelemetry SDK compatible clock based on the internal Embrace clock instance

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaOpenTelemetry
-import io.embrace.android.embracesdk.internal.otel.impl.EmbOtelJavaTracerProvider
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSinkImpl
@@ -20,9 +19,9 @@ internal class OpenTelemetryModuleImplTest {
         assertTrue(openTelemetryModule.spanService is EmbraceSpanService)
         assertTrue(openTelemetryModule.currentSessionSpan is CurrentSessionSpanImpl)
         assertTrue(openTelemetryModule.logSink is LogSinkImpl)
-        assertTrue(openTelemetryModule.externalOpenTelemetry is EmbOtelJavaOpenTelemetry)
-        assertTrue(openTelemetryModule.externalTracerProvider is EmbOtelJavaTracerProvider)
+        assertTrue(openTelemetryModule.openTelemetryJava is EmbOtelJavaOpenTelemetry)
         assertNotNull(openTelemetryModule.logger)
         assertNotNull(openTelemetryModule.sdkTracer)
+        assertNotNull(openTelemetryModule.openTelemetryKotlin)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
@@ -27,7 +27,7 @@ internal class OTelApiDelegate(
 
     override fun getOpenTelemetry(): OtelJavaOpenTelemetry {
         return if (sdkCallChecker.started.get()) {
-            bootstrapper.openTelemetryModule.externalOpenTelemetry
+            bootstrapper.openTelemetryModule.openTelemetryJava
         } else {
             OtelJavaOpenTelemetry.noop()
         }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -18,8 +18,8 @@ import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 import io.embrace.android.embracesdk.internal.spans.InternalTracer
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.embrace.opentelemetry.kotlin.logging.Logger
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 
@@ -46,10 +46,10 @@ class FakeOpenTelemetryModule(
         get() = TODO()
     override val logger: Logger
         get() = FakeOtelLogger()
-    override val externalOpenTelemetry: OtelJavaOpenTelemetry
+    override val openTelemetryJava: OtelJavaOpenTelemetry
         get() = EmbOtelJavaOpenTelemetry(traceProviderSupplier = { FakeOtelJavaTracerProvider() })
-    override val externalTracerProvider: OtelJavaTracerProvider
-        get() = FakeOtelJavaTracerProvider()
+    override val openTelemetryKotlin: OpenTelemetry
+        get() = throw UnsupportedOperationException()
     override val openTelemetryClock: Clock
         get() = FakeOtelKotlinClock(FakeClock())
 }


### PR DESCRIPTION
## Goal

Alters `OpenTelemetryModule` to have properties for both the Java/Kotlin API and hides visibility of some properties that no longer need to be public.

