### PR TITLE
Extract module dependency graph

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -58,8 +58,11 @@ internal class EmbraceActionInterface(
                 startInBackground = true,
                 activitiesAndActions = activityAndAction
             ).let { executionTimestamps ->
-                val isBackgroundActivityEnabled =
+                val isBackgroundActivityEnabled = if (bootstrapper.isInitialized()) {
                     bootstrapper.configModule.configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
+                } else {
+                    false
+                }
 
                 SessionTimestamps(
                     startTimeMs = if (isBackgroundActivityEnabled) {

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -121,9 +121,6 @@ internal class EmbraceImpl(
         val startTimeMs = clock.now()
 
         if (!bootstrapper.init(context, startTimeMs)) {
-            if (bootstrapper.configModule.configService.sdkModeBehavior.isSdkDisabled()) {
-                stop()
-            }
             return
         }
         start("post-services-setup")
@@ -165,6 +162,7 @@ internal class EmbraceImpl(
         sdkCallChecker.started.set(true)
         end()
 
+        bootstrapper.registerListeners()
         bootstrapper.loadInstrumentation()
         bootstrapper.postLoadInstrumentation()
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -1,0 +1,311 @@
+package io.embrace.android.embracesdk.internal.injection
+
+import android.content.Context
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModuleSupplier
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCoreModule
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCoreModuleSupplier
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeFeatureModule
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeFeatureModuleSupplier
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.internal.worker.Worker
+import kotlin.reflect.KClass
+
+/**
+ * Constructed module dependencies that will be used by the initialized SDK.
+ */
+@Suppress("UseCheckOrError")
+internal class InitializedModuleGraph(
+    context: Context,
+    sdkStartTimeMs: Long,
+    versionChecker: VersionChecker = BuildVersionChecker,
+    initModule: InitModule,
+    openTelemetryModule: OpenTelemetryModule,
+    private val coreModuleSupplier: CoreModuleSupplier,
+    private val configModuleSupplier: ConfigModuleSupplier,
+    private val workerThreadModuleSupplier: WorkerThreadModuleSupplier,
+    private val storageModuleSupplier: StorageModuleSupplier,
+    private val essentialServiceModuleSupplier: EssentialServiceModuleSupplier,
+    private val featureModuleSupplier: FeatureModuleSupplier,
+    private val instrumentationModuleSupplier: InstrumentationModuleSupplier,
+    private val dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier,
+    private val deliveryModuleSupplier: DeliveryModuleSupplier,
+    private val anrModuleSupplier: AnrModuleSupplier,
+    private val logModuleSupplier: LogModuleSupplier,
+    private val nativeCoreModuleSupplier: NativeCoreModuleSupplier,
+    private val nativeFeatureModuleSupplier: NativeFeatureModuleSupplier,
+    private val sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier,
+    private val payloadSourceModuleSupplier: PayloadSourceModuleSupplier,
+) : ModuleGraph {
+
+    override val coreModule: CoreModule = init(
+        module = CoreModule::class,
+        initAction = { coreModuleSupplier(context, initModule) }
+    )
+
+    override val workerThreadModule: WorkerThreadModule = init(
+        module = WorkerThreadModule::class,
+        initAction = {
+            workerThreadModuleSupplier()
+        },
+        postAction = {
+            EmbTrace.trace("span-service-init") {
+                openTelemetryModule.spanService.initializeService(sdkStartTimeMs)
+            }
+        }
+    )
+
+    override val configModule: ConfigModule = init(
+        module = ConfigModule::class,
+        initAction = {
+            configModuleSupplier(
+                initModule,
+                coreModule,
+                openTelemetryModule,
+                workerThreadModule,
+            )
+        },
+        postAction = { module ->
+            openTelemetryModule.applyConfiguration(
+                sensitiveKeysBehavior = module.configService.sensitiveKeysBehavior,
+                bypassValidation = module.configService.isOnlyUsingOtelExporters(),
+                otelBehavior = module.configService.otelBehavior
+            )
+
+            EmbTrace.trace("sdk-disable-check") {
+                // kick off config HTTP request first so the SDK can't get in a permanently disabled state
+                EmbTrace.trace("load-config-response") {
+                    module.combinedRemoteConfigSource?.scheduleConfigRequests()
+                }
+
+                EmbTrace.trace("behavior-check") {
+                    if (module.configService.sdkModeBehavior.isSdkDisabled()) {
+                        // bail out early. Caught at a higher-level that relies on this specific type
+                        throw SdkDisabledException()
+                    }
+                }
+            }
+        }
+    )
+
+    override val storageModule: StorageModule = init(
+        module = StorageModule::class,
+        initAction = {
+            storageModuleSupplier(initModule, coreModule, workerThreadModule)
+        }
+    )
+
+    override val essentialServiceModule: EssentialServiceModule = init(
+        module = EssentialServiceModule::class,
+        initAction = {
+            essentialServiceModuleSupplier(
+                initModule,
+                configModule,
+                openTelemetryModule,
+                coreModule,
+                workerThreadModule,
+                { null },
+                { null },
+            )
+        },
+        postAction = { module ->
+            workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker).submit {
+                EmbTrace.trace("network-connectivity-registration") {
+                    module.networkConnectivityService.register()
+                }
+            }
+        }
+    )
+
+    override val instrumentationModule: InstrumentationModule = init(
+        module = InstrumentationModule::class,
+        initAction = {
+            instrumentationModuleSupplier(
+                initModule,
+                workerThreadModule,
+                configModule,
+                essentialServiceModule,
+                coreModule,
+            )
+        }
+    )
+
+    override val featureModule: FeatureModule = init(
+        module = FeatureModule::class,
+        initAction = {
+            featureModuleSupplier(
+                instrumentationModule,
+                configModule.configService,
+                storageModule,
+            )
+        },
+        postAction = { module ->
+            initModule.logger.errorHandlerProvider = { module.internalErrorDataSource.dataSource }
+        }
+    )
+
+    override val dataCaptureServiceModule: DataCaptureServiceModule = init(
+        module = DataCaptureServiceModule::class,
+        initAction = {
+            dataCaptureServiceModuleSupplier(
+                initModule,
+                openTelemetryModule,
+                configModule.configService,
+                versionChecker,
+            )
+        },
+        postAction = { module ->
+            EmbTrace.trace("startup-tracker") {
+                coreModule.application.registerActivityLifecycleCallbacks(
+                    module.startupTracker
+                )
+            }
+        }
+    )
+
+    override val deliveryModule: DeliveryModule = init(
+        module = DeliveryModule::class,
+        initAction = {
+            deliveryModuleSupplier(
+                configModule,
+                initModule,
+                openTelemetryModule,
+                workerThreadModule,
+                coreModule,
+                essentialServiceModule,
+                null,
+                null,
+                null,
+                null
+            )
+        },
+        postAction = { module ->
+            module.payloadCachingService?.run {
+                openTelemetryModule.spanRepository.setSpanUpdateNotifier {
+                    reportBackgroundActivityStateChange()
+                }
+            }
+        }
+    )
+
+    override val anrModule: AnrModule = init(
+        module = AnrModule::class,
+        initAction = {
+            anrModuleSupplier(
+                instrumentationModule.instrumentationArgs,
+                essentialServiceModule.appStateTracker
+            )
+        },
+        postAction = { module ->
+            module.anrService?.startAnrCapture()
+        }
+    )
+
+    override val payloadSourceModule: PayloadSourceModule = init(
+        module = PayloadSourceModule::class,
+        initAction = {
+            payloadSourceModuleSupplier(
+                initModule,
+                coreModule,
+                workerThreadModule,
+                essentialServiceModule,
+                configModule,
+                { nativeCoreModule.symbolService.symbolsForCurrentArch },
+                openTelemetryModule,
+                { anrModule.anrOtelMapper },
+                deliveryModule
+            )
+        },
+        postAction = { module ->
+            module.metadataService.precomputeValues()
+        }
+    )
+
+    override val nativeCoreModule: NativeCoreModule = init(
+        module = NativeCoreModule::class,
+        initAction = {
+            nativeCoreModuleSupplier(
+                configModule,
+                workerThreadModule,
+                storageModule,
+                essentialServiceModule,
+                instrumentationModule,
+                openTelemetryModule,
+                { null },
+                { null },
+                { null },
+            )
+        }
+    )
+
+    override val nativeFeatureModule: NativeFeatureModule = init(
+        module = NativeFeatureModule::class,
+        initAction = {
+            nativeFeatureModuleSupplier(
+                nativeCoreModule,
+                instrumentationModule,
+            )
+        },
+        postAction = { module ->
+            nativeCoreModule.sharedObjectLoader.loadEmbraceNative()
+            nativeCoreModule.nativeCrashHandlerInstaller?.install()
+        }
+    )
+
+    override val logModule: LogModule = init(
+        module = LogModule::class,
+        initAction = {
+            logModuleSupplier(
+                initModule,
+                openTelemetryModule,
+                essentialServiceModule,
+                configModule,
+                deliveryModule,
+                workerThreadModule,
+                payloadSourceModule,
+            )
+        },
+        postAction = { module ->
+            // Start the log orchestrator
+            openTelemetryModule.logSink.registerLogStoredCallback {
+                module.logOrchestrator.onLogsAdded()
+            }
+        }
+    )
+
+    override val sessionOrchestrationModule: SessionOrchestrationModule = init(
+        module = SessionOrchestrationModule::class,
+        initAction = {
+            sessionOrchestrationModuleSupplier(
+                initModule,
+                openTelemetryModule,
+                coreModule,
+                essentialServiceModule,
+                configModule,
+                deliveryModule,
+                instrumentationModule,
+                payloadSourceModule,
+                dataCaptureServiceModule.startupService,
+                logModule
+            )
+        },
+        postAction = { module ->
+            essentialServiceModule.telemetryDestination.sessionUpdateAction =
+                module.sessionOrchestrator::onSessionDataUpdate
+        }
+    )
+
+    private fun <T> init(
+        module: KClass<*>,
+        initAction: Provider<T>,
+        postAction: (module: T) -> Unit = {},
+    ): T {
+        val name = module.simpleName?.removeSuffix("Module")?.lowercase() ?: "module"
+        return EmbTrace.trace("$name-init") {
+            initAction().apply(postAction)
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.internal.injection
+
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCoreModule
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeFeatureModule
+
+/**
+ * Contains all the dependency modules that are required by the initialized SDK.
+ */
+internal interface ModuleGraph {
+    val coreModule: CoreModule
+    val configModule: ConfigModule
+    val workerThreadModule: WorkerThreadModule
+    val storageModule: StorageModule
+    val essentialServiceModule: EssentialServiceModule
+    val dataCaptureServiceModule: DataCaptureServiceModule
+    val deliveryModule: DeliveryModule
+    val anrModule: AnrModule
+    val logModule: LogModule
+    val nativeCoreModule: NativeCoreModule
+    val nativeFeatureModule: NativeFeatureModule
+    val instrumentationModule: InstrumentationModule
+    val featureModule: FeatureModule
+    val sessionOrchestrationModule: SessionOrchestrationModule
+    val payloadSourceModule: PayloadSourceModule
+}

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.internal.injection
+
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCoreModule
+import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeFeatureModule
+
+internal class SdkDisabledException : IllegalStateException()
+
+/**
+ * Uninitialized modules that will throw an IllegalStateException if they are accessed.
+ */
+internal object UninitializedModuleGraph : ModuleGraph {
+    override val coreModule: CoreModule get() = throwSdkNotInitialized()
+    override val configModule: ConfigModule get() = throwSdkNotInitialized()
+    override val workerThreadModule: WorkerThreadModule get() = throwSdkNotInitialized()
+    override val storageModule: StorageModule get() = throwSdkNotInitialized()
+    override val essentialServiceModule: EssentialServiceModule get() = throwSdkNotInitialized()
+    override val dataCaptureServiceModule: DataCaptureServiceModule get() = throwSdkNotInitialized()
+    override val deliveryModule: DeliveryModule get() = throwSdkNotInitialized()
+    override val anrModule: AnrModule get() = throwSdkNotInitialized()
+    override val logModule: LogModule get() = throwSdkNotInitialized()
+    override val nativeCoreModule: NativeCoreModule get() = throwSdkNotInitialized()
+    override val nativeFeatureModule: NativeFeatureModule get() = throwSdkNotInitialized()
+    override val instrumentationModule: InstrumentationModule get() = throwSdkNotInitialized()
+    override val featureModule: FeatureModule get() = throwSdkNotInitialized()
+    override val sessionOrchestrationModule: SessionOrchestrationModule get() = throwSdkNotInitialized()
+    override val payloadSourceModule: PayloadSourceModule get() = throwSdkNotInitialized()
+
+    private fun throwSdkNotInitialized(): Nothing = error("SDK not initialized")
+}


### PR DESCRIPTION
## Goal

Creates `ModuleGraph`, which holds all the modules the SDK requires to be initialized. This has two implementations: uninitialized and initialized. I've extracted this out from `ModuleInitBootstrapper` as this avoids the use of `lateinit var` and will allow additional actions on the modules to be extracted out in future PRs.

## Testing

Relied on existing test coverage. I also audited every access of each module to confirm they're behind a check that the SDK is started.

