### PR TITLE
Alter tests as pre-requisite for kotlin switchover

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetry.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetry.kt
@@ -11,9 +11,8 @@ import io.embrace.opentelemetry.kotlin.tracing.TracerProvider
 @OptIn(ExperimentalApi::class)
 class EmbOpenTelemetry(
     private val impl: OpenTelemetry,
-    override val clock: Clock,
     traceProviderSupplier: () -> TracerProvider,
 ) : OpenTelemetry by impl {
-
+    override val clock: Clock = impl.clock
     override val tracerProvider: TracerProvider = traceProviderSupplier()
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetryTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbOpenTelemetryTest.kt
@@ -1,0 +1,31 @@
+package io.embrace.android.embracesdk.internal.otel.impl
+
+import io.embrace.android.embracesdk.fakes.FakeTracerProvider
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
+import io.embrace.opentelemetry.kotlin.noop
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class)
+internal class EmbOpenTelemetryTest {
+    private lateinit var tracerProvider: FakeTracerProvider
+    private lateinit var openTelemetry: EmbOpenTelemetry
+
+    @Before
+    fun setup() {
+        tracerProvider = FakeTracerProvider()
+        openTelemetry = EmbOpenTelemetry(OpenTelemetryInstance.noop()) { tracerProvider }
+    }
+
+    @Test
+    fun `tracer provider is a real implementation`() {
+        assertNotEquals(OtelJavaOpenTelemetry.noop(), openTelemetry)
+        assertNotEquals(OtelJavaTracerProvider.noop(), openTelemetry.tracerProvider)
+        assertNotEquals(OtelJavaLoggerProvider.noop(), openTelemetry.loggerProvider)
+    }
+}


### PR DESCRIPTION
## Goal

Adds some additional test cases before switching over to using opentelemetry-kotlin. This will make it easier to debug some of the failures we are seeing around context propagation.

