### PR TITLE
Add return value to captureTelemetry()

### DIFF
--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSource.kt
@@ -34,8 +34,8 @@ interface DataSource {
     /**
      * Captures telemetry from the given action, if the [DataSourceState] and limits allow it.
      */
-    fun captureTelemetry(
+    fun <T> captureTelemetry(
         inputValidation: () -> Boolean = { true },
-        action: TelemetryDestination.() -> Unit,
-    )
+        action: TelemetryDestination.() -> T?,
+    ): T?
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
@@ -35,16 +35,17 @@ abstract class DataSourceImpl(
     /**
      * Convenience function for capturing telemetry.
      */
-    override fun captureTelemetry(
+    override fun <T> captureTelemetry(
         inputValidation: () -> Boolean,
-        action: TelemetryDestination.() -> Unit,
-    ) {
+        action: TelemetryDestination.() -> T?,
+    ): T? {
         try {
             if (inputValidation() && limitStrategy.shouldCapture()) {
-                destination.action()
+                return destination.action()
             }
         } catch (exc: Throwable) {
             logger.trackInternalError(InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL, exc)
         }
+        return null
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCrashDataSource.kt
@@ -15,12 +15,10 @@ class FakeCrashDataSource : CrashDataSource {
         TODO("Not yet implemented")
     }
 
-    override fun captureTelemetry(
+    override fun <T> captureTelemetry(
         inputValidation: () -> Boolean,
-        action: TelemetryDestination.() -> Unit,
-    ) {
-        TODO("Not yet implemented")
-    }
+        action: TelemetryDestination.() -> T?,
+    ): T? = null
 
     override fun resetDataCaptureLimits() {
         TODO("Not yet implemented")

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeDataSource.kt
@@ -14,11 +14,10 @@ class FakeDataSource(
     var disableDataCaptureCount: Int = 0
     var resetCount: Int = 0
 
-    override fun captureTelemetry(
+    override fun <T> captureTelemetry(
         inputValidation: () -> Boolean,
-        action: TelemetryDestination.() -> Unit,
-    ) {
-    }
+        action: TelemetryDestination.() -> T?,
+    ): T? = null
 
     override fun onDataCaptureEnabled() {
         ctx.registerComponentCallbacks(this)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureDataSource.kt
@@ -24,10 +24,8 @@ class FakeNetworkCaptureDataSource : NetworkCaptureDataSource {
         TODO("Not yet implemented")
     }
 
-    override fun captureTelemetry(
+    override fun <T> captureTelemetry(
         inputValidation: () -> Boolean,
-        action: TelemetryDestination.() -> Unit,
-    ) {
-        TODO("Not yet implemented")
-    }
+        action: TelemetryDestination.() -> T?,
+    ): T? = null
 }


### PR DESCRIPTION
## Goal

Adds an optional return value to `captureTelemetry()`. This will make it easier to write instrumentation for OkHttp as the interceptors need to return the response for the chain.
