### PR TITLE
Use additional otel kotlin symbols

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/IdGenerator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/IdGenerator.kt
@@ -1,24 +1,32 @@
 package io.embrace.android.embracesdk.internal.otel.sdk
 
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanId
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTraceId
 import kotlin.random.Random
 
 class IdGenerator(
     private val random: Random = Random.Default,
 ) {
-    /**
-     * Generate a valid W3C-compliant traceparent. See the format here: https://www.w3.org/TR/trace-context/#traceparent-header-field-values
-     *
-     * Note: because Embrace may be recording a span on our side for the given traceparent, we have set the "sampled" flag to indicate that.
-     */
-    fun generateTraceparent(): String =
-        "00-" + OtelJavaTraceId.fromLongs(
-            validRandomLong(),
-            validRandomLong()
-        ) + "-" + OtelJavaSpanId.fromLong(validRandomLong()) + "-01"
 
-    fun generateUUID(): String = OtelJavaSpanId.fromLong(validRandomLong())
+    /**
+     * Generate a valid W3C-compliant traceparent. See the format
+     * here: https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+     *
+     * Note: because Embrace may be recording a span on our side for the given traceparent,
+     * we have set the "sampled" flag to indicate that.
+     */
+    fun generateTraceparent(): String {
+        val traceId = generateTraceId()
+        val spanId = generateSpanId()
+        return "00-$traceId-$spanId-01"
+    }
+
+    private fun generateTraceId(): String = buildString(32) {
+        appendHex(validRandomLong())
+        appendHex(validRandomLong())
+    }
+
+    internal fun generateSpanId(): String = buildString(16) {
+        appendHex(validRandomLong())
+    }
 
     private fun validRandomLong(): Long {
         var value: Long
@@ -28,11 +36,15 @@ class IdGenerator(
         return value
     }
 
+    private fun StringBuilder.appendHex(value: Long) {
+        append(value.toULong().toString(16).padStart(16, '0'))
+    }
+
     companion object {
         private val INSTANCE = IdGenerator()
 
         fun generateW3CTraceparent(): String = INSTANCE.generateTraceparent()
 
-        fun generateLaunchInstanceId(): String = INSTANCE.generateUUID()
+        fun generateLaunchInstanceId(): String = INSTANCE.generateSpanId()
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
@@ -21,7 +21,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbOtelJavaSpanTest {
+internal class EmbSpanTest {
     private lateinit var fakeClock: FakeClock
     private lateinit var openTelemetryClock: Clock
     private lateinit var fakeEmbraceSpan: FakeEmbraceSdkSpan

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
@@ -11,7 +11,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbOtelJavaTracerProviderTest {
+internal class EmbTracerProviderTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
@@ -12,7 +12,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalApi::class)
-internal class EmbOtelJavaTracerTest {
+internal class EmbTracerTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
@@ -13,12 +13,12 @@ import io.embrace.android.embracesdk.internal.otel.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.toEmbracePayload
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.k2j.tracing.convertToOtelJava
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -37,7 +37,7 @@ internal class SpanMapperTest {
         assertEquals(input.name, output.name)
         assertEquals(input.startTimeNanos, output.startTimeNanos)
         assertEquals(input.endTimeNanos, output.endTimeNanos)
-        assertEquals(input.status.convertToOtelJava().name, checkNotNull(output.status).name)
+        assertEquals(input.status.toEmbracePayload().name, checkNotNull(output.status).name)
 
         // validate event copied
         val inputEvent = input.events.single()

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeOtelJavaTracer
 import io.embrace.android.embracesdk.fakes.FakeOtelKotlinClock
 import io.embrace.android.embracesdk.fakes.FakeSpanBuilder
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_INTERNAL_SPAN_NAME
@@ -11,10 +10,13 @@ import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.getTracer
 import io.embrace.opentelemetry.kotlin.j2k.bridge.context.toOtelKotlin
-import io.embrace.opentelemetry.kotlin.k2j.tracing.TracerAdapter
 import io.embrace.opentelemetry.kotlin.k2j.tracing.fromContext
+import io.embrace.opentelemetry.kotlin.kotlinApi
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import org.junit.Assert.assertEquals
@@ -28,25 +30,27 @@ internal class OtelSpanStartArgsTest {
 
     private lateinit var clock: FakeClock
     private lateinit var otelClock: Clock
-    private lateinit var tracer: FakeOtelJavaTracer
+    private lateinit var tracer: Tracer
 
     @Before
     fun setup() {
-        tracer = FakeOtelJavaTracer()
         clock = FakeClock()
         otelClock = FakeOtelKotlinClock(clock)
+
+        val api = OpenTelemetryInstance.kotlinApi(clock = otelClock)
+        tracer = api.getTracer("my_tracer")
     }
 
     @Test
     fun `check private and internal span creation`() {
-        val originalStartTime = clock.now()
+        val originalStartTime = otelClock.now()
         val args = OtelSpanStartArgs(
             name = "test",
             type = EmbType.Performance.Default,
             internal = true,
             private = true,
-            tracer = TracerAdapter(tracer, otelClock),
-            startTimeMs = clock.now()
+            tracer = tracer,
+            startTimeMs = originalStartTime
         )
         val startTime = clock.tick()
         with(args.embraceAttributes.toSet()) {
@@ -72,13 +76,13 @@ internal class OtelSpanStartArgsTest {
             type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            tracer = TracerAdapter(tracer, otelClock),
+            tracer = tracer,
             parentCtx = OtelJavaContext.root().with(parent).toOtelKotlin()
         )
         val spanContext = Span.fromContext(args.parentContext).spanContext
         assertEquals(parent.spanContext.traceId, spanContext.traceId)
 
-        val startTime = clock.now()
+        val startTime = otelClock.now()
         args.startSpan(startTime).assertSpan(
             expectedName = "test",
             expectedStartTimeMs = startTime,
@@ -92,10 +96,10 @@ internal class OtelSpanStartArgsTest {
             type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            tracer = TracerAdapter(tracer, otelClock),
+            tracer = tracer,
             spanKind = SpanKind.CLIENT
         )
-        val startTime = clock.now()
+        val startTime = otelClock.now()
         args.startSpan(startTime).assertSpan(
             expectedName = "test",
             expectedStartTimeMs = startTime,
@@ -110,7 +114,7 @@ internal class OtelSpanStartArgsTest {
             type = EmbType.Performance.Default,
             internal = false,
             private = false,
-            tracer = TracerAdapter(tracer, otelClock),
+            tracer = tracer,
         )
         args.customAttributes["test-key"] = "test-value"
         assertEquals("test-value", args.customAttributes["test-key"])
@@ -118,8 +122,7 @@ internal class OtelSpanStartArgsTest {
 
     @Test
     fun `initial name not truncated`() {
-        val tracer = TracerAdapter(tracer, otelClock)
-        val startTime = clock.now()
+        val startTime = otelClock.now()
 
         val creator = OtelSpanStartArgs(
             tracer = tracer,


### PR DESCRIPTION
## Goal

Use additional opentelemetry-kotlin symbols rather than opentelemetry-java.