### PR TITLE
Add internal APIs for creating network request spans

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkLoggingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkLoggingService.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.network.logging
 
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
  * Logs network calls made by the application. The Embrace SDK intercepts the calls and reports
@@ -9,10 +11,24 @@ import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 interface NetworkLoggingService {
 
     /**
-     * Logs a network request.
-     * This network request is considered unique and finished, meaning that we will not receive additional data for it.
-     *
-     * @param networkRequest the network request to log
+     * Logs a completed network request. This is equivalent to calling [startNetworkRequestSpan] and [endNetworkRequestSpan].
      */
     fun logNetworkRequest(networkRequest: EmbraceNetworkRequest)
+
+    /**
+     * Attempts to start a span that models a network request, returning a span object if this is allowed.
+     */
+    fun startNetworkRequestSpan(
+        httpMethod: HttpMethod,
+        url: String,
+        startTimeMs: Long,
+    ): EmbraceSpan?
+
+    /**
+     * Ends a span that is modelling a network request.
+     */
+    fun endNetworkRequestSpan(
+        networkRequest: EmbraceNetworkRequest,
+        span: EmbraceSpan,
+    )
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/W3cTraceparentTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/W3cTraceparentTest.kt
@@ -1,0 +1,65 @@
+package io.embrace.android.embracesdk.testcases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.findSpanOfType
+import io.embrace.android.embracesdk.assertions.toMap
+import io.embrace.android.embracesdk.internal.EmbraceInternalApi
+import io.embrace.android.embracesdk.internal.otel.schema.EmbType
+import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Validation of the internal API
+ */
+@RunWith(AndroidJUnit4::class)
+internal class W3cTraceparentTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `network request captured via internal API`() {
+        val w3cTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    val internalInterface = EmbraceInternalApi.getInstance().internalInterface
+                    val span =
+                        internalInterface.startNetworkRequestSpan(HTTP_METHOD, URL, START_TIME)
+                            ?: return@recordSession
+                    val request = EmbraceNetworkRequest.fromCompletedRequest(
+                        url = URL,
+                        httpMethod = HTTP_METHOD,
+                        startTime = START_TIME,
+                        endTime = END_TIME,
+                        bytesSent = 0L,
+                        bytesReceived = 0L,
+                        statusCode = 200,
+                        traceId = null,
+                        w3cTraceparent = w3cTraceparent
+                    )
+                    internalInterface.endNetworkRequestSpan(request, span)
+                }
+
+
+            }, assertAction = {
+                val payload = getSingleSessionEnvelope()
+                val request = payload.findSpanOfType(EmbType.Performance.Network)
+                val attrs = checkNotNull(request.attributes).toMap()
+                assertEquals(w3cTraceparent, attrs["emb.w3c_traceparent"])
+            })
+    }
+
+    companion object {
+        private const val URL = "https://embrace.io"
+        private val HTTP_METHOD = HttpMethod.GET
+        private const val START_TIME = 1692201601000L
+        private const val END_TIME = 1692201603000L
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
@@ -25,6 +25,7 @@ internal class InternalInterfaceModuleImpl(
             embrace,
             initModule,
             logModule.networkCaptureService,
+            logModule.networkLoggingService,
             configModule.configService,
             openTelemetryModule.internalTracer
         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureService
+import io.embrace.android.embracesdk.fakes.FakeNetworkLoggingService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
@@ -36,6 +37,7 @@ internal class EmbraceInternalInterfaceImplTest {
     private lateinit var initModule: FakeInitModule
     private lateinit var fakeConfigService: FakeConfigService
     private lateinit var fakeNetworkCaptureService: FakeNetworkCaptureService
+    private lateinit var fakeNetworkLoggingService: FakeNetworkLoggingService
 
     @Before
     fun setUp() {
@@ -44,10 +46,12 @@ internal class EmbraceInternalInterfaceImplTest {
         initModule = FakeInitModule(clock = fakeClock, logger = FakeEmbLogger(false))
         fakeConfigService = FakeConfigService()
         fakeNetworkCaptureService = FakeNetworkCaptureService()
+        fakeNetworkLoggingService = FakeNetworkLoggingService()
         internalImpl = EmbraceInternalInterfaceImpl(
             embraceImpl,
             initModule,
             fakeNetworkCaptureService,
+            fakeNetworkLoggingService,
             fakeConfigService,
             initModule.openTelemetryModule.internalTracer
         )
@@ -207,6 +211,15 @@ internal class EmbraceInternalInterfaceImplTest {
     fun `check stopping SDK`() {
         internalImpl.stopSdk()
         assertFalse(embraceImpl.isStarted)
+    }
+
+    @Test
+    fun `check generate w3ctraceparent`() {
+        val traceId = "0af7651916cd43dd8448eb211c80319c"
+        val spanId = "b7ad6b7169203331"
+        val traceparent = internalImpl.generateW3cTraceparent(traceId, spanId)
+        val expected = "00-$traceId-$spanId-01"
+        assertEquals(expected, traceparent)
     }
 
     companion object {

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
@@ -6,6 +6,8 @@ import io.embrace.android.embracesdk.LogType
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.payload.TapBreadcrumb
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
  * Provides an internal interface to Embrace that is intended for use by hosted SDKs as their sole source of communication
@@ -151,4 +153,27 @@ interface EmbraceInternalInterface : InternalTracingApi {
      * Stop the Embrace SDK and disable its functionality
      */
     fun stopSdk()
+
+    /**
+     * Attempts to start a span that models a network request, returning a span object if this is allowed.
+     */
+    fun startNetworkRequestSpan(
+        httpMethod: HttpMethod,
+        url: String,
+        startTimeMs: Long,
+    ): EmbraceSpan?
+
+    /**
+     * Ends a span that is modelling a network request.
+     */
+    fun endNetworkRequestSpan(
+        networkRequest: EmbraceNetworkRequest,
+        span: EmbraceSpan,
+    )
+
+    /**
+     * Generates a W3C traceparent using the given trace ID and span ID. If none are supplied, a random
+     * trace ID and span ID will be generated.
+     */
+    fun generateW3cTraceparent(traceId: String?, spanId: String?): String
 }

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
@@ -9,6 +9,8 @@ import io.embrace.android.embracesdk.internal.InternalTracingApi
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.payload.TapBreadcrumb
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 @SuppressLint("EmbracePublicApiPackageRule")
 internal class NoopEmbraceInternalInterface(
@@ -85,4 +87,15 @@ internal class NoopEmbraceInternalInterface(
     override fun stopSdk() {}
 
     override fun logTap(point: Pair<Float?, Float?>, elementName: String, type: TapBreadcrumb.TapBreadcrumbType) {}
+
+    override fun startNetworkRequestSpan(httpMethod: HttpMethod, url: String, startTimeMs: Long): EmbraceSpan? {
+        return null
+    }
+
+    override fun endNetworkRequestSpan(networkRequest: EmbraceNetworkRequest, span: EmbraceSpan) {
+    }
+
+    override fun generateW3cTraceparent(traceId: String?, spanId: String?): String {
+        return "00-00000000000000000000000000000000-0000000000000000-00"
+    }
 }

--- a/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopEmbraceInternalInterfaceTest.kt
+++ b/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopEmbraceInternalInterfaceTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.api.delegate.NoopEmbraceInternalIn
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
@@ -78,5 +79,10 @@ internal class NoopEmbraceInternalInterfaceTest {
     @Test
     fun `check isNdkEnabled before SDK starts`() {
         assertFalse(impl.isNdkEnabled())
+    }
+
+    @Test
+    fun `check invalid w3ctraceparent`() {
+        assertEquals("00-00000000000000000000000000000000-0000000000000000-00", impl.generateW3cTraceparent("", ""))
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
@@ -7,6 +7,8 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.payload.TapBreadcrumb
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 
 class FakeEmbraceInternalInterface(
@@ -146,4 +148,15 @@ class FakeEmbraceInternalInterface(
     }
 
     override fun logTap(point: Pair<Float?, Float?>, elementName: String, type: TapBreadcrumb.TapBreadcrumbType) {}
+
+    override fun startNetworkRequestSpan(httpMethod: HttpMethod, url: String, startTimeMs: Long): EmbraceSpan? {
+        return null
+    }
+
+    override fun endNetworkRequestSpan(networkRequest: EmbraceNetworkRequest, span: EmbraceSpan) {
+    }
+
+    override fun generateW3cTraceparent(traceId: String?, spanId: String?): String {
+        return "00-00000000000000000000000000000000-0000000000000000-00"
+    }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.network.logging.NetworkLoggingService
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 class FakeNetworkLoggingService : NetworkLoggingService {
 
@@ -9,5 +11,19 @@ class FakeNetworkLoggingService : NetworkLoggingService {
 
     override fun logNetworkRequest(networkRequest: EmbraceNetworkRequest) {
         requests.add(networkRequest)
+    }
+
+    override fun startNetworkRequestSpan(
+        httpMethod: HttpMethod,
+        url: String,
+        startTimeMs: Long,
+    ): EmbraceSpan? {
+        return null
+    }
+
+    override fun endNetworkRequestSpan(
+        networkRequest: EmbraceNetworkRequest,
+        span: EmbraceSpan,
+    ) {
     }
 }


### PR DESCRIPTION
## Goal

Adds an internal API for creating network request spans. This is required as we need to construct a span before sending a network request when we want to inject the traceparent as a HTTP header, since the traceparent should contain the same span/trace ID as the created span. Whilst we could do this internally just for Android, this functionality should also be accessible to the hosted SDKs so that they are subject to the same domain rate-limiting logic.

## Testing

Added unit + integration test cases.
