### PR TITLE
Alter internal api entrypoint

### DIFF
--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeInternalErrorLogger.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/ComposeInternalErrorLogger.kt
@@ -5,6 +5,6 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 internal class ComposeInternalErrorLogger {
 
     fun logError(throwable: Throwable) {
-        EmbraceInternalApi.getInstance().internalInterface.logInternalError(throwable)
+        EmbraceInternalApi.internalInterface.logInternalError(throwable)
     }
 }

--- a/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceNodeIterator.kt
+++ b/embrace-android-compose/src/main/java/io/embrace/android/embracesdk/compose/internal/EmbraceNodeIterator.kt
@@ -28,7 +28,7 @@ internal class EmbraceNodeIterator {
 
         findClickedElement(semanticsNodes, x, y)?.let {
             val clickedView = ClickedView(it, x, y)
-            EmbraceInternalApi.getInstance().internalInterface.logComposeTap(
+            EmbraceInternalApi.internalInterface.logComposeTap(
                 Pair(clickedView.x, clickedView.y),
                 clickedView.tag
             )

--- a/embrace-android-fcm/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/FcmBytecodeEntrypoint.kt
+++ b/embrace-android-fcm/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/FcmBytecodeEntrypoint.kt
@@ -28,7 +28,7 @@ object FcmBytecodeEntrypoint {
                 message.data.isNotEmpty()
             )
         } catch (e: Exception) {
-            EmbraceInternalApi.getInstance().internalInterface.logInternalError(e)
+            EmbraceInternalApi.internalInterface.logInternalError(e)
         }
     }
 }

