### PR TITLE
Add HttpNetworkRequest model class

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     api(project(":embrace-android-config"))
     implementation(project(":embrace-android-instrumentation-api"))
     implementation(project(":embrace-android-instrumentation-schema"))
+    implementation(project(":embrace-android-instrumentation-network-common"))
     compileOnly(project(":embrace-android-api"))
 
     implementation(libs.androidx.annotation)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -44,7 +44,6 @@ internal class LogModuleImpl(
     override val networkLoggingService: NetworkLoggingService by singleton {
         EmbraceNetworkLoggingService(
             configModule.configService.networkBehavior.domainCountLimiter,
-            networkCaptureService,
             openTelemetryModule.spanService
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureDataSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureDataSource.kt
@@ -4,6 +4,5 @@ import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
 import io.embrace.android.embracesdk.internal.payload.NetworkCapturedCall
 
 interface NetworkCaptureDataSource : DataSource {
-
-    fun logNetworkCapturedCall(networkCapturedCall: NetworkCapturedCall)
+    fun logNetworkCapturedCall(call: NetworkCapturedCall)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureDataSourceImpl.kt
@@ -16,36 +16,34 @@ internal class NetworkCaptureDataSourceImpl(
 
     /**
      * Creates a log with data from a captured network request.
-     *
-     * @param networkCapturedCall the captured network information
      */
-    override fun logNetworkCapturedCall(networkCapturedCall: NetworkCapturedCall) {
+    override fun logNetworkCapturedCall(call: NetworkCapturedCall) {
         captureTelemetry {
             addLog(
                 SchemaType.NetworkCapturedRequest(
-                    duration = networkCapturedCall.duration,
-                    endTime = networkCapturedCall.endTime,
-                    httpMethod = networkCapturedCall.httpMethod,
-                    matchedUrl = networkCapturedCall.matchedUrl,
-                    networkId = networkCapturedCall.networkId,
-                    requestBody = networkCapturedCall.requestBody,
-                    requestBodySize = networkCapturedCall.requestBodySize,
-                    requestQuery = networkCapturedCall.requestQuery,
-                    requestQueryHeaders = networkCapturedCall.requestQueryHeaders,
-                    requestSize = networkCapturedCall.requestSize,
-                    responseBody = networkCapturedCall.responseBody,
-                    responseBodySize = networkCapturedCall.responseBodySize,
-                    responseHeaders = networkCapturedCall.responseHeaders,
-                    responseSize = networkCapturedCall.responseSize,
-                    responseStatus = networkCapturedCall.responseStatus,
-                    sessionId = networkCapturedCall.sessionId,
-                    startTime = networkCapturedCall.startTime,
-                    url = networkCapturedCall.url,
-                    errorMessage = networkCapturedCall.errorMessage,
-                    encryptedPayload = networkCapturedCall.encryptedPayload
+                    duration = call.duration,
+                    endTime = call.endTime,
+                    httpMethod = call.httpMethod,
+                    matchedUrl = call.matchedUrl,
+                    networkId = call.networkId,
+                    requestBody = call.requestBody,
+                    requestBodySize = call.requestBodySize,
+                    requestQuery = call.requestQuery,
+                    requestQueryHeaders = call.requestQueryHeaders,
+                    requestSize = call.requestSize,
+                    responseBody = call.responseBody,
+                    responseBodySize = call.responseBodySize,
+                    responseHeaders = call.responseHeaders,
+                    responseSize = call.responseSize,
+                    responseStatus = call.responseStatus,
+                    sessionId = call.sessionId,
+                    startTime = call.startTime,
+                    url = call.url,
+                    errorMessage = call.errorMessage,
+                    encryptedPayload = call.encryptedPayload
                 ),
                 LogSeverity.INFO,
-                networkCapturedCall.networkId
+                call.networkId
             )
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkCaptureService.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.network.logging
 
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
-import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
+import io.embrace.android.embracesdk.internal.instrumentation.network.HttpNetworkRequest
 
 interface NetworkCaptureService {
 
@@ -17,13 +17,5 @@ interface NetworkCaptureService {
     /**
      * Logs the network captured data if this match the rule criteria.
      */
-    fun logNetworkCapturedData(
-        url: String,
-        httpMethod: String,
-        statusCode: Int,
-        startTime: Long,
-        endTime: Long,
-        networkCaptureData: NetworkCaptureData?,
-        errorMessage: String? = null,
-    )
+    fun logNetworkRequest(request: HttpNetworkRequest)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkLoggingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/network/logging/NetworkLoggingService.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.network.logging
 
-import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.internal.instrumentation.network.HttpNetworkRequest
 
 /**
  * Logs network calls made by the application. The Embrace SDK intercepts the calls and reports
@@ -11,8 +11,6 @@ interface NetworkLoggingService {
     /**
      * Logs a network request.
      * This network request is considered unique and finished, meaning that we will not receive additional data for it.
-     *
-     * @param networkRequest the network request to log
      */
-    fun logNetworkRequest(networkRequest: EmbraceNetworkRequest)
+    fun logNetworkRequest(request: HttpNetworkRequest)
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/network/logging/EmbraceNetworkCaptureServiceTest.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.internal.comms.api.EmbraceApiUrlBuilder
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.instrumentation.network.HttpNetworkRequest
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -24,14 +24,7 @@ internal class EmbraceNetworkCaptureServiceTest {
     private lateinit var cfg: RemoteConfig
     private val sessionIdTracker: FakeSessionIdTracker = FakeSessionIdTracker()
     private lateinit var configService: FakeConfigService
-    private val networkCaptureData: NetworkCaptureData = NetworkCaptureData(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    )
+    private val networkCaptureData = HttpNetworkRequest.HttpRequestBody(null, null, null, null, null, null)
 
     @Before
     fun setUp() {
@@ -135,24 +128,28 @@ internal class EmbraceNetworkCaptureServiceTest {
 
         val service = getService()
         // duration = 2000ms shouldn't be captured
-        service.logNetworkCapturedData(
-            "https://embrace.io/changelog",
-            "GET",
-            200,
-            0,
-            2000,
-            networkCaptureData
+        service.logNetworkRequest(
+            HttpNetworkRequest(
+                url = "https://embrace.io/changelog",
+                httpMethod = "GET",
+                statusCode = 200,
+                startTime = 0,
+                endTime = 2000,
+                body = networkCaptureData,
+            )
         )
         assertEquals(0, networkCaptureDataSource.loggedCalls.size)
 
         // duration = 6000ms should be captured
-        service.logNetworkCapturedData(
-            "https://embrace.io/changelog",
-            "GET",
-            200,
-            0,
-            6000,
-            networkCaptureData
+        service.logNetworkRequest(
+            HttpNetworkRequest(
+                url = "https://embrace.io/changelog",
+                httpMethod = "GET",
+                statusCode = 200,
+                startTime = 0,
+                endTime = 6000,
+                body = networkCaptureData
+            )
         )
         assertEquals(1, networkCaptureDataSource.loggedCalls.size)
     }
@@ -163,33 +160,40 @@ internal class EmbraceNetworkCaptureServiceTest {
         cfg = RemoteConfig(networkCaptureRules = setOf(rule))
 
         val service = getService()
-        service.logNetworkCapturedData(
-            "https://embrace.io/changelog",
-            "GET",
-            200,
-            0,
-            2000,
-            networkCaptureData
+        service.logNetworkRequest(
+            HttpNetworkRequest(
+
+                url = "https://embrace.io/changelog",
+                httpMethod = "GET",
+                statusCode = 200,
+                startTime = 0,
+                endTime = 2000,
+                body = networkCaptureData
+            )
         )
         assertEquals(1, networkCaptureDataSource.loggedCalls.size)
 
-        service.logNetworkCapturedData(
-            "https://embrace.io/changelog",
-            "GET",
-            404,
-            0,
-            2000,
-            networkCaptureData
+        service.logNetworkRequest(
+            HttpNetworkRequest(
+                url = "https://embrace.io/changelog",
+                httpMethod = "GET",
+                statusCode = 404,
+                startTime = 0,
+                endTime = 2000,
+                body = networkCaptureData
+            )
         )
         assertEquals(2, networkCaptureDataSource.loggedCalls.size)
 
-        service.logNetworkCapturedData(
-            "https://embrace.io/changelog",
-            "GET",
-            500,
-            0,
-            2000,
-            networkCaptureData
+        service.logNetworkRequest(
+            HttpNetworkRequest(
+                url = "https://embrace.io/changelog",
+                httpMethod = "GET",
+                statusCode = 500,
+                startTime = 0,
+                endTime = 2000,
+                body = networkCaptureData
+            )
         )
         assertEquals(2, networkCaptureDataSource.loggedCalls.size)
     }

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/HttpNetworkRequest.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/HttpNetworkRequest.kt
@@ -1,0 +1,31 @@
+package io.embrace.android.embracesdk.internal.instrumentation.network
+
+class HttpNetworkRequest(
+    val url: String,
+    val httpMethod: String,
+    val startTime: Long,
+    val endTime: Long,
+    val bytesSent: Long? = null,
+    val bytesReceived: Long? = null,
+    val statusCode: Int? = null,
+    val errorType: String? = null,
+    val errorMessage: String? = null,
+    val traceId: String? = null,
+    val w3cTraceparent: String? = null,
+    val body: HttpRequestBody? = null,
+) {
+    class HttpRequestBody(
+        val requestHeaders: Map<String, String>?,
+        val requestQueryParams: String?,
+        val capturedRequestBody: ByteArray?,
+        val responseHeaders: Map<String, String>?,
+        val capturedResponseBody: ByteArray?,
+        val dataCaptureErrorMessage: String?,
+    ) {
+        val requestBodySize: Int
+            get() = capturedRequestBody?.size ?: 0
+
+        val responseBodySize: Int
+            get() = capturedResponseBody?.size ?: 0
+    }
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
@@ -52,7 +52,7 @@ internal class NetworkRequestApiDelegateTest {
         )
         delegate.recordNetworkRequest(request)
         assertEquals(1, orchestrator.stateChangeCount)
-        assertEquals(request, networkLoggingService.requests.single())
+        assertEquals(request.url, networkLoggingService.requests.single().url)
     }
 
     @Test

--- a/embrace-test-fakes/build.gradle.kts
+++ b/embrace-test-fakes/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":embrace-android-delivery-fakes"))
     implementation(project(":embrace-android-otel-fakes"))
     implementation(project(":embrace-android-instrumentation-api-fakes"))
+    implementation(project(":embrace-android-instrumentation-network-common"))
 
     compileOnly(project(":embrace-android-core"))
     compileOnly(project(":embrace-android-infra"))

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureDataSource.kt
@@ -8,8 +8,8 @@ class FakeNetworkCaptureDataSource : NetworkCaptureDataSource {
 
     val loggedCalls: MutableList<NetworkCapturedCall> = mutableListOf()
 
-    override fun logNetworkCapturedCall(networkCapturedCall: NetworkCapturedCall) {
-        loggedCalls.add(networkCapturedCall)
+    override fun logNetworkCapturedCall(call: NetworkCapturedCall) {
+        loggedCalls.add(call)
     }
 
     override fun onDataCaptureEnabled() {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkCaptureService.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
-import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
+import io.embrace.android.embracesdk.internal.instrumentation.network.HttpNetworkRequest
 import io.embrace.android.embracesdk.internal.network.logging.NetworkCaptureService
 
 class FakeNetworkCaptureService : NetworkCaptureService {
@@ -15,15 +15,9 @@ class FakeNetworkCaptureService : NetworkCaptureService {
         return emptySet()
     }
 
-    override fun logNetworkCapturedData(
-        url: String,
-        httpMethod: String,
-        statusCode: Int,
-        startTime: Long,
-        endTime: Long,
-        networkCaptureData: NetworkCaptureData?,
-        errorMessage: String?,
+    override fun logNetworkRequest(
+        request: HttpNetworkRequest
     ) {
-        urls.add(url)
+        urls.add(request.url)
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkLoggingService.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.instrumentation.network.HttpNetworkRequest
 import io.embrace.android.embracesdk.internal.network.logging.NetworkLoggingService
-import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 
 class FakeNetworkLoggingService : NetworkLoggingService {
 
-    var requests: MutableList<EmbraceNetworkRequest> = mutableListOf()
+    var requests: MutableList<HttpNetworkRequest> = mutableListOf()
 
-    override fun logNetworkRequest(networkRequest: EmbraceNetworkRequest) {
-        requests.add(networkRequest)
+    override fun logNetworkRequest(request: HttpNetworkRequest) {
+        requests.add(request)
     }
 }


### PR DESCRIPTION
## Goal

Adds `HttpNetworkRequest` as a class used to hold network request data internally. This avoids using the public API at the telemetry capture layer which is an obstacle to removing the use of `Embrace/EmbraceInternalApi` in our network request instrumentation.

As part of this change I also separated `NetworkLoggingService` and `NetworkCaptureService` so that they are called individually from each other & therefore have no knowledge of each other.

## Testing

Relied on existing test coverage.
