### PR TITLE
Tweak microbenchmark arguments

### DIFF
--- a/.github/workflows/android-emulator-tests.yml
+++ b/.github/workflows/android-emulator-tests.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Run tests on android emulator
         uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
+        if: matrix.working-directory == 'examples/ExampleApp'
         with:
           working-directory: ${{ matrix.working-directory }}
           api-level: ${{ matrix.api-level }}
@@ -75,8 +76,22 @@ jobs:
           cores: 4
           profile: Nexus 6
           # Grab the failures from the device so we can include them in results. Exit with non-zero so GH checks still fail.
-          script: ./gradlew connectedCheck --stacktrace || (adb logcat '[Embrace]:d' '*:S' -t 100000 > emulator_logcat.log && adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/ && exit 127)
+          script: ./gradlew connectedCheck
 
+      - name: Run tests on android emulator
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
+        if: matrix.working-directory != 'examples/ExampleApp'
+        with:
+          working-directory: ${{ matrix.working-directory }}
+          api-level: ${{ matrix.api-level }}
+          target: default
+          arch: x86_64
+          cores: 4
+          profile: Nexus 6
+          # Grab the failures from the device so we can include them in results. Exit with non-zero so GH checks still fail.
+          script: ./gradlew connectedCheck -x :embrace-microbenchmark:connectedCheck --stacktrace || (adb logcat '[Embrace]:d' '*:S' -t 100000 > emulator_logcat.log && adb pull /storage/emulated/0/Android/data/io.embrace.android.embracesdk.test/cache/test_failure/ && exit 127)
+
+    if: matrix.variant == 'with-docs'
       - name: Archive Test Results
         if: ${{ always() && matrix.working-directory == '.' }}
         uses: actions/upload-artifact@v4

--- a/embrace-microbenchmark/build.gradle.kts
+++ b/embrace-microbenchmark/build.gradle.kts
@@ -13,7 +13,6 @@ android {
     defaultConfig {
         minSdk = 26
         testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
-        testInstrumentationRunnerArguments["androidx.benchmark.dryRunMode.enable"] = "true"
     }
 
     testBuildType = "release"


### PR DESCRIPTION
## Goal

[Dry run mode](https://developer.android.com/topic/performance/benchmarking/microbenchmark-instrumentation-args#dryrunmode-enable) means the benchmark tests only run once without any warm up, so are not as accurate. Removing this should give us more meaningful benchmarking results, at the price of longer execution times.

