### PR TITLE
Propagate EmbTracer arguments correctly

### DIFF
--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
@@ -6,8 +6,11 @@ import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.FakeTracer
 import io.embrace.android.embracesdk.fakes.TestConstants.TESTS_DEFAULT_USE_KOTLIN_SDK
 import io.embrace.android.embracesdk.fakes.fakeOpenTelemetry
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.createNoopOpenTelemetry
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -43,6 +46,26 @@ internal class EmbTracerTest {
             assertNull(parent)
             assertEquals("foo", name)
             assertEquals(EmbType.Performance.Default, type)
+        }
+    }
+
+    @Test
+    fun `check span generated with non default parameters`() {
+        val parentCtx = createNoopOpenTelemetry().contextFactory.root()
+        tracer.createSpan(
+            "foo",
+            parentContext = parentCtx,
+            spanKind = SpanKind.CLIENT,
+            startTimestamp = 500L.nanosToMillis()
+        ) {
+            setStringAttribute("foo", "bar")
+        }
+        val fakeCreatedSpan = spanService.createdSpans.single()
+        with(fakeCreatedSpan) {
+            assertEquals(parentCtx, parentContext)
+            assertEquals("foo", name)
+            assertEquals(SpanKind.CLIENT, spanKind)
+            assertEquals("bar", attributes["foo"])
         }
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -210,7 +210,7 @@ class FakeEmbraceSdkSpan(
 
     override fun name(): String = name
 
-    override val spanKind: SpanKind = SpanKind.INTERNAL
+    override val spanKind: SpanKind = otelSpanStartArgs?.spanKind ?: SpanKind.INTERNAL
 
     override fun events(): List<SpanEvent> {
         throw UnsupportedOperationException()


### PR DESCRIPTION
## Goal

Propagates the parameters supplied to `EmbTracer` correctly.

## Testing

Added a unit test.

