### PR TITLE
Remove otel-java gradle deps from embrace-android-core

### DIFF
--- a/embrace-android-api/build.gradle.kts
+++ b/embrace-android-api/build.gradle.kts
@@ -15,9 +15,6 @@ android {
 }
 
 dependencies {
-    compileOnly(platform(libs.opentelemetry.bom))
-    compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.kotlin.api)
     implementation(libs.androidx.annotation)
-    implementation(libs.opentelemetry.java.aliases)
 }

--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(project(":embrace-android-otel"))
     compileOnly(project(":embrace-android-api"))
 
+    compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.semconv)
     compileOnly(libs.opentelemetry.semconv.incubating)
     compileOnly(platform(libs.opentelemetry.bom))

--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     implementation(project(":embrace-android-otel"))
     compileOnly(project(":embrace-android-api"))
 
+    compileOnly(libs.opentelemetry.semconv)
+    compileOnly(libs.opentelemetry.semconv.incubating)
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)
     implementation(libs.androidx.annotation)

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     compileOnly(platform(libs.opentelemetry.bom))
     compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.context)
+
+    compileOnly(libs.opentelemetry.semconv)
+    compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.lifecycle.process)
 
     implementation(libs.opentelemetry.kotlin.api)

--- a/embrace-android-features/build.gradle.kts
+++ b/embrace-android-features/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.context)
 
+    compileOnly(libs.opentelemetry.api)
     compileOnly(libs.opentelemetry.semconv)
     compileOnly(libs.opentelemetry.semconv.incubating)
     implementation(libs.lifecycle.process)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
@@ -13,16 +13,13 @@ import io.embrace.opentelemetry.kotlin.tracing.model.Span
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanEvent
 import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
