### PR TITLE
Fix PGP signing error in pre-release workflow by inheriting secrets

### DIFF
--- a/.github/workflows/pre-release-workflow.yml
+++ b/.github/workflows/pre-release-workflow.yml
@@ -36,3 +36,4 @@ jobs:
     uses: ./.github/workflows/upload-artifacts-to-maven-central.yml
     with:
       rc_version: ${{ inputs.rc_version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
The pre-release workflow was failing with "Could not read PGP secret key" when trying to sign Maven publications. This occurred because reusable workflows don't automatically inherit secrets from the calling workflow, even when the secrets are referenced in the `env` section of the called workflow.

The fix adds `secrets: inherit` to the `upload-artifacts-to-sonatype` job in the pre-release workflow, allowing the Maven Central upload workflow to access the required PGP signing secrets.