### PR TITLE
Allow priority loading of instrumentation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistry.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistry.kt
@@ -26,4 +26,12 @@ interface InstrumentationRegistry {
      * if necessary.
      */
     var currentSessionType: SessionType?
+
+    /**
+     * Loads instrumentation via SPI and registers it with the SDK.
+     */
+    fun loadInstrumentations(
+        instrumentationProviders: Iterable<InstrumentationProvider>,
+        args: InstrumentationArgs,
+    )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
@@ -37,7 +37,7 @@ internal class FeatureModuleImpl(
             factory = {
                 InternalErrorDataSourceImpl(instrumentationModule.instrumentationArgs)
             },
-            configGate = { configService.dataCaptureEventBehavior.isInternalExceptionCaptureEnabled() }
+            configGate = { configService.dataCaptureEventBehavior.isInternalExceptionCaptureEnabled() },
         ).apply {
             instrumentationModule.instrumentationRegistry.add(this)
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.InstrumentationArgsImpl
-import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
+import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistryImpl
 import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class InstrumentationModuleImpl(
@@ -15,7 +15,7 @@ internal class InstrumentationModuleImpl(
 ) : InstrumentationModule {
 
     override val instrumentationRegistry: InstrumentationRegistry by singleton {
-        DataCaptureOrchestrator(
+        InstrumentationRegistryImpl(
             workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
             initModule.logger
         )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
@@ -1,9 +1,12 @@
 package io.embrace.android.embracesdk.internal.arch
 
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationProvider
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
@@ -14,9 +17,9 @@ import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(AndroidJUnit4::class)
-internal class DataCaptureOrchestratorTest {
+internal class InstrumentationRegistryTest {
 
-    private lateinit var orchestrator: DataCaptureOrchestrator
+    private lateinit var registry: InstrumentationRegistry
     private lateinit var dataSource: FakeDataSource
     private lateinit var configService: FakeConfigService
     private lateinit var executorService: BlockingScheduledExecutorService
@@ -38,7 +41,7 @@ internal class DataCaptureOrchestratorTest {
         dataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         configService = FakeConfigService()
         executorService = BlockingScheduledExecutorService(blockingMode = false)
-        orchestrator = DataCaptureOrchestrator(
+        registry = InstrumentationRegistryImpl(
             BackgroundWorker(executorService),
             EmbLoggerImpl(),
         )
@@ -46,21 +49,34 @@ internal class DataCaptureOrchestratorTest {
 
     @Test
     fun `session type change is propagated`() {
-        orchestrator.add(syncDataSource)
+        registry.add(syncDataSource)
         assertEquals(0, dataSource.enableDataCaptureCount)
-        orchestrator.currentSessionType = SessionType.FOREGROUND
+        registry.currentSessionType = SessionType.FOREGROUND
         assertEquals(1, dataSource.enableDataCaptureCount)
     }
 
     @Test
     fun `async session change`() {
-        orchestrator.add(asyncDataSource)
+        registry.add(asyncDataSource)
         executorService.blockingMode = true
 
         assertEquals(0, dataSource.enableDataCaptureCount)
-        orchestrator.currentSessionType = SessionType.FOREGROUND
+        registry.currentSessionType = SessionType.FOREGROUND
         assertEquals(0, dataSource.enableDataCaptureCount)
         executorService.runCurrentlyBlocked()
         assertEquals(1, dataSource.enableDataCaptureCount)
+    }
+
+    @Test
+    fun `test instrumentation provider load`() {
+        val args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext())
+        val initOrder = mutableListOf<Int>()
+        val providers = listOf<InstrumentationProvider>(
+            FakeInstrumentationProvider(1000, initOrder::add),
+            FakeInstrumentationProvider(10, initOrder::add),
+            FakeInstrumentationProvider(100, initOrder::add),
+        )
+        registry.loadInstrumentations(providers, args)
+        assertEquals(listOf(10, 100, 1000), initOrder)
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -22,7 +22,8 @@ import io.embrace.android.embracesdk.fakes.behavior.FakeSessionBehavior
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
-import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
+import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
+import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistryImpl
 import io.embrace.android.embracesdk.internal.arch.attrs.embCrashId
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
@@ -62,7 +63,7 @@ internal class SessionOrchestratorTest {
     private lateinit var sessionIdTracker: FakeSessionIdTracker
     private lateinit var payloadCachingService: PayloadCachingService
     private lateinit var sessionCacheExecutor: BlockingScheduledExecutorService
-    private lateinit var dataCaptureOrchestrator: DataCaptureOrchestrator
+    private lateinit var instrumentationRegistry: InstrumentationRegistry
     private lateinit var fakeDataSource: FakeDataSource
     private lateinit var logger: EmbLogger
     private lateinit var currentSessionSpan: FakeCurrentSessionSpan
@@ -417,7 +418,7 @@ internal class SessionOrchestratorTest {
             store
         )
         fakeDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
-        dataCaptureOrchestrator = DataCaptureOrchestrator(
+        instrumentationRegistry = InstrumentationRegistryImpl(
             fakeBackgroundWorker(),
             logger
         ).apply {
@@ -442,7 +443,7 @@ internal class SessionOrchestratorTest {
             ),
             store,
             payloadCachingService,
-            dataCaptureOrchestrator,
+            instrumentationRegistry,
             destination,
             SessionSpanAttrPopulatorImpl(
                 destination,

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationProvider.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+
+class FakeInstrumentationProvider(
+    override val priority: Int = 10000,
+    private val action: (k: Int) -> Unit,
+) : InstrumentationProvider {
+
+    override fun register(args: InstrumentationArgs): DataSourceState<*>? {
+        action(priority)
+        return null
+    }
+}

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationProvider.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationProvider.kt
@@ -14,4 +14,15 @@ interface InstrumentationProvider {
      * is too low), then it's permissible to return null
      */
     fun register(args: InstrumentationArgs): DataSourceState<*>?
+
+    /**
+     * The priority at which this instrumentation should be loaded. This is specified so that
+     * instrumentation can be initialized in a deterministic order, if required. If no value is supplied,
+     * the default value of 10000 will be used.
+     *
+     * 0 is the highest priority. Please try to use increments of 100 to make it easier to alter priorities
+     * across multiple instrumentation in the future.
+     */
+    val priority: Int
+        get() = 10000
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/FakeInstrumentationRegistry.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/FakeInstrumentationRegistry.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.testframework.actions
 
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.SessionType
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
@@ -19,6 +21,13 @@ internal class FakeInstrumentationRegistry(private val impl: InstrumentationRegi
         set(value) {
             impl.currentSessionType = value
         }
+
+    override fun loadInstrumentations(
+        instrumentationProviders: Iterable<InstrumentationProvider>,
+        args: InstrumentationArgs,
+    ) {
+        impl.loadInstrumentations(instrumentationProviders, args)
+    }
 
     override fun <T : DataSource> findByType(clazz: KClass<T>): T? = impl.findByType(clazz)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.fakes
 
 import android.app.Application
-import io.embrace.android.embracesdk.internal.arch.DataCaptureOrchestrator
+import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistryImpl
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 
 class FakeInstrumentationModule(application: Application) : InstrumentationModule {
-    override val instrumentationRegistry: InstrumentationRegistry = DataCaptureOrchestrator(
+    override val instrumentationRegistry: InstrumentationRegistry = InstrumentationRegistryImpl(
         fakeBackgroundWorker(),
         FakeEmbLogger()
     )


### PR DESCRIPTION
## Goal

Provides a mechanism for loading instrumentations in a deterministic order by specifying an integer priority. This is not particularly important for our existing instrumentation yet but will be very important for crash/ANRs.

## Testing

Added unit tests.
