### PR TITLE
Bump gradle in test matrix

### DIFF
--- a/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
@@ -45,5 +45,5 @@ sealed class TestMatrix(
      * The maximum version we currently run tests against. Newer versions may work, but are not
      * explicitly tested.
      */
-    object MaxVersion : TestMatrix("8.9.1", "8.13", "2.1.20", JdkEnv.JAVA_17)
+    object MaxVersion : TestMatrix("8.13.0", "9.0.0", "2.2.20", JdkEnv.JAVA_17)
 }


### PR DESCRIPTION
## Goal

Bumps our maximum supported gradle version in the test matrix to run our gradle plugin integration tests against Gradle 9.0.0.

