### PR TITLE
Reduce gradle test cases

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/config/TestMatrix.kt
@@ -28,19 +28,9 @@ sealed class TestMatrix(
     object MinVersion : TestMatrix("8.0.2", "8.0.2", "2.0.21", JdkEnv.JAVA_17, "34")
 
     /**
-     * Older than middle of the pack, but not as bad as our minimum.
-     */
-    object OlderVersion : TestMatrix("8.1.4", "8.1.1", "2.0.21", JdkEnv.JAVA_17, "34")
-
-    /**
      * Middle of the pack.
      */
     object MiddleVersion : TestMatrix("8.3.2", "8.4", "2.1.21", JdkEnv.JAVA_17, "35")
-
-    /**
-     * Not the latest, but newer than the middle of the pack.
-     */
-    object NewerVersion : TestMatrix("8.5.2", "8.7", "2.1.21", JdkEnv.JAVA_21, "36")
 
     /**
      * The maximum version we currently run tests against. Newer versions may work, but are not

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
@@ -4,8 +4,6 @@ import io.embrace.android.gradle.config.TestMatrix
 import io.embrace.android.gradle.config.TestMatrix.MaxVersion
 import io.embrace.android.gradle.config.TestMatrix.MiddleVersion
 import io.embrace.android.gradle.config.TestMatrix.MinVersion
-import io.embrace.android.gradle.config.TestMatrix.NewerVersion
-import io.embrace.android.gradle.config.TestMatrix.OlderVersion
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.ProjectType
 import io.embrace.android.gradle.plugin.gradle.GradleVersion
@@ -22,13 +20,7 @@ class AgpSupportTest {
     fun `minimum supported version`() = runTest(MinVersion)
 
     @Test
-    fun `older version`() = runTest(OlderVersion)
-
-    @Test
     fun `middle version`() = runTest(MiddleVersion)
-
-    @Test
-    fun `newer version`() = runTest(NewerVersion)
 
     @Test
     fun `maximum supported version`() = runTest(MaxVersion)

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
@@ -44,30 +44,15 @@ class ReactNativeAndroidTest {
         rule.runTest(
             fixture = "react-native-android",
             androidProjectRoot = "android",
-            task = "build",
+            task = "assemble",
             setup = { projectDir ->
                 installNodeModules(projectDir)
                 setupMockResponses(handshakeLibs, handshakeArchs, defaultExpectedVariants)
             },
-            assertions = {
+            assertions = { projectDir ->
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(handshakeLibs, handshakeArchs, defaultExpectedVariants)
-            }
-        )
-    }
-
-    @Test
-    fun `react native asm injection test`() {
-        rule.runTest(
-            fixture = "react-native-android",
-            androidProjectRoot = "android",
-            task = "assembleRelease",
-            setup = { projectDir ->
-                setupEmptyHandshakeResponse()
-                installNodeModules(projectDir)
-            },
-            assertions = { projectDir ->
                 verifyAsmInjection(File(projectDir, "app"), "27D4D89A18B0426A47151D4888D4E40A")
             }
         )
@@ -86,31 +71,6 @@ class ReactNativeAndroidTest {
             assertions = { projectDir ->
                 verifyNoUploads()
                 verifyAsmInjection(projectDir, null)
-            }
-        )
-    }
-
-    @Test
-    fun `debug builds should not upload symbols`() {
-        val handshakeLibs = listOf(
-            "libfbjni.so",
-            "libhermes.so",
-            "libhermestooling.so",
-        )
-        val handshakeArchs = listOf("arm64-v8a", "armeabi-v7a")
-        rule.runTest(
-            fixture = "react-native-android",
-            task = "assembleDebug",
-            androidProjectRoot = "android",
-            setup = { projectDir ->
-                installNodeModules(projectDir)
-                setupMockResponses(handshakeLibs, handshakeArchs, defaultExpectedVariants)
-            },
-            assertions = {
-                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
-                verifyNoHandshakes()
-                verifyNoUploads()
-                verifyJvmMappingRequestsSent(0)
             }
         )
     }


### PR DESCRIPTION
## Goal

Reduces some gradle plugin test cases to speed up CI, as they're largely covered by other tests or can be combined into one test case together.

