### PR TITLE
Bump test matrix for gradle tests

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/config/TestMatrix.kt
@@ -30,21 +30,21 @@ sealed class TestMatrix(
     /**
      * Older than middle of the pack, but not as bad as our minimum.
      */
-    object OlderVersion : TestMatrix("8.1.4", "8.1.1", "2.0.21", JdkEnv.JAVA_17, "34")
+    object OlderVersion : TestMatrix("8.3.2", "8.4", "2.0.21", JdkEnv.JAVA_17, "34")
 
     /**
      * Middle of the pack.
      */
-    object MiddleVersion : TestMatrix("8.3.2", "8.4", "2.1.21", JdkEnv.JAVA_17, "35")
+    object MiddleVersion : TestMatrix("8.5.2", "8.7", "2.1.21", JdkEnv.JAVA_17, "35")
 
     /**
      * Not the latest, but newer than the middle of the pack.
      */
-    object NewerVersion : TestMatrix("8.5.2", "8.7", "2.1.21", JdkEnv.JAVA_21, "36")
+    object NewerVersion : TestMatrix("8.9.0", "8.11.1", "2.2.21", JdkEnv.JAVA_21, "36")
 
     /**
      * The maximum version we currently run tests against. Newer versions may work, but are not
      * explicitly tested.
      */
-    object MaxVersion : TestMatrix("8.9.1", "8.13", "2.2.20", JdkEnv.JAVA_21, "36")
+    object MaxVersion : TestMatrix("8.13.0", "9.2.0", "2.2.21", JdkEnv.JAVA_21, "36")
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.gradle.integration.testcases
 
+import io.embrace.android.gradle.config.TestMatrix
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.smali.SmaliConfigReader
 import io.embrace.android.gradle.integration.framework.smali.SmaliMethod
@@ -43,6 +44,7 @@ class ReactNativeAndroidTest {
         val handshakeArchs = listOf("arm64-v8a", "armeabi-v7a")
         rule.runTest(
             fixture = "react-native-android",
+            testMatrix = TestMatrix.NewerVersion,
             androidProjectRoot = "android",
             task = "build",
             setup = { projectDir ->
@@ -50,7 +52,7 @@ class ReactNativeAndroidTest {
                 setupMockResponses(handshakeLibs, handshakeArchs, defaultExpectedVariants)
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry, testMatrix = TestMatrix.NewerVersion)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(handshakeLibs, handshakeArchs, defaultExpectedVariants)
             }
@@ -61,6 +63,7 @@ class ReactNativeAndroidTest {
     fun `react native asm injection test`() {
         rule.runTest(
             fixture = "react-native-android",
+            testMatrix = TestMatrix.NewerVersion,
             androidProjectRoot = "android",
             task = "assembleRelease",
             setup = { projectDir ->
@@ -100,6 +103,7 @@ class ReactNativeAndroidTest {
         val handshakeArchs = listOf("arm64-v8a", "armeabi-v7a")
         rule.runTest(
             fixture = "react-native-android",
+            testMatrix = TestMatrix.NewerVersion,
             task = "assembleDebug",
             androidProjectRoot = "android",
             setup = { projectDir ->
@@ -107,7 +111,7 @@ class ReactNativeAndroidTest {
                 setupMockResponses(handshakeLibs, handshakeArchs, defaultExpectedVariants)
             },
             assertions = {
-                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
+                verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry, testMatrix = TestMatrix.NewerVersion)
                 verifyNoHandshakes()
                 verifyNoUploads()
                 verifyJvmMappingRequestsSent(0)


### PR DESCRIPTION
## Goal

Bumps the test matrix for our gradle plugin tests as AGP/Gradle versions have moved on quite a bit since we last did it. The RN fixture didn't pass on Gradle 9.2 but I believe this is down to the fixture itself being old.

