### PR TITLE
Ensure domain counts are reset per session

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -180,6 +180,7 @@ internal class ModuleInitBootstrapper(
                     postInit(ConfigModule::class) {
                         serviceRegistry.registerService(lazy { configModule.configService })
                         serviceRegistry.registerService(lazy { configModule.remoteConfigSource })
+                        serviceRegistry.registerService(lazy { configModule.configService.networkBehavior.domainCountLimiter })
                         openTelemetryModule.applyConfiguration(
                             sensitiveKeysBehavior = configModule.configService.sensitiveKeysBehavior,
                             bypassValidation = configModule.configService.isOnlyUsingOtelExporters(),


### PR DESCRIPTION
## Goal

Ensures that domain counts are reset per session by registering the `DomainCountLimiter` with the `ServiceRegistry`. This will ensure the `MemoryCleanerListener` implementation is invoked whenever a new session starts.
