### PR TITLE
Disable HUC instrumentation by default

### DIFF
--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
@@ -34,7 +34,7 @@ internal class NetworkBehaviorImplTest {
     fun testDefaults() {
         with(createNetworkBehavior(remoteCfg = null)) {
             assertFalse(isRequestContentLengthCaptureEnabled())
-            assertTrue(isHttpUrlConnectionCaptureEnabled())
+            assertFalse(isHttpUrlConnectionCaptureEnabled())
             assertEquals(1000, getRequestLimitPerDomain())
             assertEquals(emptyMap<String, Int>(), getLimitsByDomain())
             assertTrue(isUrlEnabled("google.com"))

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -122,7 +122,7 @@ interface EnabledFeatureConfig {
      *
      * sdk_config.networking.enable_native_monitoring
      */
-    fun isHttpUrlConnectionCaptureEnabled(): Boolean = true
+    fun isHttpUrlConnectionCaptureEnabled(): Boolean = false
 
     /**
      * Gates whether network span forwarding should be enabled

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     implementation(libs.opentelemetry.kotlin.noop)
 
     testImplementation(project(":embrace-test-fakes"))
+    testImplementation(project(":embrace-android-instrumentation-huc"))
     testImplementation(libs.protobuf.java)
     testImplementation(libs.protobuf.java.util)
     testImplementation(platform(libs.okhttp.bom))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/HucInstrumentationEnabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/HucInstrumentationEnabledTest.kt
@@ -1,0 +1,67 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.getLogOfType
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class HucInstrumentationEnabledTest {
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `sdk starts successfully but internal error logged when HUC instrumentation enabled`() {
+        testRule.runTest(
+            setupAction = {
+                getEmbLogger().throwOnInternalError = false
+            },
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(
+                    httpUrlConnectionCapture = true
+                )
+            ),
+            testCaseAction = {
+                assertTrue(embrace.isStarted)
+                recordSession()
+            },
+            assertAction = {
+                with(getSingleLogEnvelope().getLogOfType(EmbType.System.InternalError)) {
+                    assertEquals(
+                        "java.lang.reflect.InaccessibleObjectException",
+                        checkNotNull(attributes).findAttributeValue("exception.type")
+                    )
+                }
+                assertNotNull(getSingleSessionEnvelope())
+            },
+        )
+    }
+
+    @Test
+    fun `sdk starts successfully with no internal error when HUC disabled`() {
+        testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(
+                    httpUrlConnectionCapture = false
+                )
+            ),
+            testCaseAction = {
+                assertTrue(embrace.isStarted)
+                recordSession()
+            },
+            assertAction = {
+                assertNotNull(getSingleSessionEnvelope())
+            },
+        )
+    }
+}


### PR DESCRIPTION
## Goal

Disable HUC instrumentation by default and add integration tests to ensure the initialization does what's expected given the circumstances of being run on a non-Android JVM.