### PR TITLE
Module graph post init

### DIFF
--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -9,10 +9,8 @@ import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeFe
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeFeatureModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
-import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.worker.Worker
-import kotlin.reflect.KClass
 
 /**
  * Constructed module dependencies that will be used by the initialized SDK.
@@ -22,8 +20,8 @@ internal class InitializedModuleGraph(
     context: Context,
     sdkStartTimeMs: Long,
     versionChecker: VersionChecker = BuildVersionChecker,
-    initModule: InitModule,
-    openTelemetryModule: OpenTelemetryModule,
+    private val initModule: InitModule,
+    private val openTelemetryModule: OpenTelemetryModule,
     private val coreModuleSupplier: CoreModuleSupplier,
     private val configModuleSupplier: ConfigModuleSupplier,
     private val workerThreadModuleSupplier: WorkerThreadModuleSupplier,
@@ -41,271 +39,213 @@ internal class InitializedModuleGraph(
     private val payloadSourceModuleSupplier: PayloadSourceModuleSupplier,
 ) : ModuleGraph {
 
-    override val coreModule: CoreModule = init(
-        module = CoreModule::class,
-        initAction = { coreModuleSupplier(context, initModule) }
-    )
+    override val coreModule: CoreModule = init {
+        coreModuleSupplier(context, initModule)
+    }
 
-    override val workerThreadModule: WorkerThreadModule = init(
-        module = WorkerThreadModule::class,
-        initAction = {
-            workerThreadModuleSupplier()
-        },
-        postAction = {
-            EmbTrace.trace("span-service-init") {
-                openTelemetryModule.spanService.initializeService(sdkStartTimeMs)
-            }
+    override val workerThreadModule: WorkerThreadModule = init {
+        workerThreadModuleSupplier()
+    }.apply {
+        EmbTrace.trace("span-service-init") {
+            openTelemetryModule.spanService.initializeService(sdkStartTimeMs)
         }
-    )
+    }
 
-    override val configModule: ConfigModule = init(
-        module = ConfigModule::class,
-        initAction = {
-            configModuleSupplier(
-                initModule,
-                coreModule,
-                openTelemetryModule,
-                workerThreadModule,
-            )
-        },
-        postAction = { module ->
-            openTelemetryModule.applyConfiguration(
-                sensitiveKeysBehavior = module.configService.sensitiveKeysBehavior,
-                bypassValidation = module.configService.isOnlyUsingOtelExporters(),
-                otelBehavior = module.configService.otelBehavior
-            )
+    override val configModule: ConfigModule = init {
+        configModuleSupplier(
+            initModule,
+            coreModule,
+            openTelemetryModule,
+            workerThreadModule,
+        )
+    }
 
-            EmbTrace.trace("sdk-disable-check") {
-                // kick off config HTTP request first so the SDK can't get in a permanently disabled state
-                EmbTrace.trace("load-config-response") {
-                    module.combinedRemoteConfigSource?.scheduleConfigRequests()
-                }
+    override val storageModule: StorageModule = init {
+        storageModuleSupplier(initModule, coreModule, workerThreadModule)
+    }
 
-                EmbTrace.trace("behavior-check") {
-                    if (module.configService.sdkModeBehavior.isSdkDisabled()) {
-                        // bail out early. Caught at a higher-level that relies on this specific type
-                        throw SdkDisabledException()
-                    }
-                }
-            }
-        }
-    )
+    override val essentialServiceModule: EssentialServiceModule = init {
+        essentialServiceModuleSupplier(
+            initModule,
+            configModule,
+            openTelemetryModule,
+            coreModule,
+            workerThreadModule,
+            { null },
+            { null },
+        )
+    }
 
-    override val storageModule: StorageModule = init(
-        module = StorageModule::class,
-        initAction = {
-            storageModuleSupplier(initModule, coreModule, workerThreadModule)
-        }
-    )
+    override val instrumentationModule: InstrumentationModule = init {
+        instrumentationModuleSupplier(
+            initModule,
+            workerThreadModule,
+            configModule,
+            essentialServiceModule,
+            coreModule,
+        )
+    }
 
-    override val essentialServiceModule: EssentialServiceModule = init(
-        module = EssentialServiceModule::class,
-        initAction = {
-            essentialServiceModuleSupplier(
-                initModule,
-                configModule,
-                openTelemetryModule,
-                coreModule,
-                workerThreadModule,
-                { null },
-                { null },
-            )
-        },
-        postAction = { module ->
-            workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker).submit {
-                EmbTrace.trace("network-connectivity-registration") {
-                    module.networkConnectivityService.register()
-                }
-            }
-        }
-    )
+    override val featureModule: FeatureModule = init {
+        featureModuleSupplier(
+            instrumentationModule,
+            configModule.configService,
+            storageModule,
+        )
+    }
 
-    override val instrumentationModule: InstrumentationModule = init(
-        module = InstrumentationModule::class,
-        initAction = {
-            instrumentationModuleSupplier(
-                initModule,
-                workerThreadModule,
-                configModule,
-                essentialServiceModule,
-                coreModule,
-            )
-        }
-    )
+    override val dataCaptureServiceModule: DataCaptureServiceModule = init {
+        dataCaptureServiceModuleSupplier(
+            initModule,
+            openTelemetryModule,
+            configModule.configService,
+            versionChecker,
+        )
+    }
 
-    override val featureModule: FeatureModule = init(
-        module = FeatureModule::class,
-        initAction = {
-            featureModuleSupplier(
-                instrumentationModule,
-                configModule.configService,
-                storageModule,
-            )
-        },
-        postAction = { module ->
-            initModule.logger.errorHandlerProvider = { module.internalErrorDataSource.dataSource }
-        }
-    )
+    override val deliveryModule: DeliveryModule = init {
+        deliveryModuleSupplier(
+            configModule,
+            initModule,
+            openTelemetryModule,
+            workerThreadModule,
+            coreModule,
+            essentialServiceModule,
+            null,
+            null,
+            null,
+            null
+        )
+    }
 
-    override val dataCaptureServiceModule: DataCaptureServiceModule = init(
-        module = DataCaptureServiceModule::class,
-        initAction = {
-            dataCaptureServiceModuleSupplier(
-                initModule,
-                openTelemetryModule,
-                configModule.configService,
-                versionChecker,
-            )
-        },
-        postAction = { module ->
-            EmbTrace.trace("startup-tracker") {
-                coreModule.application.registerActivityLifecycleCallbacks(
-                    module.startupTracker
-                )
-            }
-        }
-    )
+    override val anrModule: AnrModule = init {
+        anrModuleSupplier(
+            instrumentationModule.instrumentationArgs,
+            essentialServiceModule.appStateTracker
+        )
+    }
 
-    override val deliveryModule: DeliveryModule = init(
-        module = DeliveryModule::class,
-        initAction = {
-            deliveryModuleSupplier(
-                configModule,
-                initModule,
-                openTelemetryModule,
-                workerThreadModule,
-                coreModule,
-                essentialServiceModule,
-                null,
-                null,
-                null,
-                null
-            )
-        },
-        postAction = { module ->
-            module.payloadCachingService?.run {
-                openTelemetryModule.spanRepository.setSpanUpdateNotifier {
-                    reportBackgroundActivityStateChange()
-                }
-            }
-        }
-    )
+    override val payloadSourceModule: PayloadSourceModule = init {
+        payloadSourceModuleSupplier(
+            initModule,
+            coreModule,
+            workerThreadModule,
+            essentialServiceModule,
+            configModule,
+            { nativeCoreModule.symbolService.symbolsForCurrentArch },
+            openTelemetryModule,
+            { anrModule.anrOtelMapper },
+            deliveryModule
+        )
+    }
 
-    override val anrModule: AnrModule = init(
-        module = AnrModule::class,
-        initAction = {
-            anrModuleSupplier(
-                instrumentationModule.instrumentationArgs,
-                essentialServiceModule.appStateTracker
-            )
-        },
-        postAction = { module ->
-            module.anrService?.startAnrCapture()
-        }
-    )
+    override val nativeCoreModule: NativeCoreModule = init {
+        nativeCoreModuleSupplier(
+            configModule,
+            workerThreadModule,
+            storageModule,
+            essentialServiceModule,
+            instrumentationModule,
+            openTelemetryModule,
+            { null },
+            { null },
+            { null },
+        )
+    }
 
-    override val payloadSourceModule: PayloadSourceModule = init(
-        module = PayloadSourceModule::class,
-        initAction = {
-            payloadSourceModuleSupplier(
-                initModule,
-                coreModule,
-                workerThreadModule,
-                essentialServiceModule,
-                configModule,
-                { nativeCoreModule.symbolService.symbolsForCurrentArch },
-                openTelemetryModule,
-                { anrModule.anrOtelMapper },
-                deliveryModule
-            )
-        },
-        postAction = { module ->
-            module.metadataService.precomputeValues()
-        }
-    )
+    override val nativeFeatureModule: NativeFeatureModule = init {
+        nativeFeatureModuleSupplier(
+            nativeCoreModule,
+            instrumentationModule,
+        )
+    }
 
-    override val nativeCoreModule: NativeCoreModule = init(
-        module = NativeCoreModule::class,
-        initAction = {
-            nativeCoreModuleSupplier(
-                configModule,
-                workerThreadModule,
-                storageModule,
-                essentialServiceModule,
-                instrumentationModule,
-                openTelemetryModule,
-                { null },
-                { null },
-                { null },
-            )
-        }
-    )
+    override val logModule: LogModule = init {
+        logModuleSupplier(
+            initModule,
+            openTelemetryModule,
+            essentialServiceModule,
+            configModule,
+            deliveryModule,
+            workerThreadModule,
+            payloadSourceModule,
+        )
+    }
 
-    override val nativeFeatureModule: NativeFeatureModule = init(
-        module = NativeFeatureModule::class,
-        initAction = {
-            nativeFeatureModuleSupplier(
-                nativeCoreModule,
-                instrumentationModule,
-            )
-        },
-        postAction = { module ->
-            nativeCoreModule.sharedObjectLoader.loadEmbraceNative()
-            nativeCoreModule.nativeCrashHandlerInstaller?.install()
-        }
-    )
+    override val sessionOrchestrationModule: SessionOrchestrationModule = init {
+        sessionOrchestrationModuleSupplier(
+            initModule,
+            openTelemetryModule,
+            coreModule,
+            essentialServiceModule,
+            configModule,
+            deliveryModule,
+            instrumentationModule,
+            payloadSourceModule,
+            dataCaptureServiceModule.startupService,
+            logModule
+        )
+    }
 
-    override val logModule: LogModule = init(
-        module = LogModule::class,
-        initAction = {
-            logModuleSupplier(
-                initModule,
-                openTelemetryModule,
-                essentialServiceModule,
-                configModule,
-                deliveryModule,
-                workerThreadModule,
-                payloadSourceModule,
-            )
-        },
-        postAction = { module ->
-            // Start the log orchestrator
-            openTelemetryModule.logSink.registerLogStoredCallback {
-                module.logOrchestrator.onLogsAdded()
-            }
-        }
-    )
-
-    override val sessionOrchestrationModule: SessionOrchestrationModule = init(
-        module = SessionOrchestrationModule::class,
-        initAction = {
-            sessionOrchestrationModuleSupplier(
-                initModule,
-                openTelemetryModule,
-                coreModule,
-                essentialServiceModule,
-                configModule,
-                deliveryModule,
-                instrumentationModule,
-                payloadSourceModule,
-                dataCaptureServiceModule.startupService,
-                logModule
-            )
-        },
-        postAction = { module ->
-            essentialServiceModule.telemetryDestination.sessionUpdateAction =
-                module.sessionOrchestrator::onSessionDataUpdate
-        }
-    )
-
-    private fun <T> init(
-        module: KClass<*>,
-        initAction: Provider<T>,
-        postAction: (module: T) -> Unit = {},
-    ): T {
+    private inline fun <reified T> init(supplier: () -> T): T {
+        val module = T::class
         val name = module.simpleName?.removeSuffix("Module")?.lowercase() ?: "module"
-        return EmbTrace.trace("$name-init") {
-            initAction().apply(postAction)
+        return EmbTrace.trace("$name-init") { supplier() }
+    }
+
+    fun postInit() {
+        openTelemetryModule.applyConfiguration(
+            sensitiveKeysBehavior = configModule.configService.sensitiveKeysBehavior,
+            bypassValidation = configModule.configService.isOnlyUsingOtelExporters(),
+            otelBehavior = configModule.configService.otelBehavior
+        )
+
+        EmbTrace.trace("sdk-disable-check") {
+            // kick off config HTTP request first so the SDK can't get in a permanently disabled state
+            EmbTrace.trace("load-config-response") {
+                configModule.combinedRemoteConfigSource?.scheduleConfigRequests()
+            }
+
+            EmbTrace.trace("behavior-check") {
+                if (configModule.configService.sdkModeBehavior.isSdkDisabled()) {
+                    // bail out early. Caught at a higher-level that relies on this specific type
+                    throw SdkDisabledException()
+                }
+            }
         }
+
+        workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker).submit {
+            EmbTrace.trace("network-connectivity-registration") {
+                essentialServiceModule.networkConnectivityService.register()
+            }
+        }
+
+        initModule.logger.errorHandlerProvider = { featureModule.internalErrorDataSource.dataSource }
+
+        EmbTrace.trace("startup-tracker") {
+            coreModule.application.registerActivityLifecycleCallbacks(
+                dataCaptureServiceModule.startupTracker
+            )
+        }
+        deliveryModule.payloadCachingService?.run {
+            openTelemetryModule.spanRepository.setSpanUpdateNotifier {
+                reportBackgroundActivityStateChange()
+            }
+        }
+
+        anrModule.anrService?.startAnrCapture()
+
+        payloadSourceModule.metadataService.precomputeValues()
+
+        nativeCoreModule.sharedObjectLoader.loadEmbraceNative()
+        nativeCoreModule.nativeCrashHandlerInstaller?.install()
+
+        // Start the log orchestrator
+        openTelemetryModule.logSink.registerLogStoredCallback {
+            logModule.logOrchestrator.onLogsAdded()
+        }
+
+        essentialServiceModule.telemetryDestination.sessionUpdateAction =
+            sessionOrchestrationModule.sessionOrchestrator::onSessionDataUpdate
     }
 }

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -322,7 +322,7 @@ internal class ModuleInitBootstrapper(
                     nativeFeatureModuleSupplier,
                     sessionOrchestrationModuleSupplier,
                     payloadSourceModuleSupplier
-                )
+                ).apply(InitializedModuleGraph::postInit)
                 return isInitialized()
             }
         } catch (ignored: SdkDisabledException) {


### PR DESCRIPTION
## Goal

Separates out the post-init actions from `InitializedModuleGraph` in the same order as which they are currently. A future PR will extract them out of this class entirely.

## Testing

Relied on existing test coverage.

