### PR TITLE
Add entrypoint for OTel kotlin

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -107,6 +107,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/OTelA
 	public abstract fun addLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
 	public abstract fun addSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
 	public abstract fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
+	public abstract fun getOpenTelemetryKotlin ()Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 	public abstract fun setResourceAttribute (Lio/opentelemetry/api/common/AttributeKey;Ljava/lang/String;)V
 	public abstract fun setResourceAttribute (Ljava/lang/String;Ljava/lang/String;)V
 }

--- a/embrace-android-api/build.gradle.kts
+++ b/embrace-android-api/build.gradle.kts
@@ -17,6 +17,7 @@ android {
 dependencies {
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)
+    compileOnly(libs.opentelemetry.kotlin.api)
     implementation(libs.lifecycle.process)
     implementation(libs.opentelemetry.java.aliases)
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/OTelApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/OTelApi.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.annotation.InternalApi
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
@@ -27,6 +29,13 @@ public interface OTelApi {
      * model.
      */
     public fun getOpenTelemetry(): OtelJavaOpenTelemetry
+
+    /**
+     * Returns an [OpenTelemetry] instance that uses the API from opentelemetry-kotlin. This API
+     * is currently experimental and is subject to breaking change without warning.
+     */
+    @ExperimentalApi
+    public fun getOpenTelemetryKotlin(): OpenTelemetry
 
     /**
      * Set an attribute on the resource used by the OTel SDK instance with the given key and String value.

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -32,6 +32,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public static final fun getInstance ()Lio/embrace/android/embracesdk/Embrace;
 	public fun getLastRunEndState ()Lio/embrace/android/embracesdk/LastRunEndState;
 	public fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
+	public fun getOpenTelemetryKotlin ()Lio/embrace/opentelemetry/kotlin/OpenTelemetry;
 	public fun getSdkCurrentTimeMs ()J
 	public fun getSpan (Ljava/lang/String;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public fun isStarted ()Z

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.noop)
 
     testImplementation(project(":embrace-test-fakes"))
     testImplementation(libs.protobuf.java)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -13,6 +13,8 @@ import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
@@ -388,6 +390,15 @@ public class Embrace private constructor(
 
     override fun getOpenTelemetry(): OtelJavaOpenTelemetry {
         return impl.getOpenTelemetry()
+    }
+
+    /**
+     * Returns an [OpenTelemetry] instance that uses the API from opentelemetry-kotlin. This API
+     * is currently experimental and is subject to breaking change without warning.
+     */
+    @ExperimentalApi
+    override fun getOpenTelemetryKotlin(): OpenTelemetry {
+        return impl.getOpenTelemetryKotlin()
     }
 
     override fun setResourceAttribute(key: String, value: String) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
@@ -2,9 +2,13 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import io.embrace.android.embracesdk.internal.api.OTelApi
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.noop
 
 internal class OTelApiDelegate(
     private val bootstrapper: ModuleInitBootstrapper,
@@ -38,5 +42,14 @@ internal class OTelApiDelegate(
             return
         }
         bootstrapper.openTelemetryModule.otelSdkConfig.setResourceAttribute(key, value)
+    }
+
+    @ExperimentalApi
+    override fun getOpenTelemetryKotlin(): OpenTelemetry {
+        return if (sdkCallChecker.started.get()) {
+            bootstrapper.openTelemetryModule.otelSdkWrapper.kotlinApi
+        } else {
+            OpenTelemetryInstance.noop()
+        }
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -12,7 +12,9 @@ import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.noop
 import io.opentelemetry.semconv.ServiceAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -73,6 +75,17 @@ internal class OTelApiDelegateTest {
     @Test
     fun `get opentelemetry after start`() {
         assertNotEquals(OtelJavaOpenTelemetry.noop(), delegate.getOpenTelemetry())
+    }
+
+    @Test
+    fun `get opentelemetry kotlin before start`() {
+        sdkCallChecker.started.set(false)
+        assertEquals(OpenTelemetryInstance.noop(), delegate.getOpenTelemetryKotlin())
+    }
+
+    @Test
+    fun `get opentelemetry kotlin after start`() {
+        assertNotEquals(OpenTelemetryInstance.noop(), delegate.getOpenTelemetryKotlin())
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,7 @@ opentelemetry-kotlin = { module = "io.embrace.opentelemetry.kotlin:opentelemetry
 opentelemetry-kotlin-api = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api", version.ref = "otelKotlin" }
 opentelemetry-kotlin-api-ext = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-api-ext", version.ref = "otelKotlin" }
 opentelemetry-kotlin-compat = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-compat", version.ref = "otelKotlin" }
+opentelemetry-kotlin-noop = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-noop", version.ref = "otelKotlin" }
 opentelemetry-java-aliases = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-java-typealiases", version.ref = "otelKotlin" }
 androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "androidxBenchmark" }
 


### PR DESCRIPTION
## Goal

Adds an entrypoint for accessing OTel kotlin as an escape hatch. This is marked as an experimental API so will be subject to change without warning.