### PR TITLE
BuildTelemetryService should not upload telemetry if upload tasks are disabled.

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/MissingConfigFileTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/MissingConfigFileTest.kt
@@ -23,11 +23,10 @@ class MissingConfigFileTest {
                 File(projectDir, "src/main/embrace-config.json").delete()
             },
             assertions = {
-                val endpoints = EmbraceEndpoint.values().filter { it != EmbraceEndpoint.BUILD_DATA }
+                val endpoints = EmbraceEndpoint.values()
                 endpoints.forEach {
                     verifyNoRequestsSent(it)
                 }
-                verifyBuildTelemetryRequestSent(listOf("debug", "release"), expectedAppIds = emptyList())
             }
         )
     }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -7,7 +7,6 @@ import io.embrace.android.gradle.plugin.agp.AgpVersion
 import io.embrace.android.gradle.plugin.agp.AgpWrapper
 import io.embrace.android.gradle.plugin.agp.AgpWrapperImpl
 import io.embrace.android.gradle.plugin.api.EmbraceExtension
-import io.embrace.android.gradle.plugin.buildreporter.BuildTelemetryService
 import io.embrace.android.gradle.plugin.config.PluginBehaviorImpl
 import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurationBuilder
 import io.embrace.android.gradle.plugin.gradle.getProperty
@@ -35,13 +34,6 @@ class EmbraceGradlePluginDelegate {
 
         val behavior = PluginBehaviorImpl(project, extension, embrace)
 
-        BuildTelemetryService.register(
-            project,
-            variantConfigurationsListProperty,
-            behavior,
-            agpWrapper
-        )
-
         val embraceVariantConfigurationBuilder =
             EmbraceVariantConfigurationBuilder(
                 project.layout.projectDirectory,
@@ -52,7 +44,8 @@ class EmbraceGradlePluginDelegate {
             project,
             behavior,
             embraceVariantConfigurationBuilder,
-            variantConfigurationsListProperty
+            variantConfigurationsListProperty,
+            agpWrapper
         )
 
         taskRegistrar.registerTasks()

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -3,6 +3,8 @@ package io.embrace.android.gradle.plugin.tasks.registration
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import io.embrace.android.gradle.plugin.EmbraceLogger
+import io.embrace.android.gradle.plugin.agp.AgpWrapper
+import io.embrace.android.gradle.plugin.buildreporter.BuildTelemetryService
 import io.embrace.android.gradle.plugin.config.PluginBehavior
 import io.embrace.android.gradle.plugin.config.variant.EmbraceVariantConfigurationBuilder
 import io.embrace.android.gradle.plugin.dependency.installDependenciesForVariant
@@ -25,6 +27,7 @@ class TaskRegistrar(
     private val behavior: PluginBehavior,
     private val embraceVariantConfigurationBuilder: EmbraceVariantConfigurationBuilder,
     private val variantConfigurationsListProperty: ListProperty<VariantConfig>,
+    private val agpWrapper: AgpWrapper
 ) {
 
     private val logger = EmbraceLogger(TaskRegistrar::class.java)
@@ -101,6 +104,12 @@ class TaskRegistrar(
         if (behavior.isIl2CppMappingFilesUploadEnabled) {
             Il2CppUploadTaskRegistration().register(params)
         }
+        BuildTelemetryService.register(
+            project,
+            variantConfigurationsListProperty,
+            behavior,
+            agpWrapper
+        )
     }
 
     private fun shouldRegisterUploadTasks(


### PR DESCRIPTION
## Goal

Disabling the plugin for certain variants or setting up the `disableMappingFileUpload` flag should disable the upload of our telemetry. 

We should also review our flags in the future. `embrace.disableMappingFileUpload` might not be ample enough, and it does disable NDK, Unity, RN, Proguard, and any other kind of uploads.