### PR TITLE
Added tests for versions that need desugaring

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/build.gradle.kts
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("com.android.application")
+    id("io.embrace.swazzler")
+    id("io.embrace.android.testplugin")
+    id("org.jetbrains.kotlin.android")
+}
+
+integrationTest.configureAndroidProject(project)
+integrationTest.configureDesugaring(project)

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/gradle.properties
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/gradle.properties
@@ -1,0 +1,1 @@
+android.useFullClasspathForDexingTransform=true

--- a/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
@@ -84,6 +84,8 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
 
         val android = checkNotNull(project.extensions.findByType(ApplicationExtension::class.java))
 
+        val customMinSdk = project.findProperty("minSdk")?.toString()?.toIntOrNull()
+
         android.apply {
             namespace = "com.example"
             compileSdk = 36
@@ -91,7 +93,7 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
             defaultConfig {
                 applicationId = "com.example.app"
                 targetSdk = 36
-                minSdk = 26
+                minSdk = customMinSdk ?: 26
                 versionCode = 1
                 versionName = "1.0"
             }
@@ -109,5 +111,28 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
 
     fun configure3rdPartyLibrary(project: Project) = with(project) {
         dependencies.add("implementation", project(":customLibrary"))
+    }
+
+    fun configureDesugaring(project: Project) = with(project) {
+        val android = checkNotNull(project.extensions.findByType(ApplicationExtension::class.java))
+
+        val embrace = checkNotNull(project.extensions.findByType(EmbraceExtension::class.java))
+        embrace.autoAddEmbraceDependencies.set(true)
+
+        repositories.apply {
+            google()
+            mavenCentral()
+            mavenLocal()
+        }
+
+        android.compileOptions {
+            // Enable core library desugaring
+            isCoreLibraryDesugaringEnabled = true
+        }
+
+        dependencies.add(
+            "coreLibraryDesugaring",
+            "com.android.tools:desugar_jdk_libs:2.1.5"
+        )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/DesugaringTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/DesugaringTest.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.gradle.integration.testcases
+
+import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
+import io.embrace.android.gradle.integration.framework.ProjectType
+import org.junit.Rule
+import org.junit.Test
+
+class DesugaringTest {
+
+    @Rule
+    @JvmField
+    val rule: PluginIntegrationTestRule = PluginIntegrationTestRule()
+
+    @Test
+    fun `app doesn't build if min sdk is less than 26 and there is no desugaring`() {
+        rule.runTest(
+            fixture = "android-version-support",
+            task = "assembleRelease",
+            additionalArgs = listOf("-PminSdk=25"),
+            projectType = ProjectType.ANDROID,
+            expectedExceptionMessage = "Desugaring must be enabled when minSdk is < 26",
+            assertions = {
+                verifyNoUploads()
+            }
+        )
+    }
+
+    @Test
+    fun `app builds correctly if min sdk is 26 or higher`() {
+        rule.runTest(
+            fixture = "android-version-support",
+            task = "assembleRelease",
+            additionalArgs = listOf("-PminSdk=26"),
+            projectType = ProjectType.ANDROID,
+            assertions = {
+                verifyBuildTelemetryRequestSent(listOf("debug", "release"))
+                verifyJvmMappingRequestsSent(1)
+            }
+        )
+    }
+
+    @Test
+    fun `app builds correctly with desugaring and min sdk less than 26`() {
+        rule.runTest(
+            fixture = "android-desugaring",
+            task = "assembleRelease",
+            additionalArgs = listOf("-PminSdk=24"),
+            projectType = ProjectType.ANDROID,
+            assertions = {
+                verifyBuildTelemetryRequestSent(listOf("debug", "release"))
+                verifyJvmMappingRequestsSent(1)
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Goal

Verify that the app doesn't build if desugaring is not enabled for apps with min sdk lower than 26, and verify that build is correct when desugaring is enabled.