### PR TITLE
Support trace instrumentation API

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanDataSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanDataSourceImpl.kt
@@ -1,17 +1,17 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
 import io.embrace.android.embracesdk.internal.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 
 /**
  * Base class for data sources.
  */
 abstract class SpanDataSourceImpl(
-    destination: SpanService,
+    destination: TraceWriter,
     logger: EmbLogger,
     limitStrategy: LimitStrategy,
-) : SpanDataSource, DataSourceImpl<SpanService>(
+) : SpanDataSource, DataSourceImpl<TraceWriter>(
     destination = destination,
     logger = logger,
     limitStrategy = limitStrategy,
@@ -20,6 +20,6 @@ abstract class SpanDataSourceImpl(
     override fun captureSpanData(
         countsTowardsLimits: Boolean,
         inputValidation: () -> Boolean,
-        captureAction: SpanService.() -> Unit,
+        captureAction: TraceWriter.() -> Unit,
     ): Boolean = captureDataImpl(inputValidation, captureAction, countsTowardsLimits)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TraceWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TraceWriterImpl.kt
@@ -1,0 +1,54 @@
+package io.embrace.android.embracesdk.internal.arch.destination
+
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.otel.spans.SpanService
+import io.embrace.android.embracesdk.spans.AutoTerminationMode
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+
+class TraceWriterImpl(private val spanService: SpanService) : TraceWriter {
+
+    override fun startSpanCapture(
+        schemaType: SchemaType,
+        startTimeMs: Long,
+        autoTerminate: Boolean,
+    ): SpanToken? {
+        val mode = when {
+            autoTerminate -> AutoTerminationMode.ON_BACKGROUND
+            else -> AutoTerminationMode.NONE
+        }
+        val span = spanService.startSpan(
+            name = schemaType.fixedObjectName,
+            startTimeMs = startTimeMs,
+            autoTerminationMode = mode,
+            type = schemaType.telemetryType
+        )?.apply {
+            schemaType.attributes().forEach {
+                addAttribute(it.key, it.value)
+            }
+        } ?: return null
+        return SpanTokenImpl(span)
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeMs: Long,
+        endTimeMs: Long,
+        type: EmbType,
+        attributes: Map<String, String>,
+    ) {
+        spanService.recordCompletedSpan(
+            name = name,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
+            type = type,
+            attributes = attributes,
+        )
+    }
+
+    private class SpanTokenImpl(private val span: EmbraceSpan) : SpanToken {
+        override fun stop(endTimeMs: Long?) {
+            span.stop(endTimeMs = endTimeMs)
+        }
+    }
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/SpanDataSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/SpanDataSourceImplTest.kt
@@ -1,10 +1,11 @@
 package io.embrace.android.embracesdk.internal.arch
 
-import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.FakeTraceWriter
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanDataSourceImpl
 import io.embrace.android.embracesdk.internal.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -15,10 +16,10 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `capture data successfully`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst)
         val success = source.captureData(inputValidation = { true }) {
-            createSpan("test")
+            startSpanCapture(SchemaType.LowPower, 0)
         }
         assertTrue(success)
         assertEquals(1, dst.createdSpans.size)
@@ -26,7 +27,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `capture data threw exception`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst)
         val success = source.captureData(inputValidation = { true }) {
             error("Whoops!")
@@ -37,7 +38,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `capture data respects limits`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
@@ -51,7 +52,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `capture data respects validation`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
@@ -65,10 +66,10 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `start span succeeds`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst)
         val success = source.captureSpanData(true, inputValidation = { true }) {
-            createSpan("test")
+            startSpanCapture(SchemaType.LowPower, 0)
         }
         assertTrue(success)
         assertEquals(1, dst.createdSpans.size)
@@ -76,7 +77,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `start span data threw exception`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst)
         val success = source.captureSpanData(true, inputValidation = { true }) {
             error("Whoops!")
@@ -87,7 +88,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `start span respects limits`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
@@ -101,7 +102,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `start span respects validation`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
@@ -115,10 +116,10 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `stop span succeeeds`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst)
         val success = source.captureSpanData(false, inputValidation = { true }) {
-            createSpan("test")
+            startSpanCapture(SchemaType.LowPower, 0)
         }
         assertTrue(success)
         assertEquals(1, dst.createdSpans.size)
