### PR TITLE
Instrument calls to applicationInitStart and applicationInitEnd

### DIFF
--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -83,6 +83,12 @@ public final class io/embrace/android/embracesdk/Embrace$Companion {
 	public final fun getInstance ()Lio/embrace/android/embracesdk/Embrace;
 }
 
+public final class io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint {
+	public static final field INSTANCE Lio/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint;
+	public static final fun applicationInitEnd ()V
+	public static final fun applicationInitStart ()V
+}
+
 public final class io/embrace/android/embracesdk/internal/instrumentation/bytecode/AutoSdkInitializationBytecodeEntrypoint {
 	public static final field INSTANCE Lio/embrace/android/embracesdk/internal/instrumentation/bytecode/AutoSdkInitializationBytecodeEntrypoint;
 	public static final fun onCreate (Landroid/app/Application;)V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.internal.instrumentation.bytecode
+
+import androidx.annotation.Keep
+import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.annotation.InternalApi
+
+/**
+ * @hide
+ */
+@InternalApi
+@Keep
+public object ApplicationInitTimeBytecodeEntrypoint {
+
+    @Keep
+    @JvmStatic
+    public fun applicationInitStart() {
+        Embrace.getInstance().applicationInitStart()
+    }
+
+    @Keep
+    @JvmStatic
+    public fun applicationInitEnd() {
+        Embrace.getInstance().applicationInitEnd()
+    }
+}

--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
@@ -14,6 +14,8 @@ class FakeBytecodeInstrumentationParams(
     override val shouldInstrumentOkHttp: Property<Boolean> = fakeProperty(true),
     override val shouldInstrumentOnLongClick: Property<Boolean> = fakeProperty(true),
     override val shouldInstrumentOnClick: Property<Boolean> = fakeProperty(true),
+    override val shouldInstrumentApplicationInitTimeStart: Property<Boolean> = fakeProperty(true),
+    override val shouldInstrumentApplicationInitTimeEnd: Property<Boolean> = fakeProperty(true),
 ) : BytecodeInstrumentationParams {
     override val config: Property<VariantConfig>
         get() = TODO("Not yet implemented")

--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
@@ -14,8 +14,7 @@ class FakeBytecodeInstrumentationParams(
     override val shouldInstrumentOkHttp: Property<Boolean> = fakeProperty(true),
     override val shouldInstrumentOnLongClick: Property<Boolean> = fakeProperty(true),
     override val shouldInstrumentOnClick: Property<Boolean> = fakeProperty(true),
-    override val shouldInstrumentApplicationInitTimeStart: Property<Boolean> = fakeProperty(true),
-    override val shouldInstrumentApplicationInitTimeEnd: Property<Boolean> = fakeProperty(true),
+    override val applicationInitTimingEnabled: Property<Boolean> = fakeProperty(true),
 ) : BytecodeInstrumentationParams {
     override val config: Property<VariantConfig>
         get() = TODO("Not yet implemented")

--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/InstrumentedBytecodeTest.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/InstrumentedBytecodeTest.kt
@@ -70,6 +70,14 @@ private val autoSdkInitializationFactory: ClassVisitorFactory = { visitor, param
     createFactory(params, visitor, "auto_sdk_initialization", "android.app.Application")
 }
 
+private val applicationInitTimeStartFactory: ClassVisitorFactory = { visitor, params ->
+    createFactory(params, visitor, "application_init_time_start", "android.app.Application")
+}
+
+private val applicationInitTimeEndFactory: ClassVisitorFactory = { visitor, params ->
+    createFactory(params, visitor, "application_init_time_end", "android.app.Application")
+}
+
 /**
  * Verifies that a [ClassVisitor] produces the correct bytecode output for a given class.
  *
@@ -132,6 +140,16 @@ class InstrumentedBytecodeTest(
             BytecodeTestParams(clz = CustomWebViewClient::class, factory = webviewFactory),
             BytecodeTestParams(clz = ExtendedCustomWebViewClient::class, factory = webviewFactory),
             BytecodeTestParams(clz = TestApplication::class, factory = autoSdkInitializationFactory),
+            BytecodeTestParams(
+                clz = TestApplication::class,
+                factory = applicationInitTimeStartFactory,
+                expectedOutput = "TestApplication_application_init_time_start_expected.txt"
+            ),
+            BytecodeTestParams(
+                clz = TestApplication::class,
+                factory = applicationInitTimeEndFactory,
+                expectedOutput = "TestApplication_application_init_time_end_expected.txt"
+            ),
             BytecodeTestParams(clz = NoOverrideWebViewClient::class, factory = webviewFactory),
         )
     }

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/TestApplication_application_init_time_end_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/TestApplication_application_init_time_end_expected.txt
@@ -1,0 +1,35 @@
+// class version 55.0 (55)
+// access flags 0x31
+public final class io/embrace/test/fixtures/TestApplication extends android/app/Application {
+
+  // compiled from: TestApplication.kt
+
+  @Lkotlin/Metadata;(mv={1, 8, 0}, k=1, xi=48, d1={"\u0000\u0012\n\u0002\u0018\u0002\n\u0002\u0018\u0002\n\u0002\u0008\u0002\n\u0002\u0010\u0002\n\u0000\u0018\u00002\u00020\u0001B\u0005\u00a2\u0006\u0002\u0010\u0002J\u0008\u0010\u0003\u001a\u00020\u0004H\u0016\u00a8\u0006\u0005"}, d2={"Lio/embrace/test/fixtures/TestApplication;", "Landroid/app/Application;", "()V", "onCreate", "", "embrace-bytecode-instrumentation-tests_release"})
+
+  // access flags 0x1
+  public <init>()V
+   L0
+    LINENUMBER 5 L0
+    ALOAD 0
+    INVOKESPECIAL android/app/Application.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TestApplication; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x1
+  public onCreate()V
+   L0
+    LINENUMBER 7 L0
+    ALOAD 0
+    INVOKESPECIAL android/app/Application.onCreate ()V
+   L1
+    LINENUMBER 8 L1
+    INVOKESTATIC io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint.applicationInitEnd ()V
+    RETURN
+   L2
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TestApplication; L0 L2 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+}

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/TestApplication_application_init_time_start_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/TestApplication_application_init_time_start_expected.txt
@@ -1,0 +1,35 @@
+// class version 55.0 (55)
+// access flags 0x31
+public final class io/embrace/test/fixtures/TestApplication extends android/app/Application {
+
+  // compiled from: TestApplication.kt
+
+  @Lkotlin/Metadata;(mv={1, 8, 0}, k=1, xi=48, d1={"\u0000\u0012\n\u0002\u0018\u0002\n\u0002\u0018\u0002\n\u0002\u0008\u0002\n\u0002\u0010\u0002\n\u0000\u0018\u00002\u00020\u0001B\u0005\u00a2\u0006\u0002\u0010\u0002J\u0008\u0010\u0003\u001a\u00020\u0004H\u0016\u00a8\u0006\u0005"}, d2={"Lio/embrace/test/fixtures/TestApplication;", "Landroid/app/Application;", "()V", "onCreate", "", "embrace-bytecode-instrumentation-tests_release"})
+
+  // access flags 0x1
+  public <init>()V
+   L0
+    LINENUMBER 5 L0
+    ALOAD 0
+    INVOKESPECIAL android/app/Application.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TestApplication; L0 L1 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+
+  // access flags 0x1
+  public onCreate()V
+    INVOKESTATIC io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint.applicationInitStart ()V
+   L0
+    LINENUMBER 7 L0
+    ALOAD 0
+    INVOKESPECIAL android/app/Application.onCreate ()V
+   L1
+    LINENUMBER 8 L1
+    RETURN
+   L2
+    LOCALVARIABLE this Lio/embrace/test/fixtures/TestApplication; L0 L2 0
+    MAXSTACK = 1
+    MAXLOCALS = 1
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
@@ -42,14 +42,9 @@ abstract class EmbraceBytecodeInstrumentation @Inject internal constructor(objec
     val autoSdkInitializationEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
     /**
-     * Whether Embrace should automatically instrument application initialization timing start. Defaults to true.
+     * Whether Embrace should automatically instrument application initialization timing. Defaults to true.
      */
-    val applicationInitTimeStartEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)
-
-    /**
-     * Whether Embrace should automatically instrument application initialization timing end. Defaults to true.
-     */
-    val applicationInitTimeEndEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)
+    val applicationInitTimingEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)
 
     /**
      * Whether Embrace should automatically instrument push notifications from Firebase. Defaults to false.

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/api/EmbraceBytecodeInstrumentation.kt
@@ -42,6 +42,16 @@ abstract class EmbraceBytecodeInstrumentation @Inject internal constructor(objec
     val autoSdkInitializationEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java)
 
     /**
+     * Whether Embrace should automatically instrument application initialization timing start. Defaults to true.
+     */
+    val applicationInitTimeStartEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)
+
+    /**
+     * Whether Embrace should automatically instrument application initialization timing end. Defaults to true.
+     */
+    val applicationInitTimeEndEnabled: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)
+
+    /**
      * Whether Embrace should automatically instrument push notifications from Firebase. Defaults to false.
      */
     val firebasePushNotificationsEnabled: Property<Boolean> =

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
@@ -28,6 +28,16 @@ interface InstrumentationBehavior {
     val autoSdkInitializationEnabled: Boolean
 
     /**
+     * Whether application initialization timing start should be auto-instrumented
+     */
+    val applicationInitTimeStartEnabled: Boolean
+
+    /**
+     * Whether application initialization timing end should be auto-instrumented
+     */
+    val applicationInitTimeEndEnabled: Boolean
+
+    /**
      * Whether FCM push notifications should be auto-instrumented
      */
     val fcmPushNotificationsEnabled: Boolean

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehavior.kt
@@ -30,12 +30,7 @@ interface InstrumentationBehavior {
     /**
      * Whether application initialization timing start should be auto-instrumented
      */
-    val applicationInitTimeStartEnabled: Boolean
-
-    /**
-     * Whether application initialization timing end should be auto-instrumented
-     */
-    val applicationInitTimeEndEnabled: Boolean
+    val applicationInitTimingEnabled: Boolean
 
     /**
      * Whether FCM push notifications should be auto-instrumented

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
@@ -38,6 +38,14 @@ class InstrumentationBehaviorImpl(
         enabled && (instrumentation.autoSdkInitializationEnabled.orNull ?: false)
     }
 
+    override val applicationInitTimeStartEnabled: Boolean by lazy {
+        enabled && (instrumentation.applicationInitTimeStartEnabled.orNull ?: true)
+    }
+
+    override val applicationInitTimeEndEnabled: Boolean by lazy {
+        enabled && (instrumentation.applicationInitTimeEndEnabled.orNull ?: true)
+    }
+
     override val fcmPushNotificationsEnabled: Boolean by lazy {
         enabled && (instrumentation.firebasePushNotificationsEnabled.orNull ?: extension.instrumentFirebaseMessaging.orNull ?: false)
     }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/InstrumentationBehaviorImpl.kt
@@ -38,12 +38,8 @@ class InstrumentationBehaviorImpl(
         enabled && (instrumentation.autoSdkInitializationEnabled.orNull ?: false)
     }
 
-    override val applicationInitTimeStartEnabled: Boolean by lazy {
-        enabled && (instrumentation.applicationInitTimeStartEnabled.orNull ?: true)
-    }
-
-    override val applicationInitTimeEndEnabled: Boolean by lazy {
-        enabled && (instrumentation.applicationInitTimeEndEnabled.orNull ?: true)
+    override val applicationInitTimingEnabled: Boolean by lazy {
+        enabled && (instrumentation.applicationInitTimingEnabled.orNull ?: true)
     }
 
     override val fcmPushNotificationsEnabled: Boolean by lazy {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -41,8 +41,7 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                 params.shouldInstrumentOkHttp.set(behavior.instrumentation.okHttpEnabled)
                 params.shouldInstrumentOnLongClick.set(behavior.instrumentation.onLongClickEnabled)
                 params.shouldInstrumentOnClick.set(behavior.instrumentation.onClickEnabled)
-                params.shouldInstrumentApplicationInitTimeStart.set(behavior.instrumentation.applicationInitTimeStartEnabled)
-                params.shouldInstrumentApplicationInitTimeEnd.set(behavior.instrumentation.applicationInitTimeEndEnabled)
+                params.applicationInitTimingEnabled.set(behavior.instrumentation.applicationInitTimingEnabled)
 
                 val encodeFileToBase64Task = project.lazyTaskLookup<EncodeFileToBase64Task>(
                     "${EncodeFileToBase64Task.NAME}${data.name.capitalizedString()}"

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -41,6 +41,8 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                 params.shouldInstrumentOkHttp.set(behavior.instrumentation.okHttpEnabled)
                 params.shouldInstrumentOnLongClick.set(behavior.instrumentation.onLongClickEnabled)
                 params.shouldInstrumentOnClick.set(behavior.instrumentation.onClickEnabled)
+                params.shouldInstrumentApplicationInitTimeStart.set(behavior.instrumentation.applicationInitTimeStartEnabled)
+                params.shouldInstrumentApplicationInitTimeEnd.set(behavior.instrumentation.applicationInitTimeEndEnabled)
 
                 val encodeFileToBase64Task = project.lazyTaskLookup<EncodeFileToBase64Task>(
                     "${EncodeFileToBase64Task.NAME}${data.name.capitalizedString()}"

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
@@ -71,4 +71,10 @@ interface BytecodeInstrumentationParams : InstrumentationParameters {
 
     @get:Input
     val shouldInstrumentOnClick: Property<Boolean>
+
+    @get:Input
+    val shouldInstrumentApplicationInitTimeStart: Property<Boolean>
+
+    @get:Input
+    val shouldInstrumentApplicationInitTimeEnd: Property<Boolean>
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
@@ -73,8 +73,5 @@ interface BytecodeInstrumentationParams : InstrumentationParameters {
     val shouldInstrumentOnClick: Property<Boolean>
 
     @get:Input
-    val shouldInstrumentApplicationInitTimeStart: Property<Boolean>
-
-    @get:Input
-    val shouldInstrumentApplicationInitTimeEnd: Property<Boolean>
+    val applicationInitTimingEnabled: Property<Boolean>
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/VisitorFactoryImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/VisitorFactoryImpl.kt
@@ -46,6 +46,8 @@ class VisitorFactoryImpl(
             "auto_sdk_initialization" -> params.shouldInstrumentAutoSdkInitialization.get()
             "on_click" -> params.shouldInstrumentOnClick.get()
             "on_long_click" -> params.shouldInstrumentOnLongClick.get()
+            "application_init_time_start" -> params.shouldInstrumentApplicationInitTimeStart.get()
+            "application_init_time_end" -> params.shouldInstrumentApplicationInitTimeEnd.get()
             else -> error("Unknown feature: $name. Please add a property that enables/disables it on EmbraceBytecodeInstrumentation.")
         }
         return enabledViaDsl && visitStrategy.shouldVisit(ctx)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/VisitorFactoryImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/VisitorFactoryImpl.kt
@@ -46,8 +46,8 @@ class VisitorFactoryImpl(
             "auto_sdk_initialization" -> params.shouldInstrumentAutoSdkInitialization.get()
             "on_click" -> params.shouldInstrumentOnClick.get()
             "on_long_click" -> params.shouldInstrumentOnLongClick.get()
-            "application_init_time_start" -> params.shouldInstrumentApplicationInitTimeStart.get()
-            "application_init_time_end" -> params.shouldInstrumentApplicationInitTimeEnd.get()
+            "application_init_time_start" -> params.applicationInitTimingEnabled.get()
+            "application_init_time_end" -> params.applicationInitTimingEnabled.get()
             else -> error("Unknown feature: $name. Please add a property that enables/disables it on EmbraceBytecodeInstrumentation.")
         }
         return enabledViaDsl && visitStrategy.shouldVisit(ctx)

--- a/embrace-gradle-plugin/src/main/resources/bytecode_instrumentation_features.json
+++ b/embrace-gradle-plugin/src/main/resources/bytecode_instrumentation_features.json
@@ -121,6 +121,51 @@
       "visitStrategy": {
         "type": "exhaustive"
       }
+    },
+    {
+      "name": "application_init_time_start",
+      "target": {
+        "name": "onCreate",
+        "descriptor": "()V"
+      },
+      "insert": {
+        "owner": "io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint",
+        "name": "applicationInitStart",
+        "descriptor": "()V",
+        "operandStackIndices": []
+      },
+      "addOverride": {
+        "owner": "android/app/Application",
+        "name": "onCreate",
+        "descriptor": "()V"
+      },
+      "visitStrategy": {
+        "type": "match_super_class_name",
+        "value": "android.app.Application"
+      }
+    },
+    {
+      "name": "application_init_time_end",
+      "target": {
+        "name": "onCreate",
+        "descriptor": "()V"
+      },
+      "insert": {
+        "owner": "io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint",
+        "name": "applicationInitEnd",
+        "descriptor": "()V",
+        "operandStackIndices": [],
+        "insertAtEnd": true
+      },
+      "addOverride": {
+        "owner": "android/app/Application",
+        "name": "onCreate",
+        "descriptor": "()V"
+      },
+      "visitStrategy": {
+        "type": "match_super_class_name",
+        "value": "android.app.Application"
+      }
     }
   ]
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryTest.kt
@@ -64,8 +64,7 @@ class EmbraceClassVisitorFactoryTest {
             instrumentOnClick = false,
             instrumentOnLongClick = false,
             instrumentAutoSdkInitialization = false,
-            instrumentApplicationInitTimeStart = false,
-            instrumentApplicationInitTimeEnd = false
+            applicationInitTimingEnabled = false,
         )
         val observed = fetchClassVisitor(config, ctx, visitor)
         assertSame(visitor, observed)
@@ -113,8 +112,7 @@ class EmbraceClassVisitorFactoryTest {
         instrumentWebview: Boolean = true,
         instrumentAutoSdkInitialization: Boolean = true,
         instrumentFirebaseMessaging: Boolean = true,
-        instrumentApplicationInitTimeStart: Boolean = false,
-        instrumentApplicationInitTimeEnd: Boolean = false,
+        applicationInitTimingEnabled: Boolean = false,
     ): TestBytecodeInstrumentationParams {
         return TestBytecodeInstrumentationParams(
             instrumentFirebaseMessaging = instrumentFirebaseMessaging,
@@ -123,8 +121,7 @@ class EmbraceClassVisitorFactoryTest {
             instrumentOkHttp = instrumentOkHttp,
             instrumentOnLongClick = instrumentOnLongClick,
             instrumentOnClick = instrumentOnClick,
-            instrumentApplicationInitTimeStart = instrumentApplicationInitTimeStart,
-            instrumentApplicationInitTimeEnd = instrumentApplicationInitTimeEnd
+            applicationInitTimingEnabled = applicationInitTimingEnabled,
         )
     }
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryTest.kt
@@ -64,6 +64,8 @@ class EmbraceClassVisitorFactoryTest {
             instrumentOnClick = false,
             instrumentOnLongClick = false,
             instrumentAutoSdkInitialization = false,
+            instrumentApplicationInitTimeStart = false,
+            instrumentApplicationInitTimeEnd = false
         )
         val observed = fetchClassVisitor(config, ctx, visitor)
         assertSame(visitor, observed)
@@ -110,7 +112,9 @@ class EmbraceClassVisitorFactoryTest {
         instrumentOnLongClick: Boolean = true,
         instrumentWebview: Boolean = true,
         instrumentAutoSdkInitialization: Boolean = true,
-        instrumentFirebaseMessaging: Boolean = true
+        instrumentFirebaseMessaging: Boolean = true,
+        instrumentApplicationInitTimeStart: Boolean = false,
+        instrumentApplicationInitTimeEnd: Boolean = false,
     ): TestBytecodeInstrumentationParams {
         return TestBytecodeInstrumentationParams(
             instrumentFirebaseMessaging = instrumentFirebaseMessaging,
@@ -118,7 +122,9 @@ class EmbraceClassVisitorFactoryTest {
             instrumentAutoSdkInitialization = instrumentAutoSdkInitialization,
             instrumentOkHttp = instrumentOkHttp,
             instrumentOnLongClick = instrumentOnLongClick,
-            instrumentOnClick = instrumentOnClick
+            instrumentOnClick = instrumentOnClick,
+            instrumentApplicationInitTimeStart = instrumentApplicationInitTimeStart,
+            instrumentApplicationInitTimeEnd = instrumentApplicationInitTimeEnd
         )
     }
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -21,6 +21,8 @@ class TestBytecodeInstrumentationParams(
     instrumentOkHttp: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_OKHTTP,
     instrumentOnLongClick: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_ON_LONG_CLICK,
     instrumentOnClick: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_ON_CLICK,
+    instrumentApplicationInitTimeStart: Boolean = true,
+    instrumentApplicationInitTimeEnd: Boolean = true,
 ) : BytecodeInstrumentationParams {
 
     override val config: Property<VariantConfig> =
@@ -47,4 +49,8 @@ class TestBytecodeInstrumentationParams(
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentOnLongClick)
     override val shouldInstrumentOnClick: Property<Boolean> =
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentOnClick)
+    override val shouldInstrumentApplicationInitTimeStart: Property<Boolean> =
+        DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentApplicationInitTimeStart)
+    override val shouldInstrumentApplicationInitTimeEnd: Property<Boolean> =
+        DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentApplicationInitTimeEnd)
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -21,8 +21,7 @@ class TestBytecodeInstrumentationParams(
     instrumentOkHttp: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_OKHTTP,
     instrumentOnLongClick: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_ON_LONG_CLICK,
     instrumentOnClick: Boolean = SwazzlerExtension.DEFAULT_INSTRUMENT_ON_CLICK,
-    instrumentApplicationInitTimeStart: Boolean = true,
-    instrumentApplicationInitTimeEnd: Boolean = true,
+    applicationInitTimingEnabled: Boolean = true,
 ) : BytecodeInstrumentationParams {
 
     override val config: Property<VariantConfig> =
@@ -49,8 +48,6 @@ class TestBytecodeInstrumentationParams(
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentOnLongClick)
     override val shouldInstrumentOnClick: Property<Boolean> =
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentOnClick)
-    override val shouldInstrumentApplicationInitTimeStart: Property<Boolean> =
-        DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentApplicationInitTimeStart)
-    override val shouldInstrumentApplicationInitTimeEnd: Property<Boolean> =
-        DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentApplicationInitTimeEnd)
+    override val applicationInitTimingEnabled: Property<Boolean> =
+        DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(applicationInitTimingEnabled)
 }


### PR DESCRIPTION
## Goal

Added bytecode instrumentation for adding calls to applicationInitStart and applicationInitEnd on any Application.onCreate()

The resulting code should look like this: 

```
class TestApplication : Application() {
    override fun onCreate() {
        // inject call to applicationInitStart
        super.onCreate()
        // inject call to applicationInitEnd
    }
}
```
## Testing

Added bytecode instrumentation tests 

Tested manually:
- [x] Calls to applicationInitStart and applicationInitEnd are made automatically by default.
- [x] The instrumentation works correctly along `autoSdkInitializationEnabled`.
- [x] Calls are injected even when multiple return instructions are present in onCreate, or when an error is thrown.
- [x] Calls are not instrumented when `applicationInitTimingEnabled` is set to false in the `embrace.bytecodeInstrumentation` config