### PR TITLE
Allow specifying events in completed spans

### DIFF
--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanToken
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
@@ -11,6 +12,7 @@ class FakeSpanToken(
     var errorCode: ErrorCodeAttribute?,
     val type: EmbType,
     val attributes: Map<String, String>,
+    val events: List<SpanEvent>
 ) : SpanToken {
     override fun stop(endTimeMs: Long?) {
         this.endTimeMs = endTimeMs ?: 0

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.arch.attrs.asPair
 import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
+import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanToken
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -55,6 +56,7 @@ class FakeTelemetryDestination : TelemetryDestination {
             null,
             schemaType.telemetryType,
             schemaType.attributes() + mapOf(schemaType.telemetryType.asPair()),
+            emptyList(),
         )
 
         createdSpans.add(token)
@@ -68,6 +70,7 @@ class FakeTelemetryDestination : TelemetryDestination {
         errorCode: ErrorCodeAttribute?,
         type: EmbType,
         attributes: Map<String, String>,
+        events: List<SpanEvent>,
     ) {
         val token = FakeSpanToken(
             name,
@@ -76,6 +79,7 @@ class FakeTelemetryDestination : TelemetryDestination {
             errorCode,
             type,
             attributes,
+            events,
         )
         createdSpans.add(token)
     }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanEvent.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanEvent.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.arch.datasource
+
+/**
+ * An event that occurred during a span
+ */
+interface SpanEvent {
+    val name: String
+    val timestampNanos: Long
+    val attributes: Map<String, String>
+}

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanEventImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanEventImpl.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.internal.arch.datasource
+
+class SpanEventImpl(
+    override val name: String,
+    override val timestampNanos: Long,
+    override val attributes: Map<String, String>,
+) : SpanEvent

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -61,5 +61,6 @@ interface TelemetryDestination {
         errorCode: ErrorCodeAttribute? = null,
         type: EmbType = EmbType.Performance.Default,
         attributes: Map<String, String> = emptyMap(),
+        events: List<SpanEvent> = emptyList(),
     )
 }


### PR DESCRIPTION
## Goal

Allows specifying events in spans that are already completed on `TelemetryDestination`. This will help support migrating the ANR instrumentation to use the `TelemetryDestination` API.

## Testing

Added unit tests.