@@ -126,7 +127,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `stop span data threw exception`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst)
         val success = source.captureSpanData(false, inputValidation = { true }) {
             error("Whoops!")
@@ -137,7 +138,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `stop span does not increment limits`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
@@ -151,7 +152,7 @@ internal class SpanDataSourceImplTest {
 
     @Test
     fun `stop span respects validation`() {
-        val dst = FakeSpanService()
+        val dst = FakeTraceWriter()
         val source = FakeDataSourceImpl(dst, UpToLimitStrategy { 2 })
 
         var count = 0
@@ -164,7 +165,7 @@ internal class SpanDataSourceImplTest {
     }
 
     private class FakeDataSourceImpl(
-        dst: FakeSpanService,
+        dst: FakeTraceWriter,
         limitStrategy: LimitStrategy = NoopLimitStrategy,
     ) : SpanDataSourceImpl(dst, EmbLoggerImpl(), limitStrategy)
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkStatusDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkStatusDataSource.kt
@@ -2,21 +2,20 @@ package io.embrace.android.embracesdk.internal.capture.connectivity
 
 import io.embrace.android.embracesdk.internal.arch.datasource.NoInputValidation
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanDataSourceImpl
-import io.embrace.android.embracesdk.internal.arch.datasource.startSpanCapture
+import io.embrace.android.embracesdk.internal.arch.destination.SpanToken
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.spans.SpanService
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 class NetworkStatusDataSource(
     private val clock: Clock,
-    spanService: SpanService,
+    traceWriter: TraceWriter,
     logger: EmbLogger,
 ) : NetworkConnectivityListener, SpanDataSourceImpl(
-    destination = spanService,
+    destination = traceWriter,
     logger = logger,
     limitStrategy = UpToLimitStrategy { MAX_CAPTURED_NETWORK_STATUS }
 ) {
@@ -24,7 +23,7 @@ class NetworkStatusDataSource(
         private const val MAX_CAPTURED_NETWORK_STATUS = 100
     }
 
-    private var span: EmbraceSpan? = null
+    private var span: SpanToken? = null
 
     override fun onNetworkConnectivityStatusChanged(status: NetworkStatus) {
         // close previous span

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/RnActionDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/RnActionDataSource.kt
@@ -1,18 +1,18 @@
 package io.embrace.android.embracesdk.internal.capture.crumbs
 
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanDataSourceImpl
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 
 class RnActionDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
-    spanService: SpanService,
+    traceWriter: TraceWriter,
     logger: EmbLogger,
 ) : SpanDataSourceImpl(
-    spanService,
+    traceWriter,
     logger,
     UpToLimitStrategy { breadcrumbBehavior.getCustomBreadcrumbLimit() }
 ) {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/ViewDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/ViewDataSource.kt
@@ -2,14 +2,13 @@ package io.embrace.android.embracesdk.internal.capture.crumbs
 
 import io.embrace.android.embracesdk.internal.arch.datasource.NoInputValidation
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanDataSourceImpl
-import io.embrace.android.embracesdk.internal.arch.datasource.startSpanCapture
+import io.embrace.android.embracesdk.internal.arch.destination.SpanToken
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.spans.SpanService
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 /**
  * Captures fragment views.
@@ -17,15 +16,15 @@ import io.embrace.android.embracesdk.spans.EmbraceSpan
 class ViewDataSource(
     breadcrumbBehavior: BreadcrumbBehavior,
     private val clock: Clock,
-    spanService: SpanService,
+    traceWriter: TraceWriter,
     logger: EmbLogger,
 ) : SpanDataSourceImpl(
-    spanService,
+    traceWriter,
     logger,
     UpToLimitStrategy { breadcrumbBehavior.getFragmentBreadcrumbLimit() }
 ) {
 
-    private val viewSpans: LinkedHashMap<String, EmbraceSpan> = LinkedHashMap()
+    private val viewSpans: LinkedHashMap<String, SpanToken> = LinkedHashMap()
 
     /**
      * Called when a view is started. If a view with the same name is already running, it will be ended.

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/powersave/LowPowerDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/powersave/LowPowerDataSource.kt
@@ -4,25 +4,24 @@ import android.content.Context
 import android.os.PowerManager
 import io.embrace.android.embracesdk.internal.arch.datasource.NoInputValidation
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanDataSourceImpl
-import io.embrace.android.embracesdk.internal.arch.datasource.startSpanCapture
+import io.embrace.android.embracesdk.internal.arch.destination.SpanToken
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 
 class LowPowerDataSource(
     private val context: Context,
-    spanService: SpanService,
+    traceWriter: TraceWriter,
     logger: EmbLogger,
     private val backgroundWorker: BackgroundWorker,
     private val clock: Clock,
     provider: Provider<PowerManager?>,
 ) : SpanDataSourceImpl(
-    destination = spanService,
+    destination = traceWriter,
     logger = logger,
     limitStrategy = UpToLimitStrategy { MAX_CAPTURED_POWER_MODE_INTERVALS }
 ) {
@@ -32,7 +31,7 @@ class LowPowerDataSource(
     }
 
     private val receiver = PowerSaveModeReceiver(provider, ::onPowerSaveModeChanged)
-    private var span: EmbraceSpan? = null
+    private var span: SpanToken? = null
 
     override fun enableDataCapture(): Unit = receiver.register(context, backgroundWorker)
     override fun disableDataCapture(): Unit = receiver.unregister(context)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSource.kt
@@ -5,27 +5,26 @@ import android.os.PowerManager
 import androidx.annotation.RequiresApi
 import io.embrace.android.embracesdk.internal.arch.datasource.NoInputValidation
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanDataSourceImpl
-import io.embrace.android.embracesdk.internal.arch.datasource.startSpanCapture
+import io.embrace.android.embracesdk.internal.arch.destination.SpanToken
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import io.embrace.android.embracesdk.spans.EmbraceSpan
 import java.util.concurrent.Executor
 
 @RequiresApi(Build.VERSION_CODES.Q)
 class ThermalStateDataSource(
-    spanService: SpanService,
+    traceWriter: TraceWriter,
     logger: EmbLogger,
     private val backgroundWorker: BackgroundWorker,
     private val clock: Clock,
     powerManagerProvider: Provider<PowerManager?>,
 ) : SpanDataSourceImpl(
-    destination = spanService,
+    destination = traceWriter,
     logger = logger,
     limitStrategy = UpToLimitStrategy { MAX_CAPTURED_THERMAL_STATES }
 ) {
@@ -37,7 +36,7 @@ class ThermalStateDataSource(
 
     private val powerManager: PowerManager? by lazy(powerManagerProvider)
 
-    private var span: EmbraceSpan? = null
+    private var span: SpanToken? = null
 
     override fun enableDataCapture() {
         backgroundWorker.submit {

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crumbs/ViewDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/crumbs/ViewDataSourceTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.capture.crumbs
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.FakeTraceWriter
 import io.embrace.android.embracesdk.internal.arch.attrs.asPair
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
@@ -16,18 +16,18 @@ internal class ViewDataSourceTest {
 
     private lateinit var configService: FakeConfigService
     private lateinit var clock: FakeClock
-    private lateinit var spanService: FakeSpanService
+    private lateinit var traceWriter: FakeTraceWriter
     private lateinit var dataSource: ViewDataSource
 
     @Before
     fun setUp() {
         configService = FakeConfigService()
         clock = FakeClock()
-        spanService = FakeSpanService()
+        traceWriter = FakeTraceWriter()
         dataSource = ViewDataSource(
             configService.breadcrumbBehavior,
             clock,
-            spanService,
+            traceWriter,
             EmbLoggerImpl(),
         )
     }
@@ -36,7 +36,7 @@ internal class ViewDataSourceTest {
     fun `start view creates a span correctly`() {
         dataSource.startView("my_fragment")
 
-        val span = spanService.createdSpans.single()
+        val span = traceWriter.createdSpans.single()
         assertEquals(EmbType.Ux.View, span.type)
         assertTrue(span.isRecording)
         assertEquals(
@@ -53,7 +53,7 @@ internal class ViewDataSourceTest {
         dataSource.startView("my_fragment")
         dataSource.startView("my_fragment")
 
-        val spans = spanService.createdSpans
+        val spans = traceWriter.createdSpans
 
         assertEquals(2, spans.size)
         assertTrue(
@@ -76,7 +76,7 @@ internal class ViewDataSourceTest {
         dataSource.startView("my_fragment")
         dataSource.startView("another_fragment")
 
-        val spans = spanService.createdSpans
+        val spans = traceWriter.createdSpans
 
         assertEquals(2, spans.size)
         assertTrue(
@@ -99,7 +99,7 @@ internal class ViewDataSourceTest {
         dataSource.startView("my_fragment")
         dataSource.endView("my_fragment")
 
-        val span = spanService.createdSpans.single()
+        val span = traceWriter.createdSpans.single()
         assertEquals(EmbType.Ux.View, span.type)
         assertFalse(span.isRecording)
         assertEquals(
@@ -114,14 +114,14 @@ internal class ViewDataSourceTest {
     @Test
     fun `end an unknown fragment`() {
         assertTrue(dataSource.endView("my_fragment"))
-        assertTrue(spanService.createdSpans.isEmpty())
+        assertTrue(traceWriter.createdSpans.isEmpty())
     }
 
     @Test
     fun `change view starts a new span`() {
         dataSource.changeView("some_view")
 
-        val span = spanService.createdSpans.single()
+        val span = traceWriter.createdSpans.single()
         assertEquals(EmbType.Ux.View, span.type)
         assertTrue(span.isRecording)
         assertEquals(
@@ -138,7 +138,7 @@ internal class ViewDataSourceTest {
         dataSource.changeView("a_view")
         dataSource.changeView("another_view")
 
-        val spans = spanService.createdSpans
+        val spans = traceWriter.createdSpans
 
         assertEquals(2, spans.size)
         assertTrue(

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/powersave/LowPowerDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/powersave/LowPowerDataSourceTest.kt
@@ -6,7 +6,7 @@ import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.FakeTraceWriter
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.attrs.asPair
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -22,14 +22,14 @@ import org.robolectric.RuntimeEnvironment
 internal class LowPowerDataSourceTest {
 
     private lateinit var dataSource: LowPowerDataSource
-    private lateinit var spanService: FakeSpanService
+    private lateinit var traceWriter: FakeTraceWriter
 
     @Before
     fun setUp() {
-        spanService = FakeSpanService()
+        traceWriter = FakeTraceWriter()
         dataSource = LowPowerDataSource(
             ApplicationProvider.getApplicationContext(),
-            spanService,
+            traceWriter,
             EmbLoggerImpl(),
             fakeBackgroundWorker(),
             FakeClock()
@@ -57,7 +57,7 @@ internal class LowPowerDataSourceTest {
     @Test
     fun `no span recorded for unbalanced calls`() {
         dataSource.onPowerSaveModeChanged(false)
-        assertEquals(0, spanService.createdSpans.size)
+        assertEquals(0, traceWriter.createdSpans.size)
     }
 
     @Test
@@ -66,7 +66,7 @@ internal class LowPowerDataSourceTest {
             dataSource.onPowerSaveModeChanged(true)
             dataSource.onPowerSaveModeChanged(false)
         }
-        assertEquals(100, spanService.createdSpans.count { it.type == EmbType.System.LowPower })
+        assertEquals(100, traceWriter.createdSpans.count { it.type == EmbType.System.LowPower })
     }
 
     @Test
@@ -78,7 +78,7 @@ internal class LowPowerDataSourceTest {
     }
 
     private fun assertSpanAdded() {
-        val span = spanService.createdSpans.single()
+        val span = traceWriter.createdSpans.single()
         assertEquals(EmbType.System.LowPower, span.type)
         assertEquals("device-low-power", span.name)
         assertEquals(

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSourceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/capture/thermalstate/ThermalStateDataSourceTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.capture.thermalstate
 
 import android.os.PowerManager
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.FakeTraceWriter
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
@@ -15,14 +15,14 @@ import org.junit.Test
 internal class ThermalStateDataSourceTest {
 
     private lateinit var dataSource: ThermalStateDataSource
-    private lateinit var spanWriter: FakeSpanService
+    private lateinit var traceWriter: FakeTraceWriter
     private val mockPowerManager = mockk<PowerManager>(relaxed = true)
 
     @Before
     fun setUp() {
-        spanWriter = FakeSpanService()
+        traceWriter = FakeTraceWriter()
         dataSource = ThermalStateDataSource(
-            spanWriter,
+            traceWriter,
             EmbLoggerImpl(),
             fakeBackgroundWorker(),
             FakeClock(100),
@@ -36,13 +36,13 @@ internal class ThermalStateDataSourceTest {
             handleThermalStateChange(PowerManager.THERMAL_STATUS_SEVERE)
             handleThermalStateChange(PowerManager.THERMAL_STATUS_CRITICAL)
         }
-        assertEquals(3, spanWriter.createdSpans.size)
-        spanWriter.createdSpans.forEach {
+        assertEquals(3, traceWriter.createdSpans.size)
+        traceWriter.createdSpans.forEach {
             assertEquals(EmbType.Performance.ThermalState, it.type)
         }
-        assertEquals(PowerManager.THERMAL_STATUS_NONE, spanWriter.createdSpans[0].attributes["status"]?.toInt())
-        assertEquals(PowerManager.THERMAL_STATUS_SEVERE, spanWriter.createdSpans[1].attributes["status"]?.toInt())
-        assertEquals(PowerManager.THERMAL_STATUS_CRITICAL, spanWriter.createdSpans[2].attributes["status"]?.toInt())
+        assertEquals(PowerManager.THERMAL_STATUS_NONE, traceWriter.createdSpans[0].attributes["status"]?.toInt())
+        assertEquals(PowerManager.THERMAL_STATUS_SEVERE, traceWriter.createdSpans[1].attributes["status"]?.toInt())
+        assertEquals(PowerManager.THERMAL_STATUS_CRITICAL, traceWriter.createdSpans[2].attributes["status"]?.toInt())
     }
 
     @Test
@@ -51,7 +51,7 @@ internal class ThermalStateDataSourceTest {
             dataSource.handleThermalStateChange(PowerManager.THERMAL_STATUS_SEVERE)
         }
 
-        assertEquals(100, spanWriter.createdSpans.size)
+        assertEquals(100, traceWriter.createdSpans.size)
     }
 
     @Test

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanDataSource.kt
@@ -1,19 +1,15 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
-import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
-import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
-import io.embrace.android.embracesdk.internal.otel.spans.SpanService
-import io.embrace.android.embracesdk.spans.AutoTerminationMode
-import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
 
 /**
  * A [DataSource] that adds or alters a span.
  */
-interface SpanDataSource : DataSource<SpanService> {
+interface SpanDataSource : DataSource<TraceWriter> {
 
     /**
      * The DataSource should call this function when it wants to start, stop, or mutate
-     * an [EmbraceSpan]. [captureData] should only be used for adding to the session span.
+     * a span. [captureData] should only be used for adding to the session span.
      *
      * The [countsTowardsLimits] parameter should be true if the [captureAction] will add data
      * that should count towards the limits.
@@ -31,23 +27,6 @@ interface SpanDataSource : DataSource<SpanService> {
     fun captureSpanData(
         countsTowardsLimits: Boolean,
         inputValidation: () -> Boolean,
-        captureAction: SpanService.() -> Unit,
+        captureAction: TraceWriter.() -> Unit,
     ): Boolean
-}
-
-fun SpanService.startSpanCapture(
-    schemaType: SchemaType,
-    startTimeMs: Long,
-    autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-): EmbraceSdkSpan? {
-    return startSpan(
-        name = schemaType.fixedObjectName,
-        startTimeMs = startTimeMs,
-        type = schemaType.telemetryType,
-        autoTerminationMode = autoTerminationMode,
-    )?.apply {
-        schemaType.attributes().forEach {
-            addAttribute(it.key, it.value)
-        }
-    }
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SpanToken.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/SpanToken.kt
@@ -1,0 +1,5 @@
+package io.embrace.android.embracesdk.internal.arch.destination
+
+interface SpanToken {
+    fun stop(endTimeMs: Long? = null)
+}

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TraceWriter.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TraceWriter.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.internal.arch.destination
+
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+
+interface TraceWriter {
+
+    fun startSpanCapture(
+        schemaType: SchemaType,
+        startTimeMs: Long,
+        autoTerminate: Boolean = false,
+    ): SpanToken?
+
+    fun recordCompletedSpan(
+        name: String,
+        startTimeMs: Long,
+        endTimeMs: Long,
+        type: EmbType = EmbType.Performance.Default,
+        attributes: Map<String, String> = emptyMap(),
+    )
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.arch.destination.SpanToken
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+
+class FakeSpanToken(private val span: EmbraceSpan) : SpanToken {
+    override fun stop(endTimeMs: Long?) {
+        span.stop(endTimeMs = endTimeMs)
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTraceWriter.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTraceWriter.kt
@@ -1,0 +1,53 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.arch.destination.SpanToken
+import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.spans.AutoTerminationMode
+
+class FakeTraceWriter : TraceWriter {
+
+    private val spanService = FakeSpanService()
+
+    val createdSpans: MutableList<FakeEmbraceSdkSpan>
+        get() = spanService.createdSpans
+
+    override fun startSpanCapture(
+        schemaType: SchemaType,
+        startTimeMs: Long,
+        autoTerminate: Boolean,
+    ): SpanToken? {
+        val mode = when {
+            autoTerminate -> AutoTerminationMode.ON_BACKGROUND
+            else -> AutoTerminationMode.NONE
+        }
+        val span = spanService.startSpan(
+            name = schemaType.fixedObjectName,
+            startTimeMs = startTimeMs,
+            type = schemaType.telemetryType,
+            autoTerminationMode = mode,
+        )?.apply {
+            schemaType.attributes().forEach {
+                addAttribute(it.key, it.value)
+            }
+        }
+        return span?.let(::FakeSpanToken)
+    }
+
+    override fun recordCompletedSpan(
+        name: String,
+        startTimeMs: Long,
+        endTimeMs: Long,
+        type: EmbType,
+        attributes: Map<String, String>,
+    ) {
+        spanService.recordCompletedSpan(
+            name = name,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
+            type = type,
+            attributes = attributes,
+        )
+    }
+}


### PR DESCRIPTION
## Goal

Moves existing code to different modules to make it possible to capture a trace via the Instrumentation API. This effectively involved wrapping the `SpanService/EmbraceSpan` APIs to avoid depending on the public module.

## Testing

Relied on existing test coverage.

