### PR TITLE
Avoid running gradle tests in parallel

### DIFF
--- a/embrace-gradle-plugin-integration-tests/build.gradle.kts
+++ b/embrace-gradle-plugin-integration-tests/build.gradle.kts
@@ -32,6 +32,9 @@ tasks.withType<Test>().configureEach {
             .filter { it.plugins.hasPlugin(MavenPublishPlugin::class.java) }
             .map { it.tasks.named("publishToMavenLocal") }
     )
+
+    // avoid default behavior of parallelisation as it can lead to resource exhaustion on CI (and locally)
+    maxParallelForks = 1
 }
 
 group = "io.embrace"


### PR DESCRIPTION
## Goal

Avoids running Gradle tests in parallel. I believe this is contributing to resource exhaustion on CI for dependabot jobs, and it doesn't make much difference in overall execution time. Bear in mind that Gradle should be able to run other independent tasks concurrently the Gradle tests - its just the Gradle tests that will be executed serially.

