### PR TITLE
Update code coverage setup

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -100,4 +100,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-          files: embrace-android-sdk/build/reports/kover/reportRelease.xml
+          files: build/reports/kover/reportRelease.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,3 +33,23 @@ subprojects {
         }
     }
 }
+
+
+kover {
+    merge {
+        subprojects { project ->
+            val ignoreList = listOf("embrace-lint", "embrace-microbenchmark")
+            !project.name.contains("-test") &&
+                !project.name.contains("-fakes") &&
+                !ignoreList.contains(project.name)
+        }
+    }
+    reports {
+        filters {
+            excludes {
+                androidGeneratedClasses()
+                classes("*.BuildConfig")
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -26,39 +26,6 @@ android {
     }
 }
 
-kover {
-    reports {
-        filters {
-            excludes {
-                androidGeneratedClasses()
-                classes("*.BuildConfig")
-            }
-        }
-        variant("release") {
-            xml {}
-        }
-    }
-}
-
-val codeCoverageModules = listOf( // FIXME: future: add gradle plugin to code coverage
-    ":embrace-android-api",
-    ":embrace-internal-api",
-    ":embrace-android-sdk",
-    ":embrace-android-core",
-    ":embrace-android-infra",
-    ":embrace-android-features",
-    ":embrace-android-payload",
-    ":embrace-android-delivery",
-    ":embrace-android-okhttp3",
-    ":embrace-android-fcm",
-    ":embrace-android-compose",
-    ":embrace-android-otel",
-    ":embrace-android-instrumentation-huc",
-)
-codeCoverageModules.forEach { projectName ->
-    dependencies.add("kover", project(projectName))
-}
-
 dependencies {
     api(project(":embrace-android-api"))
     implementation(project(":embrace-android-infra"))


### PR DESCRIPTION
## Goal

Updates the code coverage setup in the project so that all modules are included by default if they don't match an ignore list, or if they don't contain tests/fakes. I've verified this works by looking at the report generated locally. It also has the bonus of picking up coverage data from our gradle plugin module, which wasn't working with the previous approach.
