### PR TITLE
Refactor network capture to use KeyValueStore

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -28,7 +28,7 @@ internal class LogModuleImpl(
     override val networkCaptureService: NetworkCaptureService by singleton {
         EmbraceNetworkCaptureService(
             essentialServiceModule.sessionIdTracker,
-            androidServicesModule.preferencesService,
+            androidServicesModule.store,
             { networkCaptureDataSource },
             configModule.configService,
             configModule.urlBuilder,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/EmbracePreferencesService.kt
@@ -90,25 +90,6 @@ internal class EmbracePreferencesService(
         return installDate != null && clock.now() - installDate <= PreferencesService.DAY_IN_MS
     }
 
-    override fun isNetworkCaptureRuleOver(id: String): Boolean {
-        return getNetworkCaptureRuleRemainingCount(id) <= 0
-    }
-
-    override fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int) {
-        impl.edit {
-            putInt(NETWORK_CAPTURE_RULE_PREFIX_KEY + id, getNetworkCaptureRuleRemainingCount(id, maxCount) - 1)
-        }
-    }
-
-    private fun getNetworkCaptureRuleRemainingCount(id: String): Int {
-        return getNetworkCaptureRuleRemainingCount(id, 1)
-    }
-
-    private fun getNetworkCaptureRuleRemainingCount(id: String, maxCount: Int): Int {
-        val value = impl.getInt(NETWORK_CAPTURE_RULE_PREFIX_KEY + id)
-        return value ?: maxCount
-    }
-
     companion object {
         private const val DEVICE_IDENTIFIER_KEY = "io.embrace.deviceid"
         private const val PREVIOUS_APP_VERSION_KEY = "io.embrace.lastappversion"
@@ -125,7 +106,6 @@ internal class EmbracePreferencesService(
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"
         private const val JAVA_SCRIPT_BUNDLE_ID_KEY = "io.embrace.jsbundle.id"
         private const val SESSION_PROPERTIES_KEY = "io.embrace.session.properties"
-        private const val NETWORK_CAPTURE_RULE_PREFIX_KEY = "io.embrace.networkcapturerule"
         private const val SDK_CONFIG_FETCHED_TIMESTAMP = "io.embrace.sdkfetchedtimestamp"
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/PreferencesService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/PreferencesService.kt
@@ -102,16 +102,6 @@ interface PreferencesService {
      */
     fun isUsersFirstDay(): Boolean
 
-    /**
-     * Ssuffix to compose the key to get the stored value
-     */
-    fun isNetworkCaptureRuleOver(id: String): Boolean
-
-    /**
-     * Suffix to compose the key to get the stored value
-     */
-    fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int)
-
     companion object {
         const val DAY_IN_MS: Long = 60 * 60 * 24 * 1000L
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePreferenceService.kt
@@ -21,16 +21,8 @@ class FakePreferenceService(
     val bgActivityNumber: () -> Int = { 5 },
 ) : PreferencesService {
 
-    var networkCaptureRuleOver: Boolean = false
     var firstDay: Boolean = false
     var incrementAndGetSessionNumberCount: Int = 0
-
-    override fun isNetworkCaptureRuleOver(id: String): Boolean {
-        return networkCaptureRuleOver
-    }
-
-    override fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int) {
-    }
 
     override fun incrementAndGetSessionNumber(): Int {
         incrementAndGetSessionNumberCount++


### PR DESCRIPTION
## Goal

Refactors network capture to use `KeyValueStore` instead of `PreferencesService`.

## Testing

Updated existing test coverage.
