### PR TITLE
Use ErrorCodeAttribute in TelemetryDestination

### DIFF
--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -2,12 +2,13 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanToken
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 
 class FakeSpanToken(
     val name: String,
     val startTimeMs: Long,
     var endTimeMs: Long?,
-    var errorCode: String?,
+    var errorCode: ErrorCodeAttribute?,
     val type: EmbType,
     val attributes: Map<String, String>,
 ) : SpanToken {

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanToken
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 
 class FakeTelemetryDestination : TelemetryDestination {
@@ -64,7 +65,7 @@ class FakeTelemetryDestination : TelemetryDestination {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        errorCode: String?,
+        errorCode: ErrorCodeAttribute?,
         type: EmbType,
         attributes: Map<String, String>,
     ) {

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 
 /**
@@ -57,7 +58,7 @@ interface TelemetryDestination {
         name: String,
         startTimeMs: Long,
         endTimeMs: Long,
-        errorCode: String? = null,
+        errorCode: ErrorCodeAttribute? = null,
         type: EmbType = EmbType.Performance.Default,
         attributes: Map<String, String> = emptyMap(),
     )

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
@@ -153,7 +153,7 @@ class HucLiteDataSource(
             recordRequest(telemetryUrlProvider) {
                 val endTimeMs = clock.now()
                 val errorCode = if (responseCode !in 1..<400) {
-                    "failure"
+                    ErrorCodeAttribute.Failure
                 } else {
                     null
                 }
@@ -192,7 +192,7 @@ class HucLiteDataSource(
                     name = "$method ${pathProvider()}",
                     startTimeMs = getValidStartTime(),
                     endTimeMs = errorTimeMs,
-                    errorCode = ErrorCodeAttribute.Failure.value,
+                    errorCode = ErrorCodeAttribute.Failure,
                     type = EmbType.Performance.Network,
                     attributes = networkRequestSchemaType.attributes()
                 )

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/HucTestHarness.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/HucTestHarness.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.FakeSpanToken
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.instrumentation.HucLiteDataSource
 import io.embrace.opentelemetry.kotlin.semconv.ErrorAttributes
 import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
@@ -99,7 +100,7 @@ internal class HucTestHarness {
     ) {
         assertEquals(expectedResponseCode.toString(), attributes[HttpAttributes.HTTP_RESPONSE_STATUS_CODE])
         if (expectedResponseCode !in 1..400) {
-            assertEquals("failure", errorCode)
+            assertEquals(ErrorCodeAttribute.Failure, errorCode)
         } else {
             assertNull(errorCode)
         }
@@ -127,6 +128,7 @@ internal class HucTestHarness {
         assertEquals("Nope", attributes[ExceptionAttributes.EXCEPTION_MESSAGE])
         assertEquals(expectedStartTime, startTimeMs)
         assertEquals(expectedEndTime, endTimeMs)
+        assertEquals(ErrorCodeAttribute.Failure, errorCode)
     }
 }
 


### PR DESCRIPTION
## Goal

Use existing internal sealed class ErrorCodeAttribute to represent the public API concept `ErrorCode`​ in `TelemetryDestination`  
