### PR TITLE
Make span wrappers implement ImplicitContextKeyed

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
@@ -18,12 +18,15 @@ import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ImplicitContextKeyed
+import io.opentelemetry.context.Scope
 
 @OptIn(ExperimentalApi::class)
 class EmbSpan(
     private val impl: EmbraceSdkSpan,
     private val clock: Clock,
-) : Span {
+) : Span, ImplicitContextKeyed {
 
     override fun setStringAttribute(key: String, value: String) {
         impl.addAttribute(key, value)
@@ -115,6 +118,14 @@ class EmbSpan(
 
     override fun links(): List<Link> = impl.links().map {
         EmbLink(it.retrieveSpanContext(), it.attributes.toAttributeContainer())
+    }
+
+    override fun storeInContext(context: Context): Context {
+        return impl.storeInContext(context)
+    }
+
+    override fun makeCurrent(): Scope {
+        return impl.makeCurrent()
     }
 
     private fun List<Attribute>?.toAttributeContainer(): AttributeContainer {


### PR DESCRIPTION
## Goal

Makes span wrappers implement `ImplicitContextKeyed` so they can delegate how context is propagated.

