### PR TITLE
Add sourceCompatibility telemetry

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
@@ -61,6 +61,7 @@ class AgpSupportTest {
                     testMatrix = testMatrix,
                     additionalAssertions = {
                         assertEquals(testMatrix.kotlin, kotlinVersion)
+                        assertEquals(testMatrix.jdk.name.removePrefix("JAVA_"), sourceCompatibility)
                     }
                 )
                 verifyJvmMappingRequestsSent(1)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapper.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapper.kt
@@ -9,4 +9,5 @@ interface AgpWrapper {
     val usesNdkBuild: Boolean
     val minSdk: Int?
     val version: AgpVersion
+    val sourceCompatibility: String?
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapperImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapperImpl.kt
@@ -33,4 +33,8 @@ class AgpWrapperImpl(project: Project) : AgpWrapper {
     override val minSdk: Int? by lazy {
         extension.defaultConfig.minSdk
     }
+
+    override val sourceCompatibility: String? by lazy {
+        extension.compileOptions.sourceCompatibility.toString()
+    }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
@@ -45,6 +45,7 @@ class BuildTelemetryCollector {
                 pluginVersion = BuildConfig.VERSION,
                 operatingSystem = getOperatingSystem(),
                 jdkVersion = getJdkVersion(),
+                sourceCompatibility = agpWrapper.sourceCompatibility,
             )
         }
         // then return a provider that is invoked in the execution phase to avoid

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
@@ -21,6 +21,7 @@ data class BuildTelemetryRequest(
     @Json(name = "edm") val isEdmEnabled: Boolean? = null,
     @Json(name = "edmv") val edmVersion: String? = null,
     @Json(name = "kgpv") val kotlinVersion: String? = null,
+    @Json(name = "sc") val sourceCompatibility: String? = null,
 ) : Serializable {
 
     private companion object {


### PR DESCRIPTION
## Goal
Collect sourceCompatibility information as part of build telemetry

## Changes
- Add `sourceCompatibility` property to `AgpWrapper` interface
- Add source compatibility field to `BuildTelemetryRequest` with JSON name "sc"
- Update `BuildTelemetryCollector` to include source compatibility
- Add test assertion to verify source compatibility is captured correctly