### PR TITLE
Plumb through Span Status in the TelemetryDestination.recordCompletedSpan API

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.Logger
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
@@ -114,6 +115,7 @@ internal class TelemetryDestinationImpl(
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
+        errorCode: String?,
         type: EmbType,
         attributes: Map<String, String>,
     ) {
@@ -121,6 +123,9 @@ internal class TelemetryDestinationImpl(
             name = name,
             startTimeMs = startTimeMs,
             endTimeMs = endTimeMs,
+            errorCode = errorCode?.let {
+                ErrorCode.valueOf(it)
+            },
             type = type,
             attributes = attributes,
         )

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -7,6 +7,7 @@ class FakeSpanToken(
     val name: String,
     val startTimeMs: Long,
     var endTimeMs: Long?,
+    var errorCode: String?,
     val type: EmbType,
     val attributes: Map<String, String>,
 ) : SpanToken {

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -46,10 +46,11 @@ class FakeTelemetryDestination : TelemetryDestination {
         schemaType: SchemaType,
         startTimeMs: Long,
         autoTerminate: Boolean,
-    ): SpanToken? {
+    ): SpanToken {
         val token = FakeSpanToken(
             schemaType.fixedObjectName,
             startTimeMs,
+            null,
             null,
             schemaType.telemetryType,
             schemaType.attributes() + mapOf(schemaType.telemetryType.asPair()),
@@ -63,6 +64,7 @@ class FakeTelemetryDestination : TelemetryDestination {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
+        errorCode: String?,
         type: EmbType,
         attributes: Map<String, String>,
     ) {
@@ -70,6 +72,7 @@ class FakeTelemetryDestination : TelemetryDestination {
             name,
             startTimeMs,
             null,
+            errorCode,
             type,
             mapOf(type.asPair()),
         )

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -57,6 +57,7 @@ interface TelemetryDestination {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
+        errorCode: String? = null,
         type: EmbType = EmbType.Performance.Default,
         attributes: Map<String, String> = emptyMap(),
     )


### PR DESCRIPTION
## Goal

Make Span Status settable via the `recordCompletedSpan`​ API in `TelemetryDestination`​. 