### PR TITLE
Add InstrumentationTargetMethodEndVisitor to inject calls at the end of methods

### DIFF
--- a/embrace-bytecode-instrumentation-tests/src/main/java/io/embrace/test/fixtures/TargetMethodEndVisitorObj.kt
+++ b/embrace-bytecode-instrumentation-tests/src/main/java/io/embrace/test/fixtures/TargetMethodEndVisitorObj.kt
@@ -1,0 +1,29 @@
+package io.embrace.test.fixtures
+
+import kotlin.random.Random
+
+class TargetMethodEndVisitorObj {
+    fun instrumentAtEndWithReturn() {
+        print("Instrumenting at the end of a method with a return statement")
+        return
+    }
+
+    fun instrumentAtEndWithoutReturn() {
+        print("Instrumenting at the end of a method without a return statement")
+    }
+
+    fun instrumentAtEndWithThrow() {
+        print("Instrumenting at the end of a method with a throw statement")
+        throw Exception("Exception")
+    }
+
+    fun instrumentAtEndWithMultipleReturns() {
+        if (Random.nextBoolean()) {
+            print("Instrumenting at the end of a method with multiple return statements - first return")
+            return
+        } else {
+            print("Instrumenting at the end of a method with multiple return statements - second return")
+            return
+        }
+    }
+}

