### PR TITLE
Tweak JVM crash data source implementation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
@@ -28,6 +29,7 @@ internal class InstrumentationArgsImpl(
     override val ordinalStore: OrdinalStore,
     private val workerThreadModule: WorkerThreadModule,
     private val sessionIdTracker: SessionIdTracker,
+    private val sessionPropertiesService: SessionPropertiesService,
 ) : InstrumentationArgs {
 
     override fun backgroundWorker(worker: Worker.Background): BackgroundWorker = workerThreadModule.backgroundWorker(worker)
@@ -42,6 +44,8 @@ internal class InstrumentationArgsImpl(
     }
 
     override fun sessionId(): String? = sessionIdTracker.getActiveSessionId()
+
+    override fun sessionProperties(): Map<String, String> = sessionPropertiesService.getProperties()
 
     @Suppress("UNCHECKED_CAST")
     private fun <T> Context.getSystemServiceSafe(name: String): T? = runCatching {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
@@ -34,6 +34,7 @@ internal class InstrumentationModuleImpl(
             serializer = initModule.jsonSerializer,
             sessionIdTracker = essentialServiceModule.sessionIdTracker,
             ordinalStore = androidServicesModule.ordinalStore,
+            sessionPropertiesService = essentialServiceModule.sessionPropertiesService,
         )
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/ConstantNameThreadFactoryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/ConstantNameThreadFactoryTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal
 
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
-import io.embrace.android.embracesdk.internal.utils.compatThreadId
+import io.embrace.android.embracesdk.internal.arch.stacktrace.compatThreadId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/ThreadExtKtTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/ThreadExtKtTest.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.utils
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.arch.stacktrace.compatThreadId
+import io.embrace.android.embracesdk.internal.arch.stacktrace.getThreadInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/ThreadLocalExtensionsTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/utils/ThreadLocalExtensionsTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.utils
 
+import io.embrace.android.embracesdk.internal.arch.stacktrace.compatThreadId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadInfoCollector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadInfoCollector.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
+import io.embrace.android.embracesdk.internal.arch.stacktrace.getThreadInfo
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.payload.ThreadInfo
-import io.embrace.android.embracesdk.internal.utils.getThreadInfo
 
 internal class ThreadInfoCollector(
     private val targetThread: Thread,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/CrashModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/CrashModuleImpl.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash
 
-import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.internal.injection.ConfigModule
-import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 import io.embrace.android.embracesdk.internal.injection.singleton
@@ -14,20 +12,17 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
 
 internal class CrashModuleImpl(
     initModule: InitModule,
-    essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
-    androidServicesModule: AndroidServicesModule,
     instrumentationModule: InstrumentationModule,
 ) : CrashModule {
 
     override val jvmCrashDataSource: JvmCrashDataSource by singleton {
         JvmCrashDataSourceImpl(
-            essentialServiceModule.sessionPropertiesService,
-            androidServicesModule.ordinalStore,
             instrumentationModule.instrumentationArgs,
-            initModule.jsonSerializer,
-            jsCrashService?.let { it::appendCrashTelemetryAttributes }
-        )
+
+        ).apply {
+            jsCrashService?.let { telemetryModifier = it::appendCrashTelemetryAttributes }
+        }
     }
 
     override val jsCrashService: JsCrashService? by singleton {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/CrashModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/CrashModuleSupplier.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash
 
-import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
 import io.embrace.android.embracesdk.internal.injection.ConfigModule
-import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 
@@ -11,24 +9,18 @@ import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
  */
 typealias CrashModuleSupplier = (
     initModule: InitModule,
-    essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
-    androidServicesModule: AndroidServicesModule,
     instrumentationModule: InstrumentationModule,
 ) -> CrashModule
 
 fun createCrashModule(
     initModule: InitModule,
-    essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
-    androidServicesModule: AndroidServicesModule,
     instrumentationModule: InstrumentationModule,
 ): CrashModule {
     return CrashModuleImpl(
         initModule,
-        essentialServiceModule,
         configModule,
-        androidServicesModule,
         instrumentationModule,
     )
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSource.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSource.kt
@@ -1,14 +1,24 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.jvm
 
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.capture.crash.CrashTeardownHandler
 
 interface JvmCrashDataSource : DataSource {
 
+    /**
+     * Registers a callback that will be invoked after a JVM crash.
+     */
     fun addCrashTeardownHandler(handler: CrashTeardownHandler)
 
     /**
      * Logs an unhandled JVM throwable
      */
     fun logUnhandledJvmThrowable(exception: Throwable)
+
+    /**
+     * Allows modification of attributes and schema type on the crash log, if set
+     */
+    var telemetryModifier: ((TelemetryAttributes) -> SchemaType)?
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/CrashModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/CrashModuleImplTest.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.internal.instrumentation.crash
 
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
-import io.embrace.android.embracesdk.fakes.injection.FakeAndroidServicesModule
-import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.mockk.mockk
 import org.junit.Assert.assertNotNull
@@ -15,9 +13,7 @@ internal class CrashModuleImplTest {
     fun testDefaultImplementations() {
         val module = createCrashModule(
             FakeInitModule(),
-            FakeEssentialServiceModule(),
             FakeConfigModule(),
-            FakeAndroidServicesModule(),
             FakeInstrumentationModule(mockk())
         )
         assertNotNull(module.jvmCrashDataSource)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandlerTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandlerTest.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.internal.instrumentation.crash.jvm
 
 import io.embrace.android.embracesdk.fakes.FakeJvmCrashDataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.capture.crash.CrashTeardownHandler
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
@@ -70,6 +72,8 @@ internal class EmbraceUncaughtExceptionHandlerTest {
         override fun logUnhandledJvmThrowable(exception: Throwable) {
             throw RuntimeException("Test crash")
         }
+
+        override var telemetryModifier: ((TelemetryAttributes) -> SchemaType)? = null
 
         override fun addCrashTeardownHandler(handler: CrashTeardownHandler) {
         }

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
@@ -29,4 +29,6 @@ class FakeInstrumentationArgs(
     }
 
     override fun sessionId(): String? = null
+
+    override fun sessionProperties(): Map<String, String> = emptyMap()
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
@@ -80,4 +80,9 @@ interface InstrumentationArgs {
      * Retrieves the current session ID, or null if there is no active session.
      */
     fun sessionId(): String?
+
+    /**
+     * Retrieves a snapshot of the current session properties
+     */
+    fun sessionProperties(): Map<String, String>
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/stacktrace/ThreadExt.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/stacktrace/ThreadExt.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal.utils
+package io.embrace.android.embracesdk.internal.arch.stacktrace
 
 import android.os.Build
 import io.embrace.android.embracesdk.internal.config.behavior.DEFAULT_STACKTRACE_SIZE_LIMIT
@@ -18,7 +18,7 @@ fun getThreadInfo(
 }
 
 @Suppress("DEPRECATION")
-fun Thread.compatThreadId() = if (BuildVersionChecker.isAtLeast(Build.VERSION_CODES.BAKLAVA)) {
+fun Thread.compatThreadId() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
     threadId()
 } else {
     id

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -30,7 +30,7 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.payload.getSessionSpan
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
-import io.embrace.android.embracesdk.internal.utils.compatThreadId
+import io.embrace.android.embracesdk.internal.arch.stacktrace.compatThreadId
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -398,9 +398,7 @@ internal class ModuleInitBootstrapper(
                     crashModule = init(CrashModule::class) {
                         crashModuleSupplier(
                             initModule,
-                            essentialServiceModule,
                             configModule,
-                            androidServicesModule,
                             instrumentationModule,
                         )
                     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -58,7 +58,7 @@ internal fun fakeModuleInitBootstrapper(
     nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier =
         { _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
-    crashModuleSupplier: CrashModuleSupplier = { _, _, _, _, _ -> FakeCrashModule() },
+    crashModuleSupplier: CrashModuleSupplier = { _, _, _ -> FakeCrashModule() },
     payloadSourceModuleSupplier: PayloadSourceModuleSupplier =
         { _, _, _, _, _, _, _, _, _, _, _ -> FakePayloadSourceModule() },
 ) = ModuleInitBootstrapper(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJvmCrashDataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJvmCrashDataSource.kt
@@ -1,11 +1,14 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.capture.crash.CrashTeardownHandler
 import io.embrace.android.embracesdk.internal.instrumentation.crash.jvm.JvmCrashDataSource
 
 class FakeJvmCrashDataSource : JvmCrashDataSource {
     var exception: Throwable? = null
+    override var telemetryModifier: ((TelemetryAttributes) -> SchemaType)? = null
 
     override fun onDataCaptureEnabled() {
     }


### PR DESCRIPTION
## Goal

Makes a few more tweaks to the JVM crash data source to help its modularisation. This is mainly a case of decoupling session properties from the implementation and setting more values via `InstrumentationArgs`.