### PR TITLE
Increase gradle plugin network timeout from 2 to 5 minutes

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/OkHttpNetworkService.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/OkHttpNetworkService.kt
@@ -221,6 +221,6 @@ class OkHttpNetworkService(
     }
 
     companion object {
-        private const val NETWORK_WRITE_TIMEOUT_SECONDS = 120L
+        private const val NETWORK_WRITE_TIMEOUT_SECONDS = 300L
     }
 }


### PR DESCRIPTION
## Goal
Increase the network write timeout for gradle plugin requests to prevent timeouts on slower connections or larger uploads.

## Changes
- Updated `NETWORK_WRITE_TIMEOUT_SECONDS` from 120 seconds (2 minutes) to 300 seconds (5 minutes) in `OkHttpNetworkService.kt`