### PR TITLE
Move shared object loader

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModule.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.jni.JniDelegate
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.symbols.SymbolService
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleImpl.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
 import android.os.Build
-import io.embrace.android.embracesdk.internal.SharedObjectLoader
-import io.embrace.android.embracesdk.internal.SharedObjectLoaderImpl
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.internal.handler.AndroidMainThreadHandler
 import io.embrace.android.embracesdk.internal.injection.ConfigModule

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleSupplier.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.injection.ConfigModule
 import io.embrace.android.embracesdk.internal.injection.CoreModule
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.delivery.PayloadType

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.storage.FileStorageService
 import io.embrace.android.embracesdk.internal.delivery.storage.FileStorageServiceImpl

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoader.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoader.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal
+package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
 import java.util.concurrent.atomic.AtomicBoolean
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal
+package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSharedObjectLoader.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSharedObjectLoader.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.internal.SharedObjectLoader
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.SharedObjectLoader
 import java.util.concurrent.atomic.AtomicBoolean
 
 class FakeSharedObjectLoader(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeNativeCoreModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeNativeCoreModule.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeJniDelegate
 import io.embrace.android.embracesdk.fakes.FakeNativeCrashProcessor
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
 import io.embrace.android.embracesdk.fakes.FakeSymbolService
-import io.embrace.android.embracesdk.internal.SharedObjectLoader
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.SharedObjectLoader
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCoreModule
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashHandlerInstaller
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashProcessor


### PR DESCRIPTION
## Goal

Moves the `SharedObjectLoader` into the NDK instrumentation package.

