### PR TITLE
Add huc lite module to the SDK anchor module

### DIFF
--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     // automatically included instrumentation
     implementation(project(":embrace-android-instrumentation-app-exit-info"))
     implementation(project(":embrace-android-instrumentation-fcm"))
+    implementation(project(":embrace-android-instrumentation-huc-lite"))
     implementation(project(":embrace-android-instrumentation-network-status"))
     implementation(project(":embrace-android-instrumentation-power-save"))
     implementation(project(":embrace-android-instrumentation-taps"))


### PR DESCRIPTION
## Goal

Add reference to huc-lite instrumentation module so it's brought in automatically by the SDK anchor module.  
