### PR TITLE
[WIP] Fork gradle tests

### DIFF
--- a/embrace-gradle-plugin-integration-tests/build.gradle.kts
+++ b/embrace-gradle-plugin-integration-tests/build.gradle.kts
@@ -33,6 +33,9 @@ tasks.withType<Test>().configureEach {
             .filter { it.plugins.hasPlugin(MavenPublishPlugin::class.java) }
             .map { it.tasks.named("publishToMavenLocal") }
     )
+    options {
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 3) + 1
+    }
 }
 
 group = "io.embrace"


### PR DESCRIPTION
## Goal

Assesses the effect of allowing tests to fork when running the gradle plugin integration tests.

