### PR TITLE
Use entries rather than values()

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EndpointLimitExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/EndpointLimitExt.kt
@@ -1,5 +1,5 @@
 package io.embrace.android.embracesdk.internal.comms.api
 
-private val limiters = Endpoint.values().associateWith { EndpointLimiter() }
+private val limiters = Endpoint.entries.associateWith { EndpointLimiter() }
 
 internal val Endpoint.limiter: EndpointLimiter get() = checkNotNull(limiters[this])

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -131,8 +131,8 @@ internal class PayloadMessageCollatorImplTest {
     fun `session span is created when session payload is built if it did not exist before`() {
         currentSessionSpan.endSession(startNewSession = false)
         listOf(true, false).forEach { startupTemperature ->
-            LifeEventType.values().forEach { lifeEventType ->
-                ApplicationState.values().forEach { previousState ->
+            LifeEventType.entries.forEach { lifeEventType ->
+                ApplicationState.entries.forEach { previousState ->
                     collator.buildInitialSession(
                         InitialEnvelopeParams(
                             coldStart = startupTemperature,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -70,7 +70,7 @@ internal class EmbraceTracerTest {
 
     @Test
     fun `stop EmbraceSpan with different error codes`() {
-        ErrorCode.values().forEach { errorCode ->
+        ErrorCode.entries.forEach { errorCode ->
             val embraceSpan = checkNotNull(embraceTracer.createSpan(name = "test-span"))
             assertNotNull(embraceSpan)
             assertTrue(embraceSpan.start())

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
@@ -19,10 +19,10 @@ enum class PayloadType(
 
     companion object {
 
-        private val filenameMap = PayloadType.values().associateBy { it.filenameComponent }
+        private val filenameMap = PayloadType.entries.associateBy { it.filenameComponent }
 
         fun fromValue(value: String?): PayloadType {
-            return values().firstOrNull { it.value == value } ?: UNKNOWN
+            return PayloadType.entries.firstOrNull { it.value == value } ?: UNKNOWN
         }
 
         fun fromFilenameComponent(component: String): PayloadType = filenameMap[component] ?: UNKNOWN

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
@@ -21,7 +21,7 @@ enum class SupportedEnvelopeType(
 
     companion object {
         private val valueMap =
-            SupportedEnvelopeType.values().associateBy(SupportedEnvelopeType::priority)
+            SupportedEnvelopeType.entries.associateBy(SupportedEnvelopeType::priority)
 
         /**
          * Returns the [SupportedEnvelopeType] that corresponds to the given priority, if any.

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -274,7 +274,7 @@ internal class SpanServiceImplTest {
 
     @Test
     fun `record spans with different ending error codes `() {
-        ErrorCode.values().forEach { errorCode ->
+        ErrorCode.entries.forEach { errorCode ->
             assertTrue(
                 spansService.recordCompletedSpan(
                     name = "test${errorCode.name}",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
@@ -39,7 +39,7 @@ internal class DisableSdkFeatureTest {
     @Before
     fun setUp() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        embraceDirs = StorageLocation.values().map { it.asFile(ctx, FakeEmbLogger()).value }
+        embraceDirs = StorageLocation.entries.map { it.asFile(ctx, FakeEmbLogger()).value }
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -122,7 +122,7 @@ internal class LogFeatureTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     logTimestamps.add(clock.now())
                     val expectedMessage = "test message ${severity.name}"
                     embrace.logMessage(expectedMessage, severity)
@@ -132,7 +132,7 @@ internal class LogFeatureTest {
             assertAction = {
                 val logs = groupLogsBySeverity(getSingleLogEnvelope())
 
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
                     assertOtelLogReceived(
                         logs[severity],
@@ -151,7 +151,7 @@ internal class LogFeatureTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     logTimestamps.add(clock.now())
                     val expectedMessage = "test message ${severity.name}"
                     embrace.logMessage(expectedMessage, severity, customProperties)
@@ -160,7 +160,7 @@ internal class LogFeatureTest {
             },
             assertAction = {
                 val logs = groupLogsBySeverity(getSingleLogEnvelope())
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
 
                     assertOtelLogReceived(
@@ -234,7 +234,7 @@ internal class LogFeatureTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     logTimestamps.add(clock.now())
                     embrace.logException(
                         testException, severity,
@@ -244,9 +244,9 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.entries.size))
 
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = checkNotNull(testException.message),
@@ -270,7 +270,7 @@ internal class LogFeatureTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     logTimestamps.add(clock.now())
                     val expectedMessage = "test message ${severity.name}"
                     embrace.logException(testException, severity, customProperties, expectedMessage)
@@ -278,9 +278,9 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.entries.size))
 
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
                     assertOtelLogReceived(
                         logs[severity],
@@ -330,16 +330,16 @@ internal class LogFeatureTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     logTimestamps.add(clock.now())
                     embrace.logCustomStacktrace(stacktrace, severity)
                 }
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.entries.size))
 
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = "",
@@ -360,16 +360,16 @@ internal class LogFeatureTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     logTimestamps.add(clock.now())
                     embrace.logCustomStacktrace(stacktrace, severity, customProperties)
                 }
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.entries.size))
 
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     assertOtelLogReceived(
                         logs[severity],
                         expectedMessage = "",
@@ -391,7 +391,7 @@ internal class LogFeatureTest {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     logTimestamps.add(clock.now())
                     val expectedMessage = "test message ${severity.name}"
                     embrace.logCustomStacktrace(
@@ -404,9 +404,9 @@ internal class LogFeatureTest {
                 clock.tick(2000L)
             },
             assertAction = {
-                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.values().size))
+                val logs = groupLogsFromEnvelopes(getLogEnvelopes(Severity.entries.size))
 
-                Severity.values().forEach { severity ->
+                Severity.entries.forEach { severity ->
                     val expectedMessage = "test message ${severity.name}"
                     assertOtelLogReceived(
                         logs[severity],

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -230,7 +230,7 @@ internal class EmbraceImpl(
             stop()
             Executors.newSingleThreadExecutor().execute {
                 runCatching {
-                    StorageLocation.values().map { it.asFile(bootstrapper.coreModule.context, logger).value }.forEach {
+                    StorageLocation.entries.map { it.asFile(bootstrapper.coreModule.context, logger).value }.forEach {
                         it.deleteRecursively()
                     }
                 }.onFailure { exception ->

--- a/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/FakeApiServer.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/java/io/embrace/android/gradle/integration/framework/FakeApiServer.kt
@@ -8,11 +8,11 @@ import java.util.LinkedList
 
 class FakeApiServer : Dispatcher() {
 
-    private val endpoints = EmbraceEndpoint.values().associateBy(EmbraceEndpoint::url)
-    private val receivedRequests = EmbraceEndpoint.values().associateWith {
+    private val endpoints = EmbraceEndpoint.entries.associateBy(EmbraceEndpoint::url)
+    private val receivedRequests = EmbraceEndpoint.entries.associateWith {
         mutableListOf<RecordedRequest>()
     }
-    private val enqueuedResponses = EmbraceEndpoint.values().associateWith {
+    private val enqueuedResponses = EmbraceEndpoint.entries.associateWith {
         LinkedList<MockResponse>()
     }
 

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/MissingConfigFileTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/MissingConfigFileTest.kt
@@ -23,7 +23,7 @@ class MissingConfigFileTest {
                 File(projectDir, "src/main/embrace-config.json").delete()
             },
             assertions = {
-                val endpoints = EmbraceEndpoint.values()
+                val endpoints = EmbraceEndpoint.entries
                 endpoints.forEach {
                     verifyNoRequestsSent(it)
                 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/ConfigClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/ConfigClassVisitorFactory.kt
@@ -52,7 +52,7 @@ object ConfigClassVisitorFactory {
         api: Int,
         cv: ClassVisitor?,
     ): ClassVisitor? {
-        val type = ConfigClassType.values().singleOrNull { it.className == className }
+        val type = ConfigClassType.entries.singleOrNull { it.className == className }
         return type?.createClassVisitor(cfg, encodedSharedObjectFilesMap, reactNativeBundleId, api, cv)
     }
 }


### PR DESCRIPTION
## Goal

Uses `entries` rather than `values()`.

## Testing

Relied on existing test coverage.