--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/InstrumentationTargetMethodEndVisitorTest.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/InstrumentationTargetMethodEndVisitorTest.kt
@@ -1,0 +1,63 @@
+package io.embrace.gradle.plugin.instrumentation
+
+import io.embrace.android.gradle.plugin.instrumentation.visitor.BytecodeMethodInsertionParams
+import io.embrace.android.gradle.plugin.instrumentation.visitor.InstrumentationTargetMethodEndVisitor
+import io.embrace.test.fixtures.MethodReturnValueVisitorObj
+import io.embrace.test.fixtures.TargetMethodEndVisitorObj
+import org.junit.Test
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+
+class InstrumentationTargetMethodEndVisitorTest {
+
+    @Test
+    fun `instrument bytecode`() {
+        val params = BytecodeTestParams(TargetMethodEndVisitorObj::class) { nextVisitor, _ ->
+            TestClassVisitor(ASM_API_VERSION, nextVisitor)
+        }
+        InstrumentationRunner.runInstrumentationAndCompareOutput(params)
+    }
+
+    /**
+     * Visits the [MethodReturnValueVisitorObj] class and alters the return values for each function.
+     */
+    class TestClassVisitor(
+        api: Int,
+        nextClassVisitor: ClassVisitor?
+    ) : ClassVisitor(api, nextClassVisitor) {
+
+        private val testMethods = listOf(
+            "instrumentAtEndWithReturn",
+            "instrumentAtEndWithoutReturn",
+            "instrumentAtEndWithThrow",
+            "instrumentAtEndWithMultipleReturns",
+        )
+
+        private val methodDescriptor = "()V"
+
+        override fun visitMethod(
+            access: Int,
+            name: String?,
+            descriptor: String?,
+            signature: String?,
+            exceptions: Array<out String>?
+        ): MethodVisitor {
+            val nextVisitor = super.visitMethod(access, name, descriptor, signature, exceptions)
+
+            if (name in testMethods && descriptor == methodDescriptor) {
+                return InstrumentationTargetMethodEndVisitor(
+                    api,
+                    nextVisitor,
+                    BytecodeMethodInsertionParams(
+                        "io/embrace/gradle/plugin/instrumentation/InjectedClass",
+                        "injectedMethod",
+                        "()V",
+                        emptyList(),
+                        true
+                    )
+                )
+            }
+            return nextVisitor
+        }
+    }
+}

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/TargetMethodEndVisitorObj_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/TargetMethodEndVisitorObj_expected.txt
@@ -1,0 +1,110 @@
+// class version 55.0 (55)
+// access flags 0x31
+public final class io/embrace/test/fixtures/TargetMethodEndVisitorObj {
+
+  // compiled from: TargetMethodEndVisitorObj.kt
+
+  @Lkotlin/Metadata;(mv={1, 8, 0}, k=1, xi=48, d1={"\u0000\u0014\n\u0002\u0018\u0002\n\u0002\u0010\u0000\n\u0002\u0008\u0002\n\u0002\u0010\u0002\n\u0002\u0008\u0004\u0018\u00002\u00020\u0001B\u0005\u00a2\u0006\u0002\u0010\u0002J\u0006\u0010\u0003\u001a\u00020\u0004J\u0006\u0010\u0005\u001a\u00020\u0004J\u0006\u0010\u0006\u001a\u00020\u0004J\u0006\u0010\u0007\u001a\u00020\u0004\u00a8\u0006\u0008"}, d2={"Lio/embrace/test/fixtures/TargetMethodEndVisitorObj;", "", "()V", "instrumentAtEndWithMultipleReturns", "", "instrumentAtEndWithReturn", "instrumentAtEndWithThrow", "instrumentAtEndWithoutReturn", "embrace-bytecode-instrumentation-tests_release"})
+  // access flags 0x19
+  public final static INNERCLASS kotlin/random/Random$Default kotlin/random/Random Default
+
+  // access flags 0x1
+  public <init>()V
+   L0
+    LINENUMBER 5 L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TargetMethodEndVisitorObj; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x11
+  public final instrumentAtEndWithReturn()V
+   L0
+    LINENUMBER 7 L0
+    LDC "Instrumenting at the end of a method with a return statement"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.print (Ljava/lang/Object;)V
+   L1
+    LINENUMBER 8 L1
+    INVOKESTATIC io/embrace/gradle/plugin/instrumentation/InjectedClass.injectedMethod ()V
+    RETURN
+   L2
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TargetMethodEndVisitorObj; L0 L2 0
+    MAXSTACK = 2
+    MAXLOCALS = 1
+
+  // access flags 0x11
+  public final instrumentAtEndWithoutReturn()V
+   L0
+    LINENUMBER 12 L0
+    LDC "Instrumenting at the end of a method without a return statement"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.print (Ljava/lang/Object;)V
+   L1
+    LINENUMBER 13 L1
+    INVOKESTATIC io/embrace/gradle/plugin/instrumentation/InjectedClass.injectedMethod ()V
+    RETURN
+   L2
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TargetMethodEndVisitorObj; L0 L2 0
+    MAXSTACK = 2
+    MAXLOCALS = 1
+
+  // access flags 0x11
+  public final instrumentAtEndWithThrow()V
+   L0
+    LINENUMBER 16 L0
+    LDC "Instrumenting at the end of a method with a throw statement"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.print (Ljava/lang/Object;)V
+   L1
+    LINENUMBER 17 L1
+    NEW java/lang/Exception
+    DUP
+    LDC "Exception"
+    INVOKESPECIAL java/lang/Exception.<init> (Ljava/lang/String;)V
+    INVOKESTATIC io/embrace/gradle/plugin/instrumentation/InjectedClass.injectedMethod ()V
+    ATHROW
+   L2
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TargetMethodEndVisitorObj; L0 L2 0
+    MAXSTACK = 3
+    MAXLOCALS = 1
+
+  // access flags 0x11
+  public final instrumentAtEndWithMultipleReturns()V
+   L0
+    LINENUMBER 21 L0
+    GETSTATIC kotlin/random/Random.Default : Lkotlin/random/Random$Default;
+    INVOKEVIRTUAL kotlin/random/Random$Default.nextBoolean ()Z
+    IFEQ L1
+   L2
+    LINENUMBER 22 L2
+    LDC "Instrumenting at the end of a method with multiple return statements - first return"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.print (Ljava/lang/Object;)V
+   L3
+    LINENUMBER 23 L3
+    INVOKESTATIC io/embrace/gradle/plugin/instrumentation/InjectedClass.injectedMethod ()V
+    RETURN
+   L1
+    LINENUMBER 25 L1
+   FRAME FULL [io/embrace/test/fixtures/TargetMethodEndVisitorObj] []
+    LDC "Instrumenting at the end of a method with multiple return statements - second return"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.print (Ljava/lang/Object;)V
+   L4
+    LINENUMBER 26 L4
+    INVOKESTATIC io/embrace/gradle/plugin/instrumentation/InjectedClass.injectedMethod ()V
+    RETURN
+   L5
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TargetMethodEndVisitorObj; L0 L5 0
+    MAXSTACK = 2
+    MAXLOCALS = 1
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigFeaturesReader.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigFeaturesReader.kt
@@ -38,6 +38,7 @@ private fun InstrumentationConfigFeature.convertInstrumentationConfigFeature(): 
             name = insert.name,
             descriptor = insert.descriptor,
             operandStackIndices = insert.operandStackIndices,
+            insertAtEnd = insert.insertAtEnd
         ),
         visitStrategy = convertVisitStrategy(),
         addOverrideParams = addOverride?.let {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigInsert.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigInsert.kt
@@ -8,4 +8,5 @@ internal data class InstrumentationConfigInsert(
     val name: String,
     val descriptor: String,
     val operandStackIndices: List<Int>,
+    val insertAtEnd: Boolean = false
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/BytecodeMethodInsertionParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/BytecodeMethodInsertionParams.kt
@@ -31,4 +31,10 @@ data class BytecodeMethodInsertionParams(
      * foo(String, Int, Boolean)
      */
     val operandStackIndices: List<Int>,
+
+    /**
+     * Specifies if the method call should be inserted at the end of the target method.
+     * Defaults to false, which inserts the call at the method entry point.
+     */
+    val insertAtEnd: Boolean,
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InsertSuperOverrideClassVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InsertSuperOverrideClassVisitor.kt
@@ -27,11 +27,19 @@ class InsertSuperOverrideClassVisitor(
 
         return if (feature.targetParams.name == name && feature.targetParams.descriptor == desc && !isStatic(access)) {
             hasOverride = true
-            InstrumentationTargetMethodVisitor(
-                api = api,
-                methodVisitor = nextMethodVisitor,
-                params = feature.insertionParams
-            )
+            if (feature.insertionParams.insertAtEnd) {
+                InstrumentationTargetMethodEndVisitor(
+                    api = api,
+                    methodVisitor = nextMethodVisitor,
+                    params = feature.insertionParams
+                )
+            } else {
+                InstrumentationTargetMethodVisitor(
+                    api = api,
+                    methodVisitor = nextMethodVisitor,
+                    params = feature.insertionParams
+                )
+            }
         } else {
             return nextMethodVisitor
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetClassVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetClassVisitor.kt
@@ -22,11 +22,19 @@ class InstrumentationTargetClassVisitor(
         val nextMethodVisitor = super.visitMethod(access, name, desc, signature, exceptions)
 
         return if (feature.targetParams.name == name && feature.targetParams.descriptor == desc && !isStatic(access)) {
-            InstrumentationTargetMethodVisitor(
-                api = api,
-                methodVisitor = nextMethodVisitor,
-                params = feature.insertionParams
-            )
+            if (feature.insertionParams.insertAtEnd) {
+                InstrumentationTargetMethodEndVisitor(
+                    api = api,
+                    methodVisitor = nextMethodVisitor,
+                    params = feature.insertionParams
+                )
+            } else {
+                InstrumentationTargetMethodVisitor(
+                    api = api,
+                    methodVisitor = nextMethodVisitor,
+                    params = feature.insertionParams
+                )
+            }
         } else {
             nextMethodVisitor
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodEndVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodEndVisitor.kt
@@ -1,0 +1,50 @@
+package io.embrace.android.gradle.plugin.instrumentation.visitor
+
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Visits a method that should be rewritten to include an API call to instrumentation
+ * and inserts a call to a static method before all return statements (at the end).
+ */
+internal class InstrumentationTargetMethodEndVisitor(
+    api: Int,
+    methodVisitor: MethodVisitor?,
+    private val params: BytecodeMethodInsertionParams,
+) : MethodVisitor(api, methodVisitor) {
+
+    override fun visitInsn(opcode: Int) {
+        if (isReturnInstruction(opcode)) {
+            // Insert call before return instruction
+            insertCall()
+        }
+        super.visitInsn(opcode)
+    }
+
+    private fun insertCall() {
+        // load local variables required for method call (if any) and push onto the operand stack
+        params.operandStackIndices.forEach {
+            visitVarInsn(Opcodes.ALOAD, it)
+        }
+
+        // invoke the target method
+        visitMethodInsn(
+            Opcodes.INVOKESTATIC,
+            params.owner,
+            params.name,
+            params.descriptor,
+            false
+        )
+    }
+
+    // Returns true if the instruction is a return or throw instruction.
+    private fun isReturnInstruction(opcode: Int): Boolean {
+        return opcode == Opcodes.RETURN ||
+            opcode == Opcodes.IRETURN ||
+            opcode == Opcodes.LRETURN ||
+            opcode == Opcodes.FRETURN ||
+            opcode == Opcodes.DRETURN ||
+            opcode == Opcodes.ARETURN ||
+            opcode == Opcodes.ATHROW
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodEndVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodEndVisitor.kt
@@ -7,7 +7,7 @@ import org.objectweb.asm.Opcodes
  * Visits a method that should be rewritten to include an API call to instrumentation
  * and inserts a call to a static method before all return statements (at the end).
  */
-internal class InstrumentationTargetMethodEndVisitor(
+class InstrumentationTargetMethodEndVisitor(
     api: Int,
     methodVisitor: MethodVisitor?,
     private val params: BytecodeMethodInsertionParams,


### PR DESCRIPTION
## Goal

With this change, we can now add `insertAtEnd` in the insert block of an instrumentation instruction in `bytecode_instrumentation_features.json`:
```
"insert": {
       ...
        "insertAtEnd": true
      },
```

With this, we'll inject the call with ASM at the end of the method, rather than the beginning. 

"The end" is going to be any return or throw instruction, so our code will be injected immediately before those lines.
