### PR TITLE
Upgrade to Gradle 9.1.0

### DIFF
--- a/buildSrc/src/main/kotlin/io/embrace/internal/TestConfig.kt
+++ b/buildSrc/src/main/kotlin/io/embrace/internal/TestConfig.kt
@@ -17,6 +17,10 @@ fun configureTestOptions(android: LibraryExtension) {
                     this.exceptionFormat = TestExceptionFormat.FULL
                 }
                 test.maxParallelForks = (Runtime.getRuntime().availableProcessors() / 3) + 1
+
+                // Disable test discovery failure for modules without test sources
+                test.failOnNoDiscoveredTests.set(false)
+
             }
         }
         execution = "ANDROIDX_TEST_ORCHESTRATOR"

--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeProperty.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeProperty.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS")
+
 package io.embrace.gradle.plugin.instrumentation
 
 import io.mockk.every

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/NullSafeMap.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/NullSafeMap.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS", "UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS")
+
 package io.embrace.android.gradle.plugin.gradle
 
 import org.gradle.api.Transformer
@@ -11,7 +13,7 @@ import org.gradle.api.provider.Provider
  */
 fun <O, I : Any> Provider<I>.nullSafeMap(transform: (I) -> O?): Provider<O> {
     return map(
-        object : io.embrace.android.gradle.plugin.gradle.NullSafeTransformer<O?, I>() {
+        object : NullSafeTransformer<O?, I>() {
             override fun transform(input: I): O? {
                 return transform(input)
             }
@@ -24,7 +26,7 @@ fun <O, I : Any> Provider<I>.nullSafeMap(transform: (I) -> O?): Provider<O> {
  */
 @Suppress("ObjectLiteralToLambda", "WRONG_NULLABILITY_FOR_JAVA_OVERRIDE")
 inline fun <T, R> Provider<T>.safeFlatMap(
-    crossinline transform: (T) -> Provider<R>
+    crossinline transform: (T) -> Provider<R>,
 ): Provider<R> = flatMap(object : Transformer<Provider<R>, T> {
     override fun transform(input: T): Provider<R> {
         return transform(input)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/TaskRegistrationUtils.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/TaskRegistrationUtils.kt
@@ -55,6 +55,7 @@ fun <T : Task> Project.tryGetTaskProvider(taskName: String, taskType: Class<T>):
  * @param name The name of the task to look up.
  * @return A [Provider] of the task, or `provider { null }` if the task is not present.
  */
+@Suppress("UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS")
 inline fun <reified T : Task> Project.lazyTaskLookup(name: String): Provider<T?> {
     return provider {
         tryGetTaskProvider(name, T::class.java)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS", "UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS")
+
 package io.embrace.android.gradle.plugin.tasks.ndk
 
 import io.embrace.android.gradle.plugin.config.PluginBehavior

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS", "UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS")
+
 package io.embrace.android.gradle.plugin.tasks.r8
 
 import com.android.build.api.artifact.SingleArtifact

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS", "UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS")
+
 package io.embrace.android.gradle.plugin.tasks.reactnative
 
 import io.embrace.android.gradle.plugin.gradle.lazyTaskLookup

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Goal
Upgrade the project from Gradle 8.14.3 to Gradle 9.1.0 to use the latest stable version.

## Changes
- Updated gradle-wrapper.properties to use Gradle 9.1.0
- Added suppressions for nullability warnings introduced in Gradle 9
- Disabled test discovery failures for modules without test sources to prevent build failures

## Considerations
Gradle 9 migrated from JSR-305 to JSpecify annotations for nullability, which enforces stricter type checking in Kotlin. The `org.gradle.api.provider` package now uses `@NullMarked`, making all types non-null by default unless explicitly annotated with `@Nullable`.

This causes warnings when using `Provider<T?>` with nullable type parameters, as the implicit upper bound now requires non-null types. While Gradle's API semantically supports nullable values (as documented and seen in `Transformer<OUT extends @Nullable Object, IN>`), the `Provider` type parameter itself isn't explicitly marked as nullable.

We suppressed `UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS` and `NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS` warnings in files that use nullable Provider types. This is the recommended workaround until Gradle potentially adds explicit `@Nullable` annotations to Provider's type parameter in a future version.