### PR TITLE
Force desugaring to be enabled when minSdk is < 26 due to OTel issue

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -89,8 +89,8 @@ class EmbraceGradlePluginDelegate {
 
         if (enableDesugaring) {
             error(
-                "Desugaring must be enabled when minSdk is < 24, " +
-                    "otherwise devices on Android API version < 24 will fail at runtime.\n" +
+                "Desugaring must be enabled when minSdk is < 26, " +
+                    "otherwise devices on Android API version < 26 will fail at runtime.\n" +
                     "You can enable desugaring by adding the following:\n" +
                     "compileOptions\n" +
                     "{\n" +

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpUtils.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpUtils.kt
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.TaskProvider
 
 object AgpUtils {
 
-    private const val MINIMUM_DESUGARING_LEVEL = 23
+    private const val MINIMUM_DESUGARING_LEVEL = 25
     fun isDesugaringRequired(sdkLevel: Int) = sdkLevel <= MINIMUM_DESUGARING_LEVEL
 
     /**

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/AgpUtilsTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/AgpUtilsTest.kt
@@ -12,13 +12,13 @@ import org.junit.Test
 class AgpUtilsTest {
 
     @Test
-    fun `desugaring should not be required for min sdk level greater than 23`() {
-        assertFalse(AgpUtils.isDesugaringRequired(24))
+    fun `desugaring should not be required for min sdk level greater than 25`() {
+        assertFalse(AgpUtils.isDesugaringRequired(26))
     }
 
     @Test
-    fun `desugaring should be required for min sdk level less than 24`() {
-        assertTrue(AgpUtils.isDesugaringRequired(23))
+    fun `desugaring should be required for min sdk level less than 26`() {
+        assertTrue(AgpUtils.isDesugaringRequired(25))
     }
 
     @Test


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Do not put any customer information here. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>

