### PR TITLE
Use opentelemetry-kotlin semantic conventions

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
 
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)
-    compileOnly(libs.opentelemetry.semconv)
-    compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.androidx.annotation)
     implementation(libs.lifecycle.process)
     implementation(platform(libs.okhttp.bom))
@@ -43,6 +41,7 @@ dependencies {
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.semconv)
     implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(project(":embrace-android-payload"))
@@ -51,8 +50,6 @@ dependencies {
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)
     testImplementation(libs.opentelemetry.sdk)
-    testImplementation(libs.opentelemetry.semconv)
-    testImplementation(libs.opentelemetry.semconv.incubating)
     testImplementation(libs.lifecycle.runtime)
     testImplementation(libs.lifecycle.process)
     testImplementation(libs.lifecycle.testing)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImpl.kt
@@ -13,8 +13,9 @@ import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.Logger
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalApi::class)
@@ -25,6 +26,7 @@ class LogWriterImpl(
     private val clock: Clock,
 ) : LogWriter {
 
+    @OptIn(IncubatingApi::class)
     override fun addLog(
         schemaType: SchemaType,
         severity: Severity,
@@ -45,13 +47,13 @@ class LogWriterImpl(
             severityText = getSeverityText(severityNumber),
             timestamp = TimeUnit.MILLISECONDS.toNanos(logTimeMs)
         ) {
-            setStringAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key, Uuid.getEmbUuid())
+            setStringAttribute(LogAttributes.LOG_RECORD_UID, Uuid.getEmbUuid())
 
             if (addCurrentSessionInfo) {
                 var sessionState: String? = null
                 sessionIdTracker.getActiveSession()?.let { session ->
                     if (session.id.isNotBlank()) {
-                        setStringAttribute(SessionIncubatingAttributes.SESSION_ID.key, session.id)
+                        setStringAttribute(SessionAttributes.SESSION_ID, session.id)
                     }
                     sessionState = if (session.isForeground) {
                         FOREGROUND_STATE

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -9,11 +9,11 @@ import io.embrace.android.embracesdk.internal.otel.schema.SendMode
 import io.embrace.android.embracesdk.internal.payload.AppExitInfoData
 import io.embrace.android.embracesdk.internal.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.HttpAttributes
-import io.opentelemetry.semconv.UrlAttributes
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.HttpAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.UrlAttributes
 
 /**
  * The collections of attribute schemas used by the associated telemetry types.
@@ -106,7 +106,7 @@ sealed class SchemaType(
         fixedObjectName = "web-view"
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            UrlAttributes.URL_FULL.key to url
+            UrlAttributes.URL_FULL to url
         ).toNonNullMap()
     }
 
@@ -180,26 +180,27 @@ sealed class SchemaType(
     class NetworkCapturedRequest(networkCapturedCall: NetworkCapturedCall) : SchemaType(
         telemetryType = EmbType.System.NetworkCapturedRequest
     ) {
+        @OptIn(IncubatingApi::class)
         override val schemaAttributes: Map<String, String> = mapOf(
             "duration" to networkCapturedCall.duration.toString(),
             "end-time" to networkCapturedCall.endTime.toString(),
-            HttpAttributes.HTTP_REQUEST_METHOD.key to networkCapturedCall.httpMethod,
-            UrlAttributes.URL_FULL.key to networkCapturedCall.matchedUrl,
+            HttpAttributes.HTTP_REQUEST_METHOD to networkCapturedCall.httpMethod,
+            UrlAttributes.URL_FULL to networkCapturedCall.matchedUrl,
             "network-id" to networkCapturedCall.networkId,
             "request-body" to networkCapturedCall.requestBody,
-            HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key to networkCapturedCall.requestBodySize.toString(),
+            HttpAttributes.HTTP_REQUEST_BODY_SIZE to networkCapturedCall.requestBodySize.toString(),
             "request-query" to networkCapturedCall.requestQuery,
             "http.request.header" to networkCapturedCall.requestQueryHeaders.toString(),
             "request-size" to networkCapturedCall.requestSize.toString(),
             "response-body" to networkCapturedCall.responseBody,
-            HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key to networkCapturedCall.responseBodySize.toString(),
+            HttpAttributes.HTTP_RESPONSE_BODY_SIZE to networkCapturedCall.responseBodySize.toString(),
             "http.response.header" to networkCapturedCall.responseHeaders.toString(),
             "response-size" to networkCapturedCall.responseSize.toString(),
-            HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key to networkCapturedCall.responseStatus.toString(),
-            SessionIncubatingAttributes.SESSION_ID.key to networkCapturedCall.sessionId,
+            HttpAttributes.HTTP_RESPONSE_STATUS_CODE to networkCapturedCall.responseStatus.toString(),
+            SessionAttributes.SESSION_ID to networkCapturedCall.sessionId,
             "start-time" to networkCapturedCall.startTime.toString(),
             "url" to networkCapturedCall.url,
-            ExceptionAttributes.EXCEPTION_MESSAGE.key to networkCapturedCall.errorMessage,
+            ExceptionAttributes.EXCEPTION_MESSAGE to networkCapturedCall.errorMessage,
             "encrypted-payload" to networkCapturedCall.encryptedPayload
         ).toNonNullMap()
     }
@@ -224,7 +225,7 @@ sealed class SchemaType(
         fixedObjectName = "webview-info"
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            UrlAttributes.URL_FULL.key to url,
+            UrlAttributes.URL_FULL to url,
             "emb.webview_info.web_vitals" to webVitals,
             "emb.webview_info.tag" to tag
         ).toNonNullMap()
@@ -268,12 +269,12 @@ sealed class SchemaType(
         fixedObjectName = "internal-error"
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            ExceptionAttributes.EXCEPTION_TYPE.key to throwable.javaClass.name,
-            ExceptionAttributes.EXCEPTION_STACKTRACE.key to throwable.stackTrace.joinToString(
+            ExceptionAttributes.EXCEPTION_TYPE to throwable.javaClass.name,
+            ExceptionAttributes.EXCEPTION_STACKTRACE to throwable.stackTrace.joinToString(
                 "\n",
                 transform = StackTraceElement::toString
             ),
-            ExceptionAttributes.EXCEPTION_MESSAGE.key to (throwable.message ?: "")
+            ExceptionAttributes.EXCEPTION_MESSAGE to (throwable.message ?: "")
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
@@ -11,7 +11,8 @@ import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Envelope.Companion.createLogEnvelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 
 internal class LogEnvelopeSourceImpl(
     private val metadataSource: EnvelopeMetadataSource,
@@ -35,12 +36,13 @@ internal class LogEnvelopeSourceImpl(
         return getLogEnvelope(LogPayload(logs = emptyList()))
     }
 
+    @OptIn(IncubatingApi::class)
     private fun getLogEnvelope(payload: LogPayload): Envelope<LogPayload> {
         if (cachedLogEnvelopeStore != null && payload.findType() == PayloadType.NATIVE_CRASH) {
             val nativeCrash = payload.logs?.firstOrNull()
             val envelope = cachedLogEnvelopeStore.get(
                 createNativeCrashEnvelopeMetadata(
-                    sessionId = nativeCrash?.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key),
+                    sessionId = nativeCrash?.attributes?.findAttributeValue(SessionAttributes.SESSION_ID),
                     processIdentifier = nativeCrash?.attributes?.findAttributeValue(embProcessIdentifier.name)
                 )
             )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogService.kt
@@ -19,12 +19,14 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.session.orchestrator.PayloadStore
 import io.embrace.android.embracesdk.internal.utils.PropertyUtils.truncate
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import java.io.Serializable
 
 /**
  * Creates log records to be sent using the Open Telemetry Logs data model.
  */
+@OptIn(IncubatingApi::class)
 class EmbraceLogService(
     private val logWriter: LogWriter,
     private val configService: ConfigService,
@@ -100,7 +102,7 @@ class EmbraceLogService(
                 null
             },
         )
-        attributes.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key, Uuid.getEmbUuid())
+        attributes.setAttribute(LogAttributes.LOG_RECORD_UID, Uuid.getEmbUuid())
         logAttrs.forEach {
             attributes.setAttribute(it.key, it.value)
         }
@@ -116,7 +118,7 @@ class EmbraceLogService(
         if (shouldLogBeGated(severity)) {
             return
         }
-        val logId = attributes.getAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key)
+        val logId = attributes.getAttribute(LogAttributes.LOG_RECORD_UID)
         if (logId == null || !logCounters.getValue(severity).addIfAllowed()) {
             return
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkLoggingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkLoggingService.kt
@@ -11,10 +11,10 @@ import io.embrace.android.embracesdk.internal.utils.NetworkUtils.stripUrl
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.semconv.ErrorAttributes
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.HttpAttributes
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ErrorAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.HttpAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 
 /**
  * Logs network calls according to defined limits per domain.
@@ -84,14 +84,15 @@ internal class EmbraceNetworkLoggingService(
         }
     }
 
+    @OptIn(IncubatingApi::class)
     private fun generateSchemaAttributes(networkRequest: EmbraceNetworkRequest): Map<String, String> = mapOf(
         "url.full" to stripUrl(networkRequest.url),
-        HttpAttributes.HTTP_REQUEST_METHOD.key to networkRequest.httpMethod,
-        HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key to networkRequest.responseCode,
-        HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key to networkRequest.bytesSent,
-        HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key to networkRequest.bytesReceived,
-        ErrorAttributes.ERROR_TYPE.key to networkRequest.errorType,
-        ExceptionAttributes.EXCEPTION_MESSAGE.key to networkRequest.errorMessage,
+        HttpAttributes.HTTP_REQUEST_METHOD to networkRequest.httpMethod,
+        HttpAttributes.HTTP_RESPONSE_STATUS_CODE to networkRequest.responseCode,
+        HttpAttributes.HTTP_REQUEST_BODY_SIZE to networkRequest.bytesSent,
+        HttpAttributes.HTTP_RESPONSE_BODY_SIZE to networkRequest.bytesReceived,
+        ErrorAttributes.ERROR_TYPE to networkRequest.errorType,
+        ExceptionAttributes.EXCEPTION_MESSAGE to networkRequest.errorMessage,
         "emb.w3c_traceparent" to networkRequest.w3cTraceparent,
         "emb.trace_id" to getValidTraceId(networkRequest.traceId),
     ).toNonNullMap().mapValues { it.value.toString() }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeExt.kt
@@ -3,15 +3,17 @@ package io.embrace.android.embracesdk.internal.payload
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 
 fun Envelope<SessionPayload>.getSessionSpan(): Span? {
     return data.spans?.singleOrNull { it.hasEmbraceAttribute(EmbType.Ux.Session) }
         ?: data.spanSnapshots?.singleOrNull { it.hasEmbraceAttribute(EmbType.Ux.Session) }
 }
 
+@OptIn(IncubatingApi::class)
 fun Envelope<SessionPayload>.getSessionId(): String? {
-    return getSessionSpan()?.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key)
+    return getSessionSpan()?.attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
 }
 
 fun Envelope<SessionPayload>.getSessionProperties(): Map<String, String> {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -32,7 +32,8 @@ import io.embrace.android.embracesdk.internal.payload.getSessionProperties
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.Provider
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import java.util.Locale
 import java.util.zip.GZIPInputStream
 import kotlin.math.max
@@ -246,8 +247,9 @@ internal class PayloadResurrectionServiceImpl(
     /**
      * Attach crash data to the existing session span in the payload if it exists
      */
+    @OptIn(IncubatingApi::class)
     private fun Span.attachCrashToSession(nativeCrashData: NativeCrashData): Span {
-        return if (attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key) == nativeCrashData.sessionId) {
+        return if (attributes?.findAttributeValue(SessionAttributes.SESSION_ID) == nativeCrashData.sessionId) {
             copy(
                 attributes = attributes?.plus(
                     Attribute(

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/destination/LogWriterImplTest.kt
@@ -14,8 +14,9 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embState
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.session.id.SessionData
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -24,7 +25,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 internal class LogWriterImplTest {
     private lateinit var logger: FakeOpenTelemetryLogger
     private lateinit var sessionIdTracker: FakeSessionIdTracker
@@ -61,9 +62,9 @@ internal class LogWriterImplTest {
         with(logger.logs.single()) {
             assertEquals("test", body)
             assertEquals(Severity.ERROR.name, severityNumber?.name)
-            assertEquals("fake-session-id", attributes[SessionIncubatingAttributes.SESSION_ID.key])
+            assertEquals("fake-session-id", attributes[SessionAttributes.SESSION_ID])
             assertNotNull(attributes[embState.name])
-            assertNotNull(attributes[LogIncubatingAttributes.LOG_RECORD_UID.key])
+            assertNotNull(attributes[LogAttributes.LOG_RECORD_UID])
             assertTrue(attributes[PrivateSpan.key.name] != null)
             assertEquals(clock.now().millisToNanos(), timestamp)
             assertNull(observedTimestamp)
@@ -105,7 +106,7 @@ internal class LogWriterImplTest {
         with(logger.logs.last()) {
             assertEquals(
                 "foreground-session",
-                attributes[SessionIncubatingAttributes.SESSION_ID.key]
+                attributes[SessionAttributes.SESSION_ID]
             )
             assertEquals("foreground", attributes[embState.name])
         }
@@ -122,7 +123,7 @@ internal class LogWriterImplTest {
         )
 
         with(logger.logs.last()) {
-            assertNull(attributes[SessionIncubatingAttributes.SESSION_ID.key])
+            assertNull(attributes[SessionAttributes.SESSION_ID])
             assertEquals("background", attributes[embState.name])
         }
     }
@@ -154,7 +155,7 @@ internal class LogWriterImplTest {
         )
 
         with(logger.logs.last()) {
-            assertNull(attributes[SessionIncubatingAttributes.SESSION_ID.key])
+            assertNull(attributes[SessionAttributes.SESSION_ID])
             assertNull(attributes[embState.name])
         }
     }
@@ -169,7 +170,7 @@ internal class LogWriterImplTest {
         )
 
         with(logger.logs.last()) {
-            assertNull(attributes[SessionIncubatingAttributes.SESSION_ID.key])
+            assertNull(attributes[SessionAttributes.SESSION_ID])
             assertEquals("background", attributes[embState.name])
         }
     }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
@@ -5,12 +5,14 @@ import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesS
 import io.embrace.android.embracesdk.internal.otel.attrs.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.session.getSessionProperty
 import io.embrace.android.embracesdk.internal.utils.Uuid
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(IncubatingApi::class)
 internal class TelemetryAttributesTest {
 
     private lateinit var customAttributes: Map<String, String>
@@ -28,14 +30,14 @@ internal class TelemetryAttributesTest {
     @Test
     fun `only schema properties`() {
         telemetryAttributes = TelemetryAttributes()
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
-        telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE.key, "exceptionValue")
+        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, "exceptionValue")
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
-        assertEquals(sessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
-        assertEquals("exceptionValue", attributes[ExceptionAttributes.EXCEPTION_TYPE.key])
-        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionIncubatingAttributes.SESSION_ID.key))
-        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE.key))
+        assertEquals(sessionId, attributes[SessionAttributes.SESSION_ID])
+        assertEquals("exceptionValue", attributes[ExceptionAttributes.EXCEPTION_TYPE])
+        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionAttributes.SESSION_ID))
+        assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE))
     }
 
     @Test
@@ -44,7 +46,7 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        val sessionIdKey = SessionIncubatingAttributes.SESSION_ID.key
+        val sessionIdKey = SessionAttributes.SESSION_ID
         telemetryAttributes.setAttribute(sessionIdKey, sessionId)
         sessionPropertiesService.addProperty("perm", "permVal", true)
         sessionPropertiesService.addProperty("temp", "tempVal", false)
@@ -64,7 +66,7 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
         )
-        val sessionIdKey = SessionIncubatingAttributes.SESSION_ID.key
+        val sessionIdKey = SessionAttributes.SESSION_ID
         telemetryAttributes.setAttribute(sessionIdKey, sessionId)
         telemetryAttributes.setAttribute(sessionIdKey, newSessionId)
         sessionPropertiesService.addProperty("perm", "permVal", true)
@@ -83,12 +85,12 @@ internal class TelemetryAttributesTest {
     fun `schema attribute values take priority if the same key is used`() {
         val newSessionId = Uuid.getEmbUuid()
         telemetryAttributes = TelemetryAttributes(
-            customAttributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to sessionId)
+            customAttributes = mapOf(SessionAttributes.SESSION_ID to sessionId)
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, newSessionId)
+        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, newSessionId)
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
-        assertEquals(newSessionId, attributes[SessionIncubatingAttributes.SESSION_ID.key])
+        assertEquals(newSessionId, attributes[SessionAttributes.SESSION_ID])
     }
 
     @Test
@@ -100,7 +102,7 @@ internal class TelemetryAttributesTest {
             sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
+        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(4, attributes.size)
@@ -112,7 +114,7 @@ internal class TelemetryAttributesTest {
         val blankishValues = listOf("", " ", "null", "NULL")
 
         // Give me Union types, plz
-        val sessionIdKey = SessionIncubatingAttributes.SESSION_ID.key
+        val sessionIdKey = SessionAttributes.SESSION_ID
         blankishValues.forEach { value ->
             telemetryAttributes.setAttribute(sessionIdKey, value, true)
             assertEquals(value, telemetryAttributes.getAttribute(sessionIdKey))

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
@@ -17,12 +17,14 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.otel.logs.LogRequest
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(IncubatingApi::class)
 internal class LogEnvelopeSourceImplTest {
 
     private val fakeBatchedPayload = LogPayload(logs = listOf(testLog))
@@ -97,7 +99,7 @@ internal class LogEnvelopeSourceImplTest {
     fun `check native crash envelope`() {
         val crashPayload = LogPayload(logs = listOf(nativeCrashLog))
         val crashLogAttributes = checkNotNull(nativeCrashLog.attributes)
-        val expectedSessionId = crashLogAttributes.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key)
+        val expectedSessionId = crashLogAttributes.findAttributeValue(SessionAttributes.SESSION_ID)
         val expectedProcessIdentifier = crashLogAttributes.findAttributeValue(embProcessIdentifier.name)
         val cachedCrashEnvelopeMetadata = createNativeCrashEnvelopeMetadata(
             sessionId = expectedSessionId,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -17,13 +17,15 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
 import io.embrace.android.embracesdk.internal.logs.attachments.Attachment
 import io.embrace.android.embracesdk.internal.payload.AppFramework
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(IncubatingApi::class)
 internal class EmbraceLogServiceTest {
 
     private lateinit var logService: EmbraceLogService
@@ -80,12 +82,12 @@ internal class EmbraceLogServiceTest {
         val log = fakeLogWriter.logEvents.single()
         val attributes = log.schemaType.attributes()
         assertEquals("someValue", attributes["someProperty".toSessionPropertyAttributeName()])
-        assertTrue(attributes.containsKey(LogIncubatingAttributes.LOG_RECORD_UID.key))
+        assertTrue(attributes.containsKey(LogAttributes.LOG_RECORD_UID))
     }
 
     @Test
     fun `Embrace properties can not be overridden by custom properties`() {
-        val props = mapOf(LogIncubatingAttributes.LOG_RECORD_UID.key to "fakeUid")
+        val props = mapOf(LogAttributes.LOG_RECORD_UID to "fakeUid")
         logService.log(
             message = "Hello world",
             severity = Severity.INFO,
@@ -96,7 +98,7 @@ internal class EmbraceLogServiceTest {
         val log = fakeLogWriter.logEvents.single()
         assertNotEquals(
             "fakeUid",
-            log.schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key]
+            log.schemaType.attributes()[LogAttributes.LOG_RECORD_UID]
         )
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanAttributeTests.kt
@@ -7,12 +7,14 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(IncubatingApi::class)
 internal class CurrentSessionSpanAttributeTests {
 
     private lateinit var spanRepository: SpanRepository
@@ -52,7 +54,7 @@ internal class CurrentSessionSpanAttributeTests {
     }
 
     private fun EmbraceSpanData.assertCommonSessionSpanAttrs() {
-        assertNotNull(attributes.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+        assertNotNull(attributes.findAttributeValue(SessionAttributes.SESSION_ID))
         assertEquals("ux.session", attributes.findAttributeValue("emb.type"))
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/CurrentSessionSpanImplTests.kt
@@ -35,8 +35,9 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.Clock
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -46,7 +47,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 internal class CurrentSessionSpanImplTests {
 
     private lateinit var spanRepository: SpanRepository
@@ -581,7 +582,7 @@ internal class CurrentSessionSpanImplTests {
     @Test
     fun `span stop callback creates the correct span links`() {
         val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
-        val sessionId = checkNotNull(sessionSpan.getSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key))
+        val sessionId = checkNotNull(sessionSpan.getSystemAttribute(SessionAttributes.SESSION_ID))
         val span = spanService.startSpan("test")?.apply {
             stop()
         }
@@ -592,7 +593,7 @@ internal class CurrentSessionSpanImplTests {
         checkNotNull(spanSnapshot.links).single().validateSystemLink(
             linkedSpan = sessionSpanSnapshot,
             type = LinkType.EndSession,
-            expectedAttributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to sessionId)
+            expectedAttributes = mapOf(SessionAttributes.SESSION_ID to sessionId)
         )
         checkNotNull(sessionSpanSnapshot.links).single().validateSystemLink(spanSnapshot, LinkType.EndedIn)
     }

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -20,12 +20,11 @@ dependencies {
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.context)
-    compileOnly(libs.opentelemetry.semconv)
-    compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.lifecycle.process)
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.semconv)
     implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(project(":embrace-android-api"))
@@ -37,8 +36,6 @@ dependencies {
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)
     testImplementation(libs.opentelemetry.context)
-    testImplementation(libs.opentelemetry.semconv)
-    testImplementation(libs.opentelemetry.semconv.incubating)
     testImplementation(libs.protobuf.java)
     testImplementation(libs.protobuf.java.util)
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrOtelMapper.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/anr/AnrOtelMapper.kt
@@ -14,8 +14,8 @@ import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.factory.TracingIdFactory
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.JvmAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.JvmAttributes
 
 /**
  * Maps captured ANRs to OTel constructs.
@@ -88,12 +88,12 @@ class AnrOtelMapper(
             attrs.add(Attribute("sample_code", it.toString()))
         }
         sample.threads?.singleOrNull()?.let { thread ->
-            attrs.add(Attribute(JvmAttributes.JVM_THREAD_STATE.key, thread.state.toString()))
+            attrs.add(Attribute(JvmAttributes.JVM_THREAD_STATE, thread.state.toString()))
             attrs.add(Attribute("thread_priority", thread.priority.toString()))
             attrs.add(Attribute("frame_count", thread.frameCount.toString()))
 
             thread.lines?.let { lines ->
-                attrs.add(Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, lines.joinToString("\n")))
+                attrs.add(Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE, lines.joinToString("\n")))
             }
         }
         return SpanEvent(

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImpl.kt
@@ -20,8 +20,9 @@ import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.utils.getThreadInfo
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -58,6 +59,7 @@ internal class CrashDataSourceImpl(
      *
      * @param exception the exception thrown by the thread
      */
+    @OptIn(IncubatingApi::class)
     override fun handleCrash(exception: Throwable) {
         if (!mainCrashHandled) {
             mainCrashHandled = true
@@ -69,19 +71,19 @@ internal class CrashDataSourceImpl(
             )
 
             val crashException = LegacyExceptionInfo.ofThrowable(exception)
-            crashAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE.key, crashException.name)
+            crashAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, crashException.name)
             crashAttributes.setAttribute(
-                ExceptionAttributes.EXCEPTION_MESSAGE.key,
+                ExceptionAttributes.EXCEPTION_MESSAGE,
                 crashException.message
                     ?: ""
             )
             crashAttributes.setAttribute(
-                ExceptionAttributes.EXCEPTION_STACKTRACE.key,
+                ExceptionAttributes.EXCEPTION_STACKTRACE,
                 encodeToUTF8String(
                     serializer.toJson(crashException.lines, List::class.java),
                 ),
             )
-            crashAttributes.setAttribute(LogIncubatingAttributes.LOG_RECORD_UID.key, crashId)
+            crashAttributes.setAttribute(LogAttributes.LOG_RECORD_UID, crashId)
             crashAttributes.setAttribute(embCrashNumber, crashNumber.toString())
             crashAttributes.setAttribute(
                 EmbType.System.Crash.embAndroidCrashExceptionCause,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImpl.kt
@@ -12,7 +12,8 @@ import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 
 internal class NativeCrashDataSourceImpl(
     private val nativeCrashProcessor: NativeCrashProcessor,
@@ -33,6 +34,7 @@ internal class NativeCrashDataSourceImpl(
 
     override fun getNativeCrashes(): List<NativeCrashData> = nativeCrashProcessor.getNativeCrashes()
 
+    @OptIn(IncubatingApi::class)
     override fun sendNativeCrash(
         nativeCrash: NativeCrashData,
         sessionProperties: Map<String, String>,
@@ -43,7 +45,7 @@ internal class NativeCrashDataSourceImpl(
             sessionPropertiesProvider = { sessionProperties }
         )
         crashAttributes.setAttribute(
-            key = SessionIncubatingAttributes.SESSION_ID.key,
+            key = SessionAttributes.SESSION_ID,
             value = nativeCrash.sessionId,
             keepBlankishValues = false,
         )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/AnrOtelMapperTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/anr/AnrOtelMapperTest.kt
@@ -16,8 +16,8 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.payload.ThreadInfo
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.JvmAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.JvmAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -243,12 +243,12 @@ internal class AnrOtelMapperTest {
 
         // validate threads
         val thread = checkNotNull(sample.threads?.single())
-        assertEquals(thread.state.toString(), attrs.findAttribute(JvmAttributes.JVM_THREAD_STATE.key).data)
+        assertEquals(thread.state.toString(), attrs.findAttribute(JvmAttributes.JVM_THREAD_STATE).data)
         assertEquals(thread.priority, attrs.findAttribute("thread_priority").data?.toInt())
         assertEquals(thread.frameCount, attrs.findAttribute("frame_count").data?.toInt())
         assertEquals(
             thread.lines?.joinToString("\n"),
-            attrs.findAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key).data
+            attrs.findAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE).data
         )
     }
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/CrashDataSourceImplTest.kt
@@ -15,7 +15,8 @@ import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.JsException
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
@@ -23,6 +24,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(IncubatingApi::class)
 internal class CrashDataSourceImplTest {
 
     private lateinit var crashDataSource: CrashDataSourceImpl
@@ -111,7 +113,7 @@ internal class CrashDataSourceImplTest {
         assertEquals(1, logWriter.logEvents.size)
         val lastSentCrash = logWriter.logEvents.single()
         assertEquals(
-            logWriter.logEvents.single().schemaType.attributes()[LogIncubatingAttributes.LOG_RECORD_UID.key],
+            logWriter.logEvents.single().schemaType.attributes()[LogAttributes.LOG_RECORD_UID],
             sessionOrchestrator.crashId
         )
 
@@ -145,7 +147,7 @@ internal class CrashDataSourceImplTest {
         val lastSentCrashAttributes = logEvent.schemaType.attributes()
         assertEquals(1, anrService.crashCount)
         assertEquals(1, logWriter.logEvents.size)
-        assertEquals(lastSentCrashAttributes[LogIncubatingAttributes.LOG_RECORD_UID.key], sessionOrchestrator.crashId)
+        assertEquals(lastSentCrashAttributes[LogAttributes.LOG_RECORD_UID], sessionOrchestrator.crashId)
         assertEquals(
             "{\"n\":\"NullPointerException\",\"" +
                 "m\":\"Null pointer exception occurred\",\"" +

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/InternalErrorDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crash/InternalErrorDataSourceImplTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
-import io.opentelemetry.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -35,9 +35,9 @@ internal class InternalErrorDataSourceImplTest {
         dataSource.trackInternalError(InternalErrorType.DELIVERY_SCHEDULING_FAIL, IllegalStateException())
         val data = logWriter.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
-        assertEquals("java.lang.IllegalStateException", attrs[ExceptionAttributes.EXCEPTION_TYPE.key])
-        assertEquals("", attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key])
-        assertNotNull(attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key])
+        assertEquals("java.lang.IllegalStateException", attrs[ExceptionAttributes.EXCEPTION_TYPE])
+        assertEquals("", attrs[ExceptionAttributes.EXCEPTION_MESSAGE])
+        assertNotNull(attrs[ExceptionAttributes.EXCEPTION_STACKTRACE])
     }
 
     @Test
@@ -45,9 +45,9 @@ internal class InternalErrorDataSourceImplTest {
         dataSource.trackInternalError(InternalErrorType.DELIVERY_SCHEDULING_FAIL, IllegalArgumentException("Whoops!"))
         val data = logWriter.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
-        assertEquals("java.lang.IllegalArgumentException", attrs[ExceptionAttributes.EXCEPTION_TYPE.key])
-        assertEquals("Whoops!", attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key])
-        assertNotNull(attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key])
+        assertEquals("java.lang.IllegalArgumentException", attrs[ExceptionAttributes.EXCEPTION_TYPE])
+        assertEquals("Whoops!", attrs[ExceptionAttributes.EXCEPTION_MESSAGE])
+        assertNotNull(attrs[ExceptionAttributes.EXCEPTION_STACKTRACE])
     }
 
     @Test

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crumbs/WebViewUrlDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crumbs/WebViewUrlDataSourceTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.fakes.behavior.FakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
-import io.opentelemetry.semconv.UrlAttributes
+import io.embrace.opentelemetry.kotlin.semconv.UrlAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -44,7 +44,7 @@ internal class WebViewUrlDataSourceTest {
             assertEquals(15000000000, spanStartTimeMs)
             assertEquals(
                 mapOf(
-                    UrlAttributes.URL_FULL.key to "http://www.google.com?query=123"
+                    UrlAttributes.URL_FULL to "http://www.google.com?query=123"
                 ),
                 schemaType.attributes()
             )
@@ -73,7 +73,7 @@ internal class WebViewUrlDataSourceTest {
             assertEquals(15000000000, spanStartTimeMs)
             assertEquals(
                 mapOf(
-                    UrlAttributes.URL_FULL.key to "http://www.google.com"
+                    UrlAttributes.URL_FULL to "http://www.google.com"
                 ),
                 schemaType.attributes()
             )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/webview/EmbraceWebViewServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/webview/EmbraceWebViewServiceTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.payload.WebVital
 import io.embrace.android.embracesdk.internal.payload.WebVitalType
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.opentelemetry.semconv.UrlAttributes
+import io.embrace.opentelemetry.kotlin.semconv.UrlAttributes
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -70,7 +70,7 @@ internal class EmbraceWebViewServiceTest {
             val webViewInfo = it.schemaType as SchemaType.WebViewInfo
             Assert.assertEquals(
                 "https://embrace.io/",
-                webViewInfo.attributes()[UrlAttributes.URL_FULL.key]
+                webViewInfo.attributes()[UrlAttributes.URL_FULL]
             )
             val webVitals = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { it1 ->
                 serializer.fromJson(it1, List::class.java)
@@ -90,7 +90,7 @@ internal class EmbraceWebViewServiceTest {
             val webViewInfo = it.schemaType as SchemaType.WebViewInfo
             Assert.assertEquals(
                 "https://embrace.io/",
-                webViewInfo.attributes()[UrlAttributes.URL_FULL.key]
+                webViewInfo.attributes()[UrlAttributes.URL_FULL]
             )
             val webVitals = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { it1 ->
                 serializer.fromJson(it1, List::class.java)
@@ -110,7 +110,7 @@ internal class EmbraceWebViewServiceTest {
         val webViewInfo = event.schemaType as SchemaType.WebViewInfo
         Assert.assertEquals(
             "https://embrace.io/",
-            webViewInfo.attributes()[UrlAttributes.URL_FULL.key]
+            webViewInfo.attributes()[UrlAttributes.URL_FULL]
         )
         val webVitals: List<WebVital>? = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { wv ->
             val type = TypeUtils.typedList(WebVital::class)
@@ -138,7 +138,7 @@ internal class EmbraceWebViewServiceTest {
             val webViewInfo = it.schemaType as SchemaType.WebViewInfo
             Assert.assertEquals(
                 "https://embrace.io/",
-                webViewInfo.attributes()[UrlAttributes.URL_FULL.key]
+                webViewInfo.attributes()[UrlAttributes.URL_FULL]
             )
             val webVitals = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { it1 ->
                 serializer.fromJson(it1, List::class.java)
@@ -157,7 +157,7 @@ internal class EmbraceWebViewServiceTest {
         val webViewInfo = event.schemaType as SchemaType.WebViewInfo
         Assert.assertEquals(
             "https://embrace.io/",
-            webViewInfo.attributes()[UrlAttributes.URL_FULL.key]
+            webViewInfo.attributes()[UrlAttributes.URL_FULL]
         )
         val webVitals: List<WebVital>? = webViewInfo.attributes()["emb.webview_info.web_vitals"]?.let { wv ->
             val type = TypeUtils.typedList(WebVital::class)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/webview/WebViewDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/webview/WebViewDataSourceTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.payload.WebViewInfo
 import io.embrace.android.embracesdk.internal.payload.WebVital
 import io.embrace.android.embracesdk.internal.payload.WebVitalType
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.opentelemetry.semconv.UrlAttributes
+import io.embrace.opentelemetry.kotlin.semconv.UrlAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -44,8 +44,8 @@ internal class WebViewDataSourceTest {
         dataSource.loadDataIntoSession(listOf(webViewInfo1, webViewInfo2))
         assertEquals(2, writer.addedEvents.size)
         assertEquals(2, writer.addedEvents.count { it.schemaType.fixedObjectName == "webview-info" })
-        assertEquals("https://example1.com", writer.addedEvents[0].schemaType.attributes()[UrlAttributes.URL_FULL.key])
-        assertEquals("https://example2.com", writer.addedEvents[1].schemaType.attributes()[UrlAttributes.URL_FULL.key])
+        assertEquals("https://example1.com", writer.addedEvents[0].schemaType.attributes()[UrlAttributes.URL_FULL])
+        assertEquals("https://example2.com", writer.addedEvents[1].schemaType.attributes()[UrlAttributes.URL_FULL])
     }
 
     private fun getWebViewInfo(url: String): WebViewInfo {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/ndk/NativeCrashDataSourceImplTest.kt
@@ -24,8 +24,9 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -33,7 +34,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 internal class NativeCrashDataSourceImplTest {
 
     private lateinit var crashProcessor: FakeNativeCrashProcessor
@@ -95,10 +96,10 @@ internal class NativeCrashDataSourceImplTest {
             assertTrue(attributes[EmbType.System.NativeCrash.key.name] != null)
             assertEquals("value", attributes["prop".toSessionPropertyAttributeName()])
             assertEquals("background", attributes[embState.name])
-            assertNotNull(attributes[LogIncubatingAttributes.LOG_RECORD_UID.key])
+            assertNotNull(attributes[LogAttributes.LOG_RECORD_UID])
             assertEquals(
                 testNativeCrashData.sessionId,
-                attributes[SessionIncubatingAttributes.SESSION_ID.key]
+                attributes[SessionAttributes.SESSION_ID]
             )
             assertEquals("1", attributes[embCrashNumber.name])
             assertEquals(testNativeCrashData.crash, attributes[embNativeCrashException.name])
@@ -125,8 +126,8 @@ internal class NativeCrashDataSourceImplTest {
 
         with(otelLogger.logs.single()) {
             assertTrue(attributes[EmbType.System.NativeCrash.key.name] != null)
-            assertNotNull(attributes[LogIncubatingAttributes.LOG_RECORD_UID.key])
-            assertNull(attributes[SessionIncubatingAttributes.SESSION_ID.key])
+            assertNotNull(attributes[LogAttributes.LOG_RECORD_UID])
+            assertNull(attributes[SessionAttributes.SESSION_ID])
             assertEquals("1", attributes[embCrashNumber.name])
             assertNull(attributes[embNativeCrashException.name])
             assertNull(attributes[embNativeCrashSymbols.name])
@@ -149,8 +150,8 @@ internal class NativeCrashDataSourceImplTest {
 
         with(otelLogger.logs.single()) {
             assertTrue(attributes[EmbType.System.NativeCrash.key.name] != null)
-            assertNotNull(attributes[LogIncubatingAttributes.LOG_RECORD_UID.key])
-            assertNull(attributes[SessionIncubatingAttributes.SESSION_ID.key])
+            assertNotNull(attributes[LogAttributes.LOG_RECORD_UID])
+            assertNull(attributes[SessionAttributes.SESSION_ID])
             assertEquals("1", attributes[embCrashNumber.name])
             assertNull(attributes[embState.name])
             assertNull(attributes[embNativeCrashException.name])

--- a/embrace-android-otel/build.gradle.kts
+++ b/embrace-android-otel/build.gradle.kts
@@ -21,19 +21,15 @@ dependencies {
     testImplementation(project(":embrace-android-api"))
 
     compileOnly(libs.opentelemetry.api)
-    compileOnly(libs.opentelemetry.semconv)
-    compileOnly(libs.opentelemetry.semconv.incubating)
-    implementation(libs.opentelemetry.java.aliases)
 
     testImplementation(platform(libs.opentelemetry.bom))
     testImplementation(libs.opentelemetry.api)
     testImplementation(libs.opentelemetry.sdk)
-    testImplementation(libs.opentelemetry.semconv)
-    testImplementation(libs.opentelemetry.semconv.incubating)
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
     implementation(libs.opentelemetry.kotlin.sdk)
     implementation(libs.opentelemetry.kotlin.compat)
+    implementation(libs.opentelemetry.kotlin.semconv)
     implementation(libs.opentelemetry.java.aliases)
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -11,13 +11,14 @@ import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.embrace.opentelemetry.kotlin.logging.export.LogRecordExporter
+import io.embrace.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.embrace.opentelemetry.kotlin.semconv.DeviceAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.OsAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ServiceAttributes
+import io.embrace.opentelemetry.kotlin.semconv.TelemetryAttributes
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanExporter
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
-import io.opentelemetry.semconv.ServiceAttributes
-import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -39,20 +40,21 @@ class OtelSdkConfig(
 
     private val customAttributes: MutableMap<String, String> = ConcurrentHashMap()
 
+    @OptIn(IncubatingApi::class)
     val resourceAction: MutableAttributeContainer.() -> Unit
         get() = {
-            setStringAttribute(ServiceAttributes.SERVICE_NAME.key, sdkName)
-            setStringAttribute(ServiceAttributes.SERVICE_VERSION.key, sdkVersion)
-            setStringAttribute(OsIncubatingAttributes.OS_NAME.key, systemInfo.osName)
-            setStringAttribute(OsIncubatingAttributes.OS_VERSION.key, systemInfo.osVersion)
-            setStringAttribute(OsIncubatingAttributes.OS_TYPE.key, systemInfo.osType)
-            setStringAttribute(OsIncubatingAttributes.OS_BUILD_ID.key, systemInfo.osBuild)
-            setStringAttribute(AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL.key, systemInfo.androidOsApiLevel)
-            setStringAttribute(DeviceIncubatingAttributes.DEVICE_MANUFACTURER.key, systemInfo.deviceManufacturer)
-            setStringAttribute(DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER.key, systemInfo.deviceModel)
-            setStringAttribute(DeviceIncubatingAttributes.DEVICE_MODEL_NAME.key, systemInfo.deviceModel)
-            setStringAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME.key, sdkName)
-            setStringAttribute(TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION.key, sdkVersion)
+            setStringAttribute(ServiceAttributes.SERVICE_NAME, sdkName)
+            setStringAttribute(ServiceAttributes.SERVICE_VERSION, sdkVersion)
+            setStringAttribute(OsAttributes.OS_NAME, systemInfo.osName)
+            setStringAttribute(OsAttributes.OS_VERSION, systemInfo.osVersion)
+            setStringAttribute(OsAttributes.OS_TYPE, systemInfo.osType)
+            setStringAttribute(OsAttributes.OS_BUILD_ID, systemInfo.osBuild)
+            setStringAttribute(AndroidAttributes.ANDROID_OS_API_LEVEL, systemInfo.androidOsApiLevel)
+            setStringAttribute(DeviceAttributes.DEVICE_MANUFACTURER, systemInfo.deviceManufacturer)
+            setStringAttribute(DeviceAttributes.DEVICE_MODEL_IDENTIFIER, systemInfo.deviceModel)
+            setStringAttribute(DeviceAttributes.DEVICE_MODEL_NAME, systemInfo.deviceModel)
+            setStringAttribute(TelemetryAttributes.TELEMETRY_DISTRO_NAME, sdkName)
+            setStringAttribute(TelemetryAttributes.TELEMETRY_DISTRO_VERSION, sdkVersion)
 
             customAttributes.forEach {
                 setStringAttribute(it.key, it.value)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.opentelemetry.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 
 fun EmbraceSpanData.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =
     embraceAttribute.value == attributes[embraceAttribute.key.name]
@@ -26,7 +26,7 @@ fun String.toEmbraceUsageAttributeName(): String = EMBRACE_USAGE_ATTRIBUTE_NAME_
 
 fun String.isValidLongValueAttribute(): Boolean = longValueAttributes.contains(this)
 
-private val longValueAttributes: Set<String> = setOf(ExceptionAttributes.EXCEPTION_STACKTRACE.key)
+private val longValueAttributes: Set<String> = setOf(ExceptionAttributes.EXCEPTION_STACKTRACE)
 
 fun List<Attribute>.hasEmbraceAttributeKey(embraceAttributeKey: EmbraceAttributeKey): Boolean = any {
     it.key == embraceAttributeKey.name

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -32,13 +32,13 @@ import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.toOtelJavaContextKey
 import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import io.opentelemetry.context.ImplicitContextKeyed
 import io.opentelemetry.context.Scope
-import io.opentelemetry.semconv.ExceptionAttributes
 import java.util.Queue
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -225,15 +225,16 @@ private class EmbraceSpanImpl(
                 eventAttributes.putAll(attributes)
             }
 
+//            io.embrace.opentelemetry.kotlin.semconv.ErrorAttributes
             exception.javaClass.canonicalName?.let { type ->
-                eventAttributes[ExceptionAttributes.EXCEPTION_TYPE.key] = type
+                eventAttributes[ ExceptionAttributes.EXCEPTION_TYPE] = type
             }
 
             exception.message?.let { message ->
-                eventAttributes[ExceptionAttributes.EXCEPTION_MESSAGE.key] = message
+                eventAttributes[ExceptionAttributes.EXCEPTION_MESSAGE] = message
             }
 
-            eventAttributes[ExceptionAttributes.EXCEPTION_STACKTRACE.key] = exception.truncatedStacktraceText()
+            eventAttributes[ExceptionAttributes.EXCEPTION_STACKTRACE] = exception.truncatedStacktraceText()
 
             dataValidator.createTruncatedSpanEvent(
                 name = dataValidator.otelLimitsConfig.getExceptionEventName(),

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
@@ -5,10 +5,11 @@ import io.embrace.android.embracesdk.internal.otel.attrs.embSequenceId
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.export.OperationResultCode
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import io.embrace.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.embrace.opentelemetry.kotlin.tracing.model.ReadableSpan
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import java.util.concurrent.atomic.AtomicLong
 
 @OptIn(ExperimentalApi::class)
@@ -19,11 +20,12 @@ class EmbraceSpanProcessor(
 
     private val counter = AtomicLong(1)
 
+    @OptIn(IncubatingApi::class)
     override fun onStart(span: ReadWriteSpan, parentContext: Context) {
         span.setStringAttribute(embSequenceId.name, counter.getAndIncrement().toString())
         span.setStringAttribute(embProcessIdentifier.name, processIdentifier)
         sessionIdProvider()?.let { sessionId ->
-            span.setStringAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
+            span.setStringAttribute(SessionAttributes.SESSION_ID, sessionId)
         }
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
@@ -5,15 +5,16 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSinkImpl
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.semconv.ServiceAttributes
-import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.embrace.opentelemetry.kotlin.semconv.DeviceAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.OsAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ServiceAttributes
+import io.embrace.opentelemetry.kotlin.semconv.TelemetryAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 internal class OtelSdkConfigTest {
 
     @Test
@@ -40,17 +41,17 @@ internal class OtelSdkConfigTest {
         val expected = mapOf(
             ServiceAttributes.SERVICE_NAME to configuration.sdkName,
             ServiceAttributes.SERVICE_VERSION to configuration.sdkVersion,
-            TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME to configuration.sdkName,
-            TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION to configuration.sdkVersion,
-            OsIncubatingAttributes.OS_NAME to systemInfo.osName,
-            OsIncubatingAttributes.OS_VERSION to systemInfo.osVersion,
-            OsIncubatingAttributes.OS_TYPE to systemInfo.osType,
-            OsIncubatingAttributes.OS_BUILD_ID to systemInfo.osBuild,
-            AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL to systemInfo.androidOsApiLevel,
-            DeviceIncubatingAttributes.DEVICE_MANUFACTURER to systemInfo.deviceManufacturer,
-            DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER to systemInfo.deviceModel,
-            DeviceIncubatingAttributes.DEVICE_MODEL_NAME to systemInfo.deviceModel
-        ).mapKeys { it.key.key }
+            TelemetryAttributes.TELEMETRY_DISTRO_NAME to configuration.sdkName,
+            TelemetryAttributes.TELEMETRY_DISTRO_VERSION to configuration.sdkVersion,
+            OsAttributes.OS_NAME to systemInfo.osName,
+            OsAttributes.OS_VERSION to systemInfo.osVersion,
+            OsAttributes.OS_TYPE to systemInfo.osType,
+            OsAttributes.OS_BUILD_ID to systemInfo.osBuild,
+            AndroidAttributes.ANDROID_OS_API_LEVEL to systemInfo.androidOsApiLevel,
+            DeviceAttributes.DEVICE_MANUFACTURER to systemInfo.deviceManufacturer,
+            DeviceAttributes.DEVICE_MODEL_IDENTIFIER to systemInfo.deviceModel,
+            DeviceAttributes.DEVICE_MODEL_NAME to systemInfo.deviceModel
+        ).mapKeys { it.key }
         assertEquals(expected, attrs)
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -44,9 +44,9 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.getTracer
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
-import io.opentelemetry.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -287,12 +287,12 @@ internal class EmbraceSpanImplTest {
                 assertEquals(timestampNanos, timestampNanos)
                 assertEquals(
                     IllegalStateException::class.java.canonicalName,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE.key }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE }.data
                 )
-                assertEquals("oops", attrs.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE.key }.data)
+                assertEquals("oops", attrs.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE }.data)
                 assertEquals(
                     firstExceptionStackTrace,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE.key }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE }.data
                 )
             }
             with(sanitizedEvents[1]) {
@@ -301,13 +301,13 @@ internal class EmbraceSpanImplTest {
                 assertEquals(timestampNanos, timestampNanos)
                 assertEquals(
                     RuntimeException::class.java.canonicalName,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE.key }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE }.data
                 )
-                assertEquals("haha", attrs.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE.key }.data)
+                assertEquals("haha", attrs.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE }.data)
                 assertEquals("myValue", attrs.single { it.key == "myKey" }.data)
                 assertEquals(
                     secondExceptionStackTrace,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE.key }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE }.data
                 )
             }
         }

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -86,12 +86,11 @@ dependencies {
 
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.context)
-    implementation(libs.opentelemetry.semconv)
-    implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.profileinstaller)
 
     implementation(libs.opentelemetry.kotlin.api)
     implementation(libs.opentelemetry.kotlin.api.ext)
+    implementation(libs.opentelemetry.kotlin.semconv)
     implementation(libs.opentelemetry.kotlin.noop)
 
     testImplementation(project(":embrace-test-fakes"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -18,7 +18,7 @@ import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertMatches
-import io.opentelemetry.semconv.HttpAttributes
+import io.embrace.opentelemetry.kotlin.semconv.HttpAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -162,7 +162,7 @@ internal class EmbraceInternalInterfaceTest {
                 val session = getSingleSessionEnvelope()
                 val spans = checkNotNull(session.data.spans)
                 val requests =
-                    checkNotNull(spans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key) != null })
+                    checkNotNull(spans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD) != null })
                 assertEquals(
                     "Unexpected number of requests in sent session: ${requests.size}",
                     4,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaTracerTest.kt
@@ -25,7 +25,7 @@ import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.opentelemetry.context.Context
-import io.opentelemetry.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -153,10 +153,10 @@ internal class ExternalOtelJavaTracerTest {
                             timestampNanos = checkNotNull(startTimeMs?.millisToNanos()),
                             attributes = listOf(
                                 Attribute("bad", "yes"),
-                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE.key, "bah"),
-                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, stacktrace),
+                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE, "bah"),
+                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE, stacktrace),
                                 Attribute(
-                                    ExceptionAttributes.EXCEPTION_TYPE.key,
+                                    ExceptionAttributes.EXCEPTION_TYPE,
                                     checkNotNull(RuntimeException::class.java.canonicalName)
                                 )
                             )
@@ -241,10 +241,10 @@ internal class ExternalOtelJavaTracerTest {
                             timestampNanos = checkNotNull(startTimeMs?.millisToNanos()),
                             attributes = listOf(
                                 Attribute("bad", "yes"),
-                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE.key, "bah"),
-                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, stacktrace),
+                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE, "bah"),
+                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE, stacktrace),
                                 Attribute(
-                                    ExceptionAttributes.EXCEPTION_TYPE.key,
+                                    ExceptionAttributes.EXCEPTION_TYPE,
                                     checkNotNull(RuntimeException::class.java.canonicalName)
                                 )
                             )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -22,7 +22,7 @@ import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.embrace.opentelemetry.kotlin.tracing.data.SpanData
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.recordException
-import io.opentelemetry.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -143,11 +143,11 @@ internal class ExternalTracerTest {
                             attributes = listOf(
                                 Attribute("bad", "yes"),
                                 Attribute(
-                                    ExceptionAttributes.EXCEPTION_TYPE.key,
+                                    ExceptionAttributes.EXCEPTION_TYPE,
                                     checkNotNull(RuntimeException::class.java.canonicalName)
                                 ),
-                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE.key, "bah"),
-                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, stacktrace)
+                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE, "bah"),
+                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE, stacktrace)
                             )
                         )
                     )
@@ -232,11 +232,11 @@ internal class ExternalTracerTest {
                             attributes = listOf(
                                 Attribute("bad", "yes"),
                                 Attribute(
-                                    ExceptionAttributes.EXCEPTION_TYPE.key,
+                                    ExceptionAttributes.EXCEPTION_TYPE,
                                     checkNotNull(RuntimeException::class.java.canonicalName)
                                 ),
-                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE.key, "bah"),
-                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE.key, stacktrace)
+                                Attribute(ExceptionAttributes.EXCEPTION_MESSAGE, "bah"),
+                                Attribute(ExceptionAttributes.EXCEPTION_STACKTRACE, stacktrace)
                             )
                         )
                     )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
-import io.opentelemetry.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -191,7 +191,7 @@ internal class FlutterInternalInterfaceTest {
                 )
                 log.attributes?.assertMatches(
                     mapOf(
-                        ExceptionAttributes.EXCEPTION_STACKTRACE.key to expectedStacktrace,
+                        ExceptionAttributes.EXCEPTION_STACKTRACE to expectedStacktrace,
                         "emb.exception.context" to expectedContext,
                         "emb.exception.library" to expectedLibrary,
                     )
@@ -237,7 +237,7 @@ internal class FlutterInternalInterfaceTest {
                 )
                 log.attributes?.assertMatches(
                     mapOf(
-                        ExceptionAttributes.EXCEPTION_STACKTRACE.key to expectedStacktrace,
+                        ExceptionAttributes.EXCEPTION_STACKTRACE to expectedStacktrace,
                         "emb.exception.context" to expectedContext,
                         "emb.exception.library" to expectedLibrary,
                     )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -12,14 +12,15 @@ import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
 import io.embrace.android.embracesdk.assertions.assertMatches
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.HttpAttributes
-import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.HttpAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class NetworkRequestApiTest {
 
@@ -309,18 +310,18 @@ internal class NetworkRequestApiTest {
 
                     attributes?.assertMatches(mapOf(
                         "url.full" to expectedRequest.url,
-                        HttpAttributes.HTTP_REQUEST_METHOD.key to expectedRequest.httpMethod,
+                        HttpAttributes.HTTP_REQUEST_METHOD to expectedRequest.httpMethod,
                         "emb.trace_id" to expectedRequest.traceId,
                         "emb.w3c_traceparent" to expectedRequest.w3cTraceparent,
-                        HttpAttributes.HTTP_RESPONSE_STATUS_CODE.key to when {
+                        HttpAttributes.HTTP_RESPONSE_STATUS_CODE to when {
                             completed -> expectedRequest.responseCode
                             else -> null
                         },
-                        HttpIncubatingAttributes.HTTP_REQUEST_BODY_SIZE.key to when {
+                        HttpAttributes.HTTP_REQUEST_BODY_SIZE to when {
                             completed -> expectedRequest.bytesSent
                             else -> null
                         },
-                        HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE.key to when {
+                        HttpAttributes.HTTP_RESPONSE_BODY_SIZE to when {
                             completed -> expectedRequest.bytesReceived
                             else -> null
                         },
@@ -328,7 +329,7 @@ internal class NetworkRequestApiTest {
                             completed -> null
                             else -> expectedRequest.errorType
                         },
-                        ExceptionAttributes.EXCEPTION_MESSAGE.key to when {
+                        ExceptionAttributes.EXCEPTION_MESSAGE to when {
                             completed -> null
                             else -> expectedRequest.errorMessage
                         },
@@ -343,7 +344,7 @@ internal class NetworkRequestApiTest {
 
         val unfilteredSpans = checkNotNull(session.data.spans)
         val spans =
-            checkNotNull(unfilteredSpans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD.key) != null })
+            checkNotNull(unfilteredSpans.filter { it.attributes?.findAttributeValue(HttpAttributes.HTTP_REQUEST_METHOD) != null })
         assertEquals(
             "Unexpected number of requests in sent session: ${spans.size}",
             1,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/SessionApiTest.kt
@@ -9,13 +9,15 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.attrs.embFreeDiskBytes
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class SessionApiTest {
 
@@ -59,7 +61,7 @@ internal class SessionApiTest {
                 val spans = checkNotNull(message.data.spans)
                 val sessionSpan = spans.single { it.name == "emb-session" }
                 assertEquals(startTime, sessionSpan.startTimeNanos?.nanosToMillis())
-                assertNotNull(sessionSpan.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+                assertNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
 
                 val attrs = checkNotNull(sessionSpan.attributes)
                 val attributeKeys = attrs.map { it.key }
@@ -96,7 +98,7 @@ internal class SessionApiTest {
     private companion object {
         // Attributes we want to know exist, but whose value we don't need to validate
         val validateExistenceOnly = setOf(
-            SessionIncubatingAttributes.SESSION_ID.key,
+            SessionAttributes.SESSION_ID,
             "emb.kotlin_on_classpath",
             "emb.okhttp3",
             "emb.process_identifier",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -37,8 +37,9 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -52,7 +53,7 @@ import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class TracingApiTest {
     @Rule
@@ -298,9 +299,9 @@ internal class TracingApiTest {
             },
             otelExportAssertion = {
                 val sessionSpan = awaitSpansWithType(2, EmbType.Ux.Session).last().toEmbraceSpanData().toEmbracePayload()
-                val sessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+                val sessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
                 val span = awaitSpans(1) { it.name == "test-trace-root" }.single().toEmbraceSpanData().toEmbracePayload()
-                assertEquals(sessionId, span.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+                assertEquals(sessionId, span.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
             }
         )
     }
@@ -428,15 +429,15 @@ internal class TracingApiTest {
                 val span1 = sessions.first().findSpanByName("span1")
                 val span2 = sessions.last().findSpanByName("span2")
 
-                assertEquals(sessionId1, span1.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
-                assertEquals(sessionId1, span2.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+                assertEquals(sessionId1, span1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals(sessionId1, span2.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
 
             },
             otelExportAssertion = {
                 val span1 = awaitSpans(1) { it.name == "span1" }.single().toEmbraceSpanData().toEmbracePayload()
                 val span2 = awaitSpans(1) { it.name == "span2" }.single().toEmbraceSpanData().toEmbracePayload()
-                assertEquals(sessionId1, span1.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
-                assertEquals(sessionId1, span2.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+                assertEquals(sessionId1, span1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals(sessionId1, span2.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -23,7 +23,8 @@ import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -32,7 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class JvmCrashFeatureTest {
 
@@ -134,7 +135,7 @@ internal class JvmCrashFeatureTest {
                     "emb.android.react_native_crash.js_exception" to expectedJsException,
                     "emb.android.crash_number" to 1,
                     "emb.android.crash.exception_cause" to expectedExceptionCause,
-                    LogIncubatingAttributes.LOG_RECORD_UID.key to crashId
+                    LogAttributes.LOG_RECORD_UID to crashId
                 ))
                 assertNotNull(log.attributes?.findAttributeValue("emb.android.threads"))
             }
@@ -172,7 +173,7 @@ internal class JvmCrashFeatureTest {
             embState.name to state,
             "emb.android.crash_number" to 1,
             "emb.android.crash.exception_cause" to expectedExceptionCause,
-            LogIncubatingAttributes.LOG_RECORD_UID.key to crashId
+            LogAttributes.LOG_RECORD_UID to crashId
         ))
         assertNotNull(attributes?.findAttributeValue("emb.android.threads"))
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertMatches
-import io.opentelemetry.semconv.UrlAttributes.URL_FULL
+import io.embrace.opentelemetry.kotlin.semconv.UrlAttributes.URL_FULL
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -46,7 +46,7 @@ internal class WebviewFeatureTest {
                 assertEquals("emb-webview-info", event.name)
                 event.attributes?.assertMatches(mapOf(
                     "emb.webview_info.tag" to "myWebView",
-                    URL_FULL.key to "https://embrace.io/"
+                    URL_FULL to "https://embrace.io/"
                 ))
 
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -22,7 +22,8 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.getLogsOfType
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -35,6 +36,7 @@ import org.junit.runner.RunWith
 /**
  * Verify functionality of the SDK if background activities are disabled
  */
+@OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class BackgroundActivityDisabledTest {
 
@@ -87,7 +89,7 @@ internal class BackgroundActivityDisabledTest {
                             embState.name to "background"
                         )
                     )
-                    assertNull(attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+                    assertNull(attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
                 }
                 with(logs[1]) {
                     assertEquals("info", body)
@@ -96,14 +98,14 @@ internal class BackgroundActivityDisabledTest {
                             embState.name to "background"
                         )
                     )
-                    assertNull(attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+                    assertNull(attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
                 }
                 with(logs[2]) {
                     assertEquals("warning", body)
                     attributes?.assertMatches(
                         mapOf(
                             embState.name to "foreground",
-                            SessionIncubatingAttributes.SESSION_ID.key to sessions[1].getSessionId()
+                            SessionAttributes.SESSION_ID to sessions[1].getSessionId()
                         )
                     )
                 }
@@ -114,7 +116,7 @@ internal class BackgroundActivityDisabledTest {
                     attributes?.assertMatches(
                         mapOf(
                             embState.name to "foreground",
-                            SessionIncubatingAttributes.SESSION_ID.key to secondSession.getSessionId()
+                            SessionAttributes.SESSION_ID to secondSession.getSessionId()
                         )
                     )
                 }
@@ -192,8 +194,8 @@ internal class BackgroundActivityDisabledTest {
                 )
 
                 assertNotEquals(
-                    sessionSpan1.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key),
-                    sessionSpan2.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key)
+                    sessionSpan1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID),
+                    sessionSpan2.attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
                 )
 
                 assertEquals(
@@ -227,7 +229,7 @@ internal class BackgroundActivityDisabledTest {
         )
         with(checkNotNull(attributes)) {
             assertFalse(findAttributeValue(embProcessIdentifier.name).isNullOrBlank())
-            assertFalse(findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key).isNullOrBlank())
+            assertFalse(findAttributeValue(SessionAttributes.SESSION_ID).isNullOrBlank())
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
@@ -12,7 +12,8 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.threadLocal
 import io.embrace.android.embracesdk.assertions.getLastLog
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.zip.GZIPInputStream
 import okhttp3.mockwebserver.Dispatcher
@@ -94,13 +95,14 @@ internal class FakeApiServer(
         deliveryTracer.onServerCompletedRequest(endpoint.name, obj.getSessionId())
     }
 
+    @OptIn(IncubatingApi::class)
     @Suppress("UNCHECKED_CAST")
     private fun handleLogRequest(endpoint: Endpoint, envelope: Envelope<*>) {
         val obj = envelope as Envelope<LogPayload>
         logRequests.add(obj)
         deliveryTracer.onServerCompletedRequest(
             endpoint.name,
-            obj.getLastLog().attributes?.findAttributeValue(LogIncubatingAttributes.LOG_RECORD_UID.key) ?: ""
+            obj.getLastLog().attributes?.findAttributeValue(LogAttributes.LOG_RECORD_UID) ?: ""
         )
     }
 

--- a/embrace-android-sdk/src/main/baseline-prof.txt
+++ b/embrace-android-sdk/src/main/baseline-prof.txt
@@ -4043,9 +4043,9 @@ HSPLio/opentelemetry/semconv/ErrorAttributes;-><clinit>()V
 HSPLio/opentelemetry/semconv/ExceptionAttributes;-><clinit>()V
 HSPLio/opentelemetry/semconv/HttpAttributes;-><clinit>()V
 HSPLio/opentelemetry/semconv/ServiceAttributes;-><clinit>()V
-HSPLio/opentelemetry/semconv/incubating/AndroidIncubatingAttributes;-><clinit>()V
-HSPLio/opentelemetry/semconv/incubating/DeviceIncubatingAttributes;-><clinit>()V
-HSPLio/opentelemetry/semconv/incubating/HttpIncubatingAttributes;-><clinit>()V
-HSPLio/opentelemetry/semconv/incubating/OsIncubatingAttributes;-><clinit>()V
-HSPLio/opentelemetry/semconv/incubating/SessionIncubatingAttributes;-><clinit>()V
-HSPLio/opentelemetry/semconv/incubating/TelemetryIncubatingAttributes;-><clinit>()V
+HSPLio/opentelemetry/semconv/incubating/AndroidAttributes;-><clinit>()V
+HSPLio/opentelemetry/semconv/incubating/DeviceAttributes;-><clinit>()V
+HSPLio/opentelemetry/semconv/incubating/HttpAttributes;-><clinit>()V
+HSPLio/opentelemetry/semconv/incubating/OsAttributes;-><clinit>()V
+HSPLio/opentelemetry/semconv/incubating/SessionAttributes;-><clinit>()V
+HSPLio/opentelemetry/semconv/incubating/TelemetryAttributes;-><clinit>()V

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.logs.attachments.AttachmentErrorCo
 import io.embrace.android.embracesdk.internal.payload.PushNotificationBreadcrumb
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
-import io.opentelemetry.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 
 internal class LogsApiDelegate(
     bootstrapper: ModuleInitBootstrapper,
@@ -184,12 +184,12 @@ internal class LogsApiDelegate(
         if (sdkCallChecker.check("log_message")) {
             runCatching {
                 val attrs = mutableMapOf<String, String>()
-                exceptionName?.let { attrs[ExceptionAttributes.EXCEPTION_TYPE.key] = it }
-                exceptionMessage?.let { attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key] = it }
+                exceptionName?.let { attrs[ExceptionAttributes.EXCEPTION_TYPE] = it }
+                exceptionMessage?.let { attrs[ExceptionAttributes.EXCEPTION_MESSAGE] = it }
 
                 val stacktrace =
                     stackTraceElements?.let(checkNotNull(serializer)::truncatedStacktrace) ?: customStackTrace
-                stacktrace?.let { attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key] = it }
+                stacktrace?.let { attrs[ExceptionAttributes.EXCEPTION_STACKTRACE] = it }
 
                 if (attachment != null) {
                     attrs.putAll(attachment.attributes.mapKeys { it.key.name })

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.createNoopOpenTelemetry
-import io.opentelemetry.semconv.ServiceAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ServiceAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -86,9 +86,9 @@ internal class OTelApiDelegateTest {
     @Test
     fun `override resource attribute before sdk starts`() {
         sdkCallChecker.started.set(false)
-        delegate.setResourceAttribute(ServiceAttributes.SERVICE_NAME.key, "foo")
+        delegate.setResourceAttribute(ServiceAttributes.SERVICE_NAME, "foo")
         val attrs = FakeMutableAttributeContainer().apply(cfg.resourceAction).attributes
-        assertEquals("foo", attrs[ServiceAttributes.SERVICE_NAME.key])
+        assertEquals("foo", attrs[ServiceAttributes.SERVICE_NAME])
     }
 
     @Test

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -25,8 +25,6 @@ dependencies {
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.sdk)
-    compileOnly(libs.opentelemetry.semconv)
-    compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.opentelemetry.java.aliases)
 
     implementation(libs.junit)
@@ -39,4 +37,5 @@ dependencies {
     implementation(libs.opentelemetry.kotlin.api.ext)
     implementation(libs.opentelemetry.kotlin.sdk)
     implementation(libs.opentelemetry.kotlin.compat)
+    implementation(libs.opentelemetry.kotlin.semconv)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
@@ -10,13 +10,15 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 
 /**
  * Assert the [EmbraceSpanData] is as expected
  */
+@OptIn(IncubatingApi::class)
 fun assertEmbraceSpanData(
     span: Span?,
     expectedStartTimeMs: Long,
@@ -54,7 +56,7 @@ fun assertEmbraceSpanData(
         assertEquals(expectedEvents, events)
 
         if (expectedSessionId != null) {
-            assertEquals(expectedSessionId, attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key))
+            assertEquals(expectedSessionId, attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
         }
 
         if (private) {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
@@ -7,10 +7,12 @@ import io.embrace.android.embracesdk.internal.otel.schema.LinkType
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.Assert.assertTrue
 
+@OptIn(IncubatingApi::class)
 fun Link.validatePreviousSessionLink(
     previousSessionSpan: Span,
     previousSessionId: String,
@@ -18,7 +20,7 @@ fun Link.validatePreviousSessionLink(
     validateSystemLink(
         linkedSpan = previousSessionSpan,
         type = LinkType.PreviousSession,
-        expectedAttributes = mapOf(SessionIncubatingAttributes.SESSION_ID.key to previousSessionId)
+        expectedAttributes = mapOf(SessionAttributes.SESSION_ID to previousSessionId)
     )
 }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
@@ -12,13 +12,14 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 fun assertOtelLogReceived(
     logReceived: Log?,
     expectedMessage: String,
@@ -40,18 +41,18 @@ fun assertOtelLogReceived(
         assertEquals(expectedSeverityNumber.severityNumber, log.severityNumber)
         assertEquals(expectedSeverityText ?: expectedSeverityNumber.name, log.severityText)
         assertEquals(expectedTimeMs.millisToNanos(), log.timeUnixNano)
-        assertFalse(log.attributes?.findAttributeValue(SessionIncubatingAttributes.SESSION_ID.key).isNullOrBlank())
+        assertFalse(log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID).isNullOrBlank())
         expectedType?.let { assertAttribute(log, embExceptionHandling.name, it) }
         assertEquals(expectedState, log.attributes?.findAttributeValue(embState.name))
         expectedExceptionName?.let {
-            assertAttribute(log, ExceptionAttributes.EXCEPTION_TYPE.key, expectedExceptionName)
+            assertAttribute(log, ExceptionAttributes.EXCEPTION_TYPE, expectedExceptionName)
         }
         expectedExceptionMessage?.let {
-            assertAttribute(log, ExceptionAttributes.EXCEPTION_MESSAGE.key, expectedExceptionMessage)
+            assertAttribute(log, ExceptionAttributes.EXCEPTION_MESSAGE, expectedExceptionMessage)
         }
         expectedStacktrace?.let {
             val serializedStack = EmbraceSerializer().truncatedStacktrace(it.toTypedArray())
-            assertAttribute(log, ExceptionAttributes.EXCEPTION_STACKTRACE.key, serializedStack)
+            assertAttribute(log, ExceptionAttributes.EXCEPTION_STACKTRACE, serializedStack)
         }
         expectedProperties?.forEach { (key, value) ->
             assertAttribute(log, key, value.toString())

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
@@ -3,29 +3,30 @@ package io.embrace.android.embracesdk.assertions
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.semconv.ServiceAttributes
-import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
-import io.opentelemetry.semconv.incubating.TelemetryIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.embrace.opentelemetry.kotlin.semconv.DeviceAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.OsAttributes
+import io.embrace.opentelemetry.kotlin.semconv.ServiceAttributes
+import io.embrace.opentelemetry.kotlin.semconv.TelemetryAttributes
 import org.junit.Assert.assertEquals
 
-@OptIn(ExperimentalApi::class)
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
 fun Resource.assertExpectedAttributes(
     expectedServiceName: String,
     expectedServiceVersion: String,
     systemInfo: SystemInfo,
 ) {
-    assertEquals(expectedServiceName, attributes[ServiceAttributes.SERVICE_NAME.toString()])
-    assertEquals(expectedServiceVersion, attributes[ServiceAttributes.SERVICE_VERSION.toString()])
-    assertEquals(expectedServiceName, attributes[TelemetryIncubatingAttributes.TELEMETRY_DISTRO_NAME.toString()])
-    assertEquals(expectedServiceVersion, attributes[TelemetryIncubatingAttributes.TELEMETRY_DISTRO_VERSION.toString()])
-    assertEquals(systemInfo.osName, attributes[OsIncubatingAttributes.OS_NAME.toString()])
-    assertEquals(systemInfo.osVersion, attributes[OsIncubatingAttributes.OS_VERSION.toString()])
-    assertEquals(systemInfo.osType, attributes[OsIncubatingAttributes.OS_TYPE.toString()])
-    assertEquals(systemInfo.osBuild, attributes[OsIncubatingAttributes.OS_BUILD_ID.toString()])
-    assertEquals(systemInfo.androidOsApiLevel, attributes[AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL.toString()])
-    assertEquals(systemInfo.deviceManufacturer, attributes[DeviceIncubatingAttributes.DEVICE_MANUFACTURER.toString()])
-    assertEquals(systemInfo.deviceModel, attributes[DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER.toString()])
-    assertEquals(systemInfo.deviceModel, attributes[DeviceIncubatingAttributes.DEVICE_MODEL_NAME.toString()])
+    assertEquals(expectedServiceName, attributes[ServiceAttributes.SERVICE_NAME])
+    assertEquals(expectedServiceVersion, attributes[ServiceAttributes.SERVICE_VERSION])
+    assertEquals(expectedServiceName, attributes[TelemetryAttributes.TELEMETRY_DISTRO_NAME])
+    assertEquals(expectedServiceVersion, attributes[TelemetryAttributes.TELEMETRY_DISTRO_VERSION])
+    assertEquals(systemInfo.osName, attributes[OsAttributes.OS_NAME])
+    assertEquals(systemInfo.osVersion, attributes[OsAttributes.OS_VERSION])
+    assertEquals(systemInfo.osType, attributes[OsAttributes.OS_TYPE])
+    assertEquals(systemInfo.osBuild, attributes[OsAttributes.OS_BUILD_ID])
+    assertEquals(systemInfo.androidOsApiLevel, attributes[AndroidAttributes.ANDROID_OS_API_LEVEL])
+    assertEquals(systemInfo.deviceManufacturer, attributes[DeviceAttributes.DEVICE_MANUFACTURER])
+    assertEquals(systemInfo.deviceModel, attributes[DeviceAttributes.DEVICE_MODEL_IDENTIFIER])
+    assertEquals(systemInfo.deviceModel, attributes[DeviceAttributes.DEVICE_MODEL_NAME])
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -35,12 +35,13 @@ import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.toOtelJavaContextKey
 import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
 import io.embrace.opentelemetry.kotlin.tracing.ext.toOtelKotlinSpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import java.util.concurrent.ConcurrentLinkedQueue
 
 @OptIn(ExperimentalApi::class)
@@ -288,6 +289,7 @@ class FakeEmbraceSdkSpan(
                 stop()
             }
 
+        @OptIn(IncubatingApi::class)
         fun sessionSpan(
             sessionId: String,
             startTimeMs: Long,
@@ -308,7 +310,7 @@ class FakeEmbraceSdkSpan(
                     )
                 }
 
-                setSystemAttribute(SessionIncubatingAttributes.SESSION_ID.key, sessionId)
+                setSystemAttribute(SessionAttributes.SESSION_ID, sessionId)
                 setSystemAttribute(embProcessIdentifier.name, processIdentifier)
                 setSystemAttribute(embState.name, "foreground")
                 setSystemAttribute(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRequestExecutionService.kt
@@ -8,7 +8,8 @@ import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.opentelemetry.semconv.incubating.LogIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import java.io.InputStream
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.zip.GZIPInputStream
@@ -45,6 +46,7 @@ class FakeRequestExecutionService(
         return responseAction(envelope)
     }
 
+    @OptIn(IncubatingApi::class)
     @Suppress("UNCHECKED_CAST")
     private fun processEnvelope(envelope: Envelope<*>) {
         if (strictMode) {
@@ -59,7 +61,7 @@ class FakeRequestExecutionService(
                 val log = envelope as Envelope<LogPayload>
                 val logs = log.data.logs ?: error("Log payload missing logs")
                 val lidList: List<String> = logs.map {
-                    it.attributes?.findAttributeValue(LogIncubatingAttributes.LOG_RECORD_UID.key)
+                    it.attributes?.findAttributeValue(LogAttributes.LOG_RECORD_UID)
                         ?: error("Log missing log id")
                 }
                 lidList.forEach { lid ->

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeResource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeResource.kt
@@ -1,10 +1,13 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.resource.MutableResource
 import io.embrace.opentelemetry.kotlin.resource.Resource
 
 @OptIn(ExperimentalApi::class)
 internal class FakeResource(
     override val attributes: Map<String, Any> = emptyMap(),
     override val schemaUrl: String? = null,
-) : Resource
+) : Resource {
+    override fun asNewResource(action: MutableResource.() -> Unit): Resource = this
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
@@ -8,7 +8,8 @@ import io.embrace.android.embracesdk.internal.otel.schema.SendMode
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 
 val testLog: Log = Log(
     traceId = "ceadd56622414a06ae382e4e5a70bcf7",
@@ -48,12 +49,13 @@ val testNativeCrashData: NativeCrashData = NativeCrashData(
     symbols = mapOf("key" to "value"),
 )
 
+@OptIn(IncubatingApi::class)
 val nativeCrashLog = Log(
     timeUnixNano = 1681972471806000000L,
     attributes = listOf(
         Attribute(embSendMode.name, SendMode.IMMEDIATE.name),
         EmbType.System.NativeCrash.toPayload(),
-        Attribute(SessionIncubatingAttributes.SESSION_ID.key, "bb6b5b1ea2ff48928382fe81d7991ced"),
+        Attribute(SessionAttributes.SESSION_ID, "bb6b5b1ea2ff48928382fe81d7991ced"),
         Attribute(embProcessIdentifier.name, "8115ec91-3e5e-4d8a-816d-cc40306f9822"),
     )
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ openTelementrySemConv = "1.29.0-alpha"
 moshi = "1.15.2"
 lifecycle = "2.7.0" # version pinned to 2.7.0 because of AGP bug
 annotation = "1.9.1"
-otelKotlin = "0.4.2"
+otelKotlin = "0.5.1"
 protobuf = "4.32.1"
 profileinstaller = "1.3.1" # version pinned to 1.3.1 because of AGP bug
 okhttp = "4.12.0"
@@ -92,6 +92,7 @@ opentelemetry-kotlin-api-ext = { module = "io.embrace.opentelemetry.kotlin:opent
 opentelemetry-kotlin-sdk = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-implementation", version.ref = "otelKotlin" }
 opentelemetry-kotlin-compat = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-compat", version.ref = "otelKotlin" }
 opentelemetry-kotlin-noop = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-noop", version.ref = "otelKotlin" }
+opentelemetry-kotlin-semconv = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-kotlin-semconv", version.ref = "otelKotlin" }
 opentelemetry-java-aliases = { module = "io.embrace.opentelemetry.kotlin:opentelemetry-java-typealiases", version.ref = "otelKotlin" }
 androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "androidxBenchmark" }
 


### PR DESCRIPTION
## Goal

Uses the semantic conventions added in https://github.com/embrace-io/opentelemetry-kotlin/pull/386

This will require a release of opentelemetry-kotlin to pass in CI.

## Testing

Relied on existing test coverage.