### PR TITLE
Add additional logging in embrace-gradle-plugin

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -21,6 +21,7 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
 
     private fun RegistrationParams.execute() {
         try {
+            logger.info("Setting up ASM transformation.")
             variant.instrumentation.setAsmFramesComputationMode(FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS)
             variant.instrumentation.transformClassesWith(
                 EmbraceClassVisitorFactory::class.java,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.plugin.tasks.reactnative
 
+import io.embrace.android.gradle.plugin.EmbraceLogger
 import io.embrace.android.gradle.plugin.gradle.lazyTaskLookup
 import io.embrace.android.gradle.plugin.gradle.nullSafeMap
 import io.embrace.android.gradle.plugin.gradle.registerTask
@@ -25,6 +26,8 @@ private const val SOURCE_MAP_NAME = "android-embrace.bundle.map"
 
 class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
 
+    private val logger = EmbraceLogger(GenerateRnSourcemapTaskRegistration::class.java)
+
     override fun register(params: RegistrationParams) {
         params.execute()
     }
@@ -36,6 +39,7 @@ class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
     private fun RegistrationParams.execute() {
         // Prevent upload the bundle in debug variant
         if (data.isBuildTypeDebuggable) {
+            logger.info("Skipping sourcemap upload for variant: ${data.name}. Build type is debuggable.")
             return
         }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -2,6 +2,7 @@ package io.embrace.android.gradle.plugin.tasks.registration
 
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
+import io.embrace.android.gradle.plugin.EmbraceLogger
 import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurationBuilder
 import io.embrace.android.gradle.plugin.dependency.installDependenciesForVariant
@@ -25,6 +26,8 @@ class TaskRegistrar(
     private val embraceVariantConfigurationBuilder: EmbraceVariantConfigurationBuilder,
     private val variantConfigurationsListProperty: ListProperty<VariantConfig>
 ) {
+
+    private val logger = EmbraceLogger(TaskRegistrar::class.java)
 
     /**
      * It is in charge of looping through each variant and configure each task.
@@ -53,6 +56,7 @@ class TaskRegistrar(
         AsmTaskRegistration().register(params)
 
         if (behavior.isPluginDisabledForVariant(variant.name) || !shouldRegisterUploadTasks(variant, variantConfigurationsListProperty)) {
+            logger.info("Skipping upload tasks for variant: ${variant.name}")
             return
         } else {
             registerUploadTasks(params, variant)


### PR DESCRIPTION
## Goal

Add some info logs in strategic places to make it easier to know what the Embrace Gradle plugin is doing, without being too verbose.

