### PR TITLE
Remove jreVersion telemetry

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
@@ -96,7 +96,6 @@ class AssertionInterface(
             assertFalse(checkNotNull(isConfigCacheEnabled))
             assertTrue(checkNotNull(isGradleParallelExecutionEnabled))
             assertNotNull(operatingSystem)
-            assertNotNull(jreVersion)
             assertNotNull(jdkVersion)
             assertFalse(checkNotNull(isEdmEnabled))
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
@@ -43,7 +43,6 @@ class BuildTelemetryCollector {
                 metadataRequestId = UUID.randomUUID().toString(),
                 pluginVersion = BuildConfig.VERSION,
                 operatingSystem = getOperatingSystem(),
-                jreVersion = getJreVersion(),
                 jdkVersion = getJdkVersion(),
             )
         }
@@ -71,7 +70,6 @@ class BuildTelemetryCollector {
         return "$osName $osVersion $osArch"
     }
 
-    private fun getJreVersion() = getSystemProperty(SYS_PROP_JRE_VERSION)
     private fun getJdkVersion() = getSystemProperty(SYS_PROP_JDK_VERSION)
     private fun getSystemProperty(key: String) = systemWrapper.getProperty(key) ?: ""
 
@@ -107,7 +105,6 @@ class BuildTelemetryCollector {
     private fun Project.getEdmVersion() = getProperty(EMBRACE_UNITY_EDM_VERSION) ?: ""
 }
 
-private const val SYS_PROP_JRE_VERSION = "java.runtime.version"
 private const val SYS_PROP_JDK_VERSION = "java.version"
 private const val SYS_PROP_OS_NAME = "os.name"
 private const val SYS_PROP_OS_VERSION = "os.version"

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
@@ -17,7 +17,6 @@ data class BuildTelemetryRequest(
     @Json(name = "ip") val isIsolatedProjectsEnabled: Boolean? = null,
     @Json(name = "jvma") val jvmArgs: String? = null,
     @Json(name = "os") val operatingSystem: String? = null,
-    @Json(name = "jre") val jreVersion: String? = null,
     @Json(name = "jdk") val jdkVersion: String? = null,
     @Json(name = "edm") val isEdmEnabled: Boolean? = null,
     @Json(name = "edmv") val edmVersion: String? = null,


### PR DESCRIPTION
## Goal
Remove redundant jreVersion telemetry field. Both jreVersion and jdkVersion collect Java version info with minimal differences (e.g., `17.0.1+12` vs `17.0.1`). The jdkVersion field provides sufficient data for our needs.