### PR TITLE
Allow AGP 8.3.0 to be used with desugaring enabled

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -110,7 +110,7 @@ class EmbraceGradlePluginDelegate {
         val minSdk = agpWrapper.minSdk ?: return
 
         if (minSdk < 26) {
-            if (agpWrapper.version <= AgpVersion.AGP_8_3_0 ||
+            if (agpWrapper.version < AgpVersion.AGP_8_3_0 ||
                 project.getProperty("android.useFullClasspathForDexingTransform").orNull != "true"
             ) {
                 error(


### PR DESCRIPTION
## Goal

The code used to check `!AgpVersion.isAtLeast(AgpVersion.AGP_8_3_0)` but a refactor turned it into `agpExtension.version <= AgpVersion.AGP_8_3_0`. Restore the old logic so 8.3.0 becomes a valid version again.

## Testing
This will be tested in a test that Fran is adding

