### PR TITLE
Improve dependency injection property delegate

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DependencyInjection.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DependencyInjection.kt
@@ -1,64 +1,14 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.utils.Provider
-import kotlin.properties.ReadOnlyProperty
-import kotlin.reflect.KProperty
-
-/**
- * How the dependency should be loaded.
- */
-enum class LoadType {
-
-    /**
-     * The dependency should be instantiated as soon as the module is created.
-     */
-    EAGER,
-
-    /**
-     * The dependency should be instantiated at the point where it is required.
-     */
-    LAZY
-}
 
 /**
  * Creates a new dependency that is a singleton, meaning only one object will ever be created in
- * this module. By default this dependency will be created lazily.
+ * this module.
  *
  * Lazy dependencies are NOT thread safe. It is assumed that dependencies will always be
  * initialized on the same thread.
  */
 inline fun <reified T> singleton(
-    loadType: LoadType = LoadType.LAZY,
     noinline provider: Provider<T>,
-): ReadOnlyProperty<Any?, T> = SingletonDelegate(loadType, provider)
-
-/**
- * Creates a new dependency from a factory, meaning every time this property is called a
- * new object will be created.
- */
-inline fun <reified T> factory(
-    noinline provider: Provider<T>,
-): ReadOnlyProperty<Any?, T> = FactoryDelegate(provider)
-
-class FactoryDelegate<T>(private val provider: Provider<T>) : ReadOnlyProperty<Any?, T> {
-
-    override fun getValue(thisRef: Any?, property: KProperty<*>): T = provider()
-}
-
-class SingletonDelegate<T>(
-    loadType: LoadType,
-    provider: Provider<T>,
-) : ReadOnlyProperty<Any?, T> {
-
-    // optimization: use atomic checks rather than synchronized in lazy.
-    // Taking out a lock is overkill for the vast majority of objects on the graph
-    private val value: T by lazy(LazyThreadSafetyMode.PUBLICATION, provider)
-
-    init {
-        if (loadType == LoadType.EAGER) {
-            value
-        }
-    }
-
-    override fun getValue(thisRef: Any?, property: KProperty<*>): T = value
-}
+): Lazy<T> = lazy(LazyThreadSafetyMode.PUBLICATION, provider)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
@@ -64,7 +64,7 @@ internal class SessionOrchestrationModuleImpl(
         )
     }
 
-    override val sessionOrchestrator: SessionOrchestrator by singleton(LoadType.EAGER) {
+    override val sessionOrchestrator: SessionOrchestrator by singleton {
         SessionOrchestratorImpl(
             essentialServiceModule.appStateTracker,
             EmbTrace.trace("payloadFactory") { payloadFactory },

--- a/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DependencyInjectionKtTest.kt
+++ b/embrace-android-core/src/test/java/io/embrace/android/embracesdk/internal/injection/DependencyInjectionKtTest.kt
@@ -6,29 +6,13 @@ import java.util.concurrent.atomic.AtomicInteger
 
 internal class DependencyInjectionKtTest {
 
-    private val factoryCounter = AtomicInteger(0)
-    private val eagerSingletonCounter = AtomicInteger(0)
     private val lazySingletonCounter = AtomicInteger(0)
-
-    private val factory by factory { factoryCounter.incrementAndGet() }
-    private val eagerSingleton by singleton(LoadType.EAGER) { eagerSingletonCounter.incrementAndGet() }
-    private val lazySingleton by singleton(LoadType.LAZY) { lazySingletonCounter.incrementAndGet() }
+    private val lazySingleton by singleton { lazySingletonCounter.incrementAndGet() }
 
     @Test
     fun testInjection() {
-        // assert defaults
-        assertEquals(0, factoryCounter.get())
-        assertEquals(1, eagerSingletonCounter.get())
         assertEquals(0, lazySingletonCounter.get())
-
-        // get values from properties
-        assertEquals(1, factory)
-        assertEquals(1, eagerSingleton)
         assertEquals(1, lazySingleton)
-
-        // get values again from properties
-        assertEquals(2, factory)
-        assertEquals(1, eagerSingleton)
         assertEquals(1, lazySingleton)
     }
 }


### PR DESCRIPTION
## Goal

Avoids an unnecessary delegate for `singleton` that is used in dependency injection by removing some unused code.

