### PR TITLE
Avoid tracing ID factory use

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImpl.kt
@@ -48,8 +48,7 @@ internal class AnrModuleImpl(
             AnrOtelMapper(
                 checkNotNull(anrService),
                 args.clock,
-                openTelemetryModule.spanService,
-                openTelemetryModule.otelSdkWrapper.openTelemetryKotlin.tracingIdFactory
+                openTelemetryModule.spanService
             )
         } else {
             null

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrOtelMapperTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrOtelMapperTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.instrumentation.anr
 import io.embrace.android.embracesdk.assertions.assertSuccessful
 import io.embrace.android.embracesdk.fakes.FakeAnrService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -116,8 +115,7 @@ internal class AnrOtelMapperTest {
         mapper = AnrOtelMapper(
             anrService,
             clock,
-            spanService,
-            FakeOpenTelemetryModule().otelSdkWrapper.openTelemetryKotlin.tracingIdFactory
+            spanService
         )
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeAppStateService
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
 import io.embrace.android.embracesdk.fakes.FakeSymbolService
-import io.embrace.android.embracesdk.fakes.FakeTracingIdFactory
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
@@ -147,8 +146,7 @@ internal class EmbraceSetupInterface(
                     anrOtelMapper = AnrOtelMapper(
                         anrService = fakeAnrService,
                         clock = fakeInitModule.clock,
-                        spanService = fakeInitModule.openTelemetryModule.spanService,
-                        tracingIdFactory = FakeTracingIdFactory()
+                        spanService = fakeInitModule.openTelemetryModule.spanService
                     )
                 )
             }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAnrOtelMapper.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAnrOtelMapper.kt
@@ -7,6 +7,5 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 fun fakeAnrOtelMapper(): AnrOtelMapper = AnrOtelMapper(
     FakeAnrService(),
     FakeClock(),
-    FakeSpanService(),
-    FakeOpenTelemetryModule().otelSdkWrapper.openTelemetryKotlin.tracingIdFactory
+    FakeSpanService()
 )


### PR DESCRIPTION
## Goal

Refactors `AnrOtelMapper` to create its own span ID/trace ID rather than requiring a dependency on `embrace-android-otel`. This is the only bit of instrumentation that requires this & longer-term I'd like to avoid the necessity of doing it this way.