### PR TITLE
Use otel-kotlin symbols for id

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 
 fun EmbraceSpanData.toEmbracePayload(): Span = Span(
@@ -57,7 +56,7 @@ fun Span.toEmbracePayload(): EmbraceSpanData {
     return EmbraceSpanData(
         traceId = traceId ?: "",
         spanId = spanId ?: "",
-        parentSpanId = parentSpanId ?: OtelJavaSpanId.getInvalid(),
+        parentSpanId = parentSpanId ?: OtelIds.invalidSpanId,
         name = name ?: "",
         startTimeNanos = startTimeNanos ?: 0,
         endTimeNanos = endTimeNanos ?: 0L,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/id/OtelIds.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/id/OtelIds.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.otel.sdk.id
 
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
+import io.embrace.opentelemetry.kotlin.k2j.id.TracingIdGeneratorImpl
 
 object OtelIds {
 
-    private val generator = OtelJavaIdGenerator.random()
+    private val generator = TracingIdGeneratorImpl(OtelJavaIdGenerator.random())
 
     /**
      * Generates a new valid SpanId.
@@ -20,5 +20,5 @@ object OtelIds {
     /**
      * An invalid SpanId.
      */
-    val invalidSpanId: String = OtelJavaSpanId.getInvalid()
+    val invalidSpanId: String = generator.invalidSpanId
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
@@ -10,13 +10,13 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
 import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -83,7 +83,7 @@ internal class SpanMapperTest {
 
         return copy(
             endTimeNanos = endTimeMs.millisToNanos(),
-            parentSpanId = parentSpanId ?: OtelJavaSpanId.getInvalid(),
+            parentSpanId = parentSpanId ?: OtelIds.invalidSpanId,
             status = Span.Status.ERROR,
             attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
         )


### PR DESCRIPTION
## Goal

Migrates from OTel Java to OTel Kotlin for getting span/trace IDs.

