### PR TITLE
Use opentelemetry-kotlin context symbols

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
@@ -5,13 +5,13 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.attributes.AttributeContainer
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.create
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.default
 import io.embrace.opentelemetry.kotlin.k2j.tracing.model.invalid
+import io.embrace.opentelemetry.kotlin.k2j.tracing.toOtelKotlin
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.model.Link
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
@@ -96,7 +96,7 @@ class EmbSpan(
         }
 
     override val parent: SpanContext
-        get() = (impl.parent?.spanContext ?: OtelJavaSpanContext.getInvalid()).let(::SpanContextAdapter)
+        get() = impl.parent?.spanContext?.toOtelKotlin() ?: SpanContext.invalid()
 
     override val spanKind: SpanKind
         get() = impl.spanKind

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
@@ -7,9 +7,8 @@ import io.embrace.android.embracesdk.internal.otel.spans.createContext
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJava
+import io.embrace.opentelemetry.kotlin.k2j.context.current
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
@@ -32,7 +31,7 @@ class EmbTracer(
         startTimestamp: Long?,
         action: SpanRelationships.() -> Unit,
     ): Span {
-        val parentCtx: OtelJavaContext? = parentContext?.toOtelJava() ?: OtelJavaContext.current().getEmbraceSpan()?.createContext()
+        val parentCtx = parentContext ?: Context.current().getEmbraceSpan()?.createContext()
         val spanCreator = OtelSpanStartArgs(
             name = name,
             type = EmbType.Performance.Default,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/IdGenerator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/IdGenerator.kt
@@ -1,24 +1,32 @@
 package io.embrace.android.embracesdk.internal.otel.sdk
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceId
 import kotlin.random.Random
 
 class IdGenerator(
     private val random: Random = Random.Default,
 ) {
-    /**
-     * Generate a valid W3C-compliant traceparent. See the format here: https://www.w3.org/TR/trace-context/#traceparent-header-field-values
-     *
-     * Note: because Embrace may be recording a span on our side for the given traceparent, we have set the "sampled" flag to indicate that.
-     */
-    fun generateTraceparent(): String =
-        "00-" + OtelJavaTraceId.fromLongs(
-            validRandomLong(),
-            validRandomLong()
-        ) + "-" + OtelJavaSpanId.fromLong(validRandomLong()) + "-01"
 
-    fun generateUUID(): String = OtelJavaSpanId.fromLong(validRandomLong())
+    /**
+     * Generate a valid W3C-compliant traceparent. See the format
+     * here: https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+     *
+     * Note: because Embrace may be recording a span on our side for the given traceparent,
+     * we have set the "sampled" flag to indicate that.
+     */
+    fun generateTraceparent(): String {
+        val traceId = generateTraceId()
+        val spanId = generateSpanId()
+        return "00-$traceId-$spanId-01"
+    }
+
+    private fun generateTraceId(): String = buildString(32) {
+        appendHex(validRandomLong())
+        appendHex(validRandomLong())
+    }
+
+    internal fun generateSpanId(): String = buildString(16) {
+        appendHex(validRandomLong())
+    }
 
     private fun validRandomLong(): Long {
         var value: Long
@@ -28,11 +36,15 @@ class IdGenerator(
         return value
     }
 
+    private fun StringBuilder.appendHex(value: Long) {
+        append(value.toULong().toString(16).padStart(16, '0'))
+    }
+
     companion object {
         private val INSTANCE = IdGenerator()
 
         fun generateW3CTraceparent(): String = INSTANCE.generateTraceparent()
 
-        fun generateLaunchInstanceId(): String = INSTANCE.generateUUID()
+        fun generateLaunchInstanceId(): String = INSTANCE.generateSpanId()
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -29,6 +29,9 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.attributes.setAttributes
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJava
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
@@ -117,7 +120,7 @@ private class EmbraceSpanImpl(
     private val systemLinkCount = AtomicInteger(0)
     private val customLinkCount = AtomicInteger(0)
 
-    private val parentContext: OtelJavaContext = otelSpanStartArgs.parentContext
+    private val parentContext = otelSpanStartArgs.parentContext
 
     override val parent: EmbraceSpan? = parentContext.getEmbraceSpan()
 
@@ -321,12 +324,12 @@ private class EmbraceSpanImpl(
         }
     }
 
-    override fun asNewContext(): OtelJavaContext? = startedSpan.get()?.run {
+    override fun asNewContext(): Context? = startedSpan.get()?.run {
         // assumes that the underlying instance of Span implements ImplicitContextKeyed. This
         // should always be true when opentelemetry-kotlin is used to create spans, but
         // we avoid exposing this fact in the public interface.
         val span = this as ImplicitContextKeyed
-        return span.storeInContext(parentContext)
+        return span.storeInContext(parentContext.toOtelJava()).toOtelKotlin()
     }
 
     override fun storeInContext(context: OtelJavaContext): OtelJavaContext {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
@@ -22,7 +22,7 @@ class SpanServiceImpl(
     private val embraceSpanFactory: EmbraceSpanFactory,
     private val dataValidator: DataValidator,
     private val canStartNewSpan: (parentSpan: EmbraceSpan?, internal: Boolean) -> Boolean,
-    private val initCallback: (initTimeMs: Long) -> Unit
+    private val initCallback: (initTimeMs: Long) -> Unit,
 ) : SpanService {
     private val initialized = AtomicBoolean(false)
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
@@ -21,7 +21,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbOtelJavaSpanTest {
+internal class EmbSpanTest {
     private lateinit var fakeClock: FakeClock
     private lateinit var openTelemetryClock: Clock
     private lateinit var fakeEmbraceSpan: FakeEmbraceSdkSpan

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
@@ -11,7 +11,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbOtelJavaTracerProviderTest {
+internal class EmbTracerProviderTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
@@ -12,7 +12,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbOtelJavaTracerTest {
+internal class EmbTracerTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
@@ -13,12 +13,12 @@ import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.toEmbracePayload
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -37,7 +37,7 @@ internal class SpanMapperTest {
         assertEquals(input.name, output.name)
         assertEquals(input.startTimeNanos, output.startTimeNanos)
         assertEquals(input.endTimeNanos, output.endTimeNanos)
-        assertEquals(input.status.convertToOtelJava().name, checkNotNull(output.status).name)
+        assertEquals(input.status.toEmbracePayload().name, checkNotNull(output.status).name)
 
         // validate event copied
         val inputEvent = input.events.single()

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -41,11 +41,11 @@ import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.k2j.context.current
 import io.embrace.opentelemetry.kotlin.k2j.tracing.SpanContextAdapter
 import io.embrace.opentelemetry.kotlin.kotlinApi
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
-import io.opentelemetry.context.Context
 import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -528,7 +528,7 @@ internal class EmbraceSpanImplTest {
 
     @Test
     fun `validate context objects are propagated from the parent to the child span`() {
-        val newParentContext = OtelJavaContext.current().with(fakeContextKey, "fake-value")
+        val newParentContext = io.embrace.opentelemetry.kotlin.context.Context.current().set(fakeContextKey, "fake-value")
         val wrapper = createWrapperForInternalSpan(parentContext = newParentContext)
         embraceSpan = embraceSpanFactory.create(wrapper)
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeOtelJavaTracer
 import io.embrace.android.embracesdk.fakes.FakeOtelKotlinClock
 import io.embrace.android.embracesdk.fakes.FakeSpanBuilder
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_INTERNAL_SPAN_NAME
@@ -11,10 +10,13 @@ import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
-import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.fromContext
+import io.embrace.opentelemetry.kotlin.kotlinApi
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import org.junit.Assert.assertEquals
@@ -28,25 +30,27 @@ internal class OtelSpanStartArgsTest {
 
     private lateinit var clock: FakeClock
     private lateinit var otelClock: Clock
-    private lateinit var tracer: FakeOtelJavaTracer
+    private lateinit var tracer: Tracer
 
     @Before
     fun setup() {
-        tracer = FakeOtelJavaTracer()
         clock = FakeClock()
         otelClock = FakeOtelKotlinClock(clock)
+
+        val api = OpenTelemetryInstance.kotlinApi(clock = otelClock)
+        tracer = api.getTracer("my_tracer")
     }
 
     @Test
     fun `check private and internal span creation`() {
-        val originalStartTime = clock.now()
+        val originalStartTime = otelClock.now()
         val args = OtelSpanStartArgs(
             name = "test",
             type = EmbType.Performance.Default,
             internal = true,
             private = true,
-            tracer = TracerAdapter(tracer, otelClock),
-            startTimeMs = clock.now()
+            tracer = tracer,
+            startTimeMs = originalStartTime
         )
         val startTime = clock.tick()
         with(args.embraceAttributes.toSet()) {
@@ -72,13 +76,13 @@ internal class OtelSpanStartArgsTest {
             type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            tracer = TracerAdapter(tracer, otelClock),
+            tracer = tracer,
             parentCtx = OtelJavaContext.root().with(parent).toOtelKotlin()
         )
         val spanContext = Span.fromContext(args.parentContext).spanContext
         assertEquals(parent.spanContext.traceId, spanContext.traceId)
 
-        val startTime = clock.now()
+        val startTime = otelClock.now()
         args.startSpan(startTime).assertSpan(
             expectedName = "test",
             expectedStartTimeMs = startTime,
@@ -92,10 +96,10 @@ internal class OtelSpanStartArgsTest {
             type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            tracer = TracerAdapter(tracer, otelClock),
+            tracer = tracer,
             spanKind = SpanKind.CLIENT
         )
-        val startTime = clock.now()
+        val startTime = otelClock.now()
         args.startSpan(startTime).assertSpan(
             expectedName = "test",
             expectedStartTimeMs = startTime,
@@ -110,7 +114,7 @@ internal class OtelSpanStartArgsTest {
             type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            tracer = TracerAdapter(tracer, otelClock),
+            tracer = tracer,
         )
         args.customAttributes["test-key"] = "test-value"
         assertEquals("test-value", args.customAttributes["test-key"])
@@ -118,8 +122,7 @@ internal class OtelSpanStartArgsTest {
 
     @Test
     fun `initial name not truncated`() {
-        val tracer = TracerAdapter(tracer, otelClock)
-        val startTime = clock.now()
+        val startTime = otelClock.now()
 
         val creator = OtelSpanStartArgs(
             tracer = tracer,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositoryTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositoryTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.otel.spans
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -12,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class SpanRepositoryTest {
     private lateinit var repository: SpanRepository

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -35,6 +35,7 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
@@ -53,6 +54,7 @@ import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class TracingApiTest {
     @Rule

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -36,4 +36,5 @@ dependencies {
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.compat)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelJavaSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelJavaSpan.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpan
@@ -11,6 +12,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 class FakeOtelJavaSpan(
     val fakeSpanBuilder: FakeSpanBuilder,
 ) : OtelJavaSpan {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.LifeEventType
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.SessionZygote
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 fun fakeSessionZygote(): SessionZygote = SessionZygote(
     sessionId = "fakeSessionId",
@@ -18,6 +19,7 @@ fun fakeSessionZygote(): SessionZygote = SessionZygote(
     startType = LifeEventType.STATE
 )
 
+@OptIn(ExperimentalApi::class)
 fun fakeSessionEnvelope(
     sessionId: String = "fakeSessionId",
     startMs: Long = 160000000000L,
@@ -46,6 +48,7 @@ fun fakeSessionEnvelope(
     )
 }
 
+@OptIn(ExperimentalApi::class)
 fun fakeIncompleteSessionEnvelope(
     sessionId: String = "fakeIncompleteSessionId",
     processIdentifier: String = "fakeIncompleteSessionProcessId",

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanBuilder.kt
@@ -1,31 +1,36 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.otel.sdk.TracerKey
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributes
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanBuilder
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanKind
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.k2j.context.root
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalApi::class)
 class FakeSpanBuilder(
     var spanName: String,
     val tracerKey: TracerKey = TracerKey("fake-scope"),
 ) : OtelJavaSpanBuilder {
 
     var spanKind: OtelJavaSpanKind? = null
-    var parentContext: OtelJavaContext = OtelJavaContext.root()
+    var parentContext: Context = Context.root()
     var startTimestampMs: Long? = null
     var attributes: MutableMap<Any, Any> = mutableMapOf()
 
     override fun setParent(context: OtelJavaContext): OtelJavaSpanBuilder {
-        parentContext = context
+        parentContext = context.toOtelKotlin()
         return this
     }
 
     override fun setNoParent(): OtelJavaSpanBuilder {
-        parentContext = OtelJavaContext.root()
+        parentContext = Context.root()
         return this
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -9,8 +9,13 @@ import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
+import io.embrace.opentelemetry.kotlin.k2j.context.root
+import io.embrace.opentelemetry.kotlin.k2j.context.toOtelJava
 
+@OptIn(ExperimentalApi::class)
 class FakeSpanService : SpanService {
 
     val createdSpans: MutableList<FakeEmbraceSdkSpan> = mutableListOf()
@@ -29,7 +34,9 @@ class FakeSpanService : SpanService {
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
         name = name,
-        parentContext = parent?.run { OtelJavaContext.root().with(parent as EmbraceSdkSpan) } ?: OtelJavaContext.root(),
+        parentContext = parent?.run {
+            Context.root().toOtelJava().with(parent as EmbraceSdkSpan)
+        }?.toOtelKotlin() ?: Context.root(),
         type = type,
         internal = internal,
         private = private,
@@ -82,7 +89,9 @@ class FakeSpanService : SpanService {
         createdSpans.add(
             FakeEmbraceSdkSpan(
                 name = name,
-                parentContext = parent?.run { OtelJavaContext.root().with(parent as EmbraceSdkSpan) } ?: OtelJavaContext.root(),
+                parentContext = parent?.run {
+                    Context.root().toOtelJava().with(parent as EmbraceSdkSpan).toOtelKotlin()
+                } ?: Context.root(),
                 type = type,
                 internal = internal,
                 private = private

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/SpansTestFixtures.kt
@@ -13,7 +13,9 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.utils.PropertyUtils
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContextKey
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.context.ContextKey
+import io.embrace.opentelemetry.kotlin.k2j.context.current
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 
 @OptIn(ExperimentalApi::class)
@@ -47,7 +49,7 @@ val testSpan: Span = EmbraceSpanData(
     )
 ).toEmbracePayload()
 
-val fakeContextKey: OtelJavaContextKey<String> = OtelJavaContextKey.named("fake-context-key")
+val fakeContextKey: ContextKey<String> = Context.current().createKey("fake-context-key")
 
 private fun createMapOfSize(size: Int): Map<String, String> {
     val mutableMap = mutableMapOf<String, String>()


### PR DESCRIPTION
## Goal

Uses opentelemetry-kotlin's symbols for `Context` where possible.

## Testing

Relied on existing test coverage.

