### PR TITLE
Add a local flag to determine if opentelemetry-kotlin-implementation should be used

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -48,7 +48,7 @@ internal class ConfigServiceImpl(
     override val webViewVitalsBehavior = WebViewVitalsBehaviorImpl(thresholdCheck, remoteConfig)
     override val networkSpanForwardingBehavior =
         NetworkSpanForwardingBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
-    override val otelBehavior = OtelBehaviorImpl(thresholdCheck, remoteConfig)
+    override val otelBehavior = OtelBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
 
     override val appId: String? = resolveAppId(instrumentedConfig.project.getAppId(), openTelemetryCfg)
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehavior.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehavior.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.EnabledFeatureConfig
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
 
 /**
  * Provides the behavior for OpenTelemetry configuration
  */
-interface OtelBehavior : ConfigBehavior<UnimplementedConfig, RemoteConfig> {
+interface OtelBehavior : ConfigBehavior<EnabledFeatureConfig, OtelKotlinSdkConfig> {
 
     /**
      * Whether the Kotlin OpenTelemetry SDK should be used instead of the Java one.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImpl.kt
@@ -1,21 +1,21 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
-import io.embrace.android.embracesdk.internal.config.UnimplementedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-
-private const val DEFAULT_USE_KOTLIN_SDK: Boolean = false
 
 /**
  * Provides the behavior for OpenTelemetry configuration
  */
 class OtelBehaviorImpl(
     private val thresholdCheck: BehaviorThresholdCheck,
-    override val remote: RemoteConfig?,
+    local: InstrumentedConfig,
+    remote: RemoteConfig?,
 ) : OtelBehavior {
 
-    override val local: UnimplementedConfig = null
+    override val local = local.enabledFeatures
+    override val remote = remote?.otelKotlinSdkConfig
 
     override fun shouldUseKotlinSdk(): Boolean {
-        return thresholdCheck.isBehaviorEnabled(remote?.otelKotlinSdkConfig?.pctEnabled) ?: DEFAULT_USE_KOTLIN_SDK
+        return thresholdCheck.isBehaviorEnabled(remote?.pctEnabled) ?: local.isOtelKotlinSdkEnabled()
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImplTest.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.fakes.createOtelBehavior
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class OtelBehaviorImplTest {
+
+    private val remoteEnabled = RemoteConfig(otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 100.0f))
+    private val remoteDisabled = RemoteConfig(otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 0.0f))
+
+    @Test
+    fun testDefault() {
+        with(createOtelBehavior()) {
+            assertFalse(shouldUseKotlinSdk())
+        }
+    }
+
+    @Test
+    fun testRemote() {
+        with(createOtelBehavior(remoteCfg = remoteEnabled)) {
+            assertTrue(shouldUseKotlinSdk())
+        }
+
+        with(createOtelBehavior(remoteCfg = remoteDisabled)) {
+            assertFalse(shouldUseKotlinSdk())
+        }
+    }
+}

--- a/embrace-android-otel-java/src/main/kotlin/io/embrace/android/embracesdk/otel/java/EmbraceOtelJavaExtensions.kt
+++ b/embrace-android-otel-java/src/main/kotlin/io/embrace/android/embracesdk/otel/java/EmbraceOtelJavaExtensions.kt
@@ -29,10 +29,12 @@ fun Embrace.addJavaLogRecordExporter(logRecordExporter: OtelJavaLogRecordExporte
 /**
  * Returns an [OtelJavaOpenTelemetry] that provides working [Tracer] implementations that will record spans that fit into the Embrace data
  * model.
+ *
+ * Note: `sdk_config.otel.enable_otel_kotlin_sdk` must be set to `false` in your embrace-config.json file when using this method.
+ * If it is set to `true`, the OtelJavaOpenTelemetry instance may behave inconsistently.
  */
 @OptIn(ExperimentalApi::class)
 fun Embrace.getJavaOpenTelemetry(): OtelJavaOpenTelemetry {
-    // TODO: Should we return noop if getOpenTelemetryKotlin is noop?
     return this.getOpenTelemetryKotlin().toOtelJavaApi()
 }
 

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -162,4 +162,11 @@ interface EnabledFeatureConfig {
      * Will be true only if sdk_config.automatic_data_capture.end_startup_with_app_ready is true
      */
     fun isEndStartupWithAppReadyEnabled(): Boolean = false
+
+    /**
+     * Gates whether opentelemetry-kotlin-implementation should be used instead of opentelemetry-kotlin-compat. Defaults to false.
+     *
+     * sdk_config.otel.enable_otel_kotlin_sdk
+     */
+    fun isOtelKotlinSdkEnabled(): Boolean = false
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -166,7 +166,7 @@ internal class SdkIntegrationTestRule(
             bootstrapper.openTelemetryModule.applyConfiguration(
                 sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(instrumentedConfig),
                 bypassValidation = false,
-                otelBehavior = OtelBehaviorImpl(BehaviorThresholdCheck { "123456" }, persistedRemoteConfig)
+                otelBehavior = OtelBehaviorImpl(BehaviorThresholdCheck { "123456" }, instrumentedConfig, persistedRemoteConfig)
             )
 
             if (startSdk) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
@@ -37,5 +37,6 @@ fun createEnabledFeatureConfigInstrumentation(cfg: VariantConfig) = modelSdkConf
             }
         }
         boolMethod("isEndStartupWithAppReadyEnabled") { automaticDataCaptureConfig?.endStartupWithAppReadyEnabled }
+        boolMethod("isOtelKotlinSdkEnabled") { otel?.otelKotlinSdkEnabled }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/OpenTelemetryLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/OpenTelemetryLocalConfig.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.gradle.plugin.instrumentation.config.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class OpenTelemetryLocalConfig(
+    @Json(name = "enable_otel_kotlin_sdk")
+    val otelKotlinSdkEnabled: Boolean? = null
+) : Serializable {
+
+    private companion object {
+        @Suppress("ConstPropertyName")
+        private const val serialVersionUID = 1L
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
@@ -19,6 +19,12 @@ data class SdkLocalConfig(
     val taps: TapsLocalConfig? = null,
 
     /**
+     * OpenTelemetry config settings
+     */
+    @Json(name = "otel")
+    val otel: OpenTelemetryLocalConfig? = null,
+
+    /**
      * View settings
      */
     @Json(name = "view_config")

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.gradle.plugin.instrumentation.config.model.ComposeLoca
 import io.embrace.android.gradle.plugin.instrumentation.config.model.CrashHandlerLocalConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.EmbraceVariantConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.NetworkLocalConfig
+import io.embrace.android.gradle.plugin.instrumentation.config.model.OpenTelemetryLocalConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.SdkLocalConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.TapsLocalConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
@@ -96,6 +97,9 @@ class EnabledFeatureConfigInstrumentationKtTest {
                         ),
                         crashHandler = CrashHandlerLocalConfig(
                             enabled = true
+                        ),
+                        otel = OpenTelemetryLocalConfig(
+                            otelKotlinSdkEnabled = false
                         ),
                         networking = NetworkLocalConfig(
                             captureRequestContentLength = true,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -128,7 +128,7 @@ internal fun createSensitiveKeysBehavior() = SensitiveKeysBehaviorImpl(Instrumen
 /**
  * An [OtelBehaviorImpl] that returns default values.
  */
-internal fun createOtelBehavior(
+fun createOtelBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     remoteCfg: RemoteConfig? = null
-) = OtelBehaviorImpl(thresholdCheck, remoteCfg)
+) = OtelBehaviorImpl(thresholdCheck, InstrumentedConfigImpl, remoteCfg)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -28,6 +28,7 @@ class FakeEnabledFeatureConfig(
     private val uiLoadTracingEnabled: Boolean = base.isUiLoadTracingEnabled(),
     private val uiLoadTracingTraceAll: Boolean = base.isUiLoadTracingTraceAll(),
     private val endStartupWithAppReady: Boolean = base.isEndStartupWithAppReadyEnabled(),
+    private val otelKotlinSdkEnabled: Boolean = base.isOtelKotlinSdkEnabled(),
 ) : EnabledFeatureConfig {
 
     override fun isActivityBreadcrumbCaptureEnabled(): Boolean = activityBreadcrumbCapture
@@ -54,4 +55,5 @@ class FakeEnabledFeatureConfig(
     override fun isUiLoadTracingEnabled(): Boolean = uiLoadTracingEnabled
     override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
     override fun isEndStartupWithAppReadyEnabled(): Boolean = endStartupWithAppReady
+    override fun isOtelKotlinSdkEnabled(): Boolean = otelKotlinSdkEnabled
 }


### PR DESCRIPTION
## Goal

Add a local `sdk_config.otel.enable_otel_kotlin_sdk` flag that enables or disables the use of opentelemetry-kotlin-implementation, instead of opentelemetry-kotlin-compat. 

Once we remove the remote config, the default value will be changed, but this flag will be kept. If users want to use `getOpenTelemetryJava()`, they'll need to set this flag to false.

## TODO:

- [x] Gradle plugin part
- [x] Test it actually works