### PR TITLE
Reduce use of modules in instrumentation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleImpl.kt
@@ -3,10 +3,9 @@ package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 import android.os.Build
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.internal.handler.AndroidMainThreadHandler
-import io.embrace.android.embracesdk.internal.injection.ConfigModule
 import io.embrace.android.embracesdk.internal.injection.CoreModule
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
-import io.embrace.android.embracesdk.internal.injection.InitModule
+import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.injection.StorageModule
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
@@ -21,17 +20,18 @@ import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.worker.Worker
 
 internal class NativeCoreModuleImpl(
-    initModule: InitModule,
     coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
-    configModule: ConfigModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    instrumentationModule: InstrumentationModule,
     otelModule: OpenTelemetryModule,
     delegateProvider: Provider<JniDelegate?>,
     sharedObjectLoaderProvider: Provider<SharedObjectLoader?>,
     symbolServiceProvider: Provider<SymbolService?>,
 ) : NativeCoreModule {
+
+    private val args by singleton { instrumentationModule.instrumentationArgs }
 
     override val delegate by singleton {
         delegateProvider() ?: JniDelegateImpl()
@@ -40,38 +40,38 @@ internal class NativeCoreModuleImpl(
     override val symbolService: SymbolService by singleton {
         symbolServiceProvider() ?: SymbolServiceImpl(
             coreModule.cpuAbi,
-            initModule.jsonSerializer,
-            initModule.logger
+            args.serializer,
+            args.logger
         )
     }
 
     override val sharedObjectLoader: SharedObjectLoader by singleton {
-        sharedObjectLoaderProvider() ?: SharedObjectLoaderImpl(initModule.logger)
+        sharedObjectLoaderProvider() ?: SharedObjectLoaderImpl(args.logger)
     }
 
-    private val nativeOutputDir by lazy { StorageLocation.NATIVE.asFile(coreModule.context, initModule.logger) }
+    private val nativeOutputDir by lazy { StorageLocation.NATIVE.asFile(args.context, args.logger) }
 
     override val processor: NativeCrashProcessor = NativeCrashProcessorImpl(
         sharedObjectLoader,
-        initModule.logger,
+        args.logger,
         delegate,
-        initModule.jsonSerializer,
+        args.serializer,
         symbolService,
         nativeOutputDir,
         workerThreadModule.priorityWorker(Worker.Priority.DataPersistenceWorker)
     )
 
     override val nativeCrashHandlerInstaller: NativeCrashHandlerInstaller? by singleton {
-        if (configModule.configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
+        if (args.configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
             NativeCrashHandlerInstallerImpl(
-                configService = configModule.configService,
+                configService = args.configService,
                 sharedObjectLoader = sharedObjectLoader,
-                logger = initModule.logger,
+                logger = args.logger,
                 delegate = delegate,
                 backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
                 nativeInstallMessage = nativeInstallMessage ?: return@singleton null,
                 mainThreadHandler = AndroidMainThreadHandler(),
-                clock = initModule.clock,
+                clock = args.clock,
                 sessionIdTracker = essentialServiceModule.sessionIdTracker,
                 processIdProvider = { otelModule.otelSdkConfig.processIdentifier },
                 outputDir = nativeOutputDir

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleSupplier.kt
@@ -1,9 +1,8 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.injection.ConfigModule
 import io.embrace.android.embracesdk.internal.injection.CoreModule
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
-import io.embrace.android.embracesdk.internal.injection.InitModule
+import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.injection.StorageModule
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
@@ -15,12 +14,11 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  * Function that returns an instance of [NativeCoreModule]. Matches the signature of the constructor for [NativeCoreModuleImpl]
  */
 typealias NativeCoreModuleSupplier = (
-    initModule: InitModule,
     coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
-    configModule: ConfigModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    instrumentationModule: InstrumentationModule,
     otelModule: OpenTelemetryModule,
     delegateProvider: Provider<JniDelegate?>,
     sharedObjectLoaderProvider: Provider<SharedObjectLoader?>,
@@ -28,23 +26,21 @@ typealias NativeCoreModuleSupplier = (
 ) -> NativeCoreModule
 
 fun createNativeCoreModule(
-    initModule: InitModule,
     coreModule: CoreModule,
     workerThreadModule: WorkerThreadModule,
-    configModule: ConfigModule,
     storageModule: StorageModule,
     essentialServiceModule: EssentialServiceModule,
+    instrumentationModule: InstrumentationModule,
     otelModule: OpenTelemetryModule,
     delegateProvider: Provider<JniDelegate?>,
     sharedObjectLoaderProvider: Provider<SharedObjectLoader?>,
     symbolServiceProvider: Provider<SymbolService?>,
 ): NativeCoreModule = NativeCoreModuleImpl(
-    initModule,
     coreModule,
     workerThreadModule,
-    configModule,
     storageModule,
     essentialServiceModule,
+    instrumentationModule,
     otelModule,
     delegateProvider,
     sharedObjectLoaderProvider,

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/NativeCoreModuleImplTest.kt
@@ -1,9 +1,11 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -21,19 +23,24 @@ internal class NativeCoreModuleImplTest {
     @Test
     fun testDefaultImplementations() {
         val initModule = FakeInitModule()
+        val ctx = ApplicationProvider.getApplicationContext<Application>()
         val module = createNativeCoreModule(
-            initModule,
-            createCoreModule(ApplicationProvider.getApplicationContext(), initModule),
+            createCoreModule(ctx, initModule),
             FakeWorkerThreadModule(),
-            FakeConfigModule(
-                configService = FakeConfigService(
-                    autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
-                        ndkEnabled = true
+            FakeStorageModule(),
+            FakeEssentialServiceModule(),
+            FakeInstrumentationModule(
+                ctx,
+                instrumentationArgs =
+                FakeInstrumentationArgs(
+                    ctx,
+                    FakeConfigService(
+                        autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
+                            ndkEnabled = true
+                        )
                     )
                 )
             ),
-            FakeStorageModule(),
-            FakeEssentialServiceModule(),
             FakeOpenTelemetryModule(),
             { null },
             { null },

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleSupplier.kt
@@ -1,27 +1,21 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
-import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.injection.InitModule
+import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
-import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.session.lifecycle.ProcessStateService
 
 /**
  * Function that returns an instance of [AnrModule]. Matches the signature of the constructor for [AnrModuleImpl]
  */
 typealias AnrModuleSupplier = (
-    initModule: InitModule,
+    instrumentationModule: InstrumentationModule,
     openTelemetryModule: OpenTelemetryModule,
-    configService: ConfigService,
-    workerModule: WorkerThreadModule,
-    processStateService: ProcessStateService
+    processStateService: ProcessStateService,
 ) -> AnrModule
 
 fun createAnrModule(
-    initModule: InitModule,
+    instrumentationModule: InstrumentationModule,
     openTelemetryModule: OpenTelemetryModule,
-    configService: ConfigService,
-    workerModule: WorkerThreadModule,
-    processStateService: ProcessStateService
+    processStateService: ProcessStateService,
 ): AnrModule =
-    AnrModuleImpl(initModule, openTelemetryModule, configService, workerModule, processStateService)
+    AnrModuleImpl(instrumentationModule, openTelemetryModule, processStateService)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeFeatureModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeFeatureModuleImpl.kt
@@ -1,28 +1,24 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
-import io.embrace.android.embracesdk.internal.injection.ConfigModule
-import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 import io.embrace.android.embracesdk.internal.injection.singleton
 
 internal class NativeFeatureModuleImpl(
-    initModule: InitModule,
-    configModule: ConfigModule,
-    androidServicesModule: AndroidServicesModule,
     nativeCoreModule: NativeCoreModule,
     instrumentationModule: InstrumentationModule,
 ) : NativeFeatureModule {
 
+    private val args by singleton { instrumentationModule.instrumentationArgs }
+
     override val nativeCrashService: NativeCrashService? by singleton {
-        if (!configModule.configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
+        if (!args.configService.autoDataCaptureBehavior.isNativeCrashCaptureEnabled()) {
             null
         } else {
             NativeCrashDataSourceImpl(
                 nativeCrashProcessor = nativeCoreModule.processor,
-                ordinalStore = androidServicesModule.ordinalStore,
-                args = instrumentationModule.instrumentationArgs,
-                serializer = initModule.jsonSerializer,
+                ordinalStore = args.ordinalStore,
+                args = args,
+                serializer = args.serializer,
             )
         }
     }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeFeatureModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeFeatureModuleSupplier.kt
@@ -1,31 +1,19 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.injection.AndroidServicesModule
-import io.embrace.android.embracesdk.internal.injection.ConfigModule
-import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 
 /**
  * Function that returns an instance of [NativeFeatureModule]. Matches the signature of the constructor for [NativeFeatureModuleImpl]
  */
 typealias NativeFeatureModuleSupplier = (
-    initModule: InitModule,
-    configModule: ConfigModule,
-    androidServicesModule: AndroidServicesModule,
     nativeCoreModule: NativeCoreModule,
     instrumentationModule: InstrumentationModule,
 ) -> NativeFeatureModule
 
 fun createNativeFeatureModule(
-    initModule: InitModule,
-    configModule: ConfigModule,
-    androidServicesModule: AndroidServicesModule,
     nativeCoreModule: NativeCoreModule,
     instrumentationModule: InstrumentationModule,
 ): NativeFeatureModule = NativeFeatureModuleImpl(
-    initModule,
-    configModule,
-    androidServicesModule,
     nativeCoreModule,
     instrumentationModule,
 )

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImplTest.kt
@@ -1,35 +1,34 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
-import android.os.Looper
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.FakeProcessStateService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
-import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
-import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 internal class AnrModuleImplTest {
-
-    @Before
-    fun setUp() {
-        mockkStatic(Looper::class)
-        every { Looper.getMainLooper() } returns mockk(relaxed = true)
-    }
 
     @Test
     fun testDefaultImplementations() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
         val module = AnrModuleImpl(
-            FakeInitModule(),
+            FakeInstrumentationModule(
+                application,
+                instrumentationArgs = FakeInstrumentationArgs(
+                    application,
+                    configService = FakeConfigService()
+                )
+            ),
             FakeOpenTelemetryModule(),
-            FakeConfigService(),
-            FakeWorkerThreadModule(),
             FakeProcessStateService()
         )
         assertNotNull(module.anrService)
@@ -38,13 +37,18 @@ internal class AnrModuleImplTest {
 
     @Test
     fun testBehaviorDisabled() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
         val module = AnrModuleImpl(
-            FakeInitModule(),
-            FakeOpenTelemetryModule(),
-            FakeConfigService(
-                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(anrServiceEnabled = false)
+            FakeInstrumentationModule(
+                application,
+                instrumentationArgs = FakeInstrumentationArgs(
+                    application,
+                    configService = FakeConfigService(
+                        autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(anrServiceEnabled = false)
+                    )
+                )
             ),
-            FakeWorkerThreadModule(),
+            FakeOpenTelemetryModule(),
             FakeProcessStateService()
         )
         assertNull(module.anrService)

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
@@ -21,7 +21,7 @@ class FakeInstrumentationArgs(
 ) : InstrumentationArgs {
 
     override fun backgroundWorker(worker: Worker.Background): BackgroundWorker {
-        throw UnsupportedOperationException()
+        return fakeBackgroundWorker()
     }
 
     override fun <T> systemService(name: String): T? {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
-import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.BlockedThreadDetector
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
-import io.embrace.android.embracesdk.assertions.assertMatches
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -28,7 +27,6 @@ private const val SPAN_NAME = "emb-thread-blockage"
 internal class AnrFeatureTest {
 
     private lateinit var anrMonitorExecutor: BlockingScheduledExecutorService
-    private lateinit var blockedThreadDetector: BlockedThreadDetector
     private var startTimeMs: Long = 0L
 
     @Rule
@@ -41,7 +39,6 @@ internal class AnrFeatureTest {
             with(it) {
                 anrMonitorExecutor = getFakedWorkerExecutor()
                 anrMonitorExecutor.blockingMode = true
-                blockedThreadDetector = getBlockedThreadDetector()
             }
         }
     }
@@ -221,6 +218,7 @@ internal class AnrFeatureTest {
             repeat(sampleCount) {
                 moveForwardAndRunBlocked(intervalMs)
             }
+            val blockedThreadDetector = testRule.bootstrapper.anrModule.blockedThreadDetector
 
             if (!incomplete) {
                 // simulate the main thread becoming responsive again, ending the ANR interval

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -222,16 +222,6 @@ internal class ModuleInitBootstrapper(
                         }
                     }
 
-                    anrModule = init(AnrModule::class) {
-                        anrModuleSupplier(
-                            initModule,
-                            openTelemetryModule,
-                            configModule.configService,
-                            workerThreadModule,
-                            essentialServiceModule.processStateService
-                        )
-                    }
-
                     instrumentationModule = init(InstrumentationModule::class) {
                         instrumentationModuleSupplier(
                             initModule,
@@ -240,6 +230,14 @@ internal class ModuleInitBootstrapper(
                             essentialServiceModule,
                             androidServicesModule,
                             coreModule,
+                        )
+                    }
+
+                    anrModule = init(AnrModule::class) {
+                        anrModuleSupplier(
+                            instrumentationModule,
+                            openTelemetryModule,
+                            essentialServiceModule.processStateService
                         )
                     }
 
@@ -327,12 +325,11 @@ internal class ModuleInitBootstrapper(
 
                     nativeCoreModule = init(NativeCoreModule::class) {
                         nativeCoreModuleSupplier(
-                            initModule,
                             coreModule,
                             workerThreadModule,
-                            configModule,
                             storageModule,
                             essentialServiceModule,
+                            instrumentationModule,
                             openTelemetryModule,
                             { null },
                             { null },
@@ -342,9 +339,6 @@ internal class ModuleInitBootstrapper(
 
                     nativeFeatureModule = init(NativeFeatureModule::class) {
                         nativeFeatureModuleSupplier(
-                            initModule,
-                            configModule,
-                            androidServicesModule,
                             nativeCoreModule,
                             instrumentationModule,
                         )

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleInitBootstrapper.kt
@@ -51,9 +51,9 @@ internal fun fakeModuleInitBootstrapper(
     },
     dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
-    anrModuleSupplier: AnrModuleSupplier = { _, _, _, _, _ -> FakeAnrModule() },
+    anrModuleSupplier: AnrModuleSupplier = { _, _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _ -> FakeLogModule() },
-    nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
+    nativeCoreModuleSupplier: NativeCoreModuleSupplier = { _, _, _, _, _, _, _, _, _ -> FakeNativeCoreModule() },
     sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier =
         { _, _, _, _, _, _, _, _, _, _ -> FakeSessionOrchestrationModule() },
     payloadSourceModuleSupplier: PayloadSourceModuleSupplier =

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigModule
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
 import io.embrace.android.embracesdk.fakes.FakeNativeFeatureModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
@@ -14,8 +15,6 @@ import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -31,7 +30,7 @@ import org.robolectric.annotation.Config
 internal class ModuleInitBootstrapperTest {
 
     private lateinit var moduleInitBootstrapper: ModuleInitBootstrapper
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: FakeEmbLogger
     private lateinit var clock: Clock
     private lateinit var coreModule: FakeCoreModule
     private lateinit var context: Context
@@ -39,7 +38,7 @@ internal class ModuleInitBootstrapperTest {
 
     @Before
     fun setup() {
-        logger = EmbLoggerImpl()
+        logger = FakeEmbLogger(false)
         clock = FakeClock()
         coreModule = FakeCoreModule()
         val application = RuntimeEnvironment.getApplication()
@@ -49,9 +48,9 @@ internal class ModuleInitBootstrapperTest {
             clock = clock,
             configModuleSupplier = { _, _, _, _, _ -> FakeConfigModule(FakeConfigService()) },
             coreModuleSupplier = { _, _ -> coreModule },
-            nativeFeatureModuleSupplier = { _, _, _, _, _ -> FakeNativeFeatureModule() },
+            nativeFeatureModuleSupplier = { _, _ -> FakeNativeFeatureModule() },
             instrumentationModuleSupplier = { _, _, _, _, _, _ ->
-                FakeInstrumentationModule(application).apply {
+                FakeInstrumentationModule(application, logger = logger).apply {
                     registry = instrumentationRegistry
                 }
             }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
@@ -6,10 +6,13 @@ import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistryImpl
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 
-class FakeInstrumentationModule(application: Application) : InstrumentationModule {
+class FakeInstrumentationModule(
+    application: Application,
+    private val logger: FakeEmbLogger = FakeEmbLogger(),
+    override val instrumentationArgs: InstrumentationArgs = FakeInstrumentationArgs(application, logger = logger)
+) : InstrumentationModule {
     override val instrumentationRegistry: InstrumentationRegistry = InstrumentationRegistryImpl(
         fakeBackgroundWorker(),
-        FakeEmbLogger()
+        logger
     )
-    override val instrumentationArgs: InstrumentationArgs = FakeInstrumentationArgs(application)
 }


### PR DESCRIPTION
## Goal

Replaces the use of modules with `InstrumentationArgs` for ANR/NDK crash detection instrumentation code. This will make it easier to extract instrumentation to its own module in the long-term.

