### PR TITLE
Add KGP version telemetry

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
@@ -85,7 +85,8 @@ class AssertionInterface(
         request: RecordedRequest,
         expectedVariants: List<String>,
         expectedAppIds: List<String>,
-        testMatrix: TestMatrix
+        testMatrix: TestMatrix,
+        additionalAssertions: (BuildTelemetryRequest.() -> Unit)?,
     ) {
         with(deserializeRequestBody<BuildTelemetryRequest>(request)) {
             assertNotNull(metadataRequestId)
@@ -109,6 +110,9 @@ class AssertionInterface(
                 }
             }
             assertEquals(variants.size, variants.map { it.buildId }.distinct().count())
+            if (additionalAssertions != null) {
+                additionalAssertions(this)
+            }
         }
     }
 
@@ -120,6 +124,7 @@ class AssertionInterface(
         expectedVariants: List<String>,
         expectedAppIds: List<String>? = null,
         testMatrix: TestMatrix = TestMatrix.MaxVersion,
+        additionalAssertions: (BuildTelemetryRequest.() -> Unit)? = null,
     ) {
         val request = fetchRequest(EmbraceEndpoint.BUILD_DATA)
         assertHeaders(request, "application/json", null)
@@ -127,7 +132,7 @@ class AssertionInterface(
         val appIds = expectedAppIds ?: defaultAppIds(expectedVariants.size)
 
         // assert plugin telemetry was sent
-        verifyBuildTelemetryRequestContents(request, expectedVariants, appIds, testMatrix)
+        verifyBuildTelemetryRequestContents(request, expectedVariants, appIds, testMatrix, additionalAssertions)
     }
 
     /**

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.gradle.config.TestMatrix.OlderVersion
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.ProjectType
 import io.embrace.android.gradle.plugin.gradle.GradleVersion
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -55,7 +56,13 @@ class AgpSupportTest {
             testMatrix = testMatrix,
             projectType = ProjectType.ANDROID,
             assertions = {
-                verifyBuildTelemetryRequestSent(listOf("debug", "release"), testMatrix = testMatrix)
+                verifyBuildTelemetryRequestSent(
+                    listOf("debug", "release"),
+                    testMatrix = testMatrix,
+                    additionalAssertions = {
+                        assertEquals(testMatrix.kotlin, kotlinVersion)
+                    }
+                )
                 verifyJvmMappingRequestsSent(1)
             }
         )

--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/IsolatedProjectsTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/IsolatedProjectsTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.gradle.integration.testcases
 
 import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
 import io.embrace.android.gradle.integration.framework.ProjectType
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -24,7 +25,12 @@ class IsolatedProjectsTest {
             ),
             projectType = ProjectType.ANDROID,
             assertions = {
-                // build is successful
+                verifyBuildTelemetryRequestSent(
+                    listOf("debug", "release"),
+                    additionalAssertions = {
+                        assertTrue(checkNotNull(isIsolatedProjectsEnabled))
+                    }
+                )
             }
         )
     }

--- a/embrace-gradle-plugin/build.gradle.kts
+++ b/embrace-gradle-plugin/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 dependencies {
     compileOnly(libs.agp.api)
     compileOnly(gradleApi())
+    compileOnly(kotlin("gradle-plugin"))
 
     implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
@@ -12,6 +12,7 @@ import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.kotlin.gradle.plugin.kotlinToolingVersion
 import java.util.UUID
 
 /**
@@ -57,6 +58,7 @@ class BuildTelemetryCollector {
                         buildId = config.buildId,
                     )
                 },
+                kotlinVersion = getKotlinVersion(project),
             )
         }
     }
@@ -103,6 +105,14 @@ class BuildTelemetryCollector {
 
     private fun Project.getJvmArgs() = getProperty(GRADLE_JVM_ARGS) ?: ""
     private fun Project.getEdmVersion() = getProperty(EMBRACE_UNITY_EDM_VERSION) ?: ""
+
+    private fun getKotlinVersion(project: Project): String? {
+        return if (project.pluginManager.hasPlugin("org.jetbrains.kotlin.android")) {
+            project.kotlinToolingVersion.toString()
+        } else {
+            null
+        }
+    }
 }
 
 private const val SYS_PROP_JDK_VERSION = "java.version"

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
@@ -20,6 +20,7 @@ data class BuildTelemetryRequest(
     @Json(name = "jdk") val jdkVersion: String? = null,
     @Json(name = "edm") val isEdmEnabled: Boolean? = null,
     @Json(name = "edmv") val edmVersion: String? = null,
+    @Json(name = "kgpv") val kotlinVersion: String? = null,
 ) : Serializable {
 
     private companion object {


### PR DESCRIPTION
## Goal

Add BuildTelemetry that collects the customers Kotlin Gradle Plugin version.

## Changes
- Add kotlin("gradle-plugin") compileOnly dependency to access kotlinToolingVersion
- Add additionalAssertions field to verifyBuildTelemetryRequestSent so we can check if certain telemetry is tracked.
- Add kgpv field to BuildTelemetryRequest