### PR TITLE
Enable CC parallel cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,11 @@
 description="Embrace Android SDK"
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g
+org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=fail
+org.gradle.configuration-cache.parallel=true
 version=7.8.0-SNAPSHOT
 android.useAndroidX=true
 android.experimental.enableArtProfiles=true
 android.defaults.buildfeatures.buildconfig=false
-org.gradle.caching=true
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.problems=fail


### PR DESCRIPTION
## Goal

Enables parallel caching for Gradle's configuration cache, and tweaks a few other build options that should improve build perf.