### PR TITLE
Symbols of any kind are not uploaded in debug variants anymore

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
@@ -17,7 +17,8 @@ class AndroidNdkTest {
     @JvmField
     val rule: PluginIntegrationTestRule = PluginIntegrationTestRule()
 
-    private val defaultExpectedVariants = listOf("debug", "release")
+    private val defaultExpectedVariants = listOf("release")
+    private val variantsSentInBuildTelemetry = listOf("debug", "release")
     private val defaultExpectedLibs = listOf("libemb-donuts.so", "libemb-crisps.so")
     private val defaultExpectedArchs = listOf("x86_64", "x86", "armeabi-v7a", "arm64-v8a")
 
@@ -35,7 +36,7 @@ class AndroidNdkTest {
                 )
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             }
@@ -56,7 +57,7 @@ class AndroidNdkTest {
                 )
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             }
@@ -114,7 +115,7 @@ class AndroidNdkTest {
                 )
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             }
@@ -133,7 +134,7 @@ class AndroidNdkTest {
                 setupMockResponses(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
             }
@@ -154,7 +155,7 @@ class AndroidNdkTest {
                 )
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyNoUploads()
             }
@@ -177,7 +178,7 @@ class AndroidNdkTest {
                 )
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(expectedLibs, expectedArchs, defaultExpectedVariants)
             }
@@ -191,10 +192,25 @@ class AndroidNdkTest {
             task = "assembleRelease",
             projectType = ProjectType.ANDROID,
             assertions = {
-                verifyBuildTelemetryRequestSent(defaultExpectedVariants)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyNoHandshakes()
                 verifyNoUploads()
                 verifyJvmMappingRequestsSent(1)
+            }
+        )
+    }
+
+    @Test
+    fun `debug builds should not upload symbols`() {
+        rule.runTest(
+            fixture = "android-cmake",
+            task = "assembleDebug",
+            projectType = ProjectType.ANDROID,
+            assertions = {
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
+                verifyNoHandshakes()
+                verifyNoUploads()
+                verifyJvmMappingRequestsSent(0)
             }
         )
     }

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidSimpleTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AndroidSimpleTest.kt
@@ -28,6 +28,20 @@ class AndroidSimpleTest {
     }
 
     @Test
+    fun `debug builds should not upload symbols`() {
+        rule.runTest(
+            fixture = "android-simple",
+            task = "assembleDebug",
+            projectType = ProjectType.ANDROID,
+            assertions = {
+                verifyNoHandshakes()
+                verifyNoUploads()
+                verifyJvmMappingRequestsSent(0)
+            }
+        )
+    }
+
+    @Test
     fun assembleRelease() {
         rule.runTest(
             fixture = "android-simple",

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/UnityTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/UnityTest.kt
@@ -45,6 +45,23 @@ class UnityTest {
         )
     }
 
+    @Test
+    fun `debug builds should not upload symbols`() {
+        rule.runTest(
+            fixture = "unity-fake-project",
+            task = "assembleDebug",
+            projectType = ProjectType.ANDROID,
+            setup = {
+                setupMockResponses(emptyList(), emptyList(), listOf("release"))
+            },
+            assertions = {
+                verifyNoHandshakes()
+                verifyNoUploads()
+                verifyJvmMappingRequestsSent(0)
+            }
+        )
+    }
+
     /**
      * Verifies the LineNumberMappings.json file is sent
      */

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.gradle.plugin.tasks.reactnative
 
-import io.embrace.android.gradle.plugin.EmbraceLogger
 import io.embrace.android.gradle.plugin.gradle.lazyTaskLookup
 import io.embrace.android.gradle.plugin.gradle.nullSafeMap
 import io.embrace.android.gradle.plugin.gradle.registerTask
@@ -26,8 +25,6 @@ private const val SOURCE_MAP_NAME = "android-embrace.bundle.map"
 
 class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
 
-    private val logger = EmbraceLogger(GenerateRnSourcemapTaskRegistration::class.java)
-
     override fun register(params: RegistrationParams) {
         params.execute()
     }
@@ -37,12 +34,6 @@ class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
      * build variant's build process.
      */
     private fun RegistrationParams.execute() {
-        // Prevent upload the bundle in debug variant
-        if (data.isBuildTypeDebuggable) {
-            logger.info("Skipping sourcemap upload for variant: ${data.name}. Build type is debuggable.")
-            return
-        }
-
         project.registerTask(
             GenerateRnSourcemapTask.NAME,
             GenerateRnSourcemapTask::class.java,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -83,7 +83,7 @@ class TaskRegistrar(
     }
 
     private fun shouldSkipUploadTasks(variant: AndroidCompactedVariantData): Boolean {
-        return behavior.isPluginDisabledForVariant(variant.name) ||
+        return variant.isBuildTypeDebuggable || behavior.isPluginDisabledForVariant(variant.name) ||
             !shouldRegisterUploadTasks(variant, variantConfigurationsListProperty)
     }
 


### PR DESCRIPTION
## Goal

On debug builds, the gradle plugin should not upload anything.
We were only doing this for RN, and it should be done for NDK, Unity, Proguard files, and even our build telemetry.

This PR updates this behavior, and adds tests to verify it.