### PR TITLE
Add overloads for exporter API

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -104,7 +104,9 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Netwo
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/OTelApi {
+	public abstract fun addLogRecordExporter (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;)V
 	public abstract fun addLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
+	public abstract fun addSpanExporter (Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;)V
 	public abstract fun addSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
 	public abstract fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
 	public abstract fun getOpenTelemetryKotlin ()Lio/embrace/opentelemetry/kotlin/OpenTelemetry;

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/OTelApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/OTelApi.kt
@@ -7,12 +7,26 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanExporter
 
 /**
  * Methods that enable integration with the the large OTel ecosystem through standard OTel APIs and concepts.
  */
 @InternalApi
 public interface OTelApi {
+
+    /**
+     * Add a [LogRecordExporter] that OTel Logs will be exported to after logging
+     */
+    @OptIn(ExperimentalApi::class)
+    public fun addLogRecordExporter(logRecordExporter: LogRecordExporter)
+
+    /**
+     * Adds a [SpanExporter] that OTel Spans will be exported to after completion
+     */
+    @OptIn(ExperimentalApi::class)
+    public fun addSpanExporter(spanExporter: SpanExporter)
 
     /**
      * Add a [LogRecordExporter] that OTel Logs will be exported to after logging

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -66,8 +66,8 @@ class OtelSdkConfig(
         EmbTrace.trace("process-identifier-init", processIdentifierProvider)
     }
 
-    private val externalSpanExporters = mutableListOf<OtelJavaSpanExporter>()
-    private val externalLogExporters = mutableListOf<OtelJavaLogRecordExporter>()
+    private val externalSpanExporters = mutableListOf<SpanExporter>()
+    private val externalLogExporters = mutableListOf<LogRecordExporter>()
 
     private var exportEnabled: Boolean = true
     private val exportCheck: () -> Boolean = { exportEnabled }
@@ -77,14 +77,9 @@ class OtelSdkConfig(
     }
 
     val spanExporter: SpanExporter by lazy {
-        val externalExporter = if (externalSpanExporters.isNotEmpty()) {
-            OtelJavaSpanExporter.composite(externalSpanExporters)
-        } else {
-            null
-        }
         DefaultSpanExporter(
             spanSink = spanSink,
-            externalSpanExporter = externalExporter?.toOtelKotlinSpanExporter(),
+            externalExporters = externalSpanExporters.toList(),
             exportCheck = exportCheck,
         )
     }
@@ -96,23 +91,26 @@ class OtelSdkConfig(
     }
 
     val logRecordExporter: LogRecordExporter by lazy {
-        val externalExporter = if (externalLogExporters.isNotEmpty()) {
-            OtelJavaLogRecordExporter.composite(externalLogExporters)
-        } else {
-            null
-        }
         DefaultLogRecordExporter(
             logSink = logSink,
-            externalLogRecordExporter = externalExporter?.toOtelKotlinLogRecordExporter(),
+            externalExporters = externalLogExporters.toList(),
             exportCheck = exportCheck,
         )
     }
 
     fun addSpanExporter(spanExporter: OtelJavaSpanExporter) {
-        externalSpanExporters.add(spanExporter)
+        externalSpanExporters.add(spanExporter.toOtelKotlinSpanExporter())
     }
 
     fun addLogExporter(logExporter: OtelJavaLogRecordExporter) {
+        externalLogExporters.add(logExporter.toOtelKotlinLogRecordExporter())
+    }
+
+    fun addSpanExporter(spanExporter: SpanExporter) {
+        externalSpanExporters.add(spanExporter)
+    }
+
+    fun addLogExporter(logExporter: LogRecordExporter) {
         externalLogExporters.add(logExporter)
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.otel.logs
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
@@ -14,7 +15,7 @@ import io.embrace.opentelemetry.kotlin.logging.model.ReadableLogRecord
 @ExperimentalApi
 internal class DefaultLogRecordExporter(
     private val logSink: LogSink,
-    private val externalLogRecordExporter: LogRecordExporter?,
+    private val externalExporters: List<LogRecordExporter>,
     private val exportCheck: () -> Boolean,
 ) : LogRecordExporter {
 
@@ -22,13 +23,22 @@ internal class DefaultLogRecordExporter(
         if (!exportCheck()) {
             return OperationResultCode.Success
         }
-        val result = logSink.storeLogs(telemetry.map(ReadableLogRecord::toEmbracePayload))
-        if (externalLogRecordExporter != null && result == StoreDataResult.SUCCESS) {
-            return externalLogRecordExporter.export(
-                telemetry.filterNot {
-                    it.attributes.containsKey(PrivateSpan.key.name)
+        var result = logSink.storeLogs(telemetry.map(ReadableLogRecord::toEmbracePayload))
+
+        EmbTrace.trace("otel-external-export") {
+            if (externalExporters.isNotEmpty() && result == StoreDataResult.SUCCESS) {
+                externalExporters.forEach { exporter ->
+                    try {
+                        exporter.export(
+                            telemetry.filterNot {
+                                it.attributes.containsKey(PrivateSpan.key.name)
+                            }
+                        )
+                    } catch (ignored: Throwable) {
+                        result = StoreDataResult.FAILURE
+                    }
                 }
-            )
+            }
         }
         return when (result) {
             StoreDataResult.SUCCESS -> OperationResultCode.Success

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -5,8 +5,10 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun addLoadTraceAttribute (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V
 	public fun addLoadTraceChildSpan (Landroid/app/Activity;Ljava/lang/String;JJ)V
 	public fun addLoadTraceChildSpan (Landroid/app/Activity;Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
+	public fun addLogRecordExporter (Lio/embrace/opentelemetry/kotlin/logging/export/LogRecordExporter;)V
 	public fun addLogRecordExporter (Lio/opentelemetry/sdk/logs/export/LogRecordExporter;)V
 	public fun addSessionProperty (Ljava/lang/String;Ljava/lang/String;Z)Z
+	public fun addSpanExporter (Lio/embrace/opentelemetry/kotlin/tracing/export/SpanExporter;)V
 	public fun addSpanExporter (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
 	public fun addStartupTraceAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public fun addStartupTraceChildSpan (Ljava/lang/String;JJ)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.assertions.validateLinkToSpanContext
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeOtelJavaSpanExporter
+import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_KEY
@@ -75,7 +76,7 @@ internal class TracingApiTest {
         var testStartTimeMs: Long = -1
         var sessionStartTimeMs: Long = -1
         var sessionEndTimeMs: Long = -1
-        val spanExporter = FakeOtelJavaSpanExporter()
+        val spanExporter = FakeSpanExporter()
 
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true)),

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/Embrace.kt
@@ -18,6 +18,8 @@ import io.embrace.opentelemetry.kotlin.OpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanExporter
 
 /**
  * Entry point for the SDK. This class is part of the Embrace Public API.
@@ -388,6 +390,16 @@ public class Embrace private constructor(
         impl.addSpanExporter(spanExporter)
     }
 
+    /**
+     * Adds a [SpanExporter] to the tracer.
+     *
+     * @param spanExporter the span exporter to add
+     */
+    @ExperimentalApi
+    override fun addSpanExporter(spanExporter: SpanExporter) {
+        impl.addSpanExporter(spanExporter)
+    }
+
     override fun getOpenTelemetry(): OtelJavaOpenTelemetry {
         return impl.getOpenTelemetry()
     }
@@ -411,6 +423,16 @@ public class Embrace private constructor(
      * @param logRecordExporter the LogRecord exporter to add
      */
     override fun addLogRecordExporter(logRecordExporter: OtelJavaLogRecordExporter) {
+        impl.addLogRecordExporter(logRecordExporter)
+    }
+
+    /**
+     * Adds a [LogRecordExporter] to the open telemetry logger.
+     *
+     * @param logRecordExporter the LogRecord exporter to add
+     */
+    @ExperimentalApi
+    override fun addLogRecordExporter(logRecordExporter: LogRecordExporter) {
         impl.addLogRecordExporter(logRecordExporter)
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegate.kt
@@ -8,12 +8,29 @@ import io.embrace.opentelemetry.kotlin.OpenTelemetryInstance
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.embrace.opentelemetry.kotlin.noop
+import io.embrace.opentelemetry.kotlin.tracing.export.SpanExporter
 
+@OptIn(ExperimentalApi::class)
 internal class OTelApiDelegate(
     private val bootstrapper: ModuleInitBootstrapper,
     private val sdkCallChecker: SdkCallChecker,
 ) : OTelApi {
+
+    override fun addSpanExporter(spanExporter: SpanExporter) {
+        if (sdkCallChecker.started.get()) {
+            return
+        }
+        bootstrapper.openTelemetryModule.otelSdkConfig.addSpanExporter(spanExporter)
+    }
+
+    override fun addLogRecordExporter(logRecordExporter: LogRecordExporter) {
+        if (sdkCallChecker.started.get()) {
+            return
+        }
+        bootstrapper.openTelemetryModule.otelSdkConfig.addLogExporter(logRecordExporter)
+    }
 
     override fun addSpanExporter(spanExporter: OtelJavaSpanExporter) {
         if (sdkCallChecker.started.get()) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -3,9 +3,10 @@ package io.embrace.android.embracesdk.internal.api.delegate
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakeMutableAttributeContainer
 import io.embrace.android.embracesdk.fakes.FakeOtelJavaLogRecordExporter
-import io.embrace.android.embracesdk.fakes.FakeOtelJavaSpanExporter
+import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
@@ -48,7 +49,7 @@ internal class OTelApiDelegateTest {
     @Test
     fun `add span exporter before start`() {
         sdkCallChecker.started.set(false)
-        delegate.addSpanExporter(FakeOtelJavaSpanExporter())
+        delegate.addSpanExporter(FakeSpanExporter())
         assertTrue(bootstrapper.openTelemetryModule.otelSdkConfig.hasConfiguredOtelExporters())
     }
 
@@ -61,8 +62,8 @@ internal class OTelApiDelegateTest {
 
     @Test
     fun `add exporters after start`() {
-        delegate.addSpanExporter(FakeOtelJavaSpanExporter())
-        delegate.addLogRecordExporter(FakeOtelJavaLogRecordExporter())
+        delegate.addSpanExporter(FakeSpanExporter())
+        delegate.addLogRecordExporter(FakeLogRecordExporter())
         assertFalse(bootstrapper.openTelemetryModule.otelSdkConfig.hasConfiguredOtelExporters())
     }
 


### PR DESCRIPTION
## Goal

Adds overloads for the exporter API that allows configuring exporters with the Kotlin symbols instead.

## Testing

Added integration test cases.