### PR TITLE
Update CODEOWNERS to remove API surface owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,13 +3,3 @@
 
 # Global owners
 * @embrace-io/sdk-android
-
-# API surface owners
-*.api @fractalwrench @fnewberg @bidetofevil
-**/Embrace.java @fractalwrench @fnewberg @bidetofevil
-**/EmbraceApi.java @fractalwrench @fnewberg @bidetofevil
-**/EmbraceAndroidApi.java @fractalwrench @fnewberg @bidetofevil
-**/EmbraceInternalInterface.java @fractalwrench @fnewberg @bidetofevil
-**/FlutterInternalInterface.java @fractalwrench @fnewberg
-**/ReactNativeInternalInterface.java @fractalwrench @fnewberg
-**/UnityInternalInterface.java @fractalwrench @fnewberg


### PR DESCRIPTION
## Goal

Remove separate codeowners for the API surface as in practice we're just reviewing it within the Android guild.

