### PR TITLE
Make signing conditional on credentials availability

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-publishing-conventions.gradle.kts
@@ -6,8 +6,11 @@ mavenPublishing {
     coordinates("io.embrace", project.name, project.version.toString())
 
     publishToMavenCentral()
-    signAllPublications()
 
+    // Only enable signing if credentials are available (e.g., in CI during publish or locally)
+    if (project.hasProperty("signingInMemoryKey")) {
+        signAllPublications()
+    }
     pom {
         name.set(project.name)
         description.set("Embrace Android SDK")

--- a/embrace-gradle-plugin/build.gradle.kts
+++ b/embrace-gradle-plugin/build.gradle.kts
@@ -49,7 +49,11 @@ mavenPublishing {
     coordinates("io.embrace", "embrace-swazzler", project.version.toString())
 
     publishToMavenCentral()
-    signAllPublications()
+
+    // Only enable signing if credentials are available (e.g., in CI during publish or locally)
+    if (project.hasProperty("signingInMemoryKey")) {
+        signAllPublications()
+    }
 
     pom {
         name = "embrace-swazzler"


### PR DESCRIPTION
## Goal
CI fails when trying to merge to a release branch because signing not skipped by vanniktech, as the version doesn't end with SNAPSHOT. This change aims to only sign publications when we are actually publishing, so signingInMemoryKey is present.

## Changes
- Only call `signAllPublications()` when `signingInMemoryKey` is present