### PR TITLE
Send sys.exception and sys.flutter_exception logs immediately instead of batching them

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/schema/EmbType.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/schema/EmbType.kt
@@ -62,11 +62,11 @@ sealed class EmbType(type: String, subtype: String?) : EmbraceAttribute {
 
         object Log : System("log")
 
-        object Exception : System("exception")
+        object Exception : System("exception", SendMode.IMMEDIATE)
 
         object InternalError : System("internal")
 
-        object FlutterException : System("flutter_exception") {
+        object FlutterException : System("flutter_exception", SendMode.IMMEDIATE) {
             /**
              * Attribute name for the exception context in a log representing an exception
              */

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.capture.session.isSessionPropertyA
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.otel.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -243,7 +244,7 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsBySeverity(getSingleLogEnvelope())
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
 
                 Severity.values().forEach { severity ->
                     assertOtelLogReceived(
@@ -277,7 +278,7 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsBySeverity(getSingleLogEnvelope())
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
 
                 Severity.values().forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
@@ -336,7 +337,7 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsBySeverity(getSingleLogEnvelope())
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
 
                 Severity.values().forEach { severity ->
                     assertOtelLogReceived(
@@ -366,7 +367,7 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsBySeverity(getSingleLogEnvelope())
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
 
                 Severity.values().forEach { severity ->
                     assertOtelLogReceived(
@@ -403,8 +404,7 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val envelope = getSingleLogEnvelope()
-                val logs = groupLogsBySeverity(envelope)
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
 
                 Severity.values().forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
@@ -489,6 +489,15 @@ internal class LogFeatureTest {
         checkNotNull(envelope.data.logs?.associateBy {
             getEmbraceSeverity(checkNotNull(it.severityNumber))
         })
+
+    /**
+     * Groups logs from multiple envelopes by severity.
+     * Used for tests where logs are sent immediately (one envelope per log).
+     */
+    private fun groupLogsFromEnvelopes(envelopes: List<Envelope<LogPayload>>): Map<Severity, Log> =
+        envelopes.flatMap { it.data.logs.orEmpty() }.associateBy {
+            getEmbraceSeverity(checkNotNull(it.severityNumber))
+        }
 
     companion object {
         private val testException = IllegalArgumentException("nooooooo")


### PR DESCRIPTION
## Goal

Previously, exception logs (sys.exception and sys.flutter_exception) were batched together with regular logs, causing the X-EM-TYPES header to only contain the first log type seen in a batch.

This made the backend incorrectly discard the remaining types.

Changes:
- Set System.Exception to use SendMode.IMMEDIATE in EmbType.kt
- Set System.FlutterException to use SendMode.IMMEDIATE in EmbType.kt
- Updated LogFeatureTest to expect multiple envelopes when logging multiple exceptions (one envelope per exception)

## Will do in a following PR

sys.internal and sys.log logs are still batched, and will suffer from the same problem. In a following PR, I'll use a new header, X-EM-PAYLOAD-TYPES so the backend can parse them accordingly.