### PR TITLE
Suppress the logcat warning when applicationInitEnd called before SDK starts

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -349,7 +349,7 @@ internal class EmbraceImpl(
     }
 
     override fun applicationInitEnd() {
-        if (sdkCallChecker.check("application_init_end")) {
+        if (sdkCallChecker.check("application_init_end", false)) {
             bootstrapper.dataCaptureServiceModule.appStartupDataCollector.run {
                 if (applicationInitStartMs != null) {
                     applicationInitStart(applicationInitStartMs)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
@@ -20,9 +20,9 @@ internal class SdkCallChecker(
      * Every public API usage should go through this method, except the ones that are called too often and may cause a performance hit.
      * For instance, get_current_session_id go directly through checkSdkStarted.
      */
-    fun check(action: String): Boolean {
+    fun check(action: String, outputErrorMessage: Boolean = true): Boolean {
         val isStarted = started.get()
-        if (!isStarted) {
+        if (!isStarted && outputErrorMessage) {
             logger.logSdkNotInitialized(action)
         }
         telemetryService?.onPublicApiCalled(action)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkCallCheckerTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkCallCheckerTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 
 internal class SdkCallCheckerTest {
 
+    private val action = "foo"
     private lateinit var logger: FakeEmbLogger
     private lateinit var telemetryService: FakeTelemetryService
     private lateinit var checker: SdkCallChecker
@@ -23,7 +24,6 @@ internal class SdkCallCheckerTest {
 
     @Test
     fun `test not started`() {
-        val action = "foo"
         logger.throwOnInternalError = false
         assertFalse(checker.started.get())
         assertFalse(checker.check(action))
@@ -32,8 +32,16 @@ internal class SdkCallCheckerTest {
     }
 
     @Test
+    fun `error message can be suppressed`() {
+        logger.throwOnInternalError = false
+        assertFalse(checker.started.get())
+        assertFalse(checker.check(action, false))
+        assertTrue(logger.sdkNotInitializedMessages.isEmpty())
+        assertEquals(action, telemetryService.apiCalls.single())
+    }
+
+    @Test
     fun `test started`() {
-        val action = "foo"
         checker.started.set(true)
         assertTrue(checker.check(action))
         assertTrue(logger.sdkNotInitializedMessages.isEmpty())


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->

## Release Notes

<!-- Notes to add in the next Release. Do not put any customer information here. Ignore if the changes are internal. -->

**WHAT**:<br>
**WHY**:<br>