--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/OkHttpBytecodeEntrypoint.kt
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/OkHttpBytecodeEntrypoint.kt
@@ -35,7 +35,7 @@ object OkHttpBytecodeEntrypoint {
      * @param thiz the OkHttpClient builder in matter.
      */
     private fun addEmbraceInterceptors(thiz: OkHttpClient.Builder) {
-        val internalApi = EmbraceInternalApi.getInstance()
+        val internalApi = EmbraceInternalApi
         try {
             val embrace = Embrace
             addInterceptor(

--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3ApplicationInterceptor.kt
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3ApplicationInterceptor.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.okhttp3
 
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
-import io.embrace.android.embracesdk.internal.EmbraceInternalApi.Companion.CUSTOM_TRACE_ID_HEADER_NAME
+import io.embrace.android.embracesdk.internal.EmbraceInternalApi.CUSTOM_TRACE_ID_HEADER_NAME
 import io.embrace.android.embracesdk.internal.network.http.EmbraceHttpPathOverride
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod

--- a/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
+++ b/embrace-android-okhttp3/src/main/java/io/embrace/android/embracesdk/okhttp3/EmbraceOkHttp3NetworkInterceptor.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.okhttp3
 
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
-import io.embrace.android.embracesdk.internal.EmbraceInternalApi.Companion.CUSTOM_TRACE_ID_HEADER_NAME
+import io.embrace.android.embracesdk.internal.EmbraceInternalApi.CUSTOM_TRACE_ID_HEADER_NAME
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.network.http.EmbraceHttpPathOverride
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -42,7 +42,7 @@ internal class EmbraceInternalInterfaceTest {
             startSdk = false,
             testCaseAction = {
                 assertFalse(embrace.isStarted)
-                with(EmbraceInternalApi.getInstance().internalInterface) {
+                with(EmbraceInternalApi.internalInterface) {
                     logInfo("", null)
                     logWarning("", null, null)
                     logError("", null, null, false)
@@ -107,7 +107,7 @@ internal class EmbraceInternalInterfaceTest {
             testCaseAction = {
                 recordSession {
                     clock.tick()
-                    EmbraceInternalApi.getInstance().internalInterface.recordCompletedNetworkRequest(
+                    EmbraceInternalApi.internalInterface.recordCompletedNetworkRequest(
                         url = URL,
                         httpMethod = "GET",
                         startTime = START_TIME,
@@ -119,7 +119,7 @@ internal class EmbraceInternalInterfaceTest {
                         networkCaptureData = null
                     )
 
-                    EmbraceInternalApi.getInstance().internalInterface.recordIncompleteNetworkRequest(
+                    EmbraceInternalApi.internalInterface.recordIncompleteNetworkRequest(
                         url = URL,
                         httpMethod = "GET",
                         startTime = START_TIME,
@@ -129,7 +129,7 @@ internal class EmbraceInternalInterfaceTest {
                         networkCaptureData = null
                     )
 
-                    EmbraceInternalApi.getInstance().internalInterface.recordIncompleteNetworkRequest(
+                    EmbraceInternalApi.internalInterface.recordIncompleteNetworkRequest(
                         url = URL,
                         httpMethod = "GET",
                         startTime = START_TIME,
@@ -140,7 +140,7 @@ internal class EmbraceInternalInterfaceTest {
                         networkCaptureData = null
                     )
 
-                    EmbraceInternalApi.getInstance().internalInterface.recordNetworkRequest(
+                    EmbraceInternalApi.internalInterface.recordNetworkRequest(
                         embraceNetworkRequest = EmbraceNetworkRequest.fromCompletedRequest(
                             URL,
                             HttpMethod.POST,
@@ -177,7 +177,7 @@ internal class EmbraceInternalInterfaceTest {
         testRule.runTest(
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().internalInterface.logComposeTap(
+                    EmbraceInternalApi.internalInterface.logComposeTap(
                         Pair(expectedX, expectedY),
                         expectedElementName
                     )
@@ -213,19 +213,19 @@ internal class EmbraceInternalInterfaceTest {
             testCaseAction = {
                 recordSession {
                     assertTrue(
-                        EmbraceInternalApi.getInstance().internalInterface.shouldCaptureNetworkBody(
+                        EmbraceInternalApi.internalInterface.shouldCaptureNetworkBody(
                             "capture.me",
                             "GET"
                         )
                     )
                     assertFalse(
-                        EmbraceInternalApi.getInstance().internalInterface.shouldCaptureNetworkBody(
+                        EmbraceInternalApi.internalInterface.shouldCaptureNetworkBody(
                             "capture.me",
                             "POST"
                         )
                     )
-                    assertFalse(EmbraceInternalApi.getInstance().internalInterface.shouldCaptureNetworkBody(URL, "GET"))
-                    assertFalse(EmbraceInternalApi.getInstance().internalInterface.isNetworkSpanForwardingEnabled())
+                    assertFalse(EmbraceInternalApi.internalInterface.shouldCaptureNetworkBody(URL, "GET"))
+                    assertFalse(EmbraceInternalApi.internalInterface.isNetworkSpanForwardingEnabled())
                 }
             }
         )
@@ -236,7 +236,7 @@ internal class EmbraceInternalInterfaceTest {
         testRule.runTest(
             testCaseAction = {
                 recordSession {
-                    with(EmbraceInternalApi.getInstance().internalInterface) {
+                    with(EmbraceInternalApi.internalInterface) {
                         val parentSpanId = checkNotNull(startSpan(name = "tz-parent-span"))
                         clock.tick(10)
                         val childSpanId =
@@ -301,7 +301,7 @@ internal class EmbraceInternalInterfaceTest {
     fun `span logging across sessions`() {
         testRule.runTest(
             testCaseAction = {
-                val internalInterface = checkNotNull(EmbraceInternalApi.getInstance().internalInterface)
+                val internalInterface = checkNotNull(EmbraceInternalApi.internalInterface)
                 var stoppedParentId = ""
                 var activeParentId = ""
                 recordSession {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -69,8 +69,8 @@ internal class FlutterInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
+                    EmbraceInternalApi.flutterInternalInterface.setDartVersion("28.9.1")
+                    EmbraceInternalApi.flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
                 }
             },
             assertAction = {
@@ -89,8 +89,8 @@ internal class FlutterInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
+                    EmbraceInternalApi.flutterInternalInterface.setDartVersion("28.9.1")
+                    EmbraceInternalApi.flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
                 }
                 recordSession()
             },
@@ -110,13 +110,13 @@ internal class FlutterInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
+                    EmbraceInternalApi.flutterInternalInterface.setDartVersion("28.9.1")
+                    EmbraceInternalApi.flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
                 }
 
                 recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion(null)
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setEmbraceFlutterSdkVersion(null)
+                    EmbraceInternalApi.flutterInternalInterface.setDartVersion(null)
+                    EmbraceInternalApi.flutterInternalInterface.setEmbraceFlutterSdkVersion(null)
                 }
             },
             assertAction = {
@@ -135,13 +135,13 @@ internal class FlutterInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.1")
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
+                    EmbraceInternalApi.flutterInternalInterface.setDartVersion("28.9.1")
+                    EmbraceInternalApi.flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.3")
                 }
 
                 recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setDartVersion("28.9.2")
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.4")
+                    EmbraceInternalApi.flutterInternalInterface.setDartVersion("28.9.2")
+                    EmbraceInternalApi.flutterInternalInterface.setEmbraceFlutterSdkVersion("1.2.4")
                 }
             },
             assertAction = {
@@ -166,7 +166,7 @@ internal class FlutterInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 sessionStartTimeMs = recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.logHandledDartException(
+                    EmbraceInternalApi.flutterInternalInterface.logHandledDartException(
                         expectedStacktrace,
                         expectedName,
                         expectedMessage,
@@ -212,7 +212,7 @@ internal class FlutterInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 sessionStartTimeMs = recordSession {
-                    EmbraceInternalApi.getInstance().flutterInternalInterface.logUnhandledDartException(
+                    EmbraceInternalApi.flutterInternalInterface.logUnhandledDartException(
                         expectedStacktrace,
                         expectedName,
                         expectedMessage,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ReactNativeInternalInterfaceTest.kt
@@ -60,9 +60,9 @@ internal class ReactNativeInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeSdkVersion("1.2.3")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setJavaScriptPatchNumber("666")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeSdkVersion("1.2.3")
+                    EmbraceInternalApi.reactNativeInternalInterface.setJavaScriptPatchNumber("666")
                 }
             },
             assertAction = {
@@ -82,9 +82,9 @@ internal class ReactNativeInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeSdkVersion("1.2.3")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setJavaScriptPatchNumber("666")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeSdkVersion("1.2.3")
+                    EmbraceInternalApi.reactNativeInternalInterface.setJavaScriptPatchNumber("666")
                 }
 
                 recordSession()
@@ -106,15 +106,15 @@ internal class ReactNativeInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeSdkVersion("1.2.3")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setJavaScriptPatchNumber("666")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeVersionNumber("28.9.1")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeSdkVersion("1.2.3")
+                    EmbraceInternalApi.reactNativeInternalInterface.setJavaScriptPatchNumber("666")
                 }
 
                 recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeVersionNumber("28.9.2")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setReactNativeSdkVersion("1.2.4")
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.setJavaScriptPatchNumber("999")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeVersionNumber("28.9.2")
+                    EmbraceInternalApi.reactNativeInternalInterface.setReactNativeSdkVersion("1.2.4")
+                    EmbraceInternalApi.reactNativeInternalInterface.setJavaScriptPatchNumber("999")
                 }
             },
             assertAction = {
@@ -135,7 +135,7 @@ internal class ReactNativeInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnAction(
+                    EmbraceInternalApi.reactNativeInternalInterface.logRnAction(
                         "MyAction",
                         1000,
                         5000,
@@ -174,9 +174,9 @@ internal class ReactNativeInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnView("HomeScreen")
+                    EmbraceInternalApi.reactNativeInternalInterface.logRnView("HomeScreen")
                     clock.tick(1000)
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnView("DetailsScreen")
+                    EmbraceInternalApi.reactNativeInternalInterface.logRnView("DetailsScreen")
                 }
             },
             assertAction = {
@@ -197,9 +197,9 @@ internal class ReactNativeInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnView("HomeScreen")
+                    EmbraceInternalApi.reactNativeInternalInterface.logRnView("HomeScreen")
                     clock.tick(1000)
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.logRnView("HomeScreen")
+                    EmbraceInternalApi.reactNativeInternalInterface.logRnView("HomeScreen")
                 }
             },
             assertAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
@@ -50,7 +50,7 @@ internal class UnityInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().unityInternalInterface.setUnityMetaData(
+                    EmbraceInternalApi.unityInternalInterface.setUnityMetaData(
                         "28.9.1",
                         "unity build id",
                         "1.2.3"
@@ -74,7 +74,7 @@ internal class UnityInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().unityInternalInterface.setUnityMetaData(
+                    EmbraceInternalApi.unityInternalInterface.setUnityMetaData(
                         "28.9.1",
                         "unity build id",
                         "1.2.3"
@@ -99,7 +99,7 @@ internal class UnityInternalInterfaceTest {
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    EmbraceInternalApi.getInstance().unityInternalInterface.setUnityMetaData(
+                    EmbraceInternalApi.unityInternalInterface.setUnityMetaData(
                         "28.9.1",
                         "unity build id",
                         "1.2.3"
@@ -107,7 +107,7 @@ internal class UnityInternalInterfaceTest {
                 }
 
                 recordSession {
-                    EmbraceInternalApi.getInstance().unityInternalInterface.setUnityMetaData(
+                    EmbraceInternalApi.unityInternalInterface.setUnityMetaData(
                         "28.9.2",
                         "new unity build id",
                         "1.2.4"

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -117,7 +117,7 @@ internal class JvmCrashFeatureTest {
             ),
             testCaseAction = {
                 crashTimeMs = recordSession {
-                    EmbraceInternalApi.getInstance().reactNativeInternalInterface.logUnhandledJsException(
+                    EmbraceInternalApi.reactNativeInternalInterface.logUnhandledJsException(
                         "name",
                         "message",
                         "type",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
@@ -87,7 +87,7 @@ internal class PayloadTypesHeaderTest {
             testCaseAction = {
                 embrace.logInfo("log message")
                 (embrace as EmbraceImpl).internalInterface.logInternalError("internal error", "oh no!")
-                EmbraceInternalApi.getInstance().flutterInternalInterface.logUnhandledDartException(
+                EmbraceInternalApi.flutterInternalInterface.logUnhandledDartException(
                     "Flutter stacktrace",
                     "FlutterException",
                     "Flutter error occurred",
@@ -131,7 +131,7 @@ internal class PayloadTypesHeaderTest {
             testCaseAction = {
                 embrace.logInfo("log message")
                 (embrace as EmbraceImpl).internalInterface.logInternalError("internal error", "oh no!")
-                EmbraceInternalApi.getInstance().unityInternalInterface.logUnhandledUnityException(
+                EmbraceInternalApi.unityInternalInterface.logUnhandledUnityException(
                     "UnityException",
                     "Unity error occurred",
                     "Unity stacktrace"

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/TouchEvent.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/instrumentation/bytecode/TouchEvent.kt
@@ -18,12 +18,12 @@ internal fun logTouchEvent(view: View, breadcrumbType: TapBreadcrumbType) {
         } catch (e: Exception) {
             Pair(0.0f, 0.0f)
         }
-        EmbraceInternalApi.getInstance().internalInterface.logTap(
+        EmbraceInternalApi.internalInterface.logTap(
             point,
             viewName,
             breadcrumbType
         )
     } catch (throwable: Throwable) {
-        EmbraceInternalApi.getInstance().internalInterface.logInternalError(throwable)
+        EmbraceInternalApi.internalInterface.logInternalError(throwable)
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApiImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/network/http/InternalNetworkApiImpl.kt
@@ -11,7 +11,7 @@ internal class InternalNetworkApiImpl : InternalNetworkApi {
         get() = Embrace
 
     private fun getInternalInterface(): EmbraceInternalInterface =
-        checkNotNull(EmbraceInternalApi.getInstance().internalInterface)
+        checkNotNull(EmbraceInternalApi.internalInterface)
 
     override fun getSdkCurrentTimeMs(): Long = embrace.getSdkCurrentTimeMs()
 

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalApi.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalApi.kt
@@ -10,19 +10,16 @@ import io.embrace.android.embracesdk.internal.api.delegate.NoopUnityInternalInte
  * Provides access to internal Embrace SDK APIs. This is intended for use by Embrace's SDKs only and is subject
  * to breaking changes without warning.
  */
-class EmbraceInternalApi private constructor() : InternalInterfaceApi {
+object EmbraceInternalApi : InternalInterfaceApi {
 
-    companion object {
-        const val CUSTOM_TRACE_ID_HEADER_NAME: String = "x-emb-trace-id"
-        var internalTracingApi: InternalTracingApi? = null
-        var internalInterfaceApi: InternalInterfaceApi? = null
-        var isStarted: () -> Boolean = { false }
+    const val CUSTOM_TRACE_ID_HEADER_NAME: String = "x-emb-trace-id"
+    var internalTracingApi: InternalTracingApi? = null
+    var internalInterfaceApi: InternalInterfaceApi? = null
+    var isStarted: () -> Boolean = { false }
 
-        private val instance = EmbraceInternalApi()
-
-        @JvmStatic
-        fun getInstance(): EmbraceInternalApi = instance
-    }
+    @JvmStatic
+    @Deprecated("", replaceWith = ReplaceWith("EmbraceInternalApi"))
+    fun getInstance(): EmbraceInternalApi = this
 
     private val noopEmbraceInternalInterface by lazy {
         NoopEmbraceInternalInterface(internalTracingApi ?: NoopInternalTracingApi())


### PR DESCRIPTION
## Goal

Alters the entrypoint so that `EmbraceInternalApi.getInstance()` can be replaced by `EmbraceInternalApi`. This is achieved by converting the class to an object. `getInstance()` is marked as deprecated and provides a replacement pattern that automatically applies the required fix - I've tested this by removing all calls to `getInstance()` from the project via the IDE suggestion.

## Testing

Relied on existing test coverage.

