### PR TITLE
Improve React Native project detection in gradle plugin

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -57,6 +57,11 @@ class EmbraceGradlePluginDelegate {
 
         taskRegistrar.registerTasks()
 
+        // Register React Native specific tasks when React Native plugin is also applied
+        project.pluginManager.withPlugin("com.facebook.react") {
+            taskRegistrar.registerReactNativeTasks()
+        }
+
         project.afterEvaluate { evaluatedProject ->
             onProjectEvaluated(evaluatedProject, agpWrapper)
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
@@ -35,11 +35,6 @@ interface PluginBehavior {
     val baseUrl: String
 
     /**
-     * Whether the project uses React Native or not
-     */
-    val isReactNativeProject: Boolean
-
-    /**
      * The behavior for instrumenting bytecode
      */
     val instrumentation: InstrumentationBehavior

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
@@ -6,7 +6,6 @@ import io.embrace.android.gradle.plugin.api.EmbraceExtension
 import io.embrace.android.gradle.swazzler.plugin.extension.SwazzlerExtension
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
-import java.io.File
 
 class PluginBehaviorImpl(
     private val project: Project,
@@ -49,17 +48,6 @@ class PluginBehaviorImpl(
             prop
         } else {
             "https://$prop"
-        }
-    }
-
-    override val isReactNativeProject: Boolean by lazy {
-        val rootFile = project.rootDir.parentFile
-        if (rootFile != null) {
-            val nodeModules = File("${rootFile.path}/node_modules")
-            val nodeModulesEmbrace = File("${nodeModules.path}/react-native")
-            nodeModulesEmbrace.exists()
-        } else {
-            false
         }
     }
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImplTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImplTest.kt
@@ -12,7 +12,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 
 class PluginBehaviorImplTest {
 
@@ -141,20 +140,6 @@ class PluginBehaviorImplTest {
     }
 
     @Test
-    fun `react native project false`() {
-        val rnDir = findRnNodeModulesDir()
-        rnDir.deleteRecursively()
-        assertFalse(behavior.isReactNativeProject)
-    }
-
-    @Test
-    fun `react native project true`() {
-        val rnDir = findRnNodeModulesDir()
-        rnDir.mkdirs()
-        assertTrue(behavior.isReactNativeProject)
-    }
-
-    @Test
     fun `autoAddEmbraceDependencies default`() {
         assertTrue(behavior.autoAddEmbraceDependencies)
     }
@@ -269,10 +254,5 @@ class PluginBehaviorImplTest {
 
     private fun addGradleProperty(key: String, value: String) {
         project.extensions.extraProperties[key] = value
-    }
-
-    private fun findRnNodeModulesDir(): File {
-        val rootFile = project.rootDir.parentFile ?: error("Parent directory of project root is null")
-        return File("${File("${rootFile.path}/node_modules").path}/react-native")
     }
 }


### PR DESCRIPTION
## Summary
- Use `withPlugin("com.facebook.react")` instead of checking `node_modules/react-native` directory.
- Create separate task registration flow for React Native specific tasks.

Uses Gradle's plugin system instead of file system checks, which are failing for some customers. This should be configuration-cache safe, as it's the same thing we use for waiting for AGP. React Native tasks still register only when the React Native plugin is detected

## Changes
- Remove `isReactNativeProject` property from `PluginBehavior`
- Add `withPlugin("com.facebook.react")` detection in `EmbraceGradlePluginDelegate` 
- Create `registerReactNativeTasks()` method for RN-specific task registration
- Extract shared methods to reduce code duplication
- Update tests to remove obsolete React Native detection logic