### PR TITLE
Simplify app state listener

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -38,7 +38,7 @@ class EssentialServiceModuleImpl(
     override val appStateTracker: AppStateTracker by singleton {
         EmbTrace.trace("process-state-service-init") {
             val lifecycleOwner = lifecycleOwnerProvider() ?: ProcessLifecycleOwner.get()
-            AppStateTrackerImpl(initModule.clock, initModule.logger, lifecycleOwner)
+            AppStateTrackerImpl(initModule.logger, lifecycleOwner)
         }
     }
 

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/fakes/FakeAppStateListener.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/fakes/FakeAppStateListener.kt
@@ -4,20 +4,15 @@ import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import java.util.concurrent.atomic.AtomicInteger
 
 class FakeAppStateListener : AppStateListener {
-    var coldStart: Boolean = false
-    var timestamp: Long = -1
 
     val foregroundCount: AtomicInteger = AtomicInteger(0)
     val backgroundCount: AtomicInteger = AtomicInteger(0)
 
-    override fun onBackground(timestamp: Long) {
-        this.timestamp = timestamp
+    override fun onBackground() {
         backgroundCount.incrementAndGet()
     }
 
-    override fun onForeground(coldStart: Boolean, timestamp: Long) {
-        this.coldStart = coldStart
-        this.timestamp = timestamp
+    override fun onForeground() {
         foregroundCount.incrementAndGet()
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/registry/ServiceRegistryTest.kt
@@ -73,5 +73,11 @@ internal class ServiceRegistryTest {
 
         override fun cleanCollections() {
         }
+
+        override fun onBackground() {
+        }
+
+        override fun onForeground() {
+        }
     }
 }

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -114,7 +114,7 @@ internal class SessionOrchestratorTest {
         clock.tick()
         val foregroundTime = clock.now()
         val sessionSpan = currentSessionSpan.sessionSpan
-        orchestrator.onForeground(true, foregroundTime)
+        orchestrator.onForeground()
         assertEquals(2, memoryCleanerService.callCount)
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
         validateSession(
@@ -131,7 +131,7 @@ internal class SessionOrchestratorTest {
         clock.tick()
         val backgroundTime = clock.now()
         val sessionSpan = currentSessionSpan.sessionSpan
-        orchestrator.onBackground(backgroundTime)
+        orchestrator.onBackground()
         assertEquals(2, memoryCleanerService.callCount)
         validateSession(
             sessionSpan = sessionSpan,
@@ -148,9 +148,9 @@ internal class SessionOrchestratorTest {
         orchestrator.onSessionDataUpdate()
         sessionCacheExecutor.runCurrentlyBlocked()
         assertEquals(1, store.cachedSessionPayloads.size)
-        orchestrator.onForeground(true, clock.now())
+        orchestrator.onForeground()
         clock.tick()
-        orchestrator.onBackground(clock.now())
+        orchestrator.onBackground()
         assertEquals(1, store.cachedSessionPayloads.size)
         assertEquals(2, store.storedSessionPayloads.size)
     }
@@ -159,7 +159,7 @@ internal class SessionOrchestratorTest {
     fun `background activity save invoked after ending will not save it again`() {
         createOrchestrator(AppState.BACKGROUND)
         clock.tick()
-        orchestrator.onForeground(true, clock.now())
+        orchestrator.onForeground()
         clock.tick()
         assertEquals(1, store.storedSessionPayloads.size)
         sessionCacheExecutor.runCurrentlyBlocked()
@@ -172,7 +172,7 @@ internal class SessionOrchestratorTest {
         clock.tick()
         sessionCacheExecutor.runCurrentlyBlocked()
         assertEquals(1, store.cachedSessionPayloads.size)
-        orchestrator.onBackground(clock.now())
+        orchestrator.onBackground()
         clock.tick()
         assertEquals(1, store.cachedSessionPayloads.size)
         assertEquals(1, store.storedSessionPayloads.size)
@@ -182,7 +182,7 @@ internal class SessionOrchestratorTest {
     fun `session save invoked after ending will not save it again`() {
         createOrchestrator(AppState.FOREGROUND)
         clock.tick()
-        orchestrator.onBackground(clock.now())
+        orchestrator.onBackground()
         clock.tick()
         assertEquals(1, store.storedSessionPayloads.size)
         sessionCacheExecutor.runCurrentlyBlocked()
@@ -218,7 +218,7 @@ internal class SessionOrchestratorTest {
     @Test
     fun `backgrounding with background activity enabled does not cache empty crash envelope`() {
         createOrchestrator(AppState.FOREGROUND)
-        orchestrator.onBackground(orchestratorStartTimeMs)
+        orchestrator.onBackground()
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
     }
 
@@ -230,7 +230,7 @@ internal class SessionOrchestratorTest {
             )
         )
         createOrchestrator(AppState.FOREGROUND)
-        orchestrator.onBackground(orchestratorStartTimeMs)
+        orchestrator.onBackground()
         assertEquals(1, store.cachedEmptyCrashPayloads.size)
     }
 
@@ -242,7 +242,7 @@ internal class SessionOrchestratorTest {
             )
         )
         createOrchestrator(AppState.BACKGROUND)
-        orchestrator.onForeground(false, orchestratorStartTimeMs)
+        orchestrator.onForeground()
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
     }
 
@@ -329,22 +329,22 @@ internal class SessionOrchestratorTest {
     @Test
     fun `test session span cold start`() {
         createOrchestrator(AppState.BACKGROUND)
-        orchestrator.onForeground(true, clock.now())
+        orchestrator.onForeground()
         checkNotNull(store.storedSessionPayloads.last().first)
     }
 
     @Test
     fun `test session span non cold start`() {
         createOrchestrator(AppState.BACKGROUND)
-        orchestrator.onForeground(true, orchestratorStartTimeMs)
-        orchestrator.onBackground(orchestratorStartTimeMs)
+        orchestrator.onForeground()
+        orchestrator.onBackground()
         checkNotNull(store.storedSessionPayloads.last().first)
     }
 
     @Test
     fun `test session span with crash`() {
         createOrchestrator(AppState.BACKGROUND)
-        orchestrator.onForeground(true, orchestratorStartTimeMs)
+        orchestrator.onForeground()
         orchestrator.handleCrash("my-crash-id")
         checkNotNull(store.storedSessionPayloads.last().first)
     }
@@ -352,7 +352,7 @@ internal class SessionOrchestratorTest {
     @Test
     fun `test foreground session span heartbeat`() {
         createOrchestrator(AppState.BACKGROUND)
-        orchestrator.onForeground(true, orchestratorStartTimeMs)
+        orchestrator.onForeground()
         assertHeartbeatMatchesClock()
         assertEquals("true", destination.attributes["emb.terminated"])
 

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrService.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrService.kt
@@ -107,7 +107,7 @@ internal class EmbraceAnrService(
      * When app goes to foreground, we need to monitor the target thread again to
      * capture ANRs.
      */
-    override fun onForeground(coldStart: Boolean, timestamp: Long) {
+    override fun onForeground() {
         this.anrMonitorWorker.submit {
             // Cancel any pending delayed background check since we're now in foreground
             cancelDelayedBackgroundCheck()
@@ -121,7 +121,7 @@ internal class EmbraceAnrService(
      * because we don't need to capture ANRs on background and we don't
      * want to affect customer's app performance.
      */
-    override fun onBackground(timestamp: Long) {
+    override fun onBackground() {
         this.anrMonitorWorker.submit {
             livenessCheckScheduler.stopMonitoringThread()
         }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -200,8 +200,11 @@ internal class AppStartupTraceEmitter(
         customAttributes[key] = value
     }
 
-    override fun onBackground(timestamp: Long) {
-        dataCollectionComplete(timestamp, false)
+    override fun onBackground() {
+        dataCollectionComplete(clock.now(), false)
+    }
+
+    override fun onForeground() {
     }
 
     /**

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTest.kt
@@ -77,7 +77,7 @@ internal class EmbraceAnrServiceTest {
         with(rule) {
             // cold starts should always be ignored
             state.lastTargetThreadResponseMs = 1
-            anrService.onForeground(true, 0L)
+            anrService.onForeground()
 
             // assert no ANR interval was added
             assertEquals(0, stacktraceSampler.anrIntervals.size)
@@ -213,14 +213,13 @@ internal class EmbraceAnrServiceTest {
     @Test
     fun `test ANR state is reset when onForeground is executed to prevent false positive ANR`() {
         val anrStartTs = 15020000L
-        val anrInProgressTs = 15020500L
         val anrEndTs = 15023000L
         with(rule) {
             clock.setCurrentTime(anrStartTs)
-            anrService.onForeground(false, anrInProgressTs)
-            anrService.onBackground(anrEndTs)
+            anrService.onForeground()
+            anrService.onBackground()
             clock.setCurrentTime(anrEndTs)
-            anrService.onForeground(false, anrEndTs)
+            anrService.onForeground()
             // Since Looper is a mock, we execute this operation to
             // ensure onMainThreadUnblocked runs and lastTargetThreadResponseMs gets updated
             targetThreadHandler.onIdleThread()
@@ -232,15 +231,14 @@ internal class EmbraceAnrServiceTest {
     @Test
     fun `test timestamps are updated if onMainThreadUnblocked runs before onMonitorThreadHeartbeat to prevent false positive ANR`() {
         val anrStartTs = 15020000L
-        val anrInProgressTs = 15020500L
         val anrEndTs = 15023000L
 
         with(rule) {
             clock.setCurrentTime(anrStartTs)
-            anrService.onForeground(false, anrInProgressTs)
-            anrService.onBackground(anrEndTs)
+            anrService.onForeground()
+            anrService.onBackground()
             clock.setCurrentTime(anrEndTs)
-            anrService.onForeground(false, anrEndTs)
+            anrService.onForeground()
             targetThreadHandler.onIdleThread()
             val intervals = anrService.getCapturedData()
             assertEquals(0, intervals.size)
@@ -400,7 +398,7 @@ internal class EmbraceAnrServiceTest {
         with(rule) {
             clock.setCurrentTime(14000000L)
             rule.anrBehavior.bgAnrCaptureEnabled = true
-            anrService.onForeground(true, clock.now())
+            anrService.onForeground()
             anrExecutorService.submit {
                 assertTrue(state.started.get())
             }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTimingTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTimingTest.kt
@@ -63,7 +63,7 @@ internal class EmbraceAnrServiceTimingTest {
             anrExecutorService.runCurrentlyBlocked()
             anrExecutorService.runCurrentlyBlocked()
             assertEquals(1, anrExecutorService.scheduledTasksCount())
-            anrService.onForeground(true, clock.now() + 1)
+            anrService.onForeground()
             anrExecutorService.runCurrentlyBlocked()
             anrExecutorService.runCurrentlyBlocked()
             assertEquals(1, anrExecutorService.scheduledTasksCount())
@@ -114,7 +114,7 @@ internal class EmbraceAnrServiceTimingTest {
 
             // Transition to foreground before the 10-second delay
             fakeAppStateTracker.state = AppState.FOREGROUND
-            anrService.onForeground(false, clock.now())
+            anrService.onForeground()
             anrExecutorService.runCurrentlyBlocked()
 
             // Advance time by 5 more seconds to reach the 10-second mark

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -159,7 +159,7 @@ internal class AppStartupTraceEmitterTest {
             preActivityInit(false)
         }
         val abandonTime = clock.tick()
-        emitter.onBackground(abandonTime)
+        emitter.onBackground()
         val spanMap = spanSink.completedSpans().associateBy { it.name }
         with(checkNotNull(spanMap.coldAppStartupRootSpan())) {
             assertError(ErrorCode.USER_ABANDON)
@@ -187,7 +187,7 @@ internal class AppStartupTraceEmitterTest {
         }
 
         val abandonTime = clock.tick()
-        emitter.onBackground(abandonTime)
+        emitter.onBackground()
         with(spanSink.completedSpans().associateBy { it.name }) {
             with(checkNotNull(coldAppStartupRootSpan())) {
                 assertError(ErrorCode.USER_ABANDON)
@@ -216,7 +216,7 @@ internal class AppStartupTraceEmitterTest {
             )
         }
         val abandonTime = clock.tick()
-        emitter.onBackground(abandonTime)
+        emitter.onBackground()
         with(spanSink.completedSpans().associateBy { it.name }) {
             with(checkNotNull(coldAppStartupRootSpan())) {
                 assertError(ErrorCode.USER_ABANDON)
@@ -242,7 +242,7 @@ internal class AppStartupTraceEmitterTest {
             preActivityInit(false)
         }
         val abandonTime = clock.tick()
-        emitter.onBackground(abandonTime)
+        emitter.onBackground()
         val spanMap = spanSink.completedSpans().associateBy { it.name }
         with(checkNotNull(spanMap.warmAppStartupRootSpan())) {
             assertError(ErrorCode.USER_ABANDON)
@@ -265,7 +265,7 @@ internal class AppStartupTraceEmitterTest {
             )
         }
         val abandonTime = clock.tick()
-        emitter.onBackground(abandonTime)
+        emitter.onBackground()
         with(spanSink.completedSpans().associateBy { it.name }) {
             with(checkNotNull(warmAppStartupRootSpan())) {
                 assertError(ErrorCode.USER_ABANDON)

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppStateListener.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/state/AppStateListener.kt
@@ -8,13 +8,10 @@ interface AppStateListener {
     /**
      * Triggered when the app enters the background.
      */
-    fun onBackground(timestamp: Long) {}
+    fun onBackground()
 
     /**
      * Triggered when the application is resumed.
-     *
-     * @param coldStart   whether this is a cold start
-     * @param timestamp the timestamp at which the application entered the foreground
      */
-    fun onForeground(coldStart: Boolean, timestamp: Long) {}
+    fun onForeground()
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAnrService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAnrService.kt
@@ -32,4 +32,10 @@ class FakeAnrService : AnrService {
 
     override fun onThreadUnblocked(thread: Thread, timestamp: Long) {
     }
+
+    override fun onBackground() {
+    }
+
+    override fun onForeground() {
+    }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
@@ -19,4 +19,10 @@ class FakeSessionOrchestrator : SessionOrchestrator {
     override fun onSessionDataUpdate() {
         stateChangeCount++
     }
+
+    override fun onBackground() {
+    }
+
+    override fun onForeground() {
+    }
 }


### PR DESCRIPTION
## Goal

Simplifies the interface for `AppStateListener` as the `timestamp` and `coldStart` parameters are rarely used in practice and can be obtained via `Clock` or tracked within the session orchestration layer.
