### PR TITLE
Add Network request logging as a telemetry destination

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesS
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesServiceImpl
 import io.embrace.android.embracesdk.internal.capture.user.EmbraceUserService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
+import io.embrace.android.embracesdk.internal.network.logging.NetworkLoggingService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTrackerImpl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleTracker
@@ -31,6 +32,7 @@ class EssentialServiceModuleImpl(
     androidServicesModule: AndroidServicesModule,
     lifecycleOwnerProvider: Provider<LifecycleOwner?>,
     networkConnectivityServiceProvider: Provider<NetworkConnectivityService?>,
+    networkLoggingServiceProvider: Provider<NetworkLoggingService?>,
 ) : EssentialServiceModule {
 
     private val configService by lazy { configModule.configService }
@@ -88,6 +90,7 @@ class EssentialServiceModuleImpl(
             clock = initModule.clock,
             spanService = openTelemetryModule.spanService,
             currentSessionSpan = openTelemetryModule.currentSessionSpan,
+            networkLoggingServiceProvider = networkLoggingServiceProvider,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleSupplier.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import androidx.lifecycle.LifecycleOwner
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
+import io.embrace.android.embracesdk.internal.network.logging.NetworkLoggingService
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
@@ -17,6 +18,7 @@ typealias EssentialServiceModuleSupplier = (
     androidServicesModule: AndroidServicesModule,
     lifecycleOwnerProvider: Provider<LifecycleOwner?>,
     networkConnectivityServiceProvider: Provider<NetworkConnectivityService?>,
+    networkLoggingServiceProvider: Provider<NetworkLoggingService?>,
 ) -> EssentialServiceModule
 
 fun createEssentialServiceModule(
@@ -29,6 +31,7 @@ fun createEssentialServiceModule(
     androidServicesModule: AndroidServicesModule,
     lifecycleOwnerProvider: Provider<LifecycleOwner?>,
     networkConnectivityServiceProvider: Provider<NetworkConnectivityService?>,
+    networkLoggingServiceProvider: Provider<NetworkLoggingService?>,
 ): EssentialServiceModule = EssentialServiceModuleImpl(
     initModule,
     configModule,
@@ -38,5 +41,6 @@ fun createEssentialServiceModule(
     systemServiceModule,
     androidServicesModule,
     lifecycleOwnerProvider,
-    networkConnectivityServiceProvider
+    networkConnectivityServiceProvider,
+    networkLoggingServiceProvider,
 )

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkRequest.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkRequest.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.fakes
+
+data class FakeNetworkRequest(
+    val url: String,
+    val httpMethod: String,
+    val startTime: Long,
+    val endTime: Long,
+    val bytesSent: Long? = null,
+    val bytesReceived: Long? = null,
+    val statusCode: Int? = null,
+    val errorType: String? = null,
+    val errorMessage: String? = null,
+    val traceId: String? = null,
+    val w3cTraceparent: String? = null,
+)
+
+val fakeCompleteRequest = FakeNetworkRequest(
+    url = "https://fakeurl.pizza/ur?stuff=true",
+    httpMethod = "GET",
+    startTime = 1000L,
+    endTime = 2000L,
+    bytesSent = 100L,
+    bytesReceived = 200L,
+    statusCode = 200,
+    traceId = "fake-id",
+    w3cTraceparent = "fake-traceparent",
+)
+
+val fakeIncompleteRequest = FakeNetworkRequest(
+    url = "https://fakeurl.pizza/ur?stuff=true",
+    httpMethod = "GET",
+    startTime = 1000L,
+    endTime = 2000L,
+    errorType = "fakeType",
+    errorMessage = "fake message",
+    traceId = "fake-id",
+    w3cTraceparent = "fake-traceparent",
+)

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -13,6 +13,7 @@ class FakeTelemetryDestination : TelemetryDestination {
     val addedEvents = mutableListOf<FakeSessionEvent>()
     val attributes = mutableMapOf<String, String>()
     val createdSpans: MutableList<FakeSpanToken> = mutableListOf()
+    val networkRequests: MutableList<FakeNetworkRequest> = mutableListOf()
 
     override fun addLog(
         schemaType: SchemaType,
@@ -74,5 +75,55 @@ class FakeTelemetryDestination : TelemetryDestination {
             mapOf(type.asPair()),
         )
         createdSpans.add(token)
+    }
+
+    override fun recordCompletedNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        bytesSent: Long,
+        bytesReceived: Long,
+        statusCode: Int,
+        traceId: String?,
+        w3cTraceparent: String?,
+    ) {
+        networkRequests.add(
+            FakeNetworkRequest(
+                url = url,
+                httpMethod = httpMethod,
+                startTime = startTime,
+                endTime = endTime,
+                bytesSent = bytesSent,
+                bytesReceived = bytesReceived,
+                statusCode = statusCode,
+                traceId = traceId,
+                w3cTraceparent = w3cTraceparent
+            )
+        )
+    }
+
+    override fun recordIncompletedNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        errorType: String,
+        errorMessage: String,
+        traceId: String?,
+        w3cTraceparent: String?,
+    ) {
+        networkRequests.add(
+            FakeNetworkRequest(
+                url = url,
+                httpMethod = httpMethod,
+                startTime = startTime,
+                endTime = endTime,
+                errorType = errorType,
+                errorMessage = errorMessage,
+                traceId = traceId,
+                w3cTraceparent = w3cTraceparent
+            )
+        )
     }
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -60,4 +60,27 @@ interface TelemetryDestination {
         type: EmbType = EmbType.Performance.Default,
         attributes: Map<String, String> = emptyMap(),
     )
+
+    fun recordCompletedNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        bytesSent: Long,
+        bytesReceived: Long,
+        statusCode: Int,
+        traceId: String? = null,
+        w3cTraceparent: String? = null,
+    )
+
+    fun recordIncompletedNetworkRequest(
+        url: String,
+        httpMethod: String,
+        startTime: Long,
+        endTime: Long,
+        errorType: String,
+        errorMessage: String,
+        traceId: String? = null,
+        w3cTraceparent: String? = null,
+    )
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -129,7 +129,7 @@ internal class EmbraceSetupInterface(
         coreModuleSupplier = { _, _ -> coreModule },
         workerThreadModuleSupplier = { workerThreadModule },
         androidServicesModuleSupplier = { _, _ -> androidServicesModule },
-        essentialServiceModuleSupplier = { initModule, configModule, openTelemetryModule, coreModule, workerThreadModule, systemServiceModule, androidServicesModule, _, _ ->
+        essentialServiceModuleSupplier = { initModule, configModule, openTelemetryModule, coreModule, workerThreadModule, systemServiceModule, androidServicesModule, _, _, networkLoggingServiceProvider ->
             createEssentialServiceModule(
                 initModule = initModule,
                 configModule = configModule,
@@ -139,7 +139,8 @@ internal class EmbraceSetupInterface(
                 systemServiceModule = systemServiceModule,
                 androidServicesModule = androidServicesModule,
                 lifecycleOwnerProvider = { fakeLifecycleOwner },
-                networkConnectivityServiceProvider = { fakeNetworkConnectivityService }
+                networkConnectivityServiceProvider = { fakeNetworkConnectivityService },
+                networkLoggingServiceProvider = networkLoggingServiceProvider
             )
         },
         deliveryModuleSupplier = { configModule, initModule, otelModule, workerThreadModule, coreModule, essentialServiceModule, androidServicesModule, _, _, _, _ ->

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -193,7 +193,8 @@ internal class ModuleInitBootstrapper(
                             systemServiceModule,
                             androidServicesModule,
                             { null },
-                            { null }
+                            { null },
+                            { logModule.networkLoggingService }
                         )
                     }
                     postInit(EssentialServiceModule::class) {

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -43,7 +43,7 @@ internal fun fakeModuleInitBootstrapper(
     androidServicesModuleSupplier: AndroidServicesModuleSupplier = { _, _ -> FakeAndroidServicesModule() },
     workerThreadModuleSupplier: WorkerThreadModuleSupplier = { FakeWorkerThreadModule() },
     storageModuleSupplier: StorageModuleSupplier = { _, _, _ -> FakeStorageModule() },
-    essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
+    essentialServiceModuleSupplier: EssentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeEssentialServiceModule() },
     configModuleSupplier: ConfigModuleSupplier = { _, _, _, _, _ -> FakeConfigModule() },
     dataSourceModuleSupplier: DataSourceModuleSupplier = { _, _ -> FakeDataSourceModule() },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _ -> FakeDataCaptureServiceModule() },

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
@@ -34,7 +34,8 @@ internal class EssentialServiceModuleImplTest {
             systemServiceModule = FakeSystemServiceModule(),
             androidServicesModule = FakeAndroidServicesModule(),
             lifecycleOwnerProvider = { TestLifecycleOwner() },
-            networkConnectivityServiceProvider = { null }
+            networkConnectivityServiceProvider = { null },
+            networkLoggingServiceProvider = { null }
         )
 
         assertNotNull(module.processStateService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
@@ -25,7 +25,7 @@ internal class UserApiDelegateTest {
     @Before
     fun setUp() {
         val moduleInitBootstrapper = fakeModuleInitBootstrapper(
-            essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _ ->
+            essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _, _ ->
                 FakeEssentialServiceModule().apply {
                     fakeUserService = userService as FakeUserService
                 }


### PR DESCRIPTION
## Goal

Add the ability to log network requests into the `TelemetryDestination`​ API. Note that the network capture isn't part of the API that was moved over as it's not needed for the HUC Lite instrumentation.  
