### PR TITLE
Look for openConnection method in ancestor of wrapped URLStreamHandler

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpUrlStreamHandler.java
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
+import static io.embrace.android.embracesdk.internal.network.http.HttpUrlConnectionUtilsKt.findDeclaredMethod;
+
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
@@ -31,7 +33,7 @@ final class EmbraceHttpUrlStreamHandler extends EmbraceUrlStreamHandler {
 
     @Override
     protected Method getMethodOpenConnection(Class<URL> url) throws NoSuchMethodException {
-        Method method = this.handler.getClass().getDeclaredMethod(METHOD_NAME_OPEN_CONNECTION, url);
+        Method method = findDeclaredMethod(handler, handler.getClass(), METHOD_NAME_OPEN_CONNECTION, url);
 
         method.setAccessible(true);
         return method;
@@ -39,7 +41,7 @@ final class EmbraceHttpUrlStreamHandler extends EmbraceUrlStreamHandler {
 
     @Override
     protected Method getMethodOpenConnection(Class<URL> url, Class<Proxy> proxy) throws NoSuchMethodException {
-        Method method = this.handler.getClass().getDeclaredMethod(METHOD_NAME_OPEN_CONNECTION, url, proxy);
+        Method method = findDeclaredMethod(handler, handler.getClass(), METHOD_NAME_OPEN_CONNECTION, url, proxy);
 
         method.setAccessible(true);
         return method;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpsUrlStreamHandler.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/EmbraceHttpsUrlStreamHandler.java
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
+import static io.embrace.android.embracesdk.internal.network.http.HttpUrlConnectionUtilsKt.findDeclaredMethod;
+
 import java.lang.reflect.Method;
 import java.net.Proxy;
 import java.net.URL;
@@ -32,7 +34,7 @@ final class EmbraceHttpsUrlStreamHandler extends EmbraceUrlStreamHandler {
 
     @Override
     protected Method getMethodOpenConnection(Class<URL> url) throws NoSuchMethodException {
-        Method method = this.handler.getClass().getSuperclass().getDeclaredMethod(METHOD_NAME_OPEN_CONNECTION, url);
+        Method method = findDeclaredMethod(handler, handler.getClass(), METHOD_NAME_OPEN_CONNECTION, url);
 
         method.setAccessible(true);
         return method;
@@ -40,7 +42,7 @@ final class EmbraceHttpsUrlStreamHandler extends EmbraceUrlStreamHandler {
 
     @Override
     protected Method getMethodOpenConnection(Class<URL> url, Class<Proxy> proxy) throws NoSuchMethodException {
-        Method method = this.handler.getClass().getSuperclass().getDeclaredMethod(METHOD_NAME_OPEN_CONNECTION, url, proxy);
+        Method method = findDeclaredMethod(handler, handler.getClass(), METHOD_NAME_OPEN_CONNECTION, url, proxy);
 
         method.setAccessible(true);
         return method;

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/HttpUrlConnectionUtils.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/HttpUrlConnectionUtils.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.internal.network.http
+
+import java.lang.reflect.Method
+
+/**
+ * Searches the object for a declared method, and continues up the hierarchy until it finds a declaration.
+ * Otherwise this behaves the same as Class#getDeclaredMethod().
+ */
+
+@Throws(NoSuchMethodException::class)
+internal fun findDeclaredMethod(
+    obj: Any,
+    objClz: Class<*>,
+    methodName: String,
+    vararg methodParams: Class<*>,
+): Method {
+    try {
+        val method = objClz.getDeclaredMethod(methodName, *methodParams)
+        method.isAccessible = true
+        return method
+    } catch (ignored: NoSuchMethodException) {
+        val superClz = objClz.superclass ?: throw ignored
+        return findDeclaredMethod(obj, superClz, methodName, *methodParams)
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/StreamHandlerFactoryInstaller.java
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/StreamHandlerFactoryInstaller.java
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.internal.network.http;
 
+import static io.embrace.android.embracesdk.internal.network.http.EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION;
+import static io.embrace.android.embracesdk.internal.network.http.HttpUrlConnectionUtilsKt.findDeclaredMethod;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -149,7 +152,8 @@ class StreamHandlerFactoryInstaller {
                 @Override
                 protected URLConnection openConnection(URL url, Proxy proxy) {
                     try {
-                        Method method = parentHandler.getClass().getDeclaredMethod("openConnection", URL.class, Proxy.class);
+                        Method method =
+                            findDeclaredMethod(parentHandler, parentHandler.getClass(), METHOD_NAME_OPEN_CONNECTION, URL.class, Proxy.class);
                         method.setAccessible(true);
                         URLConnection parentConnection = (URLConnection) method.invoke(parentHandler, url, proxy);
                         return wrapConnection(parentConnection);
@@ -162,7 +166,8 @@ class StreamHandlerFactoryInstaller {
                 @Override
                 protected URLConnection openConnection(URL url) {
                     try {
-                        Method method = parentHandler.getClass().getDeclaredMethod("openConnection", URL.class);
+                        Method method =
+                            findDeclaredMethod(parentHandler, parentHandler.getClass(), METHOD_NAME_OPEN_CONNECTION, URL.class,  Proxy.class);
                         method.setAccessible(true);
                         URLConnection parentConnection = (URLConnection) method.invoke(parentHandler, url);
                         return wrapConnection(parentConnection);

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/network/http/FakeURLStreamHandler.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/network/http/FakeURLStreamHandler.kt
@@ -1,0 +1,25 @@
+package io.embrace.android.embracesdk.fakes.network.http
+
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+
+internal open class FakeURLStreamHandler : URLStreamHandler() {
+
+    override fun openConnection(url: URL): URLConnection {
+        return TestURLConnection(url)
+    }
+
+    private open class TestURLConnection(url: URL) : HttpURLConnection(url) {
+        override fun disconnect() {
+        }
+
+        override fun usingProxy(): Boolean {
+            return false
+        }
+
+        override fun connect() {
+        }
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/HttpUrlConnectionUtilsTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/network/http/HttpUrlConnectionUtilsTest.kt
@@ -1,0 +1,62 @@
+package io.embrace.android.embracesdk.internal.network.http
+
+import io.embrace.android.embracesdk.fakes.network.http.FakeURLStreamHandler
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.net.URL
+import java.net.URLConnection
+
+internal class HttpUrlConnectionUtilsTest {
+    private val url = URL("http", "embrace.io", 8080, "index.html")
+
+    @Test
+    fun `findDeclaredMethod traverses class hierarchy to find method`() {
+        listOf(
+            FakeURLStreamHandler(),
+            WrapperURLStreamHandler(),
+            NoOpenConnectionURLStreamHandler(),
+            WrapperNoOpenConnectionURLStreamHandler()
+        ).forEach { urlStreamHandler ->
+            val method = findDeclaredMethod(
+                obj = urlStreamHandler,
+                objClz = urlStreamHandler.javaClass,
+                methodName = EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION,
+                url.javaClass
+            )
+            assertNotNull(method)
+        }
+    }
+
+    @Test(expected = NoSuchMethodException::class)
+    fun `findDeclaredMethod throws when the method name doesn't exist`() {
+        val urlStreamHandler = FakeURLStreamHandler()
+        findDeclaredMethod(
+            obj = urlStreamHandler,
+            objClz = urlStreamHandler.javaClass,
+            methodName = "nahhhh",
+            url.javaClass
+        )
+    }
+
+    @Test(expected = NoSuchMethodException::class)
+    fun `findDeclaredMethod throws when the method parameters do not match what is expected`() {
+        val urlStreamHandler = FakeURLStreamHandler()
+        findDeclaredMethod(
+            obj = urlStreamHandler,
+            objClz = urlStreamHandler.javaClass,
+            methodName = EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION,
+            url.javaClass,
+            url.javaClass
+        )
+    }
+
+    private open class WrapperURLStreamHandler : FakeURLStreamHandler() {
+        override fun openConnection(url: URL): URLConnection {
+            return super.openConnection(url)
+        }
+    }
+
+    private open class NoOpenConnectionURLStreamHandler : FakeURLStreamHandler()
+
+    private open class WrapperNoOpenConnectionURLStreamHandler : NoOpenConnectionURLStreamHandler()
+}


### PR DESCRIPTION
Traverse up the object hierarchy to find the `openConnection` method to be invoked in an existing URLStreamingHandler installed on an app before the Embrace SDK started. Previously, we were only looking in the wrapped class, but it could have inherited the method from an ancestor instead.