### PR TITLE
Remove OtelJavaSpanContext.toOtelKotlin() from KotlinApiConversions

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/KotlinApiConversions.kt
@@ -2,11 +2,8 @@ package io.embrace.android.embracesdk.internal.otel
 
 import io.embrace.android.embracesdk.internal.payload.Span.Status
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
-import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinSpanContext
-import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 
 @OptIn(ExperimentalApi::class)
 fun StatusCode.toEmbracePayload(): Status = when (this) {
@@ -21,6 +18,3 @@ fun StatusData.toEmbracePayload(): Status = when (this) {
     StatusData.Ok -> Status.OK
     StatusData.Unset -> Status.UNSET
 }
-
-@OptIn(ExperimentalApi::class)
-fun OtelJavaSpanContext.toOtelKotlin(): SpanContext = this.toOtelKotlinSpanContext()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -22,7 +22,6 @@ import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanStartArgs
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
 import io.embrace.android.embracesdk.internal.otel.spans.getOrCreateSpanKey
 import io.embrace.android.embracesdk.internal.otel.toEmbracePayload
-import io.embrace.android.embracesdk.internal.otel.toOtelKotlin
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
@@ -37,6 +36,7 @@ import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.toOtelJavaContextKey
 import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
@@ -74,7 +74,7 @@ class FakeEmbraceSdkSpan(
         get() = if (useKotlinSdk) {
             sdkSpan?.spanContext
         } else {
-            javaSdkSpan?.spanContext?.toOtelKotlin()
+            javaSdkSpan?.spanContext?.toOtelKotlinSpanContext()
         }
 
     override val traceId: String?


### PR DESCRIPTION
## Goal

We can use it directly from `opentelemetry-kotlin`