### PR TITLE
Add correct permissions for cache clearing

### DIFF
--- a/.github/workflows/clear-ci-cache.yml
+++ b/.github/workflows/clear-ci-cache.yml
@@ -10,6 +10,8 @@ jobs:
   clear-cache:
     name: Clear CI cache
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Run GH CLI
         env:


### PR DESCRIPTION
## Goal

Adds the correct permissions to the workflow for clearing Github Action's cache so that it doesn't return 403.
