### PR TITLE
Plumb through notifier for background update to DataSourceImpl

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -123,7 +123,9 @@ internal class SessionOrchestratorImpl(
     }
 
     override fun reportBackgroundActivityStateChange() {
-        payloadCachingService?.reportBackgroundActivityStateChange()
+        if (state == ProcessState.BACKGROUND) {
+            payloadCachingService?.reportBackgroundActivityStateChange()
+        }
     }
 
     /**

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationInstallArgs.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationInstallArgs.kt
@@ -47,6 +47,11 @@ interface InstrumentationInstallArgs {
     val store: KeyValueStore
 
     /**
+     * Method that when invoked informs the SDK that a update had been made to the data of a session while the app is in the background
+     */
+    val backgroundUpdateNotifier: () -> Unit
+
+    /**
      * Retrieves a background worker matching the given name.
      */
     fun backgroundWorker(worker: Worker.Background): BackgroundWorker

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
@@ -11,6 +11,7 @@ abstract class DataSourceImpl(
     private val destination: TelemetryDestination,
     val logger: EmbLogger,
     private val limitStrategy: LimitStrategy,
+    private val backgroundUpdateNotifier: () -> Unit = { },
 ) : DataSource {
 
     override fun onDataCaptureEnabled() {
@@ -35,6 +36,7 @@ abstract class DataSourceImpl(
         try {
             if (inputValidation() && limitStrategy.shouldCapture()) {
                 destination.action()
+                backgroundUpdateNotifier()
             }
         } catch (exc: Throwable) {
             logger.trackInternalError(InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL, exc)

--- a/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceImplTest.kt
+++ b/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceImplTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class DataSourceImplTest {
@@ -63,12 +64,25 @@ internal class DataSourceImplTest {
         assertEquals(0, count)
     }
 
+    @Test
+    fun `capture data respects background update notification`() {
+        var updated = false
+        val source = FakeDataSourceImpl(FakeTelemetryDestination()) {
+            updated = true
+        }
+
+        source.captureTelemetry { }
+        assertTrue(updated)
+    }
+
     private class FakeDataSourceImpl(
         dst: TelemetryDestination,
         limitStrategy: LimitStrategy = NoopLimitStrategy,
+        backgroundUpdateNotifier: () -> Unit = { },
     ) : DataSourceImpl(
-        dst,
-        FakeEmbLogger(throwOnInternalError = false),
-        limitStrategy
+        destination = dst,
+        logger = FakeEmbLogger(throwOnInternalError = false),
+        limitStrategy = limitStrategy,
+        backgroundUpdateNotifier = backgroundUpdateNotifier
     )
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -224,6 +224,7 @@ internal class EmbraceImpl(
             telemetryDestination = bootstrapper.essentialServiceModule.telemetryDestination,
             workerThreadModule = bootstrapper.workerThreadModule,
             store = bootstrapper.androidServicesModule.store,
+            backgroundUpdateNotifier = bootstrapper.sessionOrchestrationModule.sessionOrchestrator::reportBackgroundActivityStateChange
         )
         loader.forEach { provider ->
             try {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InstrumentationInstallArgsImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/InstrumentationInstallArgsImpl.kt
@@ -19,6 +19,7 @@ internal class InstrumentationInstallArgsImpl(
     override val clock: Clock,
     override val context: Context,
     override val store: KeyValueStore,
+    override val backgroundUpdateNotifier: () -> Unit,
     private val workerThreadModule: WorkerThreadModule,
 ) : InstrumentationInstallArgs {
 


### PR DESCRIPTION
## Goal

Allow `DataSource`​ to optionally update the session orchestrator for when a background activity cached payload has been updated. By default, the notifier is set to no-op, but if a DataSource wants this behaviour, they can pass down the notifier available via the `InstrumentationInstallerArgs`​.  
  
I don't love this, but it's how sessions work right now...

