### PR TITLE
Rename and move AppStateTracker

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -10,13 +10,13 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbraceObjectName
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit
 internal class TelemetryDestinationImpl(
     private val logger: Logger,
     private val sessionIdTracker: SessionIdTracker,
-    private val appStateService: AppStateService,
+    private val appStateTracker: AppStateTracker,
     private val clock: Clock,
     private val spanService: SpanService,
     private val currentSessionSpan: CurrentSessionSpan,
@@ -74,7 +74,7 @@ internal class TelemetryDestinationImpl(
                     }
                     sessionState = session.appState
                 }
-                val state = sessionState ?: appStateService.getAppState()
+                val state = sessionState ?: appStateTracker.getAppState()
                 setStringAttribute(embState.name, state.description)
             }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupService.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.capture.startup
 
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 /**
  * Service to track the SDK startup time.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/startup/StartupServiceImpl.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.capture.startup
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 
 class StartupServiceImpl(
     private val spanService: SpanService,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingService.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.internal.delivery.caching
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.delivery.Shutdownable
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 
 typealias SessionPayloadSupplier = (
     state: AppState,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery.caching
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -7,7 +8,6 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.session.orchestrator.PayloadStore
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import java.util.concurrent.atomic.AtomicBoolean

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.internal.envelope.session
 
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
@@ -11,8 +13,6 @@ import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.captureDataSafely
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 
@@ -22,7 +22,7 @@ internal class SessionPayloadSourceImpl(
     private val currentSessionSpan: CurrentSessionSpan,
     private val spanRepository: SpanRepository,
     private val otelPayloadMapper: OtelPayloadMapper?,
-    private val appStateService: AppStateService,
+    private val appStateTracker: AppStateTracker,
     private val clock: Clock,
     private val logger: EmbLogger,
 ) : SessionPayloadSource {
@@ -36,7 +36,7 @@ internal class SessionPayloadSourceImpl(
         val isCacheAttempt = endType == SessionSnapshotType.PERIODIC_CACHE
         val includeSnapshots = endType != SessionSnapshotType.JVM_CRASH
 
-        if (!endType.forceQuit && appStateService.getAppState() == AppState.BACKGROUND) {
+        if (!endType.forceQuit && appStateTracker.getAppState() == AppState.BACKGROUND) {
             spanRepository.autoTerminateSpans(clock.now())
         }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
@@ -1,19 +1,19 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 
 /**
  * This module contains services that are essential for bootstrapping other functionality in
  * the SDK during initialization.
  */
 interface EssentialServiceModule {
-    val appStateService: AppStateService
+    val appStateTracker: AppStateTracker
     val activityLifecycleTracker: ActivityTracker
     val userService: UserService
     val networkConnectivityService: NetworkConnectivityService

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.destination.TelemetryDestinationImpl
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.capture.connectivity.EmbraceNetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
@@ -13,8 +14,7 @@ import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTrackerImpl
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateServiceImpl
+import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateTrackerImpl
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.Worker
@@ -35,10 +35,10 @@ class EssentialServiceModuleImpl(
 
     private val configService by lazy { configModule.configService }
 
-    override val appStateService: AppStateService by singleton {
+    override val appStateTracker: AppStateTracker by singleton {
         EmbTrace.trace("process-state-service-init") {
             val lifecycleOwner = lifecycleOwnerProvider() ?: ProcessLifecycleOwner.get()
-            AppStateServiceImpl(initModule.clock, initModule.logger, lifecycleOwner)
+            AppStateTrackerImpl(initModule.clock, initModule.logger, lifecycleOwner)
         }
     }
 
@@ -84,7 +84,7 @@ class EssentialServiceModuleImpl(
         TelemetryDestinationImpl(
             logger = openTelemetryModule.otelSdkWrapper.logger,
             sessionIdTracker = sessionIdTracker,
-            appStateService = appStateService,
+            appStateTracker = appStateTracker,
             clock = initModule.clock,
             spanService = openTelemetryModule.spanService,
             currentSessionSpan = openTelemetryModule.currentSessionSpan,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -58,7 +58,7 @@ internal class PayloadSourceModuleImpl(
                 otelModule.currentSessionSpan,
                 otelModule.spanRepository,
                 otelPayloadMapperProvider(),
-                essentialServiceModule.appStateService,
+                essentialServiceModule.appStateTracker,
                 initModule.clock,
                 initModule.logger
             )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
@@ -66,7 +66,7 @@ internal class SessionOrchestrationModuleImpl(
 
     override val sessionOrchestrator: SessionOrchestrator by singleton(LoadType.EAGER) {
         SessionOrchestratorImpl(
-            essentialServiceModule.appStateService,
+            essentialServiceModule.appStateTracker,
             EmbTrace.trace("payloadFactory") { payloadFactory },
             initModule.clock,
             configModule.configService,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCoreModuleImpl.kt
@@ -86,7 +86,7 @@ internal class NativeCoreModuleImpl(
             storageModule.storageService.getFileForWrite("embrace_crash_marker").absolutePath
         NativeInstallMessage(
             markerFilePath = markerFilePath,
-            appState = essentialServiceModule.appStateService.getAppState(),
+            appState = essentialServiceModule.appStateTracker.getAppState(),
             reportId = Uuid.getEmbUuid(),
             apiLevel = Build.VERSION.SDK_INT,
             is32bit = coreModule.cpuAbi.is32BitDevice,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeInstallMessage.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeInstallMessage.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 data class NativeInstallMessage(
     val markerFilePath: String,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/registry/ServiceRegistry.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/registry/ServiceRegistry.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.registry
 
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerService
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicBoolean
@@ -50,9 +50,9 @@ class ServiceRegistry : Closeable {
         initialized.set(true)
     }
 
-    fun registerActivityListeners(appStateService: AppStateService): Unit =
+    fun registerActivityListeners(appStateTracker: AppStateTracker): Unit =
         appStateListeners.forEachSafe(
-            appStateService::addListener
+            appStateTracker::addListener
         )
 
     fun registerActivityLifecycleListeners(activityLifecycleTracker: ActivityTracker): Unit =

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.attrs.embHeartbeatTimeUnixNan
 import io.embrace.android.embracesdk.internal.arch.attrs.embProcessIdentifier
 import io.embrace.android.embracesdk.internal.arch.attrs.embState
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
@@ -30,7 +31,6 @@ import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.getSessionId
 import io.embrace.android.embracesdk.internal.session.getSessionProperties
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionZygote.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionZygote.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.session
 
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 /**
  * A precursor object that holds state associated with a newly started session.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionData.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionData.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.id
 
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 data class SessionData(
     val id: String,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTracker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTracker.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.id
 
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 interface SessionIdTracker {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImpl.kt
@@ -2,9 +2,9 @@ package io.embrace.android.embracesdk.internal.session.id
 
 import android.app.ActivityManager
 import android.os.Build
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import java.util.concurrent.CopyOnWriteArraySet
 
 internal class SessionIdTrackerImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/AppStateTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/AppStateTrackerImpl.kt
@@ -5,6 +5,9 @@ import android.os.Looper
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -15,11 +18,11 @@ import java.util.concurrent.CopyOnWriteArrayList
  * Service tracking the app's current process state (foreground or background) as reported
  * by ProcessLifecycleOwner.
  */
-internal class AppStateServiceImpl(
+internal class AppStateTrackerImpl(
     private val clock: Clock,
     private val logger: EmbLogger,
     private val lifecycleOwner: LifecycleOwner,
-) : AppStateService, LifecycleEventObserver {
+) : AppStateTracker, LifecycleEventObserver {
 
     /**
      * List of listeners that subscribe to process lifecycle events.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/InitialEnvelopeParams.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/InitialEnvelopeParams.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.message
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.LifeEventType
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.store.Ordinal
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.internal.session.message
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 
 /**
  * Factory that creates payload envelopes.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.message
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
@@ -8,7 +9,6 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
 internal class PayloadFactoryImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 
 /**
  * The minimum threshold for how long a session must last. This prevents unintentional

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestrator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestrator.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.internal.arch.CrashTeardownHandler
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 
 /**
  * Orchestrates the session and background activities in response to state changes and manual

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -5,6 +5,8 @@ import io.embrace.android.embracesdk.internal.arch.SessionType
 import io.embrace.android.embracesdk.internal.arch.attrs.embHeartbeatTimeUnixNano
 import io.embrace.android.embracesdk.internal.arch.attrs.embTerminated
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.config.ConfigService
@@ -13,14 +15,12 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.SessionZygote
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 internal class SessionOrchestratorImpl(
-    appStateService: AppStateService,
+    appStateTracker: AppStateTracker,
     private val payloadFactory: PayloadFactory,
     private val clock: Clock,
     private val configService: ConfigService,
@@ -39,10 +39,10 @@ internal class SessionOrchestratorImpl(
      * The currently active session.
      */
     private var activeSession: SessionZygote? = null
-    private var state = appStateService.getAppState()
+    private var state = appStateTracker.getAppState()
 
     init {
-        appStateService.addListener(this)
+        appStateTracker.addListener(this)
         EmbTrace.trace("start-first-session") { createInitialSession() }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.LifeEventType
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 
 enum class TransitionType {
     INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH;

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/fakes/FakeAppStateListener.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/fakes/FakeAppStateListener.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import java.util.concurrent.atomic.AtomicInteger
 
 class FakeAppStateListener : AppStateListener {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.session.message.FinalEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.InitialEnvelopeParams
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollator

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
@@ -7,8 +7,8 @@ import io.embrace.android.embracesdk.fakes.FakePayloadStore
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.fakes.fakeSessionZygote
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.envelope.session
 
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
@@ -48,7 +48,7 @@ internal class SessionPayloadSourceImplTest {
             currentSessionSpan,
             spanRepository,
             FakeOtelPayloadMapper(),
-            FakeAppStateService(),
+            FakeAppStateTracker(),
             FakeClock(),
             EmbLoggerImpl()
         )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -9,9 +9,9 @@ import io.embrace.android.embracesdk.fakes.FakeMainThreadHandler
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.session.id.SessionData
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.registry
 
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeMemoryCleanerService
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityLifecycleListener
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -35,7 +35,7 @@ internal class ServiceRegistryTest {
         registry.registerService(lazy { service })
         val expected = listOf(service)
 
-        val activityService = FakeAppStateService()
+        val activityService = FakeAppStateTracker()
         registry.registerActivityListeners(activityService)
         assertEquals(expected, activityService.listeners)
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/AppStateTrackerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/AppStateTrackerTest.kt
@@ -8,9 +8,9 @@ import io.embrace.android.embracesdk.fakes.FakeAppStateListener
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateServiceImpl
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
+import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateTrackerImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -25,9 +25,9 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 
-internal class AppStateServiceTest {
+internal class AppStateTrackerTest {
 
-    private lateinit var stateService: AppStateServiceImpl
+    private lateinit var stateService: AppStateTrackerImpl
 
     companion object {
         private lateinit var looper: Looper
@@ -64,7 +64,7 @@ internal class AppStateServiceTest {
             staticMocks = false
         )
         fakeEmbLogger = FakeEmbLogger()
-        stateService = AppStateServiceImpl(
+        stateService = AppStateTrackerImpl(
             fakeClock,
             fakeEmbLogger,
             TestLifecycleOwner(Lifecycle.State.INITIALIZED)
@@ -214,7 +214,7 @@ internal class AppStateServiceTest {
 
     @Test
     fun `launched in background`() {
-        stateService = AppStateServiceImpl(
+        stateService = AppStateTrackerImpl(
             fakeClock,
             fakeEmbLogger,
             mockk {
@@ -228,7 +228,7 @@ internal class AppStateServiceTest {
 
     @Test
     fun `launched in foreground`() {
-        stateService = AppStateServiceImpl(
+        stateService = AppStateTrackerImpl(
             fakeClock,
             fakeEmbLogger,
             mockk {

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionZygote
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
@@ -22,7 +23,6 @@ import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollatorImpl
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
@@ -37,7 +37,7 @@ internal class PayloadFactoryBaTest {
     private lateinit var clock: FakeClock
     private lateinit var metadataService: MetadataService
     private lateinit var sessionIdTracker: FakeSessionIdTracker
-    private lateinit var activityService: FakeAppStateService
+    private lateinit var activityService: FakeAppStateTracker
     private lateinit var userService: UserService
     private lateinit var configService: FakeConfigService
     private lateinit var spanRepository: SpanRepository
@@ -52,7 +52,7 @@ internal class PayloadFactoryBaTest {
         clock = FakeClock(10000L)
         metadataService = FakeMetadataService()
         sessionIdTracker = FakeSessionIdTracker()
-        activityService = FakeAppStateService(AppState.BACKGROUND)
+        activityService = FakeAppStateTracker(AppState.BACKGROUND)
         store = FakeOrdinalStore()
         userService = FakeUserService()
         val initModule = FakeInitModule(clock = clock)
@@ -117,7 +117,7 @@ internal class PayloadFactoryBaTest {
                 currentSessionSpan,
                 spanRepository,
                 FakeOtelPayloadMapper(),
-                FakeAppStateService(),
+                FakeAppStateTracker(),
                 FakeClock(),
                 logger
             )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
@@ -10,13 +10,13 @@ import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollatorImpl
@@ -40,7 +40,7 @@ internal class PayloadFactorySessionTest {
     private lateinit var clock: FakeClock
     private lateinit var metadataService: MetadataService
     private lateinit var sessionIdTracker: FakeSessionIdTracker
-    private lateinit var activityService: FakeAppStateService
+    private lateinit var activityService: FakeAppStateTracker
     private lateinit var userService: UserService
     private lateinit var spanRepository: SpanRepository
     private lateinit var currentSessionSpan: CurrentSessionSpan
@@ -50,7 +50,7 @@ internal class PayloadFactorySessionTest {
 
     companion object {
 
-        private val appStateService = FakeAppStateService()
+        private val appStateTracker = FakeAppStateTracker()
 
         @BeforeClass
         @JvmStatic
@@ -73,7 +73,7 @@ internal class PayloadFactorySessionTest {
 
         metadataService = FakeMetadataService()
         sessionIdTracker = FakeSessionIdTracker()
-        activityService = FakeAppStateService(AppState.BACKGROUND)
+        activityService = FakeAppStateTracker(AppState.BACKGROUND)
         store = FakeOrdinalStore()
         userService = FakeUserService()
         val initModule = FakeInitModule(clock = clock)
@@ -95,7 +95,7 @@ internal class PayloadFactorySessionTest {
     }
 
     private fun initializeSessionService() {
-        appStateService.state = AppState.BACKGROUND
+        appStateTracker.state = AppState.BACKGROUND
 
         val payloadSourceModule = FakePayloadSourceModule()
         val logger = EmbLoggerImpl()

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.fakes.createSessionBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionZygote
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPayloadSourceImpl
@@ -28,7 +29,6 @@ import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollatorImpl
@@ -91,7 +91,7 @@ internal class SessionHandlerTest {
             currentSessionSpan,
             spanRepository,
             FakeOtelPayloadMapper(),
-            FakeAppStateService(),
+            FakeAppStateTracker(),
             FakeClock(),
             logger
         )

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/id/SessionIdTrackerImplTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.id
 
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
@@ -6,11 +6,11 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState.BACKGROUND
+import io.embrace.android.embracesdk.internal.arch.state.AppState.FOREGROUND
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState.BACKGROUND
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState.FOREGROUND
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.FakeSessionPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.injection.CoreModule
 import io.embrace.android.embracesdk.internal.injection.CoreModuleImpl
@@ -13,7 +14,6 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionSpan
 import org.junit.Assert.assertEquals

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
@@ -5,9 +5,9 @@ import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeStartupService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
 import android.os.Looper
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.injection.singleton
@@ -8,7 +9,6 @@ import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.Bloc
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.LivenessCheckScheduler
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.TargetThreadHandler
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.ThreadMonitoringState
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
@@ -16,7 +16,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 internal class AnrModuleImpl(
     instrumentationModule: InstrumentationModule,
     openTelemetryModule: OpenTelemetryModule,
-    appStateService: AppStateService,
+    appStateTracker: AppStateTracker,
 ) : AnrModule {
 
     private val args by singleton { instrumentationModule.instrumentationArgs }
@@ -34,7 +34,7 @@ internal class AnrModuleImpl(
                 state = state,
                 clock = args.clock,
                 stacktraceSampler = stacktraceSampler,
-                appStateService = appStateService,
+                appStateTracker = appStateTracker,
             )
         } else {
             null

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleSupplier.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 
 /**
  * Function that returns an instance of [AnrModule]. Matches the signature of the constructor for [AnrModuleImpl]
@@ -10,12 +10,12 @@ import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
 typealias AnrModuleSupplier = (
     instrumentationModule: InstrumentationModule,
     openTelemetryModule: OpenTelemetryModule,
-    appStateService: AppStateService,
+    appStateTracker: AppStateTracker,
 ) -> AnrModule
 
 fun createAnrModule(
     instrumentationModule: InstrumentationModule,
     openTelemetryModule: OpenTelemetryModule,
-    appStateService: AppStateService,
+    appStateTracker: AppStateTracker,
 ): AnrModule =
-    AnrModuleImpl(instrumentationModule, openTelemetryModule, appStateService)
+    AnrModuleImpl(instrumentationModule, openTelemetryModule, appStateTracker)

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrService.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
 import io.embrace.android.embracesdk.internal.arch.CrashTeardownHandler
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.AnrInterval
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
 
 /**
  * Service which detects when the application is not responding.

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.instrumentation.startup
 
 import android.os.Build.VERSION_CODES
 import io.embrace.android.embracesdk.internal.arch.attrs.embStartupActivityName
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import io.embrace.android.embracesdk.internal.capture.startup.StartupService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.hasRenderEvent
@@ -10,7 +11,6 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.instrumentation.anr
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
@@ -29,7 +29,7 @@ internal class AnrModuleImplTest {
                 )
             ),
             FakeOpenTelemetryModule(),
-            FakeAppStateService()
+            FakeAppStateTracker()
         )
         assertNotNull(module.anrService)
         assertNotNull(module.anrOtelMapper)
@@ -49,7 +49,7 @@ internal class AnrModuleImplTest {
                 )
             ),
             FakeOpenTelemetryModule(),
-            FakeAppStateService()
+            FakeAppStateTracker()
         )
         assertNull(module.anrService)
         assertNull(module.anrOtelMapper)

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceRule.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceRule.kt
@@ -1,16 +1,16 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
 import android.os.Looper
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.BlockedThreadDetector
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.LivenessCheckScheduler
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.TargetThreadHandler
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.ThreadMonitoringState
 import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.mockk
@@ -31,7 +31,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
     val logger = EmbLoggerImpl()
 
     lateinit var fakeConfigService: FakeConfigService
-    lateinit var fakeAppStateService: FakeAppStateService
+    lateinit var fakeAppStateTracker: FakeAppStateTracker
     lateinit var anrService: EmbraceAnrService
     lateinit var livenessCheckScheduler: LivenessCheckScheduler
     lateinit var state: ThreadMonitoringState
@@ -50,7 +50,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
         anrBehavior = FakeAnrBehavior()
         anrMonitorThread = AtomicReference(Thread.currentThread())
         fakeConfigService = FakeConfigService(anrBehavior = anrBehavior)
-        fakeAppStateService = FakeAppStateService(AppState.FOREGROUND)
+        fakeAppStateTracker = FakeAppStateTracker(AppState.FOREGROUND)
         anrExecutorService = scheduledExecutorSupplier.invoke()
         state = ThreadMonitoringState(clock)
         worker = BackgroundWorker(anrExecutorService)
@@ -89,7 +89,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             state = state,
             clock = clock,
             stacktraceSampler = stacktraceSampler,
-            appStateService = fakeAppStateService
+            appStateTracker = fakeAppStateTracker
         )
     }
 
@@ -106,7 +106,7 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             state = state,
             clock = clock,
             stacktraceSampler = stacktraceSampler,
-            appStateService = fakeAppStateService
+            appStateTracker = fakeAppStateTracker
         )
     }
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTimingTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTimingTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.instrumentation.anr
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -74,7 +74,7 @@ internal class EmbraceAnrServiceTimingTest {
     fun `test delayed background check stops monitoring when app remains in background`() {
         with(rule) {
             // Set background state and recreate service
-            fakeAppStateService.state = AppState.BACKGROUND
+            fakeAppStateTracker.state = AppState.BACKGROUND
             recreateService()
 
             // Start ANR capture - this should trigger scheduleDelayedBackgroundCheck
@@ -99,7 +99,7 @@ internal class EmbraceAnrServiceTimingTest {
     fun `test delayed background check does not stop monitoring when app transitions to foreground`() {
         with(rule) {
             // Set background state and recreate service
-            fakeAppStateService.state = AppState.BACKGROUND
+            fakeAppStateTracker.state = AppState.BACKGROUND
             recreateService()
 
             // Start ANR capture - this should trigger scheduleDelayedBackgroundCheck
@@ -113,7 +113,7 @@ internal class EmbraceAnrServiceTimingTest {
             anrExecutorService.moveForwardAndRunBlocked(TimeUnit.SECONDS.toMillis(5))
 
             // Transition to foreground before the 10-second delay
-            fakeAppStateService.state = AppState.FOREGROUND
+            fakeAppStateTracker.state = AppState.FOREGROUND
             anrService.onForeground(false, clock.now())
             anrExecutorService.runCurrentlyBlocked()
 

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeFeatureModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeFeatureModuleImplTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeNativeCoreModule
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.fakes.FakeProcessInfo
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.attrs.embStartupActivityName
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.startup.StartupService
 import io.embrace.android.embracesdk.internal.capture.startup.StartupServiceImpl
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -33,7 +34,6 @@ import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.spans.ErrorCode
 import org.junit.Assert.assertEquals

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
@@ -7,13 +7,13 @@ import io.embrace.android.embracesdk.assertions.findAttributeValue
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.startup.StartupService
 import io.embrace.android.embracesdk.internal.capture.startup.StartupServiceImpl
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppState.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppState.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal.session.lifecycle
+package io.embrace.android.embracesdk.internal.arch.state
 
 enum class AppState(val description: String) {
     FOREGROUND("foreground"),

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppStateListener.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppStateListener.kt
@@ -1,7 +1,7 @@
-package io.embrace.android.embracesdk.internal.session.lifecycle
+package io.embrace.android.embracesdk.internal.arch.state
 
 /**
- * Listener implemented by observers of the [AppStateService].
+ * Listener implemented by observers of the [AppStateTracker].
  */
 interface AppStateListener {
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppStateTracker.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppStateTracker.kt
@@ -1,9 +1,9 @@
-package io.embrace.android.embracesdk.internal.session.lifecycle
+package io.embrace.android.embracesdk.internal.arch.state
 
 /**
  * Service which handles Android process lifecycle callbacks.
  */
-interface AppStateService {
+interface AppStateTracker {
 
     /**
      * Adds an observer of the application's process lifecycle events.

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -29,7 +29,7 @@ import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRe
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Rule
 import org.junit.Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -18,7 +18,7 @@ import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.opentelemetry.kotlin.ExperimentalApi

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.api.SdkApi
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.getSessionProperty
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -19,7 +19,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.arch.attrs.embSessionNumber
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SequentialSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SequentialSessionTest.kt
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertFalse
 import org.junit.Rule

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionSpamTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Rule

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.testframework.assertions.JsonComparator
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import io.embrace.android.embracesdk.testframework.server.FormPart

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeJniDelegate
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
 import io.embrace.android.embracesdk.fakes.FakeSymbolService
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
@@ -137,7 +137,7 @@ internal class EmbraceSetupInterface(
                 createAnrModule(
                     instrumentationModule,
                     fakeInitModule.openTelemetryModule,
-                    FakeAppStateService()
+                    FakeAppStateTracker()
                 )
             } else {
                 val fakeAnrService = FakeAnrService()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -112,7 +112,7 @@ internal class EmbraceImpl(
     private var internalInterfaceModule: InternalInterfaceModule? = null
 
     val metadataService by embraceImplInject { bootstrapper.payloadSourceModule.metadataService }
-    val appStateService by embraceImplInject { bootstrapper.essentialServiceModule.appStateService }
+    val appStateTracker by embraceImplInject { bootstrapper.essentialServiceModule.appStateTracker }
     val activityLifecycleTracker by embraceImplInject { bootstrapper.essentialServiceModule.activityLifecycleTracker }
 
     private val configService by embraceImplInject { bootstrapper.configModule.configService }
@@ -179,7 +179,7 @@ internal class EmbraceImpl(
         dataCaptureServiceModule.startupService.setSdkStartupInfo(
             startTimeMs,
             endTimeMs,
-            bootstrapper.essentialServiceModule.appStateService.getAppState(),
+            bootstrapper.essentialServiceModule.appStateTracker.getAppState(),
             Thread.currentThread().name
         )
         end()

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -207,7 +207,7 @@ internal class ModuleInitBootstrapper(
                     postInit(EssentialServiceModule::class) {
                         with(essentialServiceModule) {
                             serviceRegistry.registerServices(
-                                lazy { essentialServiceModule.appStateService },
+                                lazy { essentialServiceModule.appStateTracker },
                                 lazy { activityLifecycleTracker },
                                 lazy { networkConnectivityService }
                             )
@@ -235,7 +235,7 @@ internal class ModuleInitBootstrapper(
                         anrModuleSupplier(
                             instrumentationModule,
                             openTelemetryModule,
-                            essentialServiceModule.appStateService
+                            essentialServiceModule.appStateTracker
                         )
                     }
 
@@ -391,7 +391,7 @@ internal class ModuleInitBootstrapper(
                     // be added to the registry. It sets listeners for any services that were registered.
                     EmbTrace.trace("service-registration") {
                         serviceRegistry.closeRegistration()
-                        serviceRegistry.registerActivityListeners(essentialServiceModule.appStateService)
+                        serviceRegistry.registerActivityListeners(essentialServiceModule.appStateTracker)
                         serviceRegistry.registerMemoryCleanerListeners(sessionOrchestrationModule.memoryCleanerService)
                         serviceRegistry.registerActivityLifecycleListeners(essentialServiceModule.activityLifecycleTracker)
                     }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/EssentialServiceModuleImplTest.kt
@@ -37,7 +37,7 @@ internal class EssentialServiceModuleImplTest {
             networkConnectivityServiceProvider = { null }
         )
 
-        assertNotNull(module.appStateService)
+        assertNotNull(module.appStateTracker)
         assertNotNull(module.activityLifecycleTracker)
         assertNotNull(module.sessionIdTracker)
         assertNotNull(module.sessionPropertiesService)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -11,8 +11,8 @@ import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.fakeModuleInitBootstrapper
 import io.embrace.android.embracesdk.fakes.injection.FakeLogModule
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.id.SessionData
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStateTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStateTracker.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateListener
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 
-class FakeAppStateService(
+class FakeAppStateTracker(
     var state: AppState = AppState.FOREGROUND,
-) : AppStateService {
+) : AppStateTracker {
 
     val listeners: MutableList<AppStateListener> = mutableListOf()
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCachingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadCachingService.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
 import io.embrace.android.embracesdk.internal.delivery.caching.SessionPayloadSupplier
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 class FakePayloadCachingService : PayloadCachingService {
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 
 class FakePayloadFactory : PayloadFactory {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSession.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionZygote
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 
 fun fakeSessionZygote(): SessionZygote = SessionZygote(

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdTracker.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.session.id.SessionData
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 class FakeSessionIdTracker : SessionIdTracker {
     var sessionData: SessionData? = null

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.capture.startup.StartupService
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 
 class FakeStartupService : StartupService {
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.fakes.FakeActivityTracker
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
-import io.embrace.android.embracesdk.fakes.FakeAppStateService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionIdTracker
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
@@ -13,10 +13,10 @@ import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.session.id.SessionIdTracker
 import io.embrace.android.embracesdk.internal.session.lifecycle.ActivityTracker
-import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateService
+import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 
 class FakeEssentialServiceModule(
-    override val appStateService: AppStateService = FakeAppStateService(),
+    override val appStateTracker: AppStateTracker = FakeAppStateTracker(),
     override val activityLifecycleTracker: ActivityTracker = FakeActivityTracker(),
     override val sessionIdTracker: SessionIdTracker = FakeSessionIdTracker(),
     override val userService: UserService = FakeUserService(),


### PR DESCRIPTION
## Goal

Renames `AppStateTracker` and moves it to the instrumentation API module.
