### PR TITLE
Remove appId from sample app

### DIFF
--- a/examples/ExampleApp/app/src/main/embrace-config.json
+++ b/examples/ExampleApp/app/src/main/embrace-config.json
@@ -1,4 +1,3 @@
 {
-  "app_id": "PFAWK",
   "ndk_enabled": true
 }


### PR DESCRIPTION
## Goal
Remove test appId from the sample app. It should be specified locally in the environment config.