### PR TITLE
Rename a bunch of test files to match their subjects

### DIFF
--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaOpenTelemetryTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaOpenTelemetryTest.kt
@@ -11,7 +11,7 @@ import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 
-internal class EmbOpenTelemetryTest {
+internal class EmbOtelJavaOpenTelemetryTest {
     private lateinit var tracerProvider: FakeOtelJavaTracerProvider
     private lateinit var openTelemetry: EmbOtelJavaOpenTelemetry
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpanBuilderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpanBuilderTest.kt
@@ -29,7 +29,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
-internal class EmbSpanBuilderTest {
+internal class EmbOtelJavaSpanBuilderTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
     private lateinit var tracer: Tracer

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaSpanTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
-internal class EmbSpanTest {
+internal class EmbOtelJavaSpanTest {
     private lateinit var fakeClock: FakeClock
     private lateinit var openTelemetryClock: Clock
     private lateinit var fakeEmbraceSpan: FakeEmbraceSdkSpan

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerBuilderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerBuilderTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-internal class EmbTracerBuilderTest {
+internal class EmbOtelJavaTracerBuilderTest {
 
     @Test
     fun `check tracer attributes from builder`() {

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerProviderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerProviderTest.kt
@@ -12,7 +12,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbTracerProviderTest {
+internal class EmbOtelJavaTracerProviderTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOtelJavaTracerTest.kt
@@ -12,7 +12,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbTracerTest {
+internal class EmbOtelJavaTracerTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
 


### PR DESCRIPTION
## Goal

Some tests files were not renamed when their associated classes were renamed with the `OtelJava` token to declare that they are implementations of the Java API.

This caused a bit of confusion when I saw what `EmbSpanTest` was testing - it wasn't `EmbSpan`, the Kotlin API impl....