### PR TITLE
Use specific NDK version for example app

### DIFF
--- a/examples/ExampleApp/app/build.gradle.kts
+++ b/examples/ExampleApp/app/build.gradle.kts
@@ -16,6 +16,7 @@ embrace {
 android {
     namespace = "io.embrace.android.exampleapp"
     compileSdk = 36
+    ndkVersion = "29.0.14206865"
 
     defaultConfig {
         applicationId = "io.embrace.android.exampleapp"


### PR DESCRIPTION
## Goal

Uses the latest NDK version for the example app. When I built the app without this it wasn't 16Kb aligned and showed a warning in Android Studio - building with the latest NDK fixes that.

