### PR TITLE
Deprecate autoAddDependencies

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,6 +36,9 @@ very little change as most alterations are internal. However, you should be awar
 - `embrace-android-fcm` has been renamed as `embrace-android-instrumentation-fcm`
 - `embrace-android-okhttp3` has been renamed as `embrace-android-instrumentation-okhttp`
 
+`embrace.autoAddDependencies` is deprecated and will be removed in a future release. You should add
+the `io.embrace:embrace-android-sdk` dependency to your classpath manually.
+
 ## Altered APIs
 
 Various deprecated APIs have been removed. Please migrate to the documented new APIs where applicable, or

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
@@ -43,6 +43,7 @@ interface PluginBehavior {
      * Whether the project should automatically add embrace dependencies to the classpath,
      * set via `swazzler.disableDependencyInjection`
      */
+    @Deprecated("This will be removed in a future release. Add embrace dependencies to the classpath manually instead.")
     val autoAddEmbraceDependencies: Boolean
 
     /**

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
@@ -49,6 +49,10 @@ class PluginBehaviorImpl(
         }
     }
 
+    @Deprecated(
+        "This will be removed in a future release." +
+            " Add embrace dependencies to the classpath manually instead."
+    )
     override val autoAddEmbraceDependencies: Boolean by lazy {
         val userValue = embrace.autoAddEmbraceDependencies.orNull ?: true
         userValue && !isUnityEdmEnabled

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/dependency/DependenciesInstaller.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/dependency/DependenciesInstaller.kt
@@ -26,6 +26,7 @@ private val embraceLogger = EmbraceLogger("DependenciesInstaller")
  * plugin) and change its behavior.
  * It is not suggested, and it is considered wrong to resolve dependencies at configuration time.
  */
+@Suppress("DEPRECATION")
 fun Project.installDependenciesForVariant(
     variantName: String,
     behavior: PluginBehavior,
@@ -66,7 +67,7 @@ fun Project.installDependenciesForVariant(
                     "true"
                 }
 
-                // set through this consumer configuration 's attribute if we want (or not) to install dependencies
+                // set through this consumer configuration's attribute if we want (or not) to install dependencies
                 configuration.attributes {
                     it.attribute(
                         Attribute.of(

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImplTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImplTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.gradle.plugin.config
 
 import io.embrace.android.gradle.plugin.api.EmbraceExtension


### PR DESCRIPTION
## Goal

Deprecates `embrace.autoAddDependencies` as it only adds the `embrace-android-sdk` and `embrace-android-instrumentation-okhttp` modules. In a future release (likely v9) we can remove this functionality entirely.

