### PR TITLE
Improve desugaring tests

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/build.gradle.kts
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/build.gradle.kts
@@ -7,3 +7,9 @@ plugins {
 
 integrationTest.configureAndroidProject(project)
 integrationTest.configureDesugaring(project)
+
+repositories {
+    google()
+    mavenCentral()
+    mavenLocal()
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/AndroidManifest.xml
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/java/com/example/app/Bar.java
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/java/com/example/app/Bar.java
@@ -1,0 +1,7 @@
+package com.example.app;
+
+public class Bar {
+    public static String getBar() {
+        return "bar";
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/kotlin/com/example/app/Foo.java
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/kotlin/com/example/app/Foo.java
@@ -1,0 +1,7 @@
+package com.example.app;
+
+public class Foo {
+    public static String getFoo() {
+        return "foo";
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/kotlin/com/example/app/HelloKotlin.kt
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-desugaring/src/main/kotlin/com/example/app/HelloKotlin.kt
@@ -1,0 +1,3 @@
+package com.example.app
+
+data class HelloKotlin(val hello: String)

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/DesugaringTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/DesugaringTest.kt
@@ -44,7 +44,7 @@ class DesugaringTest {
         rule.runTest(
             fixture = "android-desugaring",
             task = "assembleRelease",
-            additionalArgs = listOf("-PminSdk=24"),
+            additionalArgs = listOf("-PminSdk=21"),
             projectType = ProjectType.ANDROID,
             assertions = {
                 verifyBuildTelemetryRequestSent(listOf("debug", "release"))


### PR DESCRIPTION
## Goal
Improve the android-desugaring integration test fixture to represent a real Android project and ensure our minSDK is still supported.

## Changes
- Add sample Java and Kotlin source files so the javac and kotlinc tasks run with actual code.
- Lower minSdk from 24 to 21 to test our actual minimum.