### PR TITLE
Make embrace-android-payload more isolated

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
@@ -5,10 +5,10 @@ import io.embrace.android.embracesdk.internal.comms.api.ApiRequest
 import io.embrace.android.embracesdk.internal.comms.api.ApiRequestUrl
 import io.embrace.android.embracesdk.internal.comms.api.ApiUrlBuilder
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
+import io.embrace.android.embracesdk.internal.comms.api.HttpMethod
 import io.embrace.android.embracesdk.internal.comms.api.getHeaders
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.network.http.HttpMethod
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import io.embrace.android.embracesdk.internal.AndroidResourcesService
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfoService
+import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.registry.ServiceRegistry
 
 /**
@@ -37,7 +38,7 @@ interface CoreModule {
     /**
      * Whether the application is a debug build
      */
-    val isDebug: Boolean
+    val appEnvironment: AppEnvironment
 
     val buildInfoService: BuildInfoService
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import io.embrace.android.embracesdk.internal.AndroidResourcesService
 import io.embrace.android.embracesdk.internal.EmbraceAndroidResourcesService
 import io.embrace.android.embracesdk.internal.buildinfo.BuildInfoService
@@ -11,7 +12,7 @@ import io.embrace.android.embracesdk.internal.registry.ServiceRegistry
 
 class CoreModuleImpl(
     ctx: Context,
-    initModule: InitModule
+    initModule: InitModule,
 ) : CoreModule {
 
     override val context: Context by singleton {
@@ -35,8 +36,11 @@ class CoreModuleImpl(
         EmbraceAndroidResourcesService(context)
     }
 
-    override val isDebug: Boolean by lazy {
-        AppEnvironment(context.applicationInfo).isDebug
+    override val appEnvironment: AppEnvironment by lazy {
+        val isDebug: Boolean = with(context.applicationInfo) {
+            flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+        }
+        AppEnvironment(isDebug)
     }
 
     override val buildInfoService: BuildInfoService by lazy {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.DeviceArchitecture
 import io.embrace.android.embracesdk.internal.DeviceArchitectureImpl
-import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.capture.metadata.EmbraceMetadataService
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTracker
@@ -90,7 +89,7 @@ internal class PayloadSourceModuleImpl(
         EmbTrace.trace("resource-source") {
             EnvelopeResourceSourceImpl(
                 hostedSdkVersionInfo,
-                AppEnvironment(coreModule.context.applicationInfo).environment,
+                coreModule.appEnvironment.environment,
                 EmbTrace.trace("buildInfo") { coreModule.buildInfoService.getBuildInfo() },
                 EmbTrace.trace("packageInfo") { coreModule.packageVersionInfo },
                 configModule.configService.appFramework,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/ApiRequestTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/comms/api/ApiRequestTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.comms.api
 
-import io.embrace.android.embracesdk.network.http.HttpMethod
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/CoreModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/CoreModuleImplTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
+import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment.Environment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
@@ -27,10 +28,14 @@ internal class CoreModuleImplTest {
     @Test
     fun testContextObject() {
         val application = RuntimeEnvironment.getApplication()
-        val isDebug = AppEnvironment(application.applicationInfo).isDebug
         val ctx = application.applicationContext
         val module = CoreModuleImpl(ctx, initModule)
         assertSame(application, module.application)
-        assertEquals(isDebug, module.isDebug)
+    }
+
+    @Test
+    fun `test environment`() {
+        assertEquals(Environment.DEV, AppEnvironment(true).environment)
+        assertEquals(Environment.PROD, AppEnvironment(false).environment)
     }
 }

--- a/embrace-android-payload/build.gradle.kts
+++ b/embrace-android-payload/build.gradle.kts
@@ -14,11 +14,4 @@ android {
 dependencies {
     implementation(libs.moshi)
     ksp(libs.moshi.kotlin.codegen)
-
-    implementation(project(":embrace-android-api"))
-    testImplementation(project(":embrace-android-api"))
-    testImplementation(project(":embrace-android-core"))
-    testImplementation(platform(libs.opentelemetry.bom))
-    testImplementation(libs.opentelemetry.semconv)
-    testImplementation(libs.opentelemetry.semconv.incubating)
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/AppEnvironment.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/AppEnvironment.kt
@@ -1,11 +1,9 @@
 package io.embrace.android.embracesdk.internal.capture.metadata
 
-import android.content.pm.ApplicationInfo
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-class AppEnvironment(appInfo: ApplicationInfo) {
-    val isDebug: Boolean = with(appInfo) { flags and ApplicationInfo.FLAG_DEBUGGABLE != 0 }
+class AppEnvironment(val isDebug: Boolean) {
 
     val environment: Environment = if (isDebug) Environment.DEV else Environment.PROD
 

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiRequest.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiRequest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.comms.api
 
 import com.squareup.moshi.JsonClass
-import io.embrace.android.embracesdk.network.http.HttpMethod
 
 @JsonClass(generateAdapter = true)
 data class ApiRequest(

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/HttpMethod.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/HttpMethod.kt
@@ -1,0 +1,13 @@
+package io.embrace.android.embracesdk.internal.comms.api
+
+enum class HttpMethod {
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    DELETE,
+    CONNECT,
+    OPTIONS,
+    TRACE,
+    PATCH
+}

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EmbraceSerializerTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EmbraceSerializerTest.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.payload
 
 import com.squareup.moshi.Types
-import io.embrace.android.embracesdk.assertions.getSessionId
-import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import org.junit.Assert.assertEquals
@@ -11,34 +9,35 @@ import org.junit.Test
 import java.io.ByteArrayOutputStream
 
 internal class EmbraceSerializerTest {
+
     private val serializer = EmbraceSerializer()
-    private val payload: Envelope<SessionPayload> = fakeSessionEnvelope()
+    private val payload = Attribute("key", "value")
+    private val payload2 = Attribute("key_2", "value_2")
+    private val clz = Attribute::class.java
 
     @Test
     fun testWriteToFile() {
         val stream = ByteArrayOutputStream()
-        serializer.toJson(payload, Envelope.sessionEnvelopeType, stream)
+        serializer.toJson(payload, clz, stream)
         assertTrue(stream.toByteArray().isNotEmpty())
     }
 
     @Test
     fun testLoadObject() {
-        val stream = serializer.toJson(payload, Envelope.sessionEnvelopeType).byteInputStream()
-        val result = serializer.fromJson<Envelope<SessionPayload>>(stream, Envelope.sessionEnvelopeType)
-        assertEquals("fakeSessionId", result.getSessionId())
+        val stream = serializer.toJson(payload, clz).byteInputStream()
+        val result = serializer.fromJson(stream, clz)
+        assertEquals(payload, result)
     }
 
     @Test
     fun testLoadListOfObjects() {
-        val session1 = fakeSessionEnvelope(sessionId = "session1")
-        val session2 = fakeSessionEnvelope(sessionId = "session2")
-        val listOfObjects = listOf(session1, session2)
-        val type = Types.newParameterizedType(List::class.java, Envelope.sessionEnvelopeType)
+        val listOfObjects = listOf(payload, payload2)
+        val type = Types.newParameterizedType(List::class.java, clz)
         val stream = serializer.toJson(listOfObjects, type).byteInputStream()
-        val result = serializer.fromJson(stream, type) as List<Envelope<SessionPayload>>
+        val result = serializer.fromJson(stream, type) as List<Attribute>
         assertEquals(2, result.size)
-        assertEquals(session1.getSessionId(), result[0].getSessionId())
-        assertEquals(session2.getSessionId(), result[1].getSessionId())
+        assertEquals(payload, result[0])
+        assertEquals(payload2, result[1])
     }
 
     @Test

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -26,7 +26,7 @@ public class FakeCoreModule(
         if (isMockKMock(application)) getMockedContext() else application.applicationContext,
     override val serviceRegistry: ServiceRegistry = ServiceRegistry(),
     override val resources: FakeAndroidResourcesService = FakeAndroidResourcesService(),
-    override val isDebug: Boolean = if (isMockKMock(context)) false else AppEnvironment(context.applicationInfo).isDebug,
+    override val appEnvironment: AppEnvironment = AppEnvironment(true),
     override val buildInfoService: BuildInfoService = FakeBuildInfoService(),
     override val packageVersionInfo: PackageVersionInfo = fakePackageVersionInfo,
 ) : CoreModule {


### PR DESCRIPTION
## Goal

Updates the embrace-android-payload module so that it doesn't depend on other modules in the project.

## Testing

Relied on existing test coverage.

