### PR TITLE
Use JDK 21

### DIFF
--- a/.github/workflows/android-emulator-tests.yml
+++ b/.github/workflows/android-emulator-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3

--- a/.github/workflows/generate-baseline-profile.yml
+++ b/.github/workflows/generate-baseline-profile.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3

--- a/.github/workflows/upload-artifacts-to-maven-central.yml
+++ b/.github/workflows/upload-artifacts-to-maven-central.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/AnonInnerClassOnClickListener_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/AnonInnerClassOnClickListener_expected.txt
@@ -15,6 +15,7 @@ class io/embrace/test/fixtures/AnonInnerClassOnClickListener$1 implements androi
 
   // access flags 0x0
   <init>(Lio/embrace/test/fixtures/AnonInnerClassOnClickListener;)V
+    // parameter final mandated  <no name>
    L0
     LINENUMBER 10 L0
     ALOAD 0

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/AnonInnerClassOnLongClickListener_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/AnonInnerClassOnLongClickListener_expected.txt
@@ -15,6 +15,7 @@ class io/embrace/test/fixtures/AnonInnerClassOnLongClickListener$1 implements an
 
   // access flags 0x0
   <init>(Lio/embrace/test/fixtures/AnonInnerClassOnLongClickListener;)V
+    // parameter final mandated  <no name>
    L0
     LINENUMBER 10 L0
     ALOAD 0

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/JavaAnonOnClickListener_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/JavaAnonOnClickListener_expected.txt
@@ -15,6 +15,7 @@ class io/embrace/test/fixtures/JavaAnonOnClickListener$1 implements android/view
 
   // access flags 0x0
   <init>(Lio/embrace/test/fixtures/JavaAnonOnClickListener;)V
+    // parameter final mandated  <no name>
    L0
     LINENUMBER 22 L0
     ALOAD 0

--- a/embrace-bytecode-instrumentation-tests/src/test/resources/JavaInnerListener_expected.txt
+++ b/embrace-bytecode-instrumentation-tests/src/test/resources/JavaInnerListener_expected.txt
@@ -14,6 +14,7 @@ public class io/embrace/test/fixtures/JavaNested$JavaInnerListener implements an
 
   // access flags 0x1
   public <init>(Lio/embrace/test/fixtures/JavaNested;)V
+    // parameter final mandated  <no name>
    L0
     LINENUMBER 11 L0
     ALOAD 0

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/JdkEnv.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/JdkEnv.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.gradle.config
 
 enum class JdkEnv(val path: String) {
-    JAVA_11(resolveJdkPath(11)),
-    JAVA_17(resolveJdkPath(17))
+    JAVA_17(resolveJdkPath(17)),
+    JAVA_21(resolveJdkPath(21))
 }
 
 private fun resolveJdkPath(version: Int): String {

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
@@ -40,11 +40,11 @@ sealed class TestMatrix(
     /**
      * Not the latest, but newer than the middle of the pack.
      */
-    object NewerVersion : TestMatrix("8.5.2", "8.7", "2.1.21", JdkEnv.JAVA_17, "36")
+    object NewerVersion : TestMatrix("8.5.2", "8.7", "2.1.21", JdkEnv.JAVA_21, "36")
 
     /**
      * The maximum version we currently run tests against. Newer versions may work, but are not
      * explicitly tested.
      */
-    object MaxVersion : TestMatrix("8.9.1", "8.13", "2.2.20", JdkEnv.JAVA_17, "36")
+    object MaxVersion : TestMatrix("8.9.1", "8.13", "2.2.20", JdkEnv.JAVA_21, "36")
 }


### PR DESCRIPTION
## Goal
Upgrade the project to use JDK 21 (LTS) across all GitHub workflows and test configurations.

## Changes
- Updated all GitHub workflow files to use Java 21 instead of 17
- Updated JdkEnv enum to replace JAVA_11 with JAVA_21
- Updated TestMatrix configurations to use JAVA_21
- Updated bytecode instrumentation test expectations for JDK 21 output format