### PR TITLE
Use coreLibrariesVersion instead of adding the kotlin stdlib dependency

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/internal/JvmCompilerConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/internal/JvmCompilerConfig.kt
@@ -26,6 +26,7 @@ fun Project.configureCompilers(module: EmbraceBuildLogicExtension) {
             targetCompatibility = module.jvmTarget.get().toString()
         }
 
+        val coreLibrariesVersion = "2.0.21"
         when (val kotlin = project.extensions.getByName("kotlin")) {
             is KotlinJvmProjectExtension -> {
                 kotlin.compilerOptions {
@@ -34,6 +35,7 @@ fun Project.configureCompilers(module: EmbraceBuildLogicExtension) {
                     jvmTarget.set(target)
                     allWarningsAsErrors.set(true)
                 }
+                kotlin.coreLibrariesVersion = coreLibrariesVersion
             }
 
             is KotlinAndroidExtension -> {
@@ -43,6 +45,7 @@ fun Project.configureCompilers(module: EmbraceBuildLogicExtension) {
                     jvmTarget.set(target)
                     allWarningsAsErrors.set(true)
                 }
+                kotlin.coreLibrariesVersion = coreLibrariesVersion
             }
 
             else -> error("Unsupported kotlin plugin type: ${kotlin::class.java.name}")

--- a/buildSrc/src/main/kotlin/io/embrace/internal/ProductionModuleConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/internal/ProductionModuleConfig.kt
@@ -16,7 +16,6 @@ fun Project.configureProductionModule(
     project.configureBinaryCompatValidation(module)
 
     project.dependencies.apply {
-        add("implementation", findLibrary("kotlin.stdlib"))
         add("testImplementation", findLibrary("junit"))
         add("testImplementation", findLibrary("mockk"))
         add("testImplementation", project(":embrace-test-common"))

--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -52,5 +52,5 @@ dependencies {
     testImplementation(libs.lifecycle.runtime)
     testImplementation(libs.lifecycle.process)
     testImplementation(libs.lifecycle.testing)
-    testImplementation(libs.kotlin.reflect)
+    testImplementation(kotlin("reflect"))
 }

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -94,7 +94,6 @@ dependencies {
     testImplementation(project(":embrace-test-fakes"))
     testImplementation(libs.protobuf.java)
     testImplementation(libs.protobuf.java.util)
-    testImplementation(libs.kotlin.reflect)
     testImplementation(platform(libs.okhttp.bom))
     testImplementation(libs.mockwebserver)
     testImplementation(libs.opentelemetry.sdk)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@
 binaryCompatibilityValidator = "0.18.1"
 agp = "8.13.0"
 junit = "4.13.2"
-kotlinExposed = "2.0.21"
 dokka = "1.9.20"
 kotlinGradlePlugin = "2.1.21"
 koverGradlePlugin = "0.9.2"
@@ -61,7 +60,6 @@ opentelemetry-semconv = { group = "io.opentelemetry.semconv", name = "openteleme
 opentelemetry-semconv-incubating = { group = "io.opentelemetry.semconv", name = "opentelemetry-semconv-incubating", version.ref = "openTelementrySemConv" }
 protobuf-java = { group = "com.google.protobuf", name = "protobuf-java", version.ref = "protobuf" }
 protobuf-java-util = { group = "com.google.protobuf", name = "protobuf-java-util", version.ref = "protobuf" }
-kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlinExposed" }
 profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 lint-api = { group = "com.android.tools.lint", name = "lint-api", version.ref = "lint" }
 lint-tests = { group = "com.android.tools.lint", name = "lint-tests", version.ref = "lint" }
@@ -77,7 +75,6 @@ androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "andro
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxRunner" }
 androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidxOrchestrator" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver"}
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinExposed" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asmUtil" }


### PR DESCRIPTION
## Goal

There's a more "official" way of ensuring that the Kotlin version we expose is compatible with our minimum requirements: https://kotlinlang.org/api/kotlin-gradle-plugin/kotlin-gradle-plugin-api/org.jetbrains.kotlin.gradle.dsl/-kotlin-top-level-extension-config/core-libraries-version.html

> `coreLibrariesVersion` specifies the version of the core Kotlin libraries that are added to the Kotlin compile classpath, unless there is already a dependency added to this project.
> 
> The core Kotlin libraries are:
> 
> 'kotlin-stdlib'
> 'kotlin-test'
> 'kotlin-dom-api-compat'
> 'kotlin-reflect' 

This lets us avoid `Module was compiled with an incompatible version of Kotlin` errors. 

## Testing

Relied on existent testing.