-import io.opentelemetry.context.Context
-import io.opentelemetry.context.ImplicitContextKeyed
-import io.opentelemetry.context.Scope
 
 @OptIn(ExperimentalApi::class)
 class EmbSpan(
     private val impl: EmbraceSdkSpan,
     private val clock: Clock,
     private val openTelemetry: OpenTelemetry,
-) : Span, ImplicitContextKeyed {
+) : Span {
 
     override fun setStringAttribute(key: String, value: String) {
         impl.addAttribute(key, value)
@@ -118,14 +115,6 @@ class EmbSpan(
         get() = impl.links().map {
             EmbLink(it.retrieveSpanContext(), it.attributes.toMutableAttributeContainer())
         }
-
-    override fun storeInContext(context: Context): Context {
-        return impl.storeInContext(context)
-    }
-
-    override fun makeCurrent(): Scope {
-        return impl.makeCurrent()
-    }
 
     private fun List<Attribute>?.toMutableAttributeContainer(): MutableAttributeContainer {
         val raw = this ?: emptyList()

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaImplicitContextKeyed
 import io.embrace.opentelemetry.kotlin.context.Context
 import io.embrace.opentelemetry.kotlin.context.ContextKey
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
@@ -22,7 +21,7 @@ import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
  * An [EmbraceSpan] that has additional functionality to be used internally by the SDK
  */
 @OptIn(ExperimentalApi::class)
-interface EmbraceSdkSpan : EmbraceSpan, OtelJavaImplicitContextKeyed {
+interface EmbraceSdkSpan : EmbraceSpan {
 
     /**
      * Create a new context object based in this span and its parent's context. This can be used for the parent context for a new span

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -113,7 +113,7 @@ internal class OpenTelemetrySdkTest {
         return OtelSdkWrapper(
             otelClock = FakeOtelKotlinClock(FakeClock()),
             configuration = configuration,
-            spanService = FakeSpanService(useKotlinSdk = configuration.useKotlinSdk),
+            spanService = FakeSpanService(),
         )
     }
 }

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
     implementation(project(":embrace-internal-api"))
     implementation(project(":embrace-android-otel"))
 
-    implementation(platform(libs.opentelemetry.bom))
     implementation(libs.opentelemetry.java.aliases)
 
     // lifecycle
@@ -86,6 +85,8 @@ dependencies {
 
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.context)
+    implementation(libs.opentelemetry.semconv)
+    implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.profileinstaller)
 
     implementation(libs.opentelemetry.kotlin.api)

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     ksp(libs.moshi.kotlin.codegen)
 
     implementation(libs.opentelemetry.api)
-    implementation(libs.opentelemetry.context)
     implementation(libs.opentelemetry.semconv)
     implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.profileinstaller)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceLinkData
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanStartArgs
 import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
-import io.embrace.android.embracesdk.internal.otel.spans.getOrCreateSpanKey
 import io.embrace.android.embracesdk.internal.otel.toEmbracePayload
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
@@ -29,9 +28,7 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.OpenTelemetry
-import io.embrace.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.Context
-import io.embrace.opentelemetry.kotlin.context.toOtelJavaContextKey
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
@@ -221,11 +218,6 @@ class FakeEmbraceSdkSpan(
 
     override fun links(): List<Link> {
         throw UnsupportedOperationException()
-    }
-
-    override fun storeInContext(context: OtelJavaContext): OtelJavaContext {
-        val spanKey = getOrCreateSpanKey(openTelemetry)
-        return context.with(spanKey.toOtelJavaContextKey(), this)
     }
 
     private fun started(): Boolean = sdkSpan != null

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -42,7 +42,7 @@ class FakeOpenTelemetryModule(
 
     override val openTelemetryClock: Clock = FakeOtelKotlinClock(FakeClock())
 
-    override val spanService: SpanService = FakeSpanService(otelSdkConfig.useKotlinSdk)
+    override val spanService: SpanService = FakeSpanService()
 
     override val otelSdkWrapper: OtelSdkWrapper =
         OtelSdkWrapper(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -10,8 +10,6 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
-import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
-import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
 
 @OptIn(ExperimentalApi::class)
 class FakeSpanService : SpanService {
@@ -32,9 +30,7 @@ class FakeSpanService : SpanService {
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
         name = name,
-        parentContext = parent?.run {
-            fakeOpenTelemetry().contextFactory.root().toOtelJavaContext().with(parent as EmbraceSdkSpan)
-        }?.toOtelKotlinContext() ?: fakeOpenTelemetry().contextFactory.root(),
+        parentContext = fakeOpenTelemetry().contextFactory.root(),
         type = type,
         internal = internal,
         private = private,
@@ -88,9 +84,7 @@ class FakeSpanService : SpanService {
         createdSpans.add(
             FakeEmbraceSdkSpan(
                 name = name,
-                parentContext = parent?.run {
-                    fakeOpenTelemetry().contextFactory.root().toOtelJavaContext().with(parent as EmbraceSdkSpan).toOtelKotlinContext()
-                } ?: fakeOpenTelemetry().contextFactory.root(),
+                parentContext = fakeOpenTelemetry().contextFactory.root(),
                 type = type,
                 internal = internal,
                 private = private

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.internal.otel.config.USE_KOTLIN_SDK
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
@@ -15,9 +14,7 @@ import io.embrace.opentelemetry.kotlin.context.toOtelJavaContext
 import io.embrace.opentelemetry.kotlin.context.toOtelKotlinContext
 
 @OptIn(ExperimentalApi::class)
-class FakeSpanService(
-    private val useKotlinSdk: Boolean = USE_KOTLIN_SDK
-) : SpanService {
+class FakeSpanService : SpanService {
 
     val createdSpans: MutableList<FakeEmbraceSdkSpan> = mutableListOf()
 
@@ -34,7 +31,6 @@ class FakeSpanService(
         private: Boolean,
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
-        useKotlinSdk = useKotlinSdk,
         name = name,
         parentContext = parent?.run {
             fakeOpenTelemetry().contextFactory.root().toOtelJavaContext().with(parent as EmbraceSdkSpan)
@@ -51,7 +47,6 @@ class FakeSpanService(
         otelSpanStartArgs: OtelSpanStartArgs,
     ): EmbraceSdkSpan {
         return FakeEmbraceSdkSpan(
-            useKotlinSdk = useKotlinSdk,
             name = otelSpanStartArgs.initialSpanName,
             parentContext = otelSpanStartArgs.parentContext,
             type = otelSpanStartArgs.embraceAttributes.filterIsInstance<EmbType>().single(),
@@ -92,7 +87,6 @@ class FakeSpanService(
     ): Boolean {
         createdSpans.add(
             FakeEmbraceSdkSpan(
-                useKotlinSdk = useKotlinSdk,
                 name = name,
                 parentContext = parent?.run {
                     fakeOpenTelemetry().contextFactory.root().toOtelJavaContext().with(parent as EmbraceSdkSpan).toOtelKotlinContext()


### PR DESCRIPTION
## Goal

Remove unused opentelemetry-java dependencies from different gradle files.

_Still haven't removed testImplementation and androidTestImplementation dependencies, as tests haven't been correctly separated yet._