### PR TITLE
Rewrite flaky assertions

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.getLogOfType
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
@@ -13,19 +14,15 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
-import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.actions.StoredNativeCrashData
 import io.embrace.android.embracesdk.testframework.actions.createStoredNativeCrashData
-import io.embrace.android.embracesdk.assertions.getLogOfType
-import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -100,7 +97,6 @@ internal class NativeCrashFeatureTest {
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface(
             fakeStorageLayer = true,
-            workerToFake = Worker.Background.NonIoRegWorker,
         ).apply {
             getEmbLogger().throwOnInternalError = false
         }.also {
@@ -233,7 +229,7 @@ internal class NativeCrashFeatureTest {
                     assertDeadSessionResurrected(null)
                 }
                 assertEquals(0, getLogEnvelopes(0).size)
-                assertTrue(crashData.getCrashFile().exists())
+                assertNativeCrashExists(crashData)
             }
         )
     }
@@ -288,6 +284,6 @@ internal class NativeCrashFeatureTest {
         crashData: StoredNativeCrashData,
     ) {
         assertEquals(0, getLogEnvelopes(0).size)
-        assertFalse(crashData.getCrashFile().exists())
+        assertNativeCrashDoesNotExist(crashData)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.testcases.features
 
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.getLastLog
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
@@ -18,8 +19,6 @@ import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.actions.createStoredNativeCrashData
-import io.embrace.android.embracesdk.assertions.getLastLog
-import io.embrace.android.embracesdk.internal.worker.Worker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -42,7 +41,6 @@ internal class ResurrectionFeatureTest {
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface(
             fakeStorageLayer = true,
-            workerToFake = Worker.Background.NonIoRegWorker,
         ).apply {
             getEmbLogger().throwOnInternalError = false
             fakeSymbolService.symbolsForCurrentArch.putAll(fakeSymbols)


### PR DESCRIPTION
## Goal

Rewrites flaky assertions in the resurrection/native crash tests. These were checking for the existence of a file that is deleted on a background thread resulting in sporadic failures on CI. I initially attempted to fix this by faking the background worker but this was more complicated than initially thought, as there are multiple threads in play. Instead, I've rewritten the assertion to wait until the file is deleted with a timeout.