### PR TITLE
Revert Java bump

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -33,13 +33,13 @@ gradlePlugin {
 
 // ensure the Kotlin + Java compilers both use the same language level.
 project.tasks.withType(JavaCompile::class.java).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
 }
 
 // ensure the Kotlin + Java compilers both use the same language level.
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }

--- a/buildSrc/src/main/kotlin/io/embrace/internal/AndroidCompileConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/internal/AndroidCompileConfig.kt
@@ -8,7 +8,7 @@ fun LibraryExtension.configureAndroidCompileOptions() {
     defaultConfig.minSdk = 21
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }

--- a/buildSrc/src/main/kotlin/io/embrace/internal/EmbraceBuildLogicExtension.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/internal/EmbraceBuildLogicExtension.kt
@@ -33,5 +33,5 @@ abstract class EmbraceBuildLogicExtension(objectFactory: ObjectFactory) {
      * The JVM target for this module.
      */
     val jvmTarget: Property<JavaVersion> =
-        objectFactory.property(JavaVersion::class.java).convention(JavaVersion.VERSION_11)
+        objectFactory.property(JavaVersion::class.java).convention(JavaVersion.VERSION_1_8)
 }


### PR DESCRIPTION
## Goal

We only require Java 11 at build time, so bumping the minimum java version was a mistake. Rolling it back, at least until the next major
