### PR TITLE
Split up preference service implementation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -20,7 +20,7 @@ internal class DeviceImpl(
     override val systemInfo: SystemInfo,
     private val logger: EmbLogger,
 ) : Device {
-    override var isJailbroken: Boolean? = null
+    override var isJailbroken: Boolean? = false
     override var screenResolution: String = ""
     private val jailbreakLocations: List<String> = listOf(
         "/sbin/",
@@ -75,18 +75,9 @@ internal class DeviceImpl(
 
     private fun asyncRetrieveIsJailbroken() {
         // if the isJailbroken property exists in memory, don't try to retrieve it
-        if (isJailbroken != null) {
-            return
-        }
         backgroundWorker.submit {
-            val storedIsJailbroken = preferencesService.jailbroken
-            // load value from shared preferences
-            if (storedIsJailbroken != null) {
-                isJailbroken = storedIsJailbroken
-            } else {
-                isJailbroken = checkIfIsJailbroken()
-                preferencesService.jailbroken = isJailbroken
-            }
+            isJailbroken = checkIfIsJailbroken()
+            preferencesService.jailbroken = isJailbroken
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModule.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 
 interface AndroidServicesModule {
     val preferencesService: PreferencesService
+    val store: KeyValueStore
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/AndroidServicesModuleImpl.kt
@@ -3,21 +3,29 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import android.preference.PreferenceManager
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
+import io.embrace.android.embracesdk.internal.prefs.SharedPrefsStore
 
 internal class AndroidServicesModuleImpl(
     initModule: InitModule,
     coreModule: CoreModule,
 ) : AndroidServicesModule {
 
-    override val preferencesService: PreferencesService by singleton {
-        EmbracePreferencesService(
+    override val store: KeyValueStore by singleton {
+        SharedPrefsStore(
             PreferenceManager.getDefaultSharedPreferences(
                 coreModule.context
             ),
-            initModule.clock,
             initModule.jsonSerializer
+        )
+    }
+
+    override val preferencesService: PreferencesService by singleton {
+        EmbracePreferencesService(
+            store,
+            initModule.clock
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
@@ -1,123 +1,29 @@
 package io.embrace.android.embracesdk.internal.prefs
 
-import android.content.SharedPreferences
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.utils.Uuid.getEmbUuid
 
 internal class EmbracePreferencesService(
-    private val prefs: SharedPreferences,
+    private val impl: KeyValueStore,
     private val clock: Clock,
-    private val serializer: PlatformSerializer,
 ) : PreferencesService {
 
-    private fun SharedPreferences.getStringPreference(key: String): String? {
-        return getString(key, null)
-    }
-
-    private fun SharedPreferences.setStringPreference(key: String, value: String?) {
-        val editor = edit()
-        editor.putString(key, value)
-        editor.apply()
-    }
-
-    private fun SharedPreferences.getLongPreference(key: String): Long? {
-        val defaultValue: Long = -1L
-        return when (val value = getLong(key, defaultValue)) {
-            defaultValue -> null
-            else -> value
-        }
-    }
-
-    private fun SharedPreferences.setLongPreference(key: String, value: Long?) {
-        if (value != null) {
-            val editor = edit()
-            editor.putLong(key, value)
-            editor.apply()
-        }
-    }
-
-    private fun SharedPreferences.getIntegerPreference(key: String): Int? {
-        val defaultValue: Int = -1
-        return when (val value = getInt(key, defaultValue)) {
-            defaultValue -> null
-            else -> value
-        }
-    }
-
-    private fun SharedPreferences.setIntegerPreference(key: String, value: Int) {
-        val editor = edit()
-        editor.putInt(key, value)
-        editor.apply()
-    }
-
-    private fun SharedPreferences.getBooleanPreference(
-        key: String,
-        defaultValue: Boolean,
-    ): Boolean {
-        return getBoolean(key, defaultValue)
-    }
-
-    private fun SharedPreferences.setBooleanPreference(
-        key: String,
-        value: Boolean?,
-    ) {
-        if (value != null) {
-            val editor = edit()
-            editor.putBoolean(key, value)
-            editor.apply()
-        }
-    }
-
-    private fun SharedPreferences.setArrayPreference(
-        key: String,
-        value: Set<String>?,
-    ) {
-        val editor = edit()
-        editor.putStringSet(key, value)
-        editor.apply()
-    }
-
-    private fun SharedPreferences.getArrayPreference(key: String): Set<String>? {
-        return getStringSet(key, null)
-    }
-
-    private fun SharedPreferences.setMapPreference(
-        key: String,
-        value: Map<String, String>?,
-    ) {
-        val editor = edit()
-        val mapString = when (value) {
-            null -> null
-            else -> serializer.toJson(value, Map::class.java)
-        }
-        editor.putString(key, mapString)
-        editor.apply()
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun SharedPreferences.getMapPreference(
-        key: String,
-    ): Map<String, String>? {
-        val mapString = getString(key, null) ?: return null
-        return serializer.fromJson(mapString, Map::class.java) as Map<String, String>
-    }
-
     override var appVersion: String?
-        get() = prefs.getStringPreference(PREVIOUS_APP_VERSION_KEY)
-        set(value) = prefs.setStringPreference(PREVIOUS_APP_VERSION_KEY, value)
+        get() = impl.getString(PREVIOUS_APP_VERSION_KEY)
+        set(value) = impl.edit { putString(PREVIOUS_APP_VERSION_KEY, value) }
 
     override var osVersion: String?
-        get() = prefs.getStringPreference(PREVIOUS_OS_VERSION_KEY)
-        set(value) = prefs.setStringPreference(PREVIOUS_OS_VERSION_KEY, value)
+        get() = impl.getString(PREVIOUS_OS_VERSION_KEY)
+        set(value) = impl.edit { putString(PREVIOUS_OS_VERSION_KEY, value) }
 
     override var installDate: Long?
-        get() = prefs.getLongPreference(INSTALL_DATE_KEY)
-        set(value) = prefs.setLongPreference(INSTALL_DATE_KEY, value)
+        get() = impl.getLong(INSTALL_DATE_KEY)
+        set(value) = impl.edit { putLong(INSTALL_DATE_KEY, value) }
 
     override var deviceIdentifier: String
         get() {
-            val deviceId = prefs.getStringPreference(DEVICE_IDENTIFIER_KEY)
+            val deviceId = impl.getString(DEVICE_IDENTIFIER_KEY)
             if (deviceId != null) {
                 return deviceId
             }
@@ -125,123 +31,110 @@ internal class EmbracePreferencesService(
             deviceIdentifier = newId
             return newId
         }
-        set(value) = prefs.setStringPreference(DEVICE_IDENTIFIER_KEY, value)
+        set(value) = impl.edit { putString(DEVICE_IDENTIFIER_KEY, value) }
 
     override var userPayer: Boolean
-        get() = prefs.getBooleanPreference(USER_IS_PAYER_KEY, false)
-        set(value) = prefs.setBooleanPreference(USER_IS_PAYER_KEY, value)
+        get() = impl.getBoolean(USER_IS_PAYER_KEY, false)
+        set(value) = impl.edit { putBoolean(USER_IS_PAYER_KEY, value) }
 
     override var userIdentifier: String?
-        get() = prefs.getStringPreference(USER_IDENTIFIER_KEY)
-        set(value) = prefs.setStringPreference(USER_IDENTIFIER_KEY, value)
+        get() = impl.getString(USER_IDENTIFIER_KEY)
+        set(value) = impl.edit { putString(USER_IDENTIFIER_KEY, value) }
 
     override var userEmailAddress: String?
-        get() = prefs.getStringPreference(USER_EMAIL_ADDRESS_KEY)
-        set(value) = prefs.setStringPreference(USER_EMAIL_ADDRESS_KEY, value)
+        get() = impl.getString(USER_EMAIL_ADDRESS_KEY)
+        set(value) = impl.edit { putString(USER_EMAIL_ADDRESS_KEY, value) }
 
     override var userPersonas: Set<String>?
-        get() = prefs.getArrayPreference(USER_PERSONAS_KEY)
-        set(value) = prefs.setArrayPreference(USER_PERSONAS_KEY, value)
+        get() = impl.getStringSet(USER_PERSONAS_KEY)
+        set(value) = impl.edit { putStringSet(USER_PERSONAS_KEY, value) }
 
     override var permanentSessionProperties: Map<String, String>?
-        get() = prefs.getMapPreference(SESSION_PROPERTIES_KEY)
-        set(value) = prefs.setMapPreference(SESSION_PROPERTIES_KEY, value)
+        get() = impl.getStringMap(SESSION_PROPERTIES_KEY)
+        set(value) = impl.edit { putStringMap(SESSION_PROPERTIES_KEY, value) }
 
     override var username: String?
-        get() = prefs.getStringPreference(USER_USERNAME_KEY)
-        set(value) = prefs.setStringPreference(USER_USERNAME_KEY, value)
+        get() = impl.getString(USER_USERNAME_KEY)
+        set(value) = impl.edit { putString(USER_USERNAME_KEY, value) }
 
     override var lastConfigFetchDate: Long?
-        get() = prefs.getLongPreference(SDK_CONFIG_FETCHED_TIMESTAMP)
-        set(value) = prefs.setLongPreference(SDK_CONFIG_FETCHED_TIMESTAMP, value)
+        get() = impl.getLong(SDK_CONFIG_FETCHED_TIMESTAMP)
+        set(value) = impl.edit { putLong(SDK_CONFIG_FETCHED_TIMESTAMP, value) }
 
     override fun incrementAndGetSessionNumber(): Int {
-        return incrementAndGetOrdinal(LAST_SESSION_NUMBER_KEY)
+        return impl.incrementAndGet(LAST_SESSION_NUMBER_KEY)
     }
 
     override fun incrementAndGetBackgroundActivityNumber(): Int {
-        return incrementAndGetOrdinal(LAST_BACKGROUND_ACTIVITY_NUMBER_KEY)
+        return impl.incrementAndGet(LAST_BACKGROUND_ACTIVITY_NUMBER_KEY)
     }
 
     override fun incrementAndGetCrashNumber(): Int {
-        return incrementAndGetOrdinal(LAST_CRASH_NUMBER_KEY)
+        return impl.incrementAndGet(LAST_CRASH_NUMBER_KEY)
     }
 
     override fun incrementAndGetNativeCrashNumber(): Int {
-        return incrementAndGetOrdinal(LAST_NATIVE_CRASH_NUMBER_KEY)
+        return impl.incrementAndGet(LAST_NATIVE_CRASH_NUMBER_KEY)
     }
 
     override fun incrementAndGetAeiCrashNumber(): Int {
-        return incrementAndGetOrdinal(LAST_AEI_CRASH_NUMBER_KEY)
-    }
-
-    private fun incrementAndGetOrdinal(key: String): Int {
-        return try {
-            val ordinal = (prefs.getIntegerPreference(key) ?: 0) + 1
-            prefs.setIntegerPreference(key, ordinal)
-            ordinal
-        } catch (tr: Throwable) {
-            -1
-        }
+        return impl.incrementAndGet(LAST_AEI_CRASH_NUMBER_KEY)
     }
 
     override var javaScriptBundleURL: String?
-        get() = prefs.getStringPreference(JAVA_SCRIPT_BUNDLE_URL_KEY)
-        set(value) = prefs.setStringPreference(JAVA_SCRIPT_BUNDLE_URL_KEY, value)
+        get() = impl.getString(JAVA_SCRIPT_BUNDLE_URL_KEY)
+        set(value) = impl.edit { putString(JAVA_SCRIPT_BUNDLE_URL_KEY, value) }
 
     override var javaScriptBundleId: String?
-        get() = prefs.getStringPreference(JAVA_SCRIPT_BUNDLE_ID_KEY)
-        set(value) = prefs.setStringPreference(JAVA_SCRIPT_BUNDLE_ID_KEY, value)
+        get() = impl.getString(JAVA_SCRIPT_BUNDLE_ID_KEY)
+        set(value) = impl.edit { putString(JAVA_SCRIPT_BUNDLE_ID_KEY, value) }
 
     override var rnSdkVersion: String?
-        get() = prefs.getStringPreference(REACT_NATIVE_SDK_VERSION_KEY)
-        set(value) = prefs.setStringPreference(REACT_NATIVE_SDK_VERSION_KEY, value)
+        get() = impl.getString(REACT_NATIVE_SDK_VERSION_KEY)
+        set(value) = impl.edit { putString(REACT_NATIVE_SDK_VERSION_KEY, value) }
 
     override var javaScriptPatchNumber: String?
-        get() = prefs.getStringPreference(JAVA_SCRIPT_PATCH_NUMBER_KEY)
-        set(value) = prefs.setStringPreference(JAVA_SCRIPT_PATCH_NUMBER_KEY, value)
+        get() = impl.getString(JAVA_SCRIPT_PATCH_NUMBER_KEY)
+        set(value) = impl.edit { putString(JAVA_SCRIPT_PATCH_NUMBER_KEY, value) }
 
     override var reactNativeVersionNumber: String?
-        get() = prefs.getStringPreference(REACT_NATIVE_VERSION_KEY)
-        set(value) = prefs.setStringPreference(REACT_NATIVE_VERSION_KEY, value)
+        get() = impl.getString(REACT_NATIVE_VERSION_KEY)
+        set(value) = impl.edit { putString(REACT_NATIVE_VERSION_KEY, value) }
 
     override var unityVersionNumber: String?
-        get() = prefs.getStringPreference(UNITY_VERSION_NUMBER_KEY)
-        set(value) = prefs.setStringPreference(UNITY_VERSION_NUMBER_KEY, value)
+        get() = impl.getString(UNITY_VERSION_NUMBER_KEY)
+        set(value) = impl.edit { putString(UNITY_VERSION_NUMBER_KEY, value) }
 
     override var unityBuildIdNumber: String?
-        get() = prefs.getStringPreference(UNITY_BUILD_ID_NUMBER_KEY)
-        set(value) = prefs.setStringPreference(UNITY_BUILD_ID_NUMBER_KEY, value)
+        get() = impl.getString(UNITY_BUILD_ID_NUMBER_KEY)
+        set(value) = impl.edit { putString(UNITY_BUILD_ID_NUMBER_KEY, value) }
 
     override var unitySdkVersionNumber: String?
-        get() = prefs.getStringPreference(UNITY_SDK_VERSION_NUMBER_KEY)
-        set(value) = prefs.setStringPreference(UNITY_SDK_VERSION_NUMBER_KEY, value)
+        get() = impl.getString(UNITY_SDK_VERSION_NUMBER_KEY)
+        set(value) = impl.edit { putString(UNITY_SDK_VERSION_NUMBER_KEY, value) }
 
     override var dartSdkVersion: String?
-        get() = prefs.getStringPreference(DART_SDK_VERSION_KEY)
-        set(value) = prefs.setStringPreference(DART_SDK_VERSION_KEY, value)
+        get() = impl.getString(DART_SDK_VERSION_KEY)
+        set(value) = impl.edit { putString(DART_SDK_VERSION_KEY, value) }
 
     override var embraceFlutterSdkVersion: String?
-        get() = prefs.getStringPreference(EMBRACE_FLUTTER_SDK_VERSION_KEY)
-        set(value) = prefs.setStringPreference(EMBRACE_FLUTTER_SDK_VERSION_KEY, value)
+        get() = impl.getString(EMBRACE_FLUTTER_SDK_VERSION_KEY)
+        set(value) = impl.edit { putString(EMBRACE_FLUTTER_SDK_VERSION_KEY, value) }
 
     override var jailbroken: Boolean?
-        get() = when {
-            !prefs.contains(IS_JAILBROKEN_KEY) -> null
-            else -> prefs.getBooleanPreference(
-                IS_JAILBROKEN_KEY,
-                false
-            )
-        }
-        set(value) = prefs.setBooleanPreference(IS_JAILBROKEN_KEY, value)
+        get() = impl.getBoolean(
+            IS_JAILBROKEN_KEY,
+            false
+        )
+        set(value) = impl.edit { putBoolean(IS_JAILBROKEN_KEY, value) }
 
     override var screenResolution: String?
-        get() = prefs.getStringPreference(SCREEN_RESOLUTION_KEY)
-        set(value) = prefs.setStringPreference(SCREEN_RESOLUTION_KEY, value)
+        get() = impl.getString(SCREEN_RESOLUTION_KEY)
+        set(value) = impl.edit { putString(SCREEN_RESOLUTION_KEY, value) }
 
     override var deliveredAeiIds: Set<String>
-        get() = prefs.getStringSet(AEI_HASH_CODES, null) ?: emptySet()
-        set(value) = prefs.setArrayPreference(AEI_HASH_CODES, value)
+        get() = impl.getStringSet(AEI_HASH_CODES) ?: emptySet()
+        set(value) = impl.edit { putStringSet(AEI_HASH_CODES, value) }
 
     override fun isUsersFirstDay(): Boolean {
         val installDate = installDate
@@ -253,10 +146,9 @@ internal class EmbracePreferencesService(
     }
 
     override fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int) {
-        prefs.setIntegerPreference(
-            NETWORK_CAPTURE_RULE_PREFIX_KEY + id,
-            getNetworkCaptureRuleRemainingCount(id, maxCount) - 1
-        )
+        impl.edit {
+            putInt(NETWORK_CAPTURE_RULE_PREFIX_KEY + id, getNetworkCaptureRuleRemainingCount(id, maxCount) - 1)
+        }
     }
 
     private fun getNetworkCaptureRuleRemainingCount(id: String): Int {
@@ -264,7 +156,7 @@ internal class EmbracePreferencesService(
     }
 
     private fun getNetworkCaptureRuleRemainingCount(id: String, maxCount: Int): Int {
-        val value = prefs.getIntegerPreference(NETWORK_CAPTURE_RULE_PREFIX_KEY + id)
+        val value = impl.getInt(NETWORK_CAPTURE_RULE_PREFIX_KEY + id)
         return value ?: maxCount
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -1,0 +1,64 @@
+package io.embrace.android.embracesdk.internal.prefs
+
+import android.content.SharedPreferences
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStoreEditor
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+
+internal class SharedPrefsStore(
+    private val impl: SharedPreferences,
+    private val serializer: PlatformSerializer,
+) : KeyValueStore {
+
+    override fun getString(key: String): String? {
+        return impl.getString(key, null)
+    }
+
+    override fun getInt(key: String): Int? {
+        val defaultValue: Int = -1
+        return when (val value = impl.getInt(key, defaultValue)) {
+            defaultValue -> null
+            else -> value
+        }
+    }
+
+    override fun getLong(key: String): Long? {
+        val defaultValue: Long = -1L
+        return when (val value = impl.getLong(key, defaultValue)) {
+            defaultValue -> null
+            else -> value
+        }
+    }
+
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean {
+        return impl.getBoolean(key, defaultValue)
+    }
+
+    override fun getStringSet(key: String): Set<String>? {
+        return impl.getStringSet(key, null)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringMap(key: String): Map<String, String>? {
+        val mapString = impl.getString(key, null) ?: return null
+        return serializer.fromJson(mapString, Map::class.java) as Map<String, String>
+    }
+
+    override fun edit(action: KeyValueStoreEditor.() -> Unit) {
+        SharedPrefsStoreEditor(impl.edit(), serializer).use {
+            it.action()
+        }
+    }
+
+    override fun incrementAndGet(key: String): Int {
+        return try {
+            val ordinal = (getInt(key) ?: 0) + 1
+            edit {
+                putInt(key, ordinal)
+            }
+            ordinal
+        } catch (tr: Throwable) {
+            -1
+        }
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStoreEditor.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStoreEditor.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.internal.prefs
+
+import android.content.SharedPreferences
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStoreEditor
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+
+internal class SharedPrefsStoreEditor(
+    private val editor: SharedPreferences.Editor,
+    private val serializer: PlatformSerializer,
+) : KeyValueStoreEditor, AutoCloseable {
+
+    override fun putString(key: String, value: String?) {
+        editor.putString(key, value)
+    }
+
+    override fun putInt(key: String, value: Int?) {
+        editor.putInt(key, value ?: -1)
+    }
+
+    override fun putLong(key: String, value: Long?) {
+        editor.putLong(key, value ?: -1L)
+    }
+
+    override fun putBoolean(key: String, value: Boolean?) {
+        editor.putBoolean(key, value ?: false)
+    }
+
+    override fun putStringSet(key: String, value: Set<String>?) {
+        editor.putStringSet(key, value)
+    }
+
+    override fun putStringMap(
+        key: String,
+        value: Map<String, String>?,
+    ) {
+        val mapString = when {
+            value != null -> serializer.toJson(value, Map::class.java)
+            else -> null
+        }
+        editor.putString(key, mapString)
+    }
+
+    override fun close() = editor.apply()
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
@@ -1,0 +1,75 @@
+@file:Suppress("DEPRECATION")
+
+package io.embrace.android.embracesdk.internal.arch.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.internal.prefs.SharedPrefsStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class KeyValueStoreTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private lateinit var store: KeyValueStore
+
+    @Before
+    fun setUp() {
+        val prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        store = SharedPrefsStore(prefs, TestPlatformSerializer())
+    }
+
+    @Test
+    fun testDefaultRead() {
+        val key = "key"
+        assertNull(store.getString(key))
+        assertNull(store.getInt(key))
+        assertNull(store.getLong(key))
+        assertFalse(checkNotNull(store.getBoolean(key, false)))
+        assertNull(store.getStringSet(key))
+        assertNull(store.getStringMap(key))
+    }
+
+    @Test
+    fun testIncrementAndGet() {
+        val key = "a"
+        val otherKey = "b"
+        assertEquals(1, store.incrementAndGet(key))
+        assertEquals(2, store.incrementAndGet(key))
+        assertEquals(1, store.incrementAndGet(otherKey))
+    }
+
+    @Test
+    fun testOverrideValues() {
+        val strValue = "value"
+        val intValue = 1
+        val longValue = 2L
+        val boolValue = true
+        val setValue = setOf("a", "b")
+        val mapValue = mapOf("a" to "b")
+
+        store.edit {
+            putString("string", strValue)
+            putInt("int", intValue)
+            putLong("long", longValue)
+            putBoolean("bool", boolValue)
+            putStringSet("set", setValue)
+            putStringMap("map", mapValue)
+        }
+        assertEquals(strValue, store.getString("string"))
+        assertEquals(intValue, store.getInt("int"))
+        assertEquals(longValue, store.getLong("long"))
+        assertEquals(boolValue, store.getBoolean("bool", false))
+        assertEquals(setValue, store.getStringSet("set"))
+        assertEquals(mapValue, store.getStringMap("map"))
+    }
+}

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/capture/session/EmbraceSessionPropertiesTest.kt
@@ -1,18 +1,15 @@
-@file:Suppress("DEPRECATION")
-
 package io.embrace.android.embracesdk.internal.capture.session
 
 import android.content.Context
-import android.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
 import io.embrace.android.embracesdk.internal.prefs.EmbracePreferencesService
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -43,9 +40,8 @@ internal class EmbraceSessionPropertiesTest {
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         preferencesService =
-            EmbracePreferencesService(prefs, fakeClock, EmbraceSerializer())
+            EmbracePreferencesService(FakeKeyValueStore(), fakeClock)
 
         configService = FakeConfigService(
             sessionBehavior = FakeSessionBehavior(MAX_SESSION_PROPERTIES_DEFAULT)

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesServiceTest.kt
@@ -9,7 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeSharedPreferences
-import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -33,9 +33,8 @@ internal class EmbracePreferencesServiceTest {
         prefs = PreferenceManager.getDefaultSharedPreferences(context)
         fakeClock = FakeClock()
         service = EmbracePreferencesService(
-            prefs,
-            fakeClock,
-            EmbraceSerializer()
+            SharedPrefsStore(prefs, TestPlatformSerializer()),
+            fakeClock
         )
     }
 
@@ -195,9 +194,11 @@ internal class EmbracePreferencesServiceTest {
     @Test
     fun `test incrementAndGet returns -1 on an exception`() {
         service = EmbracePreferencesService(
-            FakeSharedPreferences(throwExceptionOnGet = true),
-            fakeClock,
-            EmbraceSerializer()
+            SharedPrefsStore(
+                FakeSharedPreferences(throwExceptionOnGet = true),
+                TestPlatformSerializer()
+            ),
+            fakeClock
         )
         assertEquals(-1, service.incrementAndGetSessionNumber())
     }
@@ -276,7 +277,7 @@ internal class EmbracePreferencesServiceTest {
 
     @Test
     fun `test is jail broken is saved`() {
-        assertNull(service.jailbroken)
+        assertFalse(checkNotNull(service.jailbroken))
         service.jailbroken = true
         assertTrue(checkNotNull(service.jailbroken))
     }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationInstallArgs.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationInstallArgs.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.arch
 import android.content.Context
 import io.embrace.android.embracesdk.internal.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
@@ -43,6 +44,13 @@ interface InstrumentationInstallArgs {
      * The application context
      */
     val context: Context
+
+    /**
+     * A key-value store that is shared by all instrumentation used by this SDK. Individual
+     * instrumentation should write values to this using their own abstractions, and
+     * should make good efforts to use unique keys.
+     */
+    val store: KeyValueStore
 
     /**
      * Retrieves a background worker matching the given name.

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStore.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStore.kt
@@ -1,0 +1,47 @@
+package io.embrace.android.embracesdk.internal.arch.store
+
+/**
+ * Retrieves values from a key-value store.
+ */
+interface KeyValueStore {
+
+    /**
+     * Retrieves a string from the key-value store that matches the given key.
+     */
+    fun getString(key: String): String?
+
+    /**
+     * Retrieves an int from the key-value store that matches the given key.
+     */
+    fun getInt(key: String): Int?
+
+    /**
+     * Retrieves a long from the key-value store that matches the given key.
+     */
+    fun getLong(key: String): Long?
+
+    /**
+     * Retrieves a boolean from the key-value store that matches the given key.
+     */
+    fun getBoolean(key: String, defaultValue: Boolean): Boolean
+
+    /**
+     * Retrieves a set of strings from the key-value store that matches the given key.
+     */
+    fun getStringSet(key: String): Set<String>?
+
+    /**
+     * Retrieves a Map of string key-value pairs from the key-value store that matches the given key.
+     */
+    fun getStringMap(key: String): Map<String, String>?
+
+    /**
+     * Performs a batch edit of values in the key-value store.
+     */
+    fun edit(action: KeyValueStoreEditor.() -> Unit)
+
+    /**
+     * Increments an int from the key-value store then returns it.
+     */
+    fun incrementAndGet(key: String): Int
+}

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreEditor.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreEditor.kt
@@ -1,0 +1,37 @@
+package io.embrace.android.embracesdk.internal.arch.store
+
+/**
+ * Edits values in a key-value store.
+ */
+interface KeyValueStoreEditor : AutoCloseable {
+
+    /**
+     * Associates a string value with the given key.
+     */
+    fun putString(key: String, value: String?)
+
+    /**
+     * Associates an int value with the given key.
+     */
+    fun putInt(key: String, value: Int?)
+
+    /**
+     * Associates a long value with the given key.
+     */
+    fun putLong(key: String, value: Long?)
+
+    /**
+     * Associates a boolean value with the given key.
+     */
+    fun putBoolean(key: String, value: Boolean?)
+
+    /**
+     * Associates a set of strings with the given key.
+     */
+    fun putStringSet(key: String, value: Set<String>?)
+
+    /**
+     * Associates a Map of string key-value pairs with the given key.
+     */
+    fun putStringMap(key: String, value: Map<String, String>?)
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -252,7 +252,8 @@ internal class EmbraceImpl(
             clock = bootstrapper.initModule.clock,
             context = bootstrapper.coreModule.context,
             traceWriter = TraceWriterImpl(bootstrapper.openTelemetryModule.spanService),
-            workerThreadModule = bootstrapper.workerThreadModule
+            workerThreadModule = bootstrapper.workerThreadModule,
+            store = bootstrapper.androidServicesModule.store,
         )
         loader.forEach { provider ->
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InstrumentationInstallArgsImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InstrumentationInstallArgsImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import io.embrace.android.embracesdk.internal.arch.InstrumentationInstallArgs
 import io.embrace.android.embracesdk.internal.arch.destination.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.arch.destination.TraceWriter
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
@@ -19,6 +20,7 @@ internal class InstrumentationInstallArgsImpl(
     override val clock: Clock,
     override val traceWriter: TraceWriter,
     override val context: Context,
+    override val store: KeyValueStore,
     private val workerThreadModule: WorkerThreadModule,
 ) : InstrumentationInstallArgs {
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKeyValueStore.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKeyValueStore.kt
@@ -1,0 +1,75 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStoreEditor
+import java.util.concurrent.ConcurrentHashMap
+
+class FakeKeyValueStore : KeyValueStore {
+
+    private val map = ConcurrentHashMap<String, Any?>()
+
+    override fun getString(key: String): String? {
+        return map[key] as? String
+    }
+
+    override fun getInt(key: String): Int? {
+        return map[key] as? Int
+    }
+
+    override fun getLong(key: String): Long? {
+        return map[key] as? Long
+    }
+
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean {
+        return map[key] as? Boolean ?: defaultValue
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String): Set<String>? {
+        return map[key] as? Set<String>
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringMap(key: String): Map<String, String>? {
+        return map[key] as? Map<String, String>
+    }
+
+    override fun edit(action: KeyValueStoreEditor.() -> Unit) {
+        FakeEditor(map).action()
+    }
+
+    override fun incrementAndGet(key: String): Int {
+        val newValue = (map[key] as? Int ?: 0) + 1
+        map[key] = newValue
+        return newValue
+    }
+
+    private class FakeEditor(private val map: MutableMap<String, Any?>) : KeyValueStoreEditor {
+        override fun putString(key: String, value: String?) {
+            map[key] = value
+        }
+
+        override fun putInt(key: String, value: Int?) {
+            map[key] = value
+        }
+
+        override fun putLong(key: String, value: Long?) {
+            map[key] = value
+        }
+
+        override fun putBoolean(key: String, value: Boolean?) {
+            map[key] = value
+        }
+
+        override fun putStringSet(key: String, value: Set<String>?) {
+            map[key] = value
+        }
+
+        override fun putStringMap(key: String, value: Map<String, String>?) {
+            map[key] = value
+        }
+
+        override fun close() {
+        }
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAndroidServicesModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAndroidServicesModule.kt
@@ -1,9 +1,12 @@
 package io.embrace.android.embracesdk.fakes.injection
 
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.FakePreferenceService
+import io.embrace.android.embracesdk.internal.arch.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.internal.prefs.PreferencesService
 
 class FakeAndroidServicesModule(
     override val preferencesService: PreferencesService = FakePreferenceService(),
+    override val store: KeyValueStore = FakeKeyValueStore()
 ) : AndroidServicesModule


### PR DESCRIPTION
## Goal

Creates `KeyValueStore`, an interface that abstracts away `PreferencesService` and will ultimately replace it. Currently `PreferencesService` has too many concerns and grows linearly with each bit of instrumentation we add. Replacing it allows individual instrumentation to create their own interfaces that don't know anything about other instrumentation, but have all the values show up in the same place.

## Testing

Updated existing test coverage

