### PR TITLE
Address flaky assertion

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -22,6 +22,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.actions.StoredNativeCrashData
 import io.embrace.android.embracesdk.testframework.actions.createStoredNativeCrashData
 import io.embrace.android.embracesdk.assertions.getLogOfType
+import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -98,7 +99,8 @@ internal class NativeCrashFeatureTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface(
-            fakeStorageLayer = true
+            fakeStorageLayer = true,
+            workerToFake = Worker.Background.NonIoRegWorker,
         ).apply {
             getEmbLogger().throwOnInternalError = false
         }.also {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.actions.createStoredNativeCrashData
 import io.embrace.android.embracesdk.assertions.getLastLog
+import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -40,7 +41,8 @@ internal class ResurrectionFeatureTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface(
-            fakeStorageLayer = true
+            fakeStorageLayer = true,
+            workerToFake = Worker.Background.NonIoRegWorker,
         ).apply {
             getEmbLogger().throwOnInternalError = false
             fakeSymbolService.symbolsForCurrentArch.putAll(fakeSymbols)


### PR DESCRIPTION
## Goal

`assertNativeCrashSent()` checks whether a file exists on disk. However, this behavior ends in a race as `FileStorageServiceImpl` deletes the file on a background thread. This attempts to fix the issue by making the background worker blocking for the purposes of our tests. Given this only happens very sporadically we should know for sure whether this works after several CI runs.

