### PR TITLE
Add minSdk and compileSdk telemetry

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/java/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
@@ -60,6 +60,8 @@ class AgpSupportTest {
                     listOf("debug", "release"),
                     testMatrix = testMatrix,
                     additionalAssertions = {
+                        assertEquals(26, minSdk)
+                        assertEquals(testMatrix.compileAndTargetSdk.toInt(), compileSdk)
                         assertEquals(testMatrix.kotlin, kotlinVersion)
                         assertEquals(testMatrix.jdk.name.removePrefix("JAVA_"), sourceCompatibility)
                     }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapper.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapper.kt
@@ -6,6 +6,7 @@ package io.embrace.android.gradle.plugin.agp
 interface AgpWrapper {
     val isCoreLibraryDesugaringEnabled: Boolean
     val minSdk: Int?
+    val compileSdk: Int?
     val version: AgpVersion
     val sourceCompatibility: String?
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapperImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapperImpl.kt
@@ -26,6 +26,10 @@ class AgpWrapperImpl(project: Project) : AgpWrapper {
         extension.defaultConfig.minSdk
     }
 
+    override val compileSdk: Int? by lazy {
+        extension.compileSdk
+    }
+
     override val sourceCompatibility: String? by lazy {
         extension.compileOptions.sourceCompatibility.toString()
     }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
@@ -46,6 +46,8 @@ class BuildTelemetryCollector {
                 operatingSystem = getOperatingSystem(),
                 jdkVersion = getJdkVersion(),
                 sourceCompatibility = agpWrapper.sourceCompatibility,
+                minSdk = agpWrapper.minSdk,
+                compileSdk = agpWrapper.compileSdk,
             )
         }
         // then return a provider that is invoked in the execution phase to avoid

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
@@ -22,6 +22,8 @@ data class BuildTelemetryRequest(
     @Json(name = "edmv") val edmVersion: String? = null,
     @Json(name = "kgpv") val kotlinVersion: String? = null,
     @Json(name = "sc") val sourceCompatibility: String? = null,
+    @Json(name = "msdk") val minSdk: Int? = null,
+    @Json(name = "csdk") val compileSdk: Int? = null,
 ) : Serializable {
 
     private companion object {


### PR DESCRIPTION
## Goal
Track both minSdk and compileSdk versions in build telemetry to better understand customer SDK configurations.

## Changes
- Added `compileSdk` property to `AgpWrapper` interface and implementation
- Added `minSdk` and `compileSdk` fields to `BuildTelemetryRequest` with JSON names "msdk" and "csdk"
- Updated `BuildTelemetryCollector` to capture both values from AgpWrapper
- Added test assertions to verify both values are collected correctly