### PR TITLE
Add isolated projects telemetry

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
@@ -36,6 +36,7 @@ class BuildTelemetryCollector {
                 isBuildCacheEnabled = isBuildCacheEnabled(),
                 isConfigCacheEnabled = isConfigurationCacheEnabled(),
                 isGradleParallelExecutionEnabled = isParallelExecutionEnabled(),
+                isIsolatedProjectsEnabled = isIsolatedProjectsEnabled(),
                 jvmArgs = getJvmArgs(),
                 isEdmEnabled = behavior.isUnityEdmEnabled,
                 edmVersion = getEdmVersion(),
@@ -92,6 +93,15 @@ class BuildTelemetryCollector {
 
     private fun Project.isParallelExecutionEnabled() =
         this.gradle.startParameter.isParallelProjectExecutionEnabled
+
+    private fun Project.isIsolatedProjectsEnabled(): Boolean {
+        return try {
+            getSystemProperty("org.gradle.unsafe.isolated-projects") == "true" ||
+                getProperty("org.gradle.unsafe.isolated-projects") == "true"
+        } catch (e: Throwable) {
+            false
+        }
+    }
 
     private fun Project.getJvmArgs() = getProperty(GRADLE_JVM_ARGS) ?: ""
     private fun Project.getEdmVersion() = getProperty(EMBRACE_UNITY_EDM_VERSION) ?: ""

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
@@ -14,6 +14,7 @@ data class BuildTelemetryRequest(
     @Json(name = "bc") val isBuildCacheEnabled: Boolean? = null,
     @Json(name = "cc") val isConfigCacheEnabled: Boolean? = null,
     @Json(name = "gpe") val isGradleParallelExecutionEnabled: Boolean? = null,
+    @Json(name = "ip") val isIsolatedProjectsEnabled: Boolean? = null,
     @Json(name = "jvma") val jvmArgs: String? = null,
     @Json(name = "os") val operatingSystem: String? = null,
     @Json(name = "jre") val jreVersion: String? = null,


### PR DESCRIPTION
## Goal
Track whether Gradle's isolated projects feature is enabled in build telemetry to understand customer adoption.

## Changes
- Add `isIsolatedProjectsEnabled()` method to `BuildTelemetryCollector` that checks both system property (`-Dorg.gradle.unsafe.isolated-projects`) and gradle property (`gradle.properties`) for the isolated projects setting