### PR TITLE
Call the correct method in the single param openConnection overload

### DIFF
--- a/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionTracker.kt
+++ b/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionTracker.kt
@@ -167,8 +167,7 @@ internal object HttpUrlConnectionTracker {
                                 parentHandler,
                                 parentHandler.javaClass,
                                 EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION,
-                                URL::class.java,
-                                Proxy::class.java
+                                URL::class.java
                             )
                         method.isAccessible = true
                         val parentConnection = method.invoke(parentHandler, url) as URLConnection?


### PR DESCRIPTION
## Goal

The wrapping `openConnection`​ method with one parameter was using reflection to find the wrong method (with two parameters) and calling it.  This fixes the behavior.  